### PR TITLE
Remove message_list.narrowed from codebase.

### DIFF
--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -16,11 +16,7 @@ const compose_actions = mock_esm("../../static/js/compose_actions");
 const compose_closed_ui = mock_esm("../../static/js/compose_closed_ui");
 const hashchange = mock_esm("../../static/js/hashchange");
 const message_fetch = mock_esm("../../static/js/message_fetch");
-const message_list = mock_esm("../../static/js/message_list", {
-    set_narrowed(value) {
-        message_list.narrowed = value;
-    },
-});
+const message_list = mock_esm("../../static/js/message_list");
 const message_lists = mock_esm("../../static/js/message_lists", {
     home: {},
     current: {},
@@ -183,8 +179,8 @@ run_test("basics", () => {
         then_select_id: selected_id,
     });
 
-    assert.equal(message_list.narrowed.selected_id, selected_id);
-    assert.equal(message_list.narrowed.view.offset, 25);
+    assert.equal(message_lists.current.selected_id, selected_id);
+    assert.equal(message_lists.current.view.offset, 25);
     assert.equal(narrow_state.narrowed_to_pms(), false);
 
     helper.assert_events([

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -169,10 +169,12 @@ run_test("basics", () => {
     let cont;
 
     message_fetch.load_messages_for_narrow = (opts) => {
+        // Only validates the anchor and set of fields
         cont = opts.cont;
 
         assert.deepEqual(opts, {
             cont: opts.cont,
+            msg_list: opts.msg_list,
             anchor: 1000,
         });
     };

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -13,7 +13,6 @@ import * as huddle_data from "./huddle_data";
 import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_helper from "./message_helper";
-import * as message_list from "./message_list";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as message_util from "./message_util";
@@ -130,12 +129,12 @@ export function insert_new_messages(messages, sent_by_this_client) {
         message_util.add_new_messages(messages, message_lists.home);
 
         if (narrow_state.filter().can_apply_locally()) {
-            render_info = message_util.add_new_messages(messages, message_list.narrowed);
+            render_info = message_util.add_new_messages(messages, message_lists.current);
         } else {
             // if we cannot apply locally, we have to wait for this callback to happen to notify
             maybe_add_narrowed_messages(
                 messages,
-                message_list.narrowed,
+                message_lists.current,
                 message_util.add_new_messages,
             );
         }
@@ -509,7 +508,7 @@ export function update_messages(events) {
     // changed the correct grouping of messages).
     if (any_topic_edited || any_stream_changed) {
         message_lists.home.update_muting_and_rerender();
-        // However, we don't need to rerender message_list.narrowed if
+        // However, we don't need to rerender message_list if
         // we just changed the narrow earlier in this function.
         //
         // TODO: We can potentially optimize this logic to avoid
@@ -518,8 +517,8 @@ export function update_messages(events) {
         // edit.  Doing so could save significant work, since most
         // topic edits will not match the current topic narrow in
         // large organizations.
-        if (!changed_narrow && message_lists.current === message_list.narrowed) {
-            message_list.narrowed.update_muting_and_rerender();
+        if (!changed_narrow && message_lists.current.narrowed) {
+            message_lists.current.update_muting_and_rerender();
         }
     } else {
         // If the content of the message was edited, we do a special animation.

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -292,13 +292,11 @@ export function load_messages(opts, attempt = 1) {
 }
 
 export function load_messages_for_narrow(opts) {
-    const msg_list = message_list.narrowed;
-
     load_messages({
         anchor: opts.anchor,
         num_before: consts.narrow_before,
         num_after: consts.narrow_after,
-        msg_list,
+        msg_list: opts.msg_list,
         cont: opts.cont,
     });
 }

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -55,9 +55,9 @@ function process_result(data, opts) {
     }
 
     if (
-        opts.msg_list === message_list.narrowed &&
-        message_lists.current === message_list.narrowed &&
-        message_list.narrowed.empty()
+        opts.msg_list === message_lists.current &&
+        opts.msg_list.narrowed &&
+        opts.msg_list.empty()
     ) {
         // Even after loading more messages, we have
         // no messages to display in this narrow.

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -9,12 +9,6 @@ import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as stream_data from "./stream_data";
 
-export let narrowed;
-
-export function set_narrowed(value) {
-    narrowed = value;
-}
-
 export class MessageList {
     constructor(opts) {
         if (opts.data) {
@@ -74,14 +68,14 @@ export class MessageList {
             render_info = this.append_to_view(bottom_messages, opts);
         }
 
-        if (this === narrowed && !this.empty()) {
+        if (this.narrowed && !this.empty()) {
             // If adding some new messages to the message tables caused
             // our current narrow to no longer be empty, hide the empty
             // feed placeholder text.
             narrow_banner.hide_empty_narrow_message();
         }
 
-        if (this === narrowed && !this.empty() && this.selected_id() === -1) {
+        if (this.narrowed && !this.empty() && this.selected_id() === -1) {
             // And also select the newly arrived message.
             this.select_id(this.selected_id(), {then_scroll: true, use_closest: true});
         }
@@ -365,7 +359,7 @@ export class MessageList {
         this.view.clear_rendering_state(false);
         this.view.update_render_window(this.selected_idx(), false);
 
-        if (this === narrowed) {
+        if (this.narrowed) {
             if (this.empty()) {
                 narrow_banner.show_empty_narrow_message();
             } else {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -534,6 +534,7 @@ export function activate(raw_operators, opts) {
                 msg_list.network_time = new Date();
                 maybe_report_narrow_time(msg_list);
             },
+            msg_list,
         });
     }
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -488,8 +488,7 @@ export function activate(raw_operators, opts) {
     $("#zfilt").addClass("focused_table");
     $("#zhome").removeClass("focused_table");
 
-    message_list.set_narrowed(msg_list);
-    message_lists.set_current(message_list.narrowed);
+    message_lists.set_current(msg_list);
 
     let then_select_offset;
     if (id_info.target_id === id_info.final_select_id) {

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -10,7 +10,6 @@ import * as drafts from "./drafts";
 import * as hash_util from "./hash_util";
 import * as hashchange from "./hashchange";
 import {localstorage} from "./localstorage";
-import * as message_list from "./message_list";
 import * as message_lists from "./message_lists";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
@@ -73,11 +72,13 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
         } else {
             url += "+offset=" + message_lists.home.pre_narrow_offset;
 
-            const narrow_pointer = message_list.narrowed.selected_id();
+            // narrow_state.active() is true, so this is the current
+            // narrowed message list.
+            const narrow_pointer = message_lists.current.selected_id();
             if (narrow_pointer !== -1) {
                 url += "+narrow_pointer=" + narrow_pointer;
             }
-            const $narrow_row = message_list.narrowed.selected_row();
+            const $narrow_row = message_lists.current.selected_row();
             if ($narrow_row.length > 0) {
                 url += "+narrow_offset=" + $narrow_row.offset().top;
             }

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -5,7 +5,6 @@ import * as channel from "./channel";
 import {$t_html} from "./i18n";
 import * as loading from "./loading";
 import * as message_flags from "./message_flags";
-import * as message_list from "./message_list";
 import * as message_lists from "./message_lists";
 import * as message_live_update from "./message_live_update";
 import * as message_store from "./message_store";
@@ -257,7 +256,7 @@ export function process_read_messages_event(message_ids) {
     }
 
     for (const message_id of message_ids) {
-        if (message_lists.current === message_list.narrowed) {
+        if (message_lists.current.narrowed) {
             // I'm not sure this entirely makes sense for all server
             // notifications.
             unread.set_messages_read_in_narrow(true);
@@ -285,7 +284,7 @@ export function process_unread_messages_event({message_ids, message_details}) {
         return;
     }
 
-    if (message_lists.current === message_list.narrowed) {
+    if (message_lists.current.narrowed) {
         unread.set_messages_read_in_narrow(false);
     }
 
@@ -354,7 +353,7 @@ export function notify_server_messages_read(messages, options = {}) {
     message_flags.send_read(messages);
 
     for (const message of messages) {
-        if (message_lists.current === message_list.narrowed) {
+        if (message_lists.current.narrowed) {
             unread.set_messages_read_in_narrow(true);
         }
 


### PR DESCRIPTION
Discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/message_lists.2Ecurrent.20vs.20message_list.2Enarrowed

Right now, it only has some of prep commits.