### PR TITLE
email_notifications: Give absolute path to html2text

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -1,8 +1,10 @@
 # See https://zulip.readthedocs.io/en/latest/subsystems/notifications.html
 
 import logging
+import os
 import re
 import subprocess
+import sys
 from collections import defaultdict
 from datetime import timedelta
 from email.headerregistry import Address
@@ -705,7 +707,9 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> N
 
 def convert_html_to_markdown(html: str) -> str:
     # html2text is GPL licensed, so run it as a subprocess.
-    markdown = subprocess.check_output(["html2text"], input=html, text=True).strip()
+    markdown = subprocess.check_output(
+        [os.path.join(sys.prefix, "bin", "html2text")], input=html, text=True
+    ).strip()
 
     # We want images to get linked and inline previewed, but html2text will turn
     # them into links of the form `![](http://foo.com/image.png)`, which is


### PR DESCRIPTION
Our uWSGI configuration doesn’t correctly activate our virtualenv.  We should investigate that, but until we do, we need to invoke `html2text` by an absolute path.