### PR TITLE
middleware: Pass unhandled API exceptions through to the test suite

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1631,7 +1631,7 @@ class WebhookTestCase(ZulipTestCase):
                     complete_event_type is not None
                     and all_event_types is not None
                     and complete_event_type not in all_event_types
-                ):
+                ):  # nocoverage
                     raise Exception(
                         f"""
 Error: This test triggered a message using the event "{complete_event_type}", which was not properly

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -478,7 +478,7 @@ class JsonErrorHandler(MiddlewareMixin):
 
         if isinstance(exception, JsonableError):
             return json_response_from_error(exception)
-        if RequestNotes.get_notes(request).error_format == "JSON":
+        if RequestNotes.get_notes(request).error_format == "JSON" and not settings.TEST_SUITE:
             capture_exception(exception)
             json_error_logger = logging.getLogger("zerver.middleware.json_error_handler")
             json_error_logger.error(traceback.format_exc(), extra=dict(request=request))

--- a/zerver/tests/test_integrations_dev_panel.py
+++ b/zerver/tests/test_integrations_dev_panel.py
@@ -22,7 +22,7 @@ class TestIntegrationsDevPanel(ZulipTestCase):
             "custom_headers": "{}",
             "is_json": "true",
         }
-        with self.assertLogs(level="ERROR") as logs:
+        with self.assertLogs(level="ERROR") as logs, self.settings(TEST_SUITE=False):
             response = self.client_post(target_url, data)
 
             self.assertEqual(response.status_code, 500)  # Since the response would be forwarded.

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -81,7 +81,9 @@ class AdminNotifyHandlerTest(ZulipTestCase):
             "django.request", level="ERROR"
         ) as request_error_log, self.assertLogs(
             "zerver.middleware.json_error_handler", level="ERROR"
-        ) as json_error_handler_log:
+        ) as json_error_handler_log, self.settings(
+            TEST_SUITE=False
+        ):
             rate_limit_patch.side_effect = capture_and_throw
             result = self.client_get("/json/users")
             self.assert_json_error(result, "Internal server error", status_code=500)

--- a/zerver/webhooks/travis/tests.py
+++ b/zerver/webhooks/travis/tests.py
@@ -114,25 +114,6 @@ Details: [changes](https://github.com/hl7-fhir/fhir-svn/compare/6dccb98bcfd9...6
             expect_noop=True,
         )
 
-    def test_travis_invalid_event(self) -> None:
-        payload = self.get_body("build")
-        payload = payload.replace("push", "invalid_event")
-        expected_error_messsage = """
-Error: This test triggered a message using the event "invalid_event", which was not properly
-registered via the @webhook_view(..., event_types=[...]). These registrations are important for Zulip
-self-documenting the supported event types for this integration.
-
-You can fix this by adding "invalid_event" to ALL_EVENT_TYPES for this webhook.
-""".strip()
-        with self.assertLogs("django.request"):
-            with self.assertLogs("zerver.middleware.json_error_handler", level="ERROR") as m:
-                self.client_post(
-                    self.url,
-                    payload,
-                    content_type="application/x-www-form-urlencoded",
-                )
-            self.assertIn(expected_error_messsage, m.output[0])
-
     def test_travis_noop(self) -> None:
         expected_error_message = """
 While no message is expected given expect_noop=True,


### PR DESCRIPTION
This results in more useful stack traces in failing tests.

Before:

```
======================================================================
FAIL: test_valid_avatars (zerver.tests.test_upload.AvatarTest) (fname='img.png')
A PUT request to /json/users/me/avatar with a valid file should return a URL and actually create an avatar.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip/zerver/tests/test_upload.py", line 1284, in test_valid_avatars
    response_dict = self.assert_json_success(result)
  File "/srv/zulip/zerver/lib/test_classes.py", line 958, in assert_json_success
    self.assertEqual(result.status_code, 200, json["msg"])
AssertionError: 500 != 200 : Internal server error
```

(The trace for the exception that led to the 500 error was logged somewhere way above, but you’d have to wade through lots of output to find it, and it wouldn’t be clear which test it came from, especially with parallelism.)

After:

```
======================================================================
ERROR: test_valid_avatars (zerver.tests.test_upload.AvatarTest) (fname='img.png')
A PUT request to /json/users/me/avatar with a valid file should return a URL and actually create an avatar.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip/zerver/tests/test_upload.py", line 1282, in test_valid_avatars
    result = self.client_post("/json/users/me/avatar", {"file": fp})
  File "/srv/zulip/zerver/lib/test_helpers.py", line 371, in wrapper
    result = f(self, url, info, **kwargs)
  File "/srv/zulip/zerver/lib/test_classes.py", line 411, in client_post
    result = django_client.post(url, info, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/test/client.py", line 751, in post
    response = super().post(path, data=data, content_type=content_type, secure=secure, **extra)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/test/client.py", line 407, in post
    return self.generic('POST', path, post_data, content_type,
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/test/client.py", line 473, in generic
    return self.request(**r)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/test/client.py", line 719, in request
    self.check_exception(response)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/test/client.py", line 580, in check_exception
    raise exc_value
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/srv/zulip/zerver/lib/rest.py", line 33, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/srv/zulip/zerver/lib/rest.py", line 166, in rest_dispatch
    return target_function(request, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/srv/zulip/zerver/decorator.py", line 783, in _wrapped_view_func
    return authenticate_log_and_execute_json(
  File "/srv/zulip/zerver/decorator.py", line 770, in authenticate_log_and_execute_json
    return limited_view_func(request, user_profile, *args, **kwargs)
  File "/srv/zulip/zerver/decorator.py", line 963, in wrapped_func
    return func(request, *args, **kwargs)
  File "/srv/zulip/zerver/views/user_settings.py", line 336, in set_avatar_backend
    upload_avatar_image(user_file, user_profile, user_profile)
  File "/srv/zulip/zerver/lib/upload.py", line 1072, in upload_avatar_image
    upload_backend.upload_avatar_image(
TypeError: upload_avatar_image() got an unexpected keyword argument 'content_typo'
```