### PR TITLE
help-docs: Fix UI feature references to use bold, not quotes.

### DIFF
--- a/templates/zerver/help/include/customize-organization-settings.md
+++ b/templates/zerver/help/include/customize-organization-settings.md
@@ -1,14 +1,4 @@
-Review the settings for your organization to set everything up how you
-want it to be.
-
-{start_tabs}
-
-{relative|gear|manage-organization}
-
-1. Click on "Organization settings" and "Organization permissions"
-   tabs, and any others that are of interest.
-
-{end_tabs}
+{!review-organization-settings-instructions.md!}
 
 A few settings to highlight:
 

--- a/templates/zerver/help/include/left-sidebar-topics.md
+++ b/templates/zerver/help/include/left-sidebar-topics.md
@@ -5,10 +5,10 @@ unread message counts for each stream.
 1. Click on the name of a stream in the left sidebar. You will see a list of the
    most recent unread topics in that stream.
 
-2. The initially shown list of topics usually has what you need, but you can
-   click on "more topics" underneath to see additional topics.
+1. The initially shown list of topics usually has what you need, but you can
+   click on **more topics** underneath to see additional topics.
 {end_tabs}
 
 !!! tip ""
     Older topics disappear from the left sidebar, but you can always find them
-    by clicking “more topics” or by using [search](/help/search-for-messages).
+    by clicking **more topics** or by using [search](/help/search-for-messages).

--- a/templates/zerver/help/include/reading-topics.md
+++ b/templates/zerver/help/include/reading-topics.md
@@ -1,32 +1,36 @@
 {start_tabs}
+
 {tab|via-recent-topics}
+
 1. Open **Recent topics** from the left sidebar or by pressing the `Esc` key.
 
-2. Click on the name of a topic in the **Topic** column.
+1. Click on the name of a topic in the **Topic** column.
 
-3. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
+1. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
 
-4. If the topic is not of interest, you can
+1. If the topic is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
    to the end using the `End` key.
 
-5. You can then click on another topic in the left sidebar, use the `n` key to go to the
+1. You can then click on another topic in the left sidebar, use the `n` key to go to the
    next unread topic, or go back to the **Recent topics** view.
 
 {tab|via-left-sidebar}
+
 1. Click on the name of a stream in the left sidebar. You will see a list of the
    most recent unread topics in that stream.
 
-2. Click on a topic in the left sidebar.
+1. Click on a topic in the left sidebar.
 
-3. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
+1. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
 
-4. If the topic is not of interest, you can
+1. If the topic is not of interest, you can
    [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
    to the end using the `End` key.
 
-5. Click on the next topic in the left sidebar, or use the `n` key to go to the
+1. Click on the next topic in the left sidebar, or use the `n` key to go to the
    next unread topic.
 
-6. To go to older unread topics, use the `n` key or click "more topics" to view.
+1. To go to older unread topics, use the `n` key or click **more topics** to view.
+
 {end_tabs}

--- a/templates/zerver/help/include/review-organization-settings-instructions.md
+++ b/templates/zerver/help/include/review-organization-settings-instructions.md
@@ -1,0 +1,11 @@
+Review the settings for your organization to set everything up how you
+want it to be.
+
+{start_tabs}
+
+{relative|gear|manage-organization}
+
+1. Click on the **Organization settings** and **Organization
+   permissions** tabs, as well as any others that are of interest.
+
+{end_tabs}

--- a/templates/zerver/help/public-access-option.md
+++ b/templates/zerver/help/public-access-option.md
@@ -40,8 +40,8 @@ communities such as open-source projects and research communities.
 
 {settings_tab|organization-permissions}
 
-2. Under **Stream permissions**, toggle the checkbox labeled "Allow
-   creating web-public streams (visible to anyone on the Internet)".
+1. Under **Stream permissions**, toggle the checkbox labeled **Allow
+   creating web-public streams (visible to anyone on the Internet)**.
 
 {end_tabs}
 
@@ -51,17 +51,17 @@ communities such as open-source projects and research communities.
 
 {settings_tab|organization-permissions}
 
-2. Under **Stream permissions**, make sure the checkbox labeled "Allow
-   creating web-public streams (visible to anyone on the Internet)" is
+1. Under **Stream permissions**, make sure the checkbox labeled **Allow
+   creating web-public streams (visible to anyone on the Internet)** is
    checked.
 
-3. Under **Who can create web-public streams?**, select the option you prefer.
+1. Under **Who can create web-public streams?**, select the option you prefer.
 
 {end_tabs}
 
 !!! tip ""
     See [Managing abuse](#managing-abuse) to learn why only
-    trusted roles like Moderators and Administrators can create web-public streams.
+    trusted roles like moderators and administrators can create web-public streams.
 
 ## Creating a web-public stream
 

--- a/templates/zerver/help/roles-and-permissions.md
+++ b/templates/zerver/help/roles-and-permissions.md
@@ -10,7 +10,7 @@ There are several possible roles in a Zulip organization.
   owners.
 
 * **Moderator**: Have the permissions of full members; additionally,
-  many "Organization permissions" settings allow moderators to be
+  many **Organization permissions** settings allow moderators to be
   given additional privileges or do so by default.
 
 * **Member**: Has access to all public streams.  Member is the default

--- a/templates/zerver/help/setting-up-zulip-for-a-class.md
+++ b/templates/zerver/help/setting-up-zulip-for-a-class.md
@@ -121,17 +121,7 @@ registration and login page for your organization, and in the Zulip app.
 
 ## Customize organization settings
 
-Review the settings for your organization to set everything up how you
-want it to be.
-
-{start_tabs}
-
-{relative|gear|manage-organization}
-
-1. Click on "Organization settings" and "Organization permissions"
-   tabs, and any others that are of interest.
-
-{end_tabs}
+{!review-organization-settings-instructions.md!}
 
 A few settings to highlight:
 
@@ -145,12 +135,8 @@ A few settings to highlight:
 
 * [Add custom emoji](/help/custom-emoji) that your class will enjoy.
 
-
-[topic-editing-permissions]: /help/configure-message-editing-and-deletion
 [default-code-block-language]: /help/code-blocks#default-code-block-language
 [code-playgrounds]: /help/code-blocks#code-playgrounds
-[email-address-visibility]: /help/restrict-visibility-of-email-addresses
-[who-can-invite]: /help/restrict-account-creation#change-who-can-send-invitations
 
 ### Roles and permissions
 


### PR DESCRIPTION
Fixes a few help center documentation articles where UI features were referenced with quotation marks instead of bold text. Also, updates these articles for other current documentation conventions and styles.

**Example screenshots of updates**:

<details>
<summary>Public access option</summary>

### Updated version
![Screenshot from 2022-07-11 13-18-53](https://user-images.githubusercontent.com/63245456/178253162-36bd3f03-44e7-4d32-a43d-0d1f4ceb0382.png)

### Current version
![Screenshot from 2022-07-11 13-22-04](https://user-images.githubusercontent.com/63245456/178253588-8ad7d07b-c782-4a8b-8eec-1537c7d7a722.png)
</details>

<details>
<summary>Reading strategies - topics - stream list</summary>

### Updated version
![Screenshot from 2022-07-11 13-18-33](https://user-images.githubusercontent.com/63245456/178253158-f45f71c7-0b00-42e8-83ec-2211c84f08dc.png)

### Current version
![Screenshot from 2022-07-11 13-06-50](https://user-images.githubusercontent.com/63245456/178253155-96bf1fc1-c4af-426b-8ebb-3949b8a1f8eb.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
