### PR TITLE
decorator: Only URL-decode application/x-www-form-urlencoded requests

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -726,7 +726,7 @@ def process_as_post(view_func: ViewFuncT) -> ViewFuncT:
                     request.upload_handlers,
                     request.encoding,
                 ).parse()
-            else:
+            elif request.content_type == "application/x-www-form-urlencoded":
                 request.POST = QueryDict(request.body, encoding=request.encoding)
 
         return view_func(request, *args, **kwargs)

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -157,10 +157,10 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
             # will generate the appropriate HTTP response.
             raise MissingAuthenticationError()
 
-        if request.method not in ["GET", "POST"]:
+        if request.method in ["DELETE", "PATCH", "PUT"]:
             # process_as_post needs to be the outer decorator, because
             # otherwise we might access and thus cache a value for
-            # request.REQUEST.
+            # request.POST.
             target_function = process_as_post(target_function)
 
         return target_function(request, **kwargs)

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -311,6 +311,7 @@ Output:
         We need to urlencode, since Django's function won't do it for us.
         """
         encoded = urllib.parse.urlencode(info)
+        kwargs["content_type"] = "application/x-www-form-urlencoded"
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         result = django_client.patch(url, encoded, **kwargs)
@@ -356,6 +357,7 @@ Output:
         self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
     ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
+        kwargs["content_type"] = "application/x-www-form-urlencoded"
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         return django_client.put(url, encoded, **kwargs)
@@ -373,6 +375,7 @@ Output:
         self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
     ) -> "TestHttpResponse":
         encoded = urllib.parse.urlencode(info)
+        kwargs["content_type"] = "application/x-www-form-urlencoded"
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         result = django_client.delete(url, encoded, **kwargs)
@@ -383,19 +386,17 @@ Output:
     def client_options(
         self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
     ) -> "TestHttpResponse":
-        encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
-        return django_client.options(url, encoded, **kwargs)
+        return django_client.options(url, info, **kwargs)
 
     @instrument_url
     def client_head(
         self, url: str, info: Dict[str, Any] = {}, **kwargs: ClientArg
     ) -> "TestHttpResponse":
-        encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
-        return django_client.head(url, encoded, **kwargs)
+        return django_client.head(url, info, **kwargs)
 
     @instrument_url
     def client_post(

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -119,7 +119,10 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
 
     # Verification for new email
     result = client.patch(
-        "/json/settings", urllib.parse.urlencode({"email": "hamlets-new@zulip.com"}), **host_kwargs
+        "/json/settings",
+        urllib.parse.urlencode({"email": "hamlets-new@zulip.com"}),
+        content_type="application/x-www-form-urlencoded",
+        **host_kwargs,
     )
     assert result.status_code == 200
 


### PR DESCRIPTION
We previously parsed any request with method other than {`GET`, `POST`} and `Content-Type` other than `multipart/form-data` as if it were `application/x-www-form-urlencoded`.

Check that `Content-Type` is `application/x-www-form-urlencoded` before parsing the body that way. Restrict this logic to {`DELETE`, `PATCH`, `PUT`} (having a body at all doesn’t make sense for {`CONNECT`, `HEAD`, `OPTIONS`, `TRACE`}).

I verified that the libraries we care about all correctly send `Content-Type: application/x-www-form-urlencoded` automatically for {`DELETE`, `PATCH`, `PUT`}:

* Python `requests`, given `data` as a dict
* JavaScript `fetch`, given `body` as `URLSearchParams`
* `curl`, given `--data` or `--data-urlencode`