### PR TITLE
docs: Remove CSS padding rule for multi-paragraph ordered lists.

### DIFF
--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -135,12 +135,6 @@
                 text-align: center;
             }
 
-            & > .codehilite,
-            & > p:not(:first-child) {
-                padding-left: 24px;
-                margin-left: 5px;
-            }
-
             .codehilite {
                 background-color: hsl(0, 0%, 100%);
             }


### PR DESCRIPTION
Removes CSS rule in `markdown.css` that added a left margin and padding to not first-child paragraph elements and `codehilite` class div elements in ordered list elements.

Rule was added in 2017 and likely was correcting the alignment of these elements due to another CSS rule that has since been removed. See [this CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/Padding.20ordered.20list.20paragraphs/near/1398558) for more context and many screenshots.

---

**Screenshots and screen captures:**

<details>
<summary>API docs example</summary>

[Link to current documentation](https://zulip.com/api/non-webhook-integrations)
![Screenshot from 2022-06-29 12-38-20](https://user-images.githubusercontent.com/63245456/176688347-199b1c21-7e4a-4920-9ce7-5606a3957532.png)
</details>

<details>
<summary>Integrations docs example</summary>

[Link to current documentation](https://zulip.com/integrations/doc/basecamp)
![Screenshot from 2022-06-29 12-40-33](https://user-images.githubusercontent.com/63245456/176688355-4a458cb0-d548-4200-8e56-e2d8109f98ec.png)
</details>

<details>
<summary>Help center docs example</summary>

[Link to current documentation](https://zulip.com/help/saml-authentication)
![Screenshot from 2022-06-29 12-41-32](https://user-images.githubusercontent.com/63245456/176688360-3034b710-6210-4ecc-bff3-2cbff562d4af.png)
</details>

--- 

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
