### PR TITLE
zephyr: Write out unix timestamp in check, as check_cron_file expects.

### DIFF
--- a/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
+++ b/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness
@@ -51,7 +51,7 @@ def report(state: str, short_msg: str, too_old: AbstractSet[Any] = set()) -> Non
         )
 
     with open(state_file_path + ".tmp", "w") as f:
-        f.write(f"{now}|{states[state]}|{state}|{short_msg}{too_old_data}")
+        f.write(f"{int(now.timestamp())}|{states[state]}|{state}|{short_msg}{too_old_data}")
     os.rename(state_file_path + ".tmp", state_file_path)
     print(f"{state}: {short_msg}{too_old_data}")
     exit(states[state])


### PR DESCRIPTION
A follow-up fix to 8bc26aab08ad.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
