### PR TITLE
babel: Bump configured corejs version

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,7 @@ module.exports = {
         [
             "@babel/preset-env",
             {
-                corejs: "3.22",
+                corejs: "3.23",
                 shippedProposals: true,
                 useBuiltIns: "usage",
             },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "blueimp-md5": "^2.10.0",
     "clean-css": "^5.1.0",
     "clipboard": "^2.0.4",
-    "core-js": "^3.6.5",
+    "core-js": "^3.23.3",
     "css-loader": "^6.2.0",
     "css-minimizer-webpack-plugin": "^4.0.0",
     "css.escape": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,7 +3488,7 @@ core-js-compat@^3.21.0, core-js-compat@^3.22.1:
     browserslist "^4.21.0"
     semver "7.0.0"
 
-core-js@^3.0.1, core-js@^3.6.5:
+core-js@^3.0.1, core-js@^3.23.3:
   version "3.23.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.23.3.tgz#3b977612b15da6da0c9cc4aec487e8d24f371112"
   integrity sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q==


### PR DESCRIPTION
`PROVISION_VERSION` bump is skipped because 3.23.3 was already the version being installed.