### PR TITLE
streams: Send stream creation event when changing stream to public.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -923,17 +923,22 @@ def apply_event(
         if event["op"] == "update":
             # For legacy reasons, we call stream data 'subscriptions' in
             # the state var here, for the benefit of the JS code.
-            for obj in state["subscriptions"]:
-                if obj["name"].lower() == event["name"].lower():
-                    obj[event["property"]] = event["value"]
-                    if event["property"] == "description":
-                        obj["rendered_description"] = event["rendered_description"]
-                    if event.get("history_public_to_subscribers") is not None:
-                        obj["history_public_to_subscribers"] = event[
-                            "history_public_to_subscribers"
-                        ]
-                    if event.get("is_web_public") is not None:
-                        obj["is_web_public"] = event["is_web_public"]
+            for sub_list in [
+                state["subscriptions"],
+                state["unsubscribed"],
+                state["never_subscribed"],
+            ]:
+                for obj in sub_list:
+                    if obj["name"].lower() == event["name"].lower():
+                        obj[event["property"]] = event["value"]
+                        if event["property"] == "description":
+                            obj["rendered_description"] = event["rendered_description"]
+                        if event.get("history_public_to_subscribers") is not None:
+                            obj["history_public_to_subscribers"] = event[
+                                "history_public_to_subscribers"
+                            ]
+                        if event.get("is_web_public") is not None:
+                            obj["is_web_public"] = event["is_web_public"]
             # Also update the pure streams data
             if "streams" in state:
                 for stream in state["streams"]:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2744,6 +2744,40 @@ class SubscribeActionTest(BaseAction):
         check_stream_update("events[0]", events[0])
         check_message("events[1]", events[1])
 
+        # Update stream privacy - make stream public
+        self.user_profile = self.example_user("cordelia")
+        action = lambda: do_change_stream_permission(
+            stream,
+            invite_only=False,
+            history_public_to_subscribers=True,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
+        )
+        events = self.verify_action(action, include_subscribers=include_subscribers, num_events=2)
+        check_stream_create("events[0]", events[0])
+        check_subscription_peer_add("events[1]", events[1])
+
+        do_change_stream_permission(
+            stream,
+            invite_only=True,
+            history_public_to_subscribers=True,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
+        )
+        self.subscribe(self.example_user("cordelia"), stream.name)
+        self.unsubscribe(self.example_user("cordelia"), stream.name)
+        action = lambda: do_change_stream_permission(
+            stream,
+            invite_only=False,
+            history_public_to_subscribers=True,
+            is_web_public=False,
+            acting_user=self.example_user("hamlet"),
+        )
+        events = self.verify_action(
+            action, include_subscribers=include_subscribers, num_events=2, include_streams=False
+        )
+
+        self.user_profile = self.example_user("hamlet")
         # Update stream stream_post_policy property
         action = lambda: do_change_stream_post_policy(
             stream, Stream.STREAM_POST_POLICY_ADMINS, acting_user=self.example_user("hamlet")


### PR DESCRIPTION
This PR adds code to send stream creation and peer add events
when stream is changed from private to public. These events are
only sent to users who are not susbcribed to the stream and are
not realm admins as subscribers and realm admins already have
the stream data. This will update the stream data with clients
and will remove the need to reload to view the modified stream.


<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> #22194

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![stream-privacy-event](https://user-images.githubusercontent.com/35494118/172408983-be09313d-67e9-4188-88e4-57427a9e0d4b.gif)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
