### PR TITLE
markdown: Fix rendering of nested objects in API return values.

### DIFF
--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -160,11 +160,21 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                 elif return_values[return_value]["additionalProperties"].get(
                     "additionalProperties", False
                 ):
+                    ans.append(
+                        self.render_desc(
+                            return_values[return_value]["additionalProperties"][
+                                "additionalProperties"
+                            ]["description"],
+                            spacing + 8,
+                            data_type,
+                        )
+                    )
+
                     ans += self.render_table(
                         return_values[return_value]["additionalProperties"]["additionalProperties"][
                             "properties"
                         ],
-                        spacing + 8,
+                        spacing + 12,
                     )
             if (
                 "items" in return_values[return_value]


### PR DESCRIPTION
This fixes the rendering of the description field of nested objects in the OpenAPI data for the return values of an API endpoint.