### PR TITLE
css: Remove transition due to buggy interaction with parent.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -903,7 +903,6 @@ td.pointer {
     .message_control_button {
         opacity: 0;
         visibility: hidden;
-        transition: all 0.2s ease;
         width: 16px;
         text-align: center;
         display: inline-block;


### PR DESCRIPTION
Chrome on mac applies this transition effect to its parent message
when it has an opacity due to compose being open in an interleaved
view. Removing this transition effect fixes it.

This maybe a temporary bug in chrome and will possibly be fixed in
v104.

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/bug.3F.3A.20messages.20fading.20on.20hover
possible chrome issue: https://bugs.chromium.org/p/chromium/issues/detail?id=1343653&q=opacity&can=1

This does remove the transition effect from message_control_buttons, so we can add it back later once it is fixed in chrome.