### PR TITLE
message-editing: Reword move message menu.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1529,7 +1529,7 @@ div.focused_table {
 
 .message_edit_topic_propagate {
     display: inline-block;
-    width: 300px;
+    width: 320px;
     margin-bottom: 15px !important;
     max-width: 100%;
 }

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -31,9 +31,9 @@
                 </div>
             </div>
             <select class='message_edit_topic_propagate' style='display:none;'>
-                <option selected="selected" value="change_later"> {{t "Change later messages to this topic" }}</option>
-                <option value="change_one"> {{t "Change only this message topic" }}</option>
-                <option value="change_all"> {{t "Change previous and following messages to this topic" }}</option>
+                <option selected="selected" value="change_one"> {{t "Move only this message" }}</option>
+                <option value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
+                <option value="change_all"> {{t "Move all messages in this topic" }}</option>
             </select>
         </div>
     </div>

--- a/templates/zerver/help/include/move-content-subset-options.md
+++ b/templates/zerver/help/include/move-content-subset-options.md
@@ -1,8 +1,0 @@
-    - **Change later messages to this topic**, which will move both
-      the selected message and all following messages.
-
-    - **Change only this message topic**, which will only move the
-      selected message.
-
-    - **Change previous and following messages to this topic**, which
-      will move all messages in the topic.

--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -57,9 +57,7 @@ destination streams.
 
 1. Toggle whether automated notification messages should be sent.
 
-1. From the dropdown menu, select which messages to move:
-
-{!move-content-subset-options.md!}
+1. From the dropdown menu, select which messages to move.
 
 1. Click **Save**.
 

--- a/templates/zerver/help/move-content-to-another-topic.md
+++ b/templates/zerver/help/move-content-to-another-topic.md
@@ -28,9 +28,7 @@ for the details on when topic editing is allowed.
 
 1. Set the destination topic.
 
-1. From the dropdown menu, select which messages to move:
-
-{!move-content-subset-options.md!}
+1. From the dropdown menu, select which messages to move.
 
 1. Click **Save**.
 


### PR DESCRIPTION
This rewords the move message dropdown menu.
![tmp](https://user-images.githubusercontent.com/74348920/179277404-80e29a2c-78a6-4e39-a1c1-40e87f4ae17f.png)

I also updated the width off the dropdown menu a bit to account for the new wording, adapted the order of the options and updated the help pages.
