### PR TITLE
docs: Add some basic licensing guidance for contributors (proposed revision)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,8 +197,13 @@ yourself will help your PRs be merged faster, and folks will appreciate the
 quality and professionalism of your work.
 
 Then, submit your changes. Carefully reading our [Git guide][git-guide], and in
-particular the section on [making a pull request][git-guide-make-pr],
-will help avoid many common mistakes.
+particular the section on [making a pull request][git-guide-make-pr], will help
+avoid many common mistakes. If any part of your contribution is from someone
+else (code snippets, images, sounds, or any other copyrightable work, modified
+or unmodified), be sure to review the instructions on how to [properly
+attribute][licensing] the work.
+
+[licensing]: https://zulip.readthedocs.io/en/latest/contributing/licensing.html#contributing-someone-else-s-work
 
 Once you are satisfied with the quality of your PR, follow the
 [guidelines on asking for a code


### PR DESCRIPTION
This PR is a proposed revision on #22279.

Since the great majority of the time contributors are submitting their own work, I move the details of how to do proper attributions into a separate page. CONTRIBUTING.md links to the detailed explanation.

## Contributor guide
![Screen Shot 2022-06-23 at 1 25 34 PM](https://user-images.githubusercontent.com/2090066/175394816-4d0b3f0a-f7a7-4069-aeeb-44d54a0cf8ab.png)

## Detailed info
![Screen Shot 2022-06-23 at 1 36 05 PM](https://user-images.githubusercontent.com/2090066/175394877-065b00f3-f3a2-4f1c-9894-39b4178596a1.png)

