### PR TITLE
unread: Indicate which streams and topics have unread @-mentions.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -14,7 +14,7 @@ page_params.realm_users = [];
 
 // We use this with override.
 let num_unread_for_stream;
-
+let stream_has_any_unread_mentions;
 const noop = () => {};
 
 mock_esm("../../static/js/narrow_state", {
@@ -30,6 +30,7 @@ const scroll_util = mock_esm("../../static/js/scroll_util", {
 mock_esm("../../static/js/ui", {get_scroll_element: ($element) => $element});
 mock_esm("../../static/js/unread", {
     num_unread_for_stream: () => num_unread_for_stream,
+    stream_has_any_unread_mentions: () => stream_has_any_unread_mentions,
 });
 
 const {Filter} = zrequire("../js/filter");
@@ -60,11 +61,13 @@ let inactive_subheader_flag = false;
 function create_devel_sidebar_row({mock_template}) {
     const $devel_count = $.create("devel-count");
     const $subscription_block = $.create("devel-block");
+    const $devel_unread_mention_info = $.create("devel-unread-mention-info");
 
     const $sidebar_row = $("<devel-sidebar-row-stub>");
 
     $sidebar_row.set_find_results(".subscription_block", $subscription_block);
     $subscription_block.set_find_results(".unread_count", $devel_count);
+    $subscription_block.set_find_results(".unread_mention_info", $devel_unread_mention_info);
 
     mock_template("stream_sidebar_row.hbs", false, (data) => {
         assert.equal(data.uri, "#narrow/stream/100-devel");
@@ -72,18 +75,22 @@ function create_devel_sidebar_row({mock_template}) {
     });
 
     num_unread_for_stream = 42;
+    stream_has_any_unread_mentions = false;
     stream_list.create_sidebar_row(devel);
     assert.equal($devel_count.text(), "42");
+    assert.equal($devel_unread_mention_info.text(), "");
 }
 
 function create_social_sidebar_row({mock_template}) {
     const $social_count = $.create("social-count");
     const $subscription_block = $.create("social-block");
+    const $social_unread_mention_info = $.create("social-unread-mention-info");
 
     const $sidebar_row = $("<social-sidebar-row-stub>");
 
     $sidebar_row.set_find_results(".subscription_block", $subscription_block);
     $subscription_block.set_find_results(".unread_count", $social_count);
+    $subscription_block.set_find_results(".unread_mention_info", $social_unread_mention_info);
 
     mock_template("stream_sidebar_row.hbs", false, (data) => {
         assert.equal(data.uri, "#narrow/stream/200-social");
@@ -91,8 +98,10 @@ function create_social_sidebar_row({mock_template}) {
     });
 
     num_unread_for_stream = 99;
+    stream_has_any_unread_mentions = true;
     stream_list.create_sidebar_row(social);
     assert.equal($social_count.text(), "99");
+    assert.equal($social_unread_mention_info.text(), "@");
 }
 
 function create_stream_subheader({mock_template}) {
@@ -658,8 +667,10 @@ test_ui("rename_stream", ({mock_template}) => {
 
     const $subscription_block = $.create("development-block");
     const $unread_count = $.create("development-count");
+    const $unread_mention_info = $.create("development-unread-mention-info");
     $li_stub.set_find_results(".subscription_block", $subscription_block);
     $subscription_block.set_find_results(".unread_count", $unread_count);
+    $subscription_block.set_find_results(".unread_mention_info", $unread_mention_info);
 
     stream_list.rename_stream(sub);
     assert.equal($unread_count.text(), "99");

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -582,6 +582,51 @@ test("mention updates", () => {
     test_counted(true);
 });
 
+test("stream_has_any_unread_mentions", () => {
+    const muted_stream_id = 401;
+    user_topics.add_muted_topic(401, "lunch");
+
+    const mention_me_message = {
+        id: 15,
+        type: "stream",
+        stream_id: 400,
+        topic: "lunch",
+        mentioned: true,
+        mentioned_me_directly: true,
+        unread: true,
+    };
+
+    const mention_all_message = {
+        id: 16,
+        type: "stream",
+        stream_id: 400,
+        topic: "lunch",
+        mentioned: true,
+        mentioned_me_directly: false,
+        unread: true,
+    };
+
+    // This message's stream_id should not be present in `streams_with_mentions`.
+    const muted_mention_all_message = {
+        id: 17,
+        type: "stream",
+        stream_id: muted_stream_id,
+        topic: "lunch",
+        mentioned: true,
+        mentioned_me_directly: false,
+        unread: true,
+    };
+
+    unread.process_loaded_messages([
+        mention_me_message,
+        mention_all_message,
+        muted_mention_all_message,
+    ]);
+
+    assert.equal(unread.stream_has_any_unread_mentions(400), true);
+    assert.equal(unread.stream_has_any_unread_mentions(muted_stream_id), false);
+});
+
 test("starring", () => {
     // We don't need any setup here, because we just hard code
     // this to [] in the code.

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -627,6 +627,35 @@ test("stream_has_any_unread_mentions", () => {
     assert.equal(unread.stream_has_any_unread_mentions(muted_stream_id), false);
 });
 
+test("topics with unread mentions", () => {
+    const message_with_mention = {
+        id: 98,
+        type: "stream",
+        stream_id: 999,
+        topic: "topic with mention",
+        mentioned: true,
+        mentioned_me_directly: true,
+        unread: true,
+    };
+
+    const message_without_mention = {
+        id: 99,
+        type: "stream",
+        stream_id: 999,
+        topic: "topic without mention",
+        mentioned: false,
+        mentioned_me_directly: false,
+        unread: true,
+    };
+
+    unread.process_loaded_messages([message_with_mention, message_without_mention]);
+    assert.equal(unread.get_topics_with_unread_mentions(999).size, 1);
+    assert.deepEqual(unread.get_topics_with_unread_mentions(999), new Set(["topic with mention"]));
+    unread.mark_as_read(message_with_mention.id);
+    assert.equal(unread.get_topics_with_unread_mentions(999).size, 0);
+    assert.deepEqual(unread.get_topics_with_unread_mentions(999), new Set([]));
+});
+
 test("starring", () => {
     // We don't need any setup here, because we just hard code
     // this to [] in the code.

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -82,10 +82,11 @@ export function keyed_topic_li(conversation) {
     };
 }
 
-export function more_li(more_topics_unreads) {
+export function more_li(more_topics_unreads, more_topics_have_unread_mention_messages) {
     const render = () =>
         render_more_topics({
             more_topics_unreads,
+            more_topics_have_unread_mention_messages,
         });
 
     const eq = (other) => other.more_items && more_topics_unreads === other.more_topics_unreads;
@@ -142,6 +143,8 @@ export class TopicListWidget {
 
         const num_possible_topics = list_info.num_possible_topics;
         const more_topics_unreads = list_info.more_topics_unreads;
+        const more_topics_have_unread_mention_messages =
+            list_info.more_topics_have_unread_mention_messages;
 
         const is_showing_all_possible_topics =
             list_info.items.length === num_possible_topics &&
@@ -154,7 +157,7 @@ export class TopicListWidget {
         if (spinner) {
             nodes.push(spinner_li());
         } else if (!is_showing_all_possible_topics) {
-            nodes.push(more_li(more_topics_unreads));
+            nodes.push(more_li(more_topics_unreads, more_topics_have_unread_mention_messages));
         } else if (zoomed) {
             // In the zoomed topic view, we need to add the input
             // for filtering through list of topics.

--- a/static/js/topic_list_data.js
+++ b/static/js/topic_list_data.js
@@ -14,6 +14,7 @@ const max_topics_with_unread = 8;
 export function get_list_info(stream_id, zoomed) {
     let topics_selected = 0;
     let more_topics_unreads = 0;
+    let more_topics_have_unread_mention_messages = false;
 
     let active_topic = narrow_state.topic();
 
@@ -29,12 +30,16 @@ export function get_list_info(stream_id, zoomed) {
 
     const items = [];
 
+    const topics_with_unread_mentions = unread.get_topics_with_unread_mentions(stream_id);
+
     for (const [idx, topic_name] of topic_names.entries()) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = active_topic === topic_name.toLowerCase();
         const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
         const [topic_resolved_prefix, topic_display_name] =
             resolved_topic.display_parts(topic_name);
+        // Important: Topics are lower-case in this set.
+        const contains_unread_mention = topics_with_unread_mentions.has(topic_name.toLowerCase());
 
         if (!zoomed) {
             function should_show_topic(topics_selected) {
@@ -85,6 +90,9 @@ export function get_list_info(stream_id, zoomed) {
                     // stream-level counts, only counts messages
                     // on unmuted topics.
                     more_topics_unreads += num_unread;
+                    if (contains_unread_mention) {
+                        more_topics_have_unread_mention_messages = true;
+                    }
                 }
                 continue;
             }
@@ -102,6 +110,7 @@ export function get_list_info(stream_id, zoomed) {
             is_muted: is_topic_muted,
             is_active_topic,
             url: hash_util.by_stream_topic_url(stream_id, topic_name),
+            contains_unread_mention,
         };
 
         items.push(topic_info);
@@ -111,5 +120,6 @@ export function get_list_info(stream_id, zoomed) {
         items,
         num_possible_topics: topic_names.length,
         more_topics_unreads,
+        more_topics_have_unread_mention_messages,
     };
 }

--- a/static/js/ui_util.ts
+++ b/static/js/ui_util.ts
@@ -49,6 +49,21 @@ export function update_unread_count_in_dom($unread_count_elem: JQuery, count: nu
     $unread_count_span.text(count);
 }
 
+export function update_unread_mention_info_in_dom(
+    $unread_mention_info_elem: JQuery,
+    stream_has_any_unread_mention_messages: Boolean,
+): void {
+    const $unread_mention_info_span = $unread_mention_info_elem.find(".unread_mention_info");
+    if (!stream_has_any_unread_mention_messages) {
+        $unread_mention_info_span.hide();
+        $unread_mention_info_span.text("");
+        return;
+    }
+
+    $unread_mention_info_span.show();
+    $unread_mention_info_span.text("@");
+}
+
 /**
  * Parse HTML and return a DocumentFragment.
  *

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -31,6 +31,7 @@ export const unread_mentions_counter = new Set();
 const unread_messages = new Set();
 
 class Bucketer {
+    // Maps item_id => bucket_key for items present in a bucket.
     reverse_lookup = new Map();
 
     constructor(options) {
@@ -58,12 +59,13 @@ class Bucketer {
         } else {
             bucket.add(item_id);
         }
-        this.reverse_lookup.set(item_id, bucket);
+        this.reverse_lookup.set(item_id, bucket_key);
     }
 
     delete(item_id) {
-        const bucket = this.reverse_lookup.get(item_id);
-        if (bucket) {
+        const bucket_key = this.reverse_lookup.get(item_id);
+        if (bucket_key) {
+            const bucket = this.get_bucket(bucket_key);
             bucket.delete(item_id);
             this.reverse_lookup.delete(item_id);
         }

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -563,6 +563,12 @@ div.overlay {
     color: hsl(0, 0%, 100%);
 }
 
+.unread_mention_info:not(:empty) {
+    margin-right: 5px;
+    margin-left: 2px;
+    opacity: 0.7;
+}
+
 /* Implement the web app's default-hidden convention for alert
    elements.  Portico pages lack this CSS and thus show them by
    default. */

--- a/static/templates/more_topics.hbs
+++ b/static/templates/more_topics.hbs
@@ -1,6 +1,11 @@
 <li class="topic-list-item show-more-topics bottom_left_row {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}">
     <span class='topic-box'>
         <a class="topic-name" tabindex="0">{{t "more topics" }}</a>
+        {{#if more_topics_have_unread_mention_messages}}
+            <span class="unread_mention_info">
+                @
+            </span>
+        {{/if}}
         <span class="unread_count {{#unless more_topics_unreads}}zero_count{{/unless}}">
             {{more_topics_unreads}}
         </span>

--- a/static/templates/stream_sidebar_row.hbs
+++ b/static/templates/stream_sidebar_row.hbs
@@ -10,6 +10,7 @@
 
             <a href="{{uri}}" title="{{name}}" class="stream-name">{{name}}</a>
 
+            <span class="unread_mention_info"></span>
             <span class="unread_count"></span>
         </div>
         <span class="stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>

--- a/static/templates/topic_list_item.hbs
+++ b/static/templates/topic_list_item.hbs
@@ -6,6 +6,11 @@
         <a href='{{url}}' class="topic-name" title="{{topic_name}}">
             {{topic_display_name}}
         </a>
+        {{#if contains_unread_mention}}
+            <span class="unread_mention_info">
+                @
+            </span>
+        {{/if}}
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}
         </span>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #21637 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
