### PR TITLE
footer: Reduce links for self-hosted installations on signup pages.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -351,6 +351,20 @@ input.text-error {
 
 .portico-container {
     position: relative;
+    /* To adjust for flexible footer height we do 2 things:
+      - Make the `portico-container` expand to full page height.
+      - Fill the empty space with `portico-wrap`. */
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    .portico-wrap {
+        flex: 1 0 auto;
+    }
+
+    .footer {
+        flex-shrink: 0;
+    }
 
     .if-zulip-electron {
         display: none;
@@ -400,6 +414,42 @@ input.text-error {
             margin-left: 0;
             font-weight: 400;
         }
+
+        .coloured-text {
+            color: hsl(0, 0%, 20%);
+            font-weight: bold;
+        }
+    }
+}
+
+.self-hosted-footer {
+    padding: 20px 0 10px;
+    display: flex;
+    flex-wrap: wrap;
+
+    .break {
+        flex-basis: 100%;
+        height: 0;
+    }
+
+    .powered-by-zulip {
+        padding: 0;
+        padding-top: 10px;
+        opacity: 0.9;
+        font-size: 15px;
+    }
+
+    .footer-section {
+        padding-bottom: 5px;
+        margin: 0 15px;
+    }
+
+    .footer-section ul {
+        margin: 0;
+    }
+
+    @media (width <= 500px) {
+        flex-direction: column;
     }
 }
 

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -1,3 +1,31 @@
+{% if corporate_enabled %}
+<div class="footer self-hosted-footer">
+    <div class="footer-section">
+        <ul>
+            <li>
+                <a href="/help">{{ _("Help center") }}</a>
+            </li>
+        </ul>
+    </div>
+    <div class="footer-section">
+        <ul>
+            <li>
+                <a href="/policies">{{ _("Policies") }}</a>
+            </li>
+        </ul>
+    </div>
+    <div class="break"></div>
+    <div class="footer-section powered-by-zulip">
+        <ul>
+            <li>
+                {% trans %}
+                Powered by <a href="https://zulip.com" class="coloured-text">Zulip</a>
+                {% endtrans %}
+            </li>
+        </ul>
+    </div>
+</div>
+{% else %}
 <div class="footer">
     <div class="footer-section">
         <h3>{{ _("Product") }}</h3>
@@ -151,3 +179,4 @@
         </ul>
     </div>
 </div>
+{% endif %}

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -131,6 +131,9 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         settings_path = "/etc/zulip/settings.py"
         settings_comments_path = "/etc/zulip/settings.py"
 
+    # Used to remove links to Zulip docs and landing page from footer of self-hosted pages.
+    corporate_enabled = settings.CORPORATE_ENABLED
+
     support_email = FromAddress.SUPPORT
     support_email_html_tag = SafeString(
         f'<a href="mailto:{escape(support_email)}">{escape(support_email)}</a>'
@@ -174,6 +177,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         "landing_page_navbar_message": settings.LANDING_PAGE_NAVBAR_MESSAGE,
         "is_isolated_page": is_isolated_page(request),
         "default_page_params": default_page_params,
+        "corporate_enabled": corporate_enabled,
     }
 
     context["OPEN_GRAPH_URL"] = f"{realm_uri}{request.path}"


### PR DESCRIPTION
On registration and login pages on self-hosted Zulip servers,
it is not helpful and confusing to show the full navigation footer
for the Zulip website. Instead, we should show a minimal footer.

Fixes #21776
<img width="945" alt="Screenshot 2022-06-03 at 4 38 42 PM" src="https://user-images.githubusercontent.com/25124304/171868504-a0f26121-e62b-4bbc-a482-0918160c2eef.png">
<img width="945" alt="Screenshot 2022-06-03 at 4 38 50 PM" src="https://user-images.githubusercontent.com/25124304/171868523-b4da1eea-5831-4492-b79f-47c6a6a297e7.png">
