### PR TITLE
custom_profile_fields: Some changes for default "External account" type profile fields.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -174,18 +174,24 @@ function set_up_create_field_form() {
 
     if (Number.parseInt($("#profile_field_type").val(), 10) === field_types.EXTERNAL_ACCOUNT.id) {
         $field_elem.show();
-        if ($("#profile_field_external_accounts_type").val() === "custom") {
+        const $profile_field_external_account_type = $(
+            "#profile_field_external_accounts_type",
+        ).val();
+        if ($profile_field_external_account_type === "custom") {
             $field_url_pattern_elem.show();
-            $("#profile_field_name").val("").closest(".input-group").show();
-            $("#profile_field_hint").val("").closest(".input-group").show();
+            $("#profile_field_name").val("").prop("disabled", false);
+            $("#profile_field_hint").val("").prop("disabled", false);
         } else {
             $field_url_pattern_elem.hide();
-            $("#profile_field_name").closest(".input-group").hide();
-            $("#profile_field_hint").closest(".input-group").hide();
+            const profile_field_name =
+                page_params.realm_default_external_accounts[$profile_field_external_account_type]
+                    .name;
+            $("#profile_field_name").val(profile_field_name).prop("disabled", true);
+            $("#profile_field_hint").val("").prop("disabled", true);
         }
     } else {
-        $("#profile_field_name").closest(".input-group").show();
-        $("#profile_field_hint").closest(".input-group").show();
+        $("#profile_field_name").prop("disabled", false);
+        $("#profile_field_hint").prop("disabled", false);
         $field_url_pattern_elem.hide();
         $field_elem.hide();
     }

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -392,9 +392,6 @@ function open_edit_form_modal(e) {
         $profile_field_form
             .find(".edit_profile_field_choices_container")
             .on("click", "button.delete-choice", delete_choice_row);
-        $(".profile_field_external_accounts_edit select").on("change", () => {
-            set_up_external_account_field_edit_form($profile_field_form, "");
-        });
     }
 
     function submit_form() {

--- a/static/templates/settings/edit_custom_profile_field_form.hbs
+++ b/static/templates/settings/edit_custom_profile_field_form.hbs
@@ -24,7 +24,7 @@
     {{#if is_external_account_field}}
     <div class="input-group profile_field_external_accounts_edit">
         <label for="external_acc_field_type">{{t "External account type" }}</label>
-        <select name="external_acc_field_type">
+        <select name="external_acc_field_type" disabled>
             {{#each ../realm_default_external_accounts}}
                 <option value='{{@key}}'>{{this.text}}</option>
             {{/each}}

--- a/zerver/lib/external_accounts.py
+++ b/zerver/lib/external_accounts.py
@@ -23,14 +23,14 @@ DEFAULT_EXTERNAL_ACCOUNTS = {
     "twitter": {
         "text": "Twitter",
         "url_pattern": "https://twitter.com/%(username)s",
-        "name": "Twitter",
-        "hint": "Enter your Twitter username",
+        "name": "Twitter username",
+        "hint": "",
     },
     "github": {
         "text": "GitHub",
         "url_pattern": "https://github.com/%(username)s",
-        "name": "GitHub",
-        "hint": "Enter your GitHub username",
+        "name": "GitHub username",
+        "hint": "",
     },
 }
 

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -188,8 +188,8 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         # for default custom external account fields.
         with self.assertRaises(CustomProfileField.DoesNotExist):
             field = CustomProfileField.objects.get(name=invalid_field_name, realm=realm)
-        # The field is created with 'Twitter' name as per values in default fields dict
-        field = CustomProfileField.objects.get(name="Twitter")
+        # The field is created with 'Twitter username' name as per values in default fields dict
+        field = CustomProfileField.objects.get(name="Twitter username")
         self.assertEqual(field.name, DEFAULT_EXTERNAL_ACCOUNTS["twitter"]["name"])
         self.assertEqual(field.hint, DEFAULT_EXTERNAL_ACCOUNTS["twitter"]["hint"])
 
@@ -203,10 +203,10 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_success(result)
 
         # Default external account field data cannot be updated
-        field = CustomProfileField.objects.get(name="Twitter", realm=realm)
+        field = CustomProfileField.objects.get(name="Twitter username", realm=realm)
         result = self.client_patch(
             f"/json/realm/profile_fields/{field.id}",
-            info={"name": "Twitter username", "field_type": CustomProfileField.EXTERNAL_ACCOUNT},
+            info={"name": "Twitter", "field_type": CustomProfileField.EXTERNAL_ACCOUNT},
         )
         self.assert_json_error(result, "Default custom field cannot be updated.")
 
@@ -217,7 +217,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.login("iago")
         realm = get_realm("zulip")
         data: Dict[str, Union[str, int, Dict[str, str]]] = {}
-        data["name"] = "Twitter"
+        data["name"] = "Twitter username"
         data["field_type"] = CustomProfileField.EXTERNAL_ACCOUNT
 
         data["field_data"] = "invalid"
@@ -261,9 +261,9 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_success(result)
 
-        twitter_field = CustomProfileField.objects.get(name="Twitter", realm=realm)
+        twitter_field = CustomProfileField.objects.get(name="Twitter username", realm=realm)
         self.assertEqual(twitter_field.field_type, CustomProfileField.EXTERNAL_ACCOUNT)
-        self.assertEqual(twitter_field.name, "Twitter")
+        self.assertEqual(twitter_field.name, "Twitter username")
         self.assertEqual(orjson.loads(twitter_field.field_data)["subtype"], "twitter")
 
         data["name"] = "Reddit"
@@ -598,7 +598,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             ("Birthday", "1909-03-05"),
             ("Favorite website", "https://zulip.com"),
             ("Mentor", [self.example_user("cordelia").id]),
-            ("GitHub", "zulip-mobile"),
+            ("GitHub username", "zulip-mobile"),
         ]
 
         data: List[ProfileDataElementUpdateDict] = []

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -613,7 +613,7 @@ class PermissionTest(ZulipTestCase):
             "Birthday": "1909-03-05",
             "Favorite website": "https://zulip.com",
             "Mentor": [cordelia.id],
-            "GitHub": "timabbott",
+            "GitHub username": "timabbott",
         }
 
         for field_name in fields:
@@ -721,7 +721,7 @@ class PermissionTest(ZulipTestCase):
             "Birthday": None,
             "Favorite website": "https://zulip.github.io",
             "Mentor": [hamlet.id],
-            "GitHub": "timabbott",
+            "GitHub username": "timabbott",
         }
         new_profile_data = []
         for field_name in fields:


### PR DESCRIPTION
<!-- Describe your pull request here.-->
**custom_profile_fields: Change data of default external account type.**
change the names of "github" and "twitter" external account fields to
"GitHub username" and "Twitter username" respectively and remove the
hints of them.

**custom_profile_fields: Backend tests for default external account type.**

**custom_profile_fields: Display data of default external type fields.**
Display default values of "name" and "hint" field in uneditable way
while creating new default external account type profile fields.


**custom_profile_fields: Disable "External account type" select field.**
Disable "External account type" select field from External account type
profile field edit form, doing it because this select field is not
editable and it is incorrectly looks like editable.

Fixes: [CZO](https://chat.zulip.org/#narrow/stream/378-api-design/topic/Name.20and.20Hint.20editable.20of.20default.20external.20account.20.2322371/near/1431570) <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-09-13 01-24-38](https://user-images.githubusercontent.com/41695888/189744116-fc09c717-cf00-4cbe-bed2-dd61e78d5a77.png)

![Peek 2022-09-13 01-39](https://user-images.githubusercontent.com/41695888/189748198-893eaa10-6db7-4461-8b3f-86691cf11e6c.gif)



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
