### PR TITLE
help-docs: Update translation general information text.

### DIFF
--- a/templates/zerver/help/change-the-default-language-for-your-organization.md
+++ b/templates/zerver/help/change-the-default-language-for-your-organization.md
@@ -2,9 +2,7 @@
 
 {!admin-only.md!}
 
-Zulip has been translated or partially translated into dozens of
-languages. You can see which languages Zulip supports, and help add
-support for new languages on **[Transifex](https://www.transifex.com/zulip/zulip/)**.
+{!translation-project-info.md!}
 
 Each user can use Zulip with [their preferred
 language](/help/change-your-language). In addition, if your
@@ -21,13 +19,13 @@ can set the notifications language for the organization. This setting:
   cannot detect their language preferences from their browser,
   including all users [created via the Zulip API][api-create-user].
 
-### Configure the organization notifications language
+## Configure the organization notifications language
 
 {start_tabs}
 
 {settings_tab|organization-settings}
 
-2. Under **Notifications**, change the **Notifications language**.
+1. Under **Notifications**, change the **Notifications language**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/change-your-language.md
+++ b/templates/zerver/help/change-your-language.md
@@ -1,29 +1,29 @@
 # Change your language
 
-Zulip has been translated or partially translated into dozens of
-languages. You can see which languages Zulip supports, and help add
-support for new languages on **[Transifex](https://www.transifex.com/zulip/zulip/)**.
+{!translation-project-info.md!}
 
 If your organization has a primary language other than American
 English, an administrator should also [set the organization
 notifications language][change-org-lang].
 
+!!! warn ""
+
+    **Note**: This setting controls the language of your Zulip UI.
+    It does not alter any message text or topic, or stream name
+    and description.
+
 [change-org-lang]: change-the-default-language-for-your-organization
 
-### Change your language
+## Change your language
 
 {start_tabs}
 
 {settings_tab|display-settings}
 
-2. Under **Language and time**, click the button next to **Language**.
+1. Under **Language and time**, click the button under **Language**.
 
-3. Click on a language.
+1. Select a language.
 
-4. Click **Reload**.
+1. Click **Reload**.
 
 {end_tabs}
-
-!!! tip ""
-
-    You can always send and read messages in any language.

--- a/templates/zerver/help/include/translation-project-info.md
+++ b/templates/zerver/help/include/translation-project-info.md
@@ -1,0 +1,8 @@
+Zulip has been translated or partially translated into dozens of
+languages by Zulip's amazing community of volunteer translators.
+You can see which languages Zulip supports [on Transifex][transifex-zulip].
+If you'd like to help by contributing as a translator, see the
+[Zulip translation guidelines][translating-zulip] to get started.
+
+[transifex-zulip]: https://www.transifex.com/zulip/zulip/
+[translating-zulip]: https://zulip.readthedocs.io/en/latest/translating/translating.html


### PR DESCRIPTION
Adds a shared file with general information about Zulip's translation project based on the text in web-app's language
picker, and uses that text at the beginning of the help articles for setting the organization notifications/announcement language and for the user setting their personal language setting.

Also makes some small edits/updates to the help center article about the user's personal language setting to align with current UI and current documentation styles.

Addresses this part of #21949:
> Both language articles advertise contributing support for new languages on **[Transifex](https://www.transifex.com/zulip/zulip/)**.; we should probably adjust that language to match the nicer language we have in the language picker itself. (In particular, it's a bad experience to start out on Transifex, since it has no instructions).

**Question**:
- I find the **Tip** in the **Change your language** article to be a bit confusing. I interpret the part about sending a message in any language to be that you can write the message in any language? And I'm not sure what reading a message in any language means in that context?

--- 

**Screenshots**:

![Screenshot from 2022-06-29 17-38-27](https://user-images.githubusercontent.com/63245456/176478316-a89dbbaa-8de0-4a0e-8b45-e267cd6cece7.png)

![Screenshot from 2022-06-29 17-38-42](https://user-images.githubusercontent.com/63245456/176478326-c4026f43-edf0-4ac6-8959-1145a5d99d65.png)

**Note the location of the language button is now below (and not next to) the header**
![Screenshot from 2022-06-29 17-43-47](https://user-images.githubusercontent.com/63245456/176480158-6957943e-8536-40e1-9cae-714f85dfaf92.png)

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
