### PR TITLE
django-stubs: Replace `HttpResponse` with `_MonkeyPatchedWSGIResponse.`

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import orjson
-from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
 
 from corporate.lib.stripe import add_months, update_sponsorship_status
@@ -21,13 +21,16 @@ from zerver.models import (
     get_realm,
 )
 
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
+
 
 class TestSupportEndpoint(ZulipTestCase):
     def test_search(self) -> None:
         reset_emails_in_zulip_realm()
 
         def assert_user_details_in_html_response(
-            html_response: HttpResponse, full_name: str, email: str, role: str
+            html_response: "TestHttpResponse", full_name: str, email: str, role: str
         ) -> None:
             self.assert_in_success_response(
                 [
@@ -40,7 +43,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 html_response,
             )
 
-        def check_hamlet_user_query_result(result: HttpResponse) -> None:
+        def check_hamlet_user_query_result(result: "TestHttpResponse") -> None:
             assert_user_details_in_html_response(
                 result, "King Hamlet", self.example_email("hamlet"), "Member"
             )
@@ -56,17 +59,17 @@ class TestSupportEndpoint(ZulipTestCase):
                 result,
             )
 
-        def check_othello_user_query_result(result: HttpResponse) -> None:
+        def check_othello_user_query_result(result: "TestHttpResponse") -> None:
             assert_user_details_in_html_response(
                 result, "Othello, the Moor of Venice", self.example_email("othello"), "Member"
             )
 
-        def check_polonius_user_query_result(result: HttpResponse) -> None:
+        def check_polonius_user_query_result(result: "TestHttpResponse") -> None:
             assert_user_details_in_html_response(
                 result, "Polonius", self.example_email("polonius"), "Guest"
             )
 
-        def check_zulip_realm_query_result(result: HttpResponse) -> None:
+        def check_zulip_realm_query_result(result: "TestHttpResponse") -> None:
             zulip_realm = get_realm("zulip")
             first_human_user = zulip_realm.get_first_human_user()
             assert first_human_user is not None
@@ -87,7 +90,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 result,
             )
 
-        def check_lear_realm_query_result(result: HttpResponse) -> None:
+        def check_lear_realm_query_result(result: "TestHttpResponse") -> None:
             lear_realm = get_realm("lear")
             self.assert_in_success_response(
                 [
@@ -113,7 +116,7 @@ class TestSupportEndpoint(ZulipTestCase):
             )
 
         def check_preregistration_user_query_result(
-            result: HttpResponse, email: str, invite: bool = False
+            result: "TestHttpResponse", email: str, invite: bool = False
         ) -> None:
             self.assert_in_success_response(
                 [
@@ -142,7 +145,7 @@ class TestSupportEndpoint(ZulipTestCase):
                     result,
                 )
 
-        def check_realm_creation_query_result(result: HttpResponse, email: str) -> None:
+        def check_realm_creation_query_result(result: "TestHttpResponse", email: str) -> None:
             self.assert_in_success_response(
                 [
                     '<span class="label">preregistration user</span>\n',
@@ -153,7 +156,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 result,
             )
 
-        def check_multiuse_invite_link_query_result(result: HttpResponse) -> None:
+        def check_multiuse_invite_link_query_result(result: "TestHttpResponse") -> None:
             self.assert_in_success_response(
                 [
                     '<span class="label">multiuse invite</span>\n',
@@ -163,7 +166,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 result,
             )
 
-        def check_realm_reactivation_link_query_result(result: HttpResponse) -> None:
+        def check_realm_reactivation_link_query_result(result: "TestHttpResponse") -> None:
             self.assert_in_success_response(
                 [
                     '<span class="label">realm reactivation</span>\n',

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -8,6 +8,7 @@ import urllib
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Collection,
@@ -107,6 +108,9 @@ from zerver.tornado.event_queue import clear_client_event_queues_for_testing
 
 if settings.ZILENCER_ENABLED:
     from zilencer.models import get_remote_server_by_uuid
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class EmptyResponseError(Exception):
@@ -254,7 +258,7 @@ Output:
         self,
         url: str,
         method: str,
-        result: HttpResponse,
+        result: "TestHttpResponse",
         data: Union[str, bytes, Dict[str, Any]],
         kwargs: Dict[str, ClientArg],
         intentionally_undocumented: bool = False,
@@ -302,7 +306,7 @@ Output:
         info: Dict[str, Any] = {},
         intentionally_undocumented: bool = False,
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         """
         We need to urlencode, since Django's function won't do it for us.
         """
@@ -323,7 +327,7 @@ Output:
     @instrument_url
     def client_patch_multipart(
         self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         """
         Use this for patch requests that have file uploads or
         that need some sort of multi-part content.  In the future
@@ -341,20 +345,24 @@ Output:
 
     def json_patch(
         self, url: str, payload: Dict[str, Any] = {}, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         data = orjson.dumps(payload)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         return django_client.patch(url, data=data, content_type="application/json", **kwargs)
 
     @instrument_url
-    def client_put(self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg) -> HttpResponse:
+    def client_put(
+        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+    ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         return django_client.put(url, encoded, **kwargs)
 
-    def json_put(self, url: str, payload: Dict[str, Any] = {}, **kwargs: ClientArg) -> HttpResponse:
+    def json_put(
+        self, url: str, payload: Dict[str, Any] = {}, **kwargs: ClientArg
+    ) -> "TestHttpResponse":
         data = orjson.dumps(payload)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -363,7 +371,7 @@ Output:
     @instrument_url
     def client_delete(
         self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -374,14 +382,16 @@ Output:
     @instrument_url
     def client_options(
         self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         return django_client.options(url, encoded, **kwargs)
 
     @instrument_url
-    def client_head(self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg) -> HttpResponse:
+    def client_head(
+        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+    ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
@@ -393,7 +403,7 @@ Output:
         url: str,
         info: Union[str, bytes, Dict[str, Any]] = {},
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         intentionally_undocumented = kwargs.pop("intentionally_undocumented", False)
         assert isinstance(intentionally_undocumented, bool)
         django_client = self.client  # see WRAPPER_COMMENT
@@ -405,7 +415,7 @@ Output:
         return result
 
     @instrument_url
-    def client_post_request(self, url: str, req: Any) -> HttpResponse:
+    def client_post_request(self, url: str, req: Any) -> "TestHttpResponse":
         """
         We simulate hitting an endpoint here, although we
         actually resolve the URL manually and hit the view
@@ -419,7 +429,9 @@ Output:
         return match.func(req)
 
     @instrument_url
-    def client_get(self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg) -> HttpResponse:
+    def client_get(
+        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+    ) -> "TestHttpResponse":
         intentionally_undocumented = kwargs.pop("intentionally_undocumented", False)
         assert isinstance(intentionally_undocumented, bool)
         django_client = self.client  # see WRAPPER_COMMENT
@@ -539,7 +551,7 @@ Output:
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_error(result, assert_json_error_msg)
 
-    def _get_page_params(self, result: HttpResponse) -> Dict[str, Any]:
+    def _get_page_params(self, result: "TestHttpResponse") -> Dict[str, Any]:
         """Helper for parsing page_params after fetching the web app's home view."""
         doc = lxml.html.document_fromstring(result.content)
         div = cast(lxml.html.HtmlMixin, doc).get_element_by_id("page-params")
@@ -549,7 +561,7 @@ Output:
         page_params = orjson.loads(page_params_json)
         return page_params
 
-    def check_rendered_logged_in_app(self, result: HttpResponse) -> None:
+    def check_rendered_logged_in_app(self, result: "TestHttpResponse") -> None:
         """Verifies that a visit of / was a 200 that rendered page_params
         and not for a (logged-out) spectator."""
         self.assertEqual(result.status_code, 200)
@@ -561,7 +573,7 @@ Output:
 
     def login_with_return(
         self, email: str, password: Optional[str] = None, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         if password is None:
             password = initial_password(email)
         result = self.client_post(
@@ -638,7 +650,7 @@ Output:
     def logout(self) -> None:
         self.client.logout()
 
-    def register(self, email: str, password: str, **kwargs: Any) -> HttpResponse:
+    def register(self, email: str, password: str, **kwargs: Any) -> "TestHttpResponse":
         self.client_post("/accounts/home/", {"email": email}, **kwargs)
         return self.submit_reg_form_for_user(email, password, **kwargs)
 
@@ -659,7 +671,7 @@ Output:
         enable_marketing_emails: Optional[bool] = None,
         is_demo_organization: bool = False,
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         """
         Stage two of the two-step registration process.
 
@@ -756,7 +768,7 @@ Output:
 
     def uuid_get(
         self, identifier: str, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         kwargs["HTTP_AUTHORIZATION"] = self.encode_uuid(identifier)
         return self.client_get(url, info, **kwargs)
 
@@ -766,13 +778,13 @@ Output:
         url: str,
         info: Union[str, bytes, Dict[str, Any]] = {},
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         kwargs["HTTP_AUTHORIZATION"] = self.encode_uuid(identifier)
         return self.client_post(url, info, **kwargs)
 
     def api_get(
         self, user: UserProfile, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
         return self.client_get(url, info, **kwargs)
 
@@ -782,7 +794,7 @@ Output:
         url: str,
         info: Union[str, bytes, Dict[str, Any]] = {},
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
         return self.client_post(url, info, **kwargs)
 
@@ -793,7 +805,7 @@ Output:
         info: Dict[str, Any] = {},
         intentionally_undocumented: bool = False,
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
         return self.client_patch(
             url, info, intentionally_undocumented=intentionally_undocumented, **kwargs
@@ -801,7 +813,7 @@ Output:
 
     def api_delete(
         self, user: UserProfile, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
         return self.client_delete(url, info, **kwargs)
 
@@ -927,12 +939,14 @@ Output:
 
         return [subscription.user_profile for subscription in subscriptions]
 
-    def assert_streaming_content(self, response: HttpResponse, result: bytes) -> None:
+    def assert_streaming_content(self, response: "TestHttpResponse", result: bytes) -> None:
         assert isinstance(response, StreamingHttpResponse)
         data = b"".join(response.streaming_content)
         self.assertEqual(result, data)
 
-    def assert_json_success(self, result: HttpResponse) -> Dict[str, Any]:
+    def assert_json_success(
+        self, result: Union["TestHttpResponse", HttpResponse]
+    ) -> Dict[str, Any]:
         """
         Successful POSTs return a 200 and JSON of the form {"result": "success",
         "msg": ""}.
@@ -949,7 +963,7 @@ Output:
         self.assertNotEqual(json["msg"], "Error parsing JSON in response!")
         return json
 
-    def get_json_error(self, result: HttpResponse, status_code: int = 400) -> str:
+    def get_json_error(self, result: "TestHttpResponse", status_code: int = 400) -> str:
         try:
             json = orjson.loads(result.content)
         except orjson.JSONDecodeError:  # nocoverage
@@ -958,7 +972,9 @@ Output:
         self.assertEqual(json.get("result"), "error")
         return json["msg"]
 
-    def assert_json_error(self, result: HttpResponse, msg: str, status_code: int = 400) -> None:
+    def assert_json_error(
+        self, result: "TestHttpResponse", msg: str, status_code: int = 400
+    ) -> None:
         """
         Invalid POSTs return an error status code and JSON of the form
         {"result": "error", "msg": "reason"}.
@@ -975,20 +991,26 @@ Output:
             raise AssertionError(f"{str(type(items))} is of unexpected size!")
 
     def assert_json_error_contains(
-        self, result: HttpResponse, msg_substring: str, status_code: int = 400
+        self, result: "TestHttpResponse", msg_substring: str, status_code: int = 400
     ) -> None:
         self.assertIn(msg_substring, self.get_json_error(result, status_code=status_code))
 
-    def assert_in_response(self, substring: str, response: HttpResponse) -> None:
+    def assert_in_response(
+        self, substring: str, response: Union["TestHttpResponse", HttpResponse]
+    ) -> None:
         self.assertIn(substring, response.content.decode())
 
-    def assert_in_success_response(self, substrings: List[str], response: HttpResponse) -> None:
+    def assert_in_success_response(
+        self, substrings: List[str], response: "TestHttpResponse"
+    ) -> None:
         self.assertEqual(response.status_code, 200)
         decoded = response.content.decode()
         for substring in substrings:
             self.assertIn(substring, decoded)
 
-    def assert_not_in_success_response(self, substrings: List[str], response: HttpResponse) -> None:
+    def assert_not_in_success_response(
+        self, substrings: List[str], response: "TestHttpResponse"
+    ) -> None:
         self.assertEqual(response.status_code, 200)
         decoded = response.content.decode()
         for substring in substrings:
@@ -1093,7 +1115,7 @@ Output:
         is_web_public: bool = False,
         allow_fail: bool = False,
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         post_data = {
             "subscriptions": orjson.dumps([{"name": stream} for stream in streams]).decode(),
             "is_web_public": orjson.dumps(is_web_public).decode(),
@@ -1637,7 +1659,7 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         content_type: Optional[str] = "application/json",
         expect_noop: bool = False,
         **kwargs: ClientArg,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
         return self.check_webhook(
             fixture_name, expected_topic, expected_message, content_type, expect_noop, **kwargs

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -9,7 +9,19 @@ import time
 import urllib
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+)
 from unittest import mock
 from urllib.parse import urlencode
 
@@ -24,7 +36,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core import mail
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
 from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -141,6 +153,9 @@ from zproject.backends import (
     saml_auth_enabled,
     sync_user_from_ldap,
 )
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class AuthBackendTest(ZulipTestCase):
@@ -535,7 +550,7 @@ class AuthBackendTest(ZulipTestCase):
         }
 
         def patched_authenticate(
-            request: Optional[HttpResponse] = None,
+            request: Optional["TestHttpResponse"] = None,
             **kwargs: Any,
         ) -> Any:
             # This is how we pass the subdomain to the authentication
@@ -796,12 +811,12 @@ class CheckPasswordStrengthTest(ZulipTestCase):
 
 
 class DesktopFlowTestingLib(ZulipTestCase):
-    def verify_desktop_flow_app_page(self, response: HttpResponse) -> None:
+    def verify_desktop_flow_app_page(self, response: "TestHttpResponse") -> None:
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"<h1>Finish desktop login</h1>", response.content)
 
     def verify_desktop_flow_end_page(
-        self, response: HttpResponse, email: str, desktop_flow_otp: str
+        self, response: "TestHttpResponse", email: str, desktop_flow_otp: str
     ) -> None:
         self.assertEqual(response.status_code, 200)
 
@@ -930,12 +945,12 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
 
     def social_auth_test_finish(
         self,
-        result: HttpResponse,
+        result: "TestHttpResponse",
         account_data_dict: Dict[str, str],
         expect_choose_email_screen: bool,
         headers: Any,
         **extra_data: Any,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         parsed_url = urllib.parse.urlparse(result["Location"])
         csrf_state = urllib.parse.parse_qs(parsed_url.query)["state"]
         result = self.client_get(self.AUTH_FINISH_URL, dict(state=csrf_state), **headers)
@@ -963,7 +978,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         alternative_start_url: Optional[str] = None,
         user_agent: Optional[str] = None,
         **extra_data: Any,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         """Main entry point for all social authentication tests.
 
         * account_data_dict: Dictionary containing the name/email data
@@ -1350,7 +1365,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
 
     def stage_two_of_registration(
         self,
-        result: HttpResponse,
+        result: "TestHttpResponse",
         realm: Realm,
         subdomain: str,
         email: str,
@@ -1895,7 +1910,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
         user_agent: Optional[str] = None,
         extra_attributes: Mapping[str, List[str]] = {},
         **extra_data: Any,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         url, headers = self.prepare_login_url_and_headers(
             subdomain,
             mobile_flow_otp,
@@ -2011,7 +2026,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
 
     def make_idp_initiated_logout_request(
         self, email: str, make_validity_checks_pass: bool = True
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         samlrequest = self.generate_saml_logout_request_from_idp(email)
         parameters = {"SAMLRequest": samlrequest}
 
@@ -2962,12 +2977,12 @@ class AppleIdAuthBackendTest(AppleAuthMixin, SocialAuthBase):
 
     def social_auth_test_finish(
         self,
-        result: HttpResponse,
+        result: "TestHttpResponse",
         account_data_dict: Dict[str, str],
         expect_choose_email_screen: bool,
         headers: Any,
         **extra_data: Any,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         parsed_url = urllib.parse.urlparse(result["Location"])
         state = urllib.parse.parse_qs(parsed_url.query)["state"]
         user_param = json.dumps(account_data_dict)
@@ -3140,7 +3155,7 @@ class AppleAuthBackendNativeFlowTest(AppleAuthMixin, SocialAuthBase):
         skip_id_token: bool = False,
         user_agent: Optional[str] = None,
         **extra_data: Any,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         """In Apple's native authentication flow, the client app authenticates
         with Apple and receives the JWT id_token, before contacting
         the Zulip server.  The app sends an appropriate request with
@@ -3305,7 +3320,7 @@ class GenericOpenIdConnectTest(SocialAuthBase):
         self,
         *args: Any,
         **kwargs: Any,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         # Example payload of the discovery endpoint (with appropriate values filled
         # in to match our test setup).
         # All the attributes below are REQUIRED per OIDC specification:
@@ -3344,7 +3359,7 @@ class GenericOpenIdConnectTest(SocialAuthBase):
 
         return result
 
-    def social_auth_test_finish(self, *args: Any, **kwargs: Any) -> HttpResponse:
+    def social_auth_test_finish(self, *args: Any, **kwargs: Any) -> "TestHttpResponse":
         # Trying to generate a (access_token, id_token) pair here in tests that would
         # successfully pass validation by validate_and_return_id_token is impractical
         # and unnecessary (see python-social-auth implementation of the method for
@@ -3512,13 +3527,13 @@ class GitHubAuthBackendTest(SocialAuthBase):
 
     def social_auth_test_finish(
         self,
-        result: HttpResponse,
+        result: "TestHttpResponse",
         account_data_dict: Dict[str, str],
         expect_choose_email_screen: bool,
         headers: Any,
         expect_noreply_email_allowed: bool = False,
         **extra_data: Any,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         parsed_url = urllib.parse.urlparse(result["Location"])
         csrf_state = urllib.parse.parse_qs(parsed_url.query)["state"]
         result = self.client_get(self.AUTH_FINISH_URL, dict(state=csrf_state), **headers)
@@ -4151,7 +4166,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
         *,
         subdomain: str = "zulip",
         force_token: Optional[str] = None,
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         if force_token is None:
             token = ExternalAuthResult(data_dict=data).store_data()
         else:
@@ -4160,7 +4175,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
         return self.client_get(url_path, subdomain=subdomain)
 
     def test_redirect_to_next_url_for_log_into_subdomain(self) -> None:
-        def test_redirect_to_next_url(next: str = "") -> HttpResponse:
+        def test_redirect_to_next_url(next: str = "") -> "TestHttpResponse":
             data: ExternalAuthDataDict = {
                 "full_name": "Hamlet",
                 "email": self.example_email("hamlet"),
@@ -4803,7 +4818,7 @@ class ExternalMethodDictsTests(ZulipTestCase):
 class FetchAuthBackends(ZulipTestCase):
     def test_get_server_settings(self) -> None:
         def check_result(
-            result: HttpResponse, extra_fields: Sequence[Tuple[str, Validator[object]]] = []
+            result: "TestHttpResponse", extra_fields: Sequence[Tuple[str, Validator[object]]] = []
         ) -> None:
             authentication_methods_list = [
                 ("password", check_bool),
@@ -4990,7 +5005,7 @@ class TestDevAuthBackend(ZulipTestCase):
         self.assertIn("otp_device_id", list(self.client.session.keys()))
 
     def test_redirect_to_next_url(self) -> None:
-        def do_local_login(formaction: str) -> HttpResponse:
+        def do_local_login(formaction: str) -> "TestHttpResponse":
             user_email = self.example_email("hamlet")
             data = {"direct_email": user_email}
             return self.client_post(formaction, data)
@@ -5364,7 +5379,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         """This test verifies the behavior of the redirect_to logic in
         login_or_register_remote_user."""
 
-        def test_with_redirect_to_param_set_as_next(next: str = "") -> HttpResponse:
+        def test_with_redirect_to_param_set_as_next(next: str = "") -> "TestHttpResponse":
             user_profile = self.example_user("hamlet")
             email = user_profile.delivery_email
             with self.settings(
@@ -6620,9 +6635,9 @@ class TestMaybeSendToRegistration(ZulipTestCase):
             self.assertIn("do_confirm/" + confirmation_key, result["Location"])
             self.assertEqual(PreregistrationUser.objects.all().count(), 1)
 
-        result = self.client_get(result["Location"])
-        self.assert_in_response('action="/accounts/register/"', result)
-        self.assert_in_response(f'value="{confirmation_key}" name="key"', result)
+        response = self.client_get(result["Location"])
+        self.assert_in_response('action="/accounts/register/"', response)
+        self.assert_in_response(f'value="{confirmation_key}" name="key"', response)
 
     def test_sso_only_when_preregistration_user_exists(self) -> None:
         rf = RequestFactory(HTTP_HOST=Realm.host_for_subdomain("zulip"))

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -4,7 +4,7 @@ import re
 import uuid
 from collections import defaultdict
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
 from unittest import mock, skipUnless
 
 import orjson
@@ -89,6 +89,9 @@ from zerver.models import Realm, UserProfile, get_realm, get_user
 
 if settings.ZILENCER_ENABLED:
     from zilencer.models import RemoteZulipServer
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class DecoratorTestCase(ZulipTestCase):
@@ -1772,7 +1775,7 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         )
         do_reactivate_realm(user_profile.realm)
 
-    def _do_test(self, user: UserProfile) -> HttpResponse:
+    def _do_test(self, user: UserProfile) -> "TestHttpResponse":
         stream_name = "stream name"
         self.common_subscribe_to_streams(user, [stream_name], allow_fail=True)
         data = {"password": initial_password(user.email), "stream": stream_name}
@@ -1815,7 +1818,7 @@ class TestAuthenticatedJsonViewDecorator(ZulipTestCase):
             ],
         )
 
-    def _do_test(self, user_email: str) -> HttpResponse:
+    def _do_test(self, user_email: str) -> "TestHttpResponse":
         data = {"password": initial_password(user_email)}
         return self.client_post(r"/accounts/webathena_kerberos_login/", data)
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -1,12 +1,11 @@
 import os
 import re
-from typing import Any, Dict, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Sequence
 from unittest import mock, skipUnless
 from urllib.parse import urlsplit
 
 import orjson
 from django.conf import settings
-from django.http import HttpResponse
 from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
@@ -18,14 +17,17 @@ from zerver.lib.test_helpers import HostRequestMock
 from zerver.models import Realm, get_realm
 from zerver.views.documentation import add_api_uri_context
 
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
+
 
 class DocPageTest(ZulipTestCase):
-    def get_doc(self, url: str, subdomain: str) -> HttpResponse:
+    def get_doc(self, url: str, subdomain: str) -> "TestHttpResponse":
         if url[0:23] == "/integrations/doc-html/":
             return self.client_get(url, subdomain=subdomain, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
         return self.client_get(url, subdomain=subdomain)
 
-    def print_msg_if_error(self, url: str, response: HttpResponse) -> None:  # nocoverage
+    def print_msg_if_error(self, url: str, response: "TestHttpResponse") -> None:  # nocoverage
         if response.status_code == 200:
             return
         print("Error processing URL:", url)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -4,12 +4,11 @@ import os
 import subprocess
 from email import message_from_string
 from email.message import EmailMessage, MIMEPart
-from typing import Any, Callable, Dict, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional
 from unittest import mock
 
 import orjson
 from django.conf import settings
-from django.http import HttpResponse
 
 from zerver.actions.realm_settings import do_deactivate_realm
 from zerver.actions.streams import do_change_stream_post_policy
@@ -49,6 +48,9 @@ from zerver.models import (
     get_system_bot,
 )
 from zerver.worker.queue_processors import MirrorWorker
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 logger_name = "zerver.lib.email_mirror"
 
@@ -1357,7 +1359,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
         user_message = most_recent_usermessage(user_profile)
         return create_missed_message_address(user_profile, user_message.message)
 
-    def send_offline_message(self, to_address: str, sender: UserProfile) -> HttpResponse:
+    def send_offline_message(self, to_address: str, sender: UserProfile) -> "TestHttpResponse":
         mail_template = self.fixture_data("simple.txt", type="email")
         mail = mail_template.format(stream_to_address=to_address, sender=sender.delivery_email)
         msg_base64 = base64.b64encode(mail.encode()).decode()

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -2,13 +2,12 @@ import calendar
 import datetime
 import urllib
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import orjson
 import pytz
 from django.conf import settings
-from django.http import HttpResponse
 from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
@@ -38,6 +37,9 @@ from zerver.models import (
     get_user,
 )
 from zerver.worker.queue_processors import UserActivityWorker
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 logger_string = "zulip.soft_deactivation"
 
@@ -430,14 +432,14 @@ class HomeTest(ZulipTestCase):
         html = result.content.decode()
         self.assertIn("test_stream_7", html)
 
-    def _get_home_page(self, **kwargs: Any) -> HttpResponse:
+    def _get_home_page(self, **kwargs: Any) -> "TestHttpResponse":
         with patch("zerver.lib.events.request_event_queue", return_value=42), patch(
             "zerver.lib.events.get_user_events", return_value=[]
         ):
             result = self.client_get("/", dict(**kwargs))
         return result
 
-    def _sanity_check(self, result: HttpResponse) -> None:
+    def _sanity_check(self, result: "TestHttpResponse") -> None:
         """
         Use this for tests that are geared toward specific edge cases, but
         which still want the home page to load properly.

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -1,11 +1,10 @@
 from http.cookies import SimpleCookie
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 import orjson
 from django.conf import settings
 from django.core import mail
-from django.http import HttpResponse
 from django.utils import translation
 
 from zerver.lib.email_notifications import enqueue_welcome_emails
@@ -14,6 +13,9 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import HostRequestMock
 from zerver.management.commands import makemessages
 from zerver.models import get_realm_stream
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class EmailTranslationTestCase(ZulipTestCase):
@@ -81,7 +83,9 @@ class TranslationTestCase(ZulipTestCase):
         super().tearDown()
 
     # e.g. self.client_post(url) if method is "post"
-    def fetch(self, method: str, url: str, expected_status: int, **kwargs: Any) -> HttpResponse:
+    def fetch(
+        self, method: str, url: str, expected_status: int, **kwargs: Any
+    ) -> "TestHttpResponse":
         response = getattr(self.client, method)(url, **kwargs)
         self.assertEqual(
             response.status_code,

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1,11 +1,10 @@
 import datetime
 from operator import itemgetter
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from unittest import mock
 
 import orjson
 from django.db import IntegrityError
-from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.message_edit import (
@@ -30,6 +29,9 @@ from zerver.lib.user_topics import (
 )
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import Message, Realm, Stream, UserMessage, UserProfile, get_realm, get_stream
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class EditMessageTestCase(ZulipTestCase):
@@ -2732,17 +2734,17 @@ class DeleteMessageTest(ZulipTestCase):
             )
             self.assert_json_success(result)
 
-        def test_delete_message_by_admin(msg_id: int) -> HttpResponse:
+        def test_delete_message_by_admin(msg_id: int) -> "TestHttpResponse":
             self.login("iago")
             result = self.client_delete(f"/json/messages/{msg_id}")
             return result
 
-        def test_delete_message_by_owner(msg_id: int) -> HttpResponse:
+        def test_delete_message_by_owner(msg_id: int) -> "TestHttpResponse":
             self.login("hamlet")
             result = self.client_delete(f"/json/messages/{msg_id}")
             return result
 
-        def test_delete_message_by_other_user(msg_id: int) -> HttpResponse:
+        def test_delete_message_by_other_user(msg_id: int) -> "TestHttpResponse":
             self.login("cordelia")
             result = self.client_delete(f"/json/messages/{msg_id}")
             return result

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -1,11 +1,10 @@
 import datetime
 import os
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 from unittest import mock
 
 import orjson
 from django.db import connection
-from django.http import HttpResponse
 from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 from sqlalchemy.sql import ClauseElement, Select, and_, column, select, table
@@ -58,6 +57,9 @@ from zerver.views.message_fetch import (
     ok_to_include_history,
     post_process_limited_query,
 )
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 def get_sqlalchemy_sql(query: ClauseElement) -> str:
@@ -1610,7 +1612,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.logout()
 
     def verify_web_public_query_result_success(
-        self, result: HttpResponse, expected_num_messages: int
+        self, result: "TestHttpResponse", expected_num_messages: int
     ) -> None:
         self.assert_json_success(result)
         messages = orjson.loads(result.content)["messages"]

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1,9 +1,8 @@
-from typing import Any, List, Mapping, Set
+from typing import TYPE_CHECKING, Any, List, Mapping, Set
 from unittest import mock
 
 import orjson
 from django.db import connection
-from django.http import HttpResponse
 
 from zerver.actions.message_flags import do_update_message_flags
 from zerver.actions.streams import do_change_stream_permission
@@ -34,6 +33,9 @@ from zerver.models import (
     get_realm,
     get_stream,
 )
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 def check_flags(flags: List[str], expected: Set[str]) -> None:
@@ -1019,7 +1021,9 @@ class MessageAccessTests(ZulipTestCase):
         )
         self.assert_json_error(result, "Invalid message flag operation: 'bogus'")
 
-    def change_star(self, messages: List[int], add: bool = True, **kwargs: Any) -> HttpResponse:
+    def change_star(
+        self, messages: List[int], add: bool = True, **kwargs: Any
+    ) -> "TestHttpResponse":
         return self.client_post(
             "/json/messages/flags",
             {

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1,12 +1,11 @@
 import datetime
-from typing import Any, List, Mapping, Optional, Set
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Set
 from unittest import mock
 
 import orjson
 import pytz
 from django.conf import settings
 from django.db.models import Q
-from django.http import HttpResponse
 from django.test import override_settings
 from django.utils.timezone import now as timezone_now
 
@@ -65,6 +64,9 @@ from zerver.models import (
     get_user,
 )
 from zerver.views.message_send import InvalidMirrorInput
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class MessagePOSTTest(ZulipTestCase):
@@ -1350,7 +1352,7 @@ class ScheduledMessageTest(ZulipTestCase):
         tz_guess: str = "",
         delivery_type: str = "send_later",
         realm_str: str = "zulip",
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         self.login("hamlet")
 
         topic_name = ""

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, List, Mapping
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping
 from unittest import mock
 
 import orjson
-from django.http import HttpResponse
 
 from zerver.actions.reactions import notify_reaction_update
 from zerver.actions.streams import do_change_stream_permission
@@ -13,6 +12,9 @@ from zerver.lib.message import extract_message_dict
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import zulip_reaction_info
 from zerver.models import Message, Reaction, RealmEmoji, UserMessage, get_realm
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class ReactionEmojiTest(ZulipTestCase):
@@ -622,7 +624,7 @@ class EmojiReactionBase(ZulipTestCase):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    def post_reaction(self, reaction_info: Dict[str, str]) -> HttpResponse:
+    def post_reaction(self, reaction_info: Dict[str, str]) -> "TestHttpResponse":
         message_id = 1
 
         result = self.api_post(
@@ -630,7 +632,7 @@ class EmojiReactionBase(ZulipTestCase):
         )
         return result
 
-    def post_other_reaction(self, reaction_info: Dict[str, str]) -> HttpResponse:
+    def post_other_reaction(self, reaction_info: Dict[str, str]) -> "TestHttpResponse":
         message_id = 1
 
         result = self.api_post(
@@ -638,7 +640,7 @@ class EmojiReactionBase(ZulipTestCase):
         )
         return result
 
-    def delete_reaction(self, reaction_info: Dict[str, str]) -> HttpResponse:
+    def delete_reaction(self, reaction_info: Dict[str, str]) -> "TestHttpResponse":
         message_id = 1
 
         result = self.api_delete(

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -1,15 +1,17 @@
 import copy
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping
 from unittest import mock
 
 import orjson
 from django.conf import settings
-from django.http import HttpResponse
 
 from zerver.actions.user_settings import do_change_full_name
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import SCIMClient, UserProfile, get_realm
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class SCIMTestCase(ZulipTestCase):
@@ -39,7 +41,7 @@ class SCIMTestCase(ZulipTestCase):
             },
         }
 
-    def assert_uniqueness_error(self, result: HttpResponse, extra_message: str) -> None:
+    def assert_uniqueness_error(self, result: "TestHttpResponse", extra_message: str) -> None:
         self.assertEqual(result.status_code, 409)
         output_data = orjson.loads(result.content)
 

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -1,10 +1,10 @@
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 from unittest import mock
 
 import orjson
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
 from django.test import override_settings
 
 from zerver.lib.initial_password import initial_password
@@ -19,6 +19,9 @@ from zerver.models import (
     UserProfile,
     get_user_profile_by_api_key,
 )
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class ChangeSettingsTest(ZulipTestCase):
@@ -411,7 +414,7 @@ class ChangeSettingsTest(ZulipTestCase):
             hamlet = self.example_user("hamlet")
             self.assertNotEqual(getattr(hamlet, setting_name), invalid_value)
 
-    def do_change_emojiset(self, emojiset: str) -> HttpResponse:
+    def do_change_emojiset(self, emojiset: str) -> "TestHttpResponse":
         self.login("hamlet")
         data = {"emojiset": emojiset}
         result = self.client_patch("/json/settings", data)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2,7 +2,7 @@ import datetime
 import re
 import time
 import urllib
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlencode
 
@@ -111,6 +111,9 @@ from zerver.views.development.registration import confirmation_key
 from zerver.views.invite import get_invitee_emails_set
 from zerver.views.registration import accounts_home
 from zproject.backends import ExternalAuthDataDict, ExternalAuthResult
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class RedirectAndLogIntoSubdomainTestCase(ZulipTestCase):
@@ -1077,7 +1080,7 @@ class InviteUserBase(ZulipTestCase):
         invite_expires_in_minutes: Optional[int] = settings.INVITATION_LINK_VALIDITY_MINUTES,
         body: str = "",
         invite_as: int = PreregistrationUser.INVITE_AS["MEMBER"],
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         """
         Invites the specified users to Zulip with the specified streams.
 
@@ -1162,7 +1165,7 @@ class InviteUserTest(InviteUserBase):
         realm.date_created = timezone_now()
         realm.save()
 
-        def try_invite() -> HttpResponse:
+        def try_invite() -> "TestHttpResponse":
             with self.settings(
                 OPEN_REALM_CREATION=True,
                 INVITES_DEFAULT_REALM_DAILY_MAX=site_max,
@@ -3868,7 +3871,7 @@ class RealmCreationTest(ZulipTestCase):
 
 
 class UserSignUpTest(InviteUserBase):
-    def _assert_redirected_to(self, result: HttpResponse, url: str) -> None:
+    def _assert_redirected_to(self, result: "TestHttpResponse", url: str) -> None:
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["LOCATION"], url)
 
@@ -3880,7 +3883,7 @@ class UserSignUpTest(InviteUserBase):
         full_name: str = "New user's name",
         realm: Optional[Realm] = None,
         subdomain: Optional[str] = None,
-    ) -> Union[UserProfile, HttpResponse]:
+    ) -> Union[UserProfile, "TestHttpResponse"]:
         """Common test function for signup tests.  It is a goal to use this
         common function for all signup tests to avoid code duplication; doing
         so will likely require adding new parameters."""
@@ -4089,6 +4092,8 @@ class UserSignUpTest(InviteUserBase):
         """
 
         result = self.verify_signup(full_name="<invalid>")
+        # _WSGIPatchedWSGIResponse does not exist in Django, thus the inverted isinstance check.
+        assert not isinstance(result, UserProfile)
         self.assert_in_success_response(["Invalid characters in name!"], result)
 
         # Verify that the user is asked for name and password
@@ -4115,6 +4120,8 @@ class UserSignUpTest(InviteUserBase):
         email = "newguy@zulip.com"
         password = "newpassword"
         result = self.verify_signup(email=email, password=password, full_name="")
+        # _WSGIPatchedWSGIResponse does not exist in Django, thus the inverted isinstance check.
+        assert not isinstance(result, UserProfile)
         self.assert_in_success_response(["We just need you to do one last thing."], result)
 
         # Verify that the user is asked for name and password

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2,7 +2,7 @@ import hashlib
 import random
 from datetime import timedelta
 from io import StringIO
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Set, Union
 from unittest import mock
 
 import orjson
@@ -104,6 +104,9 @@ from zerver.models import (
     validate_attachment_request_for_spectator_access,
 )
 from zerver.views.streams import compose_views
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class TestMiscStuff(ZulipTestCase):
@@ -2379,7 +2382,7 @@ class StreamAdminTest(ZulipTestCase):
         target_users_subbed: bool = True,
         using_legacy_emails: bool = False,
         other_sub_users: Sequence[UserProfile] = [],
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
 
         # Set up the main user, who is in most cases an admin.
         if is_realm_admin:
@@ -5699,7 +5702,7 @@ class GetSubscribersTest(ZulipTestCase):
 
     def make_subscriber_request(
         self, stream_id: int, user: Optional[UserProfile] = None
-    ) -> HttpResponse:
+    ) -> "TestHttpResponse":
         if user is None:
             user = self.user_profile
         return self.api_get(user, f"/api/v1/streams/{stream_id}/members")

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -1,14 +1,16 @@
 import re
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 import orjson
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.validator import check_widget_content
 from zerver.lib.widget import get_widget_data, get_widget_type
 from zerver.models import SubMessage, UserProfile
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class WidgetContentTestCase(ZulipTestCase):
@@ -238,7 +240,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         message = self.get_last_message()
 
-        def post(sender: UserProfile, data: Dict[str, object]) -> HttpResponse:
+        def post(sender: UserProfile, data: Dict[str, object]) -> "TestHttpResponse":
             payload = dict(
                 message_id=message.id, msg_type="widget", content=orjson.dumps(data).decode()
             )
@@ -266,7 +268,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         message = self.get_last_message()
 
-        def post_submessage(content: str) -> HttpResponse:
+        def post_submessage(content: str) -> "TestHttpResponse":
             payload = dict(
                 message_id=message.id,
                 msg_type="widget",
@@ -324,7 +326,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         message = self.get_last_message()
 
-        def post_submessage(content: str) -> HttpResponse:
+        def post_submessage(content: str) -> "TestHttpResponse":
             payload = dict(
                 message_id=message.id,
                 msg_type="widget",

--- a/zerver/tests/test_zephyr.py
+++ b/zerver/tests/test_zephyr.py
@@ -1,13 +1,15 @@
 import subprocess
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import orjson
-from django.http import HttpResponse
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.users import get_api_key
 from zerver.models import get_realm, get_user
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
 class ZephyrTest(ZulipTestCase):
@@ -15,7 +17,7 @@ class ZephyrTest(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
 
-        def post(subdomain: Any, **kwargs: Any) -> HttpResponse:
+        def post(subdomain: Any, **kwargs: Any) -> "TestHttpResponse":
             params = {k: orjson.dumps(v).decode() for k, v in kwargs.items()}
             return self.client_post(
                 "/accounts/webathena_kerberos_login/", params, subdomain=subdomain


### PR DESCRIPTION
Replace `HttpResponse` with `_MonkeyPatchedWSGIResponse`.

This allows us to access monkey-patched attributes on the `HttpResponse` object returned by the Django test client in a type-safe manner when django-stubs support is added.

This is a follow-up to #22152 and #22185.

This PR intentionally leaves out handling an error reported by mypy (182 occurrences), since it will be automatically [resolved](https://github.com/typeddjango/django-stubs/pull/968) with the next release of django-stubs (1.11.0+).

We have to import `_MonkeyPatchedWSGIResponse` only if `TYPE_CHECKING` is `True`, since this type only exists in the stubs.

Except for the assertion added in [zerver/tests/test_signup.py](https://github.com/zulip/zulip/pull/22209/commits/ee8897f43aa86176fd771b00ccbfcdc09d21dbe6#diff-940c870652d79870a457600e9cde59f74a5b9980268c9df6e62e0c0d846b7e66), minor changes to [zerver/tests/test_external.py](https://github.com/zulip/zulip/pull/22209/commits/ee8897f43aa86176fd771b00ccbfcdc09d21dbe6#diff-1b9b3fe3dc15729569b699c7080b27fe242ac440e98115443b7113abb26baea4), this PR is intended to have no behavioral change on the codebase other than altering the types.

```
"_MonkeyPatchedWSGIResponse" has no attribute "content"; maybe "context"?  [attr-defined]
```


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
