### PR TITLE
install: Remove redundant apt-get upgrade

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -451,13 +451,6 @@ fi
 
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
 
-if [ "$package_system" = apt ]; then
-    apt-get -y upgrade
-elif [ "$package_system" = yum ]; then
-    # No action is required because `yum update` already does upgrade.
-    :
-fi
-
 if [ -n "$USE_CERTBOT" ]; then
     "$ZULIP_PATH"/scripts/setup/setup-certbot \
         "$EXTERNAL_HOST" --email "$ZULIP_ADMINISTRATOR"


### PR DESCRIPTION
We already did an `apt-get -y dist-upgrade`. Before commit 5b71ceb03c1efbe17286802ae179a806b2502355, this extra `apt-get -y upgrade` was still necessary because `zulip-puppet-apply` was responsible for setting up APT repositories, but now `install` sets those up before the first ‘apt-get -y dist-upgrade’.