### PR TITLE
decorator: Move tornado notify `data` parameter to REQ framework.

### DIFF
--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -227,6 +227,14 @@ class EventsEndpointTest(ZulipTestCase):
         result = self.client_post_request("/notify_tornado", req)
         self.assert_json_success(result)
 
+        post_data = dict(secret=settings.SHARED_SECRET)
+        req = HostRequestMock(post_data, tornado_handler=dummy_handler)
+        req.META["REMOTE_ADDR"] = "127.0.0.1"
+        with self.assertRaises(RequestVariableMissingError) as context:
+            result = self.client_post_request("/notify_tornado", req)
+        self.assertEqual(str(context.exception), "Missing 'data' argument")
+        self.assertEqual(context.exception.http_status_code, 400)
+
 
 class GetEventsTest(ZulipTestCase):
     def tornado_call(

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -1,7 +1,6 @@
 import time
-from typing import Callable, Optional, Sequence, TypeVar
+from typing import Any, Callable, Mapping, Optional, Sequence, TypeVar
 
-import orjson
 from asgiref.sync import async_to_sync
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
@@ -13,6 +12,7 @@ from zerver.lib.request import REQ, RequestNotes, has_request_variables
 from zerver.lib.response import AsynchronousResponse, json_success
 from zerver.lib.validator import (
     check_bool,
+    check_dict,
     check_int,
     check_list,
     check_string,
@@ -34,8 +34,11 @@ def in_tornado_thread(f: Callable[P, T]) -> Callable[P, T]:
 
 
 @internal_notify_view(True)
-def notify(request: HttpRequest) -> HttpResponse:
-    in_tornado_thread(process_notification)(orjson.loads(request.POST["data"]))
+@has_request_variables
+def notify(
+    request: HttpRequest, data: Mapping[str, Any] = REQ(json_validator=check_dict([]))
+) -> HttpResponse:
+    in_tornado_thread(process_notification)(data)
     return json_success(request)
 
 


### PR DESCRIPTION
Instead of using `request.POST` to access the `data` parameter used in the internal `notify_tornado` path, adds `has_request_variables` decorator and accesses `data` as a `REQ` parameter.

Expands `test_tornado_endpoint` in `test_event_system.py` for `data` being a required parameter for this path.

Builds on #22481. Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/3-backend/topic/ignored_parameters_unsupported/near/1404272).

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
