### PR TITLE
portico: Update Recurse Center link on /plans to point to case study.

### DIFF
--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -34,7 +34,7 @@
                     Yes! Some of our biggest fans have hundreds or thousands
                     of users, including Fortune 500 companies like Akamai,
                     and open source communities like
-                    <a href="https://www.recurse.com/blog/112-how-rc-uses-zulip">The
+                    <a href="/case-studies/recurse-center/">The
                     Recurse Center</a>. If you’d like to see a large Zulip
                     in action, the
                     <a href="/development-community/">Zulip


### PR DESCRIPTION
No visual changes; manually tested the link.