### PR TITLE
nginx: Remove legacy X-XSS-Protection header

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-common/headers
+++ b/puppet/zulip/files/nginx/zulip-include-common/headers
@@ -5,4 +5,3 @@ add_header Strict-Transport-Security max-age=15768000 always;
 add_header X-Frame-Options DENY always;
 
 add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";

--- a/tools/ci/success-http-headers.template.txt
+++ b/tools/ci/success-http-headers.template.txt
@@ -7,7 +7,6 @@ content-language: en
 strict-transport-security: max-age=15768000
 x-frame-options: DENY
 x-content-type-options: nosniff
-x-xss-protection: 1; mode=block
 access-control-allow-origin: *
 access-control-allow-headers: Authorization
 access-control-allow-methods: GET, POST, DELETE, PUT, PATCH, HEAD


### PR DESCRIPTION
Support for this header was removed in Chrome 78, Safari 15.4, and Edge 17.  It was never supported in Firefox.