### PR TITLE
stream: Change the color of remove button in subscribers tab.

### DIFF
--- a/static/templates/stream_settings/new_stream_user.hbs
+++ b/static/templates/stream_settings/new_stream_user.hbs
@@ -9,6 +9,6 @@
     {{/if}}
     <td>{{user_id}} </td>
     <td>
-        <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded btn-danger">{{t 'Remove' }}</button>
+        <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded white">{{t 'Remove' }}</button>
     </td>
 </tr>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The "remove" button in the "Subscribers" part of stream creation UI
had a red text color, so I changed it to use a regular text color
by removing the 'btn-danger' class and adding 'white' class
like the "cancel" button.

Fixes: #21863.

**Screenshots and screen captures:**
Previously
![image](https://user-images.githubusercontent.com/76098475/173805851-d89036d9-2c9f-44f9-94bd-85d967312315.png)

After using regular text color (Create Stream "UI")
![Screenshot from 2022-06-14 13-12-55](https://user-images.githubusercontent.com/76098475/173805909-ce4193d9-f2b0-486b-97c5-9582d73a03c5.png)

![Screenshot from 2022-06-14 13-13-10](https://user-images.githubusercontent.com/76098475/173805929-8b02d37d-acd2-46d6-a70f-4159bd9d3ab6.png)

Screenshots from "Manage streams > Subscribers UI" after the change
![Screenshot from 2022-06-14 13-14-40](https://user-images.githubusercontent.com/76098475/173806182-36db697f-bede-4823-9e38-bc8b5862944e.png)

![Screenshot from 2022-06-14 13-15-01](https://user-images.githubusercontent.com/76098475/173806217-ec2b488d-8b88-4c31-aa3a-7dfeb4230dd5.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
