### PR TITLE
bots: Improve bots profile summary.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1294,7 +1294,12 @@ export function register_click_handlers() {
     $("body").on("click", ".sidebar-popover-manage-user", (e) => {
         hide_all();
         const user_id = elem_to_user_id($(e.target).parents("ul"));
-        settings_users.show_edit_user_info_modal(user_id, true);
+        const user = people.get_by_user_id(user_id);
+        if (user.is_bot) {
+            settings_users.show_edit_bot_info_modal(user_id, true);
+        } else {
+            settings_users.show_edit_user_info_modal(user_id, true);
+        }
     });
 }
 

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -694,6 +694,19 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
                 .find(`option[value="${CSS.escape(settings_config.user_role_values.owner.code)}"]`)
                 .hide();
         }
+
+        $("#bot-edit-form").on("click", ".deactivate_bot_button", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const bot_id = $("#bot-edit-form").data("user-id");
+            function handle_confirm() {
+                const url = "/json/bots/" + encodeURIComponent(bot_id);
+                dialog_widget.submit_api_request(channel.del, url);
+            }
+            const open_deactivate_modal_callback = () =>
+                confirm_bot_deactivation(bot_id, handle_confirm, true);
+            dialog_widget.close_modal(open_deactivate_modal_callback);
+        });
     }
 
     dialog_widget.launch({

--- a/static/templates/settings/edit_bot_form.hbs
+++ b/static/templates/settings/edit_bot_form.hbs
@@ -27,5 +27,10 @@
               widget_name="edit_bot_owner"
               list_placeholder=(t 'Filter users')}}
         </div>
+        <div class="input-group new-style">
+            <button class="button rounded btn-danger deactivate_bot_button">
+                {{t 'Deactivate bot' }}
+            </button>
+        </div>
     </form>
 </div>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -24,7 +24,7 @@
             </div>
             {{/if}}
         {{else}}
-            <li class="user_popover_email half-opacity italic">{{#tr}}This user has been deactivated.{{/tr}}</li>
+            <li class="user_popover_email half-opacity italic">{{#if is_bot}}{{#tr}}This bot has been deactivated.{{/tr}}{{else}}{{#tr}}This user has been deactivated.{{/tr}}{{/if}}</li>
         {{/if}}
 
 
@@ -125,7 +125,7 @@
             {{#if has_message_context}}
             <a tabindex="0" class="mention_user">
                 <i class="fa fa-at" aria-hidden="true"></i>
-                {{#tr}}Reply mentioning user{{/tr}}
+                {{#if is_bot}}{{#tr}}Reply mentioning bot{{/tr}}{{else}}{{#tr}}Reply mentioning user{{/tr}}{{/if}}
                 {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
             </a>
             {{else}}
@@ -181,13 +181,13 @@
             {{#if is_active}}
             <li>
                 <a tabindex="0" class="sidebar-popover-manage-user">
-                    <i class="fa fa-edit" aria-hidden="true"></i> {{#tr}}Manage this user{{/tr}}
+                    <i class="fa fa-edit" aria-hidden="true"></i> {{#if is_bot}}{{#tr}}Manage this bot{{/tr}}{{else}}{{#tr}}Manage this user{{/tr}}{{/if}}
                 </a>
             </li>
             {{else}}
             <li>
                 <a tabindex="0" class="sidebar-popover-reactivate-user">
-                    <i class="fa fa-user-plus" aria-hidden="true"></i> {{#tr}}Reactivate this user{{/tr}}
+                    <i class="fa fa-user-plus" aria-hidden="true"></i> {{#if is_bot}}{{#tr}}Reactivate this bot{{/tr}}{{else}}{{#tr}}Reactivate this user{{/tr}}{{/if}}
                 </a>
             </li>
             {{/if}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Clarify the "Bot" user in the bot profile summary.

Display "Manage bot" modal from bots profile summary.

Display the "Deactivate bot" button inside the bot edit modal.

Fixes: #22482

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>

<summary>Screenshots</summary>

![bot_profile_popover](https://user-images.githubusercontent.com/41695888/180570252-bef2e905-f810-4963-ad4b-a476db9cd522.png)
![manage_bot](https://user-images.githubusercontent.com/41695888/180570258-9cf0a93c-2de4-45bb-9ab6-d10ed059f6d2.png)
![bot_deactivate_modal](https://user-images.githubusercontent.com/41695888/180570247-c0dc2c59-a363-48f7-88b5-583eb159b860.png)
![bot_profile_popover_deactivated](https://user-images.githubusercontent.com/41695888/180570256-7e94bf41-da34-484c-a891-90d73ec8950d.png)
 
</details>

<details>

<summary>Gif</summary>

![working](https://user-images.githubusercontent.com/41695888/180570446-5c8be8af-3e9d-4f88-a42e-0c2bb9dc495c.gif)

</details>
**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
