### PR TITLE
left-sidebar: Use -, _ and / additionally as stream word separators.

### DIFF
--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -38,6 +38,12 @@ const weaving = {
     stream_id: 5,
     pin_to_top: false,
 };
+const stream_hyphen_underscore_slash = {
+    subscribed: true,
+    name: "stream-hyphen_underscore/slash",
+    stream_id: 6,
+    pin_to_top: false,
+};
 
 function sort_groups(query) {
     const streams = stream_data.subscribed_stream_ids();
@@ -68,13 +74,18 @@ test("basics", ({override_rewire}) => {
     stream_data.add_sub(pneumonia);
     stream_data.add_sub(clarinet);
     stream_data.add_sub(weaving);
+    stream_data.add_sub(stream_hyphen_underscore_slash);
 
     override_rewire(stream_data, "is_active", (sub) => sub.name !== "pneumonia");
 
     // Test sorting into categories/alphabetized
     let sorted = sort_groups("");
     assert.deepEqual(sorted.pinned_streams, [scalene.stream_id]);
-    assert.deepEqual(sorted.normal_streams, [clarinet.stream_id, fast_tortoise.stream_id]);
+    assert.deepEqual(sorted.normal_streams, [
+        clarinet.stream_id,
+        fast_tortoise.stream_id,
+        stream_hyphen_underscore_slash.stream_id,
+    ]);
     assert.deepEqual(sorted.dormant_streams, [pneumonia.stream_id]);
 
     // Test cursor helpers.
@@ -83,13 +94,20 @@ test("basics", ({override_rewire}) => {
     assert.equal(stream_sort.prev_stream_id(scalene.stream_id), undefined);
     assert.equal(stream_sort.prev_stream_id(clarinet.stream_id), scalene.stream_id);
 
-    assert.equal(stream_sort.next_stream_id(fast_tortoise.stream_id), pneumonia.stream_id);
+    assert.equal(
+        stream_sort.next_stream_id(fast_tortoise.stream_id),
+        stream_hyphen_underscore_slash.stream_id,
+    );
+    assert.equal(
+        stream_sort.next_stream_id(stream_hyphen_underscore_slash.stream_id),
+        pneumonia.stream_id,
+    );
     assert.equal(stream_sort.next_stream_id(pneumonia.stream_id), undefined);
 
     // Test filtering
     sorted = sort_groups("s");
     assert.deepEqual(sorted.pinned_streams, [scalene.stream_id]);
-    assert.deepEqual(sorted.normal_streams, []);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 
     assert.equal(stream_sort.prev_stream_id(clarinet.stream_id), undefined);
@@ -112,5 +130,22 @@ test("basics", ({override_rewire}) => {
     sorted = sort_groups("fast t");
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, [fast_tortoise.stream_id]);
+    assert.deepEqual(sorted.dormant_streams, []);
+
+    // Test searching part of stream name with non space word separators
+    sorted = sort_groups("hyphen");
+    assert.deepEqual(sorted.pinned_streams, []);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
+    assert.deepEqual(sorted.dormant_streams, []);
+
+    sorted = sort_groups("hyphen_underscore");
+    assert.deepEqual(sorted.pinned_streams, []);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
+    assert.deepEqual(sorted.dormant_streams, []);
+
+    // Test searching part of stream name with non space word separators
+    sorted = sort_groups("underscore");
+    assert.deepEqual(sorted.pinned_streams, []);
+    assert.deepEqual(sorted.normal_streams, [stream_hyphen_underscore_slash.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 });

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -288,3 +288,30 @@ run_test("clean_user_content_links", () => {
             "</div>",
     );
 });
+
+run_test("filter_by_word_prefix_match", () => {
+    const strings = ["stream-hyphen_underscore/slash", "three word stream"];
+    const values = [0, 1];
+    const item_to_string = (idx) => strings[idx];
+
+    // Default settings will match words with a space delimiter before them.
+    assert.deepEqual(util.filter_by_word_prefix_match(values, "stream", item_to_string), [0, 1]);
+    assert.deepEqual(util.filter_by_word_prefix_match(values, "word stream", item_to_string), [1]);
+
+    // Since - appears before `hyphen` in
+    // stream-hyphen_underscore/slash, we require `-` in the set of
+    // characters for it to match.
+    assert.deepEqual(util.filter_by_word_prefix_match(values, "hyphe", item_to_string), []);
+    assert.deepEqual(util.filter_by_word_prefix_match(values, "hyphe", item_to_string, /[\s/_-]/), [
+        0,
+    ]);
+    assert.deepEqual(util.filter_by_word_prefix_match(values, "hyphe", item_to_string, /[\s-]/), [
+        0,
+    ]);
+
+    // Similarly `_` must be in the set of allowed characters to match "underscore".
+    assert.deepEqual(util.filter_by_word_prefix_match(values, "unders", item_to_string, /[\s_]/), [
+        0,
+    ]);
+    assert.deepEqual(util.filter_by_word_prefix_match(values, "unders", item_to_string, /\s/), []);
+});

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -26,7 +26,14 @@ function compare_function(a, b) {
 
 export function sort_groups(streams, search_term) {
     const stream_id_to_name = (stream) => sub_store.get(stream).name;
-    streams = util.filter_by_word_prefix_match(streams, search_term, stream_id_to_name);
+    // Use -, _ and / as word separators apart from the default space character
+    const word_separator_regex = /[\s/_-]/;
+    streams = util.filter_by_word_prefix_match(
+        streams,
+        search_term,
+        stream_id_to_name,
+        word_separator_regex,
+    );
 
     function is_normal(sub) {
         return stream_data.is_active(sub);

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 import {$t} from "./i18n";
 
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
@@ -329,7 +331,12 @@ export function clean_user_content_links(html) {
     return content.innerHTML;
 }
 
-export function filter_by_word_prefix_match(items, search_term, item_to_text) {
+export function filter_by_word_prefix_match(
+    items,
+    search_term,
+    item_to_text,
+    word_separator_regex = /\s/,
+) {
     if (search_term === "") {
         return items;
     }
@@ -340,9 +347,14 @@ export function filter_by_word_prefix_match(items, search_term, item_to_text) {
     const filtered_items = items.filter((item) =>
         search_terms.some((search_term) => {
             const lower_name = item_to_text(item).toLowerCase();
-            const cands = lower_name.split(" ");
-            cands.push(lower_name);
-            return cands.some((name) => name.startsWith(search_term));
+            // returns true if the item starts with the search term or if the
+            // search term with a word separator right before it appears in the item
+            return (
+                lower_name.startsWith(search_term) ||
+                new RegExp(word_separator_regex.source + _.escapeRegExp(search_term)).test(
+                    lower_name,
+                )
+            );
         }),
     );
 


### PR DESCRIPTION
Uptil now only space was used as a word separating character when
searching streams. This meant that searching for "xyz" would not turn
up a stream named "stream-xyz" as one would expect.

Since -, _ and / are likely to be used as word separators in stream
names, these 3 are added as word separators for streams. The utility
function `filter_by_word_prefix_match` is refactored by adding an
optional `word_separator_regex` argument.

Fixes: #19700.

Earlier PRs #19726 and #20566 also aimed to fix the same issue. This PR takes a different approach (using indices and not splitting on the word separator character/s for matching stream names with search terms), but the testing strategy for util.js is inspired from #20566. This PR additionally fixes a bug not fixed in previous PRs where a sequence of consecutive words, starting after the 1st word would not match. For example, searching "test stream" would not show a stream named "A test stream"

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/68962290/174044727-ac217f31-5799-4212-9c81-fa5524342f15.png)

![image](https://user-images.githubusercontent.com/68962290/174044815-0ba0cd48-49a5-47e4-9f0f-d9c5d768d7a8.png)


**Self-review checklist**


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
