### PR TITLE
help center: Add a "Configure multi-language search" page.

### DIFF
--- a/docs/subsystems/full-text-search.md
+++ b/docs/subsystems/full-text-search.md
@@ -12,7 +12,7 @@ app's gear menu.
 
 ## The default full-text search implementation
 
-Zulip's uses [PostgreSQL's built-in full-text search
+Zulip uses [PostgreSQL's built-in full-text search
 feature](https://www.postgresql.org/docs/current/textsearch.html),
 with a custom set of English stop words to improve the quality of the
 search results.

--- a/templates/zerver/help/change-the-default-language-for-your-organization.md
+++ b/templates/zerver/help/change-the-default-language-for-your-organization.md
@@ -34,3 +34,8 @@ can set the notifications language for the organization. This setting:
 {end_tabs}
 
 [api-create-user]: https://zulip.com/api/create-user
+
+## Related articles
+
+* [Change your language](/help/change-your-language)
+* [Configure multi-language search](/help/configure-multi-language-search)

--- a/templates/zerver/help/configure-multi-language-search.md
+++ b/templates/zerver/help/configure-multi-language-search.md
@@ -1,0 +1,18 @@
+# Configure multi-language search
+
+Zulip supports [full-text search](/help/search-for-messages), which can be
+combined arbitrarily with Zulip's full suite of narrowing operators. By default,
+Zulip search only supports English text, using [PostgreSQL's built-in full-text
+search feature](https://www.postgresql.org/docs/current/textsearch.html), with a
+custom set of English stop words to improve the quality of the search results.
+
+Self-hosted Zulip organizations can instead set up an experimental
+[PGroonga](https://pgroonga.github.io/) integration that provides full-text
+search for all languages simultaneously, including Japanese and Chinese. See
+[here](https://zulip.readthedocs.io/en/latest/subsystems/full-text-search.html#multi-language-full-text-search)
+for setup instructions.
+
+## Related articles
+
+* [Configure organization notifications language](/help/change-the-default-language-for-your-organization)
+* [Searching for messages](/help/search-for-messages)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -190,6 +190,7 @@
 * [Weekly digest emails](/help/digest-emails)
 * [Disable welcome emails](/help/disable-welcome-emails)
 * [Configure notification bot](/help/configure-notification-bot)
+* [Configure multi-language search](/help/configure-multi-language-search)
 
 ## Bots & integrations
 * [Bots and integrations](/help/bots-and-integrations)

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -98,3 +98,7 @@ class="emoji-small"/>.
 Note that Zulip ignores common words like `a`, `the`, and about 100
 others. A quirk in Zulip's current implementation means that if all of your
 keywords are ignored, we'll return 0 search results.
+
+## Related articles
+
+* [Configure multi-language search](/help/configure-multi-language-search)


### PR DESCRIPTION
As [discussed on CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/full-text.20search.20across.20all.20languages).

The content is tweaked from https://zulip.readthedocs.io/en/latest/subsystems/full-text-search.html.

Is it worth noting on the **Setting up your organization** page? This PR currently does not do so.

![Screen Shot 2022-07-06 at 10 54 52 PM](https://user-images.githubusercontent.com/2090066/177701964-fc5c63f2-b11f-4e0b-989a-4208ad855e6a.png)

