### PR TITLE
backend: Migrate `secret` parameter to REQ framework.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -827,11 +827,11 @@ def is_local_addr(addr: str) -> bool:
 # These views are used by the main Django server to notify the Tornado server
 # of events.  We protect them from the outside world by checking a shared
 # secret, and also the originating IP (for now).
-def authenticate_notify(request: HttpRequest) -> bool:
-    return (
-        is_local_addr(request.META["REMOTE_ADDR"])
-        and request.POST.get("secret") == settings.SHARED_SECRET
-    )
+@has_request_variables
+def authenticate_notify(
+    request: HttpRequest, secret: Optional[str] = REQ("secret", default=None)
+) -> bool:
+    return is_local_addr(request.META["REMOTE_ADDR"]) and secret == settings.SHARED_SECRET
 
 
 def client_is_exempt_from_rate_limiting(request: HttpRequest) -> bool:

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -828,9 +828,7 @@ def is_local_addr(addr: str) -> bool:
 # of events.  We protect them from the outside world by checking a shared
 # secret, and also the originating IP (for now).
 @has_request_variables
-def authenticate_notify(
-    request: HttpRequest, secret: Optional[str] = REQ("secret", default=None)
-) -> bool:
+def authenticate_notify(request: HttpRequest, secret: str = REQ("secret")) -> bool:
     return is_local_addr(request.META["REMOTE_ADDR"]) and secret == settings.SHARED_SECRET
 
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1587,10 +1587,14 @@ class TestInternalNotifyView(ZulipTestCase):
         )
 
         with self.settings(SHARED_SECRET="random"):
-            self.assertFalse(authenticate_notify(request))
-            with self.assertRaises(AccessDeniedError) as context:
+            with self.assertRaises(RequestVariableMissingError) as context:
                 self.internal_notify(True, request)
-            self.assertEqual(context.exception.http_status_code, 403)
+            self.assertEqual(context.exception.http_status_code, 400)
+
+        with self.settings(SHARED_SECRET=None):
+            with self.assertRaises(RequestVariableMissingError) as context:
+                self.internal_notify(True, request)
+            self.assertEqual(context.exception.http_status_code, 400)
 
         secret = "random"
         request = HostRequestMock(

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1581,6 +1581,17 @@ class TestInternalNotifyView(ZulipTestCase):
                 self.internal_notify(False, request)
 
     def test_internal_requests_with_broken_secret(self) -> None:
+        request = HostRequestMock(
+            post_data=dict(data="something"),
+            meta_data=dict(REMOTE_ADDR="127.0.0.1"),
+        )
+
+        with self.settings(SHARED_SECRET="random"):
+            self.assertFalse(authenticate_notify(request))
+            with self.assertRaises(AccessDeniedError) as context:
+                self.internal_notify(True, request)
+            self.assertEqual(context.exception.http_status_code, 403)
+
         secret = "random"
         request = HostRequestMock(
             post_data=dict(secret=secret),

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -15,6 +15,7 @@ from zerver.actions.users import do_change_user_role
 from zerver.lib.event_schema import check_restart_event
 from zerver.lib.events import fetch_initial_state_data
 from zerver.lib.exceptions import AccessDeniedError
+from zerver.lib.request import RequestVariableMissingError
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
     HostRequestMock,
@@ -204,6 +205,14 @@ class EventsEndpointTest(ZulipTestCase):
                 ),
             ).decode(),
         )
+        req = HostRequestMock(post_data, user_profile=None)
+        req.META["REMOTE_ADDR"] = "127.0.0.1"
+        with self.assertRaises(RequestVariableMissingError) as context:
+            result = self.client_post_request("/notify_tornado", req)
+        self.assertEqual(str(context.exception), "Missing 'secret' argument")
+        self.assertEqual(context.exception.http_status_code, 400)
+
+        post_data["secret"] = "random"
         req = HostRequestMock(post_data, user_profile=None)
         req.META["REMOTE_ADDR"] = "127.0.0.1"
         with self.assertRaises(AccessDeniedError) as context:


### PR DESCRIPTION
Instead of using `request.POST` to get any potential `secret` parameter used in `authenticate_notify` for `internal_notify_view` decorator, moves it to the `REQ` framework parameter as `req_secret`.

Updates existing tests to explicitly test for a request without `secret` parameter, which defaults to `None`; this is also tested in `test_event_system.py`, which is how I noticed the omission in `test_decorators.py`.

Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/3-backend/topic/ignored_parameters_unsupported/near/1403986).

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
