### PR TITLE
custom_profile: Add ProfileDataElementUpdateDict.

### DIFF
--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext as _
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
 from zerver.lib.streams import render_stream_description
-from zerver.lib.types import ProfileDataElementValue, ProfileFieldData
+from zerver.lib.types import ProfileDataElementUpdateDict, ProfileFieldData
 from zerver.models import (
     CustomProfileField,
     CustomProfileFieldValue,
@@ -122,7 +122,7 @@ def notify_user_update_custom_profile_data(
 
 def do_update_user_custom_profile_data_if_changed(
     user_profile: UserProfile,
-    data: List[Dict[str, Union[int, ProfileDataElementValue]]],
+    data: List[ProfileDataElementUpdateDict],
 ) -> None:
     with transaction.atomic():
         for custom_profile_field in data:

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -33,6 +33,11 @@ class ProfileDataElement(ProfileDataElementBase):
     rendered_value: Optional[str]
 
 
+class ProfileDataElementUpdateDict(TypedDict):
+    id: int
+    value: ProfileDataElementValue
+
+
 ProfileData = List[ProfileDataElement]
 
 FieldElement = Tuple[int, Promise, Validator[ProfileDataElementValue], Callable[[Any], Any], str]

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1,7 +1,7 @@
 import re
 import unicodedata
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional, Sequence, TypedDict, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, TypedDict, Union
 
 import dateutil.parser as date_parser
 from django.conf import settings
@@ -26,7 +26,7 @@ from zerver.lib.exceptions import (
     OrganizationOwnerRequired,
 )
 from zerver.lib.timezone import canonicalize_timezone
-from zerver.lib.types import ProfileDataElementValue
+from zerver.lib.types import ProfileDataElementUpdateDict, ProfileDataElementValue
 from zerver.models import (
     CustomProfileField,
     CustomProfileFieldValue,
@@ -378,7 +378,7 @@ def validate_user_custom_profile_field(
 
 
 def validate_user_custom_profile_data(
-    realm_id: int, profile_data: List[Dict[str, Union[int, ProfileDataElementValue]]]
+    realm_id: int, profile_data: List[ProfileDataElementUpdateDict]
 ) -> None:
     # This function validate all custom field values according to their field type.
     for item in profile_data:
@@ -389,9 +389,7 @@ def validate_user_custom_profile_data(
             raise JsonableError(_("Field id {id} not found.").format(id=field_id))
 
         try:
-            validate_user_custom_profile_field(
-                realm_id, field, cast(ProfileDataElementValue, item["value"])
-            )
+            validate_user_custom_profile_field(realm_id, field, item["value"])
         except ValidationError as error:
             raise JsonableError(error.message)
 

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -13,6 +13,7 @@ from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
 from zerver.lib.markdown import markdown_convert
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import queries_captured
+from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.models import (
     CustomProfileField,
     CustomProfileFieldValue,
@@ -374,7 +375,7 @@ class DeleteCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_error(result, f"Field id {invalid_field_id} not found.")
 
         field = CustomProfileField.objects.get(name="Mentor", realm=realm)
-        data: List[Dict[str, Union[int, str, List[int]]]] = [
+        data: List[ProfileDataElementUpdateDict] = [
             {"id": field.id, "value": [self.example_user("aaron").id]},
         ]
         do_update_user_custom_profile_data_if_changed(iago, data)
@@ -404,7 +405,7 @@ class DeleteCustomProfileFieldTest(CustomProfileFieldTestCase):
         user_profile = self.example_user("iago")
         realm = user_profile.realm
         field = CustomProfileField.objects.get(name="Phone number", realm=realm)
-        data: List[Dict[str, Union[int, str, List[int]]]] = [
+        data: List[ProfileDataElementUpdateDict] = [
             {"id": field.id, "value": "123456"},
         ]
         do_update_user_custom_profile_data_if_changed(user_profile, data)
@@ -693,7 +694,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertIsNone(value)
         self.assertIsNone(rendered_value)
 
-        update_dict: Dict[str, Union[int, str, List[int]]] = {
+        update_dict: ProfileDataElementUpdateDict = {
             "id": quote.id,
             "value": "***beware*** of jealousy...",
         }
@@ -713,7 +714,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         # Set field value:
         field = CustomProfileField.objects.get(name="Mentor", realm=realm)
-        data: List[Dict[str, Union[int, str, List[int]]]] = [
+        data: List[ProfileDataElementUpdateDict] = [
             {"id": field.id, "value": [self.example_user("aaron").id]},
         ]
         do_update_user_custom_profile_data_if_changed(iago, data)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -199,6 +199,7 @@ from zerver.lib.test_helpers import (
     stdout_suppressed,
 )
 from zerver.lib.topic import TOPIC_NAME
+from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.lib.user_groups import create_user_group
 from zerver.lib.user_mutes import get_mute_object
 from zerver.models import (
@@ -1013,7 +1014,7 @@ class NormalActionsTest(BaseAction):
         field_id = self.user_profile.realm.customprofilefield_set.get(
             realm=self.user_profile.realm, name="Biography"
         ).id
-        field = {
+        field: ProfileDataElementUpdateDict = {
             "id": field_id,
             "value": "New value",
         }

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -48,7 +48,7 @@ from zerver.lib.rate_limiter import rate_limit_spectator_attachment_access_by_fi
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_response_from_error, json_success
 from zerver.lib.streams import access_stream_by_id, access_stream_by_name, subscribed_to_stream
-from zerver.lib.types import ProfileDataElementValue, Validator
+from zerver.lib.types import ProfileDataElementUpdateDict, ProfileDataElementValue, Validator
 from zerver.lib.upload import upload_avatar_image
 from zerver.lib.url_encoding import append_url_query_string
 from zerver.lib.users import (
@@ -211,9 +211,10 @@ def update_user_backend(
         check_change_full_name(target, full_name, user_profile)
 
     if profile_data is not None:
-        clean_profile_data = []
+        clean_profile_data: List[ProfileDataElementUpdateDict] = []
         for entry in profile_data:
             assert isinstance(entry["id"], int)
+            assert not isinstance(entry["value"], int)
             if entry["value"] is None or not entry["value"]:
                 field_id = entry["id"]
                 check_remove_custom_profile_field_value(target, field_id)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -86,7 +86,7 @@ from zerver.lib.redis_utils import get_dict_from_redis, get_redis_client, put_di
 from zerver.lib.request import RequestNotes
 from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.subdomains import get_subdomain
-from zerver.lib.types import ProfileDataElementValue
+from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.lib.url_encoding import append_url_query_string
 from zerver.lib.users import check_full_name, validate_user_custom_profile_field
 from zerver.models import (
@@ -1361,7 +1361,7 @@ def sync_user_profile_custom_fields(
         var_name = "_".join(data["name"].lower().split(" "))
         existing_values[var_name] = data["value"]
 
-    profile_data: List[Dict[str, Union[int, ProfileDataElementValue]]] = []
+    profile_data: List[ProfileDataElementUpdateDict] = []
     for var_name, value in custom_field_name_to_value.items():
         try:
             field = fields_by_var_name[var_name]


### PR DESCRIPTION
This replaces `Dict[str, Union[int, ProfileDataElementValue]]` with `ProfileDataElementUpdateDict`.

#### Affected errors:

```diff
2c2
< Found 296 errors in 95 files (checked 1394 source files)
---
> Found 289 errors in 93 files (checked 1394 source files)
163d162
< zerver/lib/users.py error Incompatible type for lookup 'id' (got "Union[int, Union[str, List[int]]]", expected "Union[str, int]")  [misc]
230,233d228
< zerver/tests/test_custom_profile_data.py error "object" has no attribute "is_renderable"  [attr-defined]
< zerver/tests/test_custom_profile_data.py error Argument 1 to "markdown_convert" has incompatible type "object"; expected "str"  [arg-type]
< zerver/tests/test_custom_profile_data.py error Invalid index type "object" for "Dict[Union[int, float, str, None], Optional[str]]"; expected type "Union[int, float, str, None]"  [index]
< zerver/tests/test_custom_profile_data.py error Invalid index type "object" for "Dict[Union[int, float, str, None], Optional[str]]"; expected type "Union[int, float, str, None]"  [index]
248,249d242
< zerver/tests/test_events.py error List item 0 has incompatible type "Dict[str, object]"; expected "Dict[str, Union[int, str, List[int]]]"  [list-item]
< zerver/tests/test_events.py error List item 0 has incompatible type "Dict[str, object]"; expected "Dict[str, Union[int, str, List[int]]]"  [list-item]
```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
