### PR TITLE
help-docs: Fix instructions for the "Logging out" mobile app feature.

### DIFF
--- a/templates/zerver/help/code-blocks.md
+++ b/templates/zerver/help/code-blocks.md
@@ -27,7 +27,7 @@ Sending the above message in Zulip will render like this:
 You can also use `~~~` to start code blocks, or just indent the code 4 or more
 spaces.
 
-A widget in the upper-right corner of code blocks allows you to easily
+A widget in the top right corner of code blocks allows you to easily
 copy the code to your clipboard.
 
 ## Language tagging

--- a/templates/zerver/help/connect-through-a-proxy.md
+++ b/templates/zerver/help/connect-through-a-proxy.md
@@ -15,7 +15,7 @@ a single website.
 
 {tab|system-proxy-settings}
 
-1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the lower left corner.
+{!desktop-sidebar-settings-menu.md!}
 
 2. Select the **Network** tab.
 
@@ -25,7 +25,7 @@ a single website.
 
 {tab|custom-proxy-settings}
 
-1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the lower left corner.
+{!desktop-sidebar-settings-menu.md!}
 
 2. Select the **Network** tab.
 

--- a/templates/zerver/help/custom-certificates.md
+++ b/templates/zerver/help/custom-certificates.md
@@ -96,7 +96,7 @@ server. You'll need to get a certificate file (should end in `.crt` or
 
 {start_tabs}
 
-1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the lower left corner.
+{!desktop-sidebar-settings-menu.md!}
 
 2. Select the **Organizations** tab.
 

--- a/templates/zerver/help/deactivate-your-account.md
+++ b/templates/zerver/help/deactivate-your-account.md
@@ -37,5 +37,7 @@
 
 ## Related articles
 
-You may also be interested in
-[deactivating an organization](/help/deactivate-your-organization).
+* [Logging in](logging-in)
+* [Logging out](logging-out)
+* [Switching between organizations](switching-between-organizations)
+* [Deactivate your organization](/help/deactivate-your-organization)

--- a/templates/zerver/help/include/add-a-wide-logo.md
+++ b/templates/zerver/help/include/add-a-wide-logo.md
@@ -1,6 +1,6 @@
 {!cloud-standard-only.md!}
 
-You can customize the logo users see in the upper left corner
+You can customize the logo users see in the top left corner
 of the Zulip app. For best results make sure your logo has a
 transparent background, and trim any bordering whitespace. To upload a logo:
 

--- a/templates/zerver/help/include/desktop-sidebar-settings-menu.md
+++ b/templates/zerver/help/include/desktop-sidebar-settings-menu.md
@@ -1,0 +1,1 @@
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the bottom left corner of the app.

--- a/templates/zerver/help/include/desktop-toggle-sidebar-tip.md
+++ b/templates/zerver/help/include/desktop-toggle-sidebar-tip.md
@@ -1,0 +1,4 @@
+!!! tip ""
+
+    To show or hide the **organizations sidebar** on the left, select
+    **Toggle Sidebar** from the **View** menu in the top menu bar.

--- a/templates/zerver/help/include/go-to-stream-via-all-streams.md
+++ b/templates/zerver/help/include/go-to-stream-via-all-streams.md
@@ -1,4 +1,4 @@
-1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the top
    right corner of the web or desktop app.
 
 1. Select **Manage streams**.

--- a/templates/zerver/help/include/stream-long-press-menu-tip.md
+++ b/templates/zerver/help/include/stream-long-press-menu-tip.md
@@ -1,4 +1,4 @@
 !!! tip ""
 
     If you are viewing a single stream, you can access the long-press
-    menu from the bar at the top of the screen.
+    menu from the bar at the top of the app.

--- a/templates/zerver/help/include/topic-long-press-menu-tip.md
+++ b/templates/zerver/help/include/topic-long-press-menu-tip.md
@@ -1,4 +1,4 @@
 !!! tip ""
 
     If you are viewing a single topic, you can access the long-press
-    menu from the bar at the top of the screen.
+    menu from the bar at the top of the app.

--- a/templates/zerver/help/join-a-zulip-organization.md
+++ b/templates/zerver/help/join-a-zulip-organization.md
@@ -12,9 +12,9 @@ invitation, and/or restrict user email addresses to a company domain. See
 
 1. Go to the Zulip URL of the organization.
 
-1. Click **Sign up** at the top of the screen.
+1. Click **Sign up** in the top right corner of the page.
 
-1. If you see a sign up form, invitations are not required! Otherwise, the
+1. If you see a sign-up form, invitations are not required! Otherwise, the
   page will say that you need an invitation to join.
 
 {end_tabs}
@@ -25,7 +25,7 @@ invitation, and/or restrict user email addresses to a company domain. See
 
 1. Go to the Zulip URL of the organization.
 
-1. Click **Sign up** at the top of the screen.
+1. Click **Sign up** in the top right corner of the page.
 
 1. Try to create an account with your desired email address.
 

--- a/templates/zerver/help/logging-in.md
+++ b/templates/zerver/help/logging-in.md
@@ -13,10 +13,15 @@ how you signed up. E.g. if you originally signed up using your Google
 account, you can later log in using GitHub, as long as your Google account
 and GitHub account use the same email address.
 
-
 ### Log in to a Zulip organization for the first time
 
 {start_tabs}
+
+{tab|web}
+
+1. Go to your organization's **Zulip URL**.
+
+1. Follow the on-screen instructions.
 
 {tab|desktop}
 
@@ -33,19 +38,13 @@ and GitHub account use the same email address.
 
 {tab|mobile}
 
-1. From the home screen, tap your **profile picture** in the lower right.
+{!mobile-profile-menu.md!}
 
 1. Tap **Switch account**.
 
 1. Tap **Add new account**.
 
 1. Enter your Zulip URL, and tap **Enter**.
-
-1. Follow the on-screen instructions.
-
-{tab|web}
-
-1. Go to your organization's **Zulip URL**.
 
 1. Follow the on-screen instructions.
 

--- a/templates/zerver/help/logging-in.md
+++ b/templates/zerver/help/logging-in.md
@@ -13,28 +13,32 @@ how you signed up. E.g. if you originally signed up using your Google
 account, you can later log in using GitHub, as long as your Google account
 and GitHub account use the same email address.
 
-### Log in to a Zulip organization for the first time
+## Log in to a Zulip organization for the first time
 
 {start_tabs}
 
 {tab|web}
 
-1. Go to your organization's **Zulip URL**.
+1. Go to the Zulip URL of the organization.
 
 1. Follow the on-screen instructions.
 
 {tab|desktop}
 
-1. Open the **left sidebar** (`Ctrl` + `Shift` + `s`).
+!!! warn ""
+    If you are having trouble connecting, you may need to set your
+    [proxy settings](/help/connect-through-a-proxy) or add a
+    [custom certificate](/help/custom-certificates).
 
-1. Set your [proxy settings](/help/connect-through-a-proxy) or add a
-   [custom certificate](/help/custom-certificates) if needed (rare).
+1. Click the **plus** (<i class="fa fa-plus"></i>) icon in the
+**organizations sidebar** on the left. You can also select **Add Organization**
+from the **Zulip** menu in the top menu bar.
 
-1. Click the **plus** (+) icon.
-
-1. Enter your Zulip URL, and click **Connect**.
+1. Enter the Zulip URL of the organization, and click **Connect**.
 
 1. Follow the on-screen instructions.
+
+{!desktop-toggle-sidebar-tip.md!}
 
 {tab|mobile}
 
@@ -44,7 +48,7 @@ and GitHub account use the same email address.
 
 1. Tap **Add new account**.
 
-1. Enter your Zulip URL, and tap **Enter**.
+1. Enter the Zulip URL of the organization, and tap **Enter**.
 
 1. Follow the on-screen instructions.
 
@@ -80,3 +84,9 @@ in via email/password, you can
 You can [reset your password](/help/change-your-password). This requires
 access to the email address you currently have on file. We recommend
 [keeping your email address up to date](change-your-email-address).
+
+## Related articles
+
+* [Logging out](logging-out)
+* [Switching between organizations](switching-between-organizations)
+* [Deactivate your account](deactivate-your-account)

--- a/templates/zerver/help/logging-out.md
+++ b/templates/zerver/help/logging-out.md
@@ -6,21 +6,15 @@
 1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the top
 right corner of the app.
 
-2. Click **Log out**.
+1. Click **Log out**.
 
-{tab|ios}
+{tab|mobile}
 
-1. Tap the menu (<i class="fa fa-reorder"></i>) icon in the top left
-corner of the screen.
+{!mobile-profile-menu.md!}
 
-2. Tap **Log out**.
+1. Tap **Log out**.
 
-{tab|android}
-
-1. Tap the overflow ( <i class="fa fa-ellipsis-v"></i> ) icon in
-the top right corner of the screen.
-
-2. Tap **Log out**.
+1. Approve by tapping **Log out**.
 
 {end_tabs}
 
@@ -29,3 +23,9 @@ the top right corner of the screen.
     Logging out doesn't affect any other organizations you may be logged in
     to. To log out of all your Zulip organizations, repeat the steps above
     for each one.
+
+## Related articles
+
+* [Logging in](logging-in)
+* [Switching between organizations](switching-between-organizations)
+* [Deactivate your account](deactivate-your-account)

--- a/templates/zerver/help/logging-out.md
+++ b/templates/zerver/help/logging-out.md
@@ -3,8 +3,8 @@
 {start_tabs}
 {tab|desktop-web}
 
-1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
-right corner.
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the top
+right corner of the app.
 
 2. Click **Log out**.
 

--- a/templates/zerver/help/open-the-compose-box.md
+++ b/templates/zerver/help/open-the-compose-box.md
@@ -8,7 +8,7 @@ space for the message feed. There are a number of ways to open the compose box.
 * Click on any message.
 
 * Click on **Message...**, **New topic**, or **New private message** at the
-  bottom of the screen.
+  bottom of the app.
 
 ## Using the keyboard
 

--- a/templates/zerver/help/private-messages.md
+++ b/templates/zerver/help/private-messages.md
@@ -19,7 +19,7 @@ streams.
 {start_tabs}
 
 1. [Open the compose box](/help/open-the-compose-box) by typing `x` or clicking
-   **New private message** at the bottom of the screen.
+   **New private message** at the bottom of the app.
 
 2. Start typing a user's name, and select the user from the list of
    suggestions. Repeat as necessary.
@@ -43,4 +43,3 @@ There are several ways to access an existing PM or group PM.
 ## Related articles
 
 * [Typing notifications](/help/typing-notifications)
-

--- a/templates/zerver/help/reading-strategies.md
+++ b/templates/zerver/help/reading-strategies.md
@@ -46,7 +46,7 @@ shortcut](/help/keyboard-shortcuts).
 If you're all caught up, it can be useful to have a single place to keep
 track of all messages coming in.
 
-* Click on **All messages** in the upper left, or hit `a`.
+* Click on **All messages** near the top left corner of the app, or hit `a`.
 
 * You can use `s` (narrow to stream) or `S` (narrow to topic) to zoom in,
   and `a` to get back to All messages.

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -1,7 +1,7 @@
 # Searching for messages
 
 Zulip has a powerful search engine under its hood. Search for messages using
-the search bar at the top of the screen.
+the search bar at the top of the app.
 
 ## Example
 

--- a/templates/zerver/help/start-a-new-topic.md
+++ b/templates/zerver/help/start-a-new-topic.md
@@ -9,7 +9,7 @@ start a new topic whenever you're not replying to an existing message.
 
 1. Click on a stream in the left sidebar.
 
-1. Click **New topic** at the bottom of the screen.
+1. Click **New topic** at the bottom of the app.
 
 !!! warn ""
 

--- a/templates/zerver/help/switching-between-organizations.md
+++ b/templates/zerver/help/switching-between-organizations.md
@@ -12,15 +12,10 @@ just switch tabs.
 
 {tab|desktop}
 
-1. Open the **left sidebar** (`Ctrl` + `Shift` + `s`).
+1. Click on a logo in the **organizations sidebar** on the left, or choose
+an organization from the **Window** menu in the top menu bar.
 
-1. Click on your organization's profile picture.
-
-!!! warn ""
-
-    You can ask your organization administrator to
-    [set an organization profile picture](/help/create-your-organization-profile)
-    if they haven't already.
+{!desktop-toggle-sidebar-tip.md!}
 
 {tab|mobile}
 
@@ -31,3 +26,10 @@ just switch tabs.
 1. Tap on the desired Zulip organization.
 
 {end_tabs}
+
+## Related articles
+
+* [Logging in](logging-in)
+* [Logging out](logging-out)
+* [Deactivate your account](deactivate-your-account)
+* [Create your organization profile](create-your-organization-profile)

--- a/templates/zerver/help/switching-between-organizations.md
+++ b/templates/zerver/help/switching-between-organizations.md
@@ -4,6 +4,12 @@ This article assumes you've [logged in](/help/logging-in) to each organization a
 
 {start_tabs}
 
+{tab|web}
+
+You can log in to multiple Zulip organizations by opening multiple tabs, and
+logging into one Zulip organization in each tab. To switch Zulip organizations,
+just switch tabs.
+
 {tab|desktop}
 
 1. Open the **left sidebar** (`Ctrl` + `Shift` + `s`).
@@ -18,16 +24,10 @@ This article assumes you've [logged in](/help/logging-in) to each organization a
 
 {tab|mobile}
 
-1. From the home screen, tap your **profile picture** in the lower right.
+{!mobile-profile-menu.md!}
 
 1. Tap **Switch account**.
 
 1. Tap on the desired Zulip organization.
-
-{tab|web}
-
-You can log in to multiple Zulip organizations by opening multiple tabs, and
-logging into one Zulip organization in each tab. To switch Zulip organizations,
-just switch tabs.
 
 {end_tabs}

--- a/templates/zerver/help/view-and-edit-your-message-drafts.md
+++ b/templates/zerver/help/view-and-edit-your-message-drafts.md
@@ -15,7 +15,7 @@ so that you never lose your work. Drafts are saved for 30 days.
 {tab|desktop-web}
 
 Simply close the compose box. You can hit `Esc`, click
-the <i class="fa fa-remove"></i> in the upper right corner of the
+the <i class="fa fa-remove"></i> in the top right corner of the
 compose box, or click on an empty part of the app.
 
 {end_tabs}


### PR DESCRIPTION
The logging-out instructions haven't been accurate for a long while.

- Fixes the instructions and replaces the iOS and Android tabs with a single Mobile tab plus a new macro with instructions for accessing the profile menu.

```
$ git grep "ios"
logging-out.md:{tab|ios}

$ git grep "android"
logging-out.md:{tab|android}
```

- Notice that there aren't any references left to `ios` and `android`, but they shouldn't be removed from `tabbed_sections.py` as we may need them to document [#mobile > platform differences](https://chat.zulip.org/#narrow/stream/48-mobile/topic/platform.20differences).

**Screenshots and screen captures:**
<img width="527" alt="image" src="https://user-images.githubusercontent.com/2343554/178015235-dfdfcf39-6ff6-4c1d-b1d1-1054c4aea5ea.png">

- Replaces step one with a macro for reusability.
```
$ git grep "tap your \*\*profile picture\*\* " 

logging-in.md:1. From the home screen, tap your **profile picture** in the lower right.
switching-between-organizations.md:1. From the home screen, tap your **profile picture** in the lower right.
```
- Reorders tabs Web > Desktop > Mobile for consistency.

<img width="575" alt="image" src="https://user-images.githubusercontent.com/2343554/178015372-1381a0fe-9087-4468-97ae-a91a4e2ea1c6.png">

<img width="540" alt="image" src="https://user-images.githubusercontent.com/2343554/178015433-27ceb5e6-839c-484b-bcd2-41cfc44b109e.png">


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans.
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Strings.
- [x] End-to-end functionality of buttons, interactions, and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>