### PR TITLE
copy-paste: Fix edge cases on message selection for copying.

### DIFF
--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -239,9 +239,6 @@ export function analyze_selection(selection) {
         // last message
         if ($endc.attr("id") === "bottom_whitespace" || $endc.attr("id") === "compose_close") {
             $initial_end_tr = $(".message_row").last();
-            // The selection goes off the end of the message feed, so
-            // this is a multi-message selection.
-            skip_same_td_check = true;
         } else {
             $initial_end_tr = $($endc.parents(".selectable_row")[0]);
         }

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -232,16 +232,7 @@ export function analyze_selection(selection) {
         }
 
         $endc = $(range.endContainer);
-        // If the selection ends in the bottom whitespace, we should
-        // act as though the selection ends on the final message.
-        // This handles the issue that Chrome seems to like selecting
-        // the compose_close button when you go off the end of the
-        // last message
-        if ($endc.attr("id") === "bottom_whitespace" || $endc.attr("id") === "compose_close") {
-            $initial_end_tr = $(".message_row").last();
-        } else {
-            $initial_end_tr = $($endc.parents(".selectable_row")[0]);
-        }
+        $initial_end_tr = get_end_tr_from_endc($endc);
         end_data = find_boundary_tr($initial_end_tr, ($row) => $row.prev());
 
         if (end_data === undefined) {
@@ -265,6 +256,19 @@ export function analyze_selection(selection) {
         end_id,
         skip_same_td_check,
     };
+}
+
+function get_end_tr_from_endc($endc) {
+    if ($endc.attr("id") === "bottom_whitespace" || $endc.attr("id") === "compose_close") {
+        // If the selection ends in the bottom whitespace, we should
+        // act as though the selection ends on the final message.
+        // This handles the issue that Chrome seems to like selecting
+        // the compose_close button when you go off the end of the
+        // last message
+        return $(".message_row").last();
+    }
+
+    return $($endc.parents(".selectable_row")[0]);
 }
 
 export function paste_handler_converter(paste_html) {

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -268,6 +268,29 @@ function get_end_tr_from_endc($endc) {
         return $(".message_row").last();
     }
 
+    // Sometimes (especially when three click selecting in Chrome) the selection
+    // can end in a hidden element in e.g. the next message, a date divider.
+    // We can tell this is the case because the selection isn't inside a
+    // `messagebox-content` div, which is where the message text itself is.
+    // TODO: Ideally make it so that the selection cannot end there.
+    // For now, we find find the message row directly above wherever the
+    // selection ended.
+    if ($endc.closest(".messagebox-content").length === 0) {
+        // If the selection ends within the message following the selected
+        // messages, go back to use the actual last message.
+        if ($endc.parents(".message_row").length > 0) {
+            const $parent_msg = $($endc.parents(".message_row")[0]);
+            return $parent_msg.prev(".message_row");
+        }
+        // If it's not in a .message_row, it's probably in a .message_header and
+        // we can use the last message from the previous recipient_row.
+        if ($endc.parents(".message_header").length > 0) {
+            const $overflow_recipient_row = $($endc.parents(".recipient_row")[0]);
+            return $overflow_recipient_row.prev(".recipient_row").last(".message_row");
+        }
+        // If somehow we get here, do the default return.
+    }
+
     return $($endc.parents(".selectable_row")[0]);
 }
 


### PR DESCRIPTION
When we detect that multiple messages are selected, copying will copy the
entirety of each message that is selected. [more conversation on that
here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/triple.20click.20.2B.20copy.20paste.20bug/near/1398292).

This commit fixes a bug where we would select the entirety of a message even
when none of the message itself was selected (only some HTML element in the
messages's container).

Fixes #18706.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
