### PR TITLE
help-docs: Document "Delete topic" mobile app feature. 

### DIFF
--- a/templates/zerver/help/delete-a-topic.md
+++ b/templates/zerver/help/delete-a-topic.md
@@ -22,9 +22,9 @@ whereas [archiving a stream](/help/archive-a-stream) does not.
 
 {start_tabs}
 
-1. Hover over the topic in the **left sidebar**.
+{tab|desktop-web}
 
-1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+{!topic-actions.md!}
 
 1. Click **Delete topic**.
 

--- a/templates/zerver/help/delete-a-topic.md
+++ b/templates/zerver/help/delete-a-topic.md
@@ -30,6 +30,15 @@ whereas [archiving a stream](/help/archive-a-stream) does not.
 
 1. Approve by clicking **Confirm**.
 
+{tab|mobile}
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Delete topic**.
+1. Approve by tapping **DELETE TOPIC**.
+
+{!topic-long-press-menu-tip.md!}
+
 {end_tabs}
 
 Note that deleting all of the individual messages within a particular


### PR DESCRIPTION
Adds Desktop/Web tab, replaces instructions with macros, and adds a new tab with instructions for mobile app users.

**Screenshots and screen captures:**
<img width="528" alt="desktop/web" src="https://user-images.githubusercontent.com/2343554/177461726-e7909a13-cf94-4540-a03d-72f003fee736.png">

<img width="528" alt="mobile" src="https://user-images.githubusercontent.com/2343554/177461777-0aaa3ed6-3f2a-4e67-8893-360193ad7eb6.png">

Step 3 is written in uppercase letters to match the button's text formatting in the mobile app as shown below.
Is this okay or should we change it to "**Delete topic**"?

<img width="528" alt="android" src="https://user-images.githubusercontent.com/2343554/177462754-23c8146a-198b-4c06-9451-7af303050a41.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

@alya ready for review.