### PR TITLE
confirmation: Remove Realm from ConfirmationObjT.

### DIFF
--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -59,7 +59,6 @@ ConfirmationObjT = Union[
     PreregistrationUser,
     EmailChangeStatus,
     UserProfile,
-    Realm,
     RealmReactivationStatus,
 ]
 
@@ -120,11 +119,7 @@ def create_confirmation_link(
     # determined by the confirmation_type - its main purpose is for use
     # in tests which may want to have control over the exact expiration time.
     key = generate_key()
-    realm: Optional[Realm]
-    if isinstance(obj, Realm):
-        realm = obj
-    else:
-        realm = obj.realm
+    realm = obj.realm
 
     current_time = timezone_now()
     expiry_date = None

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -19,7 +19,14 @@ from django.utils.timezone import now as timezone_now
 
 from confirmation import settings as confirmation_settings
 from zerver.lib.types import UnspecifiedValue
-from zerver.models import EmailChangeStatus, MultiuseInvite, PreregistrationUser, Realm, UserProfile
+from zerver.models import (
+    EmailChangeStatus,
+    MultiuseInvite,
+    PreregistrationUser,
+    Realm,
+    RealmReactivationStatus,
+    UserProfile,
+)
 
 
 class ConfirmationKeyException(Exception):
@@ -47,7 +54,14 @@ def generate_key() -> str:
     return b32encode(secrets.token_bytes(15)).decode().lower()
 
 
-ConfirmationObjT = Union[MultiuseInvite, PreregistrationUser, EmailChangeStatus, UserProfile, Realm]
+ConfirmationObjT = Union[
+    MultiuseInvite,
+    PreregistrationUser,
+    EmailChangeStatus,
+    UserProfile,
+    Realm,
+    RealmReactivationStatus,
+]
 
 
 def get_object_from_key(

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -374,10 +374,11 @@ class RealmTest(ZulipTestCase):
         realm = get_realm("zulip")
         do_deactivate_realm(realm, acting_user=None)
         self.assertTrue(realm.deactivated)
-        create_confirmation_link(realm, Confirmation.REALM_REACTIVATION)
+        obj = RealmReactivationStatus.objects.create(realm=realm)
+        create_confirmation_link(obj, Confirmation.REALM_REACTIVATION)
         confirmation = Confirmation.objects.last()
         assert confirmation is not None
-        self.assertEqual(confirmation.content_object, realm)
+        self.assertEqual(confirmation.content_object, obj)
         self.assertEqual(confirmation.realm, realm)
 
     def test_do_send_realm_reactivation_email(self) -> None:


### PR DESCRIPTION
In https://github.com/zulip/zulip/pull/22584, we started to use `RealmReactivationStatus` in place of `Realm` when calling `create_confirmation_link`. That in fact removes the only callers that are using `Realm` as the confirmation object. This PR is a follow-up that cleans up the legacy.

We might want to merge #22600 before the last commit, so that the new type annotation makes sense.

Affected errors:
```diff
6c6
< Found 143 errors in 40 files (checked 1405 source files)
---
> Found 137 errors in 39 files (checked 1405 source files)
145,150d144
< zerver/views/realm.py error Subclass of "EmailChangeStatus" and "RealmReactivationStatus" cannot exist would have incompatible method signatures  [unreachable]
< zerver/views/realm.py error Subclass of "MultiuseInvite" and "RealmReactivationStatus" cannot exist would have incompatible method signatures  [unreachable]
< zerver/views/realm.py error Subclass of "PreregistrationUser" and "RealmReactivationStatus" cannot exist would have incompatible method signatures  [unreachable]
< zerver/views/realm.py error Subclass of "Realm" and "RealmReactivationStatus" cannot exist would have incompatible method signatures  [unreachable]
< zerver/views/realm.py error Subclass of "UserProfile" and "RealmReactivationStatus" cannot exist would have incompatible method signatures  [unreachable]
< zerver/views/realm.py error Statement is unreachable  [unreachable]
```


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
