### PR TITLE
django-stubs: Fix HttpResponse missing attribute error.

### DIFF
--- a/analytics/tests/test_stats_views.py
+++ b/analytics/tests/test_stats_views.py
@@ -124,8 +124,7 @@ class TestGetChartData(ZulipTestCase):
         stat = COUNT_STATS["active_users_audit:is_bot:day"]
         self.insert_data(stat, ["false"], [])
         result = self.client_get("/json/analytics/chart_data", {"chart_name": "number_of_humans"})
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             data,
             {
@@ -148,8 +147,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "messages_sent_over_time"}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             data,
             {
@@ -171,8 +169,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "messages_sent_by_message_type"}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             data,
             {
@@ -215,8 +212,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "messages_sent_by_client"}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             data,
             {
@@ -240,8 +236,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "messages_read_over_time"}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             data,
             {
@@ -262,8 +257,7 @@ class TestGetChartData(ZulipTestCase):
             state=FillState.DONE,
         )
         result = self.client_get("/json/analytics/chart_data", {"chart_name": "number_of_humans"})
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(data["everyone"], {"_1day": [0], "_15day": [0], "all_time": [0]})
         self.assertFalse("user" in data)
 
@@ -275,8 +269,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "messages_sent_over_time"}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(data["everyone"], {"human": [0], "bot": [0]})
         self.assertEqual(data["user"], {"human": [0], "bot": [0]})
 
@@ -288,8 +281,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "messages_sent_by_message_type"}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             data["everyone"],
             {
@@ -317,8 +309,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "messages_sent_by_client"}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(data["everyone"], {})
         self.assertEqual(data["user"], {})
 
@@ -340,8 +331,7 @@ class TestGetChartData(ZulipTestCase):
                 "end": end_time_timestamps[2],
             },
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(data["end_times"], end_time_timestamps[1:3])
         self.assertEqual(
             data["everyone"], {"_1day": [0, 100], "_15day": [0, 100], "all_time": [0, 100]}
@@ -369,8 +359,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "number_of_humans", "min_length": 2}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             data["end_times"], [datetime_to_timestamp(dt) for dt in self.end_times_day]
         )
@@ -382,8 +371,7 @@ class TestGetChartData(ZulipTestCase):
         result = self.client_get(
             "/json/analytics/chart_data", {"chart_name": "number_of_humans", "min_length": 5}
         )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         end_times = [
             ceiling_to_day(self.realm.date_created) + timedelta(days=i) for i in range(-1, 4)
         ]

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -458,8 +458,8 @@ class StripeTestCase(ZulipTestCase):
                 "stripe_session_id": stripe_session_id,
             },
         )
-        self.assert_json_success(json_response)
-        self.assertEqual(json_response.json()["session"], expected_details)
+        response_dict = self.assert_json_success(json_response)
+        self.assertEqual(response_dict["session"], expected_details)
 
     def assert_details_of_valid_payment_intent_from_event_status_endpoint(
         self,
@@ -472,8 +472,8 @@ class StripeTestCase(ZulipTestCase):
                 "stripe_payment_intent_id": stripe_payment_intent_id,
             },
         )
-        self.assert_json_success(json_response)
-        self.assertEqual(json_response.json()["payment_intent"], expected_details)
+        response_dict = self.assert_json_success(json_response)
+        self.assertEqual(response_dict["payment_intent"], expected_details)
 
     def trigger_stripe_checkout_session_completed_webhook(
         self,
@@ -590,8 +590,9 @@ class StripeTestCase(ZulipTestCase):
                 "stripe_payment_intent_id"
             ] = last_stripe_payment_intent.stripe_payment_intent_id
 
+        response_dict = self.assert_json_success(upgrade_json_response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            upgrade_json_response.json()["stripe_session_id"], expected_session_details
+            response_dict["stripe_session_id"], expected_session_details
         )
         if payment_method is None:
             payment_method = create_payment_method(
@@ -695,8 +696,10 @@ class StripeTest(StripeTestCase):
             response = self.upgrade()
         [payment_intent] = PaymentIntent.objects.all()
         assert payment_intent.stripe_payment_intent_id is not None
+
+        response_dict = self.assert_json_success(response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "upgrade_from_billing_page",
                 "status": "completed",
@@ -1017,8 +1020,10 @@ class StripeTest(StripeTestCase):
             with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
                 response = self.upgrade()
             self.assertEqual(PaymentIntent.objects.count(), 0)
+
+            response_dict = self.assert_json_success(response)
             self.assert_details_of_valid_session_from_event_status_endpoint(
-                response.json()["stripe_session_id"],
+                response_dict["stripe_session_id"],
                 {
                     "type": "free_trial_upgrade_from_billing_page",
                     "status": "completed",
@@ -1233,8 +1238,10 @@ class StripeTest(StripeTestCase):
             with patch("corporate.lib.stripe.timezone_now", return_value=self.now):
                 response = self.upgrade(onboarding=True)
             self.assertEqual(PaymentIntent.objects.all().count(), 0)
+
+            response_dict = self.assert_json_success(response)
             self.assert_details_of_valid_session_from_event_status_endpoint(
-                response.json()["stripe_session_id"],
+                response_dict["stripe_session_id"],
                 {
                     "type": "free_trial_upgrade_from_onboarding_page",
                     "status": "completed",
@@ -1488,8 +1495,9 @@ class StripeTest(StripeTestCase):
             )
 
         [payment_intent] = PaymentIntent.objects.all()
+        response_dict = self.assert_json_success(response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "upgrade_from_billing_page",
                 "status": "completed",
@@ -1547,8 +1555,9 @@ class StripeTest(StripeTestCase):
         )
         self.assert_json_success(retry_payment_intent_json_response)
         [payment_intent] = PaymentIntent.objects.all()
+        response_dict = self.assert_json_success(retry_payment_intent_json_response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            retry_payment_intent_json_response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "retry_upgrade_with_another_payment_method",
                 "status": "created",
@@ -1568,8 +1577,9 @@ class StripeTest(StripeTestCase):
         )
         self.send_stripe_webhook_events(last_event)
 
+        response_dict = self.assert_json_success(retry_payment_intent_json_response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            retry_payment_intent_json_response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "retry_upgrade_with_another_payment_method",
                 "status": "completed",
@@ -1654,8 +1664,9 @@ class StripeTest(StripeTestCase):
 
         [payment_intent] = PaymentIntent.objects.all()
         assert payment_intent.stripe_payment_intent_id is not None
+        response_dict = self.assert_json_success(response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "upgrade_from_billing_page",
                 "status": "completed",
@@ -1712,8 +1723,9 @@ class StripeTest(StripeTestCase):
                 response = self.upgrade()
         [second_payment_intent, _] = PaymentIntent.objects.all().order_by("-id")
         assert second_payment_intent.stripe_payment_intent_id is not None
+        response_dict = self.assert_json_success(response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "upgrade_from_billing_page",
                 "status": "completed",
@@ -2068,8 +2080,9 @@ class StripeTest(StripeTestCase):
         ), self.assertLogs("corporate.stripe", "WARNING"):
             response = self.upgrade()
 
+        response_dict = self.assert_json_success(response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "upgrade_from_billing_page",
                 "status": "completed",
@@ -2095,8 +2108,9 @@ class StripeTest(StripeTestCase):
             response = self.upgrade()
 
         [payment_intent] = PaymentIntent.objects.all().order_by("-id")
+        response_dict = self.assert_json_success(response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "upgrade_from_billing_page",
                 "status": "completed",
@@ -2548,8 +2562,9 @@ class StripeTest(StripeTestCase):
         start_session_json_response = self.client_post(
             "/json/billing/session/start_card_update_session"
         )
+        response_dict = self.assert_json_success(start_session_json_response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            start_session_json_response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "card_update_from_billing_page",
                 "status": "created",
@@ -2567,8 +2582,9 @@ class StripeTest(StripeTestCase):
         start_session_json_response = self.client_post(
             "/json/billing/session/start_card_update_session"
         )
+        response_dict = self.assert_json_success(start_session_json_response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            start_session_json_response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "card_update_from_billing_page",
                 "status": "created",
@@ -2584,8 +2600,9 @@ class StripeTest(StripeTestCase):
                 m.output[0],
                 "INFO:corporate.stripe:Stripe card error: 402 card_error card_declined None",
             )
+        response_dict = self.assert_json_success(start_session_json_response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            start_session_json_response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "card_update_from_billing_page",
                 "status": "completed",
@@ -2620,8 +2637,9 @@ class StripeTest(StripeTestCase):
                 )
             )
         )
+        response_dict = self.assert_json_success(start_session_json_response)
         self.assert_details_of_valid_session_from_event_status_endpoint(
-            start_session_json_response.json()["stripe_session_id"],
+            response_dict["stripe_session_id"],
             {
                 "type": "card_update_from_billing_page",
                 "status": "completed",
@@ -2632,7 +2650,7 @@ class StripeTest(StripeTestCase):
         self.login_user(self.example_user("iago"))
         response = self.client_get(
             "/json/billing/event/status",
-            {"stripe_session_id": start_session_json_response.json()["stripe_session_id"]},
+            {"stripe_session_id": response_dict["stripe_session_id"]},
         )
         self.assert_json_error_contains(
             response, "Must be a billing administrator or an organization owner"

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -116,8 +116,8 @@ class AlertWordTests(ZulipTestCase):
         self.login_user(user)
 
         result = self.client_get("/json/users/me/alert_words")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["alert_words"], [])
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["alert_words"], [])
 
     def test_json_list_nonempty(self) -> None:
         user = self.get_user()
@@ -125,8 +125,8 @@ class AlertWordTests(ZulipTestCase):
 
         self.login_user(user)
         result = self.client_get("/json/users/me/alert_words")
-        self.assert_json_success(result)
-        self.assertEqual(set(result.json()["alert_words"]), {"one", "two", "three"})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(set(response_dict["alert_words"]), {"one", "two", "three"})
 
     def test_json_list_add(self) -> None:
         user = self.get_user()
@@ -136,8 +136,8 @@ class AlertWordTests(ZulipTestCase):
             "/json/users/me/alert_words",
             {"alert_words": orjson.dumps(["one ", "\n two", "three"]).decode()},
         )
-        self.assert_json_success(result)
-        self.assertEqual(set(result.json()["alert_words"]), {"one", "two", "three"})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(set(response_dict["alert_words"]), {"one", "two", "three"})
 
     def test_json_list_remove(self) -> None:
         user = self.get_user()
@@ -147,14 +147,14 @@ class AlertWordTests(ZulipTestCase):
             "/json/users/me/alert_words",
             {"alert_words": orjson.dumps(["one", "two", "three"]).decode()},
         )
-        self.assert_json_success(result)
-        self.assertEqual(set(result.json()["alert_words"]), {"one", "two", "three"})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(set(response_dict["alert_words"]), {"one", "two", "three"})
 
         result = self.client_delete(
             "/json/users/me/alert_words", {"alert_words": orjson.dumps(["one"]).decode()}
         )
-        self.assert_json_success(result)
-        self.assertEqual(set(result.json()["alert_words"]), {"two", "three"})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(set(response_dict["alert_words"]), {"two", "three"})
 
     def message_does_alert(self, user: UserProfile, message: str) -> bool:
         """Send a bunch of messages as othello, so our user is notified"""
@@ -170,8 +170,8 @@ class AlertWordTests(ZulipTestCase):
             "/json/users/me/alert_words",
             {"alert_words": orjson.dumps(["one", "two", "three"]).decode()},
         )
-        self.assert_json_success(result)
-        self.assertEqual(set(result.json()["alert_words"]), {"one", "two", "three"})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(set(response_dict["alert_words"]), {"one", "two", "three"})
 
         # Alerts in the middle of messages work.
         self.assertTrue(self.message_does_alert(user, "Normal alert one time"))

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -22,9 +22,9 @@ class AttachmentsTests(ZulipTestCase):
         user_profile = self.example_user("cordelia")
         self.login_user(user_profile)
         result = self.client_get("/json/attachments")
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
         attachments = user_attachments(user_profile)
-        self.assertEqual(result.json()["attachments"], attachments)
+        self.assertEqual(response_dict["attachments"], attachments)
 
     def test_remove_attachment_exception(self) -> None:
         user_profile = self.example_user("cordelia")
@@ -48,8 +48,8 @@ class AttachmentsTests(ZulipTestCase):
         user_profile = self.example_user("iago")
         self.login_user(user_profile)
         result = self.client_get("/json/attachments")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["attachments"], [])
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["attachments"], [])
 
     def test_remove_another_user(self) -> None:
         user_profile = self.example_user("iago")

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4638,8 +4638,7 @@ class DevFetchAPIKeyTest(ZulipTestCase):
 
     def test_success(self) -> None:
         result = self.client_post("/api/v1/dev_fetch_api_key", dict(username=self.email))
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(data["email"], self.email)
         user_api_keys = get_all_api_keys(self.user_profile)
         self.assertIn(data["api_key"], user_api_keys)
@@ -4812,7 +4811,7 @@ class FetchAuthBackends(ZulipTestCase):
                 authentication_methods_list.append((backend_name_with_case.lower(), check_bool))
             external_auth_methods = get_external_method_dicts()
 
-            self.assert_json_success(result)
+            response_dict = self.assert_json_success(result)
             checker = check_dict_only(
                 [
                     ("authentication_methods", check_dict_only(authentication_methods_list)),
@@ -4845,18 +4844,20 @@ class FetchAuthBackends(ZulipTestCase):
                     *extra_fields,
                 ]
             )
-            checker("data", result.json())
+            checker("data", response_dict)
 
         result = self.client_get("/api/v1/server_settings", subdomain="", HTTP_USER_AGENT="")
         check_result(result)
+        response_dict = self.assert_json_success(result)
         self.assertEqual(
-            result.json()["external_authentication_methods"], get_external_method_dicts()
+            response_dict["external_authentication_methods"], get_external_method_dicts()
         )
 
         result = self.client_get(
             "/api/v1/server_settings", subdomain="", HTTP_USER_AGENT="ZulipInvalid"
         )
-        self.assertTrue(result.json()["is_incompatible"])
+        response_dict = self.assert_json_success(result)
+        self.assertTrue(response_dict["is_incompatible"])
 
         with self.settings(ROOT_DOMAIN_LANDING_PAGE=False):
             result = self.client_get("/api/v1/server_settings", subdomain="", HTTP_USER_AGENT="")

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -53,8 +53,8 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def assert_num_bots_equal(self, count: int) -> None:
         result = self.client_get("/json/bots")
-        self.assert_json_success(result)
-        self.assert_length(result.json()["bots"], count)
+        response_dict = self.assert_json_success(result)
+        self.assert_length(response_dict["bots"], count)
 
     def create_bot(self, **extras: Any) -> Dict[str, Any]:
         bot_info = {
@@ -64,8 +64,8 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         bot_info.update(extras)
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_success(result)
-        return result.json()
+        response_dict = self.assert_json_success(result)
+        return response_dict
 
     def test_bot_domain(self) -> None:
         self.login("hamlet")
@@ -625,7 +625,8 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         result = self.client_post("/json/bots", bot_info, subdomain="zephyr")
         self.assert_json_success(result)
         result = self.client_get("/json/bots", subdomain="zephyr")
-        bot_email = result.json()["bots"][0]["username"]
+        response_dict = self.assert_json_success(result)
+        bot_email = response_dict["bots"][0]["username"]
         bot = get_user(bot_email, user.realm)
         self.login("iago")
         result = self.client_delete(f"/json/bots/{bot.id}")
@@ -680,8 +681,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def get_bot(self) -> Dict[str, Any]:
         result = self.client_get("/json/bots")
-        bots = result.json()["bots"]
-        return bots[0]
+        return self.assert_json_success(result)["bots"][0]
 
     def test_update_api_key(self) -> None:
         self.login("hamlet")
@@ -690,8 +690,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         old_api_key = bot["api_key"]
         email = "hambot-bot@zulip.testserver"
         result = self.client_post(f"/json/bots/{self.get_bot_user(email).id}/api_key/regenerate")
-        self.assert_json_success(result)
-        new_api_key = result.json()["api_key"]
+        new_api_key = self.assert_json_success(result)["api_key"]
         self.assertNotEqual(old_api_key, new_api_key)
         bot = self.get_bot()
         self.assertEqual(new_api_key, bot["api_key"])
@@ -848,9 +847,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual("Fred", result.json()["full_name"])
+        self.assertEqual("Fred", response_dict["full_name"])
 
         bot = self.get_bot()
         self.assertEqual("Fred", bot["full_name"])
@@ -928,10 +927,10 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
         # Test bot's owner has been changed successfully.
-        self.assertEqual(result.json()["bot_owner"], othello.email)
+        self.assertEqual(response_dict["bot_owner"], othello.email)
 
         self.login("othello")
         bot = self.get_bot()
@@ -1119,9 +1118,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual("Denmark", result.json()["default_sending_stream"])
+        self.assertEqual("Denmark", response_dict["default_sending_stream"])
 
         bot = self.get_bot()
         self.assertEqual("Denmark", bot["default_sending_stream"])
@@ -1139,9 +1138,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual("Rome", result.json()["default_sending_stream"])
+        self.assertEqual("Rome", response_dict["default_sending_stream"])
 
         bot = self.get_bot()
         self.assertEqual("Rome", bot["default_sending_stream"])
@@ -1212,9 +1211,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual("Denmark", result.json()["default_sending_stream"])
+        self.assertEqual("Denmark", response_dict["default_sending_stream"])
 
         bot = self.get_bot()
         self.assertEqual("Denmark", bot["default_sending_stream"])
@@ -1275,9 +1274,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         stream_name = "Denmark"
         bot_info = dict(default_events_register_stream=stream_name)
         result = self.client_patch(url, bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual(stream_name, result.json()["default_events_register_stream"])
+        self.assertEqual(stream_name, response_dict["default_events_register_stream"])
 
         bot = self.get_bot()
         self.assertEqual(stream_name, bot["default_events_register_stream"])
@@ -1320,9 +1319,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual("Denmark", result.json()["default_events_register_stream"])
+        self.assertEqual("Denmark", response_dict["default_events_register_stream"])
 
         bot = self.get_bot()
         self.assertEqual("Denmark", bot["default_events_register_stream"])
@@ -1402,9 +1401,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual(result.json()["default_all_public_streams"], True)
+        self.assertEqual(response_dict["default_all_public_streams"], True)
 
         bot = self.get_bot()
         self.assertEqual(bot["default_all_public_streams"], True)
@@ -1422,9 +1421,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         }
         email = "hambot-bot@zulip.testserver"
         result = self.client_patch(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual(result.json()["default_all_public_streams"], False)
+        self.assertEqual(response_dict["default_all_public_streams"], False)
 
         bot = self.get_bot()
         self.assertEqual(bot["default_all_public_streams"], False)
@@ -1444,9 +1443,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         email = "hambot-bot@zulip.testserver"
         # Important: We intentionally use the wrong method, post, here.
         result = self.client_post(f"/json/bots/{self.get_bot_user(email).id}", bot_info)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual("Fred", result.json()["full_name"])
+        self.assertEqual("Fred", response_dict["full_name"])
 
         bot = self.get_bot()
         self.assertEqual("Fred", bot["full_name"])

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -184,9 +184,9 @@ class TestVideoCall(ZulipTestCase):
             response = self.client_get(
                 "/json/calls/bigbluebutton/create?meeting_name=general > meeting"
             )
-            self.assert_json_success(response)
+            response_dict = self.assert_json_success(response)
             self.assertEqual(
-                response.json()["url"],
+                response_dict["url"],
                 append_url_query_string(
                     "/calls/bigbluebutton/join",
                     "bigbluebutton="

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -731,9 +731,8 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_list(self) -> None:
         self.login("iago")
         result = self.client_get("/json/realm/profile_fields")
-        self.assert_json_success(result)
+        content = self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
-        content = result.json()
         self.assert_length(content["custom_fields"], self.original_count)
 
     def test_list_order(self) -> None:
@@ -746,7 +745,7 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
         )
         try_reorder_realm_custom_profile_fields(realm, order)
         result = self.client_get("/json/realm/profile_fields")
-        content = result.json()
+        content = self.assert_json_success(result)
         self.assertListEqual(
             content["custom_fields"], sorted(content["custom_fields"], key=lambda x: -x["id"])
         )
@@ -764,8 +763,7 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         self.assert_length(queries, 4)
 
-        self.assertEqual(response.status_code, 200)
-        raw_users_data = response.json()["members"]
+        raw_users_data = self.assert_json_success(response)["members"]
 
         iago_raw_data = None
         test_bot_raw_data = None
@@ -826,8 +824,7 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertEqual(test_bot_raw_data["bot_owner_id"], iago_raw_data["user_id"])
 
         response = self.client_get("/json/users", {"client_gravatar": "false"})
-        self.assertEqual(response.status_code, 200)
-        raw_users_data = response.json()["members"]
+        raw_users_data = self.assert_json_success(response)["members"]
         for user_dict in raw_users_data:
             with self.assertRaises(KeyError):
                 user_dict["profile_data"]
@@ -858,8 +855,7 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         url = "/json/users/me"
         response = self.client_get(url)
-        self.assertEqual(response.status_code, 200)
-        raw_user_data = response.json()
+        raw_user_data = self.assert_json_success(response)
         self.assertEqual(set(raw_user_data.keys()), expected_keys)
 
 

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -238,8 +238,9 @@ class EmailChangeTestCase(ZulipTestCase):
         self.login("hamlet")
         url = "/json/settings"
         result = self.client_patch(url, data)
-        self.assertEqual("success", result.json()["result"])
-        self.assertEqual("", result.json()["msg"])
+        response_dict = self.assert_json_success(result)
+        self.assertEqual("success", response_dict["result"])
+        self.assertEqual("", response_dict["msg"])
 
     def test_change_delivery_email_end_to_end_with_admins_visibility(self) -> None:
         user_profile = self.example_user("hamlet")

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -583,8 +583,8 @@ class MissedMessageNotificationsTest(ZulipTestCase):
             "bot_type": "1",
         }
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_success(result)
-        hambot = UserProfile.objects.get(id=result.json()["user_id"])
+        response_dict = self.assert_json_success(result)
+        hambot = UserProfile.objects.get(id=response_dict["user_id"])
         client_descriptor = allocate_event_queue(hambot)
         self.assertTrue(client_descriptor.event_queue.empty())
         msg_id = self.send_personal_message(iago, hambot)

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -79,8 +79,7 @@ class EventsEndpointTest(ZulipTestCase):
                 user, "/json/register", dict(event_types=orjson.dumps([event_type]).decode())
             )
 
-        self.assert_json_success(result)
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertEqual(result_dict["last_event_id"], -1)
         self.assertEqual(result_dict["queue_id"], "15:11")
 
@@ -93,8 +92,7 @@ class EventsEndpointTest(ZulipTestCase):
                 user, "/json/register", dict(event_types=orjson.dumps([event_type]).decode())
             )
 
-        self.assert_json_success(result)
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertEqual(result_dict["last_event_id"], 6)
         self.assertEqual(result_dict["queue_id"], "15:12")
 
@@ -112,8 +110,7 @@ class EventsEndpointTest(ZulipTestCase):
                     fetch_event_types=orjson.dumps(["message"]).decode(),
                 ),
             )
-        self.assert_json_success(result)
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertEqual(result_dict["last_event_id"], 6)
         # Check that the message event types data is in there
         self.assertIn("max_message_id", result_dict)
@@ -132,8 +129,7 @@ class EventsEndpointTest(ZulipTestCase):
                     event_types=orjson.dumps(["message"]).decode(),
                 ),
             )
-        self.assert_json_success(result)
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertEqual(result_dict["last_event_id"], 6)
         # Check that we didn't fetch the messages data
         self.assertNotIn("max_message_id", result_dict)
@@ -155,8 +151,7 @@ class EventsEndpointTest(ZulipTestCase):
             )
 
         result = self.client_post("/json/register", dict())
-        self.assert_json_success(result)
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertEqual(result_dict["queue_id"], None)
         self.assertEqual(result_dict["realm_uri"], "http://zulip.testserver")
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2213,9 +2213,9 @@ class NormalActionsTest(BaseAction):
             nonlocal uri
             result = self.client_post("/json/user_uploads", {"file": fp})
 
-            self.assert_json_success(result)
-            self.assertIn("uri", result.json())
-            uri = result.json()["uri"]
+            response_dict = self.assert_json_success(result)
+            self.assertIn("uri", response_dict)
+            uri = response_dict["uri"]
             base = "/user_uploads/"
             self.assertEqual(base, uri[: len(base)])
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -2815,9 +2815,9 @@ class MarkdownApiTests(ZulipTestCase):
             "/api/v1/messages/render",
             dict(content=content),
         )
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
         self.assertEqual(
-            result.json()["rendered"], "<p>That is a <strong>bold</strong> statement</p>"
+            response_dict["rendered"], "<p>That is a <strong>bold</strong> statement</p>"
         )
 
     def test_render_mention_stream_api(self) -> None:
@@ -2828,11 +2828,11 @@ class MarkdownApiTests(ZulipTestCase):
             "/api/v1/messages/render",
             dict(content=content),
         )
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
         user_id = self.example_user("hamlet").id
         stream_id = get_stream("Denmark", get_realm("zulip")).id
         self.assertEqual(
-            result.json()["rendered"],
+            response_dict["rendered"],
             f'<p>This mentions <a class="stream" data-stream-id="{stream_id}" href="/#narrow/stream/{stream_id}-Denmark">#Denmark</a> and <span class="user-mention" data-user-id="{user_id}">@King Hamlet</span>.</p>',
         )
 

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -317,10 +317,10 @@ class EditMessageTest(EditMessageTestCase):
             content="Personal message",
         )
         result = self.client_get("/json/messages/" + str(msg_id))
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["raw_content"], "Personal message")
-        self.assertEqual(result.json()["message"]["id"], msg_id)
-        self.assertEqual(result.json()["message"]["flags"], [])
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["raw_content"], "Personal message")
+        self.assertEqual(response_dict["message"]["id"], msg_id)
+        self.assertEqual(response_dict["message"]["flags"], [])
 
         # Send message to web-public stream where hamlet is not subscribed.
         # This will test case of user having no `UserMessage` but having access
@@ -331,28 +331,28 @@ class EditMessageTest(EditMessageTestCase):
             self.example_user("cordelia"), web_public_stream.name, content="web-public message"
         )
         result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["raw_content"], "web-public message")
-        self.assertEqual(result.json()["message"]["id"], web_public_stream_msg_id)
-        self.assertEqual(result.json()["message"]["flags"], ["read", "historical"])
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["raw_content"], "web-public message")
+        self.assertEqual(response_dict["message"]["id"], web_public_stream_msg_id)
+        self.assertEqual(response_dict["message"]["flags"], ["read", "historical"])
 
         # Spectator should be able to fetch message in web-public stream.
         self.logout()
         result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["raw_content"], "web-public message")
-        self.assertEqual(result.json()["message"]["id"], web_public_stream_msg_id)
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["raw_content"], "web-public message")
+        self.assertEqual(response_dict["message"]["id"], web_public_stream_msg_id)
 
         # Verify default is apply_markdown=True
-        self.assertEqual(result.json()["message"]["content"], "<p>web-public message</p>")
+        self.assertEqual(response_dict["message"]["content"], "<p>web-public message</p>")
 
         # Verify apply_markdown=False works correctly.
         result = self.client_get(
             "/json/messages/" + str(web_public_stream_msg_id), {"apply_markdown": "false"}
         )
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["raw_content"], "web-public message")
-        self.assertEqual(result.json()["message"]["content"], "web-public message")
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["raw_content"], "web-public message")
+        self.assertEqual(response_dict["message"]["content"], "web-public message")
 
         with self.settings(WEB_PUBLIC_STREAMS_ENABLED=False):
             result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
@@ -414,9 +414,9 @@ class EditMessageTest(EditMessageTestCase):
 
         # Verify success with web-public stream and default SELF_HOSTED plan type.
         result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["raw_content"], "web-public message")
-        self.assertEqual(result.json()["message"]["flags"], ["read"])
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["raw_content"], "web-public message")
+        self.assertEqual(response_dict["message"]["flags"], ["read"])
 
         # Verify LIMITED plan type does not allow web-public access.
         do_change_realm_plan_type(user_profile.realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
@@ -430,8 +430,8 @@ class EditMessageTest(EditMessageTestCase):
             user_profile.realm, Realm.PLAN_TYPE_STANDARD_FREE, acting_user=None
         )
         result = self.client_get("/json/messages/" + str(web_public_stream_msg_id))
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["raw_content"], "web-public message")
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["raw_content"], "web-public message")
 
         # Verify private messages are rejected.
         result = self.client_get("/json/messages/" + str(private_message_id))
@@ -726,9 +726,7 @@ class EditMessageTest(EditMessageTestCase):
 
         result = self.client_get(f"/json/messages/{msg_id}/history")
 
-        self.assert_json_success(result)
-
-        message_history = result.json()["message_history"]
+        message_history = self.assert_json_success(result)["message_history"]
         self.assert_length(message_history, 1)
 
     def test_mentions_for_message_updates(self) -> None:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -2091,8 +2091,7 @@ class GetOldMessagesTest(ZulipTestCase):
         raw_params = dict(msg_ids=msg_ids, narrow=narrow)
         params = {k: orjson.dumps(v).decode() for k, v in raw_params.items()}
         result = self.client_get("/json/messages/matches_narrow", params)
-        self.assert_json_success(result)
-        messages = result.json()["messages"]
+        messages = self.assert_json_success(result)["messages"]
         self.assert_length(list(messages.keys()), 1)
         message = messages[str(good_id)]
         self.assertEqual(
@@ -2486,8 +2485,7 @@ class GetOldMessagesTest(ZulipTestCase):
         raw_params = dict(msg_ids=msg_ids, narrow=narrow)
         params = {k: orjson.dumps(v).decode() for k, v in raw_params.items()}
         result = self.client_get("/json/messages/matches_narrow", params)
-        self.assert_json_success(result)
-        messages = result.json()["messages"]
+        messages = self.assert_json_success(result)["messages"]
         self.assert_length(list(messages.keys()), 1)
         message = messages[str(good_id)]
         self.assertIn("a href=", message["match_content"])

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -21,8 +21,7 @@ class TopicHistoryTest(ZulipTestCase):
         self.subscribe(user_profile, stream_name)
         endpoint = f"/json/users/me/{stream.id}/topics"
         result = self.client_get(endpoint, {}, subdomain="zephyr")
-        self.assert_json_success(result)
-        history = result.json()["topics"]
+        history = self.assert_json_success(result)["topics"]
         self.assertEqual(history, [])
 
     def test_topics_history(self) -> None:
@@ -75,8 +74,7 @@ class TopicHistoryTest(ZulipTestCase):
 
         endpoint = f"/json/users/me/{stream.id}/topics"
         result = self.client_get(endpoint, {})
-        self.assert_json_success(result)
-        history = result.json()["topics"]
+        history = self.assert_json_success(result)["topics"]
 
         # We only look at the most recent three topics, because
         # the prior fixture data may be unreliable.
@@ -105,8 +103,7 @@ class TopicHistoryTest(ZulipTestCase):
         # same results for a public stream.
         self.login("cordelia")
         result = self.client_get(endpoint, {})
-        self.assert_json_success(result)
-        history = result.json()["topics"]
+        history = self.assert_json_success(result)["topics"]
 
         # We only look at the most recent three topics, because
         # the prior fixture data may be unreliable.
@@ -138,8 +135,7 @@ class TopicHistoryTest(ZulipTestCase):
         self.subscribe(self.example_user("cordelia"), stream.name)
 
         result = self.client_get(endpoint, {})
-        self.assert_json_success(result)
-        history = result.json()["topics"]
+        history = self.assert_json_success(result)["topics"]
         history = history[:3]
 
         # Cordelia doesn't have these recent history items when we
@@ -184,8 +180,7 @@ class TopicHistoryTest(ZulipTestCase):
 
         endpoint = f"/json/users/me/{stream.id}/topics"
         result = self.client_get(endpoint)
-        self.assert_json_success(result)
-        history = result.json()["topics"]
+        history = self.assert_json_success(result)["topics"]
         self.assertEqual(
             [topic["name"] for topic in history],
             [

--- a/zerver/tests/test_muting_users.py
+++ b/zerver/tests/test_muting_users.py
@@ -55,8 +55,7 @@ class MutedUsersTests(ZulipTestCase):
             "bot_type": "1",
         }
         result = self.client_post("/json/bots", bot_info)
-        self.assert_json_success(result)
-        muted_id = result.json()["user_id"]
+        muted_id = self.assert_json_success(result)["user_id"]
 
         url = f"/api/v1/users/me/muted_users/{muted_id}"
         result = self.api_post(hamlet, url)

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -113,8 +113,7 @@ class UserPresenceTests(ZulipTestCase):
 
         params = dict(status="idle")
         result = self.client_post("/json/users/me/presence", params)
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
         self.assertEqual(json["presences"][hamlet.email][client]["status"], "idle")
         self.assertIn("timestamp", json["presences"][hamlet.email][client])
         self.assertIsInstance(json["presences"][hamlet.email][client]["timestamp"], int)
@@ -123,7 +122,7 @@ class UserPresenceTests(ZulipTestCase):
         self.login_user(othello)
         params = dict(status="idle", slim_presence="true")
         result = self.client_post("/json/users/me/presence", params)
-        json = result.json()
+        json = self.assert_json_success(result)
         presences = json["presences"]
         self.assertEqual(
             set(presences.keys()),
@@ -149,23 +148,21 @@ class UserPresenceTests(ZulipTestCase):
 
         params = dict(status="idle")
         result = self.client_post("/json/users/me/presence", params)
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        self.assertEqual(result.json()["presences"][hamlet.email][client]["status"], "idle")
+        self.assertEqual(response_dict["presences"][hamlet.email][client]["status"], "idle")
 
         self.login("othello")
         params = dict(status="idle")
         result = self.client_post("/json/users/me/presence", params)
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
 
         self.assertEqual(json["presences"][othello.email][client]["status"], "idle")
         self.assertEqual(json["presences"][hamlet.email][client]["status"], "idle")
 
         params = dict(status="active")
         result = self.client_post("/json/users/me/presence", params)
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
 
         self.assertEqual(json["presences"][othello.email][client]["status"], "active")
         self.assertEqual(json["presences"][hamlet.email][client]["status"], "idle")
@@ -173,8 +170,7 @@ class UserPresenceTests(ZulipTestCase):
         self.login_user(hamlet)
         params = dict(status="active", slim_presence="true")
         result = self.client_post("/json/users/me/presence", params)
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
 
         presences = json["presences"]
         self.assertEqual(
@@ -276,8 +272,8 @@ class UserPresenceTests(ZulipTestCase):
         user = self.mit_user("espuser")
         self.login_user(user)
         result = self.client_post("/json/users/me/presence", {"status": "idle"}, subdomain="zephyr")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["presences"], {})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["presences"], {})
 
     def test_mirror_presence(self) -> None:
         """Zephyr mirror realms find out the status of their mirror bot"""
@@ -288,8 +284,7 @@ class UserPresenceTests(ZulipTestCase):
             result = self.client_post(
                 "/json/users/me/presence", {"status": "idle"}, subdomain="zephyr"
             )
-            self.assert_json_success(result)
-            json = result.json()
+            json = self.assert_json_success(result)
             return json
 
         json = post_presence()
@@ -321,8 +316,7 @@ class UserPresenceTests(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         self.login_user(hamlet)
         result = self.client_post("/json/users/me/presence", {"status": "idle"})
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
         self.assertEqual(json["presences"][hamlet.email]["website"]["status"], "idle")
         self.assertEqual(
             json["presences"].keys(),
@@ -402,14 +396,14 @@ class SingleUserPresenceTests(ZulipTestCase):
         # Then, we check everything works
         self.login("hamlet")
         result = self.client_get("/json/users/othello@zulip.com/presence")
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertEqual(
             set(result_dict["presence"].keys()), {"ZulipAndroid", "website", "aggregated"}
         )
         self.assertEqual(set(result_dict["presence"]["website"].keys()), {"status", "timestamp"})
 
         result = self.client_get(f"/json/users/{othello.id}/presence")
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertEqual(
             set(result_dict["presence"].keys()), {"ZulipAndroid", "website", "aggregated"}
         )
@@ -423,7 +417,7 @@ class SingleUserPresenceTests(ZulipTestCase):
             ping_only="true",
         )
         result = self.client_post("/json/users/me/presence", req)
-        self.assertEqual(result.json()["msg"], "")
+        self.assertEqual(self.assert_json_success(result)["msg"], "")
 
 
 class UserPresenceAggregationTests(ZulipTestCase):
@@ -448,7 +442,7 @@ class UserPresenceAggregationTests(ZulipTestCase):
                 {"status": status},
                 HTTP_USER_AGENT="ZulipIOS/1.0",
             )
-        latest_result_dict = latest_result.json()
+        latest_result_dict = self.assert_json_success(latest_result)
         self.assertDictEqual(
             latest_result_dict["presences"][user.email]["aggregated"],
             {
@@ -459,7 +453,7 @@ class UserPresenceAggregationTests(ZulipTestCase):
         )
 
         result = self.client_get(f"/json/users/{user.email}/presence")
-        return result.json()
+        return self.assert_json_success(result)
 
     def test_aggregated_info(self) -> None:
         user = self.example_user("othello")
@@ -475,7 +469,7 @@ class UserPresenceAggregationTests(ZulipTestCase):
                 {"status": "active"},
                 HTTP_USER_AGENT="ZulipTestDev/1.0",
             )
-        result_dict = result.json()
+        result_dict = self.assert_json_success(result)
         self.assertDictEqual(
             result_dict["presences"][user.email]["aggregated"],
             {
@@ -566,8 +560,7 @@ class GetRealmStatusesTest(ZulipTestCase):
             dict(status="idle"),
             HTTP_USER_AGENT="ZulipDesktop/1.0",
         )
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
         self.assertEqual(set(json["presences"].keys()), {hamlet.email, othello.email})
 
         result = self.api_post(
@@ -576,14 +569,12 @@ class GetRealmStatusesTest(ZulipTestCase):
             dict(status="active", slim_presence="true"),
             HTTP_USER_AGENT="ZulipDesktop/1.0",
         )
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
         self.assertEqual(set(json["presences"].keys()), {str(hamlet.id), str(othello.id)})
 
         # Check that a bot can fetch the presence data for the realm.
         result = self.api_get(self.example_user("default_bot"), "/api/v1/realm/presence")
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
         self.assertEqual(set(json["presences"].keys()), {hamlet.email, othello.email})
 
     def test_presence_disabled(self) -> None:
@@ -609,8 +600,7 @@ class GetRealmStatusesTest(ZulipTestCase):
             dict(status="idle"),
             HTTP_USER_AGENT="ZulipDesktop/1.0",
         )
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
 
         # Othello's presence status is disabled so it won't be reported.
         self.assertEqual(set(json["presences"].keys()), {hamlet.email})
@@ -621,6 +611,5 @@ class GetRealmStatusesTest(ZulipTestCase):
             dict(status="active", slim_presence="true"),
             HTTP_USER_AGENT="ZulipDesktop/1.0",
         )
-        self.assert_json_success(result)
-        json = result.json()
+        json = self.assert_json_success(result)
         self.assertEqual(set(json["presences"].keys()), {str(hamlet.id)})

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -362,8 +362,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
                 payload,
                 content_type="application/json",
             )
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         self.assertEqual(
             {"result": "success", "msg": "", "total_android_devices": 2, "total_apple_devices": 1},
             data,

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -281,8 +281,7 @@ class ReactionMessageIDTest(ZulipTestCase):
             "/api/v1/messages",
             {"type": "private", "content": "Test message", "to": pm_recipient.email},
         )
-        self.assert_json_success(result)
-        pm_id = result.json()["id"]
+        pm_id = self.assert_json_success(result)["id"]
         reaction_info = {
             "emoji_name": "smile",
         }
@@ -418,8 +417,7 @@ class ReactionEventTest(ZulipTestCase):
             "/api/v1/messages",
             {"type": "private", "content": "Test message", "to": pm_recipient.email},
         )
-        self.assert_json_success(result)
-        pm_id = result.json()["id"]
+        pm_id = self.assert_json_success(result)["id"]
 
         expected_recipient_ids = {pm_sender.id, pm_recipient.id}
 
@@ -458,8 +456,7 @@ class ReactionEventTest(ZulipTestCase):
             "/api/v1/messages",
             {"type": "private", "content": "Test message", "to": pm_recipient.email},
         )
-        self.assert_json_success(result)
-        content = result.json()
+        content = self.assert_json_success(result)
         pm_id = content["id"]
 
         expected_recipient_ids = {pm_sender.id, pm_recipient.id}

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -22,8 +22,7 @@ class RealmDomainTest(ZulipTestCase):
         realm = get_realm("zulip")
         RealmDomain.objects.create(realm=realm, domain="acme.com", allow_subdomains=True)
         result = self.client_get("/json/realm/domains")
-        self.assert_json_success(result)
-        received = result.json()["domains"]
+        received = self.assert_json_success(result)["domains"]
         expected = [
             {"domain": "zulip.com", "allow_subdomains": False},
             {"domain": "acme.com", "allow_subdomains": True},

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -32,9 +32,8 @@ class RealmEmojiTest(ZulipTestCase):
         self.create_test_emoji("my_emoji", emoji_author)
 
         result = self.client_get("/json/realm/emoji")
-        self.assert_json_success(result)
-        self.assertEqual(200, result.status_code)
-        self.assert_length(result.json()["emoji"], 2)
+        response_dict = self.assert_json_success(result)
+        self.assert_length(response_dict["emoji"], 2)
 
     def test_list_no_author(self) -> None:
         self.login("iago")
@@ -42,8 +41,7 @@ class RealmEmojiTest(ZulipTestCase):
         realm_emoji = self.create_test_emoji_with_no_author("my_emoji", realm)
 
         result = self.client_get("/json/realm/emoji")
-        self.assert_json_success(result)
-        content = result.json()
+        content = self.assert_json_success(result)
         self.assert_length(content["emoji"], 2)
         test_emoji = content["emoji"][str(realm_emoji.id)]
         self.assertIsNone(test_emoji["author_id"])
@@ -58,8 +56,7 @@ class RealmEmojiTest(ZulipTestCase):
         realm_emoji = self.create_test_emoji_with_no_author("my_emoji", realm)
 
         result = self.client_get("/json/realm/emoji")
-        self.assert_json_success(result)
-        content = result.json()
+        content = self.assert_json_success(result)
         self.assert_length(content["emoji"], 2)
         test_emoji = content["emoji"][str(realm_emoji.id)]
         self.assertIsNone(test_emoji["author_id"])
@@ -78,8 +75,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.assertEqual(realm_emoji.author.email, email)
 
         result = self.client_get("/json/realm/emoji")
-        content = result.json()
-        self.assert_json_success(result)
+        content = self.assert_json_success(result)
         self.assert_length(content["emoji"], 2)
         test_emoji = content["emoji"][str(realm_emoji.id)]
         self.assertIn("author_id", test_emoji)
@@ -222,8 +218,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.assert_json_success(result)
 
         result = self.client_get("/json/realm/emoji")
-        emojis = result.json()["emoji"]
-        self.assert_json_success(result)
+        emojis = self.assert_json_success(result)["emoji"]
         # We only mark an emoji as deactivated instead of
         # removing it from the database.
         self.assert_length(emojis, 2)
@@ -313,8 +308,7 @@ class RealmEmojiTest(ZulipTestCase):
         self.assert_json_success(result)
 
         result = self.client_get("/json/realm/emoji")
-        emojis = result.json()["emoji"]
-        self.assert_json_success(result)
+        emojis = self.assert_json_success(result)["emoji"]
         self.assert_length(emojis, 3)
 
     def test_failed_file_upload(self) -> None:

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -74,10 +74,10 @@ class RealmExportTest(ZulipTestCase):
         self.assertEqual(bucket.Object(path_id).get()["Body"].read(), b"zulip!")
 
         result = self.client_get("/json/export/realm")
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
         # Test that the export we have is the export we created.
-        export_dict = result.json()["exports"]
+        export_dict = response_dict["exports"]
         self.assertEqual(export_dict[0]["id"], audit_log_entry.id)
         self.assertEqual(
             export_dict[0]["export_url"],
@@ -144,10 +144,10 @@ class RealmExportTest(ZulipTestCase):
         self.assert_streaming_content(response, b"zulip!")
 
         result = self.client_get("/json/export/realm")
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
         # Test that the export we have is the export we created.
-        export_dict = result.json()["exports"]
+        export_dict = response_dict["exports"]
         self.assertEqual(export_dict[0]["id"], audit_log_entry.id)
         self.assertEqual(export_dict[0]["export_url"], admin.realm.uri + export_path)
         self.assertEqual(export_dict[0]["acting_user_id"], admin.id)

--- a/zerver/tests/test_realm_linkifiers.py
+++ b/zerver/tests/test_realm_linkifiers.py
@@ -17,8 +17,7 @@ class RealmFilterTest(ZulipTestCase):
         self.assert_json_success(result)
 
         result = self.client_get("/json/realm/linkifiers")
-        self.assert_json_success(result)
-        linkifiers = result.json()["linkifiers"]
+        linkifiers = self.assert_json_success(result)["linkifiers"]
         self.assert_length(linkifiers, 1)
         self.assertEqual(linkifiers[0]["pattern"], "#(?P<id>[123])")
         self.assertEqual(linkifiers[0]["url_format"], "https://realm.com/my_realm_filter/%(id)s")
@@ -151,9 +150,7 @@ class RealmFilterTest(ZulipTestCase):
             "url_format_string": "https://realm.com/my_realm_filter/%(id)s",
         }
         result = self.client_post("/json/realm/filters", info=data)
-        self.assert_json_success(result)
-
-        linkifier_id = result.json()["id"]
+        linkifier_id = self.assert_json_success(result)["id"]
         linkifiers_count = RealmFilter.objects.count()
         result = self.client_delete(f"/json/realm/filters/{linkifier_id + 1}")
         self.assert_json_error(result, "Linkifier not found.")
@@ -169,9 +166,7 @@ class RealmFilterTest(ZulipTestCase):
             "url_format_string": "https://realm.com/my_realm_filter/%(id)s",
         }
         result = self.client_post("/json/realm/filters", info=data)
-        self.assert_json_success(result)
-
-        linkifier_id = result.json()["id"]
+        linkifier_id = self.assert_json_success(result)["id"]
         data = {
             "pattern": "#(?P<id>[0-9]+)",
             "url_format_string": "https://realm.com/my_realm_filter/issues/%(id)s",
@@ -182,8 +177,7 @@ class RealmFilterTest(ZulipTestCase):
 
         # Verify that the linkifier is updated accordingly.
         result = self.client_get("/json/realm/linkifiers")
-        self.assert_json_success(result)
-        linkifier = result.json()["linkifiers"]
+        linkifier = self.assert_json_success(result)["linkifiers"]
         self.assert_length(linkifier, 1)
         self.assertEqual(linkifier[0]["pattern"], "#(?P<id>[0-9]+)")
         self.assertEqual(

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -98,7 +98,7 @@ class TestExceptionDetailsNotRevealedToClient(SCIMTestCase):
             result = self.client_get("/scim/v2/Users", {}, **self.scim_headers())
             # Only a generic error message is returned:
             self.assertEqual(
-                result.json(),
+                orjson.loads(result.content),
                 {
                     "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
                     "detail": "Exception occurred while processing the SCIM request",
@@ -351,9 +351,8 @@ class TestSCIMUser(SCIMTestCase):
         result = self.client_post(
             "/scim/v2/Users", payload, content_type="application/json", **self.scim_headers()
         )
-        response_dict = result.json()
         self.assertEqual(
-            response_dict,
+            orjson.loads(result.content),
             {
                 "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
                 "detail": "Must specify name.formatted, name.givenName or name.familyName when creating a new user",
@@ -373,9 +372,8 @@ class TestSCIMUser(SCIMTestCase):
         result = self.client_post(
             "/scim/v2/Users", payload, content_type="application/json", **self.scim_headers()
         )
-        response_dict = result.json()
         self.assertEqual(
-            response_dict,
+            orjson.loads(result.content),
             {
                 "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
                 "detail": "New user must have active=True",
@@ -399,9 +397,8 @@ class TestSCIMUser(SCIMTestCase):
         result = self.client_post(
             "/scim/v2/Users", payload, content_type="application/json", **self.scim_headers()
         )
-        response_dict = result.json()
         self.assertEqual(
-            response_dict,
+            orjson.loads(result.content),
             {
                 "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
                 "detail": "This email domain isn't allowed in this organization.",
@@ -638,7 +635,7 @@ class TestSCIMUser(SCIMTestCase):
         with self.assertLogs("django.request", "ERROR") as m:
             result = self.json_patch(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
             self.assertEqual(
-                result.json(),
+                orjson.loads(result.content),
                 {
                     "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
                     "detail": "Not Implemented",

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -267,13 +267,13 @@ class TestServiceBotStateHandler(ZulipTestCase):
             "keys": orjson.dumps(["key 1", "key 3"]).decode(),
         }
         result = self.client_get("/json/bot_storage", params)
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["storage"], {"key 3": "value 3", "key 1": "value 1"})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["storage"], {"key 3": "value 3", "key 1": "value 1"})
 
         # Assert the stored data for all keys.
         result = self.client_get("/json/bot_storage")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["storage"], initial_dict)
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["storage"], initial_dict)
 
         # Store some more data; update an entry and store a new entry
         dict_update = {"key 1": "new value", "key 4": "value 4"}
@@ -287,8 +287,8 @@ class TestServiceBotStateHandler(ZulipTestCase):
         updated_dict = initial_dict.copy()
         updated_dict.update(dict_update)
         result = self.client_get("/json/bot_storage")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["storage"], updated_dict)
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["storage"], updated_dict)
 
         # Assert errors on invalid requests.
         invalid_params = {
@@ -321,8 +321,8 @@ class TestServiceBotStateHandler(ZulipTestCase):
         for key in keys_to_remove:
             updated_dict.pop(key)
         result = self.client_get("/json/bot_storage")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["storage"], updated_dict)
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["storage"], updated_dict)
 
         # Try to remove an existing and a nonexistent key.
         params = {
@@ -333,8 +333,8 @@ class TestServiceBotStateHandler(ZulipTestCase):
 
         # Assert an error has been thrown and no entries were removed.
         result = self.client_get("/json/bot_storage")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["storage"], updated_dict)
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["storage"], updated_dict)
 
         # Remove the entire storage.
         result = self.client_delete("/json/bot_storage")
@@ -342,8 +342,8 @@ class TestServiceBotStateHandler(ZulipTestCase):
 
         # Assert the entire storage has been removed.
         result = self.client_get("/json/bot_storage")
-        self.assert_json_success(result)
-        self.assertEqual(result.json()["storage"], {})
+        response_dict = self.assert_json_success(result)
+        self.assertEqual(response_dict["storage"], {})
 
 
 class TestServiceBotConfigHandler(ZulipTestCase):

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -506,8 +506,7 @@ class UserChangesTest(ZulipTestCase):
         self.assertEqual(result.status_code, 401)
 
         result = self.api_post(user, "/api/v1/users/me/api_key/regenerate")
-        self.assert_json_success(result)
-        new_api_key = result.json()["api_key"]
+        new_api_key = self.assert_json_success(result)["api_key"]
         self.assertNotIn(new_api_key, old_api_keys)
         user = self.example_user("hamlet")
         current_api_keys = get_all_api_keys(user)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2984,9 +2984,7 @@ class MultiuseInviteTest(ZulipTestCase):
         result = self.client_post(
             "/json/invites/multiuse", {"invite_expires_in_minutes": 2 * 24 * 60}
         )
-        self.assert_json_success(result)
-
-        invite_link = result.json()["invite_link"]
+        invite_link = self.assert_json_success(result)["invite_link"]
         self.check_user_able_to_register(self.nonreg_email("test"), invite_link)
 
     def test_create_multiuse_link_with_specified_streams_api_call(self) -> None:
@@ -3002,9 +3000,7 @@ class MultiuseInviteTest(ZulipTestCase):
                 "invite_expires_in_minutes": 2 * 24 * 60,
             },
         )
-        self.assert_json_success(result)
-
-        invite_link = result.json()["invite_link"]
+        invite_link = self.assert_json_success(result)["invite_link"]
         self.check_user_able_to_register(self.nonreg_email("test"), invite_link)
         self.check_user_subscribed_only_to_streams("test", streams)
 
@@ -3018,9 +3014,7 @@ class MultiuseInviteTest(ZulipTestCase):
         result = self.client_post(
             "/json/invites/multiuse", {"invite_expires_in_minutes": 2 * 24 * 60}
         )
-        self.assert_json_success(result)
-
-        invite_link = result.json()["invite_link"]
+        invite_link = self.assert_json_success(result)["invite_link"]
         self.check_user_able_to_register(self.nonreg_email("test"), invite_link)
 
         self.login("hamlet")
@@ -3046,9 +3040,7 @@ class MultiuseInviteTest(ZulipTestCase):
                 "invite_expires_in_minutes": 2 * 24 * 60,
             },
         )
-        self.assert_json_success(result)
-
-        invite_link = result.json()["invite_link"]
+        invite_link = self.assert_json_success(result)["invite_link"]
         self.check_user_able_to_register(self.nonreg_email("test"), invite_link)
 
     def test_create_multiuse_link_invalid_stream_api_call(self) -> None:

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -97,8 +97,9 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Upload file via API
         result = self.api_post(self.example_user("hamlet"), "/api/v1/user_uploads", {"file": fp})
-        self.assertIn("uri", result.json())
-        uri = result.json()["uri"]
+        response_dict = self.assert_json_success(result)
+        self.assertIn("uri", response_dict)
+        uri = response_dict["uri"]
         base = "/user_uploads/"
         self.assertEqual(base, uri[: len(base)])
 
@@ -123,8 +124,9 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         # Upload file via API
         result = self.api_post(self.example_user("hamlet"), "/api/v1/user_uploads", {"file": fp})
-        self.assertIn("uri", result.json())
-        uri = result.json()["uri"]
+        response_dict = self.assert_json_success(result)
+        self.assertIn("uri", response_dict)
+        uri = response_dict["uri"]
         base = "/user_uploads/"
         self.assertEqual(base, uri[: len(base)])
 
@@ -151,8 +153,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         result = self.api_post(
             self.example_user("hamlet"), "/api/v1/user_uploads?mimetype=image/png", {"file": fp}
         )
-        self.assertEqual(result.status_code, 200)
-        uri = result.json()["uri"]
+        uri = self.assert_json_success(result)["uri"]
         self.assertTrue(uri.endswith("pasted_file.png"))
 
     def test_file_too_big_failure(self) -> None:
@@ -204,9 +205,9 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
 
         result = self.client_post("/json/user_uploads", {"file": fp})
-        self.assert_json_success(result)
-        self.assertIn("uri", result.json())
-        uri = result.json()["uri"]
+        response_dict = self.assert_json_success(result)
+        self.assertIn("uri", response_dict)
+        uri = response_dict["uri"]
         base = "/user_uploads/"
         self.assertEqual(base, uri[: len(base)])
 
@@ -232,8 +233,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         # Now try the endpoint that's supposed to return a temporary URL for access
         # to the file.
         result = self.client_get("/json" + uri)
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         url_only_url = data["url"]
         # Ensure this is different from the original uri:
         self.assertNotEqual(url_only_url, uri)
@@ -254,8 +254,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip_web_public.txt"
 
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = result.json()["uri"]
-        self.assert_json_success(result)
+        uri = self.assert_json_success(result)["uri"]
 
         add_ratelimit_rule(86400, 1000, domain="spectator_attachment_access_by_file")
         # Deny file access for non-web-public stream
@@ -301,11 +300,11 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        url = "/json" + result.json()["uri"]
+        response_dict = self.assert_json_success(result)
+        url = "/json" + response_dict["uri"]
 
         result = self.client_get(url)
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         url_only_url = data["url"]
 
         self.assertTrue(url_only_url.endswith("zulip.txt"))
@@ -318,13 +317,13 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        url = "/json" + result.json()["uri"]
+        response_dict = self.assert_json_success(result)
+        url = "/json" + response_dict["uri"]
 
         start_time = time.time()
         with mock.patch("django.core.signing.time.time", return_value=start_time):
             result = self.client_get(url)
-            self.assert_json_success(result)
-            data = result.json()
+            data = self.assert_json_success(result)
             url_only_url = data["url"]
 
             self.logout()
@@ -340,7 +339,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = result.json()["uri"]
+        response_dict = self.assert_json_success(result)
+        uri = response_dict["uri"]
 
         self.logout()
         response = self.client_get(uri)
@@ -355,10 +355,11 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
+        response_dict = self.assert_json_success(result)
 
         destroy_uploads()
 
-        response = self.client_get(result.json()["uri"])
+        response = self.client_get(response_dict["uri"])
         self.assertEqual(response.status_code, 404)
 
     def test_non_existing_file_download(self) -> None:
@@ -380,12 +381,14 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d1 = StringIO("zulip!")
         d1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": d1})
-        d1_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        d1_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
 
         d2 = StringIO("zulip!")
         d2.name = "dummy_2.txt"
         result = self.client_post("/json/user_uploads", {"file": d2})
-        d2_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        d2_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
 
         d3 = StringIO("zulip!")
         d3.name = "dummy_3.txt"
@@ -479,7 +482,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d1 = StringIO("zulip!")
         d1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": d1})
-        d1_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        d1_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
 
         self.subscribe(self.example_user("hamlet"), "Denmark")
         host = self.example_user("hamlet").realm.host
@@ -497,7 +501,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d1 = StringIO("zulip!")
         d1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": d1})
-        d1_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        d1_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
         host = self.example_user("hamlet").realm.host
 
         self.make_stream("private_stream", invite_only=True)
@@ -556,10 +561,12 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
         self.login_user(hamlet)
         result = self.client_post("/json/user_uploads", {"file": f1})
-        f1_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        f1_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
 
         result = self.client_post("/json/user_uploads", {"file": f2})
-        f2_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        f2_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
 
         self.subscribe(hamlet, "test")
         body = (
@@ -569,7 +576,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         msg_id = self.send_stream_message(hamlet, "test", body, "test")
 
         result = self.client_post("/json/user_uploads", {"file": f3})
-        f3_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        f3_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
 
         new_body = (
             f"[f3.txt](http://{host}/user_uploads/" + f3_path_id + ") "
@@ -620,7 +628,8 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             fp.name = urllib.parse.quote(expected)
 
             result = self.client_post("/json/user_uploads", {"f1": fp})
-            assert sanitize_name(expected) in result.json()["uri"]
+            response_dict = self.assert_json_success(result)
+            assert sanitize_name(expected) in response_dict["uri"]
 
     def test_realm_quota(self) -> None:
         """
@@ -631,9 +640,9 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         d1 = StringIO("zulip!")
         d1.name = "dummy_1.txt"
         result = self.client_post("/json/user_uploads", {"file": d1})
-        d1_path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        d1_path_id = re.sub("/user_uploads/", "", response_dict["uri"])
         d1_attachment = Attachment.objects.get(path_id=d1_path_id)
-        self.assert_json_success(result)
 
         realm = get_realm("zulip")
         realm.upload_quota_gb = 1
@@ -691,7 +700,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = result.json()["uri"]
+        uri = self.assert_json_success(result)["uri"]
         fp_path_id = re.sub("/user_uploads/", "", uri)
         body = f"First message ...[zulip.txt](http://{host}/user_uploads/" + fp_path_id + ")"
         with self.settings(CROSS_REALM_BOT_EMAILS={user_2.email, user_3.email}):
@@ -736,7 +745,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = result.json()["uri"]
+        uri = self.assert_json_success(result)["uri"]
         fp_path_id = re.sub("/user_uploads/", "", uri)
         body = f"First message ...[zulip.txt](http://{realm.host}/user_uploads/" + fp_path_id + ")"
         self.send_stream_message(hamlet, stream_name, body, "test")
@@ -790,7 +799,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = result.json()["uri"]
+        uri = self.assert_json_success(result)["uri"]
         fp_path_id = re.sub("/user_uploads/", "", uri)
         body = (
             f"First message ...[zulip.txt](http://{user.realm.host}/user_uploads/"
@@ -863,7 +872,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = result.json()["uri"]
+        uri = self.assert_json_success(result)["uri"]
         fp_path_id = re.sub("/user_uploads/", "", uri)
         for i in range(20):
             body = (
@@ -911,7 +920,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = result.json()["uri"]
+        uri = self.assert_json_success(result)["uri"]
         fp_path_id = re.sub("/user_uploads/", "", uri)
         body = f"First message ...[zulip.txt](http://{realm.host}/user_uploads/" + fp_path_id + ")"
         self.send_stream_message(self.example_user("hamlet"), "test-subscribe", body, "test")
@@ -937,7 +946,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
                 fp = StringIO("zulip!")
                 fp.name = name
                 result = self.client_post("/json/user_uploads", {"file": fp})
-                uri = result.json()["uri"]
+                uri = self.assert_json_success(result)["uri"]
                 fp_path_id = re.sub("/user_uploads/", "", uri)
                 fp_path = os.path.split(fp_path_id)[0]
                 if download:
@@ -1272,10 +1281,10 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
                 with get_test_image_file(fname) as fp:
                     result = self.client_post("/json/users/me/avatar", {"file": fp})
 
-                self.assert_json_success(result)
-                self.assertIn("avatar_url", result.json())
+                response_dict = self.assert_json_success(result)
+                self.assertIn("avatar_url", response_dict)
                 base = "/user_avatars/"
-                url = result.json()["avatar_url"]
+                url = self.assert_json_success(result)["avatar_url"]
                 self.assertEqual(base, url[: len(base)])
 
                 if rfname is not None:
@@ -1393,9 +1402,9 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
         result = self.client_delete("/json/users/me/avatar")
         user_profile = self.example_user("cordelia")
 
-        self.assert_json_success(result)
-        self.assertIn("avatar_url", result.json())
-        self.assertEqual(result.json()["avatar_url"], avatar_url(user_profile))
+        response_dict = self.assert_json_success(result)
+        self.assertIn("avatar_url", response_dict)
+        self.assertEqual(response_dict["avatar_url"], avatar_url(user_profile))
 
         self.assertEqual(user_profile.avatar_source, UserProfile.AVATAR_FROM_GRAVATAR)
         self.assertEqual(user_profile.avatar_version, 2)
@@ -1550,10 +1559,10 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
                 with get_test_image_file(fname) as fp:
                     result = self.client_post("/json/realm/icon", {"file": fp})
                 realm = get_realm("zulip")
-                self.assert_json_success(result)
-                self.assertIn("icon_url", result.json())
+                response_dict = self.assert_json_success(result)
+                self.assertIn("icon_url", response_dict)
                 base = f"/user_avatars/{realm.id}/realm/icon.png"
-                url = result.json()["icon_url"]
+                url = response_dict["icon_url"]
                 self.assertEqual(base, url[: len(base)])
 
                 if rfname is not None:
@@ -1586,10 +1595,10 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
 
         result = self.client_delete("/json/realm/icon")
 
-        self.assert_json_success(result)
-        self.assertIn("icon_url", result.json())
+        response_dict = self.assert_json_success(result)
+        self.assertIn("icon_url", response_dict)
         realm = get_realm("zulip")
-        self.assertEqual(result.json()["icon_url"], realm_icon_url(realm))
+        self.assertEqual(response_dict["icon_url"], realm_icon_url(realm))
         self.assertEqual(realm.icon_source, Realm.ICON_FROM_GRAVATAR)
 
     def test_realm_icon_version(self) -> None:
@@ -1848,7 +1857,8 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {"file": fp})
 
-        path_id = re.sub("/user_uploads/", "", result.json()["uri"])
+        response_dict = self.assert_json_success(result)
+        path_id = re.sub("/user_uploads/", "", response_dict["uri"])
         self.assertTrue(delete_message_image(path_id))
 
     def test_ensure_avatar_image_local(self) -> None:
@@ -2057,10 +2067,10 @@ class S3Test(ZulipTestCase):
         fp.name = "zulip.txt"
 
         result = self.client_post("/json/user_uploads", {"file": fp})
-        self.assert_json_success(result)
-        self.assertIn("uri", result.json())
+        response_dict = self.assert_json_success(result)
+        self.assertIn("uri", response_dict)
         base = "/user_uploads/"
-        uri = result.json()["uri"]
+        uri = response_dict["uri"]
         self.assertEqual(base, uri[: len(base)])
 
         response = self.client_get(uri)
@@ -2082,8 +2092,7 @@ class S3Test(ZulipTestCase):
         # Now try the endpoint that's supposed to return a temporary URL for access
         # to the file.
         result = self.client_get("/json" + uri)
-        self.assert_json_success(result)
-        data = result.json()
+        data = self.assert_json_success(result)
         url_only_url = data["url"]
         path = urllib.parse.urlparse(url_only_url).path
         assert path.startswith("/")

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -239,9 +239,9 @@ class UserGroupAPITestCase(UserGroupTestCase):
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
         result = self.client_get("/json/user_groups")
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
         self.assert_length(
-            result.json()["user_groups"], UserGroup.objects.filter(realm=user_profile.realm).count()
+            response_dict["user_groups"], UserGroup.objects.filter(realm=user_profile.realm).count()
         )
 
     def test_can_edit_user_groups(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -205,8 +205,7 @@ class PermissionTest(ZulipTestCase):
         do_change_user_role(iago, UserProfile.ROLE_REALM_OWNER, acting_user=None)
 
         result = self.client_get("/json/users")
-        self.assert_json_success(result)
-        members = result.json()["members"]
+        members = self.assert_json_success(result)["members"]
         iago_dict = find_dict(members, "email", iago.email)
         self.assertTrue(iago_dict["is_owner"])
         othello_dict = find_dict(members, "email", othello.email)
@@ -266,8 +265,7 @@ class PermissionTest(ZulipTestCase):
 
         # Make sure we see is_admin flag in /json/users
         result = self.client_get("/json/users")
-        self.assert_json_success(result)
-        members = result.json()["members"]
+        members = self.assert_json_success(result)["members"]
         desdemona_dict = find_dict(members, "email", desdemona.email)
         self.assertTrue(desdemona_dict["is_admin"])
         othello_dict = find_dict(members, "email", othello.email)
@@ -311,8 +309,7 @@ class PermissionTest(ZulipTestCase):
 
         # First, verify client_gravatar works normally
         result = self.client_get("/json/users", {"client_gravatar": "true"})
-        self.assert_json_success(result)
-        members = result.json()["members"]
+        members = self.assert_json_success(result)["members"]
         hamlet = find_dict(members, "user_id", user.id)
         self.assertEqual(hamlet["email"], user.email)
         self.assertIsNone(hamlet["avatar_url"])
@@ -338,8 +335,7 @@ class PermissionTest(ZulipTestCase):
                 acting_user=None,
             )
         result = self.client_get("/json/users", {"client_gravatar": "true"})
-        self.assert_json_success(result)
-        members = result.json()["members"]
+        members = self.assert_json_success(result)["members"]
         hamlet = find_dict(members, "user_id", user.id)
         self.assertEqual(hamlet["email"], f"user{user.id}@zulip.testserver")
         # Note that the Gravatar URL should still be computed from the
@@ -366,8 +362,7 @@ class PermissionTest(ZulipTestCase):
         user.refresh_from_db()
         self.login_user(admin)
         result = self.client_get("/json/users", {"client_gravatar": "true"})
-        self.assert_json_success(result)
-        members = result.json()["members"]
+        members = self.assert_json_success(result)["members"]
         hamlet = find_dict(members, "user_id", user.id)
         self.assertEqual(hamlet["email"], f"user{user.id}@zulip.testserver")
         self.assertEqual(hamlet["avatar_url"], get_gravatar_url(user.delivery_email, 1))
@@ -1955,8 +1950,7 @@ class BulkUsersTest(ZulipTestCase):
         def get_hamlet_avatar(client_gravatar: bool) -> Optional[str]:
             data = dict(client_gravatar=orjson.dumps(client_gravatar).decode())
             result = self.client_get("/json/users", data)
-            self.assert_json_success(result)
-            rows = result.json()["members"]
+            rows = self.assert_json_success(result)["members"]
             hamlet_data = [row for row in rows if row["user_id"] == hamlet.id][0]
             return hamlet_data["avatar_url"]
 
@@ -2093,9 +2087,9 @@ class GetProfileTest(ZulipTestCase):
     def test_get_all_profiles_avatar_urls(self) -> None:
         hamlet = self.example_user("hamlet")
         result = self.api_get(hamlet, "/api/v1/users")
-        self.assert_json_success(result)
+        response_dict = self.assert_json_success(result)
 
-        (my_user,) = (user for user in result.json()["members"] if user["email"] == hamlet.email)
+        (my_user,) = (user for user in response_dict["members"] if user["email"] == hamlet.email)
 
         self.assertEqual(
             my_user["avatar_url"],

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -29,12 +29,12 @@ class ZcommandTest(ZulipTestCase):
 
         payload = dict(command="/night")
         result = self.client_post("/json/zcommand", payload)
-        self.assert_json_success(result)
-        self.assertIn("Changed to dark theme", result.json()["msg"])
+        response_dict = self.assert_json_success(result)
+        self.assertIn("Changed to dark theme", response_dict["msg"])
 
         result = self.client_post("/json/zcommand", payload)
-        self.assert_json_success(result)
-        self.assertIn("still in dark theme", result.json()["msg"])
+        response_dict = self.assert_json_success(result)
+        self.assertIn("still in dark theme", response_dict["msg"])
 
     def test_day_zcommand(self) -> None:
         self.login("hamlet")
@@ -44,12 +44,12 @@ class ZcommandTest(ZulipTestCase):
 
         payload = dict(command="/day")
         result = self.client_post("/json/zcommand", payload)
-        self.assert_json_success(result)
-        self.assertIn("Changed to light theme", result.json()["msg"])
+        response_dict = self.assert_json_success(result)
+        self.assertIn("Changed to light theme", response_dict["msg"])
 
         result = self.client_post("/json/zcommand", payload)
-        self.assert_json_success(result)
-        self.assertIn("still in light theme", result.json()["msg"])
+        response_dict = self.assert_json_success(result)
+        self.assertIn("still in light theme", response_dict["msg"])
 
     def test_fluid_zcommand(self) -> None:
         self.login("hamlet")


### PR DESCRIPTION
This is a part of #18777.

As Django monkey patch attributes on the `HttpResponse` the test client returns. This does not really make the patched attributes available on the response object of the test client, but instead avoids accessing these attributes by taking a detour.

It refactors away `response.json()` with `response.assert_json_success` and a new helper `response.assert_json_error_data` manually and with regexes.

A flag `use_zulip_api_format` is added for `response.assert_json_error_data` to properly test `test_scim.py`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
