### PR TITLE
request: Refactor RemoteZulipServer as an attribute of RequestNotes

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -264,7 +264,6 @@ def validate_api_key(
         if get_subdomain(request) != Realm.SUBDOMAIN_FOR_ROOT_DOMAIN:
             raise JsonableError(_("Invalid subdomain for push notifications bouncer"))
         request.user = remote_server
-        remote_server.rate_limits = ""
         # Skip updating UserActivity, since remote_server isn't actually a UserProfile object.
         process_client(request)
         return remote_server

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 import orjson
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
@@ -31,6 +32,9 @@ from zerver.lib.notes import BaseNotes
 from zerver.lib.types import Validator, ViewFuncT
 from zerver.lib.validator import check_anything
 from zerver.models import Client, Realm
+
+if settings.ZILENCER_ENABLED:
+    from zilencer.models import RemoteZulipServer
 
 
 @dataclass
@@ -66,6 +70,7 @@ class RequestNotes(BaseNotes[HttpRequest, "RequestNotes"]):
     tornado_handler_id: Optional[int] = None
     processed_parameters: Set[str] = field(default_factory=set)
     ignored_parameters: Set[str] = field(default_factory=set)
+    remote_server: Optional["RemoteZulipServer"] = None
 
     @classmethod
     def init_notes(cls) -> "RequestNotes":

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -45,7 +45,6 @@ from zerver.lib.avatar import avatar_url
 from zerver.lib.cache import get_cache_backend
 from zerver.lib.db import Params, ParamsT, Query, TimeTrackingCursor
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
-from zerver.lib.notes import BaseNotes
 from zerver.lib.request import RequestNotes
 from zerver.lib.upload import LocalUploadBackend, S3UploadBackend
 from zerver.models import (
@@ -328,7 +327,6 @@ class HostRequestMock(HttpRequest):
         self.user = user_profile or AnonymousUser()
         self._body = b""
         self.content_type = ""
-        BaseNotes[str, str].get_notes
 
         RequestNotes.set_notes(
             self,

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -299,7 +299,8 @@ class HostRequestMock(HttpRequest):
     def __init__(
         self,
         post_data: Dict[str, Any] = {},
-        user_profile: Union[UserProfile, RemoteZulipServer, None] = None,
+        user_profile: Union[UserProfile, None] = None,
+        remote_server: Optional[RemoteZulipServer] = None,
         host: str = settings.EXTERNAL_HOST,
         client_name: Optional[str] = None,
         meta_data: Optional[Dict[str, Any]] = None,
@@ -335,6 +336,7 @@ class HostRequestMock(HttpRequest):
                 log_data={},
                 tornado_handler_id=None if tornado_handler is None else tornado_handler.handler_id,
                 client=get_client(client_name) if client_name is not None else None,
+                remote_server=remote_server,
             ),
         )
 

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -407,9 +407,9 @@ class LogRequests(MiddlewareMixin):
         request_notes = RequestNotes.get_notes(request)
         requestor_for_logs = request_notes.requestor_for_logs
         if requestor_for_logs is None:
-            # Note that request.user is a Union[RemoteZulipServer, UserProfile, AnonymousUser],
-            # if it is present.
-            if hasattr(request.user, "format_requestor_for_logs"):
+            if request_notes.remote_server is not None:
+                requestor_for_logs = request_notes.remote_server.format_requestor_for_logs()
+            elif request.user.is_authenticated:
                 requestor_for_logs = request.user.format_requestor_for_logs()
             else:
                 requestor_for_logs = "unauth@{}".format(get_subdomain(request) or "root")

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -726,7 +726,7 @@ class RateLimitTestCase(ZulipTestCase):
         )
         META = {"REMOTE_ADDR": "3.3.3.3"}
 
-        req = HostRequestMock(client_name="external", user_profile=server, meta_data=META)
+        req = HostRequestMock(client_name="external", remote_server=server, meta_data=META)
 
         f = self.get_ratelimited_view()
 

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -3,12 +3,16 @@ from typing import List
 from unittest.mock import patch
 
 from bs4 import BeautifulSoup
+from django.http import HttpResponse
 
 from zerver.lib.realm_icon import get_realm_icon_url
+from zerver.lib.request import RequestNotes
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import HostRequestMock
 from zerver.lib.utils import assert_is_not_none
-from zerver.middleware import is_slow_query, write_log_line
+from zerver.middleware import LogRequests, is_slow_query, write_log_line
 from zerver.models import get_realm
+from zilencer.models import RemoteZulipServer
 
 
 class SlowQueryTest(ZulipTestCase):
@@ -231,3 +235,34 @@ class OpenGraphTest(ZulipTestCase):
 
         assert isinstance(open_graph_url, str)
         self.assertTrue(open_graph_url.endswith("/api/"))
+
+
+class LogRequestsTest(ZulipTestCase):
+    meta_data = {"REMOTE_ADDR": "127.0.0.1"}
+
+    def test_requestor_for_logs_as_user(self) -> None:
+        hamlet = self.example_user("hamlet")
+        request = HostRequestMock(user_profile=hamlet, meta_data=self.meta_data)
+        RequestNotes.get_notes(request).log_data = None
+
+        with self.assertLogs("zulip.requests", level="INFO") as m:
+            LogRequests(lambda _: HttpResponse())(request)
+            self.assertIn(hamlet.format_requestor_for_logs(), m.output[0])
+
+    def test_requestor_for_logs_as_remote_server(self) -> None:
+        remote_server = RemoteZulipServer()
+        request = HostRequestMock(user_profile=remote_server, meta_data=self.meta_data)
+        RequestNotes.get_notes(request).log_data = None
+
+        with self.assertLogs("zulip.requests", level="INFO") as m:
+            LogRequests(lambda _: HttpResponse())(request)
+            self.assertIn(remote_server.format_requestor_for_logs(), m.output[0])
+
+    def test_requestor_for_logs_unauthenticated(self) -> None:
+        request = HostRequestMock(meta_data=self.meta_data)
+        RequestNotes.get_notes(request).log_data = None
+
+        expected_requestor = "unauth@root"
+        with self.assertLogs("zulip.requests", level="INFO") as m:
+            LogRequests(lambda _: HttpResponse())(request)
+            self.assertIn(expected_requestor, m.output[0])

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -251,7 +251,7 @@ class LogRequestsTest(ZulipTestCase):
 
     def test_requestor_for_logs_as_remote_server(self) -> None:
         remote_server = RemoteZulipServer()
-        request = HostRequestMock(user_profile=remote_server, meta_data=self.meta_data)
+        request = HostRequestMock(remote_server=remote_server, meta_data=self.meta_data)
         RequestNotes.get_notes(request).log_data = None
 
         with self.assertLogs("zulip.requests", level="INFO") as m:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -949,7 +949,7 @@ def check_server_incompatibility(request: HttpRequest) -> bool:
 @csrf_exempt
 def api_get_server_settings(request: HttpRequest) -> HttpResponse:
     # Log which client is making this request.
-    process_client(request, request.user, skip_update_user_activity=True)
+    process_client(request)
     result = dict(
         authentication_methods=get_auth_backends_data(request),
         zulip_version=ZULIP_VERSION,


### PR DESCRIPTION
This eliminates the possibility of having `request.user` as
`RemoteZulipServer` by refactoring it as an attribute of `RequestNotes`.
So we can effectively narrow the type of `request.user` by testing
`user.is_authenticated` in most cases (except that of `SCIMClient`) in
code paths that require access to `.format_requestor_for_logs` where we
previous expect either `UserProfile` or `RemoteZulipServer` backed by
the implied polymorphism.

The change is a follow-up to #22478.

Note that the `hasattr(request, "user")` is required because `LogRequests.process_response` might be called without ever passing through the Django auth middleware.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
