### PR TITLE
keyboard-shortcuts: Add class to arrow keys for Mac shortcuts.

### DIFF
--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -111,6 +111,8 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
 
     override_rewire(common, "has_mac_keyboard", () => true);
 
+    const kbd_element = false;
+
     const test_items = [];
     let key_no = 1;
 
@@ -118,6 +120,7 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
         const test_item = {};
         const $stub = $.create("hotkey_" + key_no);
         $stub.text(old_key);
+        assert.equal($stub.hasClass("arrow-key"), false);
         if (fn_shortcuts.has(old_key)) {
             $stub.before = ($elem) => {
                 assert.equal($elem, inserted_fn_key);
@@ -125,6 +128,7 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
         }
         test_item.$stub = $stub;
         test_item.mac_key = mac_key;
+        test_item.adds_arrow_key = fn_shortcuts.has(old_key) && kbd_element;
         test_items.push(test_item);
         key_no += 1;
     }
@@ -133,11 +137,11 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override_rewire}) => {
 
     $.create(".markdown_content", {children});
 
-    const kbd_element = false;
     common.adjust_mac_shortcuts(".markdown_content", kbd_element);
 
     for (const test_item of test_items) {
         assert.equal(test_item.$stub.text(), test_item.mac_key);
+        assert.equal(test_item.$stub.hasClass("arrow-key"), test_item.adds_arrow_key);
     }
 });
 
@@ -161,6 +165,8 @@ run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
 
     override_rewire(common, "has_mac_keyboard", () => true);
 
+    const kbd_element = true;
+
     const test_items = [];
     let key_no = 1;
 
@@ -168,6 +174,7 @@ run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
         const test_item = {};
         const $stub = $.create("hotkey_" + key_no);
         $stub.text(old_key);
+        assert.equal($stub.hasClass("arrow-key"), false);
         if (fn_shortcuts.has(old_key)) {
             $stub.before = ($elem) => {
                 assert.equal($elem, inserted_fn_key);
@@ -175,6 +182,7 @@ run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
         }
         test_item.$stub = $stub;
         test_item.mac_key = mac_key;
+        test_item.adds_arrow_key = fn_shortcuts.has(old_key) && kbd_element;
         test_items.push(test_item);
         key_no += 1;
     }
@@ -187,6 +195,7 @@ run_test("adjust_mac_shortcuts mac defaults", ({override_rewire}) => {
 
     for (const test_item of test_items) {
         assert.equal(test_item.$stub.text(), test_item.mac_key);
+        assert.equal(test_item.$stub.hasClass("arrow-key"), test_item.adds_arrow_key);
     }
 });
 

--- a/static/js/common.ts
+++ b/static/js/common.ts
@@ -80,6 +80,7 @@ export function adjust_mac_shortcuts(key_elem_class: string, kbd_elem = true): v
         if (fn_shortcuts.has(key_text)) {
             if (kbd_elem) {
                 $(this).before("<kbd>Fn</kbd> + ");
+                $(this).addClass("arrow-key");
             } else {
                 $(this).before("<code>Fn</code> + ");
             }


### PR DESCRIPTION
The `<kbd>` elements in `static.templates.keyboard_shortcuts.hbs` that are arrow keys have a class of "arrow-key". This adds that class to arrow keys that are updated via `adjust_mac_shortcuts`.

Follow-up task due to changes introduced in #22330.

---

**Screenshots and screen captures:**

<details>
<summary>Updated version</summary>

![Screenshot from 2022-07-13 13-34-04](https://user-images.githubusercontent.com/63245456/178735641-86d092d2-3441-4547-bb5b-4484fa84939d.png)
</details>

<details>
<summary>Current version (note the difference between "Previous message" and "Scroll up" arrows)</summary>

![Screenshot from 2022-07-13 13-34-40](https://user-images.githubusercontent.com/63245456/178735653-eda88784-d096-4f42-831f-cceb101c0099.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
