### PR TITLE
app-loading: Add a 3s delay before showing the reload message.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -37,9 +37,20 @@
     #app-loading-middle-content h3 {
     text-align: center;
     }
+    @keyframes showAtEnd {
+    99% {
+    visibility: hidden;
+    }
+    100% {
+    visibility: visible;
+    }
+    }
     #app-loading-bottom-content {
     top: unset;
     bottom: 20px;
+    animation: 7s showAtEnd;
+    animation-fill-mode: forwards;
+    visibility: hidden;
     }
     body.color-scheme-automatic #app-loading{
     color: hsl(0, 0%, 20%);
@@ -63,7 +74,7 @@
         <h3>{{ _('Loading...') }}</h3>
     </div>
     <div id="app-loading-bottom-content">
-        <p>{% trans %}If this message does not go away, please wait a couple seconds and <a id="reload-lnk">reload</a> the page.{% endtrans %}</p>
+        <p>{% trans %}If this message does not go away, try <a id="reload-lnk">reloading</a> the page.{% endtrans %}</p>
         <script nonce="{{ csp_nonce }}">
             document.addEventListener('DOMContentLoaded', function () {
                 function reload() {


### PR DESCRIPTION
Fixes #22182

This message often flashes on screen briefly, causing unnecessary
worry for the user (is the app likely to not load?).
To address this, we add a delay before the message is shown.

A good way to test this is to toggle the `display` attribute of `#app-loading` element.
<img width="1915" alt="Screenshot 2022-06-03 at 10 35 18 PM" src="https://user-images.githubusercontent.com/25124304/171912342-525a3839-f489-426e-8ad8-93735372cb83.png">
