### PR TITLE
models: Use more accurate type annotations for as_sql. 

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -136,7 +136,7 @@ class AndZero(models.Lookup):
 
     def as_sql(
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper
-    ) -> Tuple[str, List[object]]:  # nocoverage # currently only used in migrations
+    ) -> Tuple[str, List[Union[str, int]]]:  # nocoverage # currently only used in migrations
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
         return f"{lhs} & {rhs} = 0", lhs_params + rhs_params
@@ -148,7 +148,7 @@ class AndNonZero(models.Lookup):
 
     def as_sql(
         self, compiler: SQLCompiler, connection: BaseDatabaseWrapper
-    ) -> Tuple[str, List[object]]:  # nocoverage # currently only used in migrations
+    ) -> Tuple[str, List[Union[str, int]]]:  # nocoverage # currently only used in migrations
         lhs, lhs_params = self.process_lhs(compiler, connection)
         rhs, rhs_params = self.process_rhs(compiler, connection)
         return f"{lhs} & {rhs} != 0", lhs_params + rhs_params


### PR DESCRIPTION
This is a follow-up to a recently merged change in django-stubs (https://github.com/typeddjango/django-stubs/pull/1052).

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.
