### PR TITLE
process_fts_updates: Nagios may lack permissions to load Django config.

### DIFF
--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -29,6 +29,10 @@
 # however, we wish to import `zerver.settings` since we have no
 # /etc/zulip/zulip.conf to read, and that case _requires_ loading the
 # venv.
+#
+# We also must handle the cases where we are run as the `nagios` user,
+# which may not have permission to read all configuration files, and
+# thus (2) will look like (3).
 
 import argparse
 import configparser
@@ -134,7 +138,7 @@ try:
     pg_args["sslmode"] = settings.DATABASES["default"]["OPTIONS"].get("sslmode")
     pg_args["connect_timeout"] = "600"
     USING_PGROONGA = settings.USING_PGROONGA
-except ImportError:
+except (ImportError, PermissionError):
     # Case (3): we know that the PostgreSQL server is on this host.
     pg_args["user"] = "zulip"
 


### PR DESCRIPTION
Even if Django and PostgreSQL are on the same host, the `nagios` user
may lack permissions to read accessory configuration files needed to
load the Django configuration (e.g. authentication keys).

Catch those failures, and switch to loading the required settings from
`/etc/zulip/zulip.conf`.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
