### PR TITLE
Add a "Mastering the compose box" help center aricle

### DIFF
--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -294,4 +294,7 @@ A summary of the formatting syntax is available in-app.
 ## Related articles
 
 * [Create a poll](/help/create-a-poll)
+* [Mention a user or group](/help/mention-a-user-or-group)
+* [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Resize the compose box](/help/resize-the-compose-box)
 * [Messaging tips & tricks](/help/messaging-tips)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -56,6 +56,7 @@
 
 ## Sending messages
 * [Open the compose box](/help/open-the-compose-box)
+* [Mastering the compose box](/help/mastering-the-compose-box)
 * [Resize the compose box](/help/resize-the-compose-box)
 * [Format messages using Markdown](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)

--- a/templates/zerver/help/mastering-the-compose-box.md
+++ b/templates/zerver/help/mastering-the-compose-box.md
@@ -1,0 +1,28 @@
+# Mastering the compose box
+
+When composing a message, Zulip lets you view a different conversation from the
+one you are composing to. For example, you can start a new topic without
+changing your narrow, send a private message about the topic you're viewing, or
+look up a related discussion.
+
+In this context, the parts of the message view that are outside of the
+conversation you are composing to are faded for clarity.
+
+## Go to conversation
+
+To narrow the view to the conversation you're currently composing to,
+click on the **Go to conversation** (<i class="zulip-icon
+   zulip-icon-arrow-left-circle"></i>) button in the compose box.
+
+You can also use the keyboard shortcut `Ctrl` + `.` to go to the conversation to
+which you are composing.
+
+While the button is only shown when composing to a stream, the keyboard shortcut
+will work in both stream messages and private messages.
+
+## Related topics
+
+* [Resize the compose box](/help/resize-the-compose-box)
+* [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Messaging tips and tricks](/help/messaging-tips)

--- a/templates/zerver/help/preview-your-message-before-sending.md
+++ b/templates/zerver/help/preview-your-message-before-sending.md
@@ -11,3 +11,9 @@
 {end_tabs}
 
 Click the **pencil and paper** (<i class="fa fa-edit"></i>) icon to resume editing.
+
+## Related articles
+
+* [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Resize the compose box](/help/resize-the-compose-box)
+* [Mastering the compose box](/help/mastering-the-compose-box)

--- a/templates/zerver/help/resize-the-compose-box.md
+++ b/templates/zerver/help/resize-the-compose-box.md
@@ -37,3 +37,5 @@ box also stretches automatically when you type a long message.
 ## Related articles
 
 * [Open the compose box](/help/open-the-compose-box)
+* [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Mastering the compose box](/help/mastering-the-compose-box)


### PR DESCRIPTION
This PR updates/replaces #21991. The main goal is to document "Go to conversation".

I also added some cross-links between various compose box articles.

Links were manually tested.
<img width="856" alt="Screen Shot 2022-06-01 at 1 45 40 PM" src="https://user-images.githubusercontent.com/2090066/171498514-e9b210e6-ad21-4513-b624-14b343e6f01b.png">

