### PR TITLE
cache: Use getattr to access _cache.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -6,6 +6,7 @@ import shutil
 from mimetypes import guess_type
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+import bmemcached
 import orjson
 from bs4 import BeautifulSoup
 from django.conf import settings
@@ -876,7 +877,9 @@ def import_uploads(
                 process_avatars(record)
         else:
             connection.close()
-            cache._cache.disconnect_all()
+            _cache = getattr(cache, "_cache")
+            assert isinstance(_cache, bmemcached.Client)
+            _cache.disconnect_all()
             with multiprocessing.Pool(processes) as p:
                 for out in p.imap_unordered(process_avatars, records):
                     pass

--- a/zerver/lib/transfer.py
+++ b/zerver/lib/transfer.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 from mimetypes import guess_type
 
+import bmemcached
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
@@ -40,7 +41,9 @@ def transfer_avatars_to_s3(processes: int) -> None:
             _transfer_avatar_to_s3(user)
     else:  # nocoverage
         connection.close()
-        cache._cache.disconnect_all()
+        _cache = getattr(cache, "_cache")
+        assert isinstance(_cache, bmemcached.Client)
+        _cache.disconnect_all()
         with multiprocessing.Pool(processes) as p:
             for out in p.imap_unordered(_transfer_avatar_to_s3, users):
                 pass
@@ -71,7 +74,9 @@ def transfer_message_files_to_s3(processes: int) -> None:
             _transfer_message_files_to_s3(attachment)
     else:  # nocoverage
         connection.close()
-        cache._cache.disconnect_all()
+        _cache = getattr(cache, "_cache")
+        assert isinstance(_cache, bmemcached.Client)
+        _cache.disconnect_all()
         with multiprocessing.Pool(processes) as p:
             for out in p.imap_unordered(_transfer_message_files_to_s3, attachments):
                 pass
@@ -101,7 +106,9 @@ def transfer_emoji_to_s3(processes: int) -> None:
             _transfer_emoji_to_s3(realm_emoji)
     else:  # nocoverage
         connection.close()
-        cache._cache.disconnect_all()
+        _cache = getattr(cache, "_cache")
+        assert isinstance(_cache, bmemcached.Client)
+        _cache.disconnect_all()
         with multiprocessing.Pool(processes) as p:
             for out in p.imap_unordered(_transfer_emoji_to_s3, realm_emojis):
                 pass

--- a/zilencer/management/commands/mark_all_messages_unread.py
+++ b/zilencer/management/commands/mark_all_messages_unread.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import bmemcached
 from django.conf import settings
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
@@ -14,4 +15,6 @@ class Command(BaseCommand):
     def handle(self, *args: Any, **options: Any) -> None:
         assert settings.DEVELOPMENT
         UserMessage.objects.all().update(flags=F("flags").bitand(~UserMessage.flags.read))
-        cache._cache.flush_all()
+        _cache = getattr(cache, "_cache")
+        assert isinstance(_cache, bmemcached.Client)
+        _cache.flush_all()


### PR DESCRIPTION
`_cache` is not an attribute defined on `BaseCache`, but an
implementation detail of django_bmemcache.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
