### PR TITLE
storage: Fix type annotation for storage

### DIFF
--- a/zerver/lib/storage.py
+++ b/zerver/lib/storage.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+from django.core.files.base import File
 from django.core.files.storage import FileSystemStorage
 
 if settings.DEBUG:
@@ -22,7 +23,7 @@ else:
 
 class IgnoreBundlesManifestStaticFilesStorage(ManifestStaticFilesStorage):
     def hashed_name(
-        self, name: str, content: Optional[str] = None, filename: Optional[str] = None
+        self, name: str, content: Optional["File[bytes]"] = None, filename: Optional[str] = None
     ) -> str:
         ext = os.path.splitext(name)[1]
         if name.startswith("webpack-bundles"):


### PR DESCRIPTION
This fixes some errors related to paths and files in `zerver.lib.storage`.

Affected errors:

```diff
5c5
< Found 199 errors in 70 files (checked 1404 source files)
---
> Found 198 errors in 70 files (checked 1404 source files)
100,103c100
< zerver/lib/storage.py error Argument 2 of "hashed_name" is incompatible with supertype "HashedFilesMixin"; supertype defines the argument type as "Optional[File[Any]]"  [override]
< zerver/lib/storage.py note See https//mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
< zerver/lib/storage.py note This violates the Liskov substitution principle
< zerver/lib/storage.py error Argument 2 to "hashed_name" of "HashedFilesMixin" has incompatible type "Optional[str]"; expected "Optional[File[Any]]"  [arg-type]
```

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
