### PR TITLE
puppeteer_tests: Fix test_invalid_edit_bot_form, maybe

### DIFF
--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -184,11 +184,7 @@ async function test_edit_bot_form(page: Page): Promise<void> {
     await common.wait_for_micromodal_to_close(page);
 }
 
-// Disabled the below test due to non-deterministic failures.
-// The test often fails to close the modal.
-// TODO: Debug this and re-enable with a fix.
 async function test_invalid_edit_bot_form(page: Page): Promise<void> {
-    return;
     const bot1_email = "1-bot@zulip.testserver";
     const bot1_edit_btn = `.open_edit_bot_form[data-email="${CSS.escape(bot1_email)}"]`;
     await page.click(bot1_edit_btn);
@@ -213,12 +209,11 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
         "Name is already in use!",
     );
 
-    const cancel_button_selector = "#edit_bot_modal .dialog_cancel_button";
-    await page.waitForFunction(
-        (cancel_button_selector: string) =>
-            !document.querySelector(cancel_button_selector)?.hasAttribute("disabled"),
+    const cancel_button = await page.waitForSelector(
+        "#edit_bot_modal .dialog_cancel_button:not(:disabled)",
     );
-    await page.click(cancel_button_selector);
+    assert.ok(cancel_button);
+    await cancel_button.click();
     await page.waitForXPath(
         `//*[@class="btn open_edit_bot_form" and @data-email="${bot1_email}"]/ancestor::*[@class="details"]/*[@class="name" and text()="Bot one"]`,
     );


### PR DESCRIPTION
Commit 35960be510237513c9302011f1206b2260eca646 (#20815) disabled this test for being flaky.  Perhaps that was because the `waitForFunction` call was missing arguments:

```diff
     await page.waitForFunction(
         (cancel_button_selector: string) =>
             !document.querySelector(cancel_button_selector)?.hasAttribute("disabled"),
+        {},
+        cancel_button_selector,
     );
```

Replace it with a less janky `waitForSelector` call.

Cc @chdinesh1089