### PR TITLE
help center: Move typing notifications documentation to a separate page.

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -205,7 +205,7 @@
                 right stream and topic.
             </p>
         </a>
-        <a class="feature-block" href="/help/status-and-availability#typing-notifications" target="_blank" rel="noopener noreferrer">
+        <a class="feature-block" href="/help/typing-notifications" target="_blank" rel="noopener noreferrer">
             <h3>TYPING NOTIFICATIONS</h3>
             <p>Know when other users are composing messages to you.</p>
         </a>

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -60,6 +60,7 @@
 * [Resize the compose box](/help/resize-the-compose-box)
 * [Format messages using Markdown](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)
+* [Typing notifications](/help/typing-notifications)
 * [Preview messages before sending](/help/preview-your-message-before-sending)
 * [Enable Enter to send](/help/enable-enter-to-send)
 * [Verify a message was sent](/help/verify-your-message-was-successfully-sent)

--- a/templates/zerver/help/private-messages.md
+++ b/templates/zerver/help/private-messages.md
@@ -42,4 +42,5 @@ There are several ways to access an existing PM or group PM.
 
 ## Related articles
 
-* [Typing notifications](/help/status-and-availability#typing-notifications)
+* [Typing notifications](/help/typing-notifications)
+

--- a/templates/zerver/help/status-and-availability.md
+++ b/templates/zerver/help/status-and-availability.md
@@ -101,27 +101,6 @@ Note that because this setting works by making your availability stop
 updating, you'll still appear to other users as active for a few
 minutes after disabling updates to your availability.
 
-## Typing notifications
+## Related articles
 
-Zulip displays typing notifications when viewing a private message or
-group private message conversation to which one of the other
-participants is currently composing a message.
-
-Typing notifications are only sent while one is actively editing text
-in the compose box, and they disappear if typing is paused for about
-15 seconds.  Just having the compose box open will not send a typing
-notification.
-
-### Disable typing notifications
-
-If you'd prefer that others not know whether you're typing, you can
-configure Zulip to not send typing notifications.
-
-{start_tabs}
-
-{settings_tab|account-and-privacy}
-
-1. Under **Privacy**, toggle **Let recipients see when I'm typing
-   private messages**.
-
-{end_tabs}
+* [Typing notifications](/help/typing-notifications)

--- a/templates/zerver/help/typing-notifications.md
+++ b/templates/zerver/help/typing-notifications.md
@@ -1,0 +1,29 @@
+# Typing notifications
+
+Zulip displays typing notifications when viewing a private message or
+group private message conversation to which one of the other
+participants is currently composing a message.
+
+Typing notifications are only sent while one is actively editing text
+in the compose box, and they disappear if typing is paused for about
+15 seconds.  Just having the compose box open will not send a typing
+notification.
+
+### Disable typing notifications
+
+If you'd prefer that others not know whether you're typing, you can
+configure Zulip to not send typing notifications.
+
+{start_tabs}
+
+{settings_tab|account-and-privacy}
+
+1. Under **Privacy**, toggle **Let recipients see when I'm typing
+   private messages**.
+
+{end_tabs}
+
+## Related articles
+
+* [Private messages](/help/private-messages)
+* [Status and availability](/help/status-and-availability)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8234,7 +8234,7 @@ paths:
         - name: send_private_typing_notifications
           in: query
           description: |
-            Whether [typing notifications](/help/status-and-availability#typing-notifications) be sent when composing
+            Whether [typing notifications](/help/typing-notifications) be sent when composing
             private messages.
 
             **Changes**: New in Zulip 5.0 (feature level 105).
@@ -8244,7 +8244,7 @@ paths:
         - name: send_stream_typing_notifications
           in: query
           description: |
-            Whether [typing notifications](/help/status-and-availability#typing-notifications) be sent when composing
+            Whether [typing notifications](/help/typing-notifications) be sent when composing
             stream messages.
 
             **Changes**: New in Zulip 5.0 (feature level 105).
@@ -10125,7 +10125,7 @@ paths:
                             type: boolean
                             description: |
                               Whether the user has chosen to send [typing
-                              notifications](/help/status-and-availability#typing-notifications)
+                              notifications](/help/typing-notifications)
                               when composing private messages. The client should send typing
                               notifications for private messages if and only if this setting is enabled.
 
@@ -10134,7 +10134,7 @@ paths:
                             type: boolean
                             description: |
                               Whether the user has chosen to send [typing
-                              notifications](/help/status-and-availability#typing-notifications)
+                              notifications](/help/typing-notifications)
                               when composing stream messages. The client should send typing
                               notifications for stream messages if and only if this setting is enabled.
 
@@ -11936,14 +11936,14 @@ paths:
                           send_private_typing_notifications:
                             type: boolean
                             description: |
-                              Whether [typing notifications](/help/status-and-availability#typing-notifications) be sent when composing
+                              Whether [typing notifications](/help/typing-notifications) be sent when composing
                               private messages.
 
                               **Changes**: New in Zulip 5.0 (feature level 105).
                           send_stream_typing_notifications:
                             type: boolean
                             description: |
-                              Whether [typing notifications](/help/status-and-availability#typing-notifications) be sent when composing
+                              Whether [typing notifications](/help/typing-notifications) be sent when composing
                               stream messages.
 
                               **Changes**: New in Zulip 5.0 (feature level 105).
@@ -13046,7 +13046,7 @@ paths:
         - name: send_private_typing_notifications
           in: query
           description: |
-            Whether [typing notifications](/help/status-and-availability#typing-notifications) be sent when composing
+            Whether [typing notifications](/help/typing-notifications) be sent when composing
             private messages.
 
             **Changes**: New in Zulip 5.0 (feature level 105).
@@ -13056,7 +13056,7 @@ paths:
         - name: send_stream_typing_notifications
           in: query
           description: |
-            Whether [typing notifications](/help/status-and-availability#typing-notifications) be sent when composing
+            Whether [typing notifications](/help/typing-notifications) be sent when composing
             stream messages.
 
             **Changes**: New in Zulip 5.0 (feature level 105).


### PR DESCRIPTION
As discussed [on CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Compose.20box.20opens.20in.20PMs/near/1214271), it's helpful to move documentation of typing notifications to its own page.

I used `git grep` to update all the links to `/help/status-and-availability#typing-notifications` to point to the new page. Do we need a redirect, or is this fine?