### PR TITLE
puppet: Tell needrestart to not default to restarting core services.

### DIFF
--- a/puppet/zulip_ops/files/needrestart/zulip.conf
+++ b/puppet/zulip_ops/files/needrestart/zulip.conf
@@ -1,0 +1,11 @@
+# -*-cperl-*-
+my @ignore = (
+    qr/^memcached\.service$/,
+    qr/^nginx\.service$/,
+    qr/^postgresql(@[0-9a-zA-Z_-]+)?.service$/,
+    qr/^rabbitmq-server\.service$/,
+    qr/^redis-server\.service$/,
+    qr/^supervisor\.service$/,
+);
+
+$nrconf{override_rc}{$_} = 0 for @ignore;

--- a/puppet/zulip_ops/manifests/profile/base.pp
+++ b/puppet/zulip_ops/manifests/profile/base.pp
@@ -51,6 +51,13 @@ class zulip_ops::profile::base {
     mode   => '0644',
     source => 'puppet:///modules/zulip_ops/apt/apt.conf.d/50unattended-upgrades',
   }
+  if $::os['distro']['release']['major'] == '22.04' {
+    file { '/etc/needrestart/conf.d/zulip.conf':
+      ensure => file,
+      mode   => '0644',
+      source => 'puppet:///modules/zulip_ops/needrestart/zulip.conf',
+    }
+  }
 
   file { '/home/zulip/.ssh':
     ensure  => directory,


### PR DESCRIPTION
The `needrestart` tool added in 22.04 is useful in terms of listing
which services may need to be restarted to pick up updated libraries.
However, it prompts about the current state of services needing
restart for *every* subsequent `apt-get upgrade`, and defaulting core
services to restarting requires carefully manually excluding them
every time, at risk of causing an unscheduled outage.

Build a list of default-off services based on the list in
unattended-upgrades.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
