### PR TITLE
bot_settings: Fix bot owner hidden dropdown menu.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1613,6 +1613,7 @@ input[type="checkbox"] {
  *the edit bot owner selection to
  *be visible */
     position: fixed;
+    z-index:1;
 }
 
 .subsection-failed-status p {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1613,7 +1613,7 @@ input[type="checkbox"] {
  *the edit bot owner selection to
  *be visible */
     position: fixed;
-    z-index:1;
+    z-index: 1;
 }
 
 .subsection-failed-status p {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1608,6 +1608,13 @@ input[type="checkbox"] {
     }
 }
 
+#id_edit_bot_owner {
+    /* Allows the dropdown list menu for
+ *the edit bot owner selection to
+ *be visible */
+    position: fixed;
+}
+
 .subsection-failed-status p {
     background-color: hsl(0, 43%, 91%);
     padding: 2px 6px;


### PR DESCRIPTION
This pull request fixes the issue regarding the hidden dropdown menu for the bot owners in the bot organization settings.

Fixes: #22169

**Screenshots and screen captures:**
![1st solved](https://user-images.githubusercontent.com/74872466/174512504-b41b2876-9cbc-4129-9e0f-be016430b697.png)

![after z-index](https://user-images.githubusercontent.com/74872466/174512541-9704d076-d2fc-449b-bcdd-261de4060b5d.png)


**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
