### PR TITLE
ci: Avoid duplicate GitHub Actions runs for push, pull_request

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,10 @@ name: "Code scanning"
 
 on:
   push:
-    branches-ignore:
-      - dependabot/** # https://github.com/github/codeql-action/pull/435
-  pull_request: {}
+    branches: ["*.x", chat.zulip.org, main]
+    tags: ["*"]
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -1,7 +1,9 @@
 name: Zulip production suite
 
 on:
-  push: {}
+  push:
+    branches: ["*.x", chat.zulip.org, main]
+    tags: ["*"]
   pull_request:
     paths:
       - .github/workflows/production-suite.yml
@@ -21,6 +23,7 @@ on:
       - zerver/lib/push_notifications.py
       - zerver/decorator.py
       - zproject/**
+  workflow_dispatch:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -4,7 +4,12 @@
 
 name: Zulip CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["*.x", chat.zulip.org, main]
+    tags: ["*"]
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.run_id }}"


### PR DESCRIPTION
We’ve always been running CI on both `push` events and `pull_request` events, which means it runs twice for commits that are pushed to a pull request.

Filter the `push` events by branch name. Add the [`workflow_dispatch` event](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) in case developers want to manually run CI on some other branch that isn’t a pull request.