### PR TITLE
Fix keyboard shortcut formatting in help center docs

### DIFF
--- a/templates/zerver/help/configure-default-view.md
+++ b/templates/zerver/help/configure-default-view.md
@@ -12,7 +12,7 @@ on how to use these views.
 
 You can configure which view is set as your default, and whether
 the `Esc` key navigates to the default view. Also, you can always reach
-the default view by using the `Ctrl + [` shortcut.
+the default view by using the `Ctrl` + `[` shortcut.
 
 ## Change default view
 
@@ -35,7 +35,7 @@ and select a view.
 
 1. To see your changes in action, open a new Zulip tab, or use a keyboard
 shortcut twice to exit the settings and navigate to your default view
-(`Ctrl + [` or `Esc` if enabled).
+(`Ctrl` + `[` or `Esc` if enabled).
 
 [configure-esc]: /help/configure-default-view#set-whether-esc-navigates-to-the-default-view
 
@@ -49,7 +49,7 @@ designed to enhance the user experience in the app.
 By default, the `Esc` key shortcut will ultimately navigate to your
 default view. You can disable this key binding if you would prefer.
 This will not disable other `Esc` key shortcuts used in Zulip,
-and will not affect the behavior of the `Ctrl+[` shortcut.
+and will not affect the behavior of the `Ctrl` + `[` shortcut.
 
 ### Toggle whether `Esc` navigates to the default view
 

--- a/templates/zerver/help/custom-certificates.md
+++ b/templates/zerver/help/custom-certificates.md
@@ -29,7 +29,7 @@ certificate store, like your web browser.
 
 {start_tabs}
 {tab|mac}
-1. Hit Cmd+Space to bring up Spotlight Search, type **Keychain
+1. Hit `Cmd` + `Space` to bring up Spotlight Search, type **Keychain
    Access**, and press Enter.
 
 2. From the **File** menu, choose **Import Items...**

--- a/templates/zerver/help/enable-enter-to-send.md
+++ b/templates/zerver/help/enable-enter-to-send.md
@@ -1,6 +1,6 @@
 # Enable Enter to send
 
-By default, the `Enter` (or `Return`) key adds a new line to a message,
+By default, the `Enter` key adds a new line to a message,
 and `Ctrl` + `Enter` sends the message.
 
 This is convenient for typing multi-line messages, which are more common in

--- a/templates/zerver/help/enable-enter-to-send.md
+++ b/templates/zerver/help/enable-enter-to-send.md
@@ -1,7 +1,7 @@
 # Enable Enter to send
 
 By default, the `Enter` (or `Return`) key adds a new line to a message,
-and `Ctrl+Enter` sends the message.
+and `Ctrl` + `Enter` sends the message.
 
 This is convenient for typing multi-line messages, which are more common in
 Zulip than in most other chat products. However, you can also configure
@@ -17,10 +17,10 @@ Zulip so that `Enter` sends the message.
 
 {end_tabs}
 
-Note that `Shift+Enter` always adds a new line, regardless of whether
+Note that `Shift` + `Enter` always adds a new line, regardless of whether
 **Enter to send** is enabled. The full table is below.
 
-| Enter to send | `Enter` | `Ctrl+Enter` | `Shift+Enter` |
+| Enter to send | `Enter` | `Ctrl` + `Enter` | `Shift` + `Enter` |
 |---|---|---|---|
 | Enabled | Sends message | Adds line | Adds line |
 | Disabled | Adds line | Sends message | Adds line |

--- a/templates/zerver/help/include/reading-pms.md
+++ b/templates/zerver/help/include/reading-pms.md
@@ -3,7 +3,7 @@
 
 2. Click on a conversation in the left sidebar under **Private messages**.
 
-3. Read the conversation, scrolling down with the mouse or by pressing `Fn` + `↓`.
+3. Read the conversation, scrolling down with the mouse or by pressing `PgDn`.
 
 4. If the conversation is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping

--- a/templates/zerver/help/include/reading-topics.md
+++ b/templates/zerver/help/include/reading-topics.md
@@ -4,7 +4,7 @@
 
 2. Click on the name of a topic in the **Topic** column.
 
-3. Read the topic, scrolling down with the mouse or by pressing `Fn` + `↓`.
+3. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
 
 4. If the topic is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
@@ -19,7 +19,7 @@
 
 2. Click on a topic in the left sidebar.
 
-3. Read the topic, scrolling down with the mouse or by pressing `Fn` + `↓`.
+3. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
 
 4. If the topic is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -22,7 +22,7 @@ below, and add more to your repertoire as needed.
 
 * **New private message**: `x`
 
-* **Cancel compose**: `Esc` or `Ctrl + [` — Close the compose box and save
+* **Cancel compose**: `Esc` or `Ctrl` + `[` — Close the compose box and save
   the unsent message as a draft.
 
 * **View drafts**: `d` — Use the arrow keys and `Enter` to restore a draft.
@@ -41,14 +41,14 @@ below, and add more to your repertoire as needed.
 
 * **Toggle keyboard shortcuts view**: `?`
 
-* **Go to default view**: Press `Ctrl + [` (or `Esc`,
+* **Go to default view**: `Ctrl` + `[` (or `Esc`,
   [if enabled][disable-escape])
   until you are in the [default view](/help/configure-default-view).
 
 [disable-escape]: /help/configure-default-view#set-whether-esc-navigates-to-the-default-view
 ## Navigation
 
-* **Search messages**: `/` or `Ctrl+k`
+* **Search messages**: `/` or `Ctrl` + `k`
 
 * **Filter streams**: `q`
 
@@ -110,11 +110,11 @@ below, and add more to your repertoire as needed.
   settings. See
   [enable enter to send](https://zulip.com/help/enable-enter-to-send).
 
-* **Insert italic text**: `*italic*` or `Ctrl + I`
-* **Insert bold text**: `**bold**` or `Ctrl + B`
-* **Insert link**: `[Zulip website](https://zulip.org)` or `Ctrl + Shift + L`
+* **Insert italic text**: `*italic*` or `Ctrl` + `I`
+* **Insert bold text**: `**bold**` or `Ctrl` + `B`
+* **Insert link**: `[Zulip website](https://zulip.org)` or `Ctrl` + `Shift` + `L`
 
-* **Cancel compose**: `Esc` or `Ctrl + [` — Close the compose box and save
+* **Cancel compose**: `Esc` or `Ctrl` + `[` — Close the compose box and save
   the unsent message as a draft.
 
 ## Message actions
@@ -130,7 +130,7 @@ below, and add more to your repertoire as needed.
 
 * **Edit message**: `e`
 
-* **Star message**: `Ctrl + s`
+* **Star message**: `Ctrl` + `s`
 
 * **React with <img alt=":thumbs_up:" class="emoji"
 src="/static/generated/emoji/images/emoji/unicode/1f44d.png"

--- a/templates/zerver/help/logging-in.md
+++ b/templates/zerver/help/logging-in.md
@@ -20,7 +20,7 @@ and GitHub account use the same email address.
 
 {tab|desktop}
 
-1. Open the **left sidebar** (`Ctrl+Shift+s`).
+1. Open the **left sidebar** (`Ctrl` + `Shift` + `s`).
 
 1. Set your [proxy settings](/help/connect-through-a-proxy) or add a
    [custom certificate](/help/custom-certificates) if needed (rare).

--- a/templates/zerver/help/switching-between-organizations.md
+++ b/templates/zerver/help/switching-between-organizations.md
@@ -6,7 +6,7 @@ This article assumes you've [logged in](/help/logging-in) to each organization a
 
 {tab|desktop}
 
-1. Open the **left sidebar** (`Ctrl+Shift+s`).
+1. Open the **left sidebar** (`Ctrl` + `Shift` + `s`).
 
 1. Click on your organization's profile picture.
 


### PR DESCRIPTION
Addresses part of #22112 by updating any help center documentation with keyboard shortcuts that involve more than one key (e.g. `Shift` + `k`) so that the plus symbol (+) is never rendered as part of a code element. See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/format.20of.20keyboard.20shortcuts.20in.20help.20center.20docs/near/1384367).

Also, the second commit updates any keyboard shortcuts that were in the help center documentation with Mac keys. When a Mac keyboard is detected the documentation is updated for Mac keys, but the reverse is not true. Therefore all help center documentation articles / text need to be written for non-Mac keyboards. The one exception to this is `/help/custom-certificates` as those instructions are in a tabbed block for MacOS.

Follow-up help center documentation tasks known:
- `/help/enable-enter-to-send` needs it's instruction block updated for new UI ("Press Enter to send" no longer exists). See screenshot below.
- Decide on a style for uppercase / lowercase shortcuts (include `Shift` as a key or write key as upper/lower case) and update the help center documentation to be consistent. You can note the current inconsistency by comparing the two screenshots below for the keyboard shortcuts help center article.

----

**Example screenshots and screen captures:**

<details>
<summary>Enable Enter to send</summary>

![Screenshot from 2022-06-21 15-04-02](https://user-images.githubusercontent.com/63245456/174806928-448e9b68-8bb4-46da-920b-41b87210dc8b.png)

</details>


<details>
<summary>Configure default view</summary>

![Screenshot from 2022-06-21 15-04-52](https://user-images.githubusercontent.com/63245456/174807092-66023330-7dc5-444b-aa6b-ac9df19aec49.png)

</details>

<details>
<summary>Keyboard shortcuts - basics and navigation</summary>

![Screenshot from 2022-06-21 15-07-49](https://user-images.githubusercontent.com/63245456/174807552-f7aa7306-a10f-4e9c-b157-f979c212c766.png)

</details>

<details>
<summary>Keyboard shortcuts - composing messages</summary>

![Screenshot from 2022-06-21 15-08-14](https://user-images.githubusercontent.com/63245456/174807309-aa139efa-6eb5-408b-b7ec-58db8de1be03.png)

</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
