### PR TITLE
Render Mac shortcuts with `Fn` key correctly.

### DIFF
--- a/static/js/common.ts
+++ b/static/js/common.ts
@@ -48,7 +48,11 @@ export function has_mac_keyboard(): boolean {
     return /mac/i.test(navigator.platform);
 }
 
-export function adjust_mac_shortcuts(key_elem_class: string, require_cmd_style = false): void {
+export function adjust_mac_shortcuts(
+    key_elem_class: string,
+    kbd_elem = true,
+    require_cmd_style = false,
+): void {
     if (!has_mac_keyboard()) {
         return;
     }
@@ -56,26 +60,42 @@ export function adjust_mac_shortcuts(key_elem_class: string, require_cmd_style =
     const keys_map = new Map([
         ["Backspace", "Delete"],
         ["Enter", "Return"],
-        ["Home", "Fn + ←"],
-        ["End", "Fn + →"],
-        ["PgUp", "Fn + ↑"],
-        ["PgDn", "Fn + ↓"],
+        ["Home", "←"],
+        ["End", "→"],
+        ["PgUp", "↑"],
+        ["PgDn", "↓"],
         ["Ctrl", "⌘"],
     ]);
 
+    const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
+
     $(key_elem_class).each(function () {
         let key_text = $(this).text();
-        const keys = key_text.match(/[^\s+]+/g) || [];
 
-        if (key_text.includes("Ctrl") && require_cmd_style) {
+        // There may be matches to `key_elem_class` that are not
+        // keyboard shortcuts. Since keyboard shortcuts should be an
+        // exact match to the text on a physical key of a keyboard,
+        // none of which have spaces, we check and return early for
+        // any matched element's text that contains whitespace.
+        if (/\s/.test(key_text)) {
+            return;
+        }
+
+        if (key_text === "Ctrl" && require_cmd_style) {
             $(this).addClass("mac-cmd-key");
         }
 
-        for (const key of keys) {
-            const replace_key = keys_map.get(key);
-            if (replace_key !== undefined) {
-                key_text = key_text.replace(key, replace_key);
+        if (fn_shortcuts.has(key_text)) {
+            if (kbd_elem) {
+                $(this).before("<kbd>Fn</kbd> + ");
+            } else {
+                $(this).before("<code>Fn</code> + ");
             }
+        }
+
+        const replace_key = keys_map.get(key_text);
+        if (replace_key !== undefined) {
+            key_text = replace_key;
         }
 
         $(this).text(key_text);

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -58,7 +58,7 @@ function render_code_sections() {
 
     highlight_current_article();
 
-    common.adjust_mac_shortcuts(".markdown .content code", true);
+    common.adjust_mac_shortcuts(".markdown .content code", false, true);
 
     $("table").each(function () {
         $(this).addClass("table table-striped");


### PR DESCRIPTION
Updates the `adjusts_mac_shortcuts` function to render shortcuts with the `Fn` key as a separate html element (e.g. `Fn` + `arrow`) instead of rendering the shortcut as one block (e.g. `Fn + arrow`).

Also, because keyboard shortcuts should be rendered with each key as a separate html element, updates `adjusts_mac_shortcuts` to only change html elements that are an exact match to a keyboard key.

Html elements with whitespace will be ignored (e.g. `Enter` becomes `Return`, but `Enter or Backspace` is not changed though it previously would have been changes to `Return or Delete`).

Fixes #22112 (in combination with #22273).

---

**Notes on changes**:

- Because the function is used with selectors for both `code` and `kbd` elements, I decided to go with "code" as the default html element for the `Fn` key, and then to check for "kbd" as the last part of the selector passed as a function parameter to update from that default.

- If the `+` is removed in the redesign for keyboard shortcuts with multiple keys (e.g. `Fn` + `→` needs to become `Fn` `→`), then it will be easy to update for that change.

---

**Screenshots and screen captures:**

<details>
<summary>Help center keyboard shortcuts documentation</summary>

#### Note that any shortcuts in the markdown files like `Ctrl + [` are not fixed by this PR, but rather #22273.

![Screenshot from 2022-06-27 21-22-28](https://user-images.githubusercontent.com/63245456/176020146-581b1bdc-98fd-4153-bb00-354b64356258.png)

![Screenshot from 2022-06-27 21-34-23](https://user-images.githubusercontent.com/63245456/176021532-644a9b28-3ffa-4da2-aa33-c5b8df1fe921.png)

</details>

<details>
<summary>Info overlays</summary>

![Screenshot from 2022-06-27 21-20-45](https://user-images.githubusercontent.com/63245456/176020554-b4824cbc-4841-4102-b314-cd802a4fc4a4.png)
![Screenshot from 2022-06-27 21-21-04](https://user-images.githubusercontent.com/63245456/176020558-39b862b9-8ea2-4cee-9f41-bbf7de5295c0.png)
</details>

<details>
<summary>Enter sends UI</summary>

![Screenshot from 2022-06-27 21-21-27](https://user-images.githubusercontent.com/63245456/176020735-e2b2326e-adf6-41af-afe4-fda48fc6aabe.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
