### PR TITLE
stream-edit: Setup UI maxlength attribute for input elements.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -452,6 +452,7 @@ function edit_message($row, raw_content) {
             notify_new_thread: notify_new_thread_default,
             notify_old_thread: notify_old_thread_default,
             giphy_enabled: giphy.is_giphy_enabled(),
+            max_message_length: page_params.max_message_length,
         }),
     );
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -710,7 +710,11 @@ export function toggle_resolve_topic(message_id, old_topic_name) {
 }
 
 export function start_inline_topic_edit($recipient_row) {
-    const $form = $(render_topic_edit_form());
+    const $form = $(
+        render_topic_edit_form({
+            max_topic_length: page_params.max_topic_length,
+        }),
+    );
     message_lists.current.show_edit_topic_on_recipient_row($recipient_row, $form);
     $form.on("keydown", handle_inline_topic_edit_keydown);
     $(".topic_edit_spinner").hide();

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -498,6 +498,7 @@ export function initialize() {
             upgrade_text_for_wide_organization_logo:
                 page_params.upgrade_text_for_wide_organization_logo,
             is_stream_edit: true,
+            max_stream_description_length: page_params.max_stream_description_length,
         };
         const change_privacy_modal = render_stream_types(template_data);
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -498,6 +498,7 @@ export function initialize() {
             upgrade_text_for_wide_organization_logo:
                 page_params.upgrade_text_for_wide_organization_logo,
             is_stream_edit: true,
+            max_stream_name_length: page_params.max_stream_name_length,
             max_stream_description_length: page_params.max_stream_description_length,
         };
         const change_privacy_modal = render_stream_types(template_data);

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -625,8 +625,8 @@ export function setup_page(callback) {
                 settings_data.user_can_create_public_streams() ||
                 settings_data.user_can_create_web_public_streams(),
             hide_all_streams: !should_list_all_streams(),
-            max_name_length: page_params.max_stream_name_length,
-            max_description_length: page_params.max_stream_description_length,
+            max_stream_name_length: page_params.max_stream_name_length,
+            max_stream_description_length: page_params.max_stream_description_length,
             is_owner: page_params.is_owner,
             stream_privacy_policy_values: stream_data.stream_privacy_policy_values,
             stream_privacy_policy,

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -209,6 +209,8 @@ function initialize_compose_box() {
                 : "End",
             narrow_to_compose_recipients_key_html:
                 (common.has_mac_keyboard() ? "⌘" : "Ctrl") + " + .",
+            max_stream_name_length: page_params.max_stream_name_length,
+            max_topic_length: page_params.max_topic_length,
         }),
     );
     $(`.enter_sends_${user_settings.enter_sends}`).show();

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -79,9 +79,9 @@
                                 </span>
                                 <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle order-1" data-tooltip-template-id="narrow_to_compose_recipients_tooltip" tabindex="0">
                                 </a>
-                                <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
+                                <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="{{ max_stream_name_length }}" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
-                                <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                                <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
                             </div>
                         </div>
                         <div id="private-message" class="order-1">

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -41,7 +41,7 @@
     <div class="control-group no-margin">
         <div class="controls edit-controls">
             {{> copy_message_button message_id=this.message_id}}
-            <textarea class="message_edit_content" maxlength="10000">{{content}}</textarea>
+            <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
             <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
                 <div class="markdown_preview_spinner"></div>
                 <div class="preview_content rendered_markdown"></div>

--- a/static/templates/stream_settings/change_stream_info_modal.hbs
+++ b/static/templates/stream_settings/change_stream_info_modal.hbs
@@ -8,5 +8,5 @@
     <label for="change_stream_description">
         {{t 'Description' }}
     </label>
-    <textarea id="change_stream_description" maxlength="1000">{{ stream_description }}</textarea>
+    <textarea id="change_stream_description" maxlength="{{ max_stream_description_length }}">{{ stream_description }}</textarea>
 </div>

--- a/static/templates/stream_settings/change_stream_info_modal.hbs
+++ b/static/templates/stream_settings/change_stream_info_modal.hbs
@@ -2,7 +2,7 @@
     <label for="change_stream_name">
         {{t 'Stream name' }}
     </label>
-    <input type="text" id="change_stream_name" value="{{ stream_name }}" />
+    <input type="text" id="change_stream_name" value="{{ stream_name }}" maxlength="{{ max_stream_name_length }}" />
 </div>
 <div>
     <label for="change_stream_description">

--- a/static/templates/stream_settings/stream_creation_form.hbs
+++ b/static/templates/stream_settings/stream_creation_form.hbs
@@ -9,7 +9,7 @@
                     {{t "Stream name" }}
                 </label>
                 <input type="text" name="stream_name" id="create_stream_name"
-                  placeholder="{{t 'Stream name' }}" value="" autocomplete="off" maxlength="{{ max_name_length }}" />
+                  placeholder="{{t 'Stream name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
                 <div id="stream_name_error" class="stream_creation_error"></div>
             </section>
             <section class="block">
@@ -17,7 +17,7 @@
                     {{t "Stream description" }}
                 </label>
                 <input type="text" name="stream_description" id="create_stream_description"
-                  placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_description_length }}" />
+                  placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
             </section>
             <section class="block" id="make-invite-only">
                 <div class="stream-types">

--- a/static/templates/topic_edit_form.hbs
+++ b/static/templates/topic_edit_form.hbs
@@ -2,7 +2,7 @@
 
 <form id="topic_edit_form" class="form-horizontal">
     <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
-      autocomplete="off" />
+      autocomplete="off" maxlength="{{ max_topic_length }}" />
     <button type="button" class="topic_edit_save small_square_button animated-purple-button"><i class="fa fa-check" aria-hidden="true"></i></button>
     <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>
     <div class="alert alert-error edit_error" style="display: none"></div>


### PR DESCRIPTION
Restrict users to type only maxlength allowed for stream name and description while editing stream information.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
