### PR TITLE
shared: Add TypeScript build step

### DIFF
--- a/static/shared/.gitignore
+++ b/static/shared/.gitignore
@@ -2,3 +2,4 @@
 # But it does appear when developing this package in tandem with
 # mobile, using `yarn link`.
 /node_modules
+/lib

--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zulip/shared",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "rm -rf lib && tsc && cp js/*.flow lib",

--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zulip/shared",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "rm -rf lib && tsc && cp js/*.flow lib",

--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -16,7 +16,6 @@
   },
   "files": [
     "icons",
-    "js",
     "lib"
   ]
 }

--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -3,11 +3,15 @@
   "version": "0.0.16",
   "license": "Apache-2.0",
   "scripts": {
+    "prepare": "rm -rf lib && tsc && cp js/*.flow lib",
     "version": "tools/npm-version",
     "postversion": "tools/npm-postversion"
   },
   "dependencies": {
     "katex": "^0.16.2",
     "lodash": "^4.17.19"
+  },
+  "devDependencies": {
+    "typescript": "^4.8.2"
   }
 }

--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -13,5 +13,10 @@
   },
   "devDependencies": {
     "typescript": "^4.8.2"
-  }
+  },
+  "files": [
+    "icons",
+    "js",
+    "lib"
+  ]
 }

--- a/static/shared/tsconfig.json
+++ b/static/shared/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        /* Language and Environment */
+        "target": "es2019",
+
+        /* Modules */
+        "rootDir": "js",
+        "moduleResolution": "node",
+
+        /* JavaScript Support */
+        "allowJs": true,
+
+        /* Emit */
+        "declaration": true,
+        "sourceMap": true,
+        "outDir": "lib",
+
+        /* Interop Constraints */
+        "isolatedModules": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+
+        /* Type Checking */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitOverride": true,
+    },
+    "include": ["js"],
+}


### PR DESCRIPTION
This transpiles the JavaScript and (future) TypeScript in `static/shared/js` to `static/shared/lib`. It also compiles away ES2020 syntax that’s not supported by the oldest JS engines targeted by zulip-mobile.

Discussion: https://chat.zulip.org/#narrow/stream/48-mobile/topic/.40zulip.2Fshared.20building/near/1410166