### PR TITLE
help-docs: Document "Resolve/Unresolve topic" mobile app feature.

### DIFF
--- a/templates/zerver/help/include/topic-long-press-menu.md
+++ b/templates/zerver/help/include/topic-long-press-menu.md
@@ -1,1 +1,1 @@
-1. Press and hold the topic bar to access the long-press menu.
+1. Press and hold a topic until the long-press menu appears.

--- a/templates/zerver/help/resolve-a-topic.md
+++ b/templates/zerver/help/resolve-a-topic.md
@@ -42,44 +42,37 @@ on when topic editing is allowed.
 
 ## Mark a topic as resolved
 
-### Via the message recipient bar
-
 {start_tabs}
 
-1. Click on the **✔** icon to mark an unresolved topic as resolved.
-
-{end_tabs}
-
-### Via the left sidebar
-
-{start_tabs}
+{tab|desktop-web}
 
 {!topic-actions.md!}
 
 1. Select **Mark as resolved**.
 
+!!! tip ""
+
+    You can also click on the **✔** icon in the message recipient bar to
+    mark an unresolved topic as resolved.
+
 {end_tabs}
 
 ## Mark a topic as unresolved
 
-### Via the message recipient bar
-
 {start_tabs}
 
-1. Click on the **✔** icon to mark a resolved topic as unresolved.
-
-{end_tabs}
-
-### Via the left sidebar
-
-{start_tabs}
+{tab|desktop-web}
 
 {!topic-actions.md!}
 
 1. Select **Mark as unresolved**.
 
-{end_tabs}
+!!! tip ""
 
+    You can also click on the **✔** icon in the message recipient bar to
+    mark a resolved topic as unresolved.
+
+{end_tabs}
 
 ## Details
 

--- a/templates/zerver/help/resolve-a-topic.md
+++ b/templates/zerver/help/resolve-a-topic.md
@@ -55,6 +55,14 @@ on when topic editing is allowed.
     You can also click on the **✔** icon in the message recipient bar to
     mark an unresolved topic as resolved.
 
+{tab|mobile}
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Resolve topic**.
+
+{!topic-long-press-menu-tip.md!}
+
 {end_tabs}
 
 ## Mark a topic as unresolved
@@ -71,6 +79,14 @@ on when topic editing is allowed.
 
     You can also click on the **✔** icon in the message recipient bar to
     mark a resolved topic as unresolved.
+
+{tab|mobile}
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Unresolve topic**.
+
+{!topic-long-press-menu-tip.md!}
 
 {end_tabs}
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This consolidates the "message recipient bar" and "left sidebar" instructions under a "Desktop/Web" tab as proposed in issue #22178. This also adds an admin-only warning to the instructions given that other users can't see the resolve/unresolve feature via the ellipsis menu in the left sidebar. This will allow adding a new tab to document the mobile feature.

Makes the instructions in the long-press menu macro a little more explicit so that users know they won't see the menu unless they press and hold the topic long enough.

Also improves the wording of the instructions to access the long-press menu so that users are more likely to read it as saying that the whole area of a given topic, extending the whole width of the screen, is the region they can press to act on that topic. See relevant discussion in [this comment](https://github.com/zulip/zulip/pull/22221#issuecomment-1152625779
).

Fixes #22144.

**Screenshots and screen captures:**
<img width="526" alt="image" src="https://user-images.githubusercontent.com/2343554/174225611-3d50282d-0c61-4412-ac04-a17e325848e1.png">

<img width="527" alt="image" src="https://user-images.githubusercontent.com/2343554/174225652-1fe1a07e-e2ff-4020-9807-e3810e049e16.png">

**Questions/Concerns:**
- If a user goes to the help center while logged in, is there a way to display a different set of instructions based on the user’s permission level?
- During testing, I noticed that moderators have permission to resolve/unresolve any topic via the checkmark ✔ icon, but not via the ellipsis icon, is this a known issue?
- What do folks think about using the term "pops up" in the mobile instructions. Would "shows up" or "comes up" be a better choice?

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>