### PR TITLE
plans: Allow logged out access in development.

### DIFF
--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -413,9 +413,15 @@ class PlansPageTest(ZulipTestCase):
         realm = get_realm("zulip")
         realm.plan_type = Realm.PLAN_TYPE_STANDARD_FREE
         realm.save(update_fields=["plan_type"])
-        result = self.client_get("/plans/", subdomain="zulip")
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/login/?next=/plans")
+
+        with self.settings(PRODUCTION=True):
+            result = self.client_get("/plans/", subdomain="zulip")
+            self.assertEqual(result.status_code, 302)
+            self.assertEqual(result["Location"], "/accounts/login/?next=/plans")
+
+        with self.settings(DEVELOPMENT=True):
+            result = self.client_get("/plans/", subdomain="zulip")
+            self.assert_in_success_response(["Log in"], result)
 
         guest_user = "polonius"
         self.login(guest_user)

--- a/zerver/views/portico.py
+++ b/zerver/views/portico.py
@@ -46,11 +46,11 @@ def plans_view(request: HttpRequest) -> HttpResponse:
     if realm is not None:
         if realm.plan_type == Realm.PLAN_TYPE_SELF_HOSTED and settings.PRODUCTION:
             return HttpResponseRedirect("https://zulip.com/plans")
-        if not request.user.is_authenticated:
+        if not request.user.is_authenticated and settings.PRODUCTION:
             return redirect_to_login(next="/plans")
-        if request.user.is_guest:
+        if request.user.is_authenticated and request.user.is_guest:
             return TemplateResponse(request, "404.html", status=404)
-        if settings.CORPORATE_ENABLED:
+        if request.user.is_authenticated and settings.CORPORATE_ENABLED:
             from corporate.lib.stripe import is_realm_on_free_trial
             from corporate.models import get_customer_by_realm
 


### PR DESCRIPTION
Prior to this, accessing /plans while logged out, redirects you to /login.
based on discussion in https://github.com/zulip/zulip/pull/22472#issuecomment-1184795660