### PR TITLE
help-docs: Fix cross-links to help center pages about linking to Zulip.

### DIFF
--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -119,4 +119,4 @@ message](/help/quote-and-reply).
 
 * [Add a custom linkifier](/help/add-a-custom-linkifier)
 * [Format your messages using Markdown](/help/format-your-message-using-markdown)
-* [Linking to Zulip](/help/linking-to-zulip)
+* [Linking to your organization](/help/linking-to-zulip)

--- a/templates/zerver/help/linking-to-zulip.md
+++ b/templates/zerver/help/linking-to-zulip.md
@@ -1,6 +1,6 @@
-# Linking to Zulip
+# Linking to your organization
 
-You can link to your Zulip from the web with a Zulip
+You can link to your Zulip organization from the web with a Zulip
 [shields.io](https://github.com/badges/shields) badge:
 
 [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org)
@@ -21,7 +21,6 @@ HTML
 <a href="https://chat.zulip.org"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen.svg" /></a>
 ```
 
-## Link to a stream or topic
+## Related articles
 
-You can also link to a specific stream, topic, message, or search inside of
-Zulip. See [link to a message or conversation](/help/link-to-a-message-or-conversation).
+* [Link to a message or conversation](/help/link-to-a-message-or-conversation)


### PR DESCRIPTION
Renames the main heading of [Linking to your organization](https://zulip.com/help/linking-to-zulip), aka "Linking to Zulip" to match up with the sidebar index title and replaces the "Link to a stream or topic" section with a regular "Related articles" section.

<img width="228" alt="image" src="https://user-images.githubusercontent.com/2343554/181132977-e4cf43ad-e18a-43fc-896f-7ed7b9947f17.png">

<img width="575" alt="image" src="https://user-images.githubusercontent.com/2343554/181133027-c2fa9849-e9ab-48c2-9a11-74188a648f6f.png">

<img width="278" alt="image" src="https://user-images.githubusercontent.com/2343554/181133085-62e8106d-f91e-4ea4-80cc-6b7a1123af44.png">

Fixes "Linking to Zulip" cross-link title in [Link to a message or conversation](https://zulip.com/help/link-to-a-message-or-conversation).

<img width="332" alt="image" src="https://user-images.githubusercontent.com/2343554/181133141-b6646c14-adb3-4733-af37-7e5a8b557733.png">

Fixes: #22590.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>