### PR TITLE
Send notifications after topic change

### DIFF
--- a/frontend_tests/puppeteer_tests/edit.ts
+++ b/frontend_tests/puppeteer_tests/edit.ts
@@ -37,9 +37,9 @@ async function test_stream_message_edit(page: Page): Promise<void> {
         content: "test editing",
     });
 
-    await edit_stream_message(page, "edited", "test edited");
+    await edit_stream_message(page, "edits", "test edited");
 
-    await common.check_messages_sent(page, "zhome", [["Verona > edited", ["test edited"]]]);
+    await common.check_messages_sent(page, "zhome", [["Verona > edits", ["test edited"]]]);
 }
 
 async function test_edit_message_with_slash_me(page: Page): Promise<void> {
@@ -61,7 +61,7 @@ async function test_edit_message_with_slash_me(page: Page): Promise<void> {
         )} and normalize-space()="Desdemona"]`,
     );
 
-    await edit_stream_message(page, "edited", "/me test edited a message with me");
+    await edit_stream_message(page, "edits", "/me test edited a message with me");
 
     await page.waitForSelector(
         `xpath/${last_message_xpath}//*[${common.has_class_x(

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -844,6 +844,8 @@ export function save_inline_topic_edit($row) {
         message_id: message.id,
         topic: new_topic,
         propagate_mode: "change_later",
+        send_notification_to_old_thread: false,
+        send_notification_to_new_thread: false,
     };
 
     channel.patch({

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 152**
+
+* [`PATCH /messages/{message_id}`](/api/update-message): The
+  `send_notification_to_old_thread` and
+  `send_notification_to_new_thread` parameters are now respected when
+  moving a topic within a stream.
+
 **Feature level 151**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 151
+API_FEATURE_LEVEL = 152
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6259,21 +6259,30 @@ paths:
         - name: send_notification_to_old_thread
           in: query
           description: |
-            Whether to send an automated message to the old thread to
+            Whether to send an automated message to the old topic to
             notify users where the messages were moved to.
 
-            **Changes**: New in Zulip 3.0 (feature level 9).
+            **Changes**: Before Zulip 6.0 (feature level 152), this parameter
+            had a default of `true` and was ignored unless the stream was changed.
+
+            New in Zulip 3.0 (feature level 9).
           schema:
             type: boolean
-            default: true
+            default: false
           example: true
         - name: send_notification_to_new_thread
           in: query
           description: |
-            Whether to send an automated message to the new thread to
+            Whether to send an automated message to the new topic to
             notify users where the messages came from.
 
-            **Changes**: New in Zulip 3.0 (feature level 9).
+            If the move is just [resolving/unresolving a topic](/help/resolve-a-topic),
+            this parameter will not trigger an additional notification.
+
+            **Changes**: Before Zulip 6.0 (feature level 152), this parameter
+            was ignored unless the stream was changed.
+
+            New in Zulip 3.0 (feature level 9).
           schema:
             type: boolean
             default: true

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -122,7 +122,7 @@ def update_message_backend(
     propagate_mode: str = REQ(
         default="change_one", str_validator=check_string_in(PROPAGATE_MODE_VALUES)
     ),
-    send_notification_to_old_thread: bool = REQ(default=True, json_validator=check_bool),
+    send_notification_to_old_thread: bool = REQ(default=False, json_validator=check_bool),
     send_notification_to_new_thread: bool = REQ(default=True, json_validator=check_bool),
     content: Optional[str] = REQ(default=None),
 ) -> HttpResponse:


### PR DESCRIPTION
Fixes #21712

Send a notification to the old and new topic after only the topic was changed, not the stream.
![chrome-capture-2022-5-30](https://user-images.githubusercontent.com/74348920/176680531-25afd740-c651-4c69-b34b-a3dd79bbd1e8.gif)

