### PR TITLE
run-dev: Remove unnecessary finish calls

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -277,11 +277,9 @@ class BaseHandler(web.RequestHandler):
                     self.add_header(header, v)
             if response.body:
                 self.write(response.body)
-            await self.finish()
         except (ConnectionError, httpclient.HTTPError) as e:
             self.set_status(500)
             self.write("Internal server error:\n" + str(e))
-            await self.finish()
 
 
 class WebPackHandler(BaseHandler):


### PR DESCRIPTION
Tornado finishes the request automatically.  Avoids this error, hidden until commit 81f7192ca3f59f326c6d8c2fc584d35346314c6f (#22301), when the browser tab is closed:

```pytb
Traceback (most recent call last):
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/tornado/web.py", line 1683, in _execute
    result = await result
  File "tools/run-dev.py", line 280, in prepare
    await self.finish()
tornado.iostream.StreamClosedError: Stream is closed
```