### PR TITLE
exceptions: Guard validation error conversion with message_dict.

### DIFF
--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -471,4 +471,4 @@ class ValidationFailureError(JsonableError):
 
     def __init__(self, error: ValidationError) -> None:
         super().__init__(error.messages[0])
-        self.errors = dict(error)
+        self.errors = error.message_dict


### PR DESCRIPTION
Iterating over ValidatorError does not necessarily return a tuple. This uses the `message_dict` property on `ValidationError` instead to make sure that we always get a `dict` (it otherwise raises an `AttributeError` when the `dict` is not available).

Affected error(s):

```diff
5c5
< Found 201 errors in 73 files (checked 1403 source files)
---
> Found 199 errors in 72 files (checked 1403 source files)
63,69d62
< zerver/lib/exceptions.py error Argument 1 to "dict" has incompatible type "ValidationError"; expected "Iterable[Tuple[<nothing>, <nothing>]]"  [arg-type]
< zerver/lib/exceptions.py error Need type annotation for "errors" (hint "errors Dict[<type>, <type>] = ...")  [var-annotated]
< zerver/lib/exceptions.py note         def __iter__(self) -> Iterator[Tuple[<nothing>, <nothing>]]
< zerver/lib/exceptions.py note         def __iter__(self) -> Iterator[Union[Tuple[str, List[str]], str]]
< zerver/lib/exceptions.py note     Expected
< zerver/lib/exceptions.py note     Got
< zerver/lib/exceptions.py note Following member(s) of "ValidationError" have conflicts
```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
