### PR TITLE
recent-topics: Mark as read using unread counters in Recent topics.

### DIFF
--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -144,6 +144,7 @@
             margin-right: 10px;
             margin-left: 10px;
             align-self: center;
+            background-color: hsl(105, 2%, 50%);
         }
 
         .unread_hidden {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1374,6 +1374,7 @@ td.pointer {
 }
 
 .always_visible_topic_edit,
+.on_hover_topic_read,
 .on_hover_topic_unmute {
     opacity: 0.7;
 
@@ -1384,7 +1385,6 @@ td.pointer {
 }
 
 .on_hover_topic_edit,
-.on_hover_topic_read,
 .on_hover_topic_unresolve,
 .on_hover_topic_resolve,
 .on_hover_topic_mute {

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -13,7 +13,7 @@
                 <a href="{{topic_url}}">{{topic}}</a>
             </div>
             <div class="right_part">
-                <span class="unread_count {{#unless unread_count}}unread_hidden{{/unless}}">{{unread_count}}</span>
+                <span class="unread_count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
                 <div class="recent_topic_actions">
                     <div class="recent_topics_focusable hidden-for-spectators">
                         {{#if topic_muted}}
@@ -21,9 +21,6 @@
                         {{else}}
                         <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon tippy-zulip-tooltip" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mute topic' }}" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>
                         {{/if}}
-                    </div>
-                    <div class="recent_topics_focusable hidden-for-spectators">
-                        <i class="fa fa-check-circle on_hover_topic_read recipient_bar_icon tippy-zulip-tooltip" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}"></i>
                     </div>
                 </div>
             </div>

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -193,7 +193,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
-            "-n", "--num-messages", type=int, default=500, help="The number of messages to create."
+            "-n", "--num-messages", type=int, default=1000, help="The number of messages to create."
         )
 
         parser.add_argument(
@@ -300,10 +300,11 @@ class Command(BaseCommand):
                 # eliminating the possibility of such coincidences.
                 cursor.execute("SELECT setval('zerver_recipient_id_seq', 100)")
 
-        # If max_topics is not set, we set it proportional to the
-        # number of messages.
         if options["max_topics"] is None:
-            options["max_topics"] = 1 + options["num_messages"] // 100
+            # If max_topics is not set, we use a default that's big
+            # enough "more topics" should appear, and scales slowly
+            # with the number of messages.
+            options["max_topics"] = 8 + options["num_messages"] // 1000
 
         if options["delete"]:
             # Start by clearing all the data in our database
@@ -1044,7 +1045,7 @@ def generate_and_send_messages(
     # Generate different topics for each stream
     possible_topics = {}
     for stream_id in recipient_streams:
-        possible_topics[stream_id] = generate_topics(options["max_topics"])
+        possible_topics[stream_id] = generate_topics(random.randint(1, options["max_topics"]))
 
     message_batch_size = options["batch_size"]
     num_messages = 0


### PR DESCRIPTION
The PR changes the following behaviors and UI:
1. Removes the checkmark button to mark the topic as read in
"Recent Topics".
2. Make the unread messages counter be the button for marking
all messages in the topic as read. The unread messages counter
is made clickable and tooltip is set to "Mark as read".

In "recent_topic_row.hbs", remove the checkmark button and add
classes and attributes to ".unread_counter" to give it desirable
behaviour on clicking.

In "zulip.css" set "opacity: 0.7" for ".on_hover_topic_read".

In "recent_topics.css" we set the background-color of unread counter to
hsl(105, 2%, 50%) to decrease fading of unread counter.

This PR continues/replaces #21884.

Fixes: #21654