### PR TITLE
help-docs: Remove `mac-cmd-style` CSS rule.

### DIFF
--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -88,8 +88,8 @@ run_test("adjust_mac_shortcuts non-mac", ({override_rewire}) => {
     common.adjust_mac_shortcuts("selector-that-does-not-exist");
 });
 
-// Test non-default values of adjust_mac_shortcuts boolean parameters:
-// `kbd_elem = false`, and `require_cmd_style = true`.
+// Test non-default value of adjust_mac_shortcuts boolean parameter:
+// `kbd_elem = false`.
 run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
     const keys_to_test_mac = new Map([
         ["Backspace", "Delete"],
@@ -118,7 +118,6 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
         const test_item = {};
         const $stub = $.create("hotkey_" + key_no);
         $stub.text(old_key);
-        assert.equal($stub.hasClass("mac-cmd-key"), false);
         if (fn_shortcuts.has(old_key)) {
             $stub.before = ($elem) => {
                 assert.equal($elem, inserted_fn_key);
@@ -126,7 +125,6 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
         }
         test_item.$stub = $stub;
         test_item.mac_key = mac_key;
-        test_item.is_cmd_key = old_key === "Ctrl";
         test_items.push(test_item);
         key_no += 1;
     }
@@ -135,18 +133,16 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
 
     $.create(".markdown_content", {children});
 
-    const require_cmd = true;
     const kbd_element = false;
-    common.adjust_mac_shortcuts(".markdown_content", kbd_element, require_cmd);
+    common.adjust_mac_shortcuts(".markdown_content", kbd_element);
 
     for (const test_item of test_items) {
-        assert.equal(test_item.$stub.hasClass("mac-cmd-key"), test_item.is_cmd_key);
         assert.equal(test_item.$stub.text(), test_item.mac_key);
     }
 });
 
-// Test default values of adjust_mac_shortcuts boolean parameters:
-// `kbd_elem = true`, and `require_cmd_style = false`.
+// Test default value of adjust_mac_shortcuts boolean parameter:
+// `kbd_elem = true`.
 run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
     const keys_to_test_mac = new Map([
         ["Backspace", "Delete"],
@@ -172,7 +168,6 @@ run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
         const test_item = {};
         const $stub = $.create("hotkey_" + key_no);
         $stub.text(old_key);
-        assert.equal($stub.hasClass("mac-cmd-key"), false);
         if (fn_shortcuts.has(old_key)) {
             $stub.before = ($elem) => {
                 assert.equal($elem, inserted_fn_key);
@@ -191,7 +186,6 @@ run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
     common.adjust_mac_shortcuts(".hotkeys_table kbd");
 
     for (const test_item of test_items) {
-        assert.equal(test_item.$stub.hasClass("mac-cmd-key"), false);
         assert.equal(test_item.$stub.text(), test_item.mac_key);
     }
 });

--- a/static/js/common.ts
+++ b/static/js/common.ts
@@ -48,11 +48,7 @@ export function has_mac_keyboard(): boolean {
     return /mac/i.test(navigator.platform);
 }
 
-export function adjust_mac_shortcuts(
-    key_elem_class: string,
-    kbd_elem = true,
-    require_cmd_style = false,
-): void {
+export function adjust_mac_shortcuts(key_elem_class: string, kbd_elem = true): void {
     if (!has_mac_keyboard()) {
         return;
     }
@@ -79,10 +75,6 @@ export function adjust_mac_shortcuts(
         // any matched element's text that contains whitespace.
         if (/\s/.test(key_text)) {
             return;
-        }
-
-        if (key_text === "Ctrl" && require_cmd_style) {
-            $(this).addClass("mac-cmd-key");
         }
 
         if (fn_shortcuts.has(key_text)) {

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -58,7 +58,7 @@ function render_code_sections() {
 
     highlight_current_article();
 
-    common.adjust_mac_shortcuts(".markdown .content code", false, true);
+    common.adjust_mac_shortcuts(".markdown .content code", false);
 
     $("table").each(function () {
         $(this).addClass("table table-striped");

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -23,11 +23,6 @@ html {
     text-align: center;
 }
 
-.mac-cmd-key {
-    font-size: 15px;
-    font-family: monospace;
-}
-
 .normal {
     font-weight: normal;
 }


### PR DESCRIPTION
Removes the `mac-cmd-style` CSS rule that was introduced in d3e8348 when support for updating keyboard shortcuts with the `Ctrl` key to the Mac cmd key, `⌘`, was added.

Removing the rule makes the font-size and font-family CSS more consistent with other keyboard shortcuts in the documentation.

Also, removes the parameter in `adjust_mac_shortcuts` that added the CSS class / rule to these specific keyboard shortcuts.

**Notes**:
- Preps for a potential update of the style for inline code elements (ideally not code blocks) in the help center and API documentation as the current CSS rules around color, border and font come from bootstrap.
- Due to CSS font selection being very user / browser specific, the screenshots below will be particular to my computer. But these changes move these particular code elements to have a font-family with a generic value to be the same as the specific rule that we are removing.

Follow-up task from #22330.

---

**Screenshots and screen captures:**

### Updated version on Firefox on my computer
![Screenshot from 2022-07-12 19-25-30](https://user-images.githubusercontent.com/63245456/178555026-5891bc52-f586-434c-b2dc-bf577a5b67cc.png)

### Current version on Firefox on my computer
![Screenshot from 2022-07-12 19-26-07](https://user-images.githubusercontent.com/63245456/178555068-16fb553a-b077-4279-9875-c2af4957119b.png)

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
