### PR TITLE
streams: Disable subscribers tab when user does not have permission to see subscribers.

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -215,6 +215,7 @@ export function update_stream_privacy(slim_sub, values) {
     stream_ui_updates.update_change_stream_privacy_settings(sub);
     stream_ui_updates.update_settings_button_for_sub(sub);
     stream_ui_updates.update_add_subscriptions_elements(sub);
+    stream_ui_updates.enable_or_disable_subscribers_tab(sub);
     stream_list.redraw_stream_privacy(sub);
 
     const active_data = get_active_data();

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -71,6 +71,23 @@ export function update_toggler_for_sub(sub) {
         }
         stream_edit.toggler.disable_tab("personal_settings");
     }
+    enable_or_disable_subscribers_tab(sub);
+}
+
+export function enable_or_disable_subscribers_tab(sub) {
+    if (!hash_util.is_editing_stream(sub.stream_id)) {
+        return;
+    }
+
+    if (!stream_data.can_view_subscribers(sub)) {
+        stream_edit.toggler.disable_tab("subscriber_settings");
+        if (stream_edit.select_tab === "subscriber_settings") {
+            stream_edit.toggler.goto("general_settings");
+        }
+        return;
+    }
+
+    stream_edit.toggler.enable_tab("subscriber_settings");
 }
 
 export function update_settings_button_for_sub(sub) {


### PR DESCRIPTION
This PR adds a function to disable the subscribers tab for private
streams if a user is not subscribed to the stream and is not an admin.
We also live update the state of subscribers tab on changing privacy
of stream.

Completing #21537 opened by @Zoronium. Made a few improvements to
directly use `can_view_subscribers` function, enabling "General" tab in case
subscribers tab was opened when being disabled and also added code to
disable/enable the tab when changing privacy of stream.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> #20916

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-06-15 20-22-29](https://user-images.githubusercontent.com/35494118/173860100-2495f6b3-0770-4f03-bf14-69d717e5d264.png)

![Screenshot from 2022-06-15 20-23-46](https://user-images.githubusercontent.com/35494118/173860156-0b4d28ee-b0f8-4a9d-9f8d-374a000bb41a.png)

![subscribers-tab](https://user-images.githubusercontent.com/35494118/173860240-d1761e74-a717-4b76-a704-c2750b2cef8c.gif)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
