### PR TITLE
Have the Gitter importer soft-deactivate inactive users 

### DIFF
--- a/zerver/data_import/gitter.py
+++ b/zerver/data_import/gitter.py
@@ -83,7 +83,10 @@ def build_userprofile(
             user_map[user_data["id"]] = user_id
 
             email = get_user_email(user_data, domain_name)
-            build_avatar(user_id, realm_id, email, user_data["avatarUrl"], timestamp, avatar_list)
+            if user_data.get("avatarUrl"):
+                build_avatar(
+                    user_id, realm_id, email, user_data["avatarUrl"], timestamp, avatar_list
+                )
 
             # Build userprofile object
             userprofile = UserProfile(

--- a/zerver/data_import/gitter.py
+++ b/zerver/data_import/gitter.py
@@ -200,6 +200,11 @@ def build_recipient_and_subscription(
     return zerver_recipient, zerver_subscription
 
 
+def get_timestamp_from_message(message: ZerverFieldsT) -> float:
+    # Gitter's timestamps are in UTC
+    return float(dateutil.parser.parse(message["sent"]).timestamp())
+
+
 def convert_gitter_workspace_messages(
     gitter_data: GitterDataT,
     output_dir: str,
@@ -227,7 +232,7 @@ def convert_gitter_workspace_messages(
         if len(message_data) == 0:
             break
         for message in message_data:
-            message_time = dateutil.parser.parse(message["sent"]).timestamp()
+            message_time = get_timestamp_from_message(message)
             mentioned_user_ids = get_usermentions(message, user_map, user_short_name_to_full_name)
             rendered_content = None
             topic_name = "imported from Gitter" + (
@@ -237,7 +242,7 @@ def convert_gitter_workspace_messages(
             recipient_id = stream_map[message["room"]] if "room" in message else 0
             zulip_message = build_message(
                 topic_name,
-                float(message_time),
+                message_time,
                 message_id,
                 message["text"],
                 rendered_content,

--- a/zerver/data_import/gitter.py
+++ b/zerver/data_import/gitter.py
@@ -230,7 +230,7 @@ def convert_gitter_workspace_messages(
         get_user_from_message,
         get_timestamp_from_message,
         lambda id: user_map[id],
-        list(user_map.keys()),
+        iter(user_map.keys()),
         zerver_userprofile,
     )
 

--- a/zerver/data_import/gitter.py
+++ b/zerver/data_import/gitter.py
@@ -78,7 +78,7 @@ def build_userprofile(
     user_id = 0
 
     for data in gitter_data:
-        if data["fromUser"]["id"] not in user_map:
+        if get_user_from_message(data) not in user_map:
             user_data = data["fromUser"]
             user_map[user_data["id"]] = user_id
 
@@ -205,6 +205,10 @@ def get_timestamp_from_message(message: ZerverFieldsT) -> float:
     return float(dateutil.parser.parse(message["sent"]).timestamp())
 
 
+def get_user_from_message(message: ZerverFieldsT) -> str:
+    return message["fromUser"]["id"]
+
+
 def convert_gitter_workspace_messages(
     gitter_data: GitterDataT,
     output_dir: str,
@@ -238,7 +242,7 @@ def convert_gitter_workspace_messages(
             topic_name = "imported from Gitter" + (
                 f' room {message["room"]}' if "room" in message else ""
             )
-            user_id = user_map[message["fromUser"]["id"]]
+            user_id = user_map[get_user_from_message(message)]
             recipient_id = stream_map[message["room"]] if "room" in message else 0
             zulip_message = build_message(
                 topic_name,

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -755,7 +755,7 @@ def long_term_idle_helper(
     user_from_message: Callable[[ZerverFieldsT], Optional[ExternalId]],
     timestamp_from_message: Callable[[ZerverFieldsT], float],
     zulip_user_id_from_user: Callable[[ExternalId], int],
-    users: List[ZerverFieldsT],
+    all_user_ids: List[ExternalId],
     zerver_userprofile: List[ZerverFieldsT],
 ) -> Set[int]:
     """Algorithmically, we treat users who have sent at least 10 messages
@@ -786,10 +786,10 @@ def long_term_idle_helper(
 
     long_term_idle = set()
 
-    for user_data in users:
-        if user_data["id"] in recent_senders:
+    for user_id in all_user_ids:
+        if user_id in recent_senders:
             continue
-        zulip_user_id = zulip_user_id_from_user(user_data["id"])
+        zulip_user_id = zulip_user_id_from_user(user_id)
         long_term_idle.add(zulip_user_id)
 
     for user_profile_row in zerver_userprofile:

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -755,7 +755,7 @@ def long_term_idle_helper(
     user_from_message: Callable[[ZerverFieldsT], Optional[ExternalId]],
     timestamp_from_message: Callable[[ZerverFieldsT], float],
     zulip_user_id_from_user: Callable[[ExternalId], int],
-    all_user_ids: List[ExternalId],
+    all_user_ids_iterator: Iterator[ExternalId],
     zerver_userprofile: List[ZerverFieldsT],
 ) -> Set[int]:
     """Algorithmically, we treat users who have sent at least 10 messages
@@ -786,7 +786,7 @@ def long_term_idle_helper(
 
     long_term_idle = set()
 
-    for user_id in all_user_ids:
+    for user_id in all_user_ids_iterator:
         if user_id in recent_senders:
             continue
         zulip_user_id = zulip_user_id_from_user(user_id)

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -753,6 +753,7 @@ ExternalId = TypeVar("ExternalId")
 def long_term_idle_helper(
     message_iterator: Iterator[ZerverFieldsT],
     user_from_message: Callable[[ZerverFieldsT], Optional[ExternalId]],
+    timestamp_from_message: Callable[[ZerverFieldsT], float],
     zulip_user_id_from_user: Callable[[ExternalId], int],
     users: List[ZerverFieldsT],
     zerver_userprofile: List[ZerverFieldsT],
@@ -767,7 +768,7 @@ def long_term_idle_helper(
     recent_senders: Set[ExternalId] = set()
     NOW = float(timezone_now().timestamp())
     for message in message_iterator:
-        timestamp = float(message["ts"])
+        timestamp = timestamp_from_message(message)
         user = user_from_message(message)
         if user is None:
             continue

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -2,6 +2,7 @@ import logging
 import os
 import random
 import shutil
+from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from functools import partial
 from typing import (
@@ -10,6 +11,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Protocol,
@@ -21,6 +23,7 @@ from typing import (
 import orjson
 import requests
 from django.forms.models import model_to_dict
+from django.utils.timezone import now as timezone_now
 
 from zerver.data_import.sequencer import NEXT_ID
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
@@ -741,3 +744,59 @@ def create_converted_data_files(data: Any, output_dir: str, file_path: str) -> N
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
     with open(output_file, "wb") as fp:
         fp.write(orjson.dumps(data, option=orjson.OPT_INDENT_2))
+
+
+# External user-id
+ExternalId = TypeVar("ExternalId")
+
+
+def long_term_idle_helper(
+    message_iterator: Iterator[ZerverFieldsT],
+    user_from_message: Callable[[ZerverFieldsT], Optional[ExternalId]],
+    zulip_user_id_from_user: Callable[[ExternalId], int],
+    users: List[ZerverFieldsT],
+    zerver_userprofile: List[ZerverFieldsT],
+) -> Set[int]:
+    """Algorithmically, we treat users who have sent at least 10 messages
+    or have sent a message within the last 60 days as active.
+    Everyone else is treated as long-term idle, which means they will
+    have a slightly slower first page load when coming back to
+    Zulip.
+    """
+    sender_counts: Dict[ExternalId, int] = defaultdict(int)
+    recent_senders: Set[ExternalId] = set()
+    NOW = float(timezone_now().timestamp())
+    for message in message_iterator:
+        timestamp = float(message["ts"])
+        user = user_from_message(message)
+        if user is None:
+            continue
+
+        if user in recent_senders:
+            continue
+
+        if NOW - timestamp < 60:
+            recent_senders.add(user)
+
+        sender_counts[user] += 1
+    for (user, count) in sender_counts.items():
+        if count > 10:
+            recent_senders.add(user)
+
+    long_term_idle = set()
+
+    for user_data in users:
+        if user_data["id"] in recent_senders:
+            continue
+        zulip_user_id = zulip_user_id_from_user(user_data["id"])
+        long_term_idle.add(zulip_user_id)
+
+    for user_profile_row in zerver_userprofile:
+        if user_profile_row["id"] in long_term_idle:
+            user_profile_row["long_term_idle"] = True
+            # Setting last_active_message_id to 1 means the user, if
+            # imported, will get the full message history for the
+            # streams they were on.
+            user_profile_row["last_active_message_id"] = 1
+
+    return long_term_idle

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -794,7 +794,7 @@ def get_messages_iterator(
 
         # we sort the messages according to the timestamp to show messages with
         # the proper date order
-        yield from sorted(messages_for_one_day, key=lambda m: m["ts"])
+        yield from sorted(messages_for_one_day, key=get_timestamp_from_message)
 
 
 def channel_message_to_zerver_message(
@@ -924,7 +924,7 @@ def channel_message_to_zerver_message(
 
         zulip_message = build_message(
             topic_name,
-            float(message["ts"]),
+            get_timestamp_from_message(message),
             message_id,
             content,
             rendered_content,

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -29,6 +29,7 @@ from zerver.data_import.import_util import (
     build_usermessages,
     build_zerver_realm,
     create_converted_data_files,
+    long_term_idle_helper,
     make_subscriber_map,
     process_avatars,
     process_emojis,
@@ -644,51 +645,13 @@ def process_long_term_idle_users(
     dm_members: DMMembersT,
     zerver_userprofile: List[ZerverFieldsT],
 ) -> Set[int]:
-    """Algorithmically, we treat users who have sent at least 10 messages
-    or have sent a message within the last 60 days as active.
-    Everyone else is treated as long-term idle, which means they will
-    have a slightly slower first page load when coming back to
-    Zulip.
-    """
-    all_messages = get_messages_iterator(slack_data_dir, added_channels, added_mpims, dm_members)
-
-    sender_counts: Dict[str, int] = defaultdict(int)
-    recent_senders: Set[str] = set()
-    NOW = float(timezone_now().timestamp())
-    for message in all_messages:
-        timestamp = float(message["ts"])
-        slack_user_id = get_message_sending_user(message)
-        if not slack_user_id:
-            continue
-
-        if slack_user_id in recent_senders:
-            continue
-
-        if NOW - timestamp < 60:
-            recent_senders.add(slack_user_id)
-
-        sender_counts[slack_user_id] += 1
-    for (slack_sender_id, count) in sender_counts.items():
-        if count > 10:
-            recent_senders.add(slack_sender_id)
-
-    long_term_idle = set()
-
-    for slack_user in users:
-        if slack_user["id"] in recent_senders:
-            continue
-        zulip_user_id = slack_user_id_to_zulip_user_id[slack_user["id"]]
-        long_term_idle.add(zulip_user_id)
-
-    for user_profile_row in zerver_userprofile:
-        if user_profile_row["id"] in long_term_idle:
-            user_profile_row["long_term_idle"] = True
-            # Setting last_active_message_id to 1 means the user, if
-            # imported, will get the full message history for the
-            # streams they were on.
-            user_profile_row["last_active_message_id"] = 1
-
-    return long_term_idle
+    return long_term_idle_helper(
+        get_messages_iterator(slack_data_dir, added_channels, added_mpims, dm_members),
+        get_message_sending_user,
+        lambda id: slack_user_id_to_zulip_user_id[id],
+        users,
+        zerver_userprofile,
+    )
 
 
 def convert_slack_workspace_messages(

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -648,6 +648,7 @@ def process_long_term_idle_users(
     return long_term_idle_helper(
         get_messages_iterator(slack_data_dir, added_channels, added_mpims, dm_members),
         get_message_sending_user,
+        get_timestamp_from_message,
         lambda id: slack_user_id_to_zulip_user_id[id],
         users,
         zerver_userprofile,
@@ -1139,6 +1140,10 @@ def get_message_sending_user(message: ZerverFieldsT) -> Optional[str]:
     if message.get("file"):
         return message["file"].get("user")
     return None
+
+
+def get_timestamp_from_message(message: ZerverFieldsT) -> float:
+    return float(message["ts"])
 
 
 def fetch_shared_channel_users(

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -650,7 +650,7 @@ def process_long_term_idle_users(
         get_message_sending_user,
         get_timestamp_from_message,
         lambda id: slack_user_id_to_zulip_user_id[id],
-        users,
+        [user["id"] for user in users],
         zerver_userprofile,
     )
 

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -650,7 +650,7 @@ def process_long_term_idle_users(
         get_message_sending_user,
         get_timestamp_from_message,
         lambda id: slack_user_id_to_zulip_user_id[id],
-        [user["id"] for user in users],
+        iter(user["id"] for user in users),
         zerver_userprofile,
     )
 

--- a/zerver/tests/fixtures/gitter_data.json
+++ b/zerver/tests/fixtures/gitter_data.json
@@ -14,7 +14,7 @@
     "issues": [],
     "meta": [],
     "readBy": 8,
-    "sent": "2016-06-02T20:54:38.747Z",
+    "sent": "2015-06-02T20:54:38.747Z",
     "text": "test message",
     "unread": false,
     "urls": [],


### PR DESCRIPTION
This picks up on the work started by @alexmv  (starting with a small commit fixing avatar handling) to allow using soft deactivation like we do for Slack imports, to avoid creating too many `UserMessage`s when importing. These commits for now are necessary refactoring to make the `long_term_idle_helper` general enough to be usable by non-Slack import systems. They will then allow a follow-up of using it in Gitter imports like in the last commit - which requires more testing first though, so marked as `do not merge`