### PR TITLE
decorator: Type narrow the default login_url.

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -28,6 +28,7 @@ from .configured_settings import (
     AUTH_LDAP_SERVER_URI,
     AUTHENTICATION_BACKENDS,
     CAMO_URI,
+    CUSTOM_HOME_NOT_LOGGED_IN,
     DEBUG,
     DEBUG_ERROR_REPORTING,
     EMAIL_BACKEND,
@@ -38,7 +39,6 @@ from .configured_settings import (
     EXTERNAL_URI_SCHEME,
     EXTRA_INSTALLED_APPS,
     GOOGLE_OAUTH2_CLIENT_ID,
-    HOME_NOT_LOGGED_IN,
     INVITATION_LINK_VALIDITY_DAYS,
     IS_DEV_DROPLET,
     LOCAL_UPLOADS_DIR,
@@ -1039,11 +1039,15 @@ ONLY_LDAP = AUTHENTICATION_BACKENDS == ("zproject.backends.ZulipLDAPAuthBackend"
 USING_APACHE_SSO = "zproject.backends.ZulipRemoteUserBackend" in AUTHENTICATION_BACKENDS
 ONLY_SSO = AUTHENTICATION_BACKENDS == ("zproject.backends.ZulipRemoteUserBackend",)
 
-if HOME_NOT_LOGGED_IN is None:
-    if ONLY_SSO:
-        HOME_NOT_LOGGED_IN = "/accounts/login/sso/"
-    else:
-        HOME_NOT_LOGGED_IN = "/login/"
+if CUSTOM_HOME_NOT_LOGGED_IN is not None:
+    # We import this with a different name to avoid a mypy bug with
+    # type-narrowed default parameter values.
+    # https://github.com/python/mypy/issues/13087
+    HOME_NOT_LOGGED_IN = CUSTOM_HOME_NOT_LOGGED_IN
+elif ONLY_SSO:
+    HOME_NOT_LOGGED_IN = "/accounts/login/sso/"
+else:
+    HOME_NOT_LOGGED_IN = "/login/"
 
 AUTHENTICATION_BACKENDS += ("zproject.backends.ZulipDummyBackend",)
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -106,7 +106,7 @@ SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT: Dict[str, Dict[str, Dict[str, str]]] = {}
 
 # Other auth
 SSO_APPEND_DOMAIN: Optional[str] = None
-HOME_NOT_LOGGED_IN: Optional[str] = None
+CUSTOM_HOME_NOT_LOGGED_IN: Optional[str] = None
 
 VIDEO_ZOOM_CLIENT_ID = get_secret("video_zoom_client_id", development_only=True)
 VIDEO_ZOOM_CLIENT_SECRET = get_secret("video_zoom_client_secret")

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -79,7 +79,7 @@ WEB_PUBLIC_STREAMS_ENABLED = True
 INVITES_MIN_USER_AGE_DAYS = 0
 
 # Redirect to /devlogin/ by default in dev mode
-HOME_NOT_LOGGED_IN = "/devlogin/"
+CUSTOM_HOME_NOT_LOGGED_IN = "/devlogin/"
 LOGIN_URL = "/devlogin/"
 
 # For development convenience, configure the ToS/Privacy Policies


### PR DESCRIPTION
django-stubs dynamically collects the type annotation for us from the
settings, acknowledging mypy that `HOME_NOT_LOGGED_IN` is an
`Optional[str]`. Type narrowing with assertions does not play well with
the default value of the decorator, so we declare another `Final[str]`
to bypass this restriction.

Fixes: <!-- Issue link, or clear description.-->

```diff
78d77
< zerver/decorator.py error Incompatible default for argument "login_url" (default has type "Optional[str]", argument has type "str")  [assignment]
87,91d85
< zerver/decorator.py error Incompatible default for argument "login_url" (default has type "Optional[str]", argument has type "str")  [assignment]
< zerver/decorator.py error Incompatible default for argument "login_url" (default has type "Optional[str]", argument has type "str")  [assignment]
< zerver/decorator.py error Incompatible default for argument "login_url" (default has type "Optional[str]", argument has type "str")  [assignment]
< zerver/decorator.py error Incompatible default for argument "login_url" (default has type "Optional[str]", argument has type "str")  [assignment]
< zerver/decorator.py error Argument 1 to "HttpResponseRedirect" has incompatible type "Optional[str]"; expected "str"  [arg-type]
```
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
