### PR TITLE
Make it easier to work with numbered and bulleted lists

### DIFF
--- a/web/src/bulleted_numbered_list_util.js
+++ b/web/src/bulleted_numbered_list_util.js
@@ -1,0 +1,12 @@
+export const get_last_line = (text) => text.slice(text.lastIndexOf("\n") + 1);
+
+export const is_bulleted = (line) =>
+    line.startsWith("- ") || line.startsWith("* ") || line.startsWith("+ ");
+
+// testing against regex for string with numbered syntax, that is,
+// any string starting with digit/s followed by a period and space
+export const is_numbered = (line) => /^\d+\. /.test(line);
+
+export const strip_bullet = (line) => line.slice(2);
+
+export const strip_numbering = (line) => line.slice(line.indexOf(" ") + 1);

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -28,6 +28,26 @@ kbd {
     user-select: none;
 }
 
+@media (width < $mc_min) {
+    .hide-mc {
+        display: none !important;
+    }
+
+    .show-mc {
+        display: block !important;
+    }
+}
+
+@media (width < $md_min) {
+    .hide-md {
+        display: none !important;
+    }
+
+    .show-md {
+        display: flex !important;
+    }
+}
+
 @media (width < $sm_min) {
     .hide-sm {
         display: none !important;

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -22,14 +22,14 @@
     <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}} preview_mode_disabled" data-tippy-content="{{t 'Add GIF' }}">
         <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
     </div>
-    <div class="divider hide-sm">|</div>
-    <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
+    <div class="divider hide-sm show-md hide-mc">|</div>
+    <div class="{{#if message_id}}hide-lg{{else}}hide-sm show-md hide-mc{{/if}}">
         {{> compose_control_buttons_in_popover}}
     </div>
     <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tooltip-template-id="compose_draft_tooltip_template">
         {{t 'Drafts' }}
     </a>
     <div class="compose_control_menu_wrapper" role="button" tabindex=0>
-        <a class="compose_control_button zulip-icon zulip-icon-more-vertical hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
+        <a class="compose_control_button zulip-icon zulip-icon-more-vertical hide {{#if message_id}}show-lg{{else}}show-sm hide-md show-mc{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
     </div>
 </div>

--- a/web/templates/compose_control_buttons_in_popover.hbs
+++ b/web/templates/compose_control_buttons_in_popover.hbs
@@ -1,7 +1,8 @@
 <div class="compose_control_buttons_container preview_mode_disabled">
     <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bold' }}"></a>
     <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Italic' }}"></a>
+    <a role="button" data-format-type="bulleted" class="compose_control_button fa fa-list-ul formatting_button" aria-label="{{t 'Bulleted list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bulleted list' }}"></a>
     <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Link' }}"></a>
-    <div class="divider hide-sm">|</div>
+    <div class="divider hide-sm show-md hide-mc">|</div>
 </div>
 <a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>

--- a/web/templates/compose_control_buttons_in_popover.hbs
+++ b/web/templates/compose_control_buttons_in_popover.hbs
@@ -2,6 +2,7 @@
     <a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bold' }}"></a>
     <a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Italic' }}"></a>
     <a role="button" data-format-type="bulleted" class="compose_control_button fa fa-list-ul formatting_button" aria-label="{{t 'Bulleted list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Bulleted list' }}"></a>
+    <a role="button" data-format-type="numbered" class="compose_control_button fa fa-list-ol formatting_button" aria-label="{{t 'Numbered list' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Numbered list' }}"></a>
     <a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" {{#unless preview_mode_on}} tabindex=0 {{/unless}} data-tippy-content="{{t 'Link' }}"></a>
     <div class="divider hide-sm show-md hide-mc">|</div>
 </div>

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -691,6 +691,57 @@ run_test("format_text", ({override}) => {
     compose_ui.format_text($textarea, "bulleted");
     assert.equal(set_text, "first_item\nsecond_item");
     assert.equal(wrap_selection_called, false);
+
+    // Test numbered list toggling on
+    reset_state();
+    init_textarea("first_item\nsecond_item", {
+        start: 0,
+        end: 22,
+        text: "first_item\nsecond_item",
+        length: 22,
+    });
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(set_text, "1. first_item\n2. second_item");
+    assert.equal(wrap_selection_called, false);
+
+    // Test numbered list toggling off
+    reset_state();
+    init_textarea("1. first_item\n2. second_item", {
+        start: 0,
+        end: 28,
+        text: "1. first_item\n2. second_item",
+        length: 28,
+    });
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(set_text, "first_item\nsecond_item");
+    assert.equal(wrap_selection_called, false);
+
+    // Test numbered list toggling with newline at end
+    reset_state();
+    init_textarea("first_item\nsecond_item\n", {
+        start: 0,
+        end: 23,
+        text: "first_item\nsecond_item\n",
+        length: 23,
+    });
+    compose_ui.format_text($textarea, "numbered");
+    assert.equal(set_text, "1. first_item\n2. second_item\n");
+    assert.equal(wrap_selection_called, false);
+
+    // Test numbered list toggling on with partially selected lines
+    reset_state();
+    init_textarea("before_first\nfirst_item\nsecond_item\nafter_last", {
+        start: 15,
+        end: 33,
+        text: "rst_item\nsecond_it",
+        length: 18,
+    });
+    compose_ui.format_text($textarea, "numbered");
+    // Notice the blank lines inserted right before and after the list to visually demarcate it.
+    // Had the blank line after `second_item` not been inserted, `after_last` would have been
+    // (wrongly) indented as part of the list's last item too.
+    assert.equal(set_text, "before_first\n\n1. first_item\n2. second_item\n\nafter_last");
+    assert.equal(wrap_selection_called, false);
 });
 
 run_test("markdown_shortcuts", ({override_rewire}) => {


### PR DESCRIPTION
A formatting button below the compose box can format the selected text
by bulleting or unbulleting the selected (partially or completely)
lines. The behaviour is modelled closely after how GitHub's bullet
list format button works.

A formatting button below the compose box can format the selected text
by numbering or unnumbering the selected (partially or completely)
lines. The behaviour is modelled closely after how GitHub's numbered
list format button works.
    
When the user is typing a numbered / bulleted list in the compose box,
on pressing Enter the list syntax will be inserted automatically on
a new line, and removed if Enter is pressed after an empty line.

Fixes: #20305.

**Screenshots and screen captures:**

Formatting buttons: 
https://www.loom.com/share/e476156ec1cf4bac8ef641faaad8af92

Automatic insertion / removal of bulleting / numbering:
https://www.loom.com/share/a63aebbb2d9c464eb5b7a1140fcc364b

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
