### PR TITLE
help-docs: Document "Mute/Unmute topic" mobile app feature

### DIFF
--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -6,29 +6,18 @@ or **Recent topics**, nor do they generate notifications (including
 notifications), unless you are [mentioned](/help/mention-a-user-or-group).
 They also do not contribute to stream unread counts.
 
-## From the left sidebar
+## Mute a topic
 
 {start_tabs}
 
-1. In the left sidebar, click on the stream that
-   contains the topic you want to mute.
+{!topic-actions.md!}
 
-1. Hover over the topic in the left sidebar.
+1. Select **Mute topic**.
 
-1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+!!! tip ""
 
-4. Select **Mute topic**.
-
-{end_tabs}
-
-### From the message recipient bar (alternate method)
-
-{start_tabs}
-
-1. Find a message belonging to the topic that you
-   wish to mute.
-
-1. Click on the <i class="fa fa-bell-slash"></i> to mute the topic.
+    You can also click on the <i class="fa fa-bell-slash"></i> in the message
+    recipient bar to mute the topic.
 
 {end_tabs}
 
@@ -38,9 +27,9 @@ They also do not contribute to stream unread counts.
 
 {settings_tab|muted-topics}
 
-{end_tabs}
+1. Review and unmute any muted topics.
 
-From there, you can review and unmute any muted topics.
+{end_tabs}
 
 ## Related articles
 

--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -10,6 +10,8 @@ They also do not contribute to stream unread counts.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!topic-actions.md!}
 
 1. Select **Mute topic**.
@@ -19,15 +21,41 @@ They also do not contribute to stream unread counts.
     You can also click on the <i class="fa fa-bell-slash"></i> in the message
     recipient bar to mute the topic.
 
+{tab|mobile}
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Mute topic**.
+
+{!topic-long-press-menu-tip.md!}
+
 {end_tabs}
 
 ## Browse and unmute previously muted topics
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {settings_tab|muted-topics}
 
 1. Review and unmute any muted topics.
+
+{tab|mobile}
+
+1. Tap the streams (<i class="fa fa-hashtag"></i>) tab.
+
+1. Select a stream containing topics you want to unmute.
+
+1. Tap the topics list (<i class="fa fa-list-ul"></i>) icon.
+
+1. Press and hold a topic name to access the long-press menu.
+
+1. Tap **Unmute topic**.
+
+!!! tip ""
+
+    Muted topics are grayed out in the topics list.
 
 {end_tabs}
 

--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -39,7 +39,7 @@ They also do not contribute to stream unread counts.
 
 {settings_tab|muted-topics}
 
-1. Review and unmute any muted topics.
+1. Click **Unmute** next to each topic you want to unmute.
 
 {tab|mobile}
 

--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -43,11 +43,11 @@ They also do not contribute to stream unread counts.
 
 {tab|mobile}
 
-1. Tap the streams (<i class="fa fa-hashtag"></i>) tab.
+1. Tap the **Streams** (<i class="fa fa-hashtag"></i>) tab.
 
 1. Select a stream containing topics you want to unmute.
 
-1. Tap the topics list (<i class="fa fa-list-ul"></i>) icon.
+1. Tap the **Topics list** (<i class="fa fa-list-ul"></i>) icon.
 
 1. Press and hold a topic name to access the long-press menu.
 


### PR DESCRIPTION
This pull request adds documentation for muting and unmuting topics on mobile.

Fixes #22146.

## Rendered docs

**[Current docs](https://zulip.com/help/mute-a-topic)**

<details>
<summary><strong>Desktop/Web instructions</strong></summary>
<img width="527" alt="Desktop / Web instructions" src="https://user-images.githubusercontent.com/107157325/172968454-18066813-1c72-4a8d-9cb6-5e7967c669a0.png">
</details>

<details>
<summary><strong>Mobile instructions</strong></summary>
<img width="527" alt="Mobile instructions" src="https://user-images.githubusercontent.com/107157325/172968484-f096b0c7-1b08-45a3-ba04-c5190421c801.png">
</details>

## Testing

I tested these instructions on the web, desktop, and iOS apps. I haven’t got the apps building for the Android or iPad simulators yet. However, I’ve reviewed this [list of differences between mobile platforms](https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20differences) and I don’t think any of these differences will affect the instructions in this pull request.

## Writing choices

- I took the approach suggested in #22178. First, I merged the two ways of muting a topic into one set of instructions. Then, I added new tabs containing instructions for mobile.

- There are three ways to access the long-press menu (topic bar, top bar, topics list). I described the first two methods for muting topics, but described the last method for unmuting topics. I think it makes most sense to mute a topic while you’re reading its messages, but when unmuting topics, it’s easiest to do this from the topics list.

## Remaining concerns

- Is this the preferred way to unmute topics on mobile? It’s less convenient than on desktop/web because the user must tap into each stream one-by-one, rather than seeing a single list of all muted topics. Am I overlooking a better way to do this?

- Will readers be confused by the term ‘topic bar’? At first, I thought this was the bar at the top of the screen. Could a screenshot be helpful here?

- This article links to the **Muted topics** settings page. However, this link won’t work for the desktop app because it will open in the user’s browser. Should this link be replaced with a description of how to open the settings page?

- There’s some duplication related to the `topic-long-press-menu.md` macro. The macro states: “Press and hold **the topic bar** to access the long-press menu.” However I didn’t use the macro because I wanted the step to say: “Press and hold **a topic name** to access the long-press menu.” Is this amount of duplication ok?

<details>
<summary><strong>Self-review checklist</strong></summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

</details>