### PR TITLE
Use a real parser for email addresses

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -2,6 +2,8 @@
 
 const {strict: assert} = require("assert");
 
+const {parseOneAddress} = require("email-addresses");
+
 const {mock_esm, with_overrides, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
@@ -1575,7 +1577,7 @@ test("navbar_helpers", () => {
             icon: "envelope",
             title: properly_separated_names([joe.full_name]),
             redirect_url_with_search:
-                "/#narrow/pm-with/" + joe.user_id + "-" + joe.email.split("@")[0],
+                "/#narrow/pm-with/" + joe.user_id + "-" + parseOneAddress(joe.email).local,
         },
         {
             operator: group_pm,
@@ -1610,13 +1612,13 @@ test("navbar_helpers", () => {
         {
             operator: sender_me,
             redirect_url_with_search:
-                "/#narrow/sender/" + me.user_id + "-" + me.email.split("@")[0],
+                "/#narrow/sender/" + me.user_id + "-" + parseOneAddress(me.email).local,
             is_common_narrow: false,
         },
         {
             operator: sender_joe,
             redirect_url_with_search:
-                "/#narrow/sender/" + joe.user_id + "-" + joe.email.split("@")[0],
+                "/#narrow/sender/" + joe.user_id + "-" + parseOneAddress(joe.email).local,
             is_common_narrow: false,
         },
     ];

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "css.escape": "^1.5.1",
     "date-fns": "^2.16.1",
     "date-fns-tz": "^1.1.1",
+    "email-addresses": "^5.0.0",
     "emoji-datasource-google": "^14.0.0",
     "emoji-datasource-google-blob": "npm:emoji-datasource-google@^3.0.0",
     "emoji-datasource-twitter": "^14.0.0",

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1,5 +1,6 @@
 import md5 from "blueimp-md5";
 import {format, utcToZonedTime} from "date-fns-tz";
+import {parseOneAddress} from "email-addresses";
 
 import * as typeahead from "../shared/js/typeahead";
 
@@ -508,7 +509,7 @@ export function pm_with_url(message) {
     } else {
         const person = get_by_user_id(user_ids[0]);
         if (person && person.email) {
-            suffix = person.email.split("@")[0].toLowerCase();
+            suffix = parseOneAddress(person.email).local.toLowerCase();
         } else {
             blueslip.error("Unknown people in message");
             suffix = "unk";
@@ -582,7 +583,7 @@ export function emails_to_slug(emails_string) {
     const emails = emails_string.split(",");
 
     if (emails.length === 1) {
-        slug += emails[0].split("@")[0].toLowerCase();
+        slug += parseOneAddress(emails[0]).local.toLowerCase();
     } else {
         slug += "group";
     }

--- a/tools/tail-ses
+++ b/tools/tail-ses
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+from email.headerregistry import Address
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from scripts.lib.setup_path import setup_path
@@ -32,7 +33,7 @@ def main() -> None:
     session = boto3.Session()
 
     from_address = settings.NOREPLY_EMAIL_ADDRESS
-    from_host = from_address.split("@")[1]
+    from_host = Address(addr_spec=from_address).domain
 
     ses: SESClient = session.client("ses")
     possible_identities = []

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 133
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (195, 0)
+PROVISION_VERSION = (195, 1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4191,6 +4191,11 @@ elementary-circuits-directed-graph@^1.0.4:
   dependencies:
     strongly-connected-components "^1.0.1"
 
+email-addresses@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-5.0.0.tgz#7ae9e7f58eef7d5e3e2c2c2d3ea49b78dc854fa6"
+  integrity sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==
+
 "emoji-datasource-google-blob@npm:emoji-datasource-google@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emoji-datasource-google/-/emoji-datasource-google-3.0.0.tgz#d6f77b56385338e10667d2b150dbe9f9b5a4e921"

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from collections import defaultdict
+from email.headerregistry import Address
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -92,11 +93,11 @@ if TYPE_CHECKING:
 
 
 def compute_irc_user_fullname(email: str) -> str:
-    return email.split("@")[0] + " (IRC)"
+    return Address(addr_spec=email).username + " (IRC)"
 
 
 def compute_jabber_user_fullname(email: str) -> str:
-    return email.split("@")[0] + " (XMPP)"
+    return Address(addr_spec=email).username + " (XMPP)"
 
 
 def get_user_profile_delivery_email_cache_key(

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -1,3 +1,4 @@
+from email.headerregistry import Address
 from typing import Any, Dict, Literal, Optional
 
 import orjson
@@ -370,7 +371,9 @@ def do_scrub_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> None:
         do_delete_messages_by_sender(user)
         do_delete_avatar_image(user, acting_user=acting_user)
         user.full_name = f"Scrubbed {generate_key()[:15]}"
-        scrubbed_email = f"scrubbed-{generate_key()[:15]}@{realm.host}"
+        scrubbed_email = Address(
+            username=f"scrubbed-{generate_key()[:15]}", domain=realm.host
+        ).addr_spec
         user.email = scrubbed_email
         user.delivery_email = scrubbed_email
         user.save(update_fields=["full_name", "email", "delivery_email"])

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from email.headerregistry import Address
 from typing import Any, Dict, List, Optional
 
 import orjson
@@ -67,7 +68,9 @@ def do_delete_user(user_profile: UserProfile, *, acting_user: Optional[UserProfi
         personal_recipient.delete()
         replacement_user = create_user(
             force_id=user_id,
-            email=f"deleteduser{user_id}@{get_fake_email_domain(realm)}",
+            email=Address(
+                username=f"deleteduser{user_id}", domain=get_fake_email_domain(realm)
+            ).addr_spec,
             password=None,
             realm=realm,
             full_name=f"Deleted User {user_id}",

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from email.headerregistry import Address
 from typing import Optional, Union
 
 import orjson
@@ -62,7 +63,9 @@ def copy_default_settings(
 
 def get_display_email_address(user_profile: UserProfile) -> str:
     if not user_profile.email_address_is_realm_public():
-        return f"user{user_profile.id}@{get_fake_email_domain(user_profile.realm)}"
+        return Address(
+            username=f"user{user_profile.id}", domain=get_fake_email_domain(user_profile.realm)
+        ).addr_spec
     return user_profile.delivery_email
 
 

--- a/zerver/lib/dev_ldap_directory.py
+++ b/zerver/lib/dev_ldap_directory.py
@@ -1,6 +1,7 @@
 import glob
 import logging
 import os
+from email.headerregistry import Address
 from typing import Any, Dict, List, Optional
 
 from django.conf import settings
@@ -30,7 +31,7 @@ def generate_dev_ldap_dir(mode: str, num_users: int = 8) -> Dict[str, Dict[str, 
     ldap_dir = {}
     for i, user_data in enumerate(ldap_data):
         email = user_data[1].lower()
-        email_username = email.split("@")[0]
+        email_username = Address(addr_spec=email).username
         common_data = {
             "cn": [user_data[0]],
             "userPassword": [email_username],

--- a/zerver/lib/email_validation.py
+++ b/zerver/lib/email_validation.py
@@ -1,3 +1,4 @@
+from email.headerregistry import Address
 from typing import Callable, Dict, Optional, Set, Tuple
 
 from django.core import validators
@@ -13,15 +14,13 @@ from zerver.models import (
     EmailContainsPlusError,
     Realm,
     RealmDomain,
-    email_to_domain,
-    email_to_username,
     get_users_by_delivery_email,
     is_cross_realm_bot_email,
 )
 
 
 def validate_disposable(email: str) -> None:
-    if is_disposable_domain(email_to_domain(email)):
+    if is_disposable_domain(Address(addr_spec=email).domain):
         raise DisposableEmailError
 
 
@@ -59,10 +58,11 @@ def get_realm_email_validator(realm: Realm) -> Callable[[str], None]:
         a small whitelist.
         """
 
-        if "+" in email_to_username(email):
+        address = Address(addr_spec=email)
+        if "+" in address.username:
             raise EmailContainsPlusError
 
-        domain = email_to_domain(email)
+        domain = address.domain
 
         if domain in allowed_domains:
             return

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,3 +1,4 @@
+from email.headerregistry import Address
 from typing import Any, Dict, List
 from urllib.parse import quote, urlsplit
 
@@ -20,7 +21,7 @@ def encode_stream(stream_id: int, stream_name: str) -> str:
 
 def personal_narrow_url(realm: Realm, sender: UserProfile) -> str:
     base_url = f"{realm.uri}/#narrow/pm-with/"
-    email_user = sender.email.split("@")[0].lower()
+    email_user = Address(addr_spec=sender.email).username.lower()
     pm_slug = str(sender.id) + "-" + hash_util_encode(email_user)
     return base_url + pm_slug
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -15,6 +15,7 @@
 import json
 import os
 import sys
+from email.headerregistry import Address
 from functools import wraps
 from typing import Any, Callable, Dict, List, Set, TypeVar, cast
 
@@ -58,7 +59,10 @@ def ensure_users(ids_list: List[int], user_names: List[str]) -> None:
     # Ensure that the list of user ids (ids_list)
     # matches the users we want to refer to (user_names).
     realm = get_realm("zulip")
-    user_ids = [get_user(name + "@zulip.com", realm).id for name in user_names]
+    user_ids = [
+        get_user(Address(username=name, domain="zulip.com").addr_spec, realm).id
+        for name in user_names
+    ]
 
     assert ids_list == user_ids
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -90,7 +90,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         # Invalid username
         bot_info = dict(
             full_name="My bot name",
-            short_name="@",
+            short_name="my\nbot",
         )
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_error(result, "Bad name or username")

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -3,6 +3,7 @@ import email.policy
 import os
 import subprocess
 from email import message_from_string
+from email.headerregistry import Address
 from email.message import EmailMessage, MIMEPart
 from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Optional
 from unittest import mock
@@ -237,12 +238,11 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
     def create_incoming_valid_message(
         self, msgtext: str, stream: Stream, include_quotes: bool
     ) -> EmailMessage:
-        stream_to_address = encode_email_address(stream)
-        parts = stream_to_address.split("@")
-        parts[0] += "+show-sender"
+        address = Address(addr_spec=encode_email_address(stream))
+        email_username = address.username + "+show-sender"
         if include_quotes:
-            parts[0] += "+include-quotes"
-        stream_to_address = "@".join(parts)
+            email_username += "+include-quotes"
+        stream_to_address = Address(username=email_username, domain=address.domain).addr_spec
 
         incoming_valid_message = EmailMessage()
         incoming_valid_message.set_content(msgtext)
@@ -459,10 +459,9 @@ and other things
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        stream_to_address = encode_email_address(stream)
-        parts = stream_to_address.split("@")
-        parts[0] += "+show-sender"
-        stream_to_address = "@".join(parts)
+        address = Address(addr_spec=encode_email_address(stream))
+        email_username = address.username + "+show-sender"
+        stream_to_address = Address(username=email_username, domain=address.domain).addr_spec
 
         incoming_valid_message = EmailMessage()
         incoming_valid_message.set_content("TestStreamEmailMessages body")
@@ -491,10 +490,9 @@ and other things
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        stream_to_address = encode_email_address(stream)
-        parts = stream_to_address.split("@")
-        parts[0] += "+include-footer"
-        stream_to_address = "@".join(parts)
+        address = Address(addr_spec=encode_email_address(stream))
+        email_username = address.username + "+include-footer"
+        stream_to_address = Address(username=email_username, domain=address.domain).addr_spec
 
         text = """Test message
         --
@@ -520,10 +518,9 @@ and other things
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
-        stream_to_address = encode_email_address(stream)
-        parts = stream_to_address.split("@")
-        parts[0] += "+include-quotes"
-        stream_to_address = "@".join(parts)
+        address = Address(addr_spec=encode_email_address(stream))
+        email_username = address.username + "+include-quotes"
+        stream_to_address = Address(username=email_username, domain=address.domain).addr_spec
 
         text = """Reply
 
@@ -1603,8 +1600,10 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
 
-        address_parts = stream_to_address.split("@")
-        scrubbed_address = "X" * len(address_parts[0]) + "@" + address_parts[1]
+        address = Address(addr_spec=stream_to_address)
+        scrubbed_address = Address(
+            username="X" * len(address.username), domain=address.domain
+        ).addr_spec
 
         incoming_valid_message = EmailMessage()
         incoming_valid_message.set_content("Test body")
@@ -1666,8 +1665,10 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
 
         # Test for a stream address:
         stream_to_address = encode_email_address(stream)
-        stream_address_parts = stream_to_address.split("@")
-        scrubbed_stream_address = "X" * len(stream_address_parts[0]) + "@" + stream_address_parts[1]
+        address = Address(addr_spec=stream_to_address)
+        scrubbed_stream_address = Address(
+            username="X" * len(address.username), domain=address.domain
+        ).addr_spec
 
         error_message = "test message {}"
         error_message = error_message.format(stream_to_address)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1,5 +1,6 @@
 import datetime
 import sys
+from email.headerregistry import Address
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Set
 from unittest import mock
 
@@ -2308,7 +2309,7 @@ class TestCrossRealmPMs(ZulipTestCase):
         return realm
 
     def create_user(self, email: str) -> UserProfile:
-        subdomain = email.split("@")[1]
+        subdomain = Address(addr_spec=email).domain
         self.register(email, "test", subdomain=subdomain)
         # self.register has the side-effect of ending up with a logged in session
         # for the new user. We don't want that in these tests.

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1414,12 +1414,16 @@ class ScrubRealmTest(ZulipTestCase):
 
         zulip_users = UserProfile.objects.filter(realm=zulip)
         for user in zulip_users:
-            self.assertTrue(re.search("Scrubbed [a-z0-9]{15}", user.full_name))
-            self.assertTrue(re.search("scrubbed-[a-z0-9]{15}@" + zulip.host, user.email))
-            self.assertTrue(re.search("scrubbed-[a-z0-9]{15}@" + zulip.host, user.delivery_email))
+            self.assertRegex(user.full_name, r"^Scrubbed [a-z0-9]{15}$")
+            self.assertRegex(user.email, rf"^scrubbed-[a-z0-9]{{15}}@{re.escape(zulip.host)}$")
+            self.assertRegex(
+                user.delivery_email, rf"^scrubbed-[a-z0-9]{{15}}@{re.escape(zulip.host)}$"
+            )
 
         lear_users = UserProfile.objects.filter(realm=lear)
         for user in lear_users:
-            self.assertIsNone(re.search("Scrubbed [a-z0-9]{15}", user.full_name))
-            self.assertIsNone(re.search("scrubbed-[a-z0-9]{15}@" + zulip.host, user.email))
-            self.assertIsNone(re.search("scrubbed-[a-z0-9]{15}@" + zulip.host, user.delivery_email))
+            self.assertNotRegex(user.full_name, r"^Scrubbed [a-z0-9]{15}$")
+            self.assertNotRegex(user.email, rf"^scrubbed-[a-z0-9]{{15}}@{re.escape(zulip.host)}$")
+            self.assertNotRegex(
+                user.delivery_email, rf"^scrubbed-[a-z0-9]{{15}}@{re.escape(zulip.host)}$"
+            )

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -1,6 +1,7 @@
 import logging
 import secrets
 import urllib
+from email.headerregistry import Address
 from functools import wraps
 from typing import Any, Dict, List, Mapping, Optional, cast
 from urllib.parse import urlencode
@@ -482,7 +483,7 @@ def remote_user_jwt(request: HttpRequest) -> HttpResponse:
     if email_domain is None:
         raise JsonableError(_("No organization specified in JSON web token claims"))
 
-    email = f"{remote_user}@{email_domain}"
+    email = Address(username=remote_user, domain=email_domain).addr_spec
 
     try:
         realm = get_realm(subdomain)

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -1,4 +1,5 @@
 import sys
+from email.headerregistry import Address
 from typing import Iterable, Optional, Sequence, Union, cast
 
 from dateutil.parser import parse as dateparser
@@ -32,7 +33,6 @@ from zerver.models import (
     Realm,
     RealmDomain,
     UserProfile,
-    email_to_domain,
     get_user_including_cross_realm,
 )
 
@@ -97,7 +97,7 @@ def same_realm_zephyr_user(user_profile: UserProfile, email: str) -> bool:
     except ValidationError:
         return False
 
-    domain = email_to_domain(email)
+    domain = Address(addr_spec=email).domain
 
     # Assumes allow_subdomains=False for all RealmDomain's corresponding to
     # these realms.
@@ -116,7 +116,9 @@ def same_realm_irc_user(user_profile: UserProfile, email: str) -> bool:
     except ValidationError:
         return False
 
-    domain = email_to_domain(email).replace("irc.", "")
+    domain = Address(addr_spec=email).domain
+    if domain.startswith("irc."):
+        domain = domain[len("irc.") :]
 
     # Assumes allow_subdomains=False for all RealmDomain's corresponding to
     # these realms.
@@ -131,7 +133,7 @@ def same_realm_jabber_user(user_profile: UserProfile, email: str) -> bool:
 
     # If your Jabber users have a different email domain than the
     # Zulip users, this is where you would do any translation.
-    domain = email_to_domain(email)
+    domain = Address(addr_spec=email).domain
 
     # Assumes allow_subdomains=False for all RealmDomain's corresponding to
     # these realms.

--- a/zerver/views/zephyr.py
+++ b/zerver/views/zephyr.py
@@ -3,6 +3,7 @@ import logging
 import re
 import shlex
 import subprocess
+from email.headerregistry import Address
 from typing import Optional
 
 import orjson
@@ -42,7 +43,7 @@ def webathena_kerberos_login(
         user = parsed_cred["cname"]["nameString"][0]
         if user in kerberos_alter_egos:
             user = kerberos_alter_egos[user]
-        assert user == user_profile.email.split("@")[0]
+        assert user == Address(addr_spec=user_profile.email).username
         # Limit characters in usernames to valid MIT usernames
         # This is important for security since DNS is not secure.
         assert re.match(r"^[a-z0-9_.-]+$", user) is not None

--- a/zerver/webhooks/pagerduty/view.py
+++ b/zerver/webhooks/pagerduty/view.py
@@ -1,3 +1,4 @@
+from email.headerregistry import Address
 from typing import Any, Dict
 
 from django.http import HttpRequest, HttpResponse
@@ -93,7 +94,7 @@ def build_pagerduty_formatdict(message: Dict[str, Any]) -> Dict[str, Any]:
     if message["data"]["incident"].get("assigned_to_user", None):
         assigned_to_user = message["data"]["incident"]["assigned_to_user"]
         format_dict["assignee_info"] = AGENT_TEMPLATE.format(
-            username=assigned_to_user["email"].split("@")[0],
+            username=Address(addr_spec=assigned_to_user["email"]).username,
             url=assigned_to_user["html_url"],
         )
     else:
@@ -102,7 +103,7 @@ def build_pagerduty_formatdict(message: Dict[str, Any]) -> Dict[str, Any]:
     if message["data"]["incident"].get("resolved_by_user", None):
         resolved_by_user = message["data"]["incident"]["resolved_by_user"]
         format_dict["agent_info"] = AGENT_TEMPLATE.format(
-            username=resolved_by_user["email"].split("@")[0],
+            username=Address(addr_spec=resolved_by_user["email"]).username,
             url=resolved_by_user["html_url"],
         )
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -1,4 +1,5 @@
 import os
+from email.headerregistry import Address
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict
 
 from scripts.lib.zulip_tools import deport
@@ -27,9 +28,11 @@ EXTERNAL_HOST_WITHOUT_PORT = deport(EXTERNAL_HOST)
 ALLOWED_HOSTS: List[str] = []
 
 # Basic email settings
-NOREPLY_EMAIL_ADDRESS = "noreply@" + EXTERNAL_HOST_WITHOUT_PORT
+NOREPLY_EMAIL_ADDRESS = Address(username="noreply", domain=EXTERNAL_HOST_WITHOUT_PORT).addr_spec
 ADD_TOKENS_TO_NOREPLY_ADDRESS = True
-TOKENIZED_NOREPLY_EMAIL_ADDRESS = "noreply-{token}@" + EXTERNAL_HOST_WITHOUT_PORT
+TOKENIZED_NOREPLY_EMAIL_ADDRESS = Address(
+    username="noreply-{token}", domain=EXTERNAL_HOST_WITHOUT_PORT
+).addr_spec
 PHYSICAL_ADDRESS = ""
 FAKE_EMAIL_DOMAIN = EXTERNAL_HOST_WITHOUT_PORT
 


### PR DESCRIPTION
Email addresses are more complicated than just `f"{user}@{domain}"`.

```pycon
>>> from email.headerregistry import Address
>>> Address(username="a@b", domain="c").addr_spec
'"a@b"@c'
>>> Address(addr_spec='"a@b"@c')
Address(display_name='', username='a@b', domain='c')
>>> Address(username='a"b', domain="c").addr_spec
'"a\\"b"@c'
>>> Address(addr_spec='"a\\"b"@c')
Address(display_name='', username='a"b', domain='c')
```