### PR TITLE
integrations: Satisfy Python-Markdown’s archaic 4-space requirement

### DIFF
--- a/templates/zerver/integrations/jenkins.md
+++ b/templates/zerver/integrations/jenkins.md
@@ -31,9 +31,9 @@
    If you don't specify a custom topic, the project name will be used as the
    topic instead. Then click **Save**.
 
-   ![Post-build action configuration](/static/images/integrations/jenkins/003.png)
+    ![Post-build action configuration](/static/images/integrations/jenkins/003.png)
 
-   When your builds fail or succeed, you'll see a message as shown below.
+    When your builds fail or succeed, you'll see a message as shown below.
 
 {!congrats.md!}
 

--- a/zerver/webhooks/beanstalk/doc.md
+++ b/zerver/webhooks/beanstalk/doc.md
@@ -4,8 +4,8 @@ Zulip supports both SVN and Git notifications from Beanstalk.
 
 1. {!create-a-bot.md!}
 
-   {!webhook-url-with-bot-email.md!}
-   {!git-append-branches.md!}
+    {!webhook-url-with-bot-email.md!}
+    {!git-append-branches.md!}
 
 1. On your repository's webpage, click on the **Settings**
    tab. Click on the **Integrations** tab, scroll down and click on

--- a/zerver/webhooks/gitea/doc.md
+++ b/zerver/webhooks/gitea/doc.md
@@ -4,7 +4,7 @@ Receive Gitea notifications in Zulip!
 
 1. {!create-bot-construct-url.md!}
 
-   {!git-webhook-url-with-branches.md!}
+    {!git-webhook-url-with-branches.md!}
 
 1. Go to your repository on Gitea and click on **Settings**. Select
    **Webhooks** on the left sidebar, and click **Add Webhook**.

--- a/zerver/webhooks/github/doc.md
+++ b/zerver/webhooks/github/doc.md
@@ -4,7 +4,7 @@ Get GitHub notifications in Zulip!
 
 1. {!create-bot-construct-url.md!}
 
-   {!git-webhook-url-with-branches.md!}
+    {!git-webhook-url-with-branches.md!}
 
 1. Go to your repository on GitHub and click on the **Settings** tab.
    Select **Webhooks**. Click on **Add webhook**. GitHub may prompt

--- a/zerver/webhooks/gogs/doc.md
+++ b/zerver/webhooks/gogs/doc.md
@@ -4,7 +4,7 @@ Receive Gogs notifications in Zulip!
 
 1. {!create-bot-construct-url.md!}
 
-   {!git-webhook-url-with-branches.md!}
+    {!git-webhook-url-with-branches.md!}
 
 1. Go to your repository on Gogs and click on **Settings**. Select
    **Webhooks** on the left sidebar, and click **Add Webhook**.


### PR DESCRIPTION
Followup to commit dc33a0ae6734f47f407a0cdc15a94ef488da6e47 (#22315).

Context: https://github.com/zulip/zulip/pull/22315#discussion_r907391604