### PR TITLE
settings_data: Refactor logic for `waiting_period_threshold` checks.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -387,7 +387,6 @@ test_ui("finish", ({override, override_rewire}) => {
         $("#compose-textarea").val("foobarfoobar");
         compose_state.set_message_type("stream");
         compose_state.stream_name("social");
-        override_rewire(people, "get_by_user_id", () => []);
         compose_finished_event_checked = false;
         let schedule_message = false;
         override(reminder, "schedule_message", () => {

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -116,6 +116,33 @@ run_test("user_can_change_logo", () => {
     assert.equal(can_change_logo(), false);
 });
 
+run_test("days_remaining_in_waiting_period", () => {
+    const user_in_waiting_period = settings_data.user_in_waiting_period;
+    const days_remaining_in_waiting_period = settings_data.days_remaining_in_waiting_period;
+
+    page_params.user_id = 30;
+    isaac.date_joined = new Date(Date.now());
+    settings_data.initialize(isaac.date_joined);
+    page_params.realm_waiting_period_threshold = 10;
+    assert.equal(user_in_waiting_period(), true);
+    assert.equal(days_remaining_in_waiting_period(), 10);
+
+    isaac.date_joined = new Date(Date.now() - 9 * 86400000);
+    settings_data.initialize(isaac.date_joined);
+    assert.equal(user_in_waiting_period(), true);
+    assert.equal(days_remaining_in_waiting_period(), 1);
+
+    isaac.date_joined = new Date(Date.now() - 10 * 86400000);
+    settings_data.initialize(isaac.date_joined);
+    assert.equal(user_in_waiting_period(), false);
+    assert.equal(days_remaining_in_waiting_period(), 0);
+
+    isaac.date_joined = new Date(Date.now() - 20 * 86400000);
+    settings_data.initialize(isaac.date_joined);
+    assert.equal(user_in_waiting_period(), false);
+    assert.equal(days_remaining_in_waiting_period(), 0);
+});
+
 run_test("user_can_unsubscribe_other_users", () => {
     page_params.is_admin = true;
     assert.equal(settings_data.user_can_unsubscribe_other_users(), true);

--- a/static/js/settings_data.ts
+++ b/static/js/settings_data.ts
@@ -112,6 +112,23 @@ export function user_can_change_logo(): boolean {
     return page_params.is_admin && page_params.zulip_plan_is_not_limited;
 }
 
+function days_since_user_joined(): number {
+    const current_datetime = new Date();
+    const person_date_joined = new Date(user_join_date);
+    return Math.floor((current_datetime.getTime() - person_date_joined.getTime()) / 1000 / 86400);
+}
+
+export function user_in_waiting_period(): boolean {
+    return days_since_user_joined() < page_params.realm_waiting_period_threshold;
+}
+
+export function days_remaining_in_waiting_period(): number {
+    if (user_in_waiting_period()) {
+        return page_params.realm_waiting_period_threshold - days_since_user_joined();
+    }
+    return 0;
+}
+
 function user_has_permission(policy_value: number): boolean {
     /* At present, nobody and by_owners_only is not present in
      * common_policy_values, but we include a check for it here,
@@ -166,11 +183,7 @@ function user_has_permission(policy_value: number): boolean {
         return true;
     }
 
-    const current_datetime = new Date();
-    const person_date_joined = new Date(user_join_date);
-    const user_join_days =
-        (current_datetime.getTime() - person_date_joined.getTime()) / 1000 / 86400;
-    return user_join_days >= page_params.realm_waiting_period_threshold;
+    return !user_in_waiting_period();
 }
 
 export function user_can_invite_others_to_realm(): boolean {


### PR DESCRIPTION
Pulls out logic for checking if a user was a full or new member from `settings_data.user_has_permission` function because similar logic was also being used in `compose_validate.js`.

Creates two reusable functions; one that returns whether the user is still in the waiting period and one that returns the number of days remaining until the user is no longer in the waiting period.

Fixes a bug in `compose_validate.validate_stream_message_post_policy` where the number of days being returned in the error message was not the number of days remaining until the person was done with the waiting period, but rather the number of days that had passed since joining the organization; and that number was also not rounded down resulting in long decimal places.

**Testing**:
- Adds test for new `days_remaining_in_waiting_period` function, which also verifies the boolean logic of `user_in_waiting_period`.
- Updates existing tests and extends test for `test_validate_stream_message_post_policy_full_members_only` to include errors for members who are in the waiting period.
- Manually tested in dev environment with various settings that can be restricted to full members..

---

**Screenshots and screen captures:**

### Waiting period set to 2 days and user account created today

#### Current error message
![Screenshot from 2022-07-21 18-05-05](https://user-images.githubusercontent.com/63245456/180267047-38b15fae-6e00-4ca3-87ca-83579baad1b4.png)

#### Error message after updates
![Screenshot from 2022-07-21 18-36-21](https://user-images.githubusercontent.com/63245456/180267346-350ba2b4-8624-4105-8915-279654f8afa4.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
