### PR TITLE
install/upgrade: Allow new packages during `apt-get upgrade`.

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -452,7 +452,7 @@ fi
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
 
 if [ "$package_system" = apt ]; then
-    apt-get -y upgrade
+    apt-get -y --with-new-pkgs upgrade
 elif [ "$package_system" = yum ]; then
     # No action is required because `yum update` already does upgrade.
     :

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -228,7 +228,7 @@ if glob.glob("/usr/share/postgresql/*/extension/tsearch_extras.control"):
 if not (minimal_change or args.skip_puppet):
     logging.info("Upgrading system packages...")
     subprocess.check_call(["apt-get", "update"])
-    subprocess.check_call(["apt-get", "-y", "upgrade"])
+    subprocess.check_call(["apt-get", "-y", "--with-new-pkgs", "upgrade"])
 
 # To bootstrap zulip-puppet-apply, we need to install the system yaml
 # package; new installs get this, but old installs may not have it.
@@ -444,7 +444,7 @@ else:
         shutdown_server()
         logging.info("Applying Puppet changes...")
         subprocess.check_call(["./scripts/zulip-puppet-apply", "--force"])
-        subprocess.check_call(["apt-get", "-y", "upgrade"])
+        subprocess.check_call(["apt-get", "-y", "--with-new-pkgs", "upgrade"])
         # Puppet may have reloaded supervisor, and in so doing started
         # services; mark as potentially needing to stop the server.
         IS_SERVER_UP = True

--- a/tools/setup/bootstrap-aws-installer
+++ b/tools/setup/bootstrap-aws-installer
@@ -36,7 +36,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Dependencies to install AWS CLI
 (
     apt-get -qy update
-    apt-get -qy -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" upgrade
+    apt-get -qy --with-new-pkgs -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" upgrade
     apt-get -qy install jq unzip curl
     apt-get -qy autoclean
 )


### PR DESCRIPTION
`postgresql-14.4` is a notable upgrade in the PostgreSQL series, as it
fixes potential database corruption from `CREATE INDEX CONCURRENTLY`
statements which are run while rows are modified[1].  However, it also
requires an upgrade from `libllvm9` to `libllvm10`, which means it is
not installed by a mere `apt-get upgrade`.

Add the `--with-new-pkgs` flag to all of the potentially relevant
`apt-get upgrade` calls, so that this (and similar) packages are
upgraded successfully.

[1]: https://www.postgresql.org/docs/release/14.4/

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
