### PR TITLE
help-docs: Document "Copy link to stream" mobile app feature.

### DIFF
--- a/templates/zerver/help/include/stream-long-press-menu-tip.md
+++ b/templates/zerver/help/include/stream-long-press-menu-tip.md
@@ -1,0 +1,4 @@
+!!! tip ""
+
+    If you are viewing a single stream, you can access the long-press
+    menu from the bar at the top of the screen.

--- a/templates/zerver/help/include/stream-long-press-menu.md
+++ b/templates/zerver/help/include/stream-long-press-menu.md
@@ -1,0 +1,1 @@
+1. Press and hold a stream until the long-press menu appears.

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -105,6 +105,14 @@ message](/help/quote-and-reply).
     If using Zulip in a browser, you can also click on a stream in the
     left sidebar, and copy the URL from your browser's address bar.
 
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Copy link to stream**.
+
+{!stream-long-press-menu-tip.md!}
+
 {end_tabs}
 
 ## Related articles


### PR DESCRIPTION
Adds a new tab with instructions for mobile app users.

Adds new macros with instructions for accessing the long-press menu.

Fixes: #22197.

**Screenshots and screen captures:**
<img width="528" alt="image" src="https://user-images.githubusercontent.com/2343554/175429845-8633ef1a-c168-497c-9740-bb10cc1207ad.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>