### PR TITLE
api-docs: Add note to `/update-message` parameters.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5886,7 +5886,7 @@ paths:
       summary: Edit a message
       tags: ["messages"]
       description: |
-        Edit/update the content or topic of a message.
+        Edit/update the content, topic, or stream of a message.
 
         `PATCH {{ api_url }}/v1/messages/{msg_id}`
 
@@ -5896,9 +5896,8 @@ paths:
         You can [resolve topics](/help/resolve-a-topic) by editing the
         topic to `✔ {original_topic}`.
 
-        **Note**: See [configuring message
-        editing][config-message-editing] for detailed documentation on
-        when users are allowed to edit topics.
+        **Note**: See [configuring message editing][config-message-editing]
+        for detailed documentation on when users are allowed to edit topics.
 
         [config-message-editing]: /help/configure-message-editing-and-deletion
       x-curl-examples-parameters:
@@ -5913,10 +5912,10 @@ paths:
           in: query
           description: |
             The topic to move the message(s) to, to request changing the topic.
+            Maximum length of 60 characters.
+
             Should only be sent when changing the topic, and will throw an error
             if the target message is not a stream message.
-
-            Maximum length of 60 characters.
 
             **Changes**: New in Zulip 2.0. Previous Zulip releases encoded
             this as `subject`, which is currently a deprecated alias.
@@ -5926,12 +5925,14 @@ paths:
         - name: propagate_mode
           in: query
           description: |
-            Which message(s) should be edited: just the one indicated in
-            `message_id`, messages in the same topic that had been sent after this
-            one, or all of them.
+            Which message(s) should be edited:
 
-            Only the default value of `change_one` is valid when
-            editing only the content of a message.
+            - `"change_later"`: The target message and all following messages.
+            - `"change_one"`: Only the target message.
+            - `"change_all"`: All messages in this topic.
+
+            Only the default value of `"change_one"` is valid when editing
+            only the content of a message.
 
             This parameter determines both which messages get moved and also whether
             clients that are currently narrowed to the topic containing the message
@@ -5976,6 +5977,10 @@ paths:
 
             Should only be sent when changing the stream, and will throw an error
             if the target message is not a stream message.
+
+            Note that a message's content and stream cannot be changed at the
+            same time, so sending both `content` and `stream_id` parameters will
+            throw an error.
           schema:
             type: integer
           example: 43
@@ -16251,7 +16256,12 @@ components:
       name: content
       in: query
       description: |
-        The content of the message. Maximum message size of 10000 bytes.
+        The updated content of the target message. Maximum message size of
+        10000 bytes.
+
+        Note that a message's content and stream cannot be changed at the
+        same time, so sending both `content` and `stream_id` parameters will
+        throw an error.
       schema:
         type: string
       example: Hello


### PR DESCRIPTION
Adds a note to the `content` and `stream_id` parameters for the [`/update-message`](https://zulip.com/api/update-message) endpoint that indicates these parameters throw an error when sent in the same request.

Also, updates the main description of the endpoint to include changing a message's stream. And updates some of the parameter descriptions to be more consistent with each other and clear.

[Relevant CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/update.20message.20endpoint/near/1401583)

**Notes**:
- I find the first sentences of the `topic` and `stream_id` parameters to be a bit awkward, but did not land on a better phrasing. They are currently:
  - The topic to move the message(s) to, to request changing the topic.
  - The stream ID to move the message(s) to, to request moving messages to another stream.

---

**Screenshots and screen captures:**

<details>
<summary>Endpoint main description</summary>

![Screenshot from 2022-07-13 16-32-58](https://user-images.githubusercontent.com/63245456/178771852-239504fe-53b8-450f-9d06-ac0b0349670c.png)
</details>

<details>
<summary>Topic and propagate_mode parameters</summary>

![Screenshot from 2022-07-13 16-33-44](https://user-images.githubusercontent.com/63245456/178771861-b620769c-4139-48a5-9ce4-2ed5c87c94ae.png)
</details>

<details>
<summary>Content and stream_id parameters</summary>

![Screenshot from 2022-07-13 16-40-58](https://user-images.githubusercontent.com/63245456/178771862-a3ff03dd-9fff-417e-a1bd-ab95c0ee62ab.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
