### PR TITLE
realm_audit_log: Explicitly stringify dict before insertion.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -633,7 +633,7 @@ def do_change_remote_server_plan_type(remote_server: RemoteZulipServer, plan_typ
         event_type=RealmAuditLog.REMOTE_SERVER_PLAN_TYPE_CHANGED,
         server=remote_server,
         event_time=timezone_now(),
-        extra_data={"old_value": old_value, "new_value": plan_type},
+        extra_data=str({"old_value": old_value, "new_value": plan_type}),
     )
 
 
@@ -951,7 +951,7 @@ def attach_discount_to_realm(
         acting_user=acting_user,
         event_type=RealmAuditLog.REALM_DISCOUNT_CHANGED,
         event_time=timezone_now(),
-        extra_data={"old_discount": old_discount, "new_discount": discount},
+        extra_data=str({"old_discount": old_discount, "new_discount": discount}),
     )
 
 
@@ -966,9 +966,7 @@ def update_sponsorship_status(
         acting_user=acting_user,
         event_type=RealmAuditLog.REALM_SPONSORSHIP_PENDING_STATUS_CHANGED,
         event_time=timezone_now(),
-        extra_data={
-            "sponsorship_pending": sponsorship_pending,
-        },
+        extra_data=str({"sponsorship_pending": sponsorship_pending}),
     )
 
 
@@ -1213,7 +1211,5 @@ def update_billing_method_of_current_plan(
             acting_user=acting_user,
             event_type=RealmAuditLog.REALM_BILLING_METHOD_CHANGED,
             event_time=timezone_now(),
-            extra_data={
-                "charge_automatically": charge_automatically,
-            },
+            extra_data=str({"charge_automatically": charge_automatically}),
         )

--- a/zerver/actions/create_realm.py
+++ b/zerver/actions/create_realm.py
@@ -57,7 +57,7 @@ def do_change_realm_subdomain(
             event_type=RealmAuditLog.REALM_SUBDOMAIN_CHANGED,
             event_time=timezone_now(),
             acting_user=acting_user,
-            extra_data={"old_subdomain": old_subdomain, "new_subdomain": new_subdomain},
+            extra_data=str({"old_subdomain": old_subdomain, "new_subdomain": new_subdomain}),
         )
 
         # If a realm if being renamed multiple times, we should find all the placeholder

--- a/zerver/actions/realm_icon.py
+++ b/zerver/actions/realm_icon.py
@@ -20,7 +20,7 @@ def do_change_icon_source(
     RealmAuditLog.objects.create(
         realm=realm,
         event_type=RealmAuditLog.REALM_ICON_SOURCE_CHANGED,
-        extra_data={"icon_source": icon_source, "icon_version": realm.icon_version},
+        extra_data=str({"icon_source": icon_source, "icon_version": realm.icon_version}),
         event_time=event_time,
         acting_user=acting_user,
     )

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -400,7 +400,7 @@ def do_change_realm_org_type(
         realm=realm,
         event_time=timezone_now(),
         acting_user=acting_user,
-        extra_data={"old_value": old_value, "new_value": org_type},
+        extra_data=str({"old_value": old_value, "new_value": org_type}),
     )
 
     event = dict(type="realm", op="update", property="org_type", value=org_type)
@@ -419,7 +419,7 @@ def do_change_realm_plan_type(
         realm=realm,
         event_time=timezone_now(),
         acting_user=acting_user,
-        extra_data={"old_value": old_value, "new_value": plan_type},
+        extra_data=str({"old_value": old_value, "new_value": plan_type}),
     )
 
     if plan_type == Realm.PLAN_TYPE_PLUS:

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -300,7 +300,7 @@ def do_change_avatar_fields(
         realm=user_profile.realm,
         modified_user=user_profile,
         event_type=RealmAuditLog.USER_AVATAR_SOURCE_CHANGED,
-        extra_data={"avatar_source": avatar_source},
+        extra_data=str({"avatar_source": avatar_source}),
         event_time=event_time,
         acting_user=acting_user,
     )


### PR DESCRIPTION
`extra_data` as a `TextField` expects a `str`, but we had been passing
`dict` instead.

Affected errors:

```diff
5c5
< Found 199 errors in 70 files (checked 1404 source files)
---
> Found 190 errors in 65 files (checked 1404 source files)
7,10d6
< corporate/lib/stripe.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
< corporate/lib/stripe.py error Incompatible type for "extra_data" of "RemoteZulipServerAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
< corporate/lib/stripe.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
< corporate/lib/stripe.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
19d14
< zerver/actions/create_realm.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
22,24d16
< zerver/actions/realm_icon.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
< zerver/actions/realm_settings.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
< zerver/actions/realm_settings.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
38d29
< zerver/actions/user_settings.py error Incompatible type for "extra_data" of "RealmAuditLog" (got "Dict[Any, Any]", expected "Union[str, Combinable, None]")  [misc]
```
**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
