### PR TITLE
streams: Change UI for subscription status for "All streams."

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -580,6 +580,30 @@ body.dark-theme {
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 
+    .stream-row {
+        /* This is for coluring the plus sign SVGs in stream-list UI */
+        /* public */
+        .check:not(.checked) svg {
+            fill: hsl(218, 14%, 33%);
+        }
+
+        /* private */
+        .disabled svg {
+            fill: hsl(218, 14%, 33%);
+            opacity: 0.5;
+        }
+
+        /* private :hover */
+        &:hover .check.disabled:not(.checked) svg {
+            fill: hsl(218, 14%, 33%);
+        }
+
+        /* public :hover */
+        .check:not(.checked, .disabled):hover svg {
+            fill: hsl(230, 11%, 67%);
+        }
+    }
+
     .recent_topics_participant_overflow {
         color: hsl(0, 0%, 100%) !important;
         background-color: hsl(211, 18%, 25%) !important;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -538,7 +538,7 @@ h4.user_group_setting_subsection_title {
         }
 
         &.checked:hover svg {
-            opacity: 0.5;
+            fill: hsl(240, 41%, 50%);
         }
 
         .sub_unsub_status {
@@ -559,7 +559,7 @@ h4.user_group_setting_subsection_title {
     }
 
     .checked svg {
-        fill: hsl(170, 48%, 54%);
+        fill: hsl(240, 96%, 68%);
     }
 
     .check.disabled svg {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -532,18 +532,13 @@ h4.user_group_setting_subsection_title {
         background-position: center center;
 
         svg {
-            fill: transparent;
+            fill: hsl(0, 0%, 72%);
             width: 70%;
             margin: 0% 15%;
         }
 
         &.checked:hover svg {
             opacity: 0.5;
-        }
-
-        &.disabled {
-            pointer-events: none;
-            visibility: hidden;
         }
 
         .sub_unsub_status {
@@ -565,6 +560,11 @@ h4.user_group_setting_subsection_title {
 
     .checked svg {
         fill: hsl(170, 48%, 54%);
+    }
+
+    .check.disabled svg {
+        fill: hsl(0, 0%, 87%);
+        cursor: not-allowed;
     }
 
     .icon {
@@ -653,14 +653,14 @@ h4.user_group_setting_subsection_title {
         vertical-align: top;
     }
 
-    &:hover .check:not(.checked) svg,
-    &.active:hover .check:not(.checked) svg {
+    &:hover .check.disabled:not(.checked) svg,
+    &.active:hover .check.disabled:not(.checked) svg {
         fill: hsl(0, 0%, 87%);
     }
 
-    .check:not(.checked):hover svg,
-    &.active .check:not(.checked):hover svg {
-        fill: hsl(0, 0%, 72%);
+    .check:not(.checked, .disabled):hover svg,
+    &.active .check:not(.checked, .disabled):hover svg {
+        fill: hsl(0, 0%, 27%);
     }
 
     &::selection,

--- a/static/templates/stream_settings/browse_streams_list_item.hbs
+++ b/static/templates/stream_settings/browse_streams_list_item.hbs
@@ -2,12 +2,27 @@
 {{#with this}}
 <div class="stream-row" data-stream-id="{{stream_id}}" data-stream-name="{{name}}">
 
-    <div class="check {{#if subscribed }}checked{{/if}} sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}}">
-        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
-            <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
-        </svg>
-        <div class='sub_unsub_status'></div>
-    </div>
+    {{#if subscribed}}
+        <div class="check checked sub_unsub_button tippy-zulip-tooltip" data-tooltip-template-id="unsubscribe-tooltip-{{name}}">
+            <template id="unsubscribe-tooltip-{{name}}">{{t 'Unsubscribe from'}} #{{name}}</template>
+
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+                <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
+            </svg>
+            <div class='sub_unsub_status'></div>
+        </div>
+    {{else}}
+        <div class="check sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}} tippy-zulip-tooltip"
+          data-tooltip-template-id="{{#if should_display_subscription_button}}public-subscribe-tooltip-{{name}}{{else}}private-subscribe-tooltip-{{name}}{{/if}}">
+            <template id="public-subscribe-tooltip-{{name}}">{{t 'Subscribe to'}} #{{name}}</template>
+            <template id="private-subscribe-tooltip-{{name}}">{{t 'Cannot subscribe to private stream'}} #{{name}}</template>
+
+            <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+                <path d="M459.319,229.668c0,22.201-17.992,40.193-40.205,40.193H269.85v149.271c0,22.207-17.998,40.199-40.196,40.193   c-11.101,0-21.149-4.492-28.416-11.763c-7.276-7.281-11.774-17.324-11.769-28.419l-0.006-149.288H40.181   c-11.094,0-21.134-4.492-28.416-11.774c-7.264-7.264-11.759-17.312-11.759-28.413C0,207.471,17.992,189.475,40.202,189.475h149.267   V40.202C189.469,17.998,207.471,0,229.671,0c22.192,0.006,40.178,17.986,40.19,40.187v149.288h149.282   C441.339,189.487,459.308,207.471,459.319,229.668z"/>
+            </svg>
+            <div class='sub_unsub_status'></div>
+        </div>
+    {{/if}}
     {{> subscription_setting_icon }}
     <div class="sub-info-box">
         <div class="top-bar">

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -2,7 +2,9 @@
     <div class="tab-container"></div>
     {{#with sub}}
     <div class="button-group">
-        <div class="sub_unsub_button_wrapper inline-block">
+        <div class="sub_unsub_button_wrapper inline-block {{#unless should_display_subscription_button}}tippy-zulip-tooltip{{/unless}}"
+          {{#unless should_display_subscription_button}} data-tooltip-template-id="subscription-button-tooltip"{{/unless}}>
+            <template id="subscription-button-tooltip">{{t 'Cannot subscribe to private stream'}} #{{name}}</template>
             <button class="button small rounded subscribe-button sub_unsub_button {{#if should_display_subscription_button}}tippy-zulip-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}data-tippy-content="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
                 {{#if subscribed }}
                     {{#tr}}Unsubscribe{{/tr}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Changes the UI for subscribing to streams to be more like the mobile version (zulip/zulip-mobile#5333).

- For unsubscribed streams, the on hover-checkmark is replaced by a "+" which is always displayed and has on-hover highlighting.
- For unsubscribed private streams, the "+" is disabled.
- Tooltips with appropriate messages are added on the "+" sign for the above 2 cases and for the disabled "Subscribe" button in case of unsubscribed private stream.


Fixes: #22217 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![light theme](https://user-images.githubusercontent.com/59819879/179309403-6fde033d-fdd0-4509-bd30-19b86b4d2a51.jpg)
![dark theme](https://user-images.githubusercontent.com/59819879/179309418-5b1e306c-9149-4235-a76f-385413934bf1.jpg)


https://user-images.githubusercontent.com/59819879/179309688-58dd5fb2-65f4-48c4-a7bb-40fa3281ee8a.mp4

https://user-images.githubusercontent.com/59819879/179309693-3aa0c07e-884f-4d1a-8da1-e542b30cef90.mp4

Link to discussion thread: https://chat.zulip.org/#narrow/stream/101-design/topic/Improve.20.22All.20Streams.22.20UI.20.2322217

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
