### PR TITLE
compose: Add format hinting for spoilers.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -400,6 +400,14 @@ test("content_typeahead_selected", ({override}) => {
         caret_called2 = true;
         return this;
     };
+    let range_called = false;
+    fake_this.$element.range = function (...args) {
+        const [arg1, arg2] = args;
+        // .range() used in setTimeout
+        assert.ok(arg2 > arg1);
+        range_called = true;
+        return this;
+    };
     autosize_called = false;
     set_timeout_called = false;
 
@@ -621,6 +629,12 @@ test("content_typeahead_selected", ({override}) => {
     expected_value = "```python\n\n```";
     assert.equal(actual_value, expected_value);
 
+    fake_this.query = "```spo";
+    fake_this.token = "spo";
+    actual_value = ct.content_typeahead_selected.call(fake_this, "spoiler");
+    expected_value = "```spoiler translated: Header\n\n```";
+    assert.equal(actual_value, expected_value);
+
     // Test special case to not close code blocks if there is text afterward
     fake_this.query = "```p\nsome existing code";
     fake_this.token = "p";
@@ -638,6 +652,7 @@ test("content_typeahead_selected", ({override}) => {
 
     assert.ok(caret_called1);
     assert.ok(caret_called2);
+    assert.ok(range_called);
     assert.ok(autosize_called);
     assert.ok(set_timeout_called);
     assert.ok(warned_for_stream_link);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -779,8 +779,10 @@ export function content_typeahead_selected(item, event) {
     let beginning = pieces[0];
     let rest = pieces[1];
     const $textbox = this.$element;
-    // this highlight object will hold the start and end indices
-    // for highlighting any placeholder text
+    // Accepting some typeahead selections, like polls, will generate
+    // placeholder text that is selected, in order to clarify for the
+    // user what a given parameter is for. This object stores the
+    // highlight offsets for that purpose.
     const highlight = {};
 
     switch (this.completing) {
@@ -919,11 +921,9 @@ export function content_typeahead_selected(item, event) {
     // placeholder text, as Bootstrap will call $textbox.change() to
     // overwrite the text in the textbox.
     setTimeout(() => {
-        if (item.placeholder) {
-            // This placeholder block is exclusively for slash
-            // commands, which always appear at the start of the message.
-            $textbox.get(0).setSelectionRange(highlight.start, highlight.end);
-            $textbox.trigger("focus");
+        // Select any placeholder text configured to be highlighted.
+        if (highlight.start && highlight.end) {
+            $textbox.range(highlight.start, highlight.end);
         } else {
             $textbox.caret(beginning.length, beginning.length);
         }

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -422,7 +422,7 @@ export const slash_commands = [
         text: $t({defaultMessage: "/poll Where should we go to lunch today? (Create a poll)"}),
         name: "poll",
         aliases: "",
-        placeholder: "Question",
+        placeholder: $t({defaultMessage: "Question"}),
     },
     {
         text: $t({defaultMessage: "/todo (Create a todo list)"}),

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -862,16 +862,21 @@ export function content_typeahead_selected(item, event) {
             // Isolate the end index of the triple backticks/tildes, including
             // possibly a space afterward
             const backticks = beginning.length - this.token.length;
+            beginning = beginning.slice(0, backticks) + item;
+            if (item === "spoiler") {
+                // to add in and highlight placeholder "Header"
+                const placeholder = $t({defaultMessage: "Header"});
+                highlight.start = beginning.length + 1;
+                beginning = beginning + " " + placeholder;
+                highlight.end = highlight.start + placeholder.length;
+            }
+            // If cursor is at end of input ("rest" is empty), then
+            // add a closing fence after the cursor
+            // If there is more text after the cursor, then don't
+            // touch "rest" (i.e. do not add a closing fence)
             if (rest === "") {
-                // If cursor is at end of input ("rest" is empty), then
-                // complete the token before the cursor, and add a closing fence
-                // after the cursor
-                beginning = beginning.slice(0, backticks) + item + "\n";
+                beginning = beginning + "\n";
                 rest = "\n" + beginning.slice(Math.max(0, backticks - 4), backticks).trim() + rest;
-            } else {
-                // If more text after the input, then complete the token, but don't touch
-                // "rest" (i.e. do not add a closing fence)
-                beginning = beginning.slice(0, backticks) + item;
             }
             break;
         }


### PR DESCRIPTION
Until now, whenever typeahead autocompleted the spoiler syntax, there
was no indication if and how a visible header to the hidden content
could be added.

Now when autocompleting, the word "Header" is added as a placeholder
and highlighted, hinting at the format.

Fixes: #20868.

**Screenshots and screen captures:**

https://www.loom.com/share/f867f735e80e4486b4c69a6de956a8cd

**Self-review checklist**

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
