### PR TITLE
Show Organization info  in the gear menu

### DIFF
--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -100,6 +100,10 @@ export function update_org_settings_menu_item() {
 
 export function initialize() {
     const rendered_gear_menu = render_gear_menu({
+        realm_name: page_params.realm_name,
+        realm_uri: new URL(page_params.realm_uri).hostname,
+        is_owner: page_params.is_owner,
+        zulip_plan: page_params.zulip_plan_is_not_limited,
         apps_page_url: page_params.apps_page_url,
         can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
         corporate_enabled: page_params.corporate_enabled,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -361,6 +361,35 @@ p.n-margin {
     }
 }
 
+.dropdown-menu .org-head .org-name{
+   font-size: large;
+   text-align: center;
+   font-weight: bold;
+}
+
+.dropdown-menu .org-head .org-uri{
+    text-align: center;
+    line-height: 100%;
+    color: rgb(118, 121, 123);
+}
+
+.dropdown-menu .org-head .org-plan{
+    text-align: center;
+    line-height: 2.5em;
+    font-size: medium;
+    font-weight: 200px;
+    color:rgb(69, 151, 245)
+}
+
+.dropdown-menu .org-head .text{
+    text-align: center;
+    line-height:0%;
+    padding-bottom: 10px;
+    font-weight: lighter;
+    font-weight: 400;
+    color: rgb(118, 121, 123);
+}
+
 .app {
     width: 100%;
     height: 100%;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -361,33 +361,34 @@ p.n-margin {
     }
 }
 
-.dropdown-menu .org-head .org-name{
-   font-size: large;
-   text-align: center;
-   font-weight: bold;
+.dropdown-menu .org-head .org-name {
+    font-size: large;
+    text-align: center;
+    font-weight: bold;
 }
 
-.dropdown-menu .org-head .org-uri{
+.dropdown-menu .org-head .org-uri {
     text-align: center;
     line-height: 100%;
     color: rgb(118, 121, 123);
 }
 
-.dropdown-menu .org-head .org-plan{
+.dropdown-menu .org-head .org-plan {
     text-align: center;
     line-height: 2.5em;
     font-size: medium;
     font-weight: 200px;
-    color:rgb(69, 151, 245)
+    color: hsl(0, 0%, 52%)
 }
 
-.dropdown-menu .org-head .text{
+.dropdown-menu .org-head .text {
     text-align: center;
-    line-height:0%;
+    line-height: 0%;
     padding-bottom: 10px;
     font-weight: lighter;
     font-weight: 400;
-    color: rgb(118, 121, 123);
+    color: hsl(0, 0%, 52%)
+
 }
 
 .app {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -370,7 +370,7 @@ p.n-margin {
 .dropdown-menu .org-head .org-uri {
     text-align: center;
     line-height: 100%;
-    color: rgb(118, 121, 123);
+    color: hsl(0, 0%, 52%)
 }
 
 .dropdown-menu .org-head .org-plan {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -375,10 +375,10 @@ p.n-margin {
 
 .dropdown-menu .org-head .org-plan {
     text-align: center;
-    line-height: 2.5em;
-    font-size: medium;
+    font-size: 15px;
+    padding-top: 10px;
     font-weight: 200px;
-    color: hsl(0, 0%, 52%);
+    color: hsl(226, 82%, 60%);
 }
 
 .dropdown-menu .org-head .text {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -370,7 +370,7 @@ p.n-margin {
 .dropdown-menu .org-head .org-uri {
     text-align: center;
     line-height: 100%;
-    color: hsl(0, 0%, 52%)
+    color: hsl(0, 0%, 52%);
 }
 
 .dropdown-menu .org-head .org-plan {
@@ -378,7 +378,7 @@ p.n-margin {
     line-height: 2.5em;
     font-size: medium;
     font-weight: 200px;
-    color: hsl(0, 0%, 52%)
+    color: hsl(0, 0%, 52%);
 }
 
 .dropdown-menu .org-head .text {
@@ -387,8 +387,7 @@ p.n-margin {
     padding-bottom: 10px;
     font-weight: lighter;
     font-weight: 400;
-    color: hsl(0, 0%, 52%)
-
+    color: hsl(0, 0%, 52%);
 }
 
 .app {

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -21,7 +21,7 @@
                         <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to Zulip Cloud Standard</a></span>
                     {{else}}
                         <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span><br>
-                    {{/if}}    
+                {{/if}}
                 {{/if}}
                 </li>
             </ul>

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -7,7 +7,26 @@
             {{!-- It is quite ingrained in our frontend code that your Home
             view is a Bootstrap nav tab, even though we don't show the tab
             anymore --}}
+            {{#if is_guest }}
+            {{else}}
             <li class="invisible" style="display:none;" role="presentation"><a href="#message_feed_container" data-toggle="tab"></a></li>
+            <ul class="org-head hidden-for-spectators">
+                <li class="org-name hidden-for-spectators">{{realm_name}}</li>
+                <li class="org-uri hidden-for-spectators">{{realm_uri}}</li>
+                <li class="org-plan hidden-for-spectators">
+                {{#if zulip_plan }}
+                        <span class="org-plan-s">Zulip Cloud: Standard</span>
+                {{else}}
+                    {{#if is_owner}}
+                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to Zulip Cloud Standard</a></span>
+                    {{else}}
+                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span><br>
+                    {{/if}}    
+                {{/if}}
+                </li>
+            </ul>
+            <li class="divider" role="presentation"></li>
+            {{/if}}
             <li class="hidden-for-spectators" role="presentation">
                 <a href="#streams/subscribed" role="menuitem">
                     <i class="fa fa-exchange" aria-hidden="true"></i> {{t 'Manage streams' }}

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -20,7 +20,7 @@
                     {{#if is_owner}}
                         <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to Zulip Cloud Standard</a></span>
                     {{else}}
-                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span
+                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span>
                 {{/if}}
                 {{/if}}
                 </li>

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -14,15 +14,15 @@
                 <li class="org-name hidden-for-spectators">{{realm_name}}</li>
                 <li class="org-uri hidden-for-spectators">{{realm_uri}}</li>
                 <li class="org-plan hidden-for-spectators">
-                {{#if zulip_plan }}
+                    {{#if zulip_plan }}
                         <span class="org-plan-s">Zulip Cloud: Standard</span>
-                {{else}}
-                    {{#if is_owner}}
-                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to Zulip Cloud Standard</a></span>
                     {{else}}
-                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span>
-                {{/if}}
-                {{/if}}
+                        {{#if is_owner}}
+                            <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to Zulip Cloud Standard</a></span>
+                        {{else}}
+                            <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span>
+                        {{/if}}
+                    {{/if}}
                 </li>
             </ul>
             <li class="divider" role="presentation"></li>

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -15,12 +15,13 @@
                 <li class="org-uri hidden-for-spectators">{{realm_uri}}</li>
                 <li class="org-plan hidden-for-spectators">
                     {{#if zulip_plan }}
-                        <span class="org-plan-s">Zulip Cloud: Standard</span>
+                        <span class="org-plan-s">Zulip Cloud Standard</span>
                     {{else}}
                         {{#if is_owner}}
-                            <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to Zulip Cloud Standard</a></span>
+                            <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to<br/>
+                            Zulip Cloud Standard</a></span>
                         {{else}}
-                            <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span>
+                            <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud Free</a></span>
                         {{/if}}
                     {{/if}}
                 </li>

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -20,7 +20,7 @@
                     {{#if is_owner}}
                         <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/upgrade">Upgrade to Zulip Cloud Standard</a></span>
                     {{else}}
-                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span><br>
+                        <span class="org-plan-s" role="menuitem"><a href="https://zulip.com/plans/">Zulip Cloud: Free</a></span
                 {{/if}}
                 {{/if}}
                 </li>


### PR DESCRIPTION
Added the organization info for free and standard plans only

# For standard plan 
![standard](https://user-images.githubusercontent.com/83438518/175809694-443e7fd7-5d61-4ebd-a016-d2ae9706be70.png)

# For Owner with free plan
![user-owner](https://user-images.githubusercontent.com/83438518/175809744-46c6ddc3-b707-4665-a072-8fda247b1dfa.png)

# For User with free plan
![user-free](https://user-images.githubusercontent.com/83438518/175809750-ddd1d761-eae9-4a3c-a4e4-d55f900490fe.png)


Self-review checklist

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability(variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

 Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
 Corner cases, error conditions, and easily imagined bugs.