### PR TITLE
keyboard-shortcuts: Document browse back and forward in history.

### DIFF
--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -100,6 +100,7 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override}) => {
         ["PgUp", "↑"],
         ["PgDn", "↓"],
         ["Ctrl", "⌘"],
+        ["Alt", "⌘"],
         ["X + Shift", "X + Shift"],
         ["⌘ + Return", "⌘ + Return"],
         ["Enter or Backspace", "Enter or Backspace"],
@@ -157,6 +158,7 @@ run_test("adjust_mac_shortcuts mac defaults", ({override}) => {
         ["PgUp", "↑"],
         ["PgDn", "↓"],
         ["Ctrl", "⌘"],
+        ["Alt", "⌘"],
         ["[", "["],
         ["X", "X"],
     ]);

--- a/static/js/common.ts
+++ b/static/js/common.ts
@@ -61,6 +61,7 @@ export function adjust_mac_shortcuts(key_elem_class: string, kbd_elem = true): v
         ["PgUp", "↑"],
         ["PgDn", "↓"],
         ["Ctrl", "⌘"],
+        ["Alt", "⌘"],
     ]);
 
     const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -101,6 +101,14 @@
                     <td class="definition">{{t 'First message' }}</td>
                     <td><span class="hotkey"><kbd>Home</kbd></span></td>
                 </tr>
+                <tr>
+                    <td class="definition">{{t 'Go back through viewing history' }}</td>
+                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">←</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Go forward through viewing history' }}</td>
+                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">→</kbd></span></td>
+                </tr>
             </table>
         </div>
         <div>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -67,6 +67,10 @@ below, and add more to your repertoire as needed.
 
 * **Scroll down**: `PgDn`, `J`, or `Spacebar`
 
+* **Go back through viewing history**: `Alt` + `←`
+
+* **Go forward through viewing history**: `Alt` + `→`
+
 ## Narrowing
 
 * **Narrow to next unread topic**: `n`


### PR DESCRIPTION
Documents in [`/help/keyboard-shortcuts`](https://zulip.com/help/keyboard-shortcuts) and in the app `?` menu the shortcuts used by browsers for navigating back and forward through the open tab's history, which are made to work in Zulip.

Also, updates `adjust_mac_shortcuts` to update the shortcut keys for users with Mac user agents.

Fixes #18542.

**Notes**:
- The issue states that the Mac shortcut keys are `Option` + `arrow`. But through testing in Zulip on my Mac (with [Chrome](https://support.google.com/chrome/answer/157179?co=GENIE.Platform%3DDesktop&hl=en#zippy=%2Ctab-and-window-shortcuts), [Safari](https://support.apple.com/guide/safari/keyboard-and-other-shortcuts-cpsh003/mac), [Firefox](https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly#firefox:mac:fx102) and with the desktop app) as well as looking at the keyboard shortcut documentation for those browsers (see links, *note not documented in Safari*), the correct keyboard shortcut seems to be `⌘` + `arrow`.
- I did not explicitly state that these are generally browser shortcuts that Zulip makes work vs Zulip specific shortcuts. I made that choice as I didn't want the documentation to imply that these keyboard shortcuts don't work in the desktop app. But I can see wanting to make that more explicit, perhaps on the help center documentation.

---

**Screenshots and screen captures:**

<details>
<summary>Non-mac keyboard shortcuts</summary>

![Screenshot from 2022-07-13 13-37-12](https://user-images.githubusercontent.com/63245456/178737494-aeab4534-5d82-4041-9cc3-f613402394b1.png)
![Screenshot from 2022-07-13 13-37-34](https://user-images.githubusercontent.com/63245456/178737500-ad0cad93-0093-495d-a2d4-f2d7b7c299b1.png)
</details>

<details>
<summary>Mac keyboard shortcuts</summary>

![Screenshot from 2022-07-13 13-36-40](https://user-images.githubusercontent.com/63245456/178737464-c9e83675-89ad-43a8-aee8-d8158f71dc3f.png)
![Screenshot from 2022-07-13 13-36-18](https://user-images.githubusercontent.com/63245456/178737460-635e9463-f671-4c0e-a769-b97e8429f7ef.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
