### PR TITLE
emoji: Use path converter for emoji name in URL.

### DIFF
--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -123,6 +123,18 @@ class RealmEmojiTest(ZulipTestCase):
             "Emoji names must contain only numbers, lowercase English letters, spaces, dashes, underscores, and periods.",
         )
 
+    def test_forward_slash_exception(self) -> None:
+        self.login("iago")
+        with get_test_image_file("img.png") as fp1:
+            emoji_data = {"f1": fp1}
+            result = self.client_post(
+                "/json/realm/emoji/my/emoji/with/forward/slash/", info=emoji_data
+            )
+        self.assert_json_error(
+            result,
+            "Emoji names must contain only numbers, lowercase English letters, spaces, dashes, underscores, and periods.",
+        )
+
     def test_upload_uppercase_exception(self) -> None:
         self.login("iago")
         with get_test_image_file("img.png") as fp1:

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -258,7 +258,7 @@ v1_api_and_json_patterns = [
     # realm/emoji -> zerver.views.realm_emoji
     rest_path("realm/emoji", GET=list_emoji),
     rest_path(
-        "realm/emoji/<emoji_name>",
+        "realm/emoji/<path:emoji_name>",
         POST=upload_emoji,
         DELETE=(delete_emoji, {"intentionally_undocumented"}),
     ),


### PR DESCRIPTION
Fixes #22377

Reference: https://docs.djangoproject.com/en/4.0/topics/http/urls/#path-converters

![image](https://user-images.githubusercontent.com/58626718/178922684-d9a6d515-4395-4308-9c65-208508a876b5.png)

![image](https://user-images.githubusercontent.com/58626718/178922927-4491dd17-2445-49ff-9109-b068c3384a49.png)
