### PR TITLE
message-edit: Do not show topic when stream and topic are not editable.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -428,6 +428,9 @@ function edit_message($row, raw_content) {
 
     const is_stream_editable =
         message.is_stream && settings_data.user_can_move_messages_between_streams();
+
+    // we do not show topic when stream and topic are not editable.
+    const should_topic_be_visible = is_topic_editable(message) || is_stream_editable;
     const is_editable =
         editability === editability_types.TOPIC_ONLY ||
         editability === editability_types.FULL ||
@@ -461,6 +464,7 @@ function edit_message($row, raw_content) {
             file_upload_enabled,
             minutes_to_edit: Math.floor(page_params.realm_message_content_edit_limit_seconds / 60),
             is_stream_editable,
+            should_topic_be_visible,
             select_move_stream_widget_name,
             notify_new_thread: notify_new_thread_default,
             notify_old_thread: notify_old_thread_default,

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -17,7 +17,9 @@
                 </div>
                 <i class="fa fa-angle-right" aria-hidden="true"></i>
             {{/if}}
-            <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
+            {{#if should_topic_be_visible}}
+                <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
+            {{/if}}
         </div>
         <select class='message_edit_topic_propagate' style='display:none;'>
             <option value="change_one"> {{t "Move only this message" }}</option>

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -8,13 +8,15 @@
     {{#if is_stream}}
     <div class="edit-controls">
         <div class="message_edit_header">
-            <div class="stream_header_colorblock" {{#unless is_stream_editable}}style="display:none"{{/unless}}></div>
-            <div class="select_stream_setting" {{#unless is_stream_editable}}style="display:none"{{/unless}}>
-                {{> settings/dropdown_list_widget
-                  widget_name=select_move_stream_widget_name
-                  list_placeholder=(t 'Filter streams')}}
-            </div>
-            <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
+            {{#if is_stream_editable}}
+                <div class="stream_header_colorblock"></div>
+                <div class="select_stream_setting">
+                    {{> settings/dropdown_list_widget
+                      widget_name=select_move_stream_widget_name
+                      list_placeholder=(t 'Filter streams')}}
+                </div>
+                <i class="fa fa-angle-right" aria-hidden="true"></i>
+            {{/if}}
             <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
         </div>
         <select class='message_edit_topic_propagate' style='display:none;'>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #22566 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
