### PR TITLE
api: Document /realm/presence API endpoint.

### DIFF
--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -54,6 +54,7 @@
 * [Deactivate own user](/api/deactivate-own-user)
 * [Set "typing" status](/api/set-typing-status)
 * [Get user presence](/api/get-user-presence)
+* [Get presence of all the users](/api/get-presence)
 * [Get attachments](/api/get-attachments)
 * [Delete an attachment](/api/remove-attachment)
 * [Update settings](/api/update-settings)

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -160,11 +160,24 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                 elif return_values[return_value]["additionalProperties"].get(
                     "additionalProperties", False
                 ):
+                    data_type = generate_data_type(
+                        return_values[return_value]["additionalProperties"]["additionalProperties"]
+                    )
+                    ans.append(
+                        self.render_desc(
+                            return_values[return_value]["additionalProperties"][
+                                "additionalProperties"
+                            ]["description"],
+                            spacing + 8,
+                            data_type,
+                        )
+                    )
+
                     ans += self.render_table(
                         return_values[return_value]["additionalProperties"]["additionalProperties"][
                             "properties"
                         ],
-                        spacing + 8,
+                        spacing + 12,
                     )
             if (
                 "items" in return_values[return_value]

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -144,6 +144,16 @@ def test_authorization_errors_fatal(client: Client, nonadmin_client: Client) -> 
     validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "400")
 
 
+@openapi_test_function("/realm/presence:get")
+def get_presence(client: Client) -> None:
+
+    # {code_example|start}
+    # Get presence information of all the users in an organization.
+    result = client.get_realm_presence()
+    # {code_example|end}
+    validate_against_openapi_schema(result, "/realm/presence", "get", "200")
+
+
 @openapi_test_function("/users/{user_id_or_email}/presence:get")
 def get_user_presence(client: Client) -> None:
 
@@ -1489,6 +1499,7 @@ def test_users(client: Client, owner_client: Client) -> None:
     set_typing_status(client)
     update_presence(client)
     get_user_presence(client)
+    get_presence(client)
     create_user_group(client)
     user_group_id = get_user_groups(client)
     update_user_group(client, user_group_id)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7647,6 +7647,74 @@ paths:
                               },
                           },
                       }
+  /realm/presence:
+    get:
+      operationId: get-presence
+      summary: Get presence of all the users
+      tags: ["server_and_organizations"]
+      description: |
+        Get the presence information of all the users in an organization.
+
+        See
+        [Zulip's developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/presence.html)
+        for details on the data model for presence in Zulip.
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      server_timestamp:
+                        type: number
+                        description: |
+                          The time when the server fetched the `presences` data included
+                          in the response.
+                      presences:
+                        type: object
+                        description: |
+                          An object that contains `presence` objects for all the users,
+                          each identified by user email as the key.
+                        additionalProperties:
+                          type: object
+                          description: |
+                            `{user_email}`: Object containing details of a user's presence
+                            on every client the user is logged into. The keys for these
+                            objects are the emails of the different users whose presence
+                            data is included.
+                          additionalProperties:
+                            $ref: "#/components/schemas/Presence"
+                    example:
+                      {
+                        "msg": "",
+                        "presences":
+                          {
+                            "iago@zulip.com":
+                              {
+                                "ZulipPython":
+                                  {
+                                    "client": "ZulipPython",
+                                    "pushable": false,
+                                    "status": "active",
+                                    "timestamp": 1656958485,
+                                  },
+                                "aggregated":
+                                  {
+                                    "client": "ZulipPython",
+                                    "status": "active",
+                                    "timestamp": 1656958485,
+                                  },
+                              },
+                          },
+                        "result": "success",
+                        "server_timestamp": 1656958539.6287155,
+                      }
   /realm/profile_fields:
     get:
       operationId: get-custom-profile-fields

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -205,7 +205,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
     checked_endpoints: Set[str] = set()
     pending_endpoints = {
         #### TODO: These endpoints are a priority to document:
-        "/realm/presence",
         "/users/me/presence",
         "/users/me/alert_words",
         # These are a priority to document but don't match our normal URL schemes


### PR DESCRIPTION
This documents the `/realm/presence` API endpoint and fixes a bug in `render_table` that causes the description of nested objects in the response schema to not get rendered.