### PR TITLE
Rocketchat import fixes

### DIFF
--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -370,6 +370,10 @@ def process_message_attachment(
         logging.info("Skipping unknown attachment of message_id: %s", message_id)
         return "", False
 
+    if "type" not in upload:  # nocoverage
+        logging.info("Skipping attachment without type of message_id: %s", message_id)
+        return "", False
+
     upload_file_data = upload_id_to_upload_data_map[upload["_id"]]
     file_name = upload["name"]
     file_ext = f'.{upload["type"].split("/")[-1]}'

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -769,6 +769,9 @@ def process_messages(
                 parent_stream_name = get_stream_name(parent_rc_channel)
 
                 zulip_mention = f"#**{parent_stream_name}>{converted_topic_name}**"
+            else:  # nocoverage
+                logging.info("Failed to map mention '%s' to zulip syntax.", mention)
+                continue
 
             mention_data = {"rc_mention": rc_mention, "zulip_mention": zulip_mention}
             rc_channel_mention_data.append(mention_data)

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -634,6 +634,11 @@ def process_messages(
             usernames = reactions[react_code]["usernames"]
 
             for username in usernames:
+                if username not in username_to_user_id_map:  # nocoverage
+                    # This can happen with production data when old user names no longer exist. We cannot do
+                    # much about it here so we just ignore the unknown user name.
+                    continue
+
                 rc_user_id = username_to_user_id_map[username]
                 user_id = user_id_mapper.get(rc_user_id)
                 reactions_list.append({"name": name, "user_id": user_id})

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -135,11 +135,22 @@ def process_users(
             bot_user["bot_owner"] = realm_owners[0]
 
 
+def truncate_name(name: str, name_id: int, max_length: int = 60) -> str:
+    if len(name) > max_length:
+        name_id_suffix = f" [{name_id}]"
+        name = name[0 : max_length - len(name_id_suffix)] + name_id_suffix
+    return name
+
+
 def get_stream_name(rc_channel: Dict[str, Any]) -> str:
     if rc_channel.get("teamMain"):
-        return f'[TEAM] {rc_channel["name"]}'
+        stream_name = f'[TEAM] {rc_channel["name"]}'
     else:
-        return rc_channel["name"]
+        stream_name = rc_channel["name"]
+
+    stream_name = truncate_name(stream_name, rc_channel["_id"])
+
+    return stream_name
 
 
 def convert_channel_data(
@@ -575,15 +586,15 @@ def get_topic_name(
         return ""
     elif message["rid"] in dsc_id_to_dsc_map:
         dsc_channel_name = dsc_id_to_dsc_map[message["rid"]]["fname"]
-        return f"{dsc_channel_name} (Imported from Rocket.Chat)"
+        return truncate_name(f"{dsc_channel_name} (Imported from Rocket.Chat)", message["rid"])
     elif message.get("replies"):
         # Message is the start of a thread
         thread_id = thread_id_mapper.get(message["_id"])
-        return f"Thread {thread_id} (Imported from Rocket.Chat)"
+        return truncate_name(f"Thread {thread_id} (Imported from Rocket.Chat)", message["_id"])
     elif message.get("tmid"):
         # Message is a part of a thread
         thread_id = thread_id_mapper.get(message["tmid"])
-        return f"Thread {thread_id} (Imported from Rocket.Chat)"
+        return truncate_name(f"Thread {thread_id} (Imported from Rocket.Chat)", message["tmid"])
     else:
         # Normal channel message
         return "Imported from Rocket.Chat"

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -366,6 +366,10 @@ def process_message_attachment(
     upload_id_to_upload_data_map: Dict[str, Dict[str, Any]],
     output_dir: str,
 ) -> Tuple[str, bool]:
+    if upload["_id"] not in upload_id_to_upload_data_map:  # nocoverage
+        logging.info("Skipping unknown attachment of message_id: %s", message_id)
+        return "", False
+
     upload_file_data = upload_id_to_upload_data_map[upload["_id"]]
     file_name = upload["name"]
     file_ext = f'.{upload["type"].split("/")[-1]}'

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -648,7 +648,15 @@ def process_messages(
     def message_to_dict(message: Dict[str, Any]) -> Dict[str, Any]:
         rc_sender_id = message["u"]["_id"]
         sender_id = user_id_mapper.get(rc_sender_id)
-        content = message["msg"]
+        if "msg" in message:
+            content = message["msg"]
+        else:  # nocoverage
+            content = "This message imported from Rocket.Chat had no body in the data export."
+            logging.info(
+                "Message %s contains no message content: %s",
+                message["_id"],
+                message,
+            )
 
         if message.get("reactions"):
             reactions = list_reactions(message["reactions"])

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -21,6 +21,7 @@ from zerver.data_import.rocketchat import (
     process_users,
     rocketchat_data_to_dict,
     separate_channel_private_and_livechat_messages,
+    truncate_name,
 )
 from zerver.data_import.sequencer import IdMapper
 from zerver.data_import.user_handler import UserHandler
@@ -1031,3 +1032,8 @@ class RocketChatImporter(ZulipTestCase):
         )
 
         self.verify_emoji_code_foreign_keys()
+
+    def test_truncate_name(self) -> None:
+        self.assertEqual("foobar", truncate_name("foobar", 42, 60))
+
+        self.assertEqual("1234567890 [42]", truncate_name("12345678901234567890", 42, 15))

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -189,15 +189,16 @@ class RocketChatImporter(ZulipTestCase):
         huddle_id_to_huddle_map: Dict[str, Dict[str, Any]] = {}
         livechat_id_to_livechat_map: Dict[str, Dict[str, Any]] = {}
 
-        categorize_channels_and_map_with_id(
-            channel_data=rocketchat_data["room"],
-            room_id_to_room_map=room_id_to_room_map,
-            team_id_to_team_map=team_id_to_team_map,
-            dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
-            huddle_id_to_huddle_map=huddle_id_to_huddle_map,
-            livechat_id_to_livechat_map=livechat_id_to_livechat_map,
-        )
+        with self.assertLogs(level="INFO"):
+            categorize_channels_and_map_with_id(
+                channel_data=rocketchat_data["room"],
+                room_id_to_room_map=room_id_to_room_map,
+                team_id_to_team_map=team_id_to_team_map,
+                dsc_id_to_dsc_map=dsc_id_to_dsc_map,
+                direct_id_to_direct_map=direct_id_to_direct_map,
+                huddle_id_to_huddle_map=huddle_id_to_huddle_map,
+                livechat_id_to_livechat_map=livechat_id_to_livechat_map,
+            )
 
         self.assert_length(rocketchat_data["room"], 16)
         # Teams are a subset of rooms.
@@ -246,15 +247,16 @@ class RocketChatImporter(ZulipTestCase):
         huddle_id_to_huddle_map: Dict[str, Dict[str, Any]] = {}
         livechat_id_to_livechat_map: Dict[str, Dict[str, Any]] = {}
 
-        categorize_channels_and_map_with_id(
-            channel_data=rocketchat_data["room"],
-            room_id_to_room_map=room_id_to_room_map,
-            team_id_to_team_map=team_id_to_team_map,
-            dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
-            huddle_id_to_huddle_map=huddle_id_to_huddle_map,
-            livechat_id_to_livechat_map=livechat_id_to_livechat_map,
-        )
+        with self.assertLogs(level="INFO"):
+            categorize_channels_and_map_with_id(
+                channel_data=rocketchat_data["room"],
+                room_id_to_room_map=room_id_to_room_map,
+                team_id_to_team_map=team_id_to_team_map,
+                dsc_id_to_dsc_map=dsc_id_to_dsc_map,
+                direct_id_to_direct_map=direct_id_to_direct_map,
+                huddle_id_to_huddle_map=huddle_id_to_huddle_map,
+                livechat_id_to_livechat_map=livechat_id_to_livechat_map,
+            )
 
         zerver_stream = convert_channel_data(
             room_id_to_room_map=room_id_to_room_map,
@@ -330,15 +332,16 @@ class RocketChatImporter(ZulipTestCase):
         huddle_id_to_huddle_map: Dict[str, Dict[str, Any]] = {}
         livechat_id_to_livechat_map: Dict[str, Dict[str, Any]] = {}
 
-        categorize_channels_and_map_with_id(
-            channel_data=rocketchat_data["room"],
-            room_id_to_room_map=room_id_to_room_map,
-            team_id_to_team_map=team_id_to_team_map,
-            dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
-            huddle_id_to_huddle_map=huddle_id_to_huddle_map,
-            livechat_id_to_livechat_map=livechat_id_to_livechat_map,
-        )
+        with self.assertLogs(level="INFO"):
+            categorize_channels_and_map_with_id(
+                channel_data=rocketchat_data["room"],
+                room_id_to_room_map=room_id_to_room_map,
+                team_id_to_team_map=team_id_to_team_map,
+                dsc_id_to_dsc_map=dsc_id_to_dsc_map,
+                direct_id_to_direct_map=direct_id_to_direct_map,
+                huddle_id_to_huddle_map=huddle_id_to_huddle_map,
+                livechat_id_to_livechat_map=livechat_id_to_livechat_map,
+            )
 
         zerver_stream = convert_channel_data(
             room_id_to_room_map=room_id_to_room_map,
@@ -436,15 +439,16 @@ class RocketChatImporter(ZulipTestCase):
         huddle_id_to_huddle_map: Dict[str, Dict[str, Any]] = {}
         livechat_id_to_livechat_map: Dict[str, Dict[str, Any]] = {}
 
-        categorize_channels_and_map_with_id(
-            channel_data=rocketchat_data["room"],
-            room_id_to_room_map=room_id_to_room_map,
-            team_id_to_team_map=team_id_to_team_map,
-            dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
-            huddle_id_to_huddle_map=huddle_id_to_huddle_map,
-            livechat_id_to_livechat_map=livechat_id_to_livechat_map,
-        )
+        with self.assertLogs(level="INFO"):
+            categorize_channels_and_map_with_id(
+                channel_data=rocketchat_data["room"],
+                room_id_to_room_map=room_id_to_room_map,
+                team_id_to_team_map=team_id_to_team_map,
+                dsc_id_to_dsc_map=dsc_id_to_dsc_map,
+                direct_id_to_direct_map=direct_id_to_direct_map,
+                huddle_id_to_huddle_map=huddle_id_to_huddle_map,
+                livechat_id_to_livechat_map=livechat_id_to_livechat_map,
+            )
 
         zerver_huddle = convert_huddle_data(
             huddle_id_to_huddle_map=huddle_id_to_huddle_map,
@@ -536,15 +540,16 @@ class RocketChatImporter(ZulipTestCase):
         huddle_id_to_huddle_map: Dict[str, Dict[str, Any]] = {}
         livechat_id_to_livechat_map: Dict[str, Dict[str, Any]] = {}
 
-        categorize_channels_and_map_with_id(
-            channel_data=rocketchat_data["room"],
-            room_id_to_room_map=room_id_to_room_map,
-            team_id_to_team_map=team_id_to_team_map,
-            dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
-            huddle_id_to_huddle_map=huddle_id_to_huddle_map,
-            livechat_id_to_livechat_map=livechat_id_to_livechat_map,
-        )
+        with self.assertLogs(level="INFO"):
+            categorize_channels_and_map_with_id(
+                channel_data=rocketchat_data["room"],
+                room_id_to_room_map=room_id_to_room_map,
+                team_id_to_team_map=team_id_to_team_map,
+                dsc_id_to_dsc_map=dsc_id_to_dsc_map,
+                direct_id_to_direct_map=direct_id_to_direct_map,
+                huddle_id_to_huddle_map=huddle_id_to_huddle_map,
+                livechat_id_to_livechat_map=livechat_id_to_livechat_map,
+            )
 
         zerver_stream = convert_channel_data(
             room_id_to_room_map=room_id_to_room_map,
@@ -615,15 +620,16 @@ class RocketChatImporter(ZulipTestCase):
         huddle_id_to_huddle_map: Dict[str, Dict[str, Any]] = {}
         livechat_id_to_livechat_map: Dict[str, Dict[str, Any]] = {}
 
-        categorize_channels_and_map_with_id(
-            channel_data=rocketchat_data["room"],
-            room_id_to_room_map=room_id_to_room_map,
-            team_id_to_team_map=team_id_to_team_map,
-            dsc_id_to_dsc_map=dsc_id_to_dsc_map,
-            direct_id_to_direct_map=direct_id_to_direct_map,
-            huddle_id_to_huddle_map=huddle_id_to_huddle_map,
-            livechat_id_to_livechat_map=livechat_id_to_livechat_map,
-        )
+        with self.assertLogs(level="INFO"):
+            categorize_channels_and_map_with_id(
+                channel_data=rocketchat_data["room"],
+                room_id_to_room_map=room_id_to_room_map,
+                team_id_to_team_map=team_id_to_team_map,
+                dsc_id_to_dsc_map=dsc_id_to_dsc_map,
+                direct_id_to_direct_map=direct_id_to_direct_map,
+                huddle_id_to_huddle_map=huddle_id_to_huddle_map,
+                livechat_id_to_livechat_map=livechat_id_to_livechat_map,
+            )
 
         channel_messages: List[Dict[str, Any]] = []
         private_messages: List[Dict[str, Any]] = []
@@ -866,6 +872,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(
             info_log.output,
             [
+                "INFO:root:Huddle channel found. UIDs: ['LdBZ7kPxtKESyHPEe', 'M2sXGqoQRJQwQoXY2', 'os6N2Xg2JkNMCSW9Z'] -> hash 752a5854d2b6eec337fe81f0066a5dd72c3f0639",
                 "INFO:root:Starting to process custom emoji",
                 "INFO:root:Done processing emoji",
                 "INFO:root:skipping direct messages discussion mention: Discussion with Hermione",


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This MR contains various fixes I had to implement to somewhat sucessfull import our production Rocket.Chat data into Zulip. The commits are based on Zulip 5.1, but there were no other changes to the rocketchat converter so I rebased it. I did however not test the changes with a more recent version yet.

Please note that this is not yet complete, but each commit should be able to be merged on its own merit. (except likely the last one with  more verbose debug output)

Also note that I currently have to perform 3 more operation before I can import my data without errors, but due to the long runtime of the entire process, I currently have separate scripts for these and have not yet integrated them into the zulip code. I may do this eventually, but in case I don't and someone finds them useful:

```bash
# Remove NUL-bytes (0x00) since import will throw `ValueError: A string literal cannot contain NUL (0x00) characters.` otherwise
# Escape '\`' escape sequence which is probably not intentional. looks like too much data was
# copied from an error message and thus a sole backslash was at the end of a code block. thus probably best
# to convert this to \\` as done by this command
perl -i.bak -pe 's#(?<=[^\\])\\u0000#\1#g; s#([^\\])\\`#\1\\\\`#g' /data/converted-rocketchat-data-PROD/messages-*.json
```

```ruby
#!/usr/bin/ruby
#
# Run this on realm.json

require 'json'
require 'set'

stream_names = Set.new()

ARGV.each do |file|
        data = JSON.parse(File.read(file))
        data['zerver_stream'].map! do |stream|
                # check for stream names that appear with different case (e.g.
                # foo and Foo) since these will conflict during the import
                # later. Resolve this by adding the stream ID
                stream['name'] = stream['name'] + " #" + stream['id'].to_s if stream_names.include?(stream['name'].downcase)
                stream_names.add(stream['name'].downcase)
                stream
        end
        #print(JSON.dump(data))
        File.write(file, JSON.dump(data))
end

```

```ruby
#!/usr/bin/ruby
#
# Run this on message-*.json

require 'json'

ARGV.each do |file|
        data = JSON.parse(File.read(file))
        data['zerver_message'].map! do |message|
                message['subject'] = 'subject truncated for import' if message['subject'].length > 60
                message
        end
        #print(JSON.dump(data))
        File.write(file, JSON.dump(data))
end
```

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
