### PR TITLE
settings_org: Use settings_checkbox in Authentication Methods UI.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -418,7 +418,7 @@ export function populate_auth_methods(auth_methods) {
     if (!meta.loaded) {
         return;
     }
-    const $auth_methods_table = $("#id_realm_authentication_methods").expectOne();
+    const $auth_methods_list = $("#id_realm_authentication_methods").expectOne();
     auth_methods = sort_object_by_key(auth_methods);
     let rendered_auth_method_rows = "";
     for (const [auth_method, value] of Object.entries(auth_methods)) {
@@ -435,7 +435,7 @@ export function populate_auth_methods(auth_methods) {
             prefix: "id_authmethod" + auth_method.toLowerCase().replace(/[^\da-z]/g, "") + "_",
         });
     }
-    $auth_methods_table.html(rendered_auth_method_rows);
+    $auth_methods_list.html(rendered_auth_method_rows);
 }
 
 function update_dependent_subsettings(property_name) {
@@ -720,7 +720,7 @@ export function set_up() {
     maybe_disable_widgets();
 }
 
-function get_auth_method_table_data() {
+function get_auth_method_list_data() {
     const new_auth_methods = {};
     const $auth_method_rows = $("#id_realm_authentication_methods").find("div.method_row");
 
@@ -755,7 +755,7 @@ function check_property_changed(elem, for_realm_default_settings) {
         case "realm_authentication_methods":
             current_val = sort_object_by_key(current_val);
             current_val = JSON.stringify(current_val);
-            changed_val = get_auth_method_table_data();
+            changed_val = get_auth_method_list_data();
             changed_val = JSON.stringify(changed_val);
             break;
         case "realm_notifications_stream_id":
@@ -1003,7 +1003,7 @@ export function register_save_discard_widget_handlers(
             }
             case "auth_settings":
                 data = {};
-                data.authentication_methods = JSON.stringify(get_auth_method_table_data());
+                data.authentication_methods = JSON.stringify(get_auth_method_list_data());
                 break;
         }
         return data;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -285,14 +285,6 @@ td .button {
         z-index: 1;
     }
 
-    #id_realm_authentication_methods {
-        width: 20%;
-
-        td {
-            border: none;
-        }
-    }
-
     #admin_page_users_loading_indicator,
     #attachments_loading_indicator,
     #admin_page_deactivated_users_loading_indicator,

--- a/static/templates/settings/admin_auth_methods_list.hbs
+++ b/static/templates/settings/admin_auth_methods_list.hbs
@@ -1,12 +1,8 @@
-<tr class="method_row" data-method="{{method}}">
-    <td>
-        <label class="checkbox">
-            <input type="checkbox" {{#if enabled}}checked="checked"{{/if}} {{#unless is_owner}}disabled{{/unless}}/>
-            <span></span>
-        </label>
-    </td>
-    <td>
-        <span class="method">{{method}}</span>
-    </td>
-
-</tr>
+<div class="method_row" data-method="{{method}}">
+    {{> settings_checkbox
+      setting_name="realm_authentication_methods"
+      prefix=prefix
+      is_checked=enabled
+      label=method
+      is_disabled=(not is_owner) }}
+</div>

--- a/static/templates/settings/auth_methods_settings_admin.hbs
+++ b/static/templates/settings/auth_methods_settings_admin.hbs
@@ -11,15 +11,9 @@
 
             <div>
                 <p>{{t "Configure the authentication methods for your organization."}}</p>
-                <table id="id_realm_authentication_methods"
-                  class="table table-condensed table-striped prop-element">
-                    <thead>
-                        <th>{{t "Method" }}</th>
-                        <th>{{t "Enabled" }}</th>
-                    </thead>
-                    <tbody>
-                    </tbody>
-                </table>
+                <div id="id_realm_authentication_methods">
+                    {{! Empty div is intentional, it will get populated by a dedicated template }}
+                </div>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Per review feedback in #21002 ([direct link to the comment](https://github.com/zulip/zulip/pull/21002#issuecomment-1027209431)), replace HTML table with a series of `settings_checkbox` components for Authentication Methods UI.

Fixes #21001.

Notable points:
* The way `settings_checkbox` is currently implemented, its instances for respective Auth Methods all get the same `id`, `name` and `class`. That doesn't seem to break anything (both automated and my manual testing), as those aren't used anywhere, but I'm open to suggestions if that's a problem.
* I've removed the previous table-specific CSS entry and haven't added anything for the `<div>` I've introduced instead, as it doesn't seem to be necessary - but I'm open to other ideas, too.
* I've aimed at minimum necessary changes, but deemed it meaningful to change a couple of related JS function names to use "list" instead of "table" to avoid confusion for those looking at the code in the future. At the same time I didn't change mentions of "row" as that would've been a bigger change and IMHO that still fits the "list" abstraction we now use here.
* No test changes were necessary, only minor tweaking of the setting save/restore-related JS code

**Screenshots and screen captures:**
Before (logged in as Owner)
![image](https://user-images.githubusercontent.com/5199601/177057109-ff775f19-1270-49fe-b5bc-33b7439c2a00.png)


After (logged in as owner)
![image](https://user-images.githubusercontent.com/5199601/177057020-0990ec3a-809f-4bd3-8239-4871d7af6fd6.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate (no changes in tests, run manual and automated tests before submitting the PR)

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
