### PR TITLE
message-editing: Change default move option.

### DIFF
--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -31,8 +31,8 @@
                 </div>
             </div>
             <select class='message_edit_topic_propagate' style='display:none;'>
-                <option selected="selected" value="change_one"> {{t "Move only this message" }}</option>
-                <option value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
+                <option value="change_one"> {{t "Move only this message" }}</option>
+                <option selected="selected" value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
                 <option value="change_all"> {{t "Move all messages in this topic" }}</option>
             </select>
         </div>


### PR DESCRIPTION
This resolves the issue discussed in [#issues/move messages default section](https://chat.zulip.org/#narrow/stream/9-issues/topic/move.20messages.20default.20selection)

Changed the default move option from "Move only this message" to "Move this and all following messages in this topic".