### PR TITLE
message_flags: Filter msgs having (or not) the flag before updating.

### DIFF
--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -158,13 +158,13 @@ run_test("read", ({override}) => {
     }
 
     let msgs_to_flag_read = [
-        {locally_echoed: false, id: 1},
-        {locally_echoed: false, id: 2},
-        {locally_echoed: false, id: 3},
-        {locally_echoed: false, id: 4},
-        {locally_echoed: false, id: 5},
-        {locally_echoed: false, id: 6},
-        {locally_echoed: false, id: 7},
+        {locally_echoed: false, id: 1, unread: true},
+        {locally_echoed: false, id: 2, unread: true},
+        {locally_echoed: false, id: 3, unread: true},
+        {locally_echoed: false, id: 4, unread: true},
+        {locally_echoed: false, id: 5, unread: true},
+        {locally_echoed: false, id: 6, unread: true},
+        {locally_echoed: false, id: 7, unread: true},
     ];
     send_read(msgs_to_flag_read);
     assert.deepEqual(channel_post_opts, {
@@ -198,17 +198,53 @@ run_test("read", ({override}) => {
     };
     channel_post_opts.success(success_response_data);
 
+    // Messages still not acked yet
+    const events = {};
+    const stub_delay = 100;
+    function set_timeout(f, delay) {
+        assert.equal(delay, stub_delay);
+        events.f = f;
+        events.timer_set = true;
+        return;
+    }
+    set_global("setTimeout", set_timeout);
+
+    // Test already read message.
+    msgs_to_flag_read = [
+        {locally_echoed: false, id: 1, unread: true},
+        {locally_echoed: false, id: 2, unread: false},
+    ];
+    send_read(msgs_to_flag_read);
+    assert.deepEqual(channel_post_opts, {
+        url: "/json/messages/flags",
+        idempotent: true,
+        data: {
+            messages: "[1]",
+            op: "add",
+            flag: "read",
+        },
+        success: channel_post_opts.success,
+    });
+
+    // Mock successful flagging of ids
+    success_response_data = {
+        messages: [1],
+    };
+    channel_post_opts.success(success_response_data);
+    // Since all message are read, no server request was queued.
+    assert.ok(!events.timer_set);
+
     // Don't flag locally echoed messages as read
     const local_msg_1 = {locally_echoed: true, id: 1};
     const local_msg_2 = {locally_echoed: true, id: 2};
     msgs_to_flag_read = [
         local_msg_1,
         local_msg_2,
-        {locally_echoed: false, id: 3},
-        {locally_echoed: false, id: 4},
-        {locally_echoed: false, id: 5},
-        {locally_echoed: false, id: 6},
-        {locally_echoed: false, id: 7},
+        {locally_echoed: false, id: 3, unread: true},
+        {locally_echoed: false, id: 4, unread: true},
+        {locally_echoed: false, id: 5, unread: true},
+        {locally_echoed: false, id: 6, unread: true},
+        {locally_echoed: false, id: 7, unread: true},
     ];
     send_read(msgs_to_flag_read);
     assert.deepEqual(channel_post_opts, {
@@ -222,16 +258,6 @@ run_test("read", ({override}) => {
         success: channel_post_opts.success,
     });
 
-    // Messages still not acked yet
-    const events = {};
-    const stub_delay = 100;
-    function set_timeout(f, delay) {
-        assert.equal(delay, stub_delay);
-        events.f = f;
-        events.timer_set = true;
-        return;
-    }
-    set_global("setTimeout", set_timeout);
     // Mock successful flagging of ids
     success_response_data = {
         messages: [3, 4, 5, 6, 7],
@@ -278,7 +304,7 @@ run_test("read_empty_data", ({override}) => {
     }
 
     // send read to obtain success callback
-    send_read({locally_echoed: false, id: 1});
+    send_read([{locally_echoed: false, id: 1, unread: true}]);
 
     // verify early return on empty data
     const success_callback = channel_post_opts.success;

--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -53,14 +53,17 @@ export const send_read = (function () {
             return;
         }
 
-        queue = queue.filter((message) => !data.messages.includes(message.id));
-
+        // Remove messages which were marked read by server and those which are already read in local data.
+        queue = queue.filter((message) => !data.messages.includes(message.id) || !message.unread);
         if (queue.length > 0) {
             start();
         }
     };
 
     function add(messages) {
+        // Filter out messages which are already read unless they are locally_echoed.
+        // Locally echoed message will be removed on next on_success event.
+        messages = messages.filter((message) => message.locally_echoed || message.unread);
         queue = queue.concat(messages);
         start();
     }

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -652,12 +652,29 @@ class NormalActionsTest(BaseAction):
             state_change_expected=True,
         )
         check_update_message_flags_add("events[0]", events[0])
+        self.assert_length(events[0]["messages"], 1)
+        # No message_id is returned from the server if the flag is already preset and no event is
+        # sent to other clients.
+        events = self.verify_action(
+            lambda: do_update_message_flags(user_profile, "add", "starred", [message]),
+            state_change_expected=False,
+            num_events=0,
+        )
 
         events = self.verify_action(
             lambda: do_update_message_flags(user_profile, "remove", "starred", [message]),
             state_change_expected=True,
         )
         check_update_message_flags_remove("events[0]", events[0])
+        self.assert_length(events[0]["messages"], 1)
+
+        # No message_id is returned from the server if the flag is already preset and no event is
+        # sent to other clients.
+        events = self.verify_action(
+            lambda: do_update_message_flags(user_profile, "remove", "starred", [message]),
+            state_change_expected=False,
+            num_events=0,
+        )
 
     def test_update_read_flag_removes_unread_msg_ids(self) -> None:
 

--- a/zerver/views/message_flags.py
+++ b/zerver/views/message_flags.py
@@ -38,13 +38,13 @@ def update_message_flags(
     request_notes = RequestNotes.get_notes(request)
     assert request_notes.log_data is not None
 
-    count = do_update_message_flags(user_profile, operation, flag, messages)
+    count, updated_message_ids = do_update_message_flags(user_profile, operation, flag, messages)
 
     target_count_str = str(len(messages))
     log_data_str = f"[{operation} {flag}/{target_count_str}] actually {count}"
     request_notes.log_data["extra"] = log_data_str
 
-    return json_success(request, data={"messages": messages})
+    return json_success(request, data={"messages": updated_message_ids})
 
 
 @has_request_variables


### PR DESCRIPTION
This fixes the bug where frontend continuously queries the server to mark the message which was already read as read. See 8faa854267df9e3f6810979d59d242653bb0f445 for details.

The easiest way to reproduce the bug would be to just add an already read message to the queue.