### PR TITLE
search_suggestions: Show profile pictures in search auto-complete suggestions

### DIFF
--- a/frontend_tests/node_tests/search_future.js
+++ b/frontend_tests/node_tests/search_future.js
@@ -106,14 +106,14 @@ test("initialize", () => {
                     [
                         "stream:Verona",
                         {
-                            description: "Stream <strong>Ver</strong>ona",
+                            description_html: "Stream <strong>Ver</strong>ona",
                             search_string: "stream:Verona",
                         },
                     ],
                     [
                         "ver",
                         {
-                            description: "Search for ver",
+                            description_html: "Search for ver",
                             search_string: "ver",
                         },
                     ],

--- a/frontend_tests/node_tests/search_now.js
+++ b/frontend_tests/node_tests/search_now.js
@@ -92,14 +92,14 @@ run_test("initialize", () => {
                     [
                         "stream:Verona",
                         {
-                            description: "Stream <strong>Ver</strong>ona",
+                            description_html: "Stream <strong>Ver</strong>ona",
                             search_string: "stream:Verona",
                         },
                     ],
                     [
                         "ver",
                         {
-                            description: "Search for ver",
+                            description_html: "Search for ver",
                             search_string: "ver",
                         },
                     ],

--- a/frontend_tests/node_tests/search_now.js
+++ b/frontend_tests/node_tests/search_now.js
@@ -73,10 +73,21 @@ run_test("update_button_visibility", () => {
     assert.ok(!$search_button.prop("disabled"));
 });
 
-run_test("initialize", () => {
+run_test("initialize", ({mock_template}) => {
     const $search_query_box = $("#search_query");
     const $searchbox_form = $("#searchbox_form");
     const $search_button = $(".search_button");
+
+    mock_template("search_list_item.hbs", true, (data, html) => {
+        assert.equal(typeof data.description_html, "string");
+        if (data.is_person) {
+            assert.equal(typeof data.user_pill_context.id, "number");
+            assert.equal(typeof data.user_pill_context.display_value, "string");
+            assert.equal(typeof data.user_pill_context.has_image, "boolean");
+            assert.equal(typeof data.user_pill_context.img_src, "string");
+        }
+        return html;
+    });
 
     search_suggestion.max_num_of_search_results = 999;
     $search_query_box.typeahead = (opts) => {
@@ -92,7 +103,7 @@ run_test("initialize", () => {
                     [
                         "stream:Verona",
                         {
-                            description_html: "Stream <strong>Ver</strong>ona",
+                            description_html: "Stream&nbsp;<strong>Ver</strong>ona",
                             search_string: "stream:Verona",
                         },
                     ],
@@ -114,11 +125,93 @@ run_test("initialize", () => {
             assert.equal(source, expected_source_value);
 
             /* Test highlighter */
-            let expected_value = "Search for ver";
+            let expected_value = `<div class="search_list_item">\n    Search for ver\n</div>\n`;
             assert.equal(opts.highlighter(source[0]), expected_value);
 
-            expected_value = "Stream <strong>Ver</strong>ona";
+            expected_value = `<div class="search_list_item">\n    Stream&nbsp;<strong>Ver</strong>ona\n</div>\n`;
             assert.equal(opts.highlighter(source[1]), expected_value);
+
+            /* Test sorter */
+            assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);
+        }
+
+        {
+            const search_suggestions = {
+                lookup_table: new Map([
+                    [
+                        "group-pm-with:zo",
+                        {
+                            description_html: "group private messages including",
+                            is_person: true,
+                            search_string: "group-pm-with:user7@zulipdev.com",
+                            user_pill_context: {
+                                display_value: "<strong>Zo</strong>e",
+                                has_image: true,
+                                id: 7,
+                                img_src:
+                                    "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
+                            },
+                        },
+                    ],
+                    [
+                        "pm-with:zo",
+                        {
+                            description_html: "private messages with",
+                            is_person: true,
+                            search_string: "pm-with:user7@zulipdev.com",
+                            user_pill_context: {
+                                display_value: "<strong>Zo</strong>e",
+                                has_image: true,
+                                id: 7,
+                                img_src:
+                                    "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
+                            },
+                        },
+                    ],
+                    [
+                        "sender:zo",
+                        {
+                            description_html: "sent by",
+                            is_person: true,
+                            search_string: "sender:user7@zulipdev.com",
+                            user_pill_context: {
+                                display_value: "<strong>Zo</strong>e",
+                                has_image: true,
+                                id: 7,
+                                img_src:
+                                    "https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50",
+                            },
+                        },
+                    ],
+                    [
+                        "zo",
+                        {
+                            description_html: "Search for zo",
+                            search_string: "zo",
+                        },
+                    ],
+                ]),
+                strings: ["zo", "sender:zo", "pm-with:zo", "group-pm-with:zo"],
+            };
+
+            /* Test source */
+            search_suggestion.get_suggestions = () => search_suggestions;
+            const expected_source_value = search_suggestions.strings;
+            const source = opts.source("zo");
+            assert.equal(source, expected_source_value);
+
+            /* Test highlighter */
+            let expected_value = `<div class="search_list_item">\n    Search for zo\n</div>\n`;
+            assert.equal(opts.highlighter(source[0]), expected_value);
+
+            expected_value = `<div class="search_list_item">\n    sent by\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            assert.equal(opts.highlighter(source[1]), expected_value);
+
+            expected_value = `<div class="search_list_item">\n    private messages with\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            assert.equal(opts.highlighter(source[2]), expected_value);
+
+            expected_value = `<div class="search_list_item">\n    group private messages including\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            assert.equal(opts.highlighter(source[3]), expected_value);
 
             /* Test sorter */
             assert.equal(opts.sorter(search_suggestions.strings), search_suggestions.strings);

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -11,12 +11,12 @@ const search_pill = zrequire("search_pill");
 
 const is_starred_item = {
     display_value: "is:starred",
-    description: "starred messages",
+    description_html: "starred messages",
 };
 
 const is_private_item = {
     display_value: "is:private",
-    description: "private messages",
+    description_html: "private messages",
 };
 
 run_test("create_item", () => {

--- a/frontend_tests/node_tests/search_suggestion_future.js
+++ b/frontend_tests/node_tests/search_suggestion_future.js
@@ -388,7 +388,7 @@ test("empty_query_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("is:private"), "Private messages");
     assert.equal(describe("is:starred"), "Starred messages");
@@ -415,7 +415,7 @@ test("has_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("has:link"), "Messages with one or more link");
@@ -482,7 +482,7 @@ test("check_is_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("is:private"), "Private messages");
@@ -590,7 +590,10 @@ test("sent_by_me_suggestions", ({override}) => {
     let query = "";
     let suggestions = get_suggestions("", query);
     assert.ok(suggestions.strings.includes("sender:myself@zulip.com"));
-    assert.equal(suggestions.lookup_table.get("sender:myself@zulip.com").description, "Sent by me");
+    assert.equal(
+        suggestions.lookup_table.get("sender:myself@zulip.com").description_html,
+        "Sent by me",
+    );
 
     query = "sender";
     suggestions = get_suggestions("", query);
@@ -704,7 +707,7 @@ test("topic_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for te");
     assert.equal(describe("stream:office topic:team"), "Stream office &gt; team");
@@ -857,7 +860,7 @@ test("people_suggestions", ({override}) => {
 
     assert.deepEqual(suggestions.strings, expected);
 
-    const describe = (q) => suggestions.lookup_table.get(q).description;
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
 
     assert.equal(
         describe("pm-with:ted@zulip.com"),
@@ -927,7 +930,7 @@ test("people_suggestion (Admin only email visibility)", ({override}) => {
 
     assert.deepEqual(suggestions.strings, expected);
 
-    const describe = (q) => suggestions.lookup_table.get(q).description;
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
 
     assert.equal(
         describe("pm-with:ted@zulip.com"),

--- a/frontend_tests/node_tests/search_suggestion_now.js
+++ b/frontend_tests/node_tests/search_suggestion_now.js
@@ -392,7 +392,7 @@ test("empty_query_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("is:private"), "Private messages");
     assert.equal(describe("is:starred"), "Starred messages");
@@ -419,7 +419,7 @@ test("has_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("has:link"), "Messages with one or more link");
@@ -489,7 +489,7 @@ test("check_is_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
 
     assert.equal(describe("is:private"), "Private messages");
@@ -560,7 +560,10 @@ test("sent_by_me_suggestions", ({override}) => {
     let query = "";
     let suggestions = get_suggestions("", query);
     assert.ok(suggestions.strings.includes("sender:myself@zulip.com"));
-    assert.equal(suggestions.lookup_table.get("sender:myself@zulip.com").description, "Sent by me");
+    assert.equal(
+        suggestions.lookup_table.get("sender:myself@zulip.com").description_html,
+        "Sent by me",
+    );
 
     query = "sender";
     suggestions = get_suggestions("", query);
@@ -669,7 +672,7 @@ test("topic_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for te");
     assert.equal(describe("stream:office topic:team"), "Stream office &gt; team");
@@ -827,7 +830,7 @@ test("people_suggestions", ({override}) => {
 
     assert.deepEqual(suggestions.strings, expected);
     function describe(q) {
-        return suggestions.lookup_table.get(q).description;
+        return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(
         describe("pm-with:ted@zulip.com"),
@@ -971,7 +974,7 @@ test("people_suggestion (Admin only email visibility)", ({override}) => {
 
     assert.deepEqual(suggestions.strings, expected);
 
-    const describe = (q) => suggestions.lookup_table.get(q).description;
+    const describe = (q) => suggestions.lookup_table.get(q).description_html;
 
     assert.equal(
         describe("pm-with:ted@zulip.com"),

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -69,7 +69,7 @@ export function initialize() {
     const $searchbox = $("#searchbox");
 
     // Data storage for the typeahead.
-    // This maps a search string to an object with a "description" field.
+    // This maps a search string to an object with a "description_html" field.
     // (It's a bit of legacy that we have an object with only one important
     // field.  There's also a "search_string" field on each element that actually
     // just represents the key of the hash, so it's redundant.)
@@ -94,7 +94,7 @@ export function initialize() {
         naturalSearch: true,
         highlighter(item) {
             const obj = search_map.get(item);
-            return obj.description;
+            return obj.description_html;
         },
         matcher() {
             return true;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,5 +1,7 @@
 import $ from "jquery";
 
+import render_search_list_item from "../templates/search_list_item.hbs";
+
 import {Filter} from "./filter";
 import * as message_view_header from "./message_view_header";
 import * as narrow from "./narrow";
@@ -94,7 +96,7 @@ export function initialize() {
         naturalSearch: true,
         highlighter(item) {
             const obj = search_map.get(item);
-            return obj.description_html;
+            return render_search_list_item(obj);
         },
         matcher() {
             return true;

--- a/static/js/search_pill.js
+++ b/static/js/search_pill.js
@@ -3,10 +3,10 @@ import * as input_pill from "./input_pill";
 
 export function create_item_from_search_string(search_string) {
     const operator = Filter.parse(search_string);
-    const description = Filter.describe(operator);
+    const description_html = Filter.describe(operator);
     return {
         display_value: search_string,
-        description,
+        description_html,
     };
 }
 

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -19,13 +19,15 @@ function stream_matches_query(stream_name, q) {
 }
 
 function make_person_highlighter(query) {
-    const hilite = typeahead_helper.make_query_highlighter(query);
+    const highlight_query = typeahead_helper.make_query_highlighter(query);
 
     return function (person) {
         if (settings_data.show_email()) {
-            return hilite(person.full_name) + " &lt;" + hilite(person.email) + "&gt;";
+            return (
+                highlight_query(person.full_name) + " &lt;" + highlight_query(person.email) + "&gt;"
+            );
         }
-        return hilite(person.full_name);
+        return highlight_query(person.full_name);
     };
 }
 
@@ -107,11 +109,11 @@ function get_stream_suggestions(last, operators) {
     streams = typeahead_helper.sorter(query, streams);
 
     const regex = typeahead_helper.build_highlight_regex(query);
-    const hilite = typeahead_helper.highlight_with_escaping_and_regex;
+    const highlight_query = typeahead_helper.highlight_with_escaping_and_regex;
 
     const objs = streams.map((stream) => {
         const prefix = "stream";
-        const highlighted_stream = hilite(regex, stream);
+        const highlighted_stream = highlight_query(regex, stream);
         const verb = last.negated ? "exclude " : "";
         const description_html = verb + prefix + " " + highlighted_stream;
         const term = {

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -53,7 +53,7 @@ function check_validity(last, operators, valid, invalid) {
 
 function format_as_suggestion(terms) {
     return {
-        description: Filter.describe(terms),
+        description_html: Filter.describe(terms),
         search_string: Filter.unparse(terms),
     };
 }
@@ -113,14 +113,14 @@ function get_stream_suggestions(last, operators) {
         const prefix = "stream";
         const highlighted_stream = hilite(regex, stream);
         const verb = last.negated ? "exclude " : "";
-        const description = verb + prefix + " " + highlighted_stream;
+        const description_html = verb + prefix + " " + highlighted_stream;
         const term = {
             operator: "stream",
             operand: stream,
             negated: last.negated,
         };
         const search_string = Filter.unparse([term]);
-        return {description, search_string};
+        return {description_html, search_string};
     });
 
     return objs;
@@ -177,14 +177,14 @@ function get_group_suggestions(last, operators) {
             negated,
         };
         const name = highlight_person(person);
-        const description =
+        const description_html =
             prefix + " " + Handlebars.Utils.escapeExpression(all_but_last_part) + "," + name;
         let terms = [term];
         if (negated) {
             terms = [{operator: "is", operand: "private"}, term];
         }
         const search_string = Filter.unparse(terms);
-        return {description, search_string};
+        return {description_html, search_string};
     });
 
     return suggestions;
@@ -253,7 +253,7 @@ function get_person_suggestions(people_getter, last, operators, autocomplete_ope
 
     const objs = persons.map((person) => {
         const name = highlight_person(person);
-        const description = prefix + " " + name;
+        const description_html = prefix + " " + name;
         const terms = [
             {
                 operator: autocomplete_operator,
@@ -267,7 +267,7 @@ function get_person_suggestions(people_getter, last, operators, autocomplete_ope
             terms.unshift({operator: "is", operand: "private"});
         }
         const search_string = Filter.unparse(terms);
-        return {description, search_string};
+        return {description_html, search_string};
     });
 
     return objs;
@@ -277,7 +277,7 @@ function get_default_suggestion(operators) {
     // Here we return the canonical suggestion for the query that the
     // user typed. (The caller passes us the parsed query as "operators".)
     if (operators.length === 0) {
-        return {description: "", search_string: ""};
+        return {description_html: "", search_string: ""};
     }
     return format_as_suggestion(operators);
 }
@@ -430,7 +430,7 @@ function get_special_filter_suggestions(last, operators, suggestions) {
     if (last.negated || is_search_operand_negated) {
         suggestions = suggestions.map((suggestion) => ({
             search_string: "-" + suggestion.search_string,
-            description: "exclude " + suggestion.description,
+            description_html: "exclude " + suggestion.description_html,
             invalid: suggestion.invalid,
         }));
     }
@@ -452,13 +452,13 @@ function get_special_filter_suggestions(last, operators, suggestions) {
         return (
             s.search_string.toLowerCase().startsWith(last_string) ||
             show_operator_suggestions ||
-            s.description.toLowerCase().startsWith(last_string)
+            s.description_html.toLowerCase().startsWith(last_string)
         );
     });
 
     // Only show home if there's an empty bar
     if (operators.length === 0 && last_string === "") {
-        suggestions.unshift({search_string: "", description: "All messages"});
+        suggestions.unshift({search_string: "", description_html: "All messages"});
     }
     return suggestions;
 }
@@ -467,7 +467,7 @@ function get_streams_filter_suggestions(last, operators) {
     const suggestions = [
         {
             search_string: "streams:public",
-            description: "All public streams in organization",
+            description_html: "All public streams in organization",
             invalid: [
                 {operator: "is", operand: "private"},
                 {operator: "stream"},
@@ -484,7 +484,7 @@ function get_is_filter_suggestions(last, operators) {
     const suggestions = [
         {
             search_string: "is:private",
-            description: "private messages",
+            description_html: "private messages",
             invalid: [
                 {operator: "is", operand: "private"},
                 {operator: "stream"},
@@ -494,27 +494,27 @@ function get_is_filter_suggestions(last, operators) {
         },
         {
             search_string: "is:starred",
-            description: "starred messages",
+            description_html: "starred messages",
             invalid: [{operator: "is", operand: "starred"}],
         },
         {
             search_string: "is:mentioned",
-            description: "@-mentions",
+            description_html: "@-mentions",
             invalid: [{operator: "is", operand: "mentioned"}],
         },
         {
             search_string: "is:alerted",
-            description: "alerted messages",
+            description_html: "alerted messages",
             invalid: [{operator: "is", operand: "alerted"}],
         },
         {
             search_string: "is:unread",
-            description: "unread messages",
+            description_html: "unread messages",
             invalid: [{operator: "is", operand: "unread"}],
         },
         {
             search_string: "is:resolved",
-            description: "topics marked as resolved",
+            description_html: "topics marked as resolved",
             invalid: [{operator: "is", operand: "resolved"}],
         },
     ];
@@ -525,17 +525,17 @@ function get_has_filter_suggestions(last, operators) {
     const suggestions = [
         {
             search_string: "has:link",
-            description: "messages with one or more link",
+            description_html: "messages with one or more link",
             invalid: [{operator: "has", operand: "link"}],
         },
         {
             search_string: "has:image",
-            description: "messages with one or more image",
+            description_html: "messages with one or more image",
             invalid: [{operator: "has", operand: "image"}],
         },
         {
             search_string: "has:attachment",
-            description: "messages with one or more attachment",
+            description_html: "messages with one or more attachment",
             invalid: [{operator: "has", operand: "attachment"}],
         },
     ];
@@ -553,7 +553,7 @@ function get_sent_by_me_suggestions(last, operators) {
     const sender_me_query = negated_symbol + "sender:me";
     const from_me_query = negated_symbol + "from:me";
     const sent_string = negated_symbol + "sent";
-    const description = verb + "sent by me";
+    const description_html = verb + "sent by me";
 
     const invalid = [{operator: "sender"}, {operator: "from"}];
 
@@ -570,14 +570,14 @@ function get_sent_by_me_suggestions(last, operators) {
         return [
             {
                 search_string: sender_query,
-                description,
+                description_html,
             },
         ];
     } else if (from_query.startsWith(last_string) || from_me_query.startsWith(last_string)) {
         return [
             {
                 search_string: from_query,
-                description,
+                description_html,
             },
         ];
     }
@@ -614,9 +614,10 @@ class Attacher {
     }
 
     prepend_base(suggestion) {
-        if (this.base && this.base.description.length > 0) {
+        if (this.base && this.base.description_html.length > 0) {
             suggestion.search_string = this.base.search_string + " " + suggestion.search_string;
-            suggestion.description = this.base.description + ", " + suggestion.description;
+            suggestion.description_html =
+                this.base.description_html + ", " + suggestion.description_html;
         }
     }
 
@@ -780,8 +781,8 @@ export function get_suggestions(base_query, query) {
 
 export function finalize_search_result(result) {
     for (const sug of result) {
-        const first = sug.description.charAt(0).toUpperCase();
-        sug.description = first + sug.description.slice(1);
+        const first = sug.description_html.charAt(0).toUpperCase();
+        sug.description_html = first + sug.description_html.slice(1);
     }
 
     // Typeahead expects us to give it strings, not objects,

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -168,7 +168,7 @@ function get_group_suggestions(last, operators) {
 
     const prefix = Filter.operator_to_prefix("pm-with", negated);
 
-    const highlight_person = make_person_highlighter(last_part);
+    const person_highlighter = make_person_highlighter(last_part);
 
     const suggestions = persons.map((person) => {
         const term = {
@@ -176,7 +176,7 @@ function get_group_suggestions(last, operators) {
             operand: all_but_last_part + "," + person.email,
             negated,
         };
-        const name = highlight_person(person);
+        const name = person_highlighter(person);
         const description_html =
             prefix + " " + Handlebars.Utils.escapeExpression(all_but_last_part) + "," + name;
         let terms = [term];
@@ -249,10 +249,10 @@ function get_person_suggestions(people_getter, last, operators, autocomplete_ope
 
     const prefix = Filter.operator_to_prefix(autocomplete_operator, last.negated);
 
-    const highlight_person = make_person_highlighter(query);
+    const person_highlighter = make_person_highlighter(query);
 
     const objs = persons.map((person) => {
-        const name = highlight_person(person);
+        const name = person_highlighter(person);
         const description_html = prefix + " " + name;
         const terms = [
             {

--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -73,6 +73,20 @@
         }
     }
 
+    &.pill-container-btn {
+        cursor: pointer;
+        padding: 0;
+
+        .pill {
+            margin: 0;
+            border: none;
+
+            .exit {
+                display: none;
+            }
+        }
+    }
+
     .input {
         display: inline-block;
         padding: 2px 4px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -751,6 +751,16 @@ strong {
                     hsl(200, 100%, 35%)
                 );
             }
+
+            .search_list_item {
+                display: flex;
+                align-items: center;
+            }
+
+            .search_list_item .pill-container {
+                margin-left: 5px;
+            }
+
             /* styles defined for user_circle here only deal with positioning of user_presence_circle
             in typeahead list in order to ensure they are rendered correctly in in all screen sizes.
             Most of the style rules related to color, gradient etc. which are generally common throughout

--- a/static/templates/search_list_item.hbs
+++ b/static/templates/search_list_item.hbs
@@ -1,0 +1,8 @@
+<div class="search_list_item">
+    {{{ description_html }}}
+    {{#if is_person}}
+    <span class="pill-container pill-container-btn">
+        {{> input_pill user_pill_context}}
+    </span>
+    {{/if}}
+</div>


### PR DESCRIPTION
This PR adds the feature of showing users' profile pictures / avatars inline in the suggested autocomplete options. The last commit additionally fixes a bug where extra mid word segments of the search suggestions were highlighted instead of just the matching word prefixes.
(Borrows - after modifications - from #20494

Fixes: #20267

**Screenshots and screen captures:**

User profile pictures inline:
![image](https://user-images.githubusercontent.com/68962290/175644269-99175652-9de6-437a-beb7-725c570fa24c.png)

Only matching prefix highlighted (before this bug fix the "the" in the middle of O**the**llo too would be wrongly highlighted): 
![image](https://user-images.githubusercontent.com/68962290/175636409-41227632-b675-45be-98ee-8fb07b0de7be.png)


**Self-review checklist**

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
