### PR TITLE
Disable `enable_spectator_access` setting for limited plan realms.

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -166,7 +166,9 @@ export function build_page() {
         twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
         create_web_public_stream_policy_values:
             settings_config.create_web_public_stream_policy_values,
-        disable_enable_spectator_access_setting: !page_params.server_web_public_streams_enabled,
+        disable_enable_spectator_access_setting:
+            !page_params.server_web_public_streams_enabled ||
+            !page_params.zulip_plan_is_not_limited,
         can_sort_by_email: settings_data.show_email(),
         realm_push_notifications_enabled: page_params.realm_push_notifications_enabled,
         realm_org_type_values: settings_org.get_org_type_dropdown_options(),

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -373,7 +373,9 @@ function set_digest_emails_weekday_visibility() {
 function set_create_web_public_stream_dropdown_visibility() {
     change_element_block_display_property(
         "id_realm_create_web_public_stream_policy",
-        page_params.server_web_public_streams_enabled && page_params.realm_enable_spectator_access,
+        page_params.server_web_public_streams_enabled &&
+            page_params.zulip_plan_is_not_limited &&
+            page_params.realm_enable_spectator_access,
     );
 }
 

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -103,6 +103,7 @@
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
+                {{> upgrade_tip_widget }}
                 {{> settings_checkbox
                   setting_name="realm_enable_spectator_access"
                   prefix="id_"

--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -161,6 +161,10 @@ def do_create_realm(
     if org_type is not None:
         kwargs["org_type"] = org_type
     if enable_spectator_access is not None:
+        if enable_spectator_access:
+            # Realms with LIMITED plan cannot have spectators enabled.
+            assert plan_type != Realm.PLAN_TYPE_LIMITED
+            assert plan_type is not None or not settings.BILLING_ENABLED
         kwargs["enable_spectator_access"] = enable_spectator_access
 
     if date_created is not None:

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -412,6 +412,11 @@ def do_change_realm_plan_type(
     realm: Realm, plan_type: int, *, acting_user: Optional[UserProfile]
 ) -> None:
     old_value = realm.plan_type
+
+    if plan_type == Realm.PLAN_TYPE_LIMITED:
+        # We do not allow public access on limited plans.
+        do_set_realm_property(realm, "enable_spectator_access", False, acting_user=acting_user)
+
     realm.plan_type = plan_type
     realm.save(update_fields=["plan_type"])
     RealmAuditLog.objects.create(
@@ -447,7 +452,14 @@ def do_change_realm_plan_type(
 
     update_first_visible_message_id(realm)
 
-    realm.save(update_fields=["_max_invites", "message_visibility_limit", "upload_quota_gb"])
+    realm.save(
+        update_fields=[
+            "_max_invites",
+            "enable_spectator_access",
+            "message_visibility_limit",
+            "upload_quota_gb",
+        ]
+    )
 
     event = {
         "type": "realm",

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1765,9 +1765,11 @@ class NormalActionsTest(BaseAction):
         events = self.verify_action(
             lambda: do_change_realm_plan_type(
                 realm, Realm.PLAN_TYPE_LIMITED, acting_user=self.user_profile
-            )
+            ),
+            num_events=2,
         )
-        check_realm_update("events[0]", events[0], "plan_type")
+        check_realm_update("events[0]", events[0], "enable_spectator_access")
+        check_realm_update("events[1]", events[1], "plan_type")
 
         state_data = fetch_initial_state_data(self.user_profile)
         self.assertEqual(state_data["realm_plan_type"], Realm.PLAN_TYPE_LIMITED)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -425,6 +425,12 @@ class EditMessageTest(EditMessageTestCase):
             result, "Not logged in: API authentication or user session required", 401
         )
 
+        do_set_realm_property(user_profile.realm, "enable_spectator_access", True, acting_user=None)
+        result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
+        self.assert_json_error(
+            result, "Not logged in: API authentication or user session required", 401
+        )
+
         # Verify works with STANDARD_FREE plan type too.
         do_change_realm_plan_type(
             user_profile.realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=None

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -96,11 +96,27 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(realm.invite_to_stream_policy, Realm.POLICY_MODERATORS_ONLY)
 
     def test_realm_enable_spectator_access(self) -> None:
-        realm = do_create_realm("test_web_public_true", "Foo", enable_spectator_access=True)
+        realm = do_create_realm(
+            "test_web_public_true",
+            "Foo",
+            plan_type=Realm.PLAN_TYPE_STANDARD,
+            enable_spectator_access=True,
+        )
         self.assertEqual(realm.enable_spectator_access, True)
 
         realm = do_create_realm("test_web_public_false", "Boo", enable_spectator_access=False)
         self.assertEqual(realm.enable_spectator_access, False)
+
+        with self.assertRaises(AssertionError):
+            realm = do_create_realm("test_web_public_false_1", "Foo", enable_spectator_access=True)
+
+        with self.assertRaises(AssertionError):
+            realm = do_create_realm(
+                "test_web_public_false_2",
+                "Foo",
+                plan_type=Realm.PLAN_TYPE_LIMITED,
+                enable_spectator_access=True,
+            )
 
     def test_do_set_realm_name_caching(self) -> None:
         """The main complicated thing about setting realm names is fighting the
@@ -698,12 +714,14 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_STANDARD)
 
+        do_set_realm_property(realm, "enable_spectator_access", True, acting_user=None)
         do_change_realm_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=iago)
         realm = get_realm("zulip")
         self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_LIMITED)
         self.assertEqual(realm.max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, Realm.MESSAGE_VISIBILITY_LIMITED)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_LIMITED)
+        self.assertFalse(realm.enable_spectator_access)
 
         do_change_realm_plan_type(realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=iago)
         realm = get_realm("zulip")


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit disables the setting in frontend for limited plan realms.
- Second commit adds code to set the setting to `False` on changing plan to limited.

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/stream/9-issues/topic/Web-public.20streams

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-06-03 13-26-34](https://user-images.githubusercontent.com/35494118/171874230-1cdd80b6-88f8-4509-9bd6-67abc24f0c94.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
