### PR TITLE
help-docs: Rename "Related topics" to "Related articles".

### DIFF
--- a/templates/zerver/help/add-or-remove-users-from-a-stream.md
+++ b/templates/zerver/help/add-or-remove-users-from-a-stream.md
@@ -88,7 +88,7 @@ This method is useful if you need to remove one user from multiple streams.
 
 {end_tabs}
 
-## Related topics
+## Related articles
 
 * [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams)
 * [Unsubscribe from a stream](/help/unsubscribe-from-a-stream)

--- a/templates/zerver/help/communities-directory.md
+++ b/templates/zerver/help/communities-directory.md
@@ -47,7 +47,7 @@ service.
     If you administer a non-public organization, please check the box to request
     to be listed in the future.
 
-## Related topics
+## Related articles
 
 * [Create your organization profile](/help/create-your-organization-profile)
 * [Public access option](/help/public-access-option)

--- a/templates/zerver/help/manage-user-stream-subscriptions.md
+++ b/templates/zerver/help/manage-user-stream-subscriptions.md
@@ -55,7 +55,7 @@ stream](/help/unsubscribe-from-a-stream).
 
 {end_tabs}
 
-## Related topics
+## Related articles
 
 * [Stream permissions](/help/stream-permissions)
 * [Roles and permissions](/help/roles-and-permissions)

--- a/templates/zerver/help/mastering-the-compose-box.md
+++ b/templates/zerver/help/mastering-the-compose-box.md
@@ -20,7 +20,7 @@ which you are composing.
 While the button is only shown when composing to a stream, the keyboard shortcut
 will work in both stream messages and private messages.
 
-## Related topics
+## Related articles
 
 * [Resize the compose box](/help/resize-the-compose-box)
 * [Format messages using Markdown](/help/format-your-message-using-markdown)


### PR DESCRIPTION
A few help center pages have a "Related topics" section.
This renames it to the terminology we're generally using.

**Screenshots and screen captures:**

<img width="192" alt="image" src="https://user-images.githubusercontent.com/2343554/178373400-cfcfb016-61be-49c1-b562-7783f0d7acc5.png"> -->  <img width="195" alt="image" src="https://user-images.githubusercontent.com/2343554/178373483-653dbbfa-e66b-4383-850e-bcdec26c3abc.png">



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
- [x] Automated tests
- [x] Commit message(s) explain reasoning and motivation for changes.
- [x] Visual appearance of the changes.
- [x] Strings.
