### PR TITLE
templates: Use Dict instead of Mapping for the context parameter.

### DIFF
--- a/zerver/lib/templates.py
+++ b/zerver/lib/templates.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, List, Mapping, Optional
+from typing import Any, Dict, List, Optional
 
 import markdown
 import markdown.extensions.admonition
@@ -82,13 +82,15 @@ docs_without_macros = [
 @items_tuple_to_dict
 @register.filter(name="render_markdown_path", is_safe=True)
 def render_markdown_path(
-    markdown_file_path: str, context: Mapping[str, Any] = {}, pure_markdown: bool = False
+    markdown_file_path: str, context: Optional[Dict[str, Any]] = None, pure_markdown: bool = False
 ) -> str:
     """Given a path to a Markdown file, return the rendered HTML.
 
     Note that this assumes that any HTML in the Markdown file is
     trusted; it is intended to be used for documentation, not user
     data."""
+    if context is None:
+        context = {}
 
     # We set this global hackishly
     from zerver.lib.markdown.help_settings_links import set_relative_settings_links


### PR DESCRIPTION
According to the Django documentation, `Template.render` expects a
`dict`.

See also: https://docs.djangoproject.com/en/4.0/topics/templates/#django.template.backends.base.Template.render.

Affected errors:

```diff
5c5
< Found 200 errors in 71 files (checked 1401 source files)
---
> Found 199 errors in 71 files (checked 1401 source files)
109d108
< zerver/lib/templates.py error Argument 1 to "render" of "_EngineTemplate" has incompatible type "Mapping[str, Any]"; expected "Union[Context, Dict[str, Any], None]"  [arg-type]
```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
