### PR TITLE
bots: Allow bot owners to unsubscribe their own bots from streams using UI.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -316,6 +316,9 @@ test_people("basics", () => {
 
     assert.equal(people.get_bot_owner_user(bot_botson).full_name, "Isaac Newton");
 
+    assert.equal(people.can_admin_user(me), true);
+    assert.equal(people.can_admin_user(bot_botson), false);
+
     // Add our cross-realm bot.  It won't add to our human
     // count, and it has no owner.
     people.add_cross_realm_user(welcome_bot);

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -190,7 +190,6 @@ test_ui("sender_hover", ({override, mock_template}) => {
             sent_by_uri: "#narrow/sender/42-alice",
             private_message_class: "respond_personal_button",
             show_email: false,
-            show_user_profile: true,
             is_me: false,
             is_active: true,
             is_bot: undefined,

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -113,6 +113,13 @@ export function get_bot_owner_user(user) {
     return get_by_user_id(owner_id);
 }
 
+export function can_admin_user(user) {
+    return (
+        (user.is_bot && user.bot_owner_id && user.bot_owner_id === page_params.user_id) ||
+        is_my_user_id(user.user_id)
+    );
+}
+
 export function id_matches_email_operand(user_id, email) {
     const person = get_by_email(email);
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -241,7 +241,6 @@ function render_user_info_popover(
         private_message_class: private_msg_class,
         sent_by_uri: hash_util.by_sender_url(user.email),
         show_email: settings_data.show_email(),
-        show_user_profile: !user.is_bot,
         user_email: people.get_visible_email(user),
         user_full_name: user.full_name,
         user_id: user.user_id,

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -20,6 +20,7 @@ import {page_params} from "./page_params";
 import * as people from "./people";
 import * as settings_config from "./settings_config";
 import * as ui_report from "./ui_report";
+import * as user_profile from "./user_profile";
 
 const OUTGOING_WEBHOOK_BOT_TYPE = "3";
 const GENERIC_BOT_TYPE = "1";
@@ -580,6 +581,14 @@ export function set_up() {
         const $bot_info = $(this).closest(".bot-information-box").find(".bot_info");
         const bot_id = Number.parseInt($bot_info.attr("data-user-id"), 10);
         $(this).attr("href", generate_zuliprc_uri(bot_id));
+    });
+
+    $("#active_bots_list").on("click", "button.open_bots_subscribed_streams", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const bot_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
+        const bot = people.get_by_user_id(bot_id);
+        user_profile.show_user_profile(bot, "user-profile-streams-tab");
     });
 
     new ClipboardJS("#copy_zuliprc", {

--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -160,6 +160,21 @@ export function hide_user_profile() {
     overlays.close_modal("user-profile-modal");
 }
 
+function initialize_user_type_fields(user) {
+    // Avoid duplicate pill fields, by removing existing ones.
+    $("#user-profile-modal .pill").remove();
+    if (!user.is_bot) {
+        settings_account.initialize_custom_user_type_fields(
+            "#user-profile-modal #content",
+            user.user_id,
+            false,
+            false,
+        );
+    } else {
+        initialize_bot_owner("#user-profile-modal #content", user.user_id);
+    }
+}
+
 export function show_user_profile(user, default_tab_key = "profile-tab") {
     popovers.hide_all();
 
@@ -223,6 +238,9 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
             $(".tabcontent").hide();
             $("#" + key).show();
             switch (key) {
+                case "profile-tab":
+                    initialize_user_type_fields(user);
+                    break;
                 case "user-profile-groups-tab":
                     render_user_group_list(groups_of_user, user);
                     break;
@@ -236,17 +254,6 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     const $elem = components.toggle(opts).get();
     $elem.addClass("large allow-overflow");
     $("#tab-toggle").append($elem);
-
-    if (!user.is_bot) {
-        settings_account.initialize_custom_user_type_fields(
-            "#user-profile-modal #content",
-            user.user_id,
-            false,
-            false,
-        );
-    } else {
-        initialize_bot_owner("#user-profile-modal #content", user.user_id);
-    }
 }
 
 function handle_remove_stream_subscription(target_user_id, sub, success, failure) {

--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -55,7 +55,7 @@ function initialize_bot_owner(element_id, bot_id) {
 
 function format_user_stream_list_item(stream, user) {
     const show_unsubscribe_button =
-        people.is_my_user_id(user.user_id) || settings_data.user_can_unsubscribe_other_users();
+        people.can_admin_user(user) || settings_data.user_can_unsubscribe_other_users();
     const show_private_stream_unsub_tooltip =
         people.is_my_user_id(user.user_id) && stream.invite_only;
     return render_user_stream_list_item({
@@ -252,7 +252,6 @@ function handle_remove_stream_subscription(target_user_id, sub, success, failure
             error: failure,
         });
     } else {
-        // Unsubscribed by admin.
         subscriber_api.remove_user_id_from_stream(target_user_id, sub, success, failure);
     }
 }

--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -160,7 +160,7 @@ export function hide_user_profile() {
     overlays.close_modal("user-profile-modal");
 }
 
-export function show_user_profile(user) {
+export function show_user_profile(user, default_tab_key = "profile-tab") {
     popovers.hide_all();
 
     const dateFormat = new Intl.DateTimeFormat("default", {dateStyle: "long"});
@@ -203,9 +203,16 @@ export function show_user_profile(user) {
     $("#user-profile-modal-holder").html(render_user_profile_modal(args));
     overlays.open_modal("user-profile-modal", {autoremove: true});
     $(".tabcontent").hide();
-    $("#profile-tab").show(); // Show general profile details by default.
+
+    let default_tab = 0;
+    // Only checking this tab key as currently we only open this tab directly
+    // other than profile-tab.
+    if (default_tab_key === "user-profile-streams-tab") {
+        default_tab = 1;
+    }
+
     const opts = {
-        selected: 0,
+        selected: default_tab,
         child_wants_focus: true,
         values: [
             {label: $t({defaultMessage: "Profile"}), key: "profile-tab"},

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1663,19 +1663,22 @@ $option_title_width: 180px;
     }
 }
 
-.custom_user_field .pill-container {
-    padding: 2px 6px;
-    min-height: 24px;
-    max-width: 206px;
-    background-color: hsl(0, 0%, 100%);
+.custom_user_field,
+.bot_owner_user_field {
+    .pill-container {
+        padding: 2px 6px;
+        min-height: 24px;
+        max-width: 206px;
+        background-color: hsl(0, 0%, 100%);
 
-    &:focus-within {
-        border-color: hsla(206, 80%, 62%, 0.8);
-        outline: 0;
-        outline: 1px dotted \9;
+        &:focus-within {
+            border-color: hsla(206, 80%, 62%, 0.8);
+            outline: 0;
+            outline: 1px dotted \9;
 
-        box-shadow: inset 0 1px 1px hsla(0, 0%, 0%, 0.075),
-            0 0 8px hsla(206, 80%, 62%, 0.6);
+            box-shadow: inset 0 1px 1px hsla(0, 0%, 0%, 0.075),
+                0 0 8px hsla(206, 80%, 62%, 0.6);
+        }
     }
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -737,6 +737,10 @@ input[type="checkbox"] {
         .copy-gold {
             color: hsl(51, 90%, 50%);
         }
+
+        .purple {
+            color: hsl(278, 62%, 68%);
+        }
     }
 
     .bot-information-box {

--- a/static/templates/settings/bot_avatar_row.hbs
+++ b/static/templates/settings/bot_avatar_row.hbs
@@ -17,6 +17,9 @@
                 <button type="submit" class="btn deactivate_bot danger-red" title="{{t 'Deactivate bot' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-user-times" aria-hidden="true"></i>
                 </button>
+                <button type="submit" class="btn open_bots_subscribed_streams" title="{{t 'Subscribed streams' }}" data-user-id="{{user_id}}">
+                    <i class="fa fa-hashtag purple" aria-hidden="true"></i>
+                </button>
             </div>
             {{/if}}
         </div>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -102,7 +102,6 @@
     {{else}}
 
         <hr />
-        {{#if show_user_profile}}
         <li>
             <a tabindex="0" class="view_full_user_profile">
                 {{#if is_me}}
@@ -112,7 +111,6 @@
                 {{/if}}
             </a>
         </li>
-        {{/if}}
         {{#if can_send_private_message}}
             <li>
                 <a tabindex="0" class="{{ private_message_class }}">

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -30,7 +30,7 @@
 
         {{#if is_bot}}
             {{#if bot_owner}}
-                <li>{{#tr}}Owner{{/tr}}:
+                <li>{{#tr}}Bot owner{{/tr}}:
                     <span class="bot-owner-name view_user_profile" data-user-id='{{ bot_owner.user_id }}'>
                         {{bot_owner.full_name}}
                     </span>

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -5,6 +5,9 @@
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
                 <div id="name">
                     {{full_name}}
+                    {{#if is_bot}}
+                    <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                    {{/if}}
                     {{#if is_me}}
                     <a href="/#settings/profile">
                         <i class="fa fa-edit" id="edit-button" aria-hidden="true"></i>
@@ -29,7 +32,15 @@
                                     </div>
                                     <div id="user-type" class="default-field">
                                         <div class="name">{{#tr}}Role{{/tr}}</div>
-                                        <div class="value">{{user_type}}</div>
+                                        {{#if is_bot}}
+                                            {{#if is_system_bot}}
+                                            <div class="value">{{#tr}}System bot{{/tr}}</div>
+                                            {{else}}
+                                            <div class="value">{{#tr}}Bot{{/tr}}</div>
+                                            {{/if}}
+                                        {{else}}
+                                            <div class="value">{{user_type}}</div>
+                                        {{/if}}
                                     </div>
                                     <div id="date-joined" class="default-field">
                                         <div class="name">{{#tr}}Joined{{/tr}}</div>
@@ -55,26 +66,41 @@
                         </div>
                         <div class="bottom">
                             <div id="content">
-                                {{#each profile_data}}
-                                    <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
-                                        <div class="name">{{this.name}}</div>
-                                        {{#if this.is_user_field}}
-                                            <div class="pill-container not-editable" data-field-id="{{this.id}}">
-                                                <div class="input" contenteditable="false" style="display: none;"></div>
-                                            </div>
-                                        {{else if this.is_link}}
-                                            <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
-                                        {{else if this.is_external_account}}
-                                            <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
-                                        {{else}}
-                                            {{#if this.rendered_value}}
-                                            <div class="value rendered_markdown">{{rendered_markdown this.rendered_value}}</div>
-                                            {{else}}
-                                            <div class="value">{{this.value}}</div>
-                                            {{/if}}
-                                        {{/if}}
+                                {{#if is_bot}}
+                                    <div class="field-section">
+                                        <div class="name">{{#tr}}Bot type{{/tr}}</div>
+                                        <div class="bot_info_value">{{bot_type}}</div>
                                     </div>
-                                {{/each}}
+                                    {{#if bot_owner}}
+                                    <div class="field-section bot_owner_user_field" data-field-id="{{bot_owner.user_id}}">
+                                        <div class="name">{{#tr}}Owner{{/tr}}</div>
+                                        <div class="pill-container not-editable">
+                                            <div class="input" contenteditable="false" style="display: none;"></div>
+                                        </div>
+                                    </div>
+                                    {{/if}}
+                                {{else}}
+                                    {{#each profile_data}}
+                                        <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
+                                            <div class="name">{{this.name}}</div>
+                                            {{#if this.is_user_field}}
+                                                <div class="pill-container not-editable" data-field-id="{{this.id}}">
+                                                    <div class="input" contenteditable="false" style="display: none;"></div>
+                                                </div>
+                                            {{else if this.is_link}}
+                                                <a href="{{this.value}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
+                                            {{else if this.is_external_account}}
+                                                <a href="{{this.link}}" target="_blank" rel="noopener noreferrer" class="value">{{this.value}}</a>
+                                            {{else}}
+                                                {{#if this.rendered_value}}
+                                                <div class="value rendered_markdown">{{rendered_markdown this.rendered_value}}</div>
+                                                {{else}}
+                                                <div class="value">{{this.value}}</div>
+                                                {{/if}}
+                                            {{/if}}
+                                        </div>
+                                    {{/each}}
+                                {{/if}}
                             </div>
                         </div>
                     </div>

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 145**
+
+* [`DELETE users/me/subscriptions`](/api/unsubscribe): Normal users can
+  now remove bots that they own from streams.
+
 **Feature level 144**
 
 * [`GET /messages/{message_id}/read_receipts`](/api/get-read-receipts):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 144
+API_FEATURE_LEVEL = 145
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7736,6 +7736,16 @@ paths:
       tags: ["streams"]
       description: |
         Unsubscribe yourself or other users from one or more streams.
+
+        In addition to managing the current user's subscriptions, this
+        endpoint can be used by organization administrators to remove
+        other users from streams, or to remove a bot that the current
+        user is the `bot_owner` for from any stream that the current
+        user can access.
+
+        **Changes**: Before Zulip 6.0 (feature level 145), only
+        organization administrators could remove other users from
+        streams.
       x-curl-examples-parameters:
         oneOf:
           - type: include


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR allows bot owners to unsubscribe their own bots from subscribed streams using UI.
The process is the same as normal users: Profile info popover > View full profile > streams tab 

Admins can unsubscribe bots from streams using this UI like normal users.

[CZO](https://chat.zulip.org/#narrow/stream/2-general/topic/Unsubscribe.20own.20bot.20from.20streams/near/1353629)

Fixes:  #21402, #22460

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary> 

**Screenshots and screen captures:**

</summary>

![bot_profile_popover](https://user-images.githubusercontent.com/41695888/176038110-96c6952f-6964-4ed6-9e5b-2ac4d66c8acd.png)

![bot_profile_modal](https://user-images.githubusercontent.com/41695888/176038108-a259a893-9498-4189-a649-7cab52e8ccc0.png)

![full_profile_modal_from_bot_card](https://user-images.githubusercontent.com/41695888/186401210-94bb80ba-524e-4531-9fc7-ffd96a7dd5d6.gif)

![unsubscribing_own_bot_from_stream](https://user-images.githubusercontent.com/41695888/176038113-d881f6c2-35eb-455c-9b48-9cd4e8aedbf4.gif)
</details>

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
