### PR TITLE
user_profile_modal: UI changes and fixes in full user profile modal.

### DIFF
--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -157,6 +157,7 @@ export function show_user_profile(user) {
         user_avatar: people.medium_avatar_url_for_person(user),
         is_me: people.is_current_user(user.email),
         date_joined: dateFormat.format(parseISO(user.date_joined)),
+        user_circle_class: buddy_data.get_user_circle_class(user.user_id),
         last_seen: buddy_data.user_last_seen_time_status(user.user_id),
         show_email: settings_data.show_email(),
         user_time: people.get_user_time(user.user_id),

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -325,7 +325,12 @@ ul {
     }
 
     .col-left {
-        max-width: 60%;
+        padding: 0 10px 0 0;
+        word-break: break-all;
+    }
+
+    .col-right {
+        width: fit-content;
     }
 
     &.no-fields {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -260,6 +260,12 @@ ul {
         justify-content: space-between;
     }
 
+    @media (width < $ml_min) {
+        .top {
+            flex-direction: column-reverse;
+        }
+    }
+
     #avatar {
         display: inline-block;
         height: 180px;
@@ -298,6 +304,7 @@ ul {
 
     #user-status {
         text-align: center;
+        margin: 0 0 10px;
     }
 
     hr {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -252,6 +252,12 @@ ul {
         line-height: 1;
     }
 
+    #profile-tab {
+        display: flex;
+        justify-content: space-between;
+        margin: 0 5px;
+    }
+
     #avatar {
         display: inline-block;
         height: 180px;
@@ -259,7 +265,6 @@ ul {
         background-size: cover;
         background-position: center;
         border-radius: 5px;
-        margin-right: 10px;
         border: 1px solid hsla(0, 0%, 0%, 0.2);
 
         &.guest-avatar::after {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -238,8 +238,13 @@ ul {
     .name {
         color: hsl(0, 0%, 20%);
         display: inline-block;
-        min-width: 120px;
+        width: 120px;
         font-weight: 600;
+        margin-right: 10px;
+    }
+
+    .value {
+        vertical-align: top;
     }
 
     #exit-sign {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -237,7 +237,6 @@ ul {
 
     .name {
         color: hsl(0, 0%, 20%);
-        display: inline-block;
         width: 120px;
         font-weight: 600;
         margin-right: 10px;
@@ -253,9 +252,12 @@ ul {
     }
 
     #profile-tab {
+        margin: 0 5px;
+    }
+
+    .top {
         display: flex;
         justify-content: space-between;
-        margin: 0 5px;
     }
 
     #avatar {
@@ -287,16 +289,15 @@ ul {
     }
 
     #default-section {
-        display: inline-block;
         vertical-align: top;
 
         .default-field {
-            margin-bottom: 5px;
+            margin-bottom: 10px;
         }
+    }
 
-        #date-joined {
-            margin-bottom: 15px;
-        }
+    #user-status {
+        text-align: center;
     }
 
     hr {
@@ -305,10 +306,8 @@ ul {
     }
 
     #content {
-        margin-top: 10px;
-
         .field-section {
-            margin-top: 8px;
+            margin-bottom: 10px;
 
             .name {
                 color: hsl(0, 0%, 20%);
@@ -319,6 +318,14 @@ ul {
                 overflow-wrap: break-word;
             }
         }
+
+        .rendered_markdown p {
+            margin: 0;
+        }
+    }
+
+    .col-left {
+        max-width: 60%;
     }
 
     &.no-fields {

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -14,55 +14,61 @@
                 <div id="tab-toggle" class="center"></div>
                 <div class="tab-data">
                     <div class="tabcontent active" id="profile-tab">
-                        <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
-                          style="background-image: url('{{user_avatar}}');">
-                        </div>
-                        <div id="default-section">
-                            {{#if show_email}}
-                            <div id="email" class="default-field">
-                                <span class="name">{{#tr}}Email{{/tr}}</span>
-                                <span class="value">{{email}}</span>
-                            </div>
-                            {{/if}}
-                            <div id="user-id" class="default-field">
-                                <span class="name">{{#tr}}User ID{{/tr}}</span>
-                                <span class="value">{{user_id}}</span>
-                            </div>
-                            <div id="user-type" class="default-field">
-                                <span class="name">{{#tr}}Role{{/tr}}</span>
-                                <span class="value">{{user_type}}</span>
-                            </div>
-                            <div id="date-joined" class="default-field">
-                                <span class="name">{{#tr}}Joined{{/tr}}</span>
-                                <span class="value">{{date_joined}}</span>
-                            </div>
-                            <span class="value">{{last_seen}}</span>
-                            {{#if user_time}}
-                            <div class="default-field">
-                                <span class="name">{{#tr}}Local time{{/tr}}</span>
-                                <span class="value">{{user_time}}</span>
-                            </div>
-                            {{/if}}
-                        </div>
-                        <div id="content">
-                            {{#each profile_data}}
-                                <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
-                                    <div class="name">{{this.name}}</div>
-                                    {{#if this.is_user_field}}
-                                        <div class="pill-container not-editable" data-field-id="{{this.id}}">
-                                            <div class="input" contenteditable="false" style="display: none;"></div>
-                                        </div>
-                                    {{else if this.is_link}}
-                                        <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
-                                    {{else if this.is_external_account}}
-                                        <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
-                                    {{else if this.rendered_value}}
-                                        <div class="value rendered_markdown">{{rendered_markdown this.rendered_value}}</div>
-                                    {{else}}
-                                        <div class="value">{{this.value}}</div>
-                                    {{/if}}
+                        <div class="column-wrapper">
+                            <div id="default-section">
+                                {{#if show_email}}
+                                <div id="email" class="default-field">
+                                    <span class="name">{{#tr}}Email{{/tr}}</span>
+                                    <span class="value">{{email}}</span>
                                 </div>
-                            {{/each}}
+                                {{/if}}
+                                <div id="user-id" class="default-field">
+                                    <span class="name">{{#tr}}User ID{{/tr}}</span>
+                                    <span class="value">{{user_id}}</span>
+                                </div>
+                                <div id="user-type" class="default-field">
+                                    <span class="name">{{#tr}}Role{{/tr}}</span>
+                                    <span class="value">{{user_type}}</span>
+                                </div>
+                                <div id="date-joined" class="default-field">
+                                    <span class="name">{{#tr}}Joined{{/tr}}</span>
+                                    <span class="value">{{date_joined}}</span>
+                                </div>
+                                <span class="value">{{last_seen}}</span>
+                                {{#if user_time}}
+                                <div class="default-field">
+                                    <span class="name">{{#tr}}Local time{{/tr}}</span>
+                                    <span class="value">{{user_time}}</span>
+                                </div>
+                                {{/if}}
+                            </div>
+                            <div id="content">
+                                {{#each profile_data}}
+                                    <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
+                                        <div class="name">{{this.name}}</div>
+                                        {{#if this.is_user_field}}
+                                            <div class="pill-container not-editable" data-field-id="{{this.id}}">
+                                                <div class="input" contenteditable="false" style="display: none;"></div>
+                                            </div>
+                                        {{else if this.is_link}}
+                                            <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
+                                        {{else if this.is_external_account}}
+                                            <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
+                                        {{else}}
+                                            {{#if this.rendered_value}}
+                                            <div class="value rendered_markdown">{{rendered_markdown this.rendered_value}}</div>
+                                            {{else}}
+                                            <div class="value">{{this.value}}</div>
+                                            {{/if}}
+                                        {{/if}}
+                                    </div>
+                                {{/each}}
+                            </div>
+                        </div>
+                        <div class="column-wrapper">
+                            <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
+                              style="background-image: url('{{user_avatar}}');">
+                            </div>
                         </div>
                     </div>
 

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -24,6 +24,10 @@
                                 <span class="value">{{email}}</span>
                             </div>
                             {{/if}}
+                            <div id="user-id" class="default-field">
+                                <span class="name">{{#tr}}User ID{{/tr}}</span>
+                                <span class="value">{{user_id}}</span>
+                            </div>
                             <div id="user-type" class="default-field">
                                 <span class="name">{{#tr}}Role{{/tr}}</span>
                                 <span class="value">{{user_type}}</span>
@@ -31,10 +35,6 @@
                             <div id="date-joined" class="default-field">
                                 <span class="name">{{#tr}}Joined{{/tr}}</span>
                                 <span class="value">{{date_joined}}</span>
-                            </div>
-                            <div id="user-id" class="default-field">
-                                <span class="name">{{#tr}}User ID{{/tr}}</span>
-                                <span class="value">{{user_id}}</span>
                             </div>
                             <span class="value">{{last_seen}}</span>
                             {{#if user_time}}

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -14,34 +14,46 @@
                 <div id="tab-toggle" class="center"></div>
                 <div class="tab-data">
                     <div class="tabcontent active" id="profile-tab">
-                        <div class="column-wrapper">
-                            <div id="default-section">
-                                {{#if show_email}}
-                                <div id="email" class="default-field">
-                                    <span class="name">{{#tr}}Email{{/tr}}</span>
-                                    <span class="value">{{email}}</span>
+                        <div class="top">
+                            <div class="col-wrap col-left">
+                                <div id="default-section">
+                                    {{#if show_email}}
+                                    <div id="email" class="default-field">
+                                        <div class="name">{{#tr}}Email{{/tr}}</div>
+                                        <div class="value">{{email}}</div>
+                                    </div>
+                                    {{/if}}
+                                    <div id="user-id" class="default-field">
+                                        <div class="name">{{#tr}}User ID{{/tr}}</div>
+                                        <div class="value">{{user_id}}</div>
+                                    </div>
+                                    <div id="user-type" class="default-field">
+                                        <div class="name">{{#tr}}Role{{/tr}}</div>
+                                        <div class="value">{{user_type}}</div>
+                                    </div>
+                                    <div id="date-joined" class="default-field">
+                                        <div class="name">{{#tr}}Joined{{/tr}}</div>
+                                        <div class="value">{{date_joined}}</div>
+                                    </div>
+                                    {{#if user_time}}
+                                    <div class="default-field">
+                                        <div class="name">{{#tr}}Local time{{/tr}}</div>
+                                        <div class="value">{{user_time}}</div>
+                                    </div>
+                                    {{/if}}
                                 </div>
-                                {{/if}}
-                                <div id="user-id" class="default-field">
-                                    <span class="name">{{#tr}}User ID{{/tr}}</span>
-                                    <span class="value">{{user_id}}</span>
-                                </div>
-                                <div id="user-type" class="default-field">
-                                    <span class="name">{{#tr}}Role{{/tr}}</span>
-                                    <span class="value">{{user_type}}</span>
-                                </div>
-                                <div id="date-joined" class="default-field">
-                                    <span class="name">{{#tr}}Joined{{/tr}}</span>
-                                    <span class="value">{{date_joined}}</span>
-                                </div>
-                                <span class="value">{{last_seen}}</span>
-                                {{#if user_time}}
-                                <div class="default-field">
-                                    <span class="name">{{#tr}}Local time{{/tr}}</span>
-                                    <span class="value">{{user_time}}</span>
-                                </div>
-                                {{/if}}
                             </div>
+                            <div class="col-wrap col-right">
+                                <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
+                                  style="background-image: url('{{user_avatar}}');">
+                                </div>
+                                <div id="user-status" class="default-field">
+                                    <span class="value">{{last_seen}}</span>
+                                    <span class="{{user_circle_class}} user_circle popover_user_presence"></span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="bottom">
                             <div id="content">
                                 {{#each profile_data}}
                                     <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
@@ -63,11 +75,6 @@
                                         {{/if}}
                                     </div>
                                 {{/each}}
-                            </div>
-                        </div>
-                        <div class="column-wrapper">
-                            <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
-                              style="background-image: url('{{user_avatar}}');">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The Full Profile Modal has a layout different from other related pages such Manage User Modal and Settings > Profile Modal.

This PR encompasses the following UI changes and fixes to the full profile layout,

- #21805
- Move the "User ID" field below the "Email" field. ([CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Placement.20of.20User.20ID.20in.20full.20profile))
- Fix label alignment for non-English languages. ([CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Placement.20of.20User.20ID.20in.20full.20profile/near/1388239))
- Move user status to right and add status icon. ([CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/Full.20Profile.20Layout.20.2321805/near/1389031))
- Fix label gap and overlap in lengthy profile fields.
  - Lengthy profile fields can cause the avatar to be displaced out of the frame.
  - The gap between the labels in custom profile fields do not match with the default profile fields.



Fixes: #21805

CZO Discussion: [Full Profile Layout #21805](https://chat.zulip.org/#narrow/stream/101-design/topic/Full.20Profile.20Layout.20.2321805)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Full Profile Layout](https://user-images.githubusercontent.com/82862779/177844586-810d68ff-c1ba-42a6-9826-57246de9556b.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
