### PR TITLE
tornado: Fix race condition on handler._request

### DIFF
--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -125,6 +125,7 @@ def get_events_backend(
     assert tornado_handler is not None
     handler = tornado_handler()
     assert handler is not None
+    handler._request = request
 
     if user_client is None:
         valid_user_client = RequestNotes.get_notes(request).client
@@ -173,7 +174,6 @@ def get_events_backend(
         # Return an AsynchronousResponse; this will result in
         # Tornado discarding the response and instead long-polling the
         # request.  See zulip_finish for more design details.
-        handler._request = request
         return AsynchronousResponse()
     if result["type"] == "error":
         raise result["exception"]


### PR DESCRIPTION
Commit 6fd1a558b7fe2a0d5f2fb073e17294d27bb493c0 (#21469) introduced an await point where `get_events_backend` calls `fetch_events` in order to switch threads. This opened the possibility that, in the window between the `connect_handler` call in `fetch_events` and the old location of this assignment in `get_events_backend`, an event could arrive, causing `ClientDescriptor.add_event` to crash on missing `handler._request`. Fix this by assigning `handler._request` earlier.

I found this by trying to improve #22058 (cc @asah) to avoid relying on a fixed timeout. So this improved test now also serves as a test case for this race condition.