### PR TITLE
[WIP] Fix #9165 Find by parts of url

### DIFF
--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -77,7 +77,7 @@ def update_fts_columns(cursor: psycopg2.extensions.cursor) -> int:
         cursor.execute(
             "UPDATE zerver_message SET "
             "search_tsvector = to_tsvector('zulip.english_us_search', "
-            "subject || rendered_content) "
+            "subject || process_text_for_search(rendered_content)) "
             "WHERE id = %s",
             (message_id,),
         )

--- a/zerver/management/commands/audit_fts_indexes.py
+++ b/zerver/management/commands/audit_fts_indexes.py
@@ -12,8 +12,8 @@ class Command(ZulipBaseCommand):
                 """
                 UPDATE zerver_message
                 SET search_tsvector =
-                to_tsvector('zulip.english_us_search', subject || rendered_content)
-                WHERE to_tsvector('zulip.english_us_search', subject || rendered_content) != search_tsvector
+                to_tsvector('zulip.english_us_search', subject || process_text_for_search(rendered_content))
+                WHERE to_tsvector('zulip.english_us_search', subject || process_text_for_search(rendered_content)) != search_tsvector
             """
             )
 

--- a/zerver/migrations/0395_add_function_process_rendered_content_for_indexing.py
+++ b/zerver/migrations/0395_add_function_process_rendered_content_for_indexing.py
@@ -1,0 +1,42 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "0394_alter_realm_want_advertise_in_communities_directory"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=r"""
+            CREATE OR REPLACE FUNCTION extract_anchor_text(message_content text) RETURNS SETOF text IMMUTABLE LANGUAGE 'sql' AS $$
+                select anchor_text_match[1] as anchor_text from REGEXP_MATCHES(
+                    message_content,'<a [^>]+>([^<]+)<\/a>','g'
+                ) as anchor_text_match
+            $$ ;
+
+            CREATE OR REPLACE FUNCTION replace_url_delimiters(anchor_text text, replacement text) RETURNS text IMMUTABLE LANGUAGE 'sql' AS $$
+                select regexp_replace(anchor_text,'[:\/.?#@]', replacement, 'g');
+            $$ ;
+
+            CREATE OR REPLACE FUNCTION replace_anchor_text_url_delimiters(message_content text, replacement text) RETURNS text AS
+            $BODY$
+                DECLARE
+                    anchor_text text;
+                    result text;
+                BEGIN
+                    result := message_content;
+                    FOR anchor_text IN select extract_anchor_text(message_content)
+                    LOOP
+                        result := replace(result,  '>'|| anchor_text ||'<' , '>' || replace_url_delimiters(anchor_text, replacement) || '<');
+                    END LOOP;
+                RETURN result;
+                END;
+            $BODY$ LANGUAGE plpgsql;
+ 
+            CREATE OR REPLACE FUNCTION process_text_for_search(text_to_process text) RETURNS text IMMUTABLE LANGUAGE 'sql' AS $$
+                select replace_anchor_text_url_delimiters(text_to_process, ' ')
+            $$ ;
+             """,
+        ),
+    ]

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -519,13 +519,16 @@ class NarrowBuilder:
         condition = column("search_pgroonga", Text).op("&@~")(operand_escaped)
         return query.where(maybe_negate(condition))
 
+    def _process_tsearch_operand(self, operand: str):
+        return func.replace_url_delimiters(operand, ' ', type_=Text)
+
     def _by_search_tsearch(
         self, query: Select, operand: str, maybe_negate: ConditionTransform
     ) -> Select:
-        tsquery = func.plainto_tsquery(literal("zulip.english_us_search"), literal(operand))
+        tsquery = func.plainto_tsquery(literal("zulip.english_us_search"), self._process_tsearch_operand(operand))
         query = query.add_columns(
             ts_locs_array(
-                literal("zulip.english_us_search", Text), func.process_rendered_content_for_indexing(column("rendered_content"), type_=Text), tsquery
+                literal("zulip.english_us_search", Text), func.process_text_for_search(column("rendered_content"), type_=Text), tsquery
             ).label("content_matches"),
             # We HTML-escape the topic in PostgreSQL to avoid doing a server round-trip
             ts_locs_array(

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -525,7 +525,7 @@ class NarrowBuilder:
         tsquery = func.plainto_tsquery(literal("zulip.english_us_search"), literal(operand))
         query = query.add_columns(
             ts_locs_array(
-                literal("zulip.english_us_search", Text), column("rendered_content", Text), tsquery
+                literal("zulip.english_us_search", Text), func.process_rendered_content_for_indexing(column("rendered_content"), type_=Text), tsquery
             ).label("content_matches"),
             # We HTML-escape the topic in PostgreSQL to avoid doing a server round-trip
             ts_locs_array(
@@ -1367,6 +1367,7 @@ def messages_in_narrow_backend(
             rendered_content = row._mapping["rendered_content"]
             if "content_matches" in row._mapping:
                 content_matches = row._mapping["content_matches"]
+                print(content_matches)
                 topic_matches = row._mapping["topic_matches"]
             else:
                 content_matches = topic_matches = []

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -89,7 +89,7 @@ TERMS_OF_SERVICE_MESSAGE: Optional[str] = "Description of changes to the ToS!"
 EMBEDDED_BOTS_ENABLED = True
 
 SYSTEM_ONLY_REALMS: Set[str] = set()
-USING_PGROONGA = True
+USING_PGROONGA = False
 # Flush cache after migration.
 POST_MIGRATION_CACHE_FLUSHING = True
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR replaces url delimiters within text within anchor tag using spaces so they are indexed as normal words so we can search them by its parts. To search for exact match quoted "" exact search method can always be used.

Reason to do this by default in Postgres full text search system, the way url are parsed, tokenised and indexed we are not able to search them by parts of the url. A better way would be to implement a native parser but for this PR we are not going the way of implementing a native tokeniser because using custom native parser need [superuser permission which might not be available to some customers](https://chat.zulip.org/#narrow/stream/3-backend/topic/Searching.20parts.20of.20url.20.239165/near/996827) 

Fixes: <!-- Issue link, or clear description.-->
[#9165](https://github.com/zulip/zulip/pull/9165)

- This PR is for non PGROOGNA search system as PGROONGA don't face this issue
- For manual testing this draft PR have PGROONGA disabled

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**

<img width="1048" alt="Screenshot 2022-06-05 at 5 22 00 PM" src="https://user-images.githubusercontent.com/23462580/172049163-fe622ca2-f044-445a-94f3-d0d330626acf.png">
<img width="933" alt="Screenshot 2022-06-05 at 5 21 41 PM" src="https://user-images.githubusercontent.com/23462580/172049175-391dedfc-9936-4fe2-9f81-3fe6a41dcee7.png">
<img width="1506" alt="Screenshot 2022-06-05 at 5 20 16 PM" src="https://user-images.githubusercontent.com/23462580/172049176-07743105-2d0f-4a6b-8f49-bd822aa08991.png">
<img width="1507" alt="Screenshot 2022-06-05 at 5 20 06 PM" src="https://user-images.githubusercontent.com/23462580/172049177-9b8a3446-7040-40a4-a2ca-522073908904.png">
<img width="1496" alt="Screenshot 2022-06-05 at 5 19 55 PM" src="https://user-images.githubusercontent.com/23462580/172049179-b1c4b367-5925-475b-91e1-60ef7954584f.png">
<img width="1509" alt="Screenshot 2022-06-05 at 5 19 44 PM" src="https://user-images.githubusercontent.com/23462580/172049181-8e50cdb0-e1c7-4fa4-abc8-631cdea6aad3.png">


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
