### PR TITLE
django-stubs: Testing related refactorings

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -162,12 +162,6 @@ def get_failed_tests() -> List[str]:
         return []
 
 
-def write_failed_tests(failed_tests: List[str]) -> None:
-    if failed_tests:
-        with open(FAILED_TEST_PATH, "wb") as f:
-            f.write(orjson.dumps(failed_tests))
-
-
 @contextlib.contextmanager
 def block_internet() -> Iterator[None]:
     # Monkey-patching - responses library raises requests.ConnectionError when access to an unregistered URL
@@ -429,10 +423,12 @@ def main() -> None:
             reverse=options.reverse,
             keepdb=True,
         )
-        failures, failed_tests = test_runner.run_tests(
-            suites, full_suite=full_suite, include_webhooks=include_webhooks
+        failures = test_runner.run_tests(
+            suites,
+            failed_tests_path=FAILED_TEST_PATH,
+            full_suite=full_suite,
+            include_webhooks=include_webhooks,
         )
-    write_failed_tests(failed_tests)
 
     templates_not_rendered = test_runner.get_shallow_tested_templates()
     # We only check the templates if all the tests ran and passed

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -10,7 +10,6 @@ from unittest.result import TestResult
 
 from django.conf import settings
 from django.db import ProgrammingError, connections
-from django.test import TestCase
 from django.test import runner as django_runner
 from django.test.runner import DiscoverRunner
 from django.test.signals import template_rendered
@@ -56,10 +55,10 @@ class TextTestResult(runner.TextTestResult):
         super().__init__(*args, **kwargs)
         self.failed_tests: List[str] = []
 
-    def addInstrumentation(self, test: TestCase, data: Dict[str, Any]) -> None:
+    def addInstrumentation(self, test: unittest.TestCase, data: Dict[str, Any]) -> None:
         append_instrumentation_data(data)
 
-    def startTest(self, test: TestCase) -> None:
+    def startTest(self, test: unittest.TestCase) -> None:
         TestResult.startTest(self, test)
         self.stream.write(f"Running {test.id()}\n")
         self.stream.flush()
@@ -77,7 +76,7 @@ class TextTestResult(runner.TextTestResult):
         test_name = args[0].id()
         self.failed_tests.append(test_name)
 
-    def addSkip(self, test: TestCase, reason: str) -> None:
+    def addSkip(self, test: unittest.TestCase, reason: str) -> None:
         TestResult.addSkip(self, test, reason)
         self.stream.write(f"** Skipping {test.id()}: {reason}\n")
         self.stream.flush()
@@ -89,7 +88,7 @@ class RemoteTestResult(django_runner.RemoteTestResult):
     base class.
     """
 
-    def addInstrumentation(self, test: TestCase, data: Dict[str, Any]) -> None:
+    def addInstrumentation(self, test: unittest.TestCase, data: Dict[str, Any]) -> None:
         # Some elements of data['info'] cannot be serialized.
         if "info" in data:
             del data["info"]
@@ -377,7 +376,7 @@ class Runner(DiscoverRunner):
     def run_tests(
         self,
         test_labels: List[str],
-        extra_tests: Optional[List[TestCase]] = None,
+        extra_tests: Optional[List[unittest.TestCase]] = None,
         full_suite: bool = False,
         include_webhooks: bool = False,
         **kwargs: Any,

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -155,7 +155,7 @@ class DecoratorTestCase(ZulipTestCase):
         with mock.patch(
             "zerver.middleware.parse_client", side_effect=JsonableError("message")
         ) as m, self.assertLogs(level="ERROR"):
-            LogRequests.process_request(self, request)
+            LogRequests(lambda request: HttpResponse()).process_request(request)
         request_notes = RequestNotes.get_notes(request)
         self.assertEqual(request_notes.client_name, "Unparsable")
         m.assert_called_once()

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -215,10 +215,10 @@ class EventsEndpointTest(ZulipTestCase):
         post_data["secret"] = "random"
         req = HostRequestMock(post_data, user_profile=None)
         req.META["REMOTE_ADDR"] = "127.0.0.1"
-        with self.assertRaises(AccessDeniedError) as context:
+        with self.assertRaises(AccessDeniedError) as access_denied_error:
             result = self.client_post_request("/notify_tornado", req)
-        self.assertEqual(str(context.exception), "Access denied")
-        self.assertEqual(context.exception.http_status_code, 403)
+        self.assertEqual(str(access_denied_error.exception), "Access denied")
+        self.assertEqual(access_denied_error.exception.http_status_code, 403)
 
         assert settings.SHARED_SECRET is not None
         post_data["secret"] = settings.SHARED_SECRET


### PR DESCRIPTION
A series of changes related to the backend test suites and tooling.

Affected errors:
```diff
6c6
< Found 143 errors in 40 files (checked 1405 source files)
---
> Found 127 errors in 38 files (checked 1405 source files)
11,13d10
< tools/test-backend error "int" object is not iterable  [misc]
< tools/test-backend error "DiscoverRunner" has no attribute "get_shallow_tested_templates"  [attr-defined]
< tools/test-backend error Cannot determine type of "failures"  [has-type]
70d66
< zerver/lib/test_runner.py error The return type of a generator function should be "Generator" or one of its supertypes  [misc]
72d67
< zerver/lib/test_runner.py error Module has no attribute "multiprocessing"  [attr-defined]
76,91d70
< zerver/lib/test_runner.py error Signature of "run_tests" incompatible with supertype "DiscoverRunner"  [override]
< zerver/lib/test_runner.py note          def run_tests(self, test_labels List[str], extra_tests Optional[List[Any]] = ..., **kwargs Any) -> int
< zerver/lib/test_runner.py note          def run_tests(test_labels List[str], extra_tests Optional[List[TestCase]] = ..., full_suite bool = ..., include_webhooks bool = ..., **kwargs Any) -> Tuple[bool, List[str]]
< zerver/lib/test_runner.py note      Subclass
< zerver/lib/test_runner.py note      Superclass
< zerver/lib/test_runner.py error "TextTestResult" has no attribute "failed_tests"  [attr-defined]
< zerver/lib/test_runner.py error Incompatible return value type (got "Tuple[int, Any]", expected "Tuple[bool, List[str]]")  [return-value]
< zerver/lib/test_runner.py error "TestCase" has no attribute "__iter__" (not iterable)  [attr-defined]
< zerver/lib/test_runner.py error "yield from" can't be applied to "TestCase"  [misc]
< zerver/lib/test_runner.py error "TestCase" has no attribute "__iter__" (not iterable)  [attr-defined]
< zerver/lib/test_runner.py error Argument 1 of "startTest" is incompatible with supertype "TestResult"; supertype defines the argument type as "TestCase"  [override]
< zerver/lib/test_runner.py note See https//mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
< zerver/lib/test_runner.py note This violates the Liskov substitution principle
< zerver/lib/test_runner.py error Argument 1 of "addSkip" is incompatible with supertype "TestResult"; supertype defines the argument type as "TestCase"  [override]
< zerver/lib/test_runner.py note See https//mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
< zerver/lib/test_runner.py note This violates the Liskov substitution principle
134,136d112
< zerver/tests/test_rate_limiter.py error "RateLimiterBackendBase" has no attribute "backend"  [attr-defined]
< zerver/tests/test_signup.py error "_MonkeyPatchedWSGIResponse" has no attribute "context_data"  [attr-defined]
< zerver/tests/test_signup.py error "_MonkeyPatchedWSGIResponse" has no attribute "redirect_chain"  [attr-defined]
```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
