### PR TITLE
draft: Fix vertical ellipsis color on hover.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -503,6 +503,7 @@ body.dark-theme {
     #user_presences li:hover .user-list-sidebar-menu-icon,
     li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
     li.top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,
+    li.top_left_drafts:hover .drafts-sidebar-menu-icon,
     #stream_filters li:hover .stream-sidebar-menu-icon,
     li.topic-list-item:hover .topic-sidebar-menu-icon {
         color: hsl(236, 33%, 80%);
@@ -520,6 +521,7 @@ body.dark-theme {
     #user_presences li .user-list-sidebar-menu-icon:hover,
     .all-messages-sidebar-menu-icon:hover,
     .starred-messages-sidebar-menu-icon:hover,
+    .drafts-sidebar-menu-icon:hover,
     .stream-sidebar-menu-icon:hover,
     .topic-sidebar-menu-icon:hover {
         color: hsl(0, 0%, 100%) !important;


### PR DESCRIPTION
The vertical ellipsis on the "Draft" row in the top left sidebar has a different color on hover than other vertical ellipsis.
This PR fixes that.

## Before
![do](https://user-images.githubusercontent.com/58626718/178547902-4744b5a0-e2ae-4915-bd91-2c005787e514.png)
![d1o](https://user-images.githubusercontent.com/58626718/178548760-0f4259e3-2ef5-45a7-80b0-ba180bab8841.png)

## After
![dn](https://user-images.githubusercontent.com/58626718/178548803-0d7f373e-0520-4935-9473-827df8837fa7.png)
![d1n](https://user-images.githubusercontent.com/58626718/178549057-a5a82dcb-f4da-47a3-9f24-ad94e2f92927.png)

