### PR TITLE
migrations: Replace NullBooleanField

### DIFF
--- a/zerver/migrations/0001_initial.py
+++ b/zerver/migrations/0001_initial.py
@@ -128,7 +128,7 @@ CREATE TRIGGER zerver_message_update_search_tsvector_async
                 ),
                 ("rate_limits", models.CharField(default="", max_length=100)),
                 ("default_all_public_streams", models.BooleanField(default=False)),
-                ("enter_sends", models.NullBooleanField(default=True)),
+                ("enter_sends", models.BooleanField(null=True, default=True)),
                 ("autoscroll_forever", models.BooleanField(default=False)),
                 ("twenty_four_hour_time", models.BooleanField(default=False)),
                 (
@@ -401,7 +401,7 @@ CREATE TRIGGER zerver_message_update_search_tsvector_async
                     ),
                 ),
                 ("name", models.CharField(db_index=True, max_length=60)),
-                ("invite_only", models.NullBooleanField(default=False)),
+                ("invite_only", models.BooleanField(null=True, default=False)),
                 (
                     "email_token",
                     models.CharField(default=generate_email_token_for_stream, max_length=32),
@@ -427,7 +427,7 @@ CREATE TRIGGER zerver_message_update_search_tsvector_async
                     ),
                 ),
                 ("active", models.BooleanField(default=True)),
-                ("in_home_view", models.NullBooleanField(default=True)),
+                ("in_home_view", models.BooleanField(null=True, default=True)),
                 ("color", models.CharField(default="#c2c2c2", max_length=10)),
                 ("desktop_notifications", models.BooleanField(default=True)),
                 ("audible_notifications", models.BooleanField(default=True)),

--- a/zerver/migrations/0048_enter_sends_default_to_false.py
+++ b/zerver/migrations/0048_enter_sends_default_to_false.py
@@ -12,6 +12,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="userprofile",
             name="enter_sends",
-            field=models.NullBooleanField(default=False),
+            field=models.BooleanField(null=True, default=False),
         ),
     ]

--- a/zerver/migrations/0220_subscription_notification_settings.py
+++ b/zerver/migrations/0220_subscription_notification_settings.py
@@ -13,21 +13,21 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="subscription",
             name="audible_notifications",
-            field=models.NullBooleanField(default=None),
+            field=models.BooleanField(null=True, default=None),
         ),
         migrations.AlterField(
             model_name="subscription",
             name="desktop_notifications",
-            field=models.NullBooleanField(default=None),
+            field=models.BooleanField(null=True, default=None),
         ),
         migrations.AlterField(
             model_name="subscription",
             name="email_notifications",
-            field=models.NullBooleanField(default=None),
+            field=models.BooleanField(null=True, default=None),
         ),
         migrations.AlterField(
             model_name="subscription",
             name="push_notifications",
-            field=models.NullBooleanField(default=None),
+            field=models.BooleanField(null=True, default=None),
         ),
     ]

--- a/zerver/migrations/0223_rename_to_is_muted.py
+++ b/zerver/migrations/0223_rename_to_is_muted.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="subscription",
             name="is_muted",
-            field=models.NullBooleanField(default=False),
+            field=models.BooleanField(null=True, default=False),
         ),
         migrations.RunPython(
             set_initial_value_for_is_muted,

--- a/zerver/migrations/0253_userprofile_wildcard_mentions_notify.py
+++ b/zerver/migrations/0253_userprofile_wildcard_mentions_notify.py
@@ -18,6 +18,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="subscription",
             name="wildcard_mentions_notify",
-            field=models.NullBooleanField(default=None),
+            field=models.BooleanField(null=True, default=None),
         ),
     ]


### PR DESCRIPTION
This was removed in Django 4.0 except in historical migrations. We might as well replace it everywhere.

(Split from #22341.)