### PR TITLE
ci: Limit CodeQL analysis with the same branches for push, pull_request

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches: ["*.x", chat.zulip.org, main]
     tags: ["*"]
   pull_request:
+    branches: ["*.x", chat.zulip.org, main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Silences “Warning: 1 issue was detected with this workflow: Please make sure that every branch in `on.pull_request` is also in `on.push` so that Code Scanning can compare pull requests against the state of the base branch.”

Followup to #22385. Reported at https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/duplicate.20CI.20runs/near/1401202.