### PR TITLE
scim: Make "userName eq <some email>" lookups case-insensitive.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ module = [
     "re2.*",
     "requests_oauthlib.*", # https://github.com/requests/requests-oauthlib/issues/428
     "scim2_filter_parser.attr_paths",
+    "scim2_filter_parser.queries.sql",
     "scrapy.*", # https://github.com/scrapy/scrapy/issues/4041
     "social_core.*",
     "social_django.*",

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -170,6 +170,33 @@ class TestSCIMUser(SCIMTestCase):
 
         self.assertEqual(output_data, expected_empty_results_response_schema)
 
+    def test_get_basic_filter_by_username_case_insensitive(self) -> None:
+        """
+        Verifies that the "userName eq XXXX" syntax is case-insensitive.
+        """
+
+        hamlet = self.example_user("hamlet")
+
+        # The assumption for the test to make sense is that these two are not the same:
+        self.assertNotEqual(hamlet.delivery_email.upper(), hamlet.delivery_email)
+
+        expected_response_schema = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            "totalResults": 1,
+            "itemsPerPage": 50,
+            "startIndex": 1,
+            "Resources": [self.generate_user_schema(hamlet)],
+        }
+
+        result = self.client_get(
+            f'/scim/v2/Users?filter=userName eq "{hamlet.delivery_email.upper()}"',
+            {},
+            **self.scim_headers(),
+        )
+        self.assertEqual(result.status_code, 200)
+        output_data = orjson.loads(result.content)
+        self.assertEqual(output_data, expected_response_schema)
+
     def test_get_all_with_pagination(self) -> None:
         realm = get_realm("zulip")
 


### PR DESCRIPTION
This is a PR for an issue we've run into before, where a customer using SCIM had different capitalization of the user email in Zulip vs their Okta directory, resulting in Okta provisioning getting confused. This approach of messing around with SQL formed in `django-scim2` (well, the `scim2-filter-parser` component specifically - https://github.com/15five/scim2-filter-parser/blob/master/src/scim2_filter_parser/queries/sql.py#L26) is very ugly, but the simplest thing I came up with :disappointed: 

Specifically, in this commit we make the lookups made via requests of
the form
GET /scim/v2/Users?filter=userName eq "Hamlet@zulip.com"
case-insensitive.

I opened https://github.com/15five/django-scim2/issues/76 since this is
something that should ideally be resolved upstream to let us avoid the
hacky approach.
