### PR TITLE
tornado: Define missing attributes on AsyncDjangoHandler.

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -287,7 +287,7 @@ def get_user_messages(user_profile: UserProfile) -> List[Message]:
 
 class DummyHandler(AsyncDjangoHandler):
     def __init__(self) -> None:
-        allocate_handler_id(self)
+        self.handler_id = allocate_handler_id(self)
 
 
 dummy_handler = DummyHandler()

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -182,6 +182,7 @@ class ClientDescriptor:
     def add_event(self, event: Mapping[str, Any]) -> None:
         if self.current_handler_id is not None:
             handler = get_handler_by_id(self.current_handler_id)
+            assert handler._request is not None
             async_request_timer_restart(handler._request)
 
         self.event_queue.push(event)

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -27,9 +27,9 @@ def get_handler_by_id(handler_id: int) -> "AsyncDjangoHandler":
 def allocate_handler_id(handler: "AsyncDjangoHandler") -> int:
     global current_handler_id
     handlers[current_handler_id] = handler
-    handler.handler_id = current_handler_id
+    handler_id = current_handler_id
     current_handler_id += 1
-    return handler.handler_id
+    return handler_id
 
 
 def clear_handler_by_id(handler_id: int) -> None:
@@ -90,7 +90,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
 
         # Handler IDs are allocated here, and the handler ID map must
         # be cleared when the handler finishes its response
-        allocate_handler_id(self)
+        self.handler_id = allocate_handler_id(self)
 
     def __repr__(self) -> str:
         descriptor = get_descriptor_by_handler_id(self.handler_id)

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -1,6 +1,6 @@
 import logging
 import urllib
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import tornado.web
 from asgiref.sync import sync_to_async
@@ -54,6 +54,7 @@ def finish_handler(
         # get_events request has supplanted this request)
         handler = get_handler_by_id(handler_id)
         request = handler._request
+        assert request is not None
         async_request_timer_restart(request)
         log_data = RequestNotes.get_notes(request).log_data
         assert log_data is not None
@@ -91,6 +92,8 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         # Handler IDs are allocated here, and the handler ID map must
         # be cleared when the handler finishes its response
         self.handler_id = allocate_handler_id(self)
+
+        self._request: Optional[HttpRequest] = None
 
     def __repr__(self) -> str:
         descriptor = get_descriptor_by_handler_id(self.handler_id)


### PR DESCRIPTION
We monkey-patch `_request` and `handler_id` after initializing an
`AsyncDjangoHandler` object. This makes these attributes explicit
as a part of `AsyncDjangoHandler` for typing purposes.

This is a part of the django-stubs refactorings.