### PR TITLE
digest: Add header above plain text view of digest.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -256,8 +256,9 @@ html {
     margin-bottom: 60px;
 }
 
-#digest-page-title {
+.digest-page-title {
     text-align: center;
+    font-weight: 400;
 }
 
 .thanks-page div {

--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -8,13 +8,16 @@
     </div>
     <div class="digest-container">
         <div class="digest-email-container">
-            <div class="portico-page" id="digest-page-title">
+            <div class="portico-page digest-page-title">
                 <h1> Zulip digest </h1>
             </div>
             <div class="digest-email-html">
                 {% include 'zerver/emails/compiled/digest.html' %}
                 <img id="digest-footer" src="/static/images/emails/footer.png"/>
             </div>
+            <br />
+            <br />
+            <h2 class="digest-page-title">Plain text version</h2>
             <pre>{% include 'zerver/emails/digest.txt' %}</pre>
             <div class="digest-address-link"> {{physical_address}}</div>
         </div>


### PR DESCRIPTION
This PR adds a header above the plain text view
of the digest to be more clear about what the user is
seeing.

Fixes #21165


**Screenshots and screen captures:**
![issue-21165-after](https://user-images.githubusercontent.com/74872466/174699535-11527f25-9399-4695-b72a-7dc4a00bac20.png)


**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
