### PR TITLE
response: Replace json_unauthorized with UnauthorizedError.

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -36,6 +36,7 @@ class ErrorCode(Enum):
     PASSWORD_AUTH_DISABLED = auto()
     PASSWORD_RESET_REQUIRED = auto()
     AUTHENTICATION_FAILED = auto()
+    UNAUTHORIZED = auto()
 
 
 class JsonableError(Exception):
@@ -122,6 +123,28 @@ class JsonableError(Exception):
 
     def __str__(self) -> str:
         return self.msg
+
+
+class UnauthorizedError(JsonableError):
+    code: ErrorCode = ErrorCode.UNAUTHORIZED
+    http_status_code: int = 401
+
+    def __init__(self, msg: Optional[str] = None, www_authenticate: Optional[str] = None) -> None:
+        if msg is None:
+            msg = _("Not logged in: API authentication or user session required")
+        super().__init__(msg)
+        if www_authenticate is None:
+            self.www_authenticate = 'Basic realm="zulip"'
+        elif www_authenticate == "session":
+            self.www_authenticate = 'Session realm="zulip"'
+        else:
+            raise AssertionError("Invalid www_authenticate value!")
+
+    @property
+    def extra_headers(self) -> Dict[str, Any]:
+        extra_headers_dict = super().extra_headers
+        extra_headers_dict["WWW-Authenticate"] = self.www_authenticate
+        return extra_headers_dict
 
 
 class StreamDoesNotExistError(JsonableError):


### PR DESCRIPTION
The purpose of this change is to reuse `JsonableError` and `json_response_from_error` to remove `json_unauthorized`.
This makes it easier for refactoring since errors propagate to the exception handling middleware.

Since the `realm` argument is unused in `HttpResponseUnauthorized`, `WWW_Authenticate` will always have it be `"zulip"` as we did before. This refactoring is designed to be consistent with the previous behavior of `json_unauthorized`. For convenience, the signature of `json_unauthorized` is unchanged.

It is possible that we can refactor `MissingAuthenticationError` to avoid the separate `isinstance` check we have in the middleware, but then there will need to be more changes with `JsonableError` to dynamically set the `WWW_Authenticate` header according to the path (e.g.: set different headers for `/api` and `/json`).

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
