### PR TITLE
help center: Document reactivating a user in greater detail.

### DIFF
--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -45,10 +45,11 @@ email address.
 
 ## Reactivate a user
 
-Organization administrators can reactivate a deactivated user. They will
-have the same API key and bot API keys, but the bots will be deactivated
-until the user manually [reactivates](deactivate-or-reactivate-a-bot) them
-again.
+Organization administrators can reactivate a deactivated user. The reactivated
+user will have the same role, stream subscriptions, user group memberships, and
+other settings and permissions as they did prior to deactivation. They will also
+have the same API key and bot API keys, but the bots will be deactivated until
+the user manually [reactivates](deactivate-or-reactivate-a-bot) them again.
 
 {start_tabs}
 
@@ -58,3 +59,7 @@ again.
 want to reactivate.
 
 {end_tabs}
+
+!!! tip ""
+    You may want to [review and adjust](/help/manage-user-stream-subscriptions)
+    the reactivated user's stream subscriptions.


### PR DESCRIPTION
Adds info from the user reactivation modal to the help center page, following up on [CZO discussion](https://chat.zulip.org/#narrow/stream/2-general/topic/Not.20authorized.20to.20execute.20queries.3F/near/1215350).

## Modal
![Screen Shot 2022-07-06 at 10 07 56 PM](https://user-images.githubusercontent.com/2090066/177696385-ecd2240d-1014-4a3e-b1f5-bc24595ac5fb.png)

## Before
![Screen Shot 2022-07-06 at 10 08 36 PM](https://user-images.githubusercontent.com/2090066/177696397-bb2305d9-a864-4a13-8d85-5ff292c4fc2f.png)

## After
![Screen Shot 2022-07-06 at 10 07 38 PM](https://user-images.githubusercontent.com/2090066/177696409-6eb64c2a-cbb0-498c-8e2d-a7e18f18d321.png)

