### PR TITLE
check-thirdparty: License under GPLv2+

### DIFF
--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -114,6 +114,10 @@ Source: https://github.com/ionic-team/ionicons/blob/v5.5.2/src/svg/earth.svg, mo
 Copyright: 2015-present Ionic (http://ionic.io/)
 License: Expat
 
+Files: tools/check-thirdparty
+Copyright: 2020 Kandra Labs, Inc.
+License: GPL-2.0+
+
 License: Apache-2.0
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -1273,3 +1277,17 @@ License: GPL-2.0
  .
  On Debian systems, the complete text of the GNU General Public License
  can be found in /usr/share/common-licenses/GPL-2 file.
+
+License: GPL-2.0+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or (at
+ your option) any later version.
+ .
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ .
+ On Debian systems, the complete text of the GNU General Public
+ License can be found in /usr/share/common-licenses/GPL-2 file.

--- a/tools/check-thirdparty
+++ b/tools/check-thirdparty
@@ -7,6 +7,24 @@ Disclaimer: This script is not a lawyer.  It cannot validate that the
 claimed licenses are correct.  It can only check for basic syntactic
 issues.
 """
+
+# Copyright © 2020 Kandra Labs, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
 import difflib
 import io
 import os


### PR DESCRIPTION
Since python-debian is GPL licensed, our script that imports it should arguably be GPL licensed as well.