### PR TITLE
node_tests: Remove low-hanging uses of `__Rewire__`

### DIFF
--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -18,7 +18,7 @@ const helpers = mock_esm("../../static/js/billing/helpers", {
     set_tab: () => {},
 });
 
-const billing = zrequire("billing/billing");
+zrequire("billing/billing");
 
 run_test("initialize", ({override}) => {
     let set_tab_called = false;
@@ -76,10 +76,9 @@ run_test("planchange", ({override}) => {
     assert.ok(create_ajax_request_called);
 });
 
-run_test("licensechange", ({override, override_rewire}) => {
+run_test("licensechange", ({override}) => {
     override(helpers, "set_tab", () => {});
     let create_ajax_request_called = false;
-    create_ajax_request_called = false;
     function license_change_ajax(url, form_name, ignored_inputs, method, success_callback) {
         assert.equal(url, "/json/billing/plan");
         assert.equal(form_name, "licensechange");
@@ -92,13 +91,6 @@ run_test("licensechange", ({override, override_rewire}) => {
         create_ajax_request_called = true;
     }
     override(helpers, "create_ajax_request", license_change_ajax);
-    billing.create_update_license_request();
-    assert.ok(create_ajax_request_called);
-
-    let create_update_license_request_called = false;
-    override_rewire(billing, "create_update_license_request", () => {
-        create_update_license_request_called = true;
-    });
 
     $.get_initialize_function()();
 
@@ -106,7 +98,7 @@ run_test("licensechange", ({override, override_rewire}) => {
         "click",
     );
     confirm_license_update_click_handler({preventDefault: () => {}});
-    assert.ok(create_update_license_request_called);
+    assert.ok(create_ajax_request_called);
 
     let confirm_license_modal_shown = false;
     override(helpers, "is_valid_input", () => true);
@@ -119,17 +111,17 @@ run_test("licensechange", ({override, override_rewire}) => {
         return 20;
     };
     $("#new_licenses_input").val = () => 15;
-    create_update_license_request_called = false;
+    create_ajax_request_called = false;
     const update_licenses_button_click_handler =
         $("#update-licenses-button").get_on_handler("click");
     update_licenses_button_click_handler({preventDefault: () => {}});
-    assert.ok(create_update_license_request_called);
+    assert.ok(create_ajax_request_called);
     assert.ok(!confirm_license_modal_shown);
 
     $("#new_licenses_input").val = () => 25;
-    create_update_license_request_called = false;
+    create_ajax_request_called = false;
     update_licenses_button_click_handler({preventDefault: () => {}});
-    assert.ok(!create_update_license_request_called);
+    assert.ok(!create_ajax_request_called);
     assert.ok(confirm_license_modal_shown);
 
     override(helpers, "is_valid_input", () => false);

--- a/frontend_tests/node_tests/color_data.js
+++ b/frontend_tests/node_tests/color_data.js
@@ -8,39 +8,29 @@ const {run_test} = require("../zjsunit/test");
 const color_data = zrequire("color_data");
 
 run_test("pick_color", () => {
-    color_data.__Rewire__("colors", ["blue", "orange", "red", "yellow"]);
-
     color_data.reset();
 
     color_data.claim_colors([
-        {color: "orange"},
+        {color: color_data.colors[1]},
         {foo: "whatever"},
-        {color: "yellow"},
+        {color: color_data.colors[3]},
         {color: "bogus"},
     ]);
 
     const expected_colors = [
-        "blue",
-        "red",
+        color_data.colors[0],
+        color_data.colors[2],
+        ...color_data.colors.slice(4),
         // ok, now we'll cycle through all colors
-        "blue",
-        "orange",
-        "red",
-        "yellow",
-        "blue",
-        "orange",
-        "red",
-        "yellow",
-        "blue",
-        "orange",
-        "red",
-        "yellow",
+        ...color_data.colors,
+        ...color_data.colors,
+        ...color_data.colors,
     ];
 
     for (const expected_color of expected_colors) {
         assert.equal(color_data.pick_color(), expected_color);
     }
 
-    color_data.claim_color("blue");
-    assert.equal(color_data.pick_color(), "orange");
+    color_data.claim_color(color_data.colors[0]);
+    assert.equal(color_data.pick_color(), color_data.colors[1]);
 });

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -16,6 +16,7 @@ mock_esm("tippy.js", {
 });
 
 set_global("document", {});
+const navigator = set_global("navigator", {});
 
 const common = zrequire("common");
 
@@ -79,8 +80,8 @@ run_test("copy_data_attribute_value", ({override}) => {
     assert.ok(faded_out);
 });
 
-run_test("adjust_mac_shortcuts non-mac", ({override_rewire}) => {
-    override_rewire(common, "has_mac_keyboard", () => false);
+run_test("adjust_mac_shortcuts non-mac", ({override}) => {
+    override(navigator, "platform", "Windows");
 
     // The adjust_mac_shortcuts has a really simple guard
     // at the top, and we just test the early-return behavior
@@ -90,7 +91,7 @@ run_test("adjust_mac_shortcuts non-mac", ({override_rewire}) => {
 
 // Test non-default value of adjust_mac_shortcuts boolean parameter:
 // `kbd_elem = false`.
-run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
+run_test("adjust_mac_shortcuts mac non-defaults", ({override}) => {
     const keys_to_test_mac = new Map([
         ["Backspace", "Delete"],
         ["Enter", "Return"],
@@ -109,7 +110,7 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
     const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
     const inserted_fn_key = "<code>Fn</code> + ";
 
-    override_rewire(common, "has_mac_keyboard", () => true);
+    override(navigator, "platform", "MacIntel");
 
     const test_items = [];
     let key_no = 1;
@@ -143,7 +144,7 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
 
 // Test default value of adjust_mac_shortcuts boolean parameter:
 // `kbd_elem = true`.
-run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
+run_test("adjust_mac_shortcuts mac defaults", ({override}) => {
     const keys_to_test_mac = new Map([
         ["Backspace", "Delete"],
         ["Enter", "Return"],
@@ -159,7 +160,7 @@ run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
     const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
     const inserted_fn_key = "<kbd>Fn</kbd> + ";
 
-    override_rewire(common, "has_mac_keyboard", () => true);
+    override(navigator, "platform", "MacIntel");
 
     const test_items = [];
     let key_no = 1;

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -17,6 +17,10 @@ const compose_fade = mock_esm("../../static/js/compose_fade", {
     clear_compose: noop,
 });
 const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
+const compose_ui = mock_esm("../../static/js/compose_ui", {
+    autosize_textarea: noop,
+    is_full_size: () => false,
+});
 const hash_util = mock_esm("../../static/js/hash_util");
 const narrow_state = mock_esm("../../static/js/narrow_state", {
     set_compose_defaults: noop,
@@ -50,7 +54,6 @@ mock_esm("../../static/js/resize", {
 
 const people = zrequire("people");
 
-const compose_ui = zrequire("compose_ui");
 const compose = zrequire("compose");
 const compose_state = zrequire("compose_state");
 const compose_actions = zrequire("compose_actions");
@@ -72,23 +75,12 @@ function assert_hidden(sel) {
     assert.ok(!$(sel).visible());
 }
 
-function override_private_message_recipient({override_rewire}) {
-    override_rewire(
-        compose_state,
-        "private_message_recipient",
-        (function () {
-            let recipient;
-
-            return function (arg) {
-                if (arg === undefined) {
-                    return recipient;
-                }
-
-                recipient = arg;
-                return undefined;
-            };
-        })(),
-    );
+function override_private_message_recipient({override}) {
+    let recipient;
+    override(compose_pm_pill, "set_from_emails", (value) => {
+        recipient = value;
+    });
+    override(compose_pm_pill, "get_emails", () => recipient, {unused: false});
 }
 
 function test(label, f) {
@@ -110,7 +102,7 @@ test("initial_state", () => {
 });
 
 test("start", ({override, override_rewire}) => {
-    override_private_message_recipient({override_rewire});
+    override_private_message_recipient({override});
     override_rewire(compose_actions, "autosize_message_content", () => {});
     override_rewire(compose_actions, "expand_compose_box", () => {});
     override_rewire(compose_actions, "set_focus", () => {});
@@ -236,7 +228,7 @@ test("respond_to_message", ({override, override_rewire}) => {
     override_rewire(compose_actions, "set_focus", () => {});
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
-    override_private_message_recipient({override_rewire});
+    override_private_message_recipient({override});
 
     // Test PM
     const person = {
@@ -277,7 +269,7 @@ test("reply_with_mention", ({override, override_rewire}) => {
     override_rewire(compose_actions, "set_focus", () => {});
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
-    override_private_message_recipient({override_rewire});
+    override_private_message_recipient({override});
 
     const msg = {
         type: "stream",
@@ -289,7 +281,7 @@ test("reply_with_mention", ({override, override_rewire}) => {
     override(message_lists.current, "selected_message", () => msg);
 
     let syntax_to_insert;
-    override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
+    override(compose_ui, "insert_syntax_and_focus", (syntax) => {
         syntax_to_insert = syntax;
     });
 
@@ -330,14 +322,14 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     override_rewire(compose_actions, "set_focus", () => {});
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
-    override_private_message_recipient({override_rewire});
+    override_private_message_recipient({override});
 
     let selected_message;
     override(message_lists.current, "selected_message", () => selected_message);
 
     let expected_replacement;
     let replaced;
-    override_rewire(compose_ui, "replace_syntax", (syntax, replacement) => {
+    override(compose_ui, "replace_syntax", (syntax, replacement) => {
         assert.equal(syntax, "translated: [Quoting…]");
         assert.equal(replacement, expected_replacement);
         replaced = true;
@@ -360,7 +352,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
 
     override(message_lists.current, "selected_id", () => 100);
 
-    override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
+    override(compose_ui, "insert_syntax_and_focus", (syntax) => {
         assert.equal(syntax, "translated: [Quoting…]\n");
     });
 
@@ -428,13 +420,13 @@ test("get_focus_area", () => {
     );
 });
 
-test("focus_in_empty_compose", ({override_rewire}) => {
+test("focus_in_empty_compose", () => {
     document.activeElement = {id: "compose-textarea"};
-    override_rewire(compose_state, "composing", () => true);
+    compose_state.set_message_type("stream");
     $("#compose-textarea").val("");
     assert.ok(compose_state.focus_in_empty_compose());
 
-    override_rewire(compose_state, "composing", () => false);
+    compose_state.set_message_type(false);
     assert.ok(!compose_state.focus_in_empty_compose());
 
     $("#compose-textarea").val("foo");
@@ -450,9 +442,6 @@ test("on_narrow", ({override, override_rewire}) => {
 
     let narrowed_by_pm_reply;
     override(narrow_state, "narrowed_by_pm_reply", () => narrowed_by_pm_reply);
-
-    let has_message_content;
-    override_rewire(compose_state, "has_message_content", () => has_message_content);
 
     let cancel_called = false;
     override_rewire(compose_actions, "cancel", () => {
@@ -478,13 +467,13 @@ test("on_narrow", ({override, override_rewire}) => {
     compose_fade.update_message_list = () => {
         update_message_list_called = true;
     };
-    has_message_content = true;
+    compose_state.message_content("foo");
     compose_actions.on_narrow({
         force_close: false,
     });
     assert.ok(update_message_list_called);
 
-    has_message_content = false;
+    compose_state.message_content("");
     let start_called = false;
     override_rewire(compose_actions, "start", () => {
         start_called = true;

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -7,10 +7,10 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
 const compose_actions = mock_esm("../../static/js/compose_actions");
+const input_pill = mock_esm("../../static/js/input_pill");
 const people = zrequire("people");
 
 const compose_pm_pill = zrequire("compose_pm_pill");
-const input_pill = zrequire("input_pill");
 
 let pills = {
     pill: {},
@@ -140,7 +140,7 @@ run_test("pills", ({override}) => {
         return pills;
     }
 
-    input_pill.__Rewire__("create", input_pill_stub);
+    override(input_pill, "create", input_pill_stub);
 
     // We stub the return value of input_pill.create(), manually add widget functions to it.
     pills.onPillCreate = (callback) => {
@@ -185,28 +185,21 @@ run_test("pills", ({override}) => {
     assert.ok(text_cleared);
 });
 
-run_test("has_unconverted_data", () => {
-    compose_pm_pill.__Rewire__("widget", {
-        is_pending: () => true,
-    });
+run_test("has_unconverted_data", ({override}) => {
+    override(compose_pm_pill.widget, "is_pending", () => true);
 
     // If the pill itself has pending data, we have unconverted
     // data.
     assert.equal(compose_pm_pill.has_unconverted_data(), true);
 
-    compose_pm_pill.__Rewire__("widget", {
-        is_pending: () => false,
-        items: () => [{user_id: 99}],
-    });
+    override(compose_pm_pill.widget, "is_pending", () => false);
+    override(compose_pm_pill.widget, "items", () => [{user_id: 99}]);
 
     // Our pill is complete and all items contain user_id, so
     // we do NOT have unconverted data.
     assert.equal(compose_pm_pill.has_unconverted_data(), false);
 
-    compose_pm_pill.__Rewire__("widget", {
-        is_pending: () => false,
-        items: () => [{user_id: 99}, {email: "random@mit.edu"}],
-    });
+    override(compose_pm_pill.widget, "items", () => [{user_id: 99}, {email: "random@mit.edu"}]);
 
     // One of our items only knows email (as in a bridge-with-zephyr
     // scenario where we might not have registered the user yet), so

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -60,9 +60,9 @@ people.add_cross_realm_user(welcome_bot);
 
 function test_ui(label, f) {
     // The sloppy_$ flag lets us re-use setup from prior tests.
-    run_test(label, ({override, override_rewire, mock_template}) => {
+    run_test(label, (helpers) => {
         $("#compose-textarea").val("some message");
-        f({override, override_rewire, mock_template});
+        f(helpers);
     });
 }
 

--- a/frontend_tests/node_tests/compose_video.js
+++ b/frontend_tests/node_tests/compose_video.js
@@ -10,6 +10,7 @@ const {page_params} = require("../zjsunit/zpage_params");
 const events = require("./lib/events");
 
 const channel = mock_esm("../../static/js/channel");
+const compose_ui = mock_esm("../../static/js/compose_ui");
 const upload = mock_esm("../../static/js/upload");
 mock_esm("../../static/js/resize", {
     watch_manual_resize() {},
@@ -26,7 +27,6 @@ set_global(
 );
 
 const server_events_dispatch = zrequire("server_events_dispatch");
-const compose_ui = zrequire("compose_ui");
 const compose_closed = zrequire("compose_closed_ui");
 const compose = zrequire("compose");
 function stub_out_video_calls() {
@@ -61,13 +61,13 @@ const realm_available_video_chat_providers = {
 };
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         page_params.realm_available_video_chat_providers = realm_available_video_chat_providers;
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 
-test("videos", ({override, override_rewire}) => {
+test("videos", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
 
     override(upload, "setup_upload", () => {});
@@ -92,8 +92,8 @@ test("videos", ({override, override_rewire}) => {
         const handler = $("body").get_on_handler("click", ".video_link");
         $("#compose-textarea").val("");
 
-        with_overrides(({disallow_rewire}) => {
-            disallow_rewire(compose_ui, "insert_syntax_and_focus");
+        with_overrides(({disallow}) => {
+            disallow(compose_ui, "insert_syntax_and_focus");
             handler(ev);
         });
     })();
@@ -113,7 +113,7 @@ test("videos", ({override, override_rewire}) => {
             },
         };
 
-        override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
+        override(compose_ui, "insert_syntax_and_focus", (syntax) => {
             syntax_to_insert = syntax;
             called = true;
         });
@@ -151,7 +151,7 @@ test("videos", ({override, override_rewire}) => {
             },
         };
 
-        override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
+        override(compose_ui, "insert_syntax_and_focus", (syntax) => {
             syntax_to_insert = syntax;
             called = true;
         });
@@ -197,7 +197,7 @@ test("videos", ({override, override_rewire}) => {
             },
         };
 
-        override_rewire(compose_ui, "insert_syntax_and_focus", (syntax) => {
+        override(compose_ui, "insert_syntax_and_focus", (syntax) => {
             syntax_to_insert = syntax;
             called = true;
         });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -28,6 +28,7 @@ const activity = mock_esm("../../static/js/activity");
 const alert_words_ui = mock_esm("../../static/js/alert_words_ui");
 const attachments_ui = mock_esm("../../static/js/attachments_ui");
 const bot_data = mock_esm("../../static/js/bot_data");
+const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
 const composebox_typeahead = mock_esm("../../static/js/composebox_typeahead");
 const dark_theme = mock_esm("../../static/js/dark_theme");
 const emoji_picker = mock_esm("../../static/js/emoji_picker");
@@ -66,8 +67,13 @@ const settings_user_groups = mock_esm("../../static/js/settings_user_groups");
 const settings_users = mock_esm("../../static/js/settings_users");
 const stream_data = mock_esm("../../static/js/stream_data");
 const stream_events = mock_esm("../../static/js/stream_events");
+const stream_list = mock_esm("../../static/js/stream_list");
 const stream_settings_ui = mock_esm("../../static/js/stream_settings_ui");
+const stream_topic_history = mock_esm("../../static/js/stream_topic_history");
 const submessage = mock_esm("../../static/js/submessage");
+mock_esm("../../static/js/top_left_corner", {
+    update_starred_count() {},
+});
 const typing_events = mock_esm("../../static/js/typing_events");
 const ui = mock_esm("../../static/js/ui");
 const unread_ops = mock_esm("../../static/js/unread_ops");
@@ -89,14 +95,10 @@ page_params.realm_description = "already set description";
 // For data-oriented modules, just use them, don't stub them.
 const alert_words = zrequire("alert_words");
 const emoji = zrequire("emoji");
-const stream_topic_history = zrequire("stream_topic_history");
-const stream_list = zrequire("stream_list");
 const message_helper = zrequire("message_helper");
 const message_store = zrequire("message_store");
 const people = zrequire("people");
-const starred_messages = zrequire("starred_messages");
 const user_status = zrequire("user_status");
-const compose_pm_pill = zrequire("compose_pm_pill");
 
 const server_events_dispatch = zrequire("server_events_dispatch");
 
@@ -723,7 +725,7 @@ run_test("typing", ({override}) => {
     dispatch(event);
 });
 
-run_test("user_settings", ({override, override_rewire}) => {
+run_test("user_settings", ({override}) => {
     settings_display.set_default_language_name = () => {};
     let event = event_fixtures.user_settings__default_language;
     user_settings.default_language = "en";
@@ -859,7 +861,6 @@ run_test("user_settings", ({override, override_rewire}) => {
         assert_same(user_settings.emojiset, "google");
     }
 
-    override_rewire(starred_messages, "rerender_ui", noop);
     event = event_fixtures.user_settings__starred_message_counts;
     user_settings.starred_message_counts = false;
     dispatch(event);
@@ -875,7 +876,7 @@ run_test("user_settings", ({override, override_rewire}) => {
         const stub = make_stub();
         event = event_fixtures.user_settings__demote_inactive_streams;
         override(stream_data, "set_filter_out_inactives", noop);
-        override_rewire(stream_list, "update_streams_sidebar", stub.f);
+        override(stream_list, "update_streams_sidebar", stub.f);
         user_settings.demote_inactive_streams = 1;
         dispatch(event);
         assert.equal(stub.num_calls, 1);
@@ -931,9 +932,7 @@ run_test("update_message (unread)", ({override}) => {
     });
 });
 
-run_test("update_message (add star)", ({override, override_rewire}) => {
-    override_rewire(starred_messages, "rerender_ui", noop);
-
+run_test("update_message (add star)", ({override}) => {
     const event = event_fixtures.update_message_flags__starred_add;
     const stub = make_stub();
     override(ui, "update_starred_view", stub.f);
@@ -946,8 +945,7 @@ run_test("update_message (add star)", ({override, override_rewire}) => {
     assert.equal(msg.starred, true);
 });
 
-run_test("update_message (remove star)", ({override, override_rewire}) => {
-    override_rewire(starred_messages, "rerender_ui", noop);
+run_test("update_message (remove star)", ({override}) => {
     const event = event_fixtures.update_message_flags__starred_remove;
     const stub = make_stub();
     override(ui, "update_starred_view", stub.f);
@@ -960,8 +958,7 @@ run_test("update_message (remove star)", ({override, override_rewire}) => {
     assert.equal(msg.starred, false);
 });
 
-run_test("update_message (wrong data)", ({override_rewire}) => {
-    override_rewire(starred_messages, "rerender_ui", noop);
+run_test("update_message (wrong data)", () => {
     const event = {
         ...event_fixtures.update_message_flags__starred_add,
         messages: [0], // message does not exist
@@ -970,10 +967,10 @@ run_test("update_message (wrong data)", ({override_rewire}) => {
     // update_starred_view never gets invoked, early return is successful
 });
 
-run_test("delete_message", ({override, override_rewire}) => {
+run_test("delete_message", ({override}) => {
     const event = event_fixtures.delete_message;
 
-    override_rewire(stream_list, "update_streams_sidebar", noop);
+    override(stream_list, "update_streams_sidebar", noop);
 
     const message_events_stub = make_stub();
     override(message_events, "remove_messages", message_events_stub.f);
@@ -982,7 +979,7 @@ run_test("delete_message", ({override, override_rewire}) => {
     override(unread_ops, "process_read_messages_event", unread_ops_stub.f);
 
     const stream_topic_history_stub = make_stub();
-    override_rewire(stream_topic_history, "remove_messages", stream_topic_history_stub.f);
+    override(stream_topic_history, "remove_messages", stream_topic_history_stub.f);
 
     dispatch(event);
 
@@ -1001,7 +998,7 @@ run_test("delete_message", ({override, override_rewire}) => {
     assert_same(args.opts.max_removed_msg_id, 1337);
 });
 
-run_test("user_status", ({override, override_rewire}) => {
+run_test("user_status", ({override}) => {
     let event = event_fixtures.user_status__set_away;
     {
         const stub = make_stub();
@@ -1044,7 +1041,7 @@ run_test("user_status", ({override, override_rewire}) => {
     {
         const stub = make_stub();
         override(activity, "redraw_user", stub.f);
-        override_rewire(compose_pm_pill, "get_user_ids", () => [event.user_id]);
+        override(compose_pm_pill, "get_user_ids", () => [event.user_id]);
         dispatch(event);
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("user_id");

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -18,6 +18,9 @@ const compose_state = mock_esm("../../static/js/compose_state");
 mock_esm("../../static/js/markdown", {
     apply_markdown: noop,
 });
+mock_esm("../../static/js/overlays", {
+    open_overlay: noop,
+});
 mock_esm("../../static/js/stream_data", {
     get_color() {
         return "#FFFFFF";
@@ -89,10 +92,10 @@ const short_msg = {
 };
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire, mock_template}) => {
+    run_test(label, (helpers) => {
         $("#draft_overlay").css = () => {};
         window.localStorage.clear();
-        f({override, override_rewire, mock_template});
+        f(helpers);
     });
 }
 
@@ -419,7 +422,6 @@ test("format_drafts", ({override_rewire, mock_template}) => {
         return "<draft table stub>";
     });
 
-    override_rewire(drafts, "open_overlay", noop);
     override_rewire(drafts, "set_initial_element", noop);
 
     $.create("#drafts_table .draft-row", {children: []});
@@ -440,5 +442,4 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     drafts.launch();
-    timerender.__Rewire__("render_now", stub_render_now);
 });

--- a/frontend_tests/node_tests/example7.js
+++ b/frontend_tests/node_tests/example7.js
@@ -72,7 +72,7 @@ const denmark_stream = {
     subscribed: false,
 };
 
-run_test("unread_ops", ({override, override_rewire}) => {
+run_test("unread_ops", ({override}) => {
     stream_data.clear_subscriptions();
     stream_data.add_sub(denmark_stream);
     message_store.clear_for_testing();
@@ -90,7 +90,7 @@ run_test("unread_ops", ({override, override_rewire}) => {
     ];
 
     // We don't want recent topics to process message for this test.
-    override_rewire(recent_topics_util, "is_visible", () => false);
+    recent_topics_util.set_visible(false);
 
     // Make our test message appear to be unread, so that
     // we then need to subsequently process them as read.

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {mock_esm, with_overrides, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
+const blueslip = require("../zjsunit/zblueslip");
 const $ = require("../zjsunit/zjquery");
 const {page_params} = require("../zjsunit/zpage_params");
 
@@ -61,9 +62,9 @@ function make_sub(name, stream_id) {
 }
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 
@@ -1666,13 +1667,13 @@ test("navbar_helpers", () => {
     assert.equal(filter.generate_redirect_url(), default_redirect.redirect_url);
 });
 
-test("error_cases", ({override_rewire}) => {
+test("error_cases", () => {
     // This test just gives us 100% line coverage on defensive code that
     // should not be reached unless we break other code.
-    override_rewire(people, "pm_with_user_ids", () => {});
 
     const predicate = get_predicate([["pm-with", "Joe@example.com"]]);
-    assert.ok(!predicate({type: "private"}));
+    blueslip.expect("error", "Empty recipient list in message");
+    assert.ok(!predicate({type: "private", display_recipient: []}));
 });
 
 run_test("is_spectator_compatible", () => {

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -22,8 +22,9 @@ const drafts = mock_esm("../../static/js/drafts");
 const floating_recipient_bar = mock_esm("../../static/js/floating_recipient_bar");
 const info_overlay = mock_esm("../../static/js/info_overlay");
 const message_viewport = mock_esm("../../static/js/message_viewport");
-const narrow = zrequire("../../static/js/narrow");
+const narrow = mock_esm("../../static/js/narrow");
 const overlays = mock_esm("../../static/js/overlays");
+const recent_topics_ui = mock_esm("../../static/js/recent_topics_ui");
 const settings = mock_esm("../../static/js/settings");
 const stream_settings_ui = mock_esm("../../static/js/stream_settings_ui");
 const ui_util = mock_esm("../../static/js/ui_util");
@@ -38,9 +39,6 @@ const people = zrequire("people");
 const hash_util = zrequire("hash_util");
 const hashchange = zrequire("hashchange");
 const stream_data = zrequire("stream_data");
-
-const recent_topics_util = zrequire("recent_topics_util");
-const recent_topics_ui = zrequire("recent_topics_ui");
 
 run_test("operators_round_trip", () => {
     let operators;
@@ -117,7 +115,7 @@ run_test("people_slugs", () => {
     assert.equal(hash, "#narrow/pm-with/42-alice");
 });
 
-function test_helper({override, override_rewire, change_tab}) {
+function test_helper({override, change_tab}) {
     let events = [];
     let narrow_terms;
 
@@ -143,7 +141,7 @@ function test_helper({override, override_rewire, change_tab}) {
             events.push("change_tab_to " + hash);
         });
 
-        override_rewire(narrow, "activate", (terms) => {
+        override(narrow, "activate", (terms) => {
             narrow_terms = terms;
             events.push("narrow.activate");
         });
@@ -164,15 +162,14 @@ function test_helper({override, override_rewire, change_tab}) {
     };
 }
 
-run_test("hash_interactions", ({override, override_rewire}) => {
+run_test("hash_interactions", ({override}) => {
     $window_stub = $.create("window-stub");
     user_settings.default_view = "recent_topics";
 
-    override_rewire(recent_topics_util, "is_visible", () => false);
-    const helper = test_helper({override, override_rewire, change_tab: true});
+    const helper = test_helper({override, change_tab: true});
 
     let recent_topics_ui_shown = false;
-    override_rewire(recent_topics_ui, "show", () => {
+    override(recent_topics_ui, "show", () => {
         recent_topics_ui_shown = true;
     });
     window.location.hash = "#unknown_hash";
@@ -317,10 +314,8 @@ run_test("hash_interactions", ({override, override_rewire}) => {
     helper.assert_events([[ui_util, "blur_active_element"]]);
 });
 
-run_test("save_narrow", ({override, override_rewire}) => {
-    override_rewire(recent_topics_util, "is_visible", () => false);
-
-    const helper = test_helper({override, override_rewire});
+run_test("save_narrow", ({override}) => {
+    const helper = test_helper({override});
 
     let operators = [{operator: "is", operand: "private"}];
 

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -16,20 +16,20 @@ mock_esm("../../static/js/overlays", {
 mock_esm("../../static/js/popovers", {
     hide_all: () => {},
 });
+const rows = mock_esm("../../static/js/rows");
 
 const message_store = mock_esm("../../static/js/message_store");
-const rows = zrequire("rows");
 
 const lightbox = zrequire("lightbox");
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         lightbox.clear_for_testing();
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 
-test("pan_and_zoom", ({override_rewire}) => {
+test("pan_and_zoom", ({override}) => {
     const $img = $.create("img-stub");
     const $link = $.create("link-stub");
     const $msg = $.create("msg-stub");
@@ -39,7 +39,7 @@ test("pan_and_zoom", ({override_rewire}) => {
     $img.set_parent($link);
     $link.closest = () => $msg;
 
-    override_rewire(rows, "id", ($row) => {
+    override(rows, "id", ($row) => {
         assert.equal($row, $msg);
         return 1234;
     });
@@ -53,20 +53,20 @@ test("pan_and_zoom", ({override_rewire}) => {
         return "message-stub";
     };
 
-    override_rewire(lightbox, "render_lightbox_list_images", () => {});
+    $.create(".focused_table .message_inline_image img", {children: []});
     const open_image = lightbox.build_open_image_function();
     open_image($img);
 
     assert.equal(fetched_zid, 1234);
 });
 
-test("youtube", ({override_rewire}) => {
+test("youtube", ({override}) => {
     const href = "https://youtube.com/some-random-clip";
     const $img = $.create("img-stub");
     const $link = $.create("link-stub");
     const $msg = $.create("msg-stub");
 
-    override_rewire(rows, "id", ($row) => {
+    override(rows, "id", ($row) => {
         assert.equal($row, $msg);
         return 4321;
     });
@@ -86,7 +86,7 @@ test("youtube", ({override_rewire}) => {
     $link.closest = () => $msg;
     $link.attr("href", href);
 
-    override_rewire(lightbox, "render_lightbox_list_images", () => {});
+    $.create(".focused_table .message_inline_image img", {children: []});
 
     const open_image = lightbox.build_open_image_function();
     open_image($img);

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -181,10 +181,10 @@ markdown.initialize(markdown_config.get_helpers());
 linkifiers.initialize(example_realm_linkifiers);
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         page_params.realm_users = [];
         linkifiers.update_linkifier_rules(example_realm_linkifiers);
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 
@@ -824,7 +824,7 @@ test("parse_non_message", () => {
     assert.equal(markdown.parse_non_message("type `/day`"), "<p>type <code>/day</code></p>");
 });
 
-test("missing unicode emojis", ({override_rewire}) => {
+test("missing unicode emojis", ({override}) => {
     const message = {raw_content: "\u{1F6B2}"};
 
     markdown.apply_markdown(message);
@@ -833,11 +833,8 @@ test("missing unicode emojis", ({override_rewire}) => {
         '<p><span aria-label="bike" class="emoji emoji-1f6b2" role="img" title="bike">:bike:</span></p>',
     );
 
-    override_rewire(emoji, "get_emoji_name", (codepoint) => {
-        // Now simulate that we don't know any emoji names.
-        assert.equal(codepoint, "1f6b2");
-        // return undefined
-    });
+    // Now simulate that we don't know this emoji name.
+    override(emoji_codes.codepoint_to_name, "1f6b2", undefined);
 
     markdown.initialize(markdown_config.get_helpers());
     markdown.apply_markdown(message);

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {with_overrides, zrequire} = require("../zjsunit/namespace");
+const {zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 
@@ -143,26 +143,20 @@ run_test("muting", () => {
         {id: 9, type: "private", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
     ];
 
+    muted_topics.add_muted_topic(1, "muted");
+    muted_users.add_muted_user(10);
+
     // `messages_filtered_for_topic_mutes` should skip filtering
     // messages if `excludes_muted_topics` is false.
-    with_overrides(({disallow_rewire}) => {
-        disallow_rewire(muted_topics, "is_topic_muted");
-        const res = mld.messages_filtered_for_topic_mutes(msgs);
-        assert.deepEqual(res, msgs);
-    });
+    assert.deepEqual(mld.messages_filtered_for_topic_mutes(msgs), msgs);
 
     // If we are in a 1:1 PM narrow, `messages_filtered_for_user_mutes` should skip
     // filtering messages.
-    with_overrides(({disallow_rewire}) => {
-        disallow_rewire(muted_users, "is_user_muted");
-        const res = mld.messages_filtered_for_user_mutes(msgs);
-        assert.deepEqual(res, msgs);
-    });
+    assert.deepEqual(mld.messages_filtered_for_user_mutes(msgs), msgs);
 
     // Test actual behaviour of `messages_filtered_for_*` methods.
     mld.excludes_muted_topics = true;
     mld.filter = new Filter([{operator: "stream", operand: "general"}]);
-    muted_topics.add_muted_topic(1, "muted");
     const res = mld.messages_filtered_for_topic_mutes(msgs);
     assert.deepEqual(res, [
         {id: 2, type: "stream", stream_id: 1, topic: "whatever"},
@@ -177,7 +171,6 @@ run_test("muting", () => {
         {id: 9, type: "private", to_user_ids: "9", sender_id: 11},
     ]);
 
-    muted_users.add_muted_user(10);
     const res_user = mld.messages_filtered_for_user_mutes(msgs);
     assert.deepEqual(res_user, [
         // `messages_filtered_for_user_mutes` does not affect stream messages

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -16,6 +16,7 @@ const stream_data = zrequire("stream_data");
 const {Filter} = zrequire("../js/filter");
 const narrow = zrequire("narrow");
 
+const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
 mock_esm("../../static/js/spectators", {
     login_to_access: () => {},
 });
@@ -653,7 +654,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
     assert.deepEqual(args.operators, [{operator: "stream", operand: "ROME"}]);
 });
 
-run_test("narrow_to_compose_target PMs", ({override_rewire}) => {
+run_test("narrow_to_compose_target PMs", ({override, override_rewire}) => {
     const args = {called: false};
     override_rewire(narrow, "activate", (operators, opts) => {
         args.operators = operators;
@@ -662,7 +663,7 @@ run_test("narrow_to_compose_target PMs", ({override_rewire}) => {
     });
 
     let emails;
-    override_rewire(compose_state, "private_message_recipient", () => emails);
+    override(compose_pm_pill, "get_emails", () => emails);
 
     compose_state.set_message_type("private");
     people.add_active_user(ray);

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -4,6 +4,7 @@ const {strict: assert} = require("assert");
 
 const {set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
+const $ = require("../zjsunit/zjquery");
 const {page_params, user_settings} = require("../zjsunit/zpage_params");
 
 // Dependencies
@@ -20,7 +21,6 @@ set_global("navigator", _navigator);
 
 const muted_topics = zrequire("muted_topics");
 const stream_data = zrequire("stream_data");
-const ui = zrequire("ui");
 const spoilers = zrequire("spoilers");
 spoilers.hide_spoilers_in_notification = () => {};
 
@@ -50,14 +50,14 @@ stream_data.add_sub(muted);
 muted_topics.add_muted_topic(general.stream_id, "muted topic");
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         page_params.is_admin = false;
         page_params.realm_users = [];
         user_settings.enable_desktop_notifications = true;
         user_settings.enable_sounds = true;
         user_settings.wildcard_mentions_notify = true;
         user_settings.notification_sound = "ding";
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 
@@ -280,8 +280,8 @@ test("message_is_notifiable", () => {
     assert.equal(notifications.message_is_notifiable(message), true);
 });
 
-test("basic_notifications", ({override_rewire}) => {
-    override_rewire(ui, "replace_emoji_with_text", () => {});
+test("basic_notifications", () => {
+    $("<div>").set_find_results(".emoji", {replaceWith() {}});
 
     let n; // Object for storing all notification data for assertions.
     let last_closed_message_id = null;

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -40,7 +40,7 @@ run_test("is_my_user_id", () => {
     assert.equal(people.is_my_user_id(me.user_id.toString()), true);
 });
 
-run_test("blueslip", ({override_rewire}) => {
+run_test("blueslip", () => {
     const unknown_email = "alicebobfred@example.com";
 
     blueslip.expect("debug", "User email operand unknown: " + unknown_email);
@@ -104,10 +104,9 @@ run_test("blueslip", ({override_rewire}) => {
     const reply_to = people.pm_reply_to(message);
     assert.ok(reply_to.includes("?"));
 
-    override_rewire(people, "pm_with_user_ids", () => [42]);
-    override_rewire(people, "get_by_user_id", () => {});
+    blueslip.expect("error", "Unknown user_id in get_by_user_id: 42");
     blueslip.expect("error", "Unknown people in message");
-    const uri = people.pm_with_url({});
+    const uri = people.pm_with_url({type: "private", display_recipient: [{id: 42}]});
     assert.equal(uri.indexOf("unk"), uri.length - 3);
 
     blueslip.expect("error", "Undefined field id");

--- a/frontend_tests/node_tests/pm_list_data.js
+++ b/frontend_tests/node_tests/pm_list_data.js
@@ -96,10 +96,10 @@ people.add_active_user(bot_test);
 people.initialize_current_user(me.user_id);
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         narrow_state.reset_current_filter();
         pm_conversations.clear_for_testing();
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {mock_esm, with_overrides, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
 const {user_settings} = require("../zjsunit/zpage_params");
@@ -100,11 +100,10 @@ test("unknown user", ({override}) => {
     // If the server is suspected to be offline or reloading,
     // then we suppress errors.  The use case here is that we
     // haven't gotten info for a brand new user yet.
-    with_overrides(({override_rewire}) => {
-        override_rewire(watchdog, "suspects_user_is_offline", () => true);
-        presence.set_info(presences, now);
-    });
+    watchdog.set_suspect_offline(true);
+    presence.set_info(presences, now);
 
+    watchdog.set_suspect_offline(false);
     override(reload_state, "is_in_progress", () => true);
     presence.set_info(presences, now);
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -107,6 +107,9 @@ const narrow = mock_esm("../../static/js/narrow", {
     handle_middle_pane_transition: noop,
     has_shown_message_list_view: true,
 });
+mock_esm("../../static/js/popovers", {
+    any_active: () => false,
+});
 mock_esm("../../static/js/recent_senders", {
     get_topic_recent_senders: () => [1, 2],
 });
@@ -153,6 +156,7 @@ mock_esm("../../static/js/unread", {
 const {all_messages_data} = zrequire("all_messages_data");
 const people = zrequire("people");
 const rt = zrequire("recent_topics_ui");
+const recent_topics_util = zrequire("recent_topics_util");
 const rt_data = zrequire("recent_topics_data");
 
 people.is_my_user_id = (id) => id === 1;
@@ -320,11 +324,11 @@ function stub_out_filter_buttons() {
 }
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire, mock_template}) => {
+    run_test(label, (helpers) => {
         $(".header").css = () => {};
 
         messages = sample_messages.map((message) => ({...message}));
-        f({override, override_rewire, mock_template});
+        f(helpers);
     });
 }
 
@@ -363,7 +367,7 @@ test("test_recent_topics_show", ({mock_template, override}) => {
     assert.equal(rt.inplace_rerender("stream_unknown:topic_unknown"), false);
 });
 
-test("test_filter_all", ({override_rewire, mock_template}) => {
+test("test_filter_all", ({mock_template}) => {
     // Just tests inplace rerender of a message
     // in All topics filter.
     page_params.is_spectator = true;
@@ -392,7 +396,7 @@ test("test_filter_all", ({override_rewire, mock_template}) => {
     i = row_data.length;
     rt.clear_for_tests();
     stub_out_filter_buttons();
-    override_rewire(rt, "is_visible", () => true);
+    recent_topics_util.set_visible(true);
     rt.set_filter("all");
     rt.process_messages([messages[0]]);
 
@@ -412,11 +416,11 @@ test("test_filter_all", ({override_rewire, mock_template}) => {
     row_data = generate_topic_data([[1, "topic-1", 0, false, true]]);
     i = row_data.length;
     rt.set_default_focus();
-    override_rewire(rt, "is_in_focus", () => false);
+    $(".home-page-input").trigger("focus");
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 });
 
-test("test_filter_unread", ({override_rewire, mock_template}) => {
+test("test_filter_unread", ({mock_template}) => {
     let expected_filter_unread = false;
     page_params.is_spectator = false;
 
@@ -460,12 +464,12 @@ test("test_filter_unread", ({override_rewire, mock_template}) => {
     });
 
     rt.clear_for_tests();
-    override_rewire(rt, "is_visible", () => true);
+    recent_topics_util.set_visible(true);
     rt.set_default_focus();
 
     stub_out_filter_buttons();
     rt.process_messages(messages);
-    override_rewire(rt, "is_in_focus", () => false);
+    $(".home-page-input").trigger("focus");
     assert.equal(rt.inplace_rerender("1:topic-1"), true);
 
     $("#recent_topics_filter_buttons").removeClass("btn-recent-selected");
@@ -526,7 +530,7 @@ test("test_filter_unread", ({override_rewire, mock_template}) => {
     rt.set_filter("all");
 });
 
-test("test_filter_participated", ({override_rewire, mock_template}) => {
+test("test_filter_participated", ({mock_template}) => {
     let expected_filter_participated;
 
     page_params.is_spectator = false;
@@ -569,13 +573,13 @@ test("test_filter_participated", ({override_rewire, mock_template}) => {
     });
 
     rt.clear_for_tests();
-    override_rewire(rt, "is_visible", () => true);
+    recent_topics_util.set_visible(true);
     rt.set_default_focus();
     stub_out_filter_buttons();
     expected_filter_participated = false;
     rt.process_messages(messages);
 
-    override_rewire(rt, "is_in_focus", () => false);
+    $(".home-page-input").trigger("focus");
     assert.equal(rt.inplace_rerender("1:topic-4"), true);
 
     // Set muted filter
@@ -635,8 +639,8 @@ test("test_filter_participated", ({override_rewire, mock_template}) => {
     rt.set_filter("all");
 });
 
-test("test_update_unread_count", ({override_rewire}) => {
-    override_rewire(rt, "is_visible", () => false);
+test("test_update_unread_count", () => {
+    recent_topics_util.set_visible(false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
     rt.set_filter("all");
@@ -647,7 +651,7 @@ test("test_update_unread_count", ({override_rewire}) => {
     rt.update_topic_unread_count(messages[9]);
 });
 
-test("basic assertions", ({override_rewire, mock_template}) => {
+test("basic assertions", ({mock_template}) => {
     rt.clear_for_tests();
 
     mock_template("recent_topics_table.hbs", false, () => {});
@@ -656,7 +660,7 @@ test("basic assertions", ({override_rewire, mock_template}) => {
     });
 
     stub_out_filter_buttons();
-    override_rewire(rt, "is_visible", () => true);
+    recent_topics_util.set_visible(true);
     rt.set_default_focus();
     rt.set_filter("all");
     rt.process_messages(messages);
@@ -764,19 +768,19 @@ test("basic assertions", ({override_rewire, mock_template}) => {
     // update_topic_is_muted now relies on external libraries completely
     // so we don't need to check anythere here.
     generate_topic_data([[1, topic1, 0, false, true]]);
-    override_rewire(rt, "is_in_focus", () => false);
+    $(".home-page-input").trigger("focus");
     assert.equal(rt.update_topic_is_muted(stream1, topic1), true);
     // a topic gets muted which we are not tracking
     assert.equal(rt.update_topic_is_muted(stream1, "topic-10"), false);
 });
 
-test("test_reify_local_echo_message", ({override_rewire, mock_template}) => {
+test("test_reify_local_echo_message", ({mock_template}) => {
     mock_template("recent_topics_table.hbs", false, () => {});
     mock_template("recent_topic_row.hbs", false, () => {});
 
     rt.clear_for_tests();
     stub_out_filter_buttons();
-    override_rewire(rt, "is_visible", () => true);
+    recent_topics_util.set_visible(true);
     rt.set_filter("all");
     rt.process_messages(messages);
 
@@ -822,8 +826,8 @@ test("test_reify_local_echo_message", ({override_rewire, mock_template}) => {
     );
 });
 
-test("test_delete_messages", ({override, override_rewire}) => {
-    override_rewire(rt, "is_visible", () => false);
+test("test_delete_messages", ({override}) => {
+    recent_topics_util.set_visible(false);
     rt.clear_for_tests();
     stub_out_filter_buttons();
     rt.set_filter("all");
@@ -861,9 +865,9 @@ test("test_delete_messages", ({override, override_rewire}) => {
     rt.update_topics_of_deleted_message_ids([-1]);
 });
 
-test("test_topic_edit", ({override, override_rewire}) => {
+test("test_topic_edit", ({override}) => {
     override(all_messages_data, "all_messages", () => messages);
-    override_rewire(rt, "is_visible", () => false);
+    recent_topics_util.set_visible(false);
 
     // NOTE: This test should always run in the end as it modified the messages data.
     rt.clear_for_tests();

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -2,11 +2,12 @@
 
 const {strict: assert} = require("assert");
 
-const {zrequire} = require("../zjsunit/namespace");
+const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
+const input_pill = mock_esm("../../static/js/input_pill");
+
 const search_pill = zrequire("search_pill");
-const input_pill = zrequire("input_pill");
 
 const is_starred_item = {
     display_value: "is:starred",
@@ -70,10 +71,10 @@ run_test("get_items", () => {
     );
 });
 
-run_test("create_pills", ({override_rewire}) => {
+run_test("create_pills", ({override}) => {
     let input_pill_create_called = false;
 
-    override_rewire(input_pill, "create", () => {
+    override(input_pill, "create", () => {
         input_pill_create_called = true;
         return {dummy: "dummy"};
     });

--- a/frontend_tests/node_tests/search_suggestion_now.js
+++ b/frontend_tests/node_tests/search_suggestion_now.js
@@ -6,13 +6,13 @@ const {mock_esm, with_overrides, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const {page_params} = require("../zjsunit/zpage_params");
 
+const narrow_state = mock_esm("../../static/js/narrow_state");
 const stream_topic_history_util = mock_esm("../../static/js/stream_topic_history_util");
 
 const settings_config = zrequire("settings_config");
 
 const huddle_data = zrequire("huddle_data");
 
-const narrow_state = zrequire("narrow_state");
 const stream_data = zrequire("stream_data");
 const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
@@ -67,6 +67,7 @@ function init() {
 
     stream_topic_history.reset();
     huddle_data.clear_for_testing();
+    stream_data.clear_subscriptions();
 }
 
 function get_suggestions(base_query, query) {
@@ -74,18 +75,16 @@ function get_suggestions(base_query, query) {
 }
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         init();
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 
-test("basic_get_suggestions", ({override_rewire}) => {
+test("basic_get_suggestions", ({override}) => {
     const query = "fred";
 
-    override_rewire(stream_data, "subscribed_streams", () => []);
-
-    override_rewire(narrow_state, "stream", () => "office");
+    override(narrow_state, "stream", () => "office");
 
     const suggestions = get_suggestions("", query);
 
@@ -93,8 +92,7 @@ test("basic_get_suggestions", ({override_rewire}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("basic_get_suggestions_for_spectator", ({override_rewire}) => {
-    override_rewire(stream_data, "subscribed_streams", () => []);
+test("basic_get_suggestions_for_spectator", () => {
     page_params.is_spectator = true;
 
     const query = "";
@@ -366,10 +364,11 @@ test("group_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("empty_query_suggestions", ({override_rewire}) => {
+test("empty_query_suggestions", () => {
     const query = "";
 
-    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
+    stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
+    stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
 
     const suggestions = get_suggestions("", query);
 
@@ -407,12 +406,13 @@ test("empty_query_suggestions", ({override_rewire}) => {
     assert.equal(describe("has:attachment"), "Messages with one or more attachment");
 });
 
-test("has_suggestions", ({override_rewire}) => {
+test("has_suggestions", ({override}) => {
     // Checks that category wise suggestions are displayed instead of a single
     // default suggestion when suggesting `has` operator.
     let query = "h";
-    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
-    override_rewire(narrow_state, "stream", () => {});
+    stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
+    stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
+    override(narrow_state, "stream", () => {});
 
     let suggestions = get_suggestions("", query);
     let expected = ["h", "has:link", "has:image", "has:attachment"];
@@ -466,9 +466,10 @@ test("has_suggestions", ({override_rewire}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("check_is_suggestions", ({override_rewire}) => {
-    override_rewire(stream_data, "subscribed_streams", () => ["devel", "office"]);
-    override_rewire(narrow_state, "stream", () => {});
+test("check_is_suggestions", ({override}) => {
+    stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
+    stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
+    override(narrow_state, "stream", () => {});
 
     let query = "i";
     let suggestions = get_suggestions("", query);
@@ -553,10 +554,8 @@ test("check_is_suggestions", ({override_rewire}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("sent_by_me_suggestions", ({override_rewire}) => {
-    override_rewire(stream_data, "subscribed_streams", () => []);
-
-    override_rewire(narrow_state, "stream", () => {});
+test("sent_by_me_suggestions", ({override}) => {
+    override(narrow_state, "stream", () => {});
 
     let query = "";
     let suggestions = get_suggestions("", query);
@@ -624,28 +623,18 @@ test("sent_by_me_suggestions", ({override_rewire}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("topic_suggestions", ({override, override_rewire}) => {
+test("topic_suggestions", ({override}) => {
     let suggestions;
     let expected;
 
     override(stream_topic_history_util, "get_server_history", () => {});
-    override_rewire(stream_data, "subscribed_streams", () => ["office"]);
-    override_rewire(narrow_state, "stream", () => "office");
+    stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
+    override(narrow_state, "stream", () => "office");
 
     const devel_id = 44;
     const office_id = 77;
-
-    override_rewire(stream_data, "get_stream_id", (stream_name) => {
-        switch (stream_name) {
-            case "office":
-                return office_id;
-            case "devel":
-                return devel_id;
-            /* istanbul ignore next */
-            default:
-                throw new Error(`unknown stream ${stream_name}`);
-        }
-    });
+    stream_data.add_sub({stream_id: devel_id, name: "devel", subscribed: true});
+    stream_data.add_sub({stream_id: office_id, name: "office", subscribed: true});
 
     suggestions = get_suggestions("", "te");
     expected = [
@@ -763,10 +752,11 @@ test("topic_suggestions (limits)", () => {
     assert_result("z", []);
 });
 
-test("whitespace_glitch", ({override_rewire}) => {
+test("whitespace_glitch", ({override}) => {
     const query = "stream:office "; // note trailing space
 
-    override_rewire(stream_data, "subscribed_streams", () => ["office"]);
+    override(stream_topic_history_util, "get_server_history", () => {});
+    stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
 
     const suggestions = get_suggestions("", query);
 
@@ -775,10 +765,11 @@ test("whitespace_glitch", ({override_rewire}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("stream_completion", ({override_rewire}) => {
-    override_rewire(stream_data, "subscribed_streams", () => ["office", "dev help"]);
+test("stream_completion", ({override}) => {
+    stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
+    stream_data.add_sub({stream_id: 88, name: "dev help", subscribed: true});
 
-    override_rewire(narrow_state, "stream", () => {});
+    override(narrow_state, "stream", () => {});
 
     let query = "stream:of";
     let suggestions = get_suggestions("", query);
@@ -796,12 +787,10 @@ test("stream_completion", ({override_rewire}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("people_suggestions", ({override_rewire}) => {
+test("people_suggestions", ({override}) => {
     let query = "te";
 
-    override_rewire(stream_data, "subscribed_streams", () => []);
-
-    override_rewire(narrow_state, "stream", () => {});
+    override(narrow_state, "stream", () => {});
 
     const ted = {
         email: "ted@zulip.com",
@@ -876,7 +865,9 @@ test("people_suggestions", ({override_rewire}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("operator_suggestions", () => {
+test("operator_suggestions", ({override}) => {
+    override(narrow_state, "stream", () => undefined);
+
     // Completed operator should return nothing
     let query = "stream:";
     let suggestions = get_suggestions("", query);
@@ -910,8 +901,9 @@ test("operator_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("queries_with_spaces", ({override_rewire}) => {
-    override_rewire(stream_data, "subscribed_streams", () => ["office", "dev help"]);
+test("queries_with_spaces", () => {
+    stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
+    stream_data.add_sub({stream_id: 88, name: "dev help", subscribed: true});
 
     // test allowing spaces with quotes surrounding operand
     let query = 'stream:"dev he"';
@@ -955,10 +947,10 @@ function people_suggestion_setup() {
     people.add_active_user(alice);
 }
 
-test("people_suggestion (Admin only email visibility)", ({override_rewire}) => {
+test("people_suggestion (Admin only email visibility)", ({override}) => {
     /* Suggestions when realm_email_address_visibility is set to admin
     only */
-    override_rewire(narrow_state, "stream", () => {});
+    override(narrow_state, "stream", () => {});
     people_suggestion_setup();
 
     const query = "te";

--- a/frontend_tests/node_tests/settings_muted_topics.js
+++ b/frontend_tests/node_tests/settings_muted_topics.js
@@ -6,6 +6,7 @@ const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
+const list_widget = mock_esm("../../static/js/list_widget");
 const muted_topics_ui = mock_esm("../../static/js/muted_topics_ui");
 
 const settings_muted_topics = zrequire("settings_muted_topics");
@@ -20,12 +21,11 @@ const frontend = {
 };
 stream_data.add_sub(frontend);
 
-run_test("settings", ({override_rewire}) => {
+run_test("settings", ({override}) => {
     muted_topics.add_muted_topic(frontend.stream_id, "js", 1577836800);
     let populate_list_called = false;
-    override_rewire(settings_muted_topics, "populate_list", () => {
-        const opts = muted_topics.get_muted_topics();
-        assert.deepEqual(opts, [
+    override(list_widget, "create", ($container, list) => {
+        assert.deepEqual(list, [
             {
                 date_muted: 1577836800000,
                 date_muted_str: "Jan\u00A001,\u00A02020",

--- a/frontend_tests/node_tests/settings_muted_users.js
+++ b/frontend_tests/node_tests/settings_muted_users.js
@@ -6,23 +6,25 @@ const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
+const list_widget = mock_esm("../../static/js/list_widget");
 const muted_users_ui = mock_esm("../../static/js/muted_users_ui");
 
 const settings_muted_users = zrequire("settings_muted_users");
 const muted_users = zrequire("muted_users");
+const people = zrequire("people");
 
 const noop = () => {};
 
-run_test("settings", ({override_rewire}) => {
+run_test("settings", ({override}) => {
+    people.add_active_user({user_id: 5, email: "five@zulip.com", full_name: "Feivel Fiverson"});
     muted_users.add_muted_user(5, 1577836800);
     let populate_list_called = false;
-    override_rewire(settings_muted_users, "populate_list", () => {
-        const opts = muted_users.get_muted_users();
-        assert.deepEqual(opts, [
+    override(list_widget, "create", ($container, list) => {
+        assert.deepEqual(list, [
             {
-                date_muted: 1577836800000,
                 date_muted_str: "Jan\u00A001,\u00A02020",
-                id: 5,
+                user_id: 5,
+                user_name: "Feivel Fiverson",
             },
         ]);
         populate_list_called = true;

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -42,7 +42,7 @@ const settings_org = zrequire("settings_org");
 const dropdown_list_widget = zrequire("dropdown_list_widget");
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire, mock_template}) => {
+    run_test(label, (helpers) => {
         $("#realm-icon-upload-widget .upload-spinner-background").css = () => {};
         page_params.is_admin = false;
         page_params.realm_domains = [
@@ -51,7 +51,7 @@ function test(label, f) {
         ];
         page_params.realm_authentication_methods = {};
         settings_org.reset();
-        f({override, override_rewire, mock_template});
+        f(helpers);
     });
 }
 
@@ -506,12 +506,8 @@ function test_discard_changes_button(discard_changes) {
         $message_content_delete_limit_minutes,
     ];
 
-    $("#org-discard-msg-editing").closest = () => $discard_button_parent;
-
-    const stubbed_function = settings_org.change_save_button_state;
-    settings_org.__Rewire__("change_save_button_state", (save_button_controls, state) => {
-        assert.equal(state, "discarded");
-    });
+    const {$discard_button, props} = createSaveButtons("msg-editing");
+    $discard_button.closest = (selector) => $(selector);
 
     discard_changes(ev);
 
@@ -524,8 +520,7 @@ function test_discard_changes_button(discard_changes) {
     assert.equal($message_content_edit_limit_minutes.val(), "60");
     assert.equal($msg_delete_limit_setting.val(), "upto_two_min");
     assert.equal($message_content_delete_limit_minutes.val(), "2");
-
-    settings_org.__Rewire__("change_save_button_state", stubbed_function);
+    assert.ok(props.hidden);
 }
 
 test("set_up", ({override, override_rewire}) => {
@@ -575,7 +570,7 @@ test("set_up", ({override, override_rewire}) => {
 
     // TEST set_up() here, but this mostly just allows us to
     // get access to the click handlers.
-    override_rewire(settings_org, "maybe_disable_widgets", noop);
+    override(page_params, "is_owner", true);
     settings_org.set_up();
 
     test_submit_settings_form(

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -86,7 +86,7 @@ const name_selector = `#user-groups #${CSS.escape(1)} .name`;
 const description_selector = `#user-groups #${CSS.escape(1)} .description`;
 const instructions_selector = `#user-groups #${CSS.escape(1)} .save-instructions`;
 
-test_ui("populate_user_groups", ({override_rewire, mock_template}) => {
+test_ui("populate_user_groups", ({mock_template}) => {
     const realm_user_group = {
         id: 1,
         name: "Mobile",
@@ -147,7 +147,7 @@ test_ui("populate_user_groups", ({override_rewire, mock_template}) => {
         return people.get_by_user_id !== undefined && people.get_by_user_id !== noop;
     };
 
-    override_rewire(settings_user_groups, "can_edit", () => true);
+    page_params.is_admin = true;
 
     const all_pills = new Map();
 
@@ -500,7 +500,7 @@ test_ui("on_events", ({override_rewire, mock_template}) => {
         return "stub";
     });
 
-    override_rewire(settings_user_groups, "can_edit", () => true);
+    page_params.is_admin = true;
 
     (function test_admin_user_group_form_submit_triggered() {
         const handler = settings_user_groups.add_user_group;

--- a/frontend_tests/node_tests/starred_messages.js
+++ b/frontend_tests/node_tests/starred_messages.js
@@ -2,28 +2,33 @@
 
 const {strict: assert} = require("assert");
 
-const {with_overrides, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, with_overrides, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
 const {page_params, user_settings} = require("../zjsunit/zpage_params");
 
+const top_left_corner = mock_esm("../../static/js/top_left_corner", {
+    update_starred_count() {},
+});
+const stream_popover = mock_esm("../../static/js/stream_popover", {
+    hide_topic_popover() {},
+    hide_starred_messages_popover() {},
+});
+
 const message_store = zrequire("message_store");
 const starred_messages = zrequire("starred_messages");
-const stream_popover = zrequire("stream_popover");
-const top_left_corner = zrequire("top_left_corner");
 
-run_test("add starred", ({override_rewire}) => {
+run_test("add starred", () => {
     starred_messages.starred_ids.clear();
     assert.deepEqual(starred_messages.get_starred_msg_ids(), []);
     assert.equal(starred_messages.get_count(), 0);
 
-    override_rewire(starred_messages, "rerender_ui", () => {});
     starred_messages.add([1, 2]);
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [1, 2]);
     assert.equal(starred_messages.get_count(), 2);
 });
 
-run_test("remove starred", ({override_rewire}) => {
+run_test("remove starred", () => {
     starred_messages.starred_ids.clear();
     assert.deepEqual(starred_messages.get_starred_msg_ids(), []);
 
@@ -32,7 +37,6 @@ run_test("remove starred", ({override_rewire}) => {
     }
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [1, 2, 3]);
 
-    override_rewire(starred_messages, "rerender_ui", () => {});
     starred_messages.remove([2, 3]);
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [1]);
     assert.equal(starred_messages.get_count(), 1);
@@ -77,14 +81,13 @@ run_test("get starred ids in topic", () => {
     assert.deepEqual(starred_messages.get_count_in_topic(20, "topic"), 1);
 });
 
-run_test("initialize", ({override_rewire}) => {
+run_test("initialize", () => {
     starred_messages.starred_ids.clear();
     for (const id of [1, 2, 3]) {
         starred_messages.starred_ids.add(id);
     }
 
     page_params.starred_messages = [4, 5, 6];
-    override_rewire(starred_messages, "rerender_ui", () => {});
     starred_messages.initialize();
     assert.deepEqual(starred_messages.get_starred_msg_ids(), [4, 5, 6]);
 });
@@ -96,10 +99,10 @@ run_test("rerender_ui", () => {
     }
 
     user_settings.starred_message_counts = true;
-    with_overrides(({override_rewire}) => {
+    with_overrides(({override}) => {
         const stub = make_stub();
-        override_rewire(stream_popover, "hide_topic_popover", () => {});
-        override_rewire(top_left_corner, "update_starred_count", stub.f);
+        override(stream_popover, "hide_topic_popover", () => {});
+        override(top_left_corner, "update_starred_count", stub.f);
         starred_messages.rerender_ui();
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("count");
@@ -107,10 +110,10 @@ run_test("rerender_ui", () => {
     });
 
     user_settings.starred_message_counts = false;
-    with_overrides(({override_rewire}) => {
+    with_overrides(({override}) => {
         const stub = make_stub();
-        override_rewire(stream_popover, "hide_topic_popover", () => {});
-        override_rewire(top_left_corner, "update_starred_count", stub.f);
+        override(stream_popover, "hide_topic_popover", () => {});
+        override(top_left_corner, "update_starred_count", stub.f);
         starred_messages.rerender_ui();
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("count");

--- a/frontend_tests/node_tests/stream_create_subscribers_data.js
+++ b/frontend_tests/node_tests/stream_create_subscribers_data.js
@@ -34,7 +34,7 @@ const test_user103 = {
 };
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         page_params.is_admin = false;
         people.init();
         people.add_active_user(me);
@@ -43,7 +43,7 @@ function test(label, f) {
         people.add_active_user(test_user103);
         page_params.user_id = me.user_id;
         people.initialize_current_user(me.user_id);
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -40,7 +40,7 @@ function contains_sub(subs, sub) {
 }
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         page_params.is_admin = false;
         page_params.realm_users = [];
         page_params.is_guest = false;
@@ -48,7 +48,7 @@ function test(label, f) {
         people.add_active_user(me);
         people.initialize_current_user(me.user_id);
         stream_data.clear_subscriptions();
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 
@@ -764,7 +764,7 @@ test("canonicalized_name", () => {
     assert.deepStrictEqual(stream_data.canonicalized_name("Stream_Bar"), "stream_bar");
 });
 
-test("create_sub", ({override_rewire}) => {
+test("create_sub", () => {
     const india = {
         stream_id: 102,
         name: "India",
@@ -783,11 +783,9 @@ test("create_sub", ({override_rewire}) => {
         color: "#76ce90",
     };
 
-    override_rewire(color_data, "pick_color", () => "#bd86e5");
-
     const india_sub = stream_data.create_sub_from_server_data(india);
     assert.ok(india_sub);
-    assert.equal(india_sub.color, "#bd86e5");
+    assert.equal(india_sub.color, color_data.colors[0]);
     const new_sub = stream_data.create_sub_from_server_data(india);
     // make sure sub doesn't get created twice
     assert.equal(india_sub, new_sub);

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -45,9 +45,9 @@ function sort_groups(query) {
 }
 
 function test(label, f) {
-    run_test(label, ({override, override_rewire}) => {
+    run_test(label, (helpers) => {
         stream_data.clear_subscriptions();
-        f({override, override_rewire});
+        f(helpers);
     });
 }
 

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -6,25 +6,25 @@ const {mock_esm, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
+const pm_list = mock_esm("../../static/js/pm_list");
 mock_esm("../../static/js/resize", {
     resize_stream_filters_container: () => {},
 });
 
 const {Filter} = zrequire("../js/filter");
 const people = zrequire("people");
-const pm_list = zrequire("pm_list");
 const top_left_corner = zrequire("top_left_corner");
 
-run_test("narrowing", ({override_rewire}) => {
+run_test("narrowing", ({override}) => {
     // activating narrow
 
     let pm_expanded;
     let pm_closed;
 
-    override_rewire(pm_list, "close", () => {
+    override(pm_list, "close", () => {
         pm_closed = true;
     });
-    override_rewire(pm_list, "expand", () => {
+    override(pm_list, "expand", () => {
         pm_expanded = true;
     });
 

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -95,7 +95,7 @@ run_test("transmit_message_ajax_reload_pending", () => {
     assert.ok(reload_initiated);
 });
 
-run_test("reply_message_stream", ({override_rewire}) => {
+run_test("reply_message_stream", ({override}) => {
     const stream_message = {
         type: "stream",
         stream: "social",
@@ -108,8 +108,8 @@ run_test("reply_message_stream", ({override_rewire}) => {
 
     let send_message_args;
 
-    override_rewire(transmit, "send_message", (args) => {
-        send_message_args = args;
+    override(channel, "post", ({data}) => {
+        send_message_args = data;
     });
 
     page_params.user_id = 44;
@@ -132,7 +132,7 @@ run_test("reply_message_stream", ({override_rewire}) => {
     });
 });
 
-run_test("reply_message_private", ({override_rewire}) => {
+run_test("reply_message_private", ({override}) => {
     const fred = {
         user_id: 3,
         email: "fred@example.com",
@@ -149,8 +149,8 @@ run_test("reply_message_private", ({override_rewire}) => {
 
     let send_message_args;
 
-    override_rewire(transmit, "send_message", (args) => {
-        send_message_args = args;
+    override(channel, "post", ({data}) => {
+        send_message_args = data;
     });
 
     page_params.user_id = 155;

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -2,11 +2,12 @@
 
 const {strict: assert} = require("assert");
 
-const {set_global, zrequire} = require("../zjsunit/namespace");
+const {mock_esm, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
+const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
+
 const typing = zrequire("typing");
-const compose_pm_pill = zrequire("compose_pm_pill");
 const typing_status = zrequire("../shared/js/typing_status");
 
 function make_time(secs) {
@@ -20,7 +21,7 @@ function returns_time(secs) {
     };
 }
 
-run_test("basics", ({override_rewire}) => {
+run_test("basics", ({override, override_rewire}) => {
     typing_status.initialize_state();
 
     // invalid conversation basically does nothing
@@ -263,7 +264,7 @@ run_test("basics", ({override_rewire}) => {
     // test that we correctly detect if worker.get_recipient
     // and typing_status.state.current_recipient are the same
 
-    override_rewire(compose_pm_pill, "get_user_ids_string", () => "1,2,3");
+    override(compose_pm_pill, "get_user_ids_string", () => "1,2,3");
     typing_status.state.current_recipient = typing.get_recipient();
 
     const call_count = {
@@ -294,14 +295,14 @@ run_test("basics", ({override_rewire}) => {
 
     // change in recipient and new_recipient should make us
     // call typing_status.stop_last_notification
-    override_rewire(compose_pm_pill, "get_user_ids_string", () => "2,3,4");
+    override(compose_pm_pill, "get_user_ids_string", () => "2,3,4");
     typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);
     assert.deepEqual(call_count.stop_last_notification, 1);
 
     // Stream messages are represented as get_user_ids_string being empty
-    override_rewire(compose_pm_pill, "get_user_ids_string", () => "");
+    override(compose_pm_pill, "get_user_ids_string", () => "");
     typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -134,7 +134,6 @@ EXEMPT_FILES = make_set(
         "static/js/realm_playground.js",
         "static/js/realm_user_settings_defaults.ts",
         "static/js/recent_topics_ui.js",
-        "static/js/recent_topics_util.js",
         "static/js/reload.js",
         "static/js/reminder.js",
         "static/js/resize.js",


### PR DESCRIPTION
When we were preparing the conversion to ES modules in 2019, the primary obstacle was that the Node tests extensively relied on the ability to reach into modules and mutate their CommonJS exports in order to mock things.  ES module bindings are not mutable, so in commit 173c9cee4220e547d6cbeab468668484e8f79000 we added babel-plugin-rewire-ts as a kludgy transpilation-based workaround for this to unblock the conversion.

However, babel-plugin-rewire-ts is slow, buggy, nonstandard, confusing, and unmaintained.  It’s incompatible with running our ES modules as native ES modules, and prevents us from taking advantage of modern tools for ES modules.  So we want to excise all use of `__Rewire__` (and the `disallow_rewire`, `override_rewire` helper functions that rely on it) from the tests and remove babel-plugin-rewire-ts.

Commits 64abdc199ea7a757af763f7e2e60187d3a8b3862 and e17ba5260a44095591e2ead23e852d8ae088ad65 (#20730) prepared for this by letting us see where `__Rewire__` is being used.  Now we go through and remove most of the uses that are easy to remove without modifying the production code at all.

Context: <https://chat.zulip.org/#narrow/stream/18-tools/topic/__Rewire__>