### PR TITLE
help-docs: Document "Pin to top"/"Unpin from top" mobile app feature.

### DIFF
--- a/templates/zerver/help/include/mobile-stream-settings-menu-tip.md
+++ b/templates/zerver/help/include/mobile-stream-settings-menu-tip.md
@@ -1,0 +1,5 @@
+!!! tip ""
+
+    If you are viewing a single stream or topic, you can access the
+    stream settings menu from the information (**ⓘ**) icon in the top right
+    corner of the app.

--- a/templates/zerver/help/pin-a-stream.md
+++ b/templates/zerver/help/pin-a-stream.md
@@ -14,6 +14,16 @@ sidebar.
 
 {end_tabs}
 
+## Unpin a stream
+
+{start_tabs}
+
+{!stream-actions.md!}
+
+1. Click **Unpin stream from top**.
+
+{end_tabs}
+
 ### From the streams page (alternate method)
 
 {start_tabs}

--- a/templates/zerver/help/pin-a-stream.md
+++ b/templates/zerver/help/pin-a-stream.md
@@ -8,9 +8,19 @@ sidebar.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!stream-actions.md!}
 
 1. Click **Pin stream to top**.
+
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Pin to top**.
+
+{!stream-long-press-menu-tip.md!}
 
 {end_tabs}
 
@@ -18,15 +28,27 @@ sidebar.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!stream-actions.md!}
 
 1. Click **Unpin stream from top**.
 
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Unpin from top**.
+
+{!stream-long-press-menu-tip.md!}
+
 {end_tabs}
 
-### From the streams page (alternate method)
+### Alternate method
 
 {start_tabs}
+
+{tab|desktop-web}
 
 {relative|stream|subscribed}
 
@@ -35,5 +57,15 @@ sidebar.
 {!select-stream-view-personal.md!}
 
 1. Under **Personal settings**, toggle **Pin stream to top of left sidebar**.
+
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Stream settings**.
+
+1. Toggle **Pinned**.
+
+{!mobile-stream-settings-menu-tip.md!}
 
 {end_tabs}


### PR DESCRIPTION
- Adds step-by-step instructions for mobile app users.

- Adds "Unpin a stream" section to the "Pin a stream" page.

- Adds a new macro with instructions for accessing the stream settings menu via the information icon.

Fixes: #22198.

**Screenshots and screen captures:**

<img width="527" alt="image" src="https://user-images.githubusercontent.com/2343554/178083901-375d0b91-c530-47ee-ace0-19b1ae2e5e97.png">

Since there is an alternate Desktop/Web method documented already, I think it makes sense to add a Mobile tab and document both ways of accessing the stream settings menu, as shown below:
<img width="530" alt="image" src="https://user-images.githubusercontent.com/2343554/178126386-ee8f0b40-de38-4552-b15d-0095db69d6a9.png">

 This pattern should also apply to the other stream settings: #22196, Notifications, and Subscribing.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans.
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Strings.
- [x] End-to-end functionality of buttons, interactions, and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
