### PR TITLE
recent-topics: Mark as read using unread counters in Recent topics.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -720,6 +720,30 @@ export function focus_clicked_element(topic_row_index, col, topic_key) {
     set_table_focus(row_focus, col_focus);
 }
 
+function left_arrow_navigation() {
+    col_focus -= 1;
+
+    if (col_focus < 0) {
+        col_focus = MAX_SELECTABLE_COLS - 1;
+    }
+}
+
+function right_arrow_navigation() {
+    col_focus += 1;
+
+    if (col_focus >= MAX_SELECTABLE_COLS) {
+        col_focus = 0;
+    }
+}
+
+function up_arrow_navigation() {
+    row_focus -= 1;
+}
+
+function down_arrow_navigation() {
+    row_focus += 1;
+}
+
 export function change_focused_element($elt, input_key) {
     // Called from hotkeys.js; like all logic in that module,
     // returning true will cause the caller to do
@@ -833,18 +857,12 @@ export function change_focused_element($elt, input_key) {
             case "shift_tab":
             case "vim_left":
             case "left_arrow":
-                col_focus -= 1;
-                if (col_focus < 0) {
-                    col_focus = MAX_SELECTABLE_COLS - 1;
-                }
+                left_arrow_navigation();
                 break;
             case "tab":
             case "vim_right":
             case "right_arrow":
-                col_focus += 1;
-                if (col_focus >= MAX_SELECTABLE_COLS) {
-                    col_focus = 0;
-                }
+                right_arrow_navigation();
                 break;
             case "vim_down":
                 // We stop user at last table row
@@ -857,10 +875,10 @@ export function change_focused_element($elt, input_key) {
                 if (is_focus_at_last_table_row()) {
                     return true;
                 }
-                row_focus += 1;
+                down_arrow_navigation();
                 break;
             case "down_arrow":
-                row_focus += 1;
+                down_arrow_navigation();
                 break;
             case "vim_up":
                 // See comment on vim_down.
@@ -870,10 +888,10 @@ export function change_focused_element($elt, input_key) {
                 if (row_focus === 0) {
                     return true;
                 }
-                row_focus -= 1;
+                up_arrow_navigation();
                 break;
             case "up_arrow":
-                row_focus -= 1;
+                up_arrow_navigation();
         }
         set_table_focus(row_focus, col_focus, true);
         return true;

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -141,8 +141,9 @@
         }
 
         .unread_count {
-            margin-right: 10px;
-            margin-left: 10px;
+            /* Focus underline can only occupy the total length of the unread count */
+            margin-right: 1px;
+            margin-left: 1px;
             align-self: center;
             background-color: hsl(105, 2%, 50%);
         }
@@ -166,6 +167,8 @@
         }
 
         .recent_topic_actions {
+            /* To add spacing between unread count and mute icon */
+            margin-left: 10px;
             display: flex;
             flex-flow: row nowrap;
         }

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -13,7 +13,11 @@
                 <a href="{{topic_url}}">{{topic}}</a>
             </div>
             <div class="right_part">
-                <span class="unread_count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                <div class="recent_topic_actions">
+                    <div class="recent_topics_focusable hidden-for-spectators">
+                        <span class="unread_count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                    </div>
+                </div>
                 <div class="recent_topic_actions">
                     <div class="recent_topics_focusable hidden-for-spectators">
                         {{#if topic_muted}}


### PR DESCRIPTION
@timabbott  Copy of PR #22201 

The PR changes the following behaviors and UI:
1. Removes the checkmark button to mark the topic as read in
"Recent Topics".
2. Make the unread messages counter be the button for marking
all messages in the topic as read. The unread messages counter
is made clickable and tooltip is set to "Mark as read".

In "recent_topic_row.hbs", remove the checkmark button and add
classes and attributes to ".unread_counter" to give it desirable
behaviour on clicking.

In "zulip.css" set "opacity: 0.7" for ".on_hover_topic_read".

In "recent_topics.css" we set the background-color of unread counter to
hsl(105, 2%, 50%) to decrease fading of unread counter.

Fixes: #21654