### PR TITLE
message_list_data: Store message_list_data objects created locally.

### DIFF
--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -12,6 +12,7 @@ import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_helper from "./message_helper";
 import * as message_list from "./message_list";
+import * as message_list_data from "./message_list_data";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as message_util from "./message_util";
@@ -516,4 +517,5 @@ export function remove_messages(message_ids) {
     }
     recent_senders.update_topics_of_deleted_message_ids(message_ids);
     recent_topics_ui.update_topics_of_deleted_message_ids(message_ids);
+    message_list_data.remove_message_ids(message_ids);
 }

--- a/static/js/muted_topics_ui.js
+++ b/static/js/muted_topics_ui.js
@@ -5,6 +5,7 @@ import render_topic_muted from "../templates/topic_muted.hbs";
 import * as channel from "./channel";
 import * as feedback_widget from "./feedback_widget";
 import {$t} from "./i18n";
+import * as message_list_data from "./message_list_data";
 import * as message_lists from "./message_lists";
 import * as muted_topics from "./muted_topics";
 import * as overlays from "./overlays";
@@ -33,6 +34,7 @@ export function rerender_for_muted_topic(old_muted_topics) {
 
     for (const topic_data of maybe_affected_topics) {
         recent_topics_ui.update_topic_is_muted(topic_data.stream_id, topic_data.topic);
+        message_list_data.update_data_for_muted_topic(topic_data.stream);
     }
 }
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -15,7 +15,7 @@ import * as message_edit from "./message_edit";
 import * as message_fetch from "./message_fetch";
 import * as message_helper from "./message_helper";
 import * as message_list from "./message_list";
-import {MessageListData} from "./message_list_data";
+import * as message_list_data from "./message_list_data";
 import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as message_store from "./message_store";
@@ -445,10 +445,7 @@ export function activate(raw_operators, opts) {
 
     const excludes_muted_topics = narrow_state.excludes_muted_topics();
 
-    let msg_data = new MessageListData({
-        filter: narrow_state.filter(),
-        excludes_muted_topics,
-    });
+    let msg_data = message_list_data.get_message_list_data(excludes_muted_topics, filter);
 
     // Populate the message list if we can apply our filter locally (i.e.
     // with no backend help) and we have the message we want to select.
@@ -466,10 +463,8 @@ export function activate(raw_operators, opts) {
         // messages in the MessageListData built inside
         // maybe_add_local_messages is likely not be contiguous with
         // the block we're about to request from the server instead.
-        msg_data = new MessageListData({
-            filter: narrow_state.filter(),
-            excludes_muted_topics,
-        });
+        message_list_data.clear_message_list_data_for_filter(filter);
+        msg_data = message_list_data.get_message_list_data(excludes_muted_topics, filter);
     }
 
     const msg_list = new message_list.MessageList({

--- a/static/js/zulip_test.js
+++ b/static/js/zulip_test.js
@@ -15,3 +15,4 @@ export {cancel as cancel_compose} from "./compose_actions";
 export {page_params, page_params_parse_time} from "./page_params";
 export {initiate as initiate_reload} from "./reload";
 export {add_user_id_to_new_stream} from "./stream_create_subscribers";
+export {msg_list_data_map} from "./message_list_data";


### PR DESCRIPTION
For #15131

@timabbott here is the list of events for which we will have to update the message_list_data objects we have stored locally:

* muted_topics
* muted_users
* stream update/create/delete events
* delete_message
* update_message events (stream/topic change)


Does the approach look good to you? I implemented what an update would look like for `muted_topics`.