### PR TITLE
todo_widget: Improve its functionality and customizability

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -429,6 +429,7 @@ export const slash_commands = [
         text: $t({defaultMessage: "/todo (Create a todo list)"}),
         name: "todo",
         aliases: "",
+        placeholder: $t({defaultMessage: "Task list"}),
     },
 ];
 

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -7,7 +7,6 @@ import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
 import * as people from "./people";
-import * as util from "./util";
 
 // Any single user should send add a finite number of tasks
 // to a todo list. We arbitrarily pick this value.
@@ -23,22 +22,9 @@ export class TaskData {
 
     get_widget_data() {
         const all_tasks = Array.from(this.task_map.values());
-        all_tasks.sort((a, b) => util.strcmp(a.task, b.task));
-
-        const pending_tasks = [];
-        const completed_tasks = [];
-
-        for (const item of all_tasks) {
-            if (item.completed) {
-                completed_tasks.push(item);
-            } else {
-                pending_tasks.push(item);
-            }
-        }
 
         const widget_data = {
-            pending_tasks,
-            completed_tasks,
+            all_tasks,
         };
 
         return widget_data;

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -22,6 +22,7 @@ export class TaskData {
         current_user_id,
         is_my_task_list,
         task_list_title,
+        tasks,
         report_error_function,
     }) {
         this.message_sender_id = message_sender_id;
@@ -36,6 +37,18 @@ export class TaskData {
         } else {
             this.set_task_list_title($t({defaultMessage: "Task list"}));
         }
+
+        for (const [i, data] of tasks.entries()) {
+            this.handle.new_task.inbound("canned", {
+                // due to legacy reasons, key / idx for a task list
+                // starts at 2 and increments by 2 for each task
+                key: (i + 1) * 2,
+                task: data.task,
+                desc: data.desc,
+            });
+        }
+
+        this.my_idx = 2 * tasks.length + 1;
     }
 
     set_task_list_title(new_title) {
@@ -256,13 +269,19 @@ export class TaskData {
     }
 }
 
-export function activate({$elem, callback, extra_data: {task_list_title = ""} = {}, message}) {
+export function activate({
+    $elem,
+    callback,
+    extra_data: {task_list_title = "", tasks = []} = {},
+    message,
+}) {
     const is_my_task_list = people.is_my_user_id(message.sender_id);
     const task_data = new TaskData({
         message_sender_id: message.sender_id,
         current_user_id: people.my_current_user_id(),
         is_my_task_list,
         task_list_title,
+        tasks,
         report_error_function: blueslip.warn,
     });
 

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import {Sortable} from "sortablejs";
 
 import render_widgets_todo_widget from "../templates/widgets/todo_widget.hbs";
 import render_widgets_todo_widget_tasks from "../templates/widgets/todo_widget_tasks.hbs";
@@ -22,6 +23,8 @@ export class TaskData {
 
     get_widget_data() {
         const all_tasks = Array.from(this.task_map.values());
+        // idx indicates the (current and changeable) order of the todos
+        all_tasks.sort((a, b) => a.idx - b.idx);
 
         const widget_data = {
             all_tasks,
@@ -131,6 +134,48 @@ export class TaskData {
                 item.completed = !item.completed;
             },
         },
+
+        change_order: {
+            outbound: (old_idx, new_idx) => {
+                const event = {
+                    type: "change_order",
+                    old_idx,
+                    new_idx,
+                };
+
+                return event;
+            },
+
+            inbound: (sender_id, data) => {
+                // All message readers may change order of todo tasks.
+                const old_idx = data.old_idx;
+                const new_idx = data.new_idx;
+
+                if (!Number.isInteger(new_idx) || new_idx < 0 || new_idx > MAX_IDX) {
+                    blueslip.warn("todo widget: bad type for inbound task idx");
+                    return;
+                }
+
+                if (!Number.isInteger(old_idx) || old_idx < 0 || old_idx > MAX_IDX) {
+                    blueslip.warn("todo widget: bad type for inbound task idx");
+                    return;
+                }
+
+                const {all_tasks} = this.get_widget_data();
+                all_tasks[old_idx / 2 - 1].idx = new_idx;
+                if (old_idx < new_idx) {
+                    // if a todo was moved down, shift up all todos between old and new position
+                    for (let idx = old_idx + 2; idx <= new_idx; idx += 2) {
+                        all_tasks[idx / 2 - 1].idx = idx - 2;
+                    }
+                } else {
+                    // if a todo was moved up, shift down all todos between old and new position
+                    for (let idx = new_idx; idx < old_idx; idx += 2) {
+                        all_tasks[idx / 2 - 1].idx = idx + 2;
+                    }
+                }
+            },
+        },
     };
 
     handle_event(sender_id, data) {
@@ -183,6 +228,22 @@ export function activate(opts) {
         const widget_data = task_data.get_widget_data();
         const html = render_widgets_todo_widget_tasks(widget_data);
         $elem.find("ul.todo-widget").html(html);
+        Sortable.create($elem.find("ul.todo-widget")[0], {
+            onUpdate(e) {
+                const old_pos = e.oldDraggableIndex;
+                const new_pos = e.newDraggableIndex;
+                // The way `idx` is assigned initially is such that it starts
+                // at 2 for a task list and increments by 2 for each task.
+                // For example, for a list with 3 tasks, the `idx` values would
+                // be 2, 4, and 6, while the actual indices in the tasks array
+                // would, of course, be 0, 1 and 2. Hence the addition by 1
+                // and doubling to convert from array index (`pos`) to `idx`
+                const old_idx = (old_pos + 1) * 2;
+                const new_idx = (new_pos + 1) * 2;
+                const data = task_data.handle.change_order.outbound(old_idx, new_idx);
+                callback(data);
+            },
+        });
         $elem.find(".widget-error").text("");
 
         $elem.find("input.task").on("click", (e) => {

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -141,7 +141,8 @@ button {
     &.add-task,
     &.add-desc,
     &.poll-option,
-    &.poll-question {
+    &.poll-question,
+    &.todo-task-list-title {
         padding: 4px 6px;
         margin: 2px 0;
     }
@@ -153,7 +154,9 @@ button {
 }
 
 .poll-question-check,
-.poll-question-remove {
+.poll-question-remove,
+.todo-task-list-title-check,
+.todo-task-list-title-remove {
     width: 28px !important;
     height: 28px;
     border-radius: 3px;
@@ -165,7 +168,8 @@ button {
     }
 }
 
-.poll-edit-question {
+.poll-edit-question,
+.todo-edit-task-list-title {
     opacity: 0.4;
     display: inline-block;
     margin-left: 5px;
@@ -175,7 +179,8 @@ button {
     }
 }
 
-.poll-question-header {
+.poll-question-header,
+.todo-task-list-title-header {
     display: inline;
 }
 

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -44,6 +44,10 @@
             display: flex;
         }
     }
+
+    .add-task-bar {
+        margin-bottom: 5px;
+    }
 }
 
 .todo-widget,
@@ -64,7 +68,7 @@
     }
 
     ul {
-        margin: 0 0 5px;
+        margin: 5px 0;
         padding: 0;
     }
 }

--- a/static/styles/widgets.css
+++ b/static/styles/widgets.css
@@ -25,9 +25,24 @@
         margin-left: 2px;
     }
 
-    /* Arrange that a multi-line description line wraps properly. */
-    label.checkbox {
+    li {
         display: flex;
+
+        .drag-icon {
+            visibility: hidden;
+            padding-right: 8px;
+            cursor: move;
+            color: hsl(0, 0%, 75%);
+        }
+
+        &:hover .drag-icon {
+            visibility: visible;
+        }
+
+        /* Arrange that a multi-line description line wraps properly. */
+        label.checkbox {
+            display: flex;
+        }
     }
 }
 

--- a/static/templates/widgets/todo_widget.hbs
+++ b/static/templates/widgets/todo_widget.hbs
@@ -1,5 +1,11 @@
 <div class="todo-widget">
-    <h4>{{t "Task list" }}</h4>
+    <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
+    <i class="fa fa-pencil todo-edit-task-list-title"></i>
+    <div class="todo-task-list-title-bar">
+        <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
+        <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
+        <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
+    </div>
     <div class="add-task-bar">
         <input type="text" class="add-task" placeholder="{{t 'New task'}}" />
         <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />

--- a/static/templates/widgets/todo_widget.hbs
+++ b/static/templates/widgets/todo_widget.hbs
@@ -6,12 +6,12 @@
         <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
         <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
     </div>
+    <ul class="todo-widget new-style">
+    </ul>
     <div class="add-task-bar">
         <input type="text" class="add-task" placeholder="{{t 'New task'}}" />
         <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />
         <button class="add-task">{{t "Add task" }}</button>
         <div class="widget-error"></div>
     </div>
-    <ul class="todo-widget new-style">
-    </ul>
 </div>

--- a/static/templates/widgets/todo_widget_tasks.hbs
+++ b/static/templates/widgets/todo_widget_tasks.hbs
@@ -1,6 +1,10 @@
 <br />
 {{#each all_tasks}}
     <li>
+        <span class="drag-icon">
+            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+        </span>
         <label class="checkbox">
             <div>
                 <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}}/>

--- a/static/templates/widgets/todo_widget_tasks.hbs
+++ b/static/templates/widgets/todo_widget_tasks.hbs
@@ -12,9 +12,9 @@
             </div>
             <div>
                 {{#if completed}}
-                <strike><strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}</strike>
+                <strike><strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}</strike>
                 {{else}}
-                <strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}
+                <strong>{{ task }}</strong>{{#if desc }}: {{ desc }}{{/if}}
                 {{/if}}
             </div>
         </label>

--- a/static/templates/widgets/todo_widget_tasks.hbs
+++ b/static/templates/widgets/todo_widget_tasks.hbs
@@ -1,26 +1,18 @@
 <br />
-{{#each pending_tasks}}
+{{#each all_tasks}}
     <li>
         <label class="checkbox">
             <div>
-                <input type="checkbox" class="task" data-key="{{ key }}" />
+                <input type="checkbox" class="task" data-key="{{ key }}" {{#if completed}}checked{{/if}}/>
                 <span></span>
             </div>
             <div>
+                {{#if completed}}
+                <strike><strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}</strike>
+                {{else}}
                 <strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}
+                {{/if}}
             </div>
-        </label>
-
-    </li>
-{{/each}}
-{{#each completed_tasks}}
-    <li>
-        <label class="checkbox">
-            <div>
-                <input type="checkbox" class="task" data-key="{{ key }}" checked="checked"/>
-                <span></span>
-            </div>
-            <strike><em><strong>{{ task }}</strong>{{#if desc }} - {{ desc }}{{/if}}</em></strike>
         </label>
     </li>
 {{/each}}

--- a/static/templates/widgets/todo_widget_tasks.hbs
+++ b/static/templates/widgets/todo_widget_tasks.hbs
@@ -1,4 +1,3 @@
-<br />
 {{#each all_tasks}}
     <li>
         <span class="drag-icon">

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -530,7 +530,7 @@ def validate_poll_data(poll_data: object, is_widget_author: bool) -> None:
     raise ValidationError(f"Unknown type for poll data: {poll_data['type']}")
 
 
-def validate_todo_data(todo_data: object) -> None:
+def validate_todo_data(todo_data: object, is_widget_author: bool) -> None:
     check_dict([("type", check_string)])("todo data", todo_data)
 
     assert isinstance(todo_data, dict)
@@ -564,6 +564,19 @@ def validate_todo_data(todo_data: object) -> None:
                 ("type", check_string),
                 ("old_idx", check_int),
                 ("new_idx", check_int),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
+    if todo_data["type"] == "new_task_list_title":
+        if not is_widget_author:
+            raise ValidationError("You can't edit the task list title unless you are the author.")
+
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("title", check_string),
             ]
         )
         checker("todo data", todo_data)

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -558,6 +558,17 @@ def validate_todo_data(todo_data: object) -> None:
         checker("todo data", todo_data)
         return
 
+    if todo_data["type"] == "change_order":
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("old_idx", check_int),
+                ("new_idx", check_int),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
     raise ValidationError(f"Unknown type for todo data: {todo_data['type']}")
 
 

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -14,7 +14,7 @@ def get_widget_data(content: str) -> Tuple[Optional[str], Any]:
     if tokens[0].startswith("/"):
         widget_type = tokens[0][1:]
         if widget_type in valid_widget_types:
-            remaining_content = content.replace(tokens[0], "", 1).strip()
+            remaining_content = content.replace(tokens[0], "", 1)
             extra_data = get_extra_data_from_widget_type(remaining_content, widget_type)
             return widget_type, extra_data
 

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -41,7 +41,15 @@ def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) ->
             "options": options,
         }
         return extra_data
-    return None
+    else:
+        # This is used to extract the task list title from the todo command.
+        # The command '/todo Title' will pre-set the task list title
+        lines = content.splitlines()
+        task_list_title = ""
+        if lines and lines[0]:
+            task_list_title = lines.pop(0).strip()
+        extra_data = {"task_list_title": task_list_title}
+        return extra_data
 
 
 def do_widget_post_save_actions(send_request: SendMessageRequest) -> None:

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -357,6 +357,15 @@ class WidgetContentTestCase(ZulipTestCase):
         assert_error('{"type": "strike"}', "key is missing")
         assert_error('{"type": "strike", "key": 999}', 'data["key"] is not a string')
 
+        assert_error(
+            '{"type": "change_order", "new_idx": 24}',
+            "old_idx key is missing from todo data",
+        )
+        assert_error(
+            '{"type": "change_order", "old_idx": "string", "new_idx": 24}',
+            'data["old_idx"] is not an int',
+        )
+
         def assert_success(data: Dict[str, object]) -> None:
             content = orjson.dumps(data).decode()
             result = post_submessage(content)
@@ -364,6 +373,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         assert_success(dict(type="new_task", key=7, task="eat", desc="", completed=False))
         assert_success(dict(type="strike", key="5,9"))
+        assert_success(dict(type="change_order", old_idx=4, new_idx=8))
 
     def test_get_widget_type(self) -> None:
         sender = self.example_user("cordelia")

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -98,7 +98,7 @@ class WidgetContentTestCase(ZulipTestCase):
             self.assertEqual(get_widget_data(content=message), (None, None))
 
         # Add a positive check for context
-        self.assertEqual(get_widget_data(content="/todo"), ("todo", None))
+        self.assertEqual(get_widget_data(content="/todo"), ("todo", {"task_list_title": ""}))
 
     def test_explicit_widget_content(self) -> None:
         # Users can send widget_content directly on messages
@@ -164,7 +164,24 @@ class WidgetContentTestCase(ZulipTestCase):
 
         expected_submessage_content = dict(
             widget_type="todo",
-            extra_data=None,
+            extra_data={"task_list_title": ""},
+        )
+
+        submessage = SubMessage.objects.get(message_id=message.id)
+        self.assertEqual(submessage.msg_type, "widget")
+        self.assertEqual(orjson.loads(submessage.content), expected_submessage_content)
+
+        content = "/todo Example Task List Title"
+        payload["content"] = content
+        result = self.api_post(sender, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        message = self.get_last_message()
+        self.assertEqual(message.content, content)
+
+        expected_submessage_content = dict(
+            widget_type="todo",
+            extra_data={"task_list_title": "Example Task List Title"},
         )
 
         submessage = SubMessage.objects.get(message_id=message.id)
@@ -223,6 +240,55 @@ class WidgetContentTestCase(ZulipTestCase):
         self.assertEqual(submessage.msg_type, "widget")
         self.assertEqual(orjson.loads(submessage.content), expected_submessage_content)
 
+    def test_todo_command_extra_data(self) -> None:
+        sender = self.example_user("cordelia")
+        stream_name = "Verona"
+        # We test for leading spaces.
+        content = "/todo   School Work"
+
+        payload = dict(
+            type="stream",
+            to=orjson.dumps(stream_name).decode(),
+            topic="whatever",
+            content=content,
+        )
+        result = self.api_post(sender, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        message = self.get_last_message()
+        self.assertEqual(message.content, content)
+
+        expected_submessage_content = dict(
+            widget_type="todo",
+            extra_data=dict(
+                task_list_title="School Work",
+            ),
+        )
+
+        submessage = SubMessage.objects.get(message_id=message.id)
+        self.assertEqual(submessage.msg_type, "widget")
+        self.assertEqual(orjson.loads(submessage.content), expected_submessage_content)
+
+        # Now don't supply a task list title.
+
+        content = "/todo"
+        payload["content"] = content
+        result = self.api_post(sender, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        expected_submessage_content = dict(
+            widget_type="todo",
+            extra_data=dict(
+                task_list_title="",
+            ),
+        )
+
+        message = self.get_last_message()
+        self.assertEqual(message.content, content)
+        submessage = SubMessage.objects.get(message_id=message.id)
+        self.assertEqual(submessage.msg_type, "widget")
+        self.assertEqual(orjson.loads(submessage.content), expected_submessage_content)
+
     def test_poll_permissions(self) -> None:
         cordelia = self.example_user("cordelia")
         hamlet = self.example_user("hamlet")
@@ -251,6 +317,37 @@ class WidgetContentTestCase(ZulipTestCase):
 
         result = post(hamlet, dict(type="question", question="Tabs or spaces?"))
         self.assert_json_error(result, "You can't edit a question unless you are the author.")
+
+    def test_todo_permissions(self) -> None:
+        cordelia = self.example_user("cordelia")
+        hamlet = self.example_user("hamlet")
+        stream_name = "Verona"
+        content = "/todo School Work"
+
+        payload = dict(
+            type="stream",
+            to=orjson.dumps(stream_name).decode(),
+            topic="whatever",
+            content=content,
+        )
+        result = self.api_post(cordelia, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        message = self.get_last_message()
+
+        def post(sender: UserProfile, data: Dict[str, object]) -> "TestHttpResponse":
+            payload = dict(
+                message_id=message.id, msg_type="widget", content=orjson.dumps(data).decode()
+            )
+            return self.api_post(sender, "/api/v1/submessage", payload)
+
+        result = post(cordelia, dict(type="new_task_list_title", title="School Work"))
+        self.assert_json_success(result)
+
+        result = post(hamlet, dict(type="new_task_list_title", title="School Work"))
+        self.assert_json_error(
+            result, "You can't edit the task list title unless you are the author."
+        )
 
     def test_poll_type_validation(self) -> None:
         sender = self.example_user("cordelia")
@@ -366,6 +463,15 @@ class WidgetContentTestCase(ZulipTestCase):
             'data["old_idx"] is not an int',
         )
 
+        assert_error(
+            '{"type": "new_task_list_title"}',
+            "title key is missing from todo data",
+        )
+        assert_error(
+            '{"type": "new_task_list_title", "title": 7}',
+            'data["title"] is not a string',
+        )
+
         def assert_success(data: Dict[str, object]) -> None:
             content = orjson.dumps(data).decode()
             result = post_submessage(content)
@@ -374,6 +480,7 @@ class WidgetContentTestCase(ZulipTestCase):
         assert_success(dict(type="new_task", key=7, task="eat", desc="", completed=False))
         assert_success(dict(type="strike", key="5,9"))
         assert_success(dict(type="change_order", old_idx=4, new_idx=8))
+        assert_success(dict(type="new_task_list_title", title="School Work"))
 
     def test_get_widget_type(self) -> None:
         sender = self.example_user("cordelia")

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -98,7 +98,9 @@ class WidgetContentTestCase(ZulipTestCase):
             self.assertEqual(get_widget_data(content=message), (None, None))
 
         # Add a positive check for context
-        self.assertEqual(get_widget_data(content="/todo"), ("todo", {"task_list_title": ""}))
+        self.assertEqual(
+            get_widget_data(content="/todo"), ("todo", {"task_list_title": "", "tasks": []})
+        )
 
     def test_explicit_widget_content(self) -> None:
         # Users can send widget_content directly on messages
@@ -164,7 +166,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         expected_submessage_content = dict(
             widget_type="todo",
-            extra_data={"task_list_title": ""},
+            extra_data={"task_list_title": "", "tasks": []},
         )
 
         submessage = SubMessage.objects.get(message_id=message.id)
@@ -181,7 +183,42 @@ class WidgetContentTestCase(ZulipTestCase):
 
         expected_submessage_content = dict(
             widget_type="todo",
-            extra_data={"task_list_title": "Example Task List Title"},
+            extra_data={"task_list_title": "Example Task List Title", "tasks": []},
+        )
+
+        submessage = SubMessage.objects.get(message_id=message.id)
+        self.assertEqual(submessage.msg_type, "widget")
+        self.assertEqual(orjson.loads(submessage.content), expected_submessage_content)
+
+        # We test for both trailing and leading spaces, along with blank lines
+        # for the tasks.
+        content = "/todo Example Task List Title\n\n    task without description\ntask: with description    \n\n - task as list : also with description"
+        payload["content"] = content
+        result = self.api_post(sender, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        message = self.get_last_message()
+        self.assertEqual(message.content, content)
+
+        expected_submessage_content = dict(
+            widget_type="todo",
+            extra_data=dict(
+                task_list_title="Example Task List Title",
+                tasks=[
+                    dict(
+                        task="task without description",
+                        desc="",
+                    ),
+                    dict(
+                        task="task",
+                        desc="with description",
+                    ),
+                    dict(
+                        task="task as list",
+                        desc="also with description",
+                    ),
+                ],
+            ),
         )
 
         submessage = SubMessage.objects.get(message_id=message.id)
@@ -260,9 +297,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         expected_submessage_content = dict(
             widget_type="todo",
-            extra_data=dict(
-                task_list_title="School Work",
-            ),
+            extra_data=dict(task_list_title="School Work", tasks=[]),
         )
 
         submessage = SubMessage.objects.get(message_id=message.id)
@@ -278,8 +313,35 @@ class WidgetContentTestCase(ZulipTestCase):
 
         expected_submessage_content = dict(
             widget_type="todo",
+            extra_data=dict(task_list_title="", tasks=[]),
+        )
+
+        message = self.get_last_message()
+        self.assertEqual(message.content, content)
+        submessage = SubMessage.objects.get(message_id=message.id)
+        self.assertEqual(submessage.msg_type, "widget")
+        self.assertEqual(orjson.loads(submessage.content), expected_submessage_content)
+        # Now supply both task list title and tasks.
+
+        content = "/todo School Work\nchemistry homework: assignment 2\nstudy for english test: pages 56-67"
+        payload["content"] = content
+        result = self.api_post(sender, "/api/v1/messages", payload)
+        self.assert_json_success(result)
+
+        expected_submessage_content = dict(
+            widget_type="todo",
             extra_data=dict(
-                task_list_title="",
+                task_list_title="School Work",
+                tasks=[
+                    dict(
+                        task="chemistry homework",
+                        desc="assignment 2",
+                    ),
+                    dict(
+                        task="study for english test",
+                        desc="pages 56-67",
+                    ),
+                ],
             ),
         )
 

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -49,7 +49,7 @@ def process_submessage(
 
     if widget_type == "todo":
         try:
-            validate_todo_data(todo_data=widget_data)
+            validate_todo_data(todo_data=widget_data, is_widget_author=is_widget_author)
         except ValidationError as error:
             raise JsonableError(error.message)
 


### PR DESCRIPTION
Earlier the tasks in a list were sorted alphabetically and on marking
one complete, it was pushed under any incomplete tasks. This behaviour
can be unexpected and confusing, so now each task is appended to the
bottom of the list on being added, and no shifting takes place on
marking it completed.

Message readers can now reorder todo tasks in the message view by
dragging and dropping them. The new order is persisted.

Users can now name task lists by providing the task list title in the
`/todo` command on the same line. Example: `/todo School Work`. If no
title is provided by the user, "Task List Title" is used as default.

The author of a task list can later edit / update the task list title
in the todo widget, just like the question in the poll widget.

Fixes part of #20213.

**Screenshots and screen captures:**

https://www.loom.com/share/74415f4ef43043fcadeb00b001f4f323

![image](https://user-images.githubusercontent.com/68962290/181759913-0b8729b4-0199-45a8-ba1c-29a808b34125.png)

![image](https://user-images.githubusercontent.com/68962290/181759082-f8bab0c2-e0c5-4a36-a624-b4dbd237dfa6.png)

![image](https://user-images.githubusercontent.com/68962290/181759265-661f9c46-2511-4d69-ad85-22c4052f1009.png)

![image](https://user-images.githubusercontent.com/68962290/181759380-225dce5d-924c-4d68-b288-4d1a639664df.png)


**Self-review checklist**

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
