### PR TITLE
2fa: Refactor is_2fa_verified to require type narrowing.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -1046,13 +1046,13 @@ def zulip_otp_required_if_logged_in(
         if not if_configured:
             return True
 
-        # User has completed 2FA verification
-        if is_2fa_verified(user):
-            return True
-
         # This request is unauthenticated (logged-out) access; 2FA is
         # not required or possible.
         if not user.is_authenticated:
+            return True
+
+        # User has completed 2FA verification
+        if is_2fa_verified(user):
             return True
 
         # If the user doesn't have 2FA set up, we can't enforce 2FA.

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -1,11 +1,10 @@
 import re
 import unicodedata
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional, Sequence, TypedDict, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, TypedDict
 
 import dateutil.parser as date_parser
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict
@@ -622,7 +621,7 @@ def get_active_bots_owned_by_user(user_profile: UserProfile) -> QuerySet[UserPro
     return UserProfile.objects.filter(is_bot=True, is_active=True, bot_owner=user_profile)
 
 
-def is_2fa_verified(user: Union[UserProfile, AnonymousUser]) -> bool:
+def is_2fa_verified(user: UserProfile) -> bool:
     """
     It is generally unsafe to call is_verified directly on `request.user` since
     the attribute `otp_device` does not exist on an `AnonymousUser`, and `is_verified`
@@ -633,4 +632,4 @@ def is_2fa_verified(user: Union[UserProfile, AnonymousUser]) -> bool:
     # Explicitly require the caller to ensure that settings.TWO_FACTOR_AUTHENTICATION_ENABLED
     # is True before calling `is_2fa_verified`.
     assert settings.TWO_FACTOR_AUTHENTICATION_ENABLED
-    return user.is_authenticated and is_verified(user)
+    return is_verified(user)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -764,7 +764,7 @@ def login_page(
     # logged-in app.
     is_preview = "preview" in request.GET
     if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
-        if request.user and is_2fa_verified(request.user):
+        if request.user.is_authenticated and is_2fa_verified(request.user):
             return HttpResponseRedirect(request.user.realm.uri)
     elif request.user.is_authenticated and not is_preview:
         return HttpResponseRedirect(request.user.realm.uri)


### PR DESCRIPTION
This makes it mandatory to narrow the type of the user to `UserProfile`
before calling this helper.

This effectively removes the `request.user` check. We do not call login_page
anywhere else without getting through the authentication middleware.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
