### PR TITLE
provision: Avoid distutils; keep PROVISION_VERSION as a tuple

### DIFF
--- a/docs/subsystems/dependencies.md
+++ b/docs/subsystems/dependencies.md
@@ -43,7 +43,7 @@ In `version.py`, we have a special parameter, `PROVISION_VERSION`,
 which is used to help ensure developers don't spend time debugging
 test/linter/etc. failures that actually were caused by the developer
 rebasing and forgetting to provision". `PROVISION_VERSION` has a
-format of `x.y`; when `x` doesn't match the value from the last time
+format of `(x, y)`; when `x` doesn't match the value from the last time
 the user provisioned, or `y` is higher than the value from last
 time, most Zulip tools will crash early and ask the user to provision.
 This has empirically made a huge impact on how often developers spend

--- a/tools/diagnose
+++ b/tools/diagnose
@@ -76,12 +76,12 @@ def check_django() -> bool:
 def provision_version() -> bool:
     fn = os.path.join(UUID_VAR_PATH, "provision_version")
     with open(fn) as f:
-        version = f.read().strip()
+        version = tuple(map(int, f.read().strip().split(".")))
     print("latest version provisioned:", version)
     from version import PROVISION_VERSION
 
     print("desired version:", PROVISION_VERSION)
-    if version != PROVISION_VERSION:
+    if not (PROVISION_VERSION <= version < (PROVISION_VERSION[0] + 1,)):
         print("You need to provision!")
         return False
     return True

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -362,7 +362,7 @@ def main(options: argparse.Namespace) -> int:
     version_file = os.path.join(UUID_VAR_PATH, "provision_version")
     print(f"writing to {version_file}\n")
     with open(version_file, "w") as f:
-        f.write(PROVISION_VERSION + "\n")
+        f.write(".".join(map(str, PROVISION_VERSION)) + "\n")
 
     print()
     print(OKBLUE + "Zulip development environment setup succeeded!" + ENDC)

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 133
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = "195.0"
+PROVISION_VERSION = (195, 0)


### PR DESCRIPTION
distutils is deprecated in Python 3.10 and will be removed in Python 3.12. We don’t need a full-powered version parser for this anyway.

Context: https://chat.zulip.org/#narrow/stream/3-backend/topic/.22Obsolete.22.20Python.20Libraries/near/1407615