### PR TITLE
help-docs: Update Homebrew instructions for the latest release on macOS.

### DIFF
--- a/templates/zerver/help/desktop-app-install-guide.md
+++ b/templates/zerver/help/desktop-app-install-guide.md
@@ -14,7 +14,6 @@ look at the newest features, consider the [beta releases](#install-a-beta-releas
 {tab|mac}
 
 #### Disk image (recommended)
-<!-- TODO why zip? -->
 
 1. Download [Zulip for macOS](https://zulip.com/apps/mac).
 
@@ -24,12 +23,12 @@ The app will update automatically to future versions.
 
 #### Homebrew
 
-1. Run `brew cask install zulip` in Terminal.
+1. Run the command `brew install --cask zulip` from a terminal.
 
-1. Run Zulip from `Applications`. <!-- TODO fact check -->
+1. Run Zulip from `Applications`.
 
-The app will update automatically to future versions. `brew upgrade` will
-also work, if you prefer.
+The app will update automatically to future versions. Alternatively, you can
+run the command `brew upgrade zulip` to immediately upgrade.
 
 {tab|windows}
 


### PR DESCRIPTION
The command `brew cask` is no longer a `brew` command as of Homebrew version 3.5.2.

Updates the instruction to use `brew <command> --cask` instead.
Makes the upgrade instructions a bit more explicit.

Fixes: #22277.


Also removes a couple of TODO comments:
1. The current macOS release is a .dmg file download, but perhaps it used to be shipped as a .zip file before?
2. Verified that Zulip ends up in the `Applications` folder when installed via Homebrew. 

**Screenshots and screen captures:**
<img width="534" alt="image" src="https://user-images.githubusercontent.com/2343554/175437302-55aecd9b-7ab8-415a-82a6-c9b3aaf0d206.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>