### PR TITLE
nginx: Add Cache-Control headers for Django-hashed static files

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -14,17 +14,14 @@ location /static/ {
 
     # Set a nonexistent path, so we just serve the nice Django 404 page.
     error_page 404 /django_static_404.html;
-}
 
-# These files are hashed and thus immutable; cache them aggressively.
-location /static/webpack-bundles/ {
-    alias /home/zulip/prod-static/webpack-bundles/;
-    include /etc/nginx/zulip-include/headers;
-    add_header Access-Control-Allow-Origin *;
-    add_header Cache-Control "public, max-age=31536000, immutable";
-
-    # Set a nonexistent path, so we just serve the nice Django 404 page.
-    error_page 404 /django_static_404.html;
+    # These files are hashed and thus immutable; cache them aggressively.
+    # Django adds 12 hex digits; Webpack adds 20.
+    location ~ '\.[0-9a-f]{12}\.|[./][0-9a-f]{20}\.' {
+        include /etc/nginx/zulip-include/headers;
+        add_header Access-Control-Allow-Origin *;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
 }
 
 # Send longpoll requests to Tornado


### PR DESCRIPTION
Context: #22067, https://chat.zulip.org/#narrow/stream/378-api-design/topic/currently.20supported.20emoji/near/1394698

Tested on andersk.zulipdev.org:

```console
$ curl -I https://andersk.zulipdev.org/static/webpack-bundles/files/64.0cdafdf0b6596657a9be.png
HTTP/2 200 
server: nginx/1.18.0 (Ubuntu)
date: Tue, 21 Jun 2022 22:12:39 GMT
content-type: image/png
content-length: 3120663
last-modified: Tue, 21 Jun 2022 22:09:10 GMT
etag: "62b24186-2f9e17"
strict-transport-security: max-age=15768000
x-frame-options: DENY
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
access-control-allow-origin: *
cache-control: public, max-age=31536000, immutable
accept-ranges: bytes

$ curl -I https://andersk.zulipdev.org/static/generated/emoji/emoji_codes.cb56a7041ede.json
HTTP/2 200 
server: nginx/1.18.0 (Ubuntu)
date: Tue, 21 Jun 2022 22:12:43 GMT
content-type: application/json
content-length: 77820
last-modified: Fri, 25 Feb 2022 03:11:22 GMT
vary: Accept-Encoding
etag: "621848da-12ffc"
strict-transport-security: max-age=15768000
x-frame-options: DENY
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
access-control-allow-origin: *
cache-control: public, max-age=31536000, immutable
accept-ranges: bytes

$ curl -I https://andersk.zulipdev.org/static/webpack-bundles/14afb694c9855ab102bc.js
HTTP/2 200 
server: nginx/1.18.0 (Ubuntu)
date: Tue, 21 Jun 2022 23:40:49 GMT
content-type: application/javascript
content-length: 1740
last-modified: Tue, 21 Jun 2022 23:07:51 GMT
vary: Accept-Encoding
etag: "62b24f47-6cc"
strict-transport-security: max-age=15768000
x-frame-options: DENY
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
access-control-allow-origin: *
cache-control: public, max-age=31536000, immutable
accept-ranges: bytes
```