### PR TITLE
tests: Refactor test client wrappers with explicitly typed fields.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -544,17 +544,13 @@ class StripeTestCase(ZulipTestCase):
         invoice: bool = False,
         talk_to_stripe: bool = True,
         onboarding: bool = False,
-        realm: Optional[Realm] = None,
         payment_method: Optional[stripe.PaymentMethod] = None,
         upgrade_page_response: Optional["TestHttpResponse"] = None,
         del_args: Sequence[str] = [],
         **kwargs: Any,
     ) -> "TestHttpResponse":
-        host_args = {}
-        if realm is not None:  # nocoverage: TODO
-            host_args["HTTP_HOST"] = realm.host
         if upgrade_page_response is None:
-            upgrade_page_response = self.client_get("/upgrade/", {}, **host_args)
+            upgrade_page_response = self.client_get("/upgrade/", {})
         params: Dict[str, Any] = {
             "schedule": "annual",
             "signed_seat_count": self.get_signed_seat_count_from_response(upgrade_page_response),
@@ -584,7 +580,7 @@ class StripeTestCase(ZulipTestCase):
         if talk_to_stripe:
             [last_event] = stripe.Event.list(limit=1)
 
-        upgrade_json_response = self.client_post("/json/billing/upgrade", params, **host_args)
+        upgrade_json_response = self.client_post("/json/billing/upgrade", params)
 
         if invoice or not talk_to_stripe:
             return upgrade_json_response

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -137,12 +137,6 @@ class UploadSerializeMixin(SerializeMixin):
         super().setUpClass()
 
 
-# We could be more specific about which arguments are bool (Django's
-# follow and secure, our intentionally_undocumented) and which are str
-# (everything else), but explaining that to mypy is tedious.
-ClientArg = Union[str, bool]
-
-
 class ZulipTestCase(TestCase):
     # Ensure that the test system just shows us diffs
     maxDiff: Optional[int] = None
@@ -215,16 +209,16 @@ Output:
     DEFAULT_SUBDOMAIN = "zulip"
     TOKENIZED_NOREPLY_REGEX = settings.TOKENIZED_NOREPLY_EMAIL_ADDRESS.format(token="[a-z0-9_]{24}")
 
-    def set_http_headers(self, kwargs: Dict[str, ClientArg]) -> None:
-        if "subdomain" in kwargs:
-            assert isinstance(kwargs["subdomain"], str)
-            kwargs["HTTP_HOST"] = Realm.host_for_subdomain(kwargs["subdomain"])
-            del kwargs["subdomain"]
-        elif "HTTP_HOST" not in kwargs:
-            kwargs["HTTP_HOST"] = Realm.host_for_subdomain(self.DEFAULT_SUBDOMAIN)
+    def set_http_headers(self, extra: Dict[str, str], skip_user_agent: bool = False) -> None:
+        if "subdomain" in extra:
+            assert isinstance(extra["subdomain"], str)
+            extra["HTTP_HOST"] = Realm.host_for_subdomain(extra["subdomain"])
+            del extra["subdomain"]
+        elif "HTTP_HOST" not in extra:
+            extra["HTTP_HOST"] = Realm.host_for_subdomain(self.DEFAULT_SUBDOMAIN)
 
         # set User-Agent
-        if "HTTP_AUTHORIZATION" in kwargs:
+        if "HTTP_AUTHORIZATION" in extra:
             # An API request; use mobile as the default user agent
             default_user_agent = "ZulipMobile/26.22.145 (iOS 10.3.1)"
         else:
@@ -234,12 +228,11 @@ Output:
                 + "AppleWebKit/537.36 (KHTML, like Gecko) "
                 + "Chrome/79.0.3945.130 Safari/537.36"
             )
-        if kwargs.get("skip_user_agent"):
+        if skip_user_agent:
             # Provide a way to disable setting User-Agent if desired.
-            assert "HTTP_USER_AGENT" not in kwargs
-            del kwargs["skip_user_agent"]
-        elif "HTTP_USER_AGENT" not in kwargs:
-            kwargs["HTTP_USER_AGENT"] = default_user_agent
+            assert "HTTP_USER_AGENT" not in extra
+        elif "HTTP_USER_AGENT" not in extra:
+            extra["HTTP_USER_AGENT"] = default_user_agent
 
     def extract_api_suffix_url(self, url: str) -> Tuple[str, Dict[str, List[str]]]:
         """
@@ -260,7 +253,7 @@ Output:
         method: str,
         result: "TestHttpResponse",
         data: Union[str, bytes, Dict[str, Any]],
-        kwargs: Dict[str, ClientArg],
+        extra: Dict[str, str],
         intentionally_undocumented: bool = False,
     ) -> None:
         """
@@ -288,12 +281,11 @@ Output:
             content, url, method, str(result.status_code)
         )
         if response_validated:
-            http_headers = {k: v for k, v in kwargs.items() if isinstance(v, str)}
             validate_request(
                 url,
                 method,
                 data,
-                http_headers,
+                extra,
                 json_url,
                 str(result.status_code),
                 intentionally_undocumented=intentionally_undocumented,
@@ -304,30 +296,40 @@ Output:
         self,
         url: str,
         info: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
         intentionally_undocumented: bool = False,
-        **kwargs: ClientArg,
+        **extra: str,
     ) -> "TestHttpResponse":
         """
         We need to urlencode, since Django's function won't do it for us.
         """
         encoded = urllib.parse.urlencode(info)
-        kwargs["content_type"] = "application/x-www-form-urlencoded"
+        extra["content_type"] = "application/x-www-form-urlencoded"
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        result = django_client.patch(url, encoded, **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        result = django_client.patch(url, encoded, follow=follow, secure=secure, **extra)
         self.validate_api_response_openapi(
             url,
             "patch",
             result,
             info,
-            kwargs,
+            extra,
             intentionally_undocumented=intentionally_undocumented,
         )
         return result
 
     @instrument_url
     def client_patch_multipart(
-        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        info: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        intentionally_undocumented: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
         """
         Use this for patch requests that have file uploads or
@@ -339,79 +341,143 @@ Output:
         """
         encoded = encode_multipart(BOUNDARY, info)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        result = django_client.patch(url, encoded, content_type=MULTIPART_CONTENT, **kwargs)
-        self.validate_api_response_openapi(url, "patch", result, info, kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        result = django_client.patch(
+            url, encoded, content_type=MULTIPART_CONTENT, follow=follow, secure=secure, **extra
+        )
+        self.validate_api_response_openapi(
+            url,
+            "patch",
+            result,
+            info,
+            extra,
+            intentionally_undocumented=intentionally_undocumented,
+        )
         return result
 
     def json_patch(
-        self, url: str, payload: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        payload: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
         data = orjson.dumps(payload)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        return django_client.patch(url, data=data, content_type="application/json", **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        return django_client.patch(
+            url, data=data, content_type="application/json", follow=follow, secure=secure, **extra
+        )
 
     @instrument_url
     def client_put(
-        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        info: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
-        kwargs["content_type"] = "application/x-www-form-urlencoded"
+        extra["content_type"] = "application/x-www-form-urlencoded"
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        return django_client.put(url, encoded, **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        return django_client.put(url, encoded, follow=follow, secure=secure, **extra)
 
     def json_put(
-        self, url: str, payload: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        payload: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
         data = orjson.dumps(payload)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        return django_client.put(url, data=data, content_type="application/json", **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        return django_client.put(
+            url, data=data, content_type="application/json", follow=follow, secure=secure, **extra
+        )
 
     @instrument_url
     def client_delete(
-        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        info: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        intentionally_undocumented: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
-        kwargs["content_type"] = "application/x-www-form-urlencoded"
+        extra["content_type"] = "application/x-www-form-urlencoded"
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        result = django_client.delete(url, encoded, **kwargs)
-        self.validate_api_response_openapi(url, "delete", result, info, kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        result = django_client.delete(url, encoded, follow=follow, secure=secure, **extra)
+        self.validate_api_response_openapi(
+            url,
+            "delete",
+            result,
+            info,
+            extra,
+            intentionally_undocumented=intentionally_undocumented,
+        )
         return result
 
     @instrument_url
     def client_options(
-        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        info: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        return django_client.options(url, info, **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        return django_client.options(url, info, follow=follow, secure=secure, **extra)
 
     @instrument_url
     def client_head(
-        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        info: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        return django_client.head(url, info, **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        return django_client.head(url, info, follow=follow, secure=secure, **extra)
 
     @instrument_url
     def client_post(
         self,
         url: str,
         info: Union[str, bytes, Dict[str, Any]] = {},
-        **kwargs: ClientArg,
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        intentionally_undocumented: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
-        intentionally_undocumented = kwargs.pop("intentionally_undocumented", False)
-        assert isinstance(intentionally_undocumented, bool)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        result = django_client.post(url, info, **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        result = django_client.post(url, info, follow=follow, secure=secure, **extra)
         self.validate_api_response_openapi(
-            url, "post", result, info, kwargs, intentionally_undocumented=intentionally_undocumented
+            url,
+            "post",
+            result,
+            info,
+            extra,
+            intentionally_undocumented=intentionally_undocumented,
         )
         return result
 
@@ -431,15 +497,20 @@ Output:
 
     @instrument_url
     def client_get(
-        self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self,
+        url: str,
+        info: Dict[str, Any] = {},
+        skip_user_agent: bool = False,
+        follow: bool = False,
+        secure: bool = False,
+        intentionally_undocumented: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
-        intentionally_undocumented = kwargs.pop("intentionally_undocumented", False)
-        assert isinstance(intentionally_undocumented, bool)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_headers(kwargs)
-        result = django_client.get(url, info, **kwargs)
+        self.set_http_headers(extra, skip_user_agent)
+        result = django_client.get(url, info, follow=follow, secure=secure, **extra)
         self.validate_api_response_openapi(
-            url, "get", result, info, kwargs, intentionally_undocumented=intentionally_undocumented
+            url, "get", result, info, extra, intentionally_undocumented=intentionally_undocumented
         )
         return result
 
@@ -573,12 +644,18 @@ Output:
         self.assertEqual(page_params["is_spectator"], False)
 
     def login_with_return(
-        self, email: str, password: Optional[str] = None, **kwargs: ClientArg
+        self, email: str, password: Optional[str] = None, **extra: str
     ) -> "TestHttpResponse":
         if password is None:
             password = initial_password(email)
         result = self.client_post(
-            "/accounts/login/", {"username": email, "password": password}, **kwargs
+            "/accounts/login/",
+            {"username": email, "password": password},
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
         )
         self.assertNotEqual(result.status_code, 500)
         return result
@@ -671,7 +748,7 @@ Output:
         realm_type: int = Realm.ORG_TYPES["business"]["id"],
         enable_marketing_emails: Optional[bool] = None,
         is_demo_organization: bool = False,
-        **kwargs: ClientArg,
+        **extra: str,
     ) -> "TestHttpResponse":
         """
         Stage two of the two-step registration process.
@@ -679,7 +756,7 @@ Output:
         If things are working correctly the account should be fully
         registered after this call.
 
-        You can pass the HTTP_HOST variable for subdomains via kwargs.
+        You can pass the HTTP_HOST variable for subdomains via extra.
         """
         if full_name is None:
             full_name = email.replace("@", "_")
@@ -702,7 +779,15 @@ Output:
             payload["password"] = password
         if realm_in_root_domain is not None:
             payload["realm_in_root_domain"] = realm_in_root_domain
-        return self.client_post("/accounts/register/", payload, **kwargs)
+        return self.client_post(
+            "/accounts/register/",
+            payload,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
+        )
 
     def get_confirmation_url_from_outbox(
         self,
@@ -768,55 +853,97 @@ Output:
         return "Basic " + base64.b64encode(credentials.encode()).decode()
 
     def uuid_get(
-        self, identifier: str, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self, identifier: str, url: str, info: Dict[str, Any] = {}, **extra: str
     ) -> "TestHttpResponse":
-        kwargs["HTTP_AUTHORIZATION"] = self.encode_uuid(identifier)
-        return self.client_get(url, info, **kwargs)
+        extra["HTTP_AUTHORIZATION"] = self.encode_uuid(identifier)
+        return self.client_get(
+            url,
+            info,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
+        )
 
     def uuid_post(
         self,
         identifier: str,
         url: str,
         info: Union[str, bytes, Dict[str, Any]] = {},
-        **kwargs: ClientArg,
+        **extra: str,
     ) -> "TestHttpResponse":
-        kwargs["HTTP_AUTHORIZATION"] = self.encode_uuid(identifier)
-        return self.client_post(url, info, **kwargs)
+        extra["HTTP_AUTHORIZATION"] = self.encode_uuid(identifier)
+        return self.client_post(
+            url,
+            info,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
+        )
 
     def api_get(
-        self, user: UserProfile, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self, user: UserProfile, url: str, info: Dict[str, Any] = {}, **extra: str
     ) -> "TestHttpResponse":
-        kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
-        return self.client_get(url, info, **kwargs)
+        extra["HTTP_AUTHORIZATION"] = self.encode_user(user)
+        return self.client_get(
+            url,
+            info,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
+        )
 
     def api_post(
         self,
         user: UserProfile,
         url: str,
         info: Union[str, bytes, Dict[str, Any]] = {},
-        **kwargs: ClientArg,
+        intentionally_undocumented: bool = False,
+        **extra: str,
     ) -> "TestHttpResponse":
-        kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
-        return self.client_post(url, info, **kwargs)
+        extra["HTTP_AUTHORIZATION"] = self.encode_user(user)
+        return self.client_post(
+            url,
+            info,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=intentionally_undocumented,
+            **extra,
+        )
 
     def api_patch(
-        self,
-        user: UserProfile,
-        url: str,
-        info: Dict[str, Any] = {},
-        intentionally_undocumented: bool = False,
-        **kwargs: ClientArg,
+        self, user: UserProfile, url: str, info: Dict[str, Any] = {}, **extra: str
     ) -> "TestHttpResponse":
-        kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
+        extra["HTTP_AUTHORIZATION"] = self.encode_user(user)
         return self.client_patch(
-            url, info, intentionally_undocumented=intentionally_undocumented, **kwargs
+            url,
+            info,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
         )
 
     def api_delete(
-        self, user: UserProfile, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
+        self, user: UserProfile, url: str, info: Dict[str, Any] = {}, **extra: str
     ) -> "TestHttpResponse":
-        kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
-        return self.client_delete(url, info, **kwargs)
+        extra["HTTP_AUTHORIZATION"] = self.encode_user(user)
+        return self.client_delete(
+            url,
+            info,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
+        )
 
     def get_streams(self, user_profile: UserProfile) -> List[str]:
         """
@@ -1115,7 +1242,7 @@ Output:
         invite_only: bool = False,
         is_web_public: bool = False,
         allow_fail: bool = False,
-        **kwargs: ClientArg,
+        **extra: str,
     ) -> "TestHttpResponse":
         post_data = {
             "subscriptions": orjson.dumps([{"name": stream} for stream in streams]).decode(),
@@ -1123,7 +1250,13 @@ Output:
             "invite_only": orjson.dumps(invite_only).decode(),
         }
         post_data.update(extra_post_data)
-        result = self.api_post(user, "/api/v1/users/me/subscriptions", post_data, **kwargs)
+        result = self.api_post(
+            user,
+            "/api/v1/users/me/subscriptions",
+            post_data,
+            intentionally_undocumented=False,
+            **extra,
+        )
         if not allow_fail:
             self.assert_json_success(result)
         return result
@@ -1148,7 +1281,7 @@ Output:
         user_profile: UserProfile,
         url: str,
         payload: Union[str, Dict[str, Any]],
-        **post_params: ClientArg,
+        **extra: str,
     ) -> Message:
         """
         Send a webhook payload to the server, and verify that the
@@ -1171,7 +1304,15 @@ Output:
 
         prior_msg = self.get_last_message()
 
-        result = self.client_post(url, payload, **post_params)
+        result = self.client_post(
+            url,
+            payload,
+            skip_user_agent=False,
+            follow=False,
+            secure=False,
+            intentionally_undocumented=False,
+            **extra,
+        )
         self.assert_json_success(result)
 
         # Check the correct message was sent
@@ -1659,11 +1800,16 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         expected_message: Optional[str] = None,
         content_type: Optional[str] = "application/json",
         expect_noop: bool = False,
-        **kwargs: ClientArg,
+        **extra: str,
     ) -> None:
-        kwargs["HTTP_AUTHORIZATION"] = self.encode_user(user)
+        extra["HTTP_AUTHORIZATION"] = self.encode_user(user)
         self.check_webhook(
-            fixture_name, expected_topic, expected_message, content_type, expect_noop, **kwargs
+            fixture_name,
+            expected_topic,
+            expected_message,
+            content_type,
+            expect_noop,
+            **extra,
         )
 
     def check_webhook(
@@ -1673,7 +1819,7 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         expected_message: Optional[str] = None,
         content_type: Optional[str] = "application/json",
         expect_noop: bool = False,
-        **kwargs: ClientArg,
+        **extra: str,
     ) -> None:
         """
         check_webhook is the main way to test "normal" webhooks that
@@ -1688,7 +1834,7 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
             expected_message: content
 
         We simulate the delivery of the payload with `content_type`,
-        and you can pass other headers via `kwargs`.
+        and you can pass other headers via `extra`.
 
         For the rare cases of webhooks actually sending private messages,
         see send_and_test_private_message.
@@ -1700,17 +1846,17 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
 
         payload = self.get_payload(fixture_name)
         if content_type is not None:
-            kwargs["content_type"] = content_type
+            extra["content_type"] = content_type
         if self.WEBHOOK_DIR_NAME is not None:
             headers = get_fixture_http_headers(self.WEBHOOK_DIR_NAME, fixture_name)
             headers = standardize_headers(headers)
-            kwargs.update(headers)
+            extra.update(headers)
         try:
             msg = self.send_webhook_payload(
                 self.test_user,
                 self.url,
                 payload,
-                **kwargs,
+                **extra,
             )
         except EmptyResponseError:
             if expect_noop:
@@ -1755,7 +1901,7 @@ one or more new messages.
         content_type: str = "application/json",
         *,
         sender: Optional[UserProfile] = None,
-        **kwargs: ClientArg,
+        **extra: str,
     ) -> Message:
         """
         For the rare cases that you are testing a webhook that sends
@@ -1765,12 +1911,12 @@ one or more new messages.
         check_webhook.
         """
         payload = self.get_payload(fixture_name)
-        kwargs["content_type"] = content_type
+        extra["content_type"] = content_type
 
         if self.WEBHOOK_DIR_NAME is not None:
             headers = get_fixture_http_headers(self.WEBHOOK_DIR_NAME, fixture_name)
             headers = standardize_headers(headers)
-            kwargs.update(headers)
+            extra.update(headers)
 
         if sender is None:
             sender = self.test_user
@@ -1779,7 +1925,7 @@ one or more new messages.
             sender,
             self.url,
             payload,
-            **kwargs,
+            **extra,
         )
         self.assertEqual(msg.content, expected_message)
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
     # Avoid an import cycle; we only need these for type annotations.
-    from zerver.lib.test_classes import ClientArg, MigrationsTestCase, ZulipTestCase
+    from zerver.lib.test_classes import MigrationsTestCase, ZulipTestCase
 
 
 class MockLDAP(fakeldap.MockLDAP):
@@ -363,12 +363,13 @@ def append_instrumentation_data(data: Dict[str, Any]) -> None:
 
 
 def instrument_url(f: UrlFuncT) -> UrlFuncT:
+    # TODO: Type this with ParamSpec to preserve the function signature.
     if not INSTRUMENTING:  # nocoverage -- option is always enabled; should we remove?
         return f
     else:
 
         def wrapper(
-            self: "ZulipTestCase", url: str, info: object = {}, **kwargs: "ClientArg"
+            self: "ZulipTestCase", url: str, info: object = {}, **kwargs: Union[bool, str]
         ) -> HttpResponseBase:
             start = time.time()
             result = f(self, url, info, **kwargs)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5121,8 +5121,9 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         self.assertEqual(parsed_url.query, "param1=value1&params=value2")
 
     def test_start_remote_user_sso_with_desktop_app(self) -> None:
-        headers = dict(HTTP_USER_AGENT="ZulipElectron/5.0.0")
-        result = self.client_get("/accounts/login/start/sso/", {}, **headers)
+        result = self.client_get(
+            "/accounts/login/start/sso/", {}, HTTP_USER_AGENT="ZulipElectron/5.0.0"
+        )
         self.verify_desktop_flow_app_page(result)
 
     def test_login_success(self) -> None:

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -1,6 +1,6 @@
 import copy
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, Dict, Iterator, TypedDict
 from unittest import mock
 
 import orjson
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
     from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
 
 
+class SCIMHeadersDict(TypedDict):
+    HTTP_AUTHORIZATION: str
+
+
 class SCIMTestCase(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -22,7 +26,7 @@ class SCIMTestCase(ZulipTestCase):
             realm=self.realm, name=settings.SCIM_CONFIG["zulip"]["scim_client_name"]
         )
 
-    def scim_headers(self) -> Mapping[str, str]:
+    def scim_headers(self) -> SCIMHeadersDict:
         return {"HTTP_AUTHORIZATION": f"Bearer {settings.SCIM_CONFIG['zulip']['bearer_token']}"}
 
     def generate_user_schema(self, user_profile: UserProfile) -> Dict[str, Any]:

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -66,8 +66,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
 
     async def tornado_client_get(self, path: str, **kwargs: Any) -> HTTPResponse:
         self.add_session_cookie(kwargs)
-        kwargs["skip_user_agent"] = True
-        self.set_http_headers(kwargs)
+        self.set_http_headers(kwargs, skip_user_agent=True)
         if "HTTP_HOST" in kwargs:
             kwargs["headers"]["Host"] = kwargs["HTTP_HOST"]
             del kwargs["HTTP_HOST"]
@@ -75,16 +74,14 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
 
     async def fetch_async(self, method: str, path: str, **kwargs: Any) -> HTTPResponse:
         self.add_session_cookie(kwargs)
-        kwargs["skip_user_agent"] = True
-        self.set_http_headers(kwargs)
+        self.set_http_headers(kwargs, skip_user_agent=True)
         if "HTTP_HOST" in kwargs:
             kwargs["headers"]["Host"] = kwargs["HTTP_HOST"]
             del kwargs["HTTP_HOST"]
         return await self.http_client.fetch(self.get_url(path), method=method, **kwargs)
 
     async def client_get_async(self, path: str, **kwargs: Any) -> HTTPResponse:
-        kwargs["skip_user_agent"] = True
-        self.set_http_headers(kwargs)
+        self.set_http_headers(kwargs, skip_user_agent=True)
         return await self.fetch_async("GET", path, **kwargs)
 
     def login_user(self, *args: Any, **kwargs: Any) -> None:
@@ -108,7 +105,6 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
         response = await self.tornado_client_get(
             "/json/events?dont_block=true",
             subdomain="zulip",
-            skip_user_agent=True,
         )
         self.assertEqual(response.code, 200)
         body = orjson.loads(response.body)

--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -80,11 +80,12 @@ Requester Bob <requester-bob@example.com> updated [ticket #11](http://test1234zz
         """
         self.url = self.build_webhook_url()
         payload = self.get_body("unknown_payload")
-        kwargs = {
-            "HTTP_AUTHORIZATION": self.encode_email(self.test_user.email),
-            "content_type": "application/x-www-form-urlencoded",
-        }
-        result = self.client_post(self.url, payload, **kwargs)
+        result = self.client_post(
+            self.url,
+            payload,
+            HTTP_AUTHORIZATION=self.encode_email(self.test_user.email),
+            content_type="application/x-www-form-urlencoded",
+        )
         self.assertFalse(check_send_webhook_message_mock.called)
         self.assert_json_success(result)
 

--- a/zerver/webhooks/pagerduty/tests.py
+++ b/zerver/webhooks/pagerduty/tests.py
@@ -77,10 +77,9 @@ class PagerDutyHookTests(WebhookTestCase):
         self.check_webhook("mp_fail", "Incident 48219", expected_message)
 
     def test_unsupported_webhook_event(self) -> None:
-        post_params = dict(content_type="application/json")
         for version in range(1, 4):
             payload = self.get_body(f"unsupported_v{version}")
-            result = self.client_post(self.url, payload, **post_params)
+            result = self.client_post(self.url, payload, content_type="application/json")
             self.assert_json_error(
                 result,
                 "The 'incident.unsupported' event isn't currently supported by the PagerDuty webhook",


### PR DESCRIPTION
This is a part of the django-stubs refactorings.

We wrap methods of the django test client for the test suite, and
type keyword variadic arguments as `ClientArg` as it might called
with a mix of `bool` and `str`.

This is problematic when we call the original methods on the test
client as we attempt to unpack the dictionary of keyword arguments,
which has no type guarantee that certain keys that the test client
requires to be bool will certainly be bool.

For example, you can call
`self.client_post(url, info, follow="invalid")` without getting a
mypy error while the django test client requires `follow: bool`.

The unsafely typed keyword variadic arguments leads to error within
the body the wrapped test client functions as we call
`django_client.post` with `**kwargs` when django-stubs gets added,
making it necessary to refactor these wrappers for type safety.

The approach here minimizes the need to refactor callers, as we
keep `kwargs` being variadic while change its type from `ClientArg`
to `str` after defining all the possible `bool` arguments that might
previously appear in `kwargs`. We also copy the defaults from the
django test client as they are unlikely to change.

