### PR TITLE
settings_users: Change text of deactivate confirmation modals.

### DIFF
--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -103,7 +103,7 @@ async function test_bot_deactivation_and_reactivation(page: Page): Promise<void>
 
     assert.strictEqual(
         await common.get_text_from_selector(page, ".dialog_heading"),
-        "Deactivate Zulip Default Bot",
+        "Deactivate Zulip Default Bot?",
         "Unexpected title for deactivate bot modal",
     );
     assert.strictEqual(

--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -44,7 +44,7 @@ async function test_deactivate_user(page: Page): Promise<void> {
 
     assert.strictEqual(
         await common.get_text_from_selector(page, ".dialog_heading"),
-        "Deactivate " + common.fullname.cordelia,
+        "Deactivate " + common.fullname.cordelia + "?",
         "Unexpected title for deactivate user modal",
     );
     assert.strictEqual(

--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -49,7 +49,7 @@ async function test_deactivate_user(page: Page): Promise<void> {
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
-        "Confirm",
+        "Deactivate",
         "Deactivate button has incorrect text.",
     );
     await page.click("#dialog_widget_modal .dialog_submit_button");
@@ -108,7 +108,7 @@ async function test_bot_deactivation_and_reactivation(page: Page): Promise<void>
     );
     assert.strictEqual(
         await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
-        "Confirm",
+        "Deactivate",
         "Deactivate button has incorrect text.",
     );
     await page.click("#dialog_widget_modal .dialog_submit_button");

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -453,13 +453,14 @@ export function confirm_deactivation(user_id, handle_confirm, loading_spinner) {
             };
             const html_body = render_settings_deactivation_user_modal(opts);
 
-            confirm_dialog.launch({
+            dialog_widget.launch({
                 html_heading: $t_html(
                     {defaultMessage: "Deactivate {name}?"},
                     {name: user.full_name},
                 ),
                 help_link: "/help/deactivate-or-reactivate-a-user#deactivate-ban-a-user",
                 html_body,
+                html_submit_button: $t_html({defaultMessage: "Deactivate"}),
                 id: "deactivate-user-modal",
                 on_click: handle_confirm,
                 loading_spinner,
@@ -491,10 +492,11 @@ function confirm_bot_deactivation(bot_id, handle_confirm, loading_spinner) {
     const bot = people.get_by_user_id(bot_id);
     const html_body = render_settings_deactivation_bot_modal();
 
-    confirm_dialog.launch({
+    dialog_widget.launch({
         html_heading: $t_html({defaultMessage: "Deactivate {name}?"}, {name: bot.full_name}),
         help_link: "/help/deactivate-or-reactivate-a-bot",
         html_body,
+        html_submit_button: $t_html({defaultMessage: "Deactivate"}),
         on_click: handle_confirm,
         loading_spinner,
     });

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -455,7 +455,7 @@ export function confirm_deactivation(user_id, handle_confirm, loading_spinner) {
 
             confirm_dialog.launch({
                 html_heading: $t_html(
-                    {defaultMessage: "Deactivate {name}"},
+                    {defaultMessage: "Deactivate {name}?"},
                     {name: user.full_name},
                 ),
                 help_link: "/help/deactivate-or-reactivate-a-user#deactivate-ban-a-user",

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -489,14 +489,10 @@ function handle_deactivation($tbody) {
 
 function confirm_bot_deactivation(bot_id, handle_confirm, loading_spinner) {
     const bot = people.get_by_user_id(bot_id);
-    const opts = {
-        username: bot.full_name,
-        email: settings_data.email_for_user_settings(bot),
-    };
-    const html_body = render_settings_deactivation_bot_modal(opts);
+    const html_body = render_settings_deactivation_bot_modal();
 
     confirm_dialog.launch({
-        html_heading: $t_html({defaultMessage: "Deactivate {name}"}, {name: bot.full_name}),
+        html_heading: $t_html({defaultMessage: "Deactivate {name}?"}, {name: bot.full_name}),
         help_link: "/help/deactivate-or-reactivate-a-bot",
         html_body,
         on_click: handle_confirm,

--- a/static/templates/confirm_dialog/confirm_deactivate_bot.hbs
+++ b/static/templates/confirm_dialog/confirm_deactivate_bot.hbs
@@ -1,7 +1,1 @@
-<p>
-    {{#tr}}
-        When you deactivate <z-user></z-user>.
-        {{#*inline "z-user"}}<strong>{{username}}</strong>{{#if email}} &lt;{{email}}&gt;{{/if}}{{/inline}}
-    {{/tr}}
-</p>
 <p>{{t "A deactivated bot cannot send messages, access data, or take any other action." }}</p>

--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -25,7 +25,7 @@ Note that organization administrators cannot deactivate organization owners.
 
 1. Click the **Deactivate user** button at the bottom.
 
-1. Approve by clicking **Confirm**.
+1. Approve by clicking **Deactivate**.
 
 {tab|via-organization-settings}
 
@@ -34,7 +34,7 @@ Note that organization administrators cannot deactivate organization owners.
 1. Click the **Deactivate** button to the right of the user account that you
    want to deactivate.
 
-1. Approve by clicking **Confirm**.
+1. Approve by clicking **Deactivate**.
 
 {end_tabs}
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
**settings_bots: Change text of bot deactivate confirmation modal.**
Also, add `?` at the end of title of the this modal.

**settings_users: Add `?` in deactivate confirmation modal title.**

**deactivate_users: Change submit button text of confirmation modal.**
Change submit button text of both bot and user deactivation confirm
modal from "Confirm" to "Deactivate".
Calling `launch()` function from `dialog_widget.js` because
`confirm_dialog.js` set submit button text to "Confirm".

Fixes: <!-- Issue link, or clear description.-->[CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/Confirmation.20modal.20of.20.22Deactivate.22.20bot.2E/near/1409338)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![bot_deactivate_confirmation](https://user-images.githubusercontent.com/41695888/181095709-f12baaba-9290-47d8-abb0-d35f4806a74d.png)
![user_deactivate_confirmation](https://user-images.githubusercontent.com/41695888/181095712-2a56e029-0742-4931-a230-9be278402554.png)



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
