### PR TITLE
2fa: Avoid using the user.is_verified shortcut

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -63,6 +63,7 @@ from zerver.lib.response import json_method_not_allowed, json_success, json_unau
 from zerver.lib.subdomains import get_subdomain, user_matches_subdomain
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.lib.types import ViewFuncT
+from zerver.lib.users import is_2fa_verified
 from zerver.lib.utils import has_api_key_format, statsd
 from zerver.models import Realm, UserProfile, get_client, get_user_profile_by_api_key
 
@@ -1035,7 +1036,7 @@ def zulip_otp_required(
     to :setting:`OTP_LOGIN_URL`.
     """
 
-    def test(user: UserProfile) -> bool:
+    def test(user: Union[UserProfile, AnonymousUser]) -> bool:
         """
         :if_configured: If ``True``, an authenticated user with no confirmed
         OTP devices will be allowed. Also, non-authenticated users will be
@@ -1047,7 +1048,7 @@ def zulip_otp_required(
             return True
 
         # User has completed 2FA verification
-        if user.is_verified():
+        if is_2fa_verified(user):
             return True
 
         # This request is unauthenticated (logged-out) access; 2FA is

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -1052,9 +1052,7 @@ def zulip_otp_required(
 
         # This request is unauthenticated (logged-out) access; 2FA is
         # not required or possible.
-        #
-        # TODO: Add a test for 2FA-enabled with web-public views.
-        if not user.is_authenticated:  # nocoverage
+        if not user.is_authenticated:
             return True
 
         # If the user doesn't have 2FA set up, we can't enforce 2FA.

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -528,7 +528,7 @@ def zulip_login_required(
         login_url=login_url,
         redirect_field_name=redirect_field_name,
     )(
-        zulip_otp_required(
+        zulip_otp_required_if_logged_in(
             redirect_field_name=redirect_field_name,
             login_url=login_url,
         )(add_logging_data(function))
@@ -548,7 +548,7 @@ def web_public_view(
     This wrapper adds client info for unauthenticated users but
     forces authenticated users to go through 2fa.
     """
-    actual_decorator = lambda view_func: zulip_otp_required(
+    actual_decorator = lambda view_func: zulip_otp_required_if_logged_in(
         redirect_field_name=redirect_field_name, login_url=login_url
     )(add_logging_data(view_func))
 
@@ -1021,7 +1021,7 @@ def return_success_on_head_request(view_func: ViewFuncT) -> ViewFuncT:
     return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927
 
 
-def zulip_otp_required(
+def zulip_otp_required_if_logged_in(
     redirect_field_name: str = "next",
     login_url: str = settings.HOME_NOT_LOGGED_IN,
 ) -> Callable[[ViewFuncT], ViewFuncT]:
@@ -1033,7 +1033,7 @@ def zulip_otp_required(
 
     Similar to :func:`~django.contrib.auth.decorators.login_required`, but
     requires the user to be :term:`verified`. By default, this redirects users
-    to :setting:`OTP_LOGIN_URL`.
+    to :setting:`OTP_LOGIN_URL`. Returns True if the user is not authenticated.
     """
 
     def test(user: Union[UserProfile, AnonymousUser]) -> bool:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -34,6 +34,7 @@ from zerver.decorator import (
     validate_api_key,
     webhook_view,
     zulip_login_required,
+    zulip_otp_required,
 )
 from zerver.forms import OurAuthenticationForm
 from zerver.lib.cache import dict_to_items_tuple, ignore_unhashable_lru_cache, items_tuple_to_dict
@@ -1897,6 +1898,17 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             assert type(request.user) is UserProfile
             self.create_default_device(request.user)
 
+            response = test_view(request)
+            self.assertEqual(response.content.decode(), "Success")
+
+    def test_otp_not_authenticated(self) -> None:
+        @zulip_otp_required()
+        def test_view(request: HttpRequest) -> HttpResponse:
+            return HttpResponse("Success")
+
+        with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):
+            user = AnonymousUser()
+            request = HostRequestMock(user_profile=user)
             response = test_view(request)
             self.assertEqual(response.content.decode(), "Success")
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -34,7 +34,7 @@ from zerver.decorator import (
     validate_api_key,
     webhook_view,
     zulip_login_required,
-    zulip_otp_required,
+    zulip_otp_required_if_logged_in,
 )
 from zerver.forms import OurAuthenticationForm
 from zerver.lib.cache import dict_to_items_tuple, ignore_unhashable_lru_cache, items_tuple_to_dict
@@ -1902,7 +1902,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
                 self.assertEqual(response.content.decode(), "Success")
 
     def test_otp_not_authenticated(self) -> None:
-        @zulip_otp_required()
+        @zulip_otp_required_if_logged_in()
         def test_view(request: HttpRequest) -> HttpResponse:
             return HttpResponse("Success")
 

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -67,7 +67,7 @@ from zerver.lib.subdomains import get_subdomain, is_subdomain_root_or_alias
 from zerver.lib.types import ViewFuncT
 from zerver.lib.url_encoding import append_url_query_string
 from zerver.lib.user_agent import parse_user_agent
-from zerver.lib.users import get_api_key
+from zerver.lib.users import get_api_key, is_2fa_verified
 from zerver.lib.utils import has_api_key_format
 from zerver.lib.validator import validate_login_email
 from zerver.models import (
@@ -760,7 +760,7 @@ def login_page(
     # logged-in app.
     is_preview = "preview" in request.GET
     if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
-        if request.user and request.user.is_verified():
+        if request.user and is_2fa_verified(request.user):
             return HttpResponseRedirect(request.user.realm.uri)
     elif request.user.is_authenticated and not is_preview:
         return HttpResponseRedirect(request.user.realm.uri)


### PR DESCRIPTION
`request.user.is_verified` is functionally the same as `is_verified`
from `django_otp.middleware`, except that the former is monkey-patched
onto the user object by the 2FA middleware. We use the latter wrapped
in `is_2fa_verified` instead to avoid accessing the patched attribute.

This is a part of the django-stubs refactoring.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
