### PR TITLE
help-docs: Update keyboard keys in left sidebar text.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -59,6 +59,7 @@ function render_code_sections() {
     highlight_current_article();
 
     common.adjust_mac_shortcuts(".markdown .content code", false);
+    common.adjust_mac_shortcuts(".help .sidebar li a code", false);
 
     $("table").each(function () {
         $(this).addClass("table table-striped");

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -216,6 +216,17 @@ html {
             a {
                 color: inherit;
                 display: block;
+
+                /* Allows adjust_mac_shortcuts to update text in left sidebar,
+                but make no other style or visual changes. */
+                code {
+                    color: inherit;
+                    background-color: inherit;
+                    font-size: inherit;
+                    font-family: inherit;
+                    border: 0;
+                    padding: 0;
+                }
             }
         }
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -62,7 +62,7 @@
 * [Mention a user or group](/help/mention-a-user-or-group)
 * [Typing notifications](/help/typing-notifications)
 * [Preview messages before sending](/help/preview-your-message-before-sending)
-* [Enable Enter to send](/help/enable-enter-to-send)
+* [Enable `Enter` to send](/help/enable-enter-to-send)
 * [Verify a message was sent](/help/verify-your-message-was-successfully-sent)
 * [Edit or delete a message](/help/edit-or-delete-a-message)
 * [Message drafts](/help/view-and-edit-your-message-drafts)


### PR DESCRIPTION
Allows for text / titles in the left sidebar of the help center documentation to have keyboard keys as html code elements that will be updated by `adjust_mac_shortcuts` for users with a Mac user agent, but creates a specific CSS rule so that the code elements are the same style as the general left sidebar list anchor elements.

Follow up task from #22344, which updated the help center article `/enable-enter-to-send`.

**Notes**:
- Does not update the text in the browser tab (this seems to be set in the view on the back end, `documentation.py`).
- Added comment to the new CSS rule so there would be context updates / changes.

**Screenshots and screen captures:**

![Screenshot from 2022-07-12 12-13-55](https://user-images.githubusercontent.com/63245456/178552634-6fa3e9e9-3a31-4006-968c-f7ec49819ab9.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
