### PR TITLE
support: Extract PlanData as a dataclass.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 class TestSupportEndpoint(ZulipTestCase):
     def test_search(self) -> None:
         reset_emails_in_zulip_realm()
+        lear_realm = get_realm("lear")
 
         def assert_user_details_in_html_response(
             html_response: "TestHttpResponse", full_name: str, email: str, role: str
@@ -106,7 +107,6 @@ class TestSupportEndpoint(ZulipTestCase):
             )
 
         def check_lear_realm_query_result(result: "TestHttpResponse") -> None:
-            lear_realm = get_realm("lear")
             self.assert_in_success_response(
                 [
                     f'<input type="hidden" name="realm_id" value="{lear_realm.id}"',
@@ -213,7 +213,7 @@ class TestSupportEndpoint(ZulipTestCase):
             acting_user=None,
         )
 
-        customer = Customer.objects.create(realm=get_realm("lear"), stripe_customer_id="cus_123")
+        customer = Customer.objects.create(realm=lear_realm, stripe_customer_id="cus_123")
         now = datetime(2016, 1, 2, tzinfo=timezone.utc)
         plan = CustomerPlan.objects.create(
             customer=customer,

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -287,30 +287,11 @@ def support(
             except ValidationError:
                 users.update(UserProfile.objects.filter(full_name__iexact=key_word))
 
-        plan_data: Dict[int, PlanData] = {}
-        for realm in realms:
-            current_plan = get_current_plan_by_realm(realm)
-            plan_data[realm.id] = PlanData(
-                customer=get_customer_by_realm(realm),
-                current_plan=current_plan,
-            )
-            if current_plan is not None:
-                new_plan, last_ledger_entry = make_end_of_cycle_updates_if_needed(
-                    current_plan, timezone_now()
-                )
-                if last_ledger_entry is not None:
-                    if new_plan is not None:
-                        plan_data[realm.id].current_plan = new_plan
-                    else:
-                        plan_data[realm.id].current_plan = current_plan
-                    plan_data[realm.id].licenses = last_ledger_entry.licenses
-                    plan_data[realm.id].licenses_used = get_latest_seat_count(realm)
         # full_names can have , in them
         users.update(UserProfile.objects.filter(full_name__iexact=query))
 
         context["users"] = users
         context["realms"] = realms
-        context["plan_data"] = plan_data
 
         confirmations: List[Dict[str, Any]] = []
 
@@ -329,6 +310,39 @@ def support(
         )
 
         context["confirmations"] = confirmations
+
+        # We want a union of all realms that might appear in the search result,
+        # but not necessary as a separate result item.
+        # Therefore, we do not modify the realms object in the context.
+        all_realms = realms.union(
+            [
+                confirmation["object"].realm
+                for confirmation in confirmations
+                # For confirmations, we only display realm details when the type is USER_REGISTRATION
+                # or INVITATION.
+                if confirmation["type"] in (Confirmation.USER_REGISTRATION, Confirmation.INVITATION)
+            ]
+            + [user.realm for user in users]
+        )
+        plan_data: Dict[int, PlanData] = {}
+        for realm in all_realms:
+            current_plan = get_current_plan_by_realm(realm)
+            plan_data[realm.id] = PlanData(
+                customer=get_customer_by_realm(realm),
+                current_plan=current_plan,
+            )
+            if current_plan is not None:
+                new_plan, last_ledger_entry = make_end_of_cycle_updates_if_needed(
+                    current_plan, timezone_now()
+                )
+                if last_ledger_entry is not None:
+                    if new_plan is not None:
+                        plan_data[realm.id].current_plan = new_plan
+                    else:
+                        plan_data[realm.id].current_plan = current_plan
+                    plan_data[realm.id].licenses = last_ledger_entry.licenses
+                    plan_data[realm.id].licenses_used = get_latest_seat_count(realm)
+        context["plan_data"] = plan_data
 
     def get_realm_owner_emails_as_string(realm: Realm) -> str:
         return ", ".join(

--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -80,13 +80,13 @@
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     <select name="sponsorship_pending">
-        <option value="true" {% if realm.customer and realm.customer.sponsorship_pending %}selected{% endif %}>Yes</option>
-        <option value="false" {% if not realm.customer or not realm.customer.sponsorship_pending %}selected{% endif %}>No</option>
+        <option value="true" {% if plan_data[realm.id].customer and plan_data[realm.id].customer.sponsorship_pending %}selected{% endif %}>Yes</option>
+        <option value="false" {% if not plan_data[realm.id].customer or not plan_data[realm.id].customer.sponsorship_pending %}selected{% endif %}>No</option>
     </select>
     <button type="submit" class="btn btn-default support-submit-button">Update</button>
 </form>
 
-{% if realm.customer and realm.customer.sponsorship_pending %}
+{% if plan_data[realm.id].customer and plan_data[realm.id].customer.sponsorship_pending %}
 <form method="POST" class="approve-sponsorship-form">
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
@@ -102,7 +102,7 @@
     <b>Discount (use 85 for nonprofits)</b>:<br />
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-    {% if realm.current_plan and realm.current_plan.fixed_price %}
+    {% if plan_data[realm.id].current_plan and plan_data[realm.id].current_plan.fixed_price %}
     <input type="number" name="discount" value="{{ get_discount_for_realm(realm) }}" disabled />
     <button type="submit" class="btn btn-default support-submit-button" disabled>Update</button>
     {% else %}
@@ -110,19 +110,19 @@
     <button type="submit" class="btn btn-default support-submit-button">Update</button>
     {% endif %}
 </form>
-{% if realm.current_plan %}
+{% if plan_data[realm.id].current_plan %}
 <div class="current-plan-details">
     <h3>📅 Current plan</h3>
-    <b>Name</b>: {{ realm.current_plan.name }}<br />
-    <b>Status</b>: {{realm.current_plan.get_plan_status_as_text()}}<br />
-    <b>Billing schedule</b>: {% if realm.current_plan.billing_schedule == realm.current_plan.ANNUAL %}Annual{% else %}Monthly{% endif %}<br />
-    <b>Licenses</b>: {{ realm.current_plan.licenses_used }}/{{ realm.current_plan.licenses }} ({% if realm.current_plan.automanage_licenses %}Automatic{% else %}Manual{% endif %})<br />
-    {% if realm.current_plan.price_per_license %}
-    <b>Price per license</b>: ${{ realm.current_plan.price_per_license/100 }}<br />
+    <b>Name</b>: {{ plan_data[realm.id].current_plan.name }}<br />
+    <b>Status</b>: {{plan_data[realm.id].current_plan.get_plan_status_as_text()}}<br />
+    <b>Billing schedule</b>: {% if plan_data[realm.id].current_plan.billing_schedule == plan_data[realm.id].current_plan.ANNUAL %}Annual{% else %}Monthly{% endif %}<br />
+    <b>Licenses</b>: {{ plan_data[realm.id].licenses_used }}/{{ plan_data[realm.id].licenses }} ({% if plan_data[realm.id].current_plan.automanage_licenses %}Automatic{% else %}Manual{% endif %})<br />
+    {% if plan_data[realm.id].current_plan.price_per_license %}
+    <b>Price per license</b>: ${{ plan_data[realm.id].current_plan.price_per_license/100 }}<br />
     {% else %}
-    <b>Fixed price</b>: ${{ realm.current_plan.fixed_price/100 }}<br />
+    <b>Fixed price</b>: ${{ plan_data[realm.id].current_plan.fixed_price/100 }}<br />
     {% endif %}
-    <b>Next invoice date</b>: {{ realm.current_plan.next_invoice_date.strftime('%d %B %Y') }}<br />
+    <b>Next invoice date</b>: {{ plan_data[realm.id].current_plan.next_invoice_date.strftime('%d %B %Y') }}<br />
 </div>
 
 <form method="POST" class="billing-method-form">
@@ -131,8 +131,8 @@
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     <select name="billing_method" class="billing-method-select" required>
-        <option value="charge_automatically" {% if realm.current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
-        <option value="send_invoice" {% if not realm.current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
+        <option value="charge_automatically" {% if plan_data[realm.id].current_plan.charge_automatically %}selected{% endif %}>Charge automatically</option>
+        <option value="send_invoice" {% if not plan_data[realm.id].current_plan.charge_automatically %}selected{% endif %}>Pay by invoice</option>
     </select>
     <button type="submit" class="btn btn-default support-submit-button">Update</button>
 </form>


### PR DESCRIPTION
This avoids monkey-patching `CustomerPlan` and other related information
onto the `Realm` object by having a separate dictionary with the realm
id as the key, each corresponds to a `PlandData` dataclass.

This is a part of the django-stubs refactorings.

Fixes: <!-- Issue link, or clear description.-->

```diff
3,10d2
< analytics/views/support.py error Incompatible types in assignment (expression has type "Optional[Customer]", variable has type "Customer")  [assignment]
< analytics/views/support.py error "Realm" has no attribute "current_plan"  [attr-defined]
< analytics/views/support.py error "Realm" has no attribute "current_plan"  [attr-defined]
< analytics/views/support.py error "Realm" has no attribute "current_plan"  [attr-defined]
< analytics/views/support.py error Cannot assign to a method  [assignment]
< analytics/views/support.py error Incompatible types in assignment (expression has type "int", variable has type "Callable[[], int]")  [assignment]
< analytics/views/support.py error "CustomerPlan" has no attribute "licenses_used"; maybe "licenses"?  [attr-defined]
< analytics/views/support.py error "Realm" has no attribute "current_plan"  [attr-defined]
```

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
