### PR TITLE
manage: Remove ineffective Python 2 check

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,20 +2,14 @@
 import configparser
 import os
 import sys
+from collections import defaultdict
 from typing import Dict, List, Optional
-
-if sys.version_info <= (3, 0):
-    print("Error: Zulip is a Python 3 project, and cannot be run with Python 2.")
-    print("Use e.g. `/path/to/manage.py` not `python /path/to/manage.py`.")
-    sys.exit(1)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(BASE_DIR)
 from scripts.lib.setup_path import setup_path
 
 setup_path()
-
-from collections import defaultdict
 
 from django.core.management import ManagementUtility, get_commands
 from django.core.management.color import color_style


### PR DESCRIPTION
Python 2 can’t parse this file, so it never gets as far as running the check.

This isn’t really a problem anymore. The `python` → `python2` symlink is optional and deprecated in Ubuntu 20.04 and Debian 11; it’s removed in Ubuntu 22.04 and Debian 12.

(Also the `<=` was weird.)