### PR TITLE
muting: Add validation for update options.

### DIFF
--- a/zerver/views/muting.py
+++ b/zerver/views/muting.py
@@ -21,7 +21,7 @@ from zerver.lib.streams import (
 from zerver.lib.user_mutes import get_mute_object
 from zerver.lib.user_topics import topic_is_muted
 from zerver.lib.users import access_user_by_id
-from zerver.lib.validator import check_int
+from zerver.lib.validator import check_int, check_string_in
 from zerver.models import UserProfile
 
 
@@ -71,7 +71,7 @@ def update_muted_topic(
     stream_id: Optional[int] = REQ(json_validator=check_int, default=None),
     stream: Optional[str] = REQ(default=None),
     topic: str = REQ(),
-    op: str = REQ(),
+    op: str = REQ(str_validator=check_string_in(["add", "remove"])),
 ) -> HttpResponse:
 
     check_for_exactly_one_stream_arg(stream_id=stream_id, stream=stream)
@@ -84,7 +84,6 @@ def update_muted_topic(
             topic_name=topic,
             date_muted=timezone_now(),
         )
-        return json_success(request)
     elif op == "remove":
         unmute_topic(
             user_profile=user_profile,
@@ -92,7 +91,7 @@ def update_muted_topic(
             stream_name=stream,
             topic_name=topic,
         )
-        return json_success(request)
+    return json_success(request)
 
 
 def mute_user(request: HttpRequest, user_profile: UserProfile, muted_user_id: int) -> HttpResponse:


### PR DESCRIPTION
This adds a `check_string_in` validator to ensure that `op` is actually
valid before we finally return `json_success()`.

For this change, I am unsure about whether we should add a test case or not. Do we generally test `check_string_in` before?

Affected mypy errors:
```diff
5c5
< Found 206 errors in 74 files (checked 1400 source files)
---
> Found 205 errors in 73 files (checked 1400 source files)
222d221
< zerver/views/muting.py error Missing return statement  [return]
```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
