### PR TITLE
docs: Update documentation of max number of thumbnails per message.

### DIFF
--- a/templates/zerver/help/share-and-upload-files.md
+++ b/templates/zerver/help/share-and-upload-files.md
@@ -19,7 +19,7 @@ sending to see what the thumbnail will look like.
 
 ## Troubleshooting info
 
-Zulip does not generate thumbnails for messages with more than 5
+Zulip does not generate thumbnails for messages with more than ten
 attachments.
 
 The maximum file size for attachments is 25MB in most Zulip installations.


### PR DESCRIPTION
The max was changed to 10 in https://github.com/zulip/zulip/pull/20789.
