### PR TITLE
markdown: Parse included blocks in a new parser state

### DIFF
--- a/zerver/lib/markdown/include.py
+++ b/zerver/lib/markdown/include.py
@@ -47,7 +47,9 @@ class IncludeBlockProcessor(BlockProcessor):
         return "\n".join(lines)
 
     def run(self, parent: Element, blocks: List[str]) -> None:
-        blocks[:1] = self.RE.sub(self.expand_include, blocks[0]).split("\n\n")
+        self.parser.state.set("include")
+        self.parser.parseChunk(parent, self.RE.sub(self.expand_include, blocks.pop(0)))
+        self.parser.state.reset()
 
 
 def makeExtension(base_path: str) -> IncludeExtension:


### PR DESCRIPTION
This fixes inclusion of a multi-paragraph file into a list item.

Followup to commit dc33a0ae6734f47f407a0cdc15a94ef488da6e47 (#22315).

Context: https://github.com/zulip/zulip/pull/22315#discussion_r907422775