### PR TITLE
polls: Add option for modal to create polls.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -128,6 +128,7 @@ EXEMPT_FILES = make_set(
         "web/src/page_params.ts",
         "web/src/pm_list.js",
         "web/src/pm_list_dom.js",
+        "web/src/poll_modal.js",
         "web/src/poll_widget.js",
         "web/src/popover_menus.js",
         "web/src/popover_menus_data.js",

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -752,23 +752,30 @@ export function initialize() {
         e.preventDefault();
         e.stopPropagation();
 
+        const initial_recipient_data = {
+            message_type: compose_state.get_message_type(),
+            topic_name: compose_state.topic(),
+            stream_id: stream_data.get_stream_id(compose_state.stream_name()),
+            private_message_recipient: compose_state.private_message_recipient(),
+        };
+
         dialog_widget.launch({
             html_heading: $t_html({defaultMessage: "Send a poll"}),
-            html_body: render_add_poll_modal(),
+            html_body: render_add_poll_modal(initial_recipient_data),
             html_submit_button: $t_html({defaultMessage: "Send poll"}),
             loading_spinner: true,
             on_click(e) {
                 // create a message using data input in modal, then send that directly
                 e.preventDefault();
                 e.stopPropagation();
-                const poll_message_content = poll_modal.frame_poll_message_content();
-                const poll_message_object = create_message_object(poll_message_content);
+                const poll_message_data = poll_modal.get_poll_message_data();
+                const poll_message_object = create_message_object(poll_message_data);
                 const from_modal = true;
                 send_message(poll_message_object, from_modal);
             },
             form_id: "add-poll-form",
             id: "add-poll-modal",
-            post_render: poll_modal.poll_options_setup,
+            post_render: poll_modal.setup,
             help_link: "https://zulip.com/help/create-a-poll",
         });
     });

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -136,9 +136,9 @@ export function empty_topic_placeholder() {
     return $t({defaultMessage: "(no topic)"});
 }
 
-export function create_message_object() {
+export function create_message_object(args = {}) {
     // Topics are optional, and we provide a placeholder if one isn't given.
-    let topic = compose_state.topic();
+    let topic = args.topic || compose_state.topic();
     if (topic === "") {
         topic = empty_topic_placeholder();
     }
@@ -146,7 +146,9 @@ export function create_message_object() {
     // Changes here must also be kept in sync with echo.try_deliver_locally
     const message = {
         type: compose_state.get_message_type(),
-        content: compose_state.message_content(),
+        // optional parameter content is used when it is not sourced from the compose
+        // box. Currently it is just used when creating and sending a poll using a modal
+        content: args.message_content || compose_state.message_content(),
         sender_id: page_params.user_id,
         queue_id: page_params.queue_id,
         stream: "",
@@ -155,7 +157,8 @@ export function create_message_object() {
 
     if (message.type === "private") {
         // TODO: this should be collapsed with the code in composebox_typeahead.js
-        const recipient = compose_state.private_message_recipient();
+        const recipient =
+            args.private_message_recipient || compose_state.private_message_recipient();
         const emails = util.extract_pm_recipients(recipient);
         message.to = emails;
         message.reply_to = recipient;
@@ -170,7 +173,7 @@ export function create_message_object() {
             message.to = people.user_ids_string_to_ids_array(message.to_user_ids);
         }
     } else {
-        const stream_name = compose_state.stream_name();
+        const stream_name = args.stream_name || compose_state.stream_name();
         message.stream = stream_name;
         const sub = stream_data.get_sub(stream_name);
         if (sub) {

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -8,7 +8,7 @@ import * as channel from "./channel";
 import * as compose from "./compose";
 import * as compose_banner from "./compose_banner";
 import * as compose_fade from "./compose_fade";
-import * as compose_pm_pill from "./compose_pm_pill";
+import {compose_pm_pill} from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as compose_validate from "./compose_validate";

--- a/web/src/compose_pm_pill.js
+++ b/web/src/compose_pm_pill.js
@@ -1,81 +1,18 @@
 import $ from "jquery";
 
 import * as compose_actions from "./compose_actions";
-import * as input_pill from "./input_pill";
-import * as people from "./people";
-import * as user_pill from "./user_pill";
-import * as util from "./util";
+import {DirectMessageRecipientPill} from "./direct_message_recipient_pill";
 
-export let widget;
-
-const pill_config = {
-    show_user_status_emoji: true,
-};
-
-export function initialize_pill() {
-    const $container = $("#private_message_recipient").parent();
-
-    const pill = input_pill.create({
-        $container,
-        pill_config,
-        create_item_from_text: user_pill.create_item_from_email,
-        get_text_from_item: user_pill.get_email_from_item,
-    });
-
-    return pill;
-}
+export let compose_pm_pill;
 
 export function initialize() {
-    widget = initialize_pill();
+    compose_pm_pill = new DirectMessageRecipientPill($("#private_message_recipient").parent());
 
-    widget.onPillCreate(() => {
+    compose_pm_pill.widget.onPillCreate(() => {
         compose_actions.update_placeholder_text();
     });
 
-    widget.onPillRemove(() => {
+    compose_pm_pill.widget.onPillRemove(() => {
         compose_actions.update_placeholder_text();
     });
-}
-
-export function clear() {
-    widget.clear();
-}
-
-export function set_from_typeahead(person) {
-    user_pill.append_person({
-        pill_widget: widget,
-        person,
-    });
-}
-
-export function set_from_emails(value) {
-    // value is something like "alice@example.com,bob@example.com"
-    clear();
-    widget.appendValue(value);
-}
-
-export function get_user_ids() {
-    return user_pill.get_user_ids(widget);
-}
-
-export function has_unconverted_data() {
-    return user_pill.has_unconverted_data(widget);
-}
-
-export function get_user_ids_string() {
-    const user_ids = get_user_ids();
-    const sorted_user_ids = util.sorted_ids(user_ids);
-    const user_ids_string = sorted_user_ids.join(",");
-    return user_ids_string;
-}
-
-export function get_emails() {
-    // return something like "alice@example.com,bob@example.com"
-    const user_ids = get_user_ids();
-    const emails = user_ids.map((id) => people.get_by_user_id(id).email).join(",");
-    return emails;
-}
-
-export function filter_taken_users(persons) {
-    return user_pill.filter_taken_users(persons, widget);
 }

--- a/web/src/compose_state.js
+++ b/web/src/compose_state.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-import * as compose_pm_pill from "./compose_pm_pill";
+import {compose_pm_pill} from "./compose_pm_pill";
 
 let message_type = false; // 'stream', 'private', or false-y
 let recipient_edited_manually = false;

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -8,7 +8,7 @@ import render_wildcard_warning from "../templates/compose_banner/wildcard_warnin
 
 import * as channel from "./channel";
 import * as compose_banner from "./compose_banner";
-import * as compose_pm_pill from "./compose_pm_pill";
+import {compose_pm_pill} from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import {$t} from "./i18n";

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -5,7 +5,7 @@ import * as typeahead from "../shared/src/typeahead";
 import render_topic_typeahead_hint from "../templates/topic_typeahead_hint.hbs";
 
 import * as compose from "./compose";
-import * as compose_pm_pill from "./compose_pm_pill";
+import {compose_pm_pill} from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as compose_validate from "./compose_validate";

--- a/web/src/direct_message_recipient_pill.js
+++ b/web/src/direct_message_recipient_pill.js
@@ -1,0 +1,61 @@
+import * as input_pill from "./input_pill";
+import * as people from "./people";
+import * as user_pill from "./user_pill";
+import * as util from "./util";
+
+export class DirectMessageRecipientPill {
+    constructor($container) {
+        const pill_config = {
+            show_user_status_emoji: true,
+        };
+        this.widget = input_pill.create({
+            $container,
+            pill_config,
+            create_item_from_text: user_pill.create_item_from_email,
+            get_text_from_item: user_pill.get_email_from_item,
+        });
+    }
+
+    clear() {
+        this.widget.clear();
+    }
+
+    set_from_typeahead(person) {
+        user_pill.append_person({
+            pill_widget: this.widget,
+            person,
+        });
+    }
+
+    set_from_emails(value) {
+        // value is something like "alice@example.com,bob@example.com"
+        this.clear();
+        this.widget.appendValue(value);
+    }
+
+    get_user_ids() {
+        return user_pill.get_user_ids(this.widget);
+    }
+
+    has_unconverted_data() {
+        return user_pill.has_unconverted_data(this.widget);
+    }
+
+    get_user_ids_string() {
+        const user_ids = this.get_user_ids();
+        const sorted_user_ids = util.sorted_ids(user_ids);
+        const user_ids_string = sorted_user_ids.join(",");
+        return user_ids_string;
+    }
+
+    get_emails() {
+        // return something like "alice@example.com,bob@example.com"
+        const user_ids = this.get_user_ids();
+        const emails = user_ids.map((id) => people.get_by_user_id(id).email).join(",");
+        return emails;
+    }
+
+    filter_taken_users(persons) {
+        return user_pill.filter_taken_users(persons, this.widget);
+    }
+}

--- a/web/src/poll_modal.js
+++ b/web/src/poll_modal.js
@@ -1,0 +1,58 @@
+import $ from "jquery";
+import {Sortable} from "sortablejs";
+
+import render_poll_modal_option from "../templates/poll_modal_option.hbs";
+
+function create_option_row(container) {
+    const row = render_poll_modal_option();
+    $(container).append(row);
+}
+
+function add_option_row(e) {
+    // if the option triggering the input event e is not the last,
+    // that is, its next sibling has the class `option-row`, we
+    // do not add a new option row and return from this function
+    // This handles a case when the next empty input row is already
+    // added and user is updating the above row(s).
+    if ($(e.target).parent().next().hasClass("option-row")) {
+        return;
+    }
+    const $options_div = $(e.target).parent().parent();
+    create_option_row($options_div);
+}
+
+function delete_option_row(e) {
+    const $row = $(e.currentTarget).parent();
+    $row.remove();
+}
+
+export function poll_options_setup() {
+    const $poll_options_list = $("#add-poll-form .poll-options-list");
+
+    $poll_options_list.on("input", ".option-row input", add_option_row);
+    $poll_options_list.on("click", "button.delete-option", delete_option_row);
+
+    // setTimeout is needed to here to give time for simplebar to initialise
+    setTimeout(() => {
+        Sortable.create($("#add-poll-form .poll-options-list .simplebar-content")[0], {
+            onUpdate() {},
+            filter: "input",
+            preventOnFilter: false,
+        });
+    }, 0);
+}
+
+export function frame_poll_message_content() {
+    // if the question field is left empty we use the placeholder instead as
+    // the question is anyway editable by the poll creator in the widget
+    const question =
+        $("#poll-question-textarea").val().trim() ||
+        $("#poll-question-textarea").attr("placeholder");
+    const options = $(".poll-option-input")
+        .map(function () {
+            return $(this).val().trim();
+        })
+        .toArray()
+        .filter(Boolean);
+    return "/poll " + question + "\n" + options.join("\n");
+}

--- a/web/src/poll_modal.js
+++ b/web/src/poll_modal.js
@@ -3,6 +3,19 @@ import {Sortable} from "sortablejs";
 
 import render_poll_modal_option from "../templates/poll_modal_option.hbs";
 
+import * as composebox_typeahead from "./composebox_typeahead";
+import {DirectMessageRecipientPill} from "./direct_message_recipient_pill";
+import {DropdownListWidget} from "./dropdown_list_widget";
+import {$t} from "./i18n";
+import * as keydown_util from "./keydown_util";
+import * as message_edit from "./message_edit";
+import * as stream_bar from "./stream_bar";
+import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
+
+let recipient_type;
+let poll_pm_pill;
+
 function create_option_row(container) {
     const row = render_poll_modal_option();
     $(container).append(row);
@@ -26,7 +39,7 @@ function delete_option_row(e) {
     $row.remove();
 }
 
-export function poll_options_setup() {
+function poll_options_setup() {
     const $poll_options_list = $("#add-poll-form .poll-options-list");
 
     $poll_options_list.on("input", ".option-row input", add_option_row);
@@ -42,7 +55,72 @@ export function poll_options_setup() {
     }, 0);
 }
 
-export function frame_poll_message_content() {
+function stream_recipient_setup() {
+    const $topic_input = $("#add-poll-form .inline_topic_edit");
+    const $stream_id = $("#add-poll-form .stream_id");
+    const $stream_header_colorblock = $("#dialog_widget_modal .topic_stream_edit_header").find(
+        ".stream_header_colorblock",
+    );
+
+    const stream_id = Number($stream_id.val(), 10);
+    const stream_name = sub_store.get(stream_id)?.name;
+    stream_bar.decorate(stream_name, $stream_header_colorblock, false);
+    const streams_list = message_edit.get_available_streams_for_moving_messages(stream_id);
+    let stream_widget;
+    const opts = {
+        widget_name: "select_stream",
+        data: streams_list,
+        default_text: $t({defaultMessage: "Select a stream"}),
+        include_current_item: false,
+        value: stream_id,
+        on_update() {
+            const new_stream_id = Number(stream_widget.value(), 10);
+            $stream_id.val(new_stream_id);
+            const new_stream_name = sub_store.get(new_stream_id).name;
+            $topic_input.data("typeahead").unlisten();
+            composebox_typeahead.initialize_topic_edit_typeahead(
+                $topic_input,
+                new_stream_name,
+                false,
+            );
+        },
+    };
+    stream_widget = new DropdownListWidget(opts);
+    composebox_typeahead.initialize_topic_edit_typeahead($topic_input, stream_name, false);
+    stream_widget.setup();
+
+    $("#add-poll-form").on("click keypress", ".stream-dropdown .list_item", (e) => {
+        // We want the dropdown to collapse once any of the list item is pressed
+        // and thus don't want to kill the natural bubbling of event.
+        e.preventDefault();
+        if (e.type === "keypress" && !keydown_util.is_enter_event(e)) {
+            return;
+        }
+        const stream_name = stream_data.maybe_get_stream_name(
+            Number.parseInt(stream_widget.value(), 10),
+        );
+        stream_bar.decorate(stream_name, $stream_header_colorblock, false);
+    });
+}
+
+function private_recipient_setup() {
+    poll_pm_pill = new DirectMessageRecipientPill($("#private_message_recipient_poll").parent());
+    composebox_typeahead.initialize_poll_private_recipient_typeahead(poll_pm_pill);
+    const initial_pm_recipient = $("#add-poll-form .initial_pm_recipient").val();
+    poll_pm_pill.set_from_emails(initial_pm_recipient);
+}
+
+export function setup() {
+    poll_options_setup();
+    recipient_type = $("#add-poll-form .message_type").val();
+    if (recipient_type === "stream") {
+        stream_recipient_setup();
+    } else if (recipient_type === "private") {
+        private_recipient_setup();
+    }
+}
+
+function frame_poll_message_content() {
     // if the question field is left empty we use the placeholder instead as
     // the question is anyway editable by the poll creator in the widget
     const question =
@@ -55,4 +133,30 @@ export function frame_poll_message_content() {
         .toArray()
         .filter(Boolean);
     return "/poll " + question + "\n" + options.join("\n");
+}
+
+function get_stream_name() {
+    const stream_id = Number($("#add-poll-form .stream_id").val(), 10);
+    return sub_store.get(stream_id).name;
+}
+
+function get_topic() {
+    return $("#add-poll-form .inline_topic_edit").val().trim();
+}
+
+function get_pm_recipient() {
+    return poll_pm_pill.get_emails();
+}
+
+export function get_poll_message_data() {
+    const message_content = frame_poll_message_content();
+    if (recipient_type === "stream") {
+        const stream_name = get_stream_name();
+        const topic = get_topic();
+        return {message_content, stream_name, topic};
+    } else if (recipient_type === "private") {
+        const private_message_recipient = get_pm_recipient();
+        return {message_content, private_message_recipient};
+    }
+    return {message_content};
 }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -10,7 +10,7 @@ import {buddy_list} from "./buddy_list";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_fade from "./compose_fade";
-import * as compose_pm_pill from "./compose_pm_pill";
+import {compose_pm_pill} from "./compose_pm_pill";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as dark_theme from "./dark_theme";
 import * as emoji from "./emoji";

--- a/web/src/typing.js
+++ b/web/src/typing.js
@@ -4,7 +4,7 @@ import * as typing_status from "../shared/src/typing_status";
 
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
-import * as compose_pm_pill from "./compose_pm_pill";
+import {compose_pm_pill} from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as people from "./people";
 import {user_settings} from "./user_settings";

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1463,6 +1463,12 @@
             }
         }
     }
+
+    .stream_header_colorblock {
+        box-shadow: inset 0 2px 2px -2px hsl(0deg 0% 0%),
+            inset 2px 0 2px -2px hsl(0deg 0% 0%),
+            inset 0 -2px 2px -2px hsl(0deg 0% 0%);
+    }
 }
 
 @supports (-moz-appearance: none) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3001,8 +3001,14 @@ select.invite-as {
 }
 
 #add-poll-modal {
-    height: 60vh;
+    /* on wide screens, this height allows roughly 3 option
+    rows to fit in without need for scrolling */
+    height: 500px;
     overflow: hidden;
+
+    @media (width < $sm_min) {
+        height: 90vh;
+    }
 
     .modal__content {
         flex-grow: 1;
@@ -3037,6 +3043,29 @@ select.invite-as {
         .stream_header_colorblock,
         .inline_topic_edit {
             margin-bottom: 10px;
+        }
+
+        .topic_stream_edit_header {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+
+            .dropdown-menu {
+                position: fixed;
+                top: 125px;
+                left: 30px;
+            }
+        }
+
+        .pm_recipient {
+            display: flex;
+            align-items: center;
+            width: 100%;
+            margin-bottom: 10px;
+
+            .input {
+                height: auto;
+            }
         }
 
         #poll-question-textarea {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2999,3 +2999,93 @@ select.invite-as {
         but we don't want it to have an outline when focused anywhere in the app. */
     outline: none;
 }
+
+#add-poll-modal {
+    height: 60vh;
+    overflow: hidden;
+
+    .modal__content {
+        flex-grow: 1;
+        /* Ensure that the dropdown can overflow the modal. */
+        overflow: visible;
+    }
+
+    .simplebar-content {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
+    #add-poll-form {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        height: 100%;
+
+        & label {
+            font-weight: bold;
+            margin: 5px 0;
+        }
+
+        /* Override the default border-radius to properly align
+            the button corners with `stream_header_colorblock`. */
+        .dropdown-toggle {
+            border-radius: 1px 4px 4px 1px !important;
+        }
+
+        .dropdown-list-widget,
+        .stream_header_colorblock,
+        .inline_topic_edit {
+            margin-bottom: 10px;
+        }
+
+        #poll-question-textarea {
+            /* Take up full width, leaving space for padding and border */
+            width: calc(100% - 14px);
+            box-shadow: none;
+            resize: none;
+            margin: 0;
+            margin-bottom: 10px;
+            height: 50px;
+        }
+
+        .poll-options-list {
+            margin: 0;
+            height: 0;
+            overflow: auto;
+            flex-grow: 1;
+
+            .option-row {
+                list-style-type: none;
+                cursor: move;
+                margin-top: 10px;
+                padding: 0;
+
+                .fa-ellipsis-v {
+                    color: hsl(0deg 0% 75%);
+                    position: relative;
+                    top: 1px;
+                }
+
+                /* To space the 2nd icon - the right side one - from the input next to it */
+                & i + i {
+                    margin-right: 5px;
+                }
+
+                & input {
+                    width: clamp(190px, 50%, 300px);
+                }
+            }
+
+            .option-row:first-child {
+                margin-top: 0;
+            }
+
+            .option-row:last-child {
+                .delete-option {
+                    display: none;
+                }
+            }
+        }
+    }
+}

--- a/web/templates/add_poll_modal.hbs
+++ b/web/templates/add_poll_modal.hbs
@@ -1,0 +1,11 @@
+<form id="add-poll-form" class="new-style">
+    <label>{{t "Question"}}</label>
+    <textarea id="poll-question-textarea" placeholder="{{t 'Your question'}}"></textarea>
+    <label>{{t "Options"}}</label>
+    <p>{{t "Anyone can add more options after the poll is posted."}}</p>
+    <ul class="poll-options-list" data-simplebar>
+        {{> poll_modal_option }}
+        {{> poll_modal_option }}
+        {{> poll_modal_option }}
+    </ul>
+</form>

--- a/web/templates/add_poll_modal.hbs
+++ b/web/templates/add_poll_modal.hbs
@@ -1,4 +1,26 @@
 <form id="add-poll-form" class="new-style">
+    <label>{{t "Send poll to:"}}</label>
+    <input class="message_type" type="hidden" value="{{message_type}}" />
+    {{#if (eq message_type "stream")}}
+        <div class="topic_stream_edit_header">
+            <div class="stream_header_colorblock"></div>
+            <div class="stream-dropdown">
+                {{> settings/dropdown_list_widget
+                  widget_name="select_stream"
+                  list_placeholder=(t 'Filter streams')}}
+            </div>
+            <i class="fa fa-angle-right" aria-hidden="true"></i>
+            <input name="topic_name" type="text" class="inline_topic_edit" autocomplete="off" value="{{topic_name}}" placeholder="{{t 'Topic'}}"/>
+            <input class="stream_id" type="hidden" value="{{stream_id}}" />
+        </div>
+    {{else}}
+        <div class="pm_recipient">
+            <div class="pill-container">
+                <div class="input" contenteditable="true" id="private_message_recipient_poll" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user...' }}"></div>
+            </div>
+        </div>
+        <input class="initial_pm_recipient" type="hidden" value="{{private_message_recipient}}" />
+    {{/if}}
     <label>{{t "Question"}}</label>
     <textarea id="poll-question-textarea" placeholder="{{t 'Your question'}}"></textarea>
     <label>{{t "Options"}}</label>

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -9,6 +9,7 @@
     <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
     <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"></a>
     <a role="button" class="compose_control_button compose_gif_icon {{#unless giphy_enabled }} hide {{/unless}} zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0 data-tippy-content="{{t 'Add GIF' }}"></a>
+    <a role="button" class="compose_control_button fa fa-hand-paper-o add_poll" aria-label="{{t 'Add poll' }}" tabindex=0 data-tippy-content="{{t 'Add poll' }}"></a>
     <div class="divider hide-sm">|</div>
     <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
         {{> compose_control_buttons_in_popover}}

--- a/web/templates/poll_modal_option.hbs
+++ b/web/templates/poll_modal_option.hbs
@@ -1,0 +1,8 @@
+<li class='option-row'>
+    <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+    <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+    <input type='text' class="poll-option-input" placeholder='{{t "New option" }}' />
+    <button type='button' class="button rounded small btn-secondary delete-option" title="{{t 'Delete' }}">
+        <i class="fa fa-trash-o" aria-hidden="true"></i>
+    </button>
+</li>

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -177,7 +177,9 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         compose_state.topic("");
         compose_state.set_message_type("private");
         page_params.user_id = new_user.user_id;
-        override(compose_pm_pill, "get_emails", () => "alice@example.com");
+        compose_pm_pill.compose_pm_pill = {
+            get_emails: () => "alice@example.com",
+        };
 
         const server_message_id = 127;
         override_rewire(echo, "insert_message", (message) => {
@@ -387,8 +389,10 @@ test_ui("finish", ({override, override_rewire}) => {
         $("#compose-textarea").val("foobarfoobar");
         compose_ui.compose_spinner_visible = false;
         compose_state.set_message_type("private");
-        override(compose_pm_pill, "get_emails", () => "bob@example.com");
-        override(compose_pm_pill, "get_user_ids", () => []);
+        compose_pm_pill.compose_pm_pill = {
+            get_emails: () => "bob@example.com",
+            get_user_ids: () => [],
+        };
 
         let compose_finished_event_checked = false;
         $(document).on("compose_finished.zulip", () => {
@@ -744,7 +748,7 @@ test_ui("on_events", ({override}) => {
     })();
 });
 
-test_ui("create_message_object", ({override, override_rewire}) => {
+test_ui("create_message_object", ({override_rewire}) => {
     compose_state.set_stream_name("social");
     $("#stream_message_recipient_topic").val("lunch");
     $("#compose-textarea").val("burrito");
@@ -765,7 +769,9 @@ test_ui("create_message_object", ({override, override_rewire}) => {
     assert.equal(message.content, "burrito");
 
     compose_state.set_message_type("private");
-    override(compose_pm_pill, "get_emails", () => "alice@example.com,bob@example.com");
+    compose_pm_pill.compose_pm_pill = {
+        get_emails: () => "alice@example.com,bob@example.com",
+    };
 
     message = compose.create_message_object();
     assert.deepEqual(message.to, [alice.user_id, bob.user_id]);

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -78,12 +78,14 @@ function assert_hidden(sel) {
     assert.ok(!$(sel).visible());
 }
 
-function override_private_message_recipient({override}) {
+function override_private_message_recipient() {
     let recipient;
-    override(compose_pm_pill, "set_from_emails", (value) => {
-        recipient = value;
-    });
-    override(compose_pm_pill, "get_emails", () => recipient, {unused: false});
+    compose_pm_pill.compose_pm_pill = {
+        get_emails: () => recipient,
+        set_from_emails(value) {
+            recipient = value;
+        },
+    };
 }
 
 function test(label, f) {
@@ -208,7 +210,7 @@ test("start", ({override, override_rewire}) => {
 
     // Cancel compose.
     let pill_cleared;
-    compose_pm_pill.clear = () => {
+    compose_pm_pill.compose_pm_pill.clear = () => {
         pill_cleared = true;
     };
 

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -10,7 +10,7 @@ const compose_actions = mock_esm("../src/compose_actions");
 const input_pill = mock_esm("../src/input_pill");
 const people = zrequire("people");
 
-const compose_pm_pill = zrequire("compose_pm_pill");
+let compose_pm_pill = zrequire("compose_pm_pill");
 
 let pills = {
     pill: {},
@@ -154,6 +154,7 @@ run_test("pills", ({override}) => {
     };
 
     compose_pm_pill.initialize();
+    compose_pm_pill = compose_pm_pill.compose_pm_pill;
     assert.ok(compose_pm_pill.widget);
 
     compose_pm_pill.set_from_typeahead(othello);

--- a/web/tests/compose_state.test.js
+++ b/web/tests/compose_state.test.js
@@ -9,25 +9,27 @@ const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 
 const compose_state = zrequire("compose_state");
 
-run_test("private_message_recipient", ({override}) => {
+run_test("private_message_recipient", () => {
     let emails;
-    override(compose_pm_pill, "set_from_emails", (value) => {
-        emails = value;
-    });
-
-    override(compose_pm_pill, "get_emails", () => emails);
+    compose_pm_pill.compose_pm_pill = {
+        get_emails: () => emails,
+        set_from_emails(value) {
+            emails = value;
+        },
+    };
 
     compose_state.private_message_recipient("fred@fred.org");
     assert.equal(compose_state.private_message_recipient(), "fred@fred.org");
 });
 
-run_test("has_full_recipient", ({override}) => {
+run_test("has_full_recipient", () => {
     let emails;
-    override(compose_pm_pill, "set_from_emails", (value) => {
-        emails = value;
-    });
-
-    override(compose_pm_pill, "get_emails", () => emails);
+    compose_pm_pill.compose_pm_pill = {
+        get_emails: () => emails,
+        set_from_emails(value) {
+            emails = value;
+        },
+    };
 
     compose_state.set_message_type("stream");
     compose_state.set_stream_name("");

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -1078,7 +1078,9 @@ run_test("user_status", ({override}) => {
     {
         const stub = make_stub();
         override(activity, "redraw_user", stub.f);
-        override(compose_pm_pill, "get_user_ids", () => [event.user_id]);
+        compose_pm_pill.compose_pm_pill = {
+            get_user_ids: () => [event.user_id],
+        };
         dispatch(event);
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("user_id");

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -9,7 +9,6 @@ const {user_settings} = require("./lib/zpage_params");
 
 const blueslip = zrequire("blueslip");
 const compose_pm_pill = zrequire("compose_pm_pill");
-const user_pill = zrequire("user_pill");
 const people = zrequire("people");
 const compose_state = zrequire("compose_state");
 const sub_store = zrequire("sub_store");
@@ -149,14 +148,16 @@ test("draft_model delete", ({override}) => {
     assert.deepEqual(draft_model.getDraft(id), false);
 });
 
-test("snapshot_message", ({override_rewire}) => {
+test("snapshot_message", () => {
     stream_data.get_sub = (stream_name) => {
         assert.equal(stream_name, "stream");
         return {stream_id: 30};
     };
 
-    override_rewire(user_pill, "get_user_ids", () => [aaron.user_id]);
-    override_rewire(compose_pm_pill, "set_from_emails", noop);
+    compose_pm_pill.compose_pm_pill = {
+        set_from_emails: noop,
+        get_emails: () => aaron.email,
+    };
 
     let curr_draft;
 
@@ -230,13 +231,15 @@ test("remove_old_drafts", () => {
     assert.deepEqual(draft_model.get(), {id3: draft_3});
 });
 
-test("update_draft", ({override, override_rewire}) => {
+test("update_draft", ({override}) => {
     compose_state.set_message_type(null);
     let draft_id = drafts.update_draft();
     assert.equal(draft_id, undefined);
 
-    override_rewire(compose_pm_pill, "set_from_emails", noop);
-    override_rewire(user_pill, "get_user_ids", () => [aaron.user_id]);
+    compose_pm_pill.compose_pm_pill = {
+        set_from_emails: noop,
+        get_emails: () => aaron.email,
+    };
     compose_state.set_message_type("private");
     compose_state.message_content("dummy content");
     compose_state.private_message_recipient(aaron.email);
@@ -579,7 +582,9 @@ test("format_drafts", ({override_rewire, mock_template}) => {
         return {name: "stream"};
     };
 
-    override_rewire(user_pill, "get_user_ids", () => []);
+    compose_pm_pill.compose_pm_pill = {
+        get_emails: () => "",
+    };
     compose_state.set_message_type("private");
     compose_state.private_message_recipient(null);
 
@@ -744,8 +749,10 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
 
     override_rewire(drafts, "set_initial_element", noop);
 
-    override_rewire(user_pill, "get_user_ids", () => [aaron.user_id]);
-    override_rewire(compose_pm_pill, "set_from_emails", noop);
+    compose_pm_pill.compose_pm_pill = {
+        set_from_emails: noop,
+        get_emails: () => aaron.email,
+    };
     compose_state.set_message_type("private");
     compose_state.private_message_recipient(aaron.email);
 

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -699,7 +699,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
 });
 
-run_test("narrow_to_compose_target PMs", ({override, override_rewire}) => {
+run_test("narrow_to_compose_target PMs", ({override_rewire}) => {
     const args = {called: false};
     override_rewire(narrow, "activate", (operators, opts) => {
         args.operators = operators;
@@ -708,7 +708,9 @@ run_test("narrow_to_compose_target PMs", ({override, override_rewire}) => {
     });
 
     let emails;
-    override(compose_pm_pill, "get_emails", () => emails);
+    compose_pm_pill.compose_pm_pill = {
+        get_emails: () => emails,
+    };
 
     compose_state.set_message_type("private");
     people.add_active_user(ray);

--- a/web/tests/typing_status.test.js
+++ b/web/tests/typing_status.test.js
@@ -21,7 +21,7 @@ function returns_time(secs) {
     };
 }
 
-run_test("basics", ({override, override_rewire}) => {
+run_test("basics", ({override_rewire}) => {
     typing_status.initialize_state();
 
     // invalid conversation basically does nothing
@@ -264,7 +264,9 @@ run_test("basics", ({override, override_rewire}) => {
     // test that we correctly detect if worker.get_recipient
     // and typing_status.state.current_recipient are the same
 
-    override(compose_pm_pill, "get_user_ids_string", () => "1,2,3");
+    compose_pm_pill.compose_pm_pill = {
+        get_user_ids_string: () => "1,2,3",
+    };
     typing_status.state.current_recipient = typing.get_recipient();
 
     const call_count = {
@@ -295,14 +297,18 @@ run_test("basics", ({override, override_rewire}) => {
 
     // change in recipient and new_recipient should make us
     // call typing_status.stop_last_notification
-    override(compose_pm_pill, "get_user_ids_string", () => "2,3,4");
+    compose_pm_pill.compose_pm_pill = {
+        get_user_ids_string: () => "2,3,4",
+    };
     typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);
     assert.deepEqual(call_count.stop_last_notification, 1);
 
     // Stream messages are represented as get_user_ids_string being empty
-    override(compose_pm_pill, "get_user_ids_string", () => "");
+    compose_pm_pill.compose_pm_pill = {
+        get_user_ids_string: () => "",
+    };
     typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);


### PR DESCRIPTION
Earlier the `/poll` slash command was the only way to create polls.
To increase user friendliness with a UI, a button to launch a modal
to create a poll and send it, has been added to the compose box.

The modal has a form which on submission frames a message using the
`/poll` syntax and the data input in the form, and sends it directly.

Fixes: #20304.

**Screenshots and screen captures:**

https://www.loom.com/share/c0528232229b450285c0214ea7813e4d

**Self-review checklist**


- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
