### PR TITLE
storage: Use Django 4.0 manifest_storage option

### DIFF
--- a/zerver/lib/storage.py
+++ b/zerver/lib/storage.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+from django.core.files.storage import FileSystemStorage
 
 if settings.DEBUG:
     from django.contrib.staticfiles.finders import find
@@ -56,9 +57,5 @@ class ZulipStorage(IgnoreBundlesManifestStaticFilesStorage):
     # so, we can use a different copy of staticfiles.json for each
     # deployment, which ensures that we always use the correct static
     # assets for each deployment.
-    manifest_name = os.path.join(settings.DEPLOY_ROOT, "staticfiles.json")
-
-    def path(self, name: str) -> str:
-        if name == self.manifest_name:
-            return name
-        return super().path(name)
+    def __init__(self) -> None:
+        return super().__init__(manifest_storage=FileSystemStorage(location=settings.DEPLOY_ROOT))


### PR DESCRIPTION
https://code.djangoproject.com/ticket/27590
https://docs.djangoproject.com/en/4.0/ref/contrib/staticfiles/#manifeststaticfilesstorage

Tested in production on andersk.zulipdev.org; the manifest is written to /home/zulip/deployments/current/staticfiles.json and successfully used.