### PR TITLE
translation: Translate new user messages to realm's default language.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -77,14 +77,16 @@ def create_historical_user_messages(*, user_id: int, message_ids: List[int]) -> 
 
 
 def send_message_to_signup_notification_stream(
-    sender: UserProfile, realm: Realm, message: str, topic_name: str = _("signups")
+    sender: UserProfile, realm: Realm, message: str
 ) -> None:
     signup_notifications_stream = realm.get_signup_notifications_stream()
     if signup_notifications_stream is None:
         return
 
     with override_language(realm.default_language):
-        internal_send_stream_message(sender, signup_notifications_stream, topic_name, message)
+        topic_name = _("signups")
+
+    internal_send_stream_message(sender, signup_notifications_stream, topic_name, message)
 
 
 def notify_new_user(user_profile: UserProfile) -> None:
@@ -94,9 +96,10 @@ def notify_new_user(user_profile: UserProfile) -> None:
 
     is_first_user = user_count == 1
     if not is_first_user:
-        message = _("{user} just signed up for Zulip. (total: {user_count})").format(
-            user=silent_mention_syntax_for_user(user_profile), user_count=user_count
-        )
+        with override_language(user_profile.realm.default_language):
+            message = _("{user} just signed up for Zulip. (total: {user_count})").format(
+                user=silent_mention_syntax_for_user(user_profile), user_count=user_count
+            )
 
         if settings.BILLING_ENABLED:
             from corporate.lib.registration import generate_licenses_low_warning_message_if_required
@@ -117,9 +120,10 @@ def notify_new_user(user_profile: UserProfile) -> None:
         # Check whether the stream exists
         signups_stream = get_signups_stream(admin_realm)
         # We intentionally use the same strings as above to avoid translation burden.
-        message = _("{user} just signed up for Zulip. (total: {user_count})").format(
-            user=f"{user_profile.full_name} <`{user_profile.email}`>", user_count=user_count
-        )
+        with override_language(admin_realm.default_language):
+            message = _("{user} just signed up for Zulip. (total: {user_count})").format(
+                user=f"{user_profile.full_name} <`{user_profile.email}`>", user_count=user_count
+            )
         internal_send_stream_message(
             admin_realm_sender, signups_stream, user_profile.realm.display_subdomain, message
         )


### PR DESCRIPTION
Previously, automated stream messages for new user signups were not being translated into the realm's default language for said messages.

Moves `override_language` context manager so that it wraps the new user message content in `notify_new_user` and topic string in `send_message_to_signup_notification_stream`.

Fixes #22510. Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/9-issues/topic/Notification.20Bot.20language.20.2322510/near/1406526)

Manually tested in the development environment.

**Screenshots and screen captures:**

![Screenshot from 2022-07-20 12-10-49](https://user-images.githubusercontent.com/63245456/179964709-a40da8e5-fadc-4181-9bce-fbcc275631c6.png)

<details>
<summary>GIF of adding new users and changing the organization language setting</summary>

![Peek 2022-07-20 12-07](https://user-images.githubusercontent.com/63245456/179964869-8be66507-eff8-4d2e-bc32-ce7d7dbc7518.gif)
</details>

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
