### PR TITLE
tools: Support running mypy daemon for better performance.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ show_error_codes = true
 # Warn of unreachable or redundant code.
 warn_unreachable = true
 
+# dmypy enables local_partial_types implicitly. We need mypy to align
+# with this behavior.
+local_partial_types = true
+
 [[tool.mypy.overrides]]
 module = ["zproject.configured_settings", "zproject.settings"]
 no_implicit_reexport = false

--- a/tools/lint
+++ b/tools/lint
@@ -31,6 +31,7 @@ def run() -> None:
     parser = argparse.ArgumentParser()
     add_provision_check_override_param(parser)
     parser.add_argument("--full", action="store_true", help="Check some things we typically ignore")
+    parser.add_argument("--use-mypy-daemon", action="store_true", help="Run mypy daemon instead")
     add_default_linter_arguments(parser)
     args = parser.parse_args()
 
@@ -131,12 +132,19 @@ def run() -> None:
     command = ["tools/run-mypy", "--quiet"]
     if args.skip_provision_check:
         command.append("--skip-provision-check")
+    if args.use_mypy_daemon:
+        command.append("--use-daemon")
     linter_config.external_linter(
         "mypy",
         command,
         ["py", "pyi"],
         pass_targets=False,
         description="Static type checker for Python (config: pyproject.toml)",
+        suppress_line=(
+            lambda line: line.startswith("Daemon") or line == "Restarting: configuration changed"
+        )
+        if args.use_mypy_daemon
+        else lambda _: False,
     )
     linter_config.external_linter(
         "tsc",

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -338,7 +338,7 @@ def print_listeners() -> None:
     print()
 
 
-children = []
+children: List["subprocess.Popen[bytes]"] = []
 
 
 async def serve() -> None:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -28,12 +28,16 @@ parser.add_argument(
 parser.add_argument(
     "-a", "--all", action="store_true", help="check all files, bypassing the default exclude list"
 )
+parser.add_argument("-d", "--use-daemon", action="store_true", help="run mypy daemon instead")
 add_provision_check_override_param(parser)
 parser.add_argument("--quiet", action="store_true", help="suppress mypy summary output")
 args = parser.parse_args()
 assert_provisioning_status_ok(args.skip_provision_check)
 
-command_name = "mypy"
+if args.use_daemon:
+    command_name = "dmypy"
+else:
+    command_name = "mypy"
 
 # Use zulip-py3-venv's mypy if it's available.
 VENV_DIR = "/srv/zulip-py3-venv"
@@ -69,6 +73,9 @@ if not python_files and not pyi_files:
     sys.exit(0)
 
 mypy_args: List[str] = []
+# --no-error-summary is a mypy flag that comes after all dmypy options
+if args.use_daemon:
+    mypy_args += ["run", "--"]
 if args.quiet:
     mypy_args += ["--no-error-summary"]
 mypy_args += ["--", *python_files, *pyi_files]

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -8,9 +8,10 @@ from typing import List
 from zulint import lister
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-os.chdir(os.path.dirname(TOOLS_DIR))
+ROOT_DIR = os.path.dirname(TOOLS_DIR)
+os.chdir(ROOT_DIR)
 
-sys.path.append(os.path.dirname(TOOLS_DIR))
+sys.path.append(ROOT_DIR)
 from tools.lib.test_script import add_provision_check_override_param, assert_provisioning_status_ok
 
 exclude = """


### PR DESCRIPTION
mypy daemon performs significantly better than running the regular
mypy cli tool when we type check the entire codebase multiple
times locally.

This adds running mypy daemon as an option for both
`tools/run-mypy` and `tools/lint`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
