### PR TITLE
Fix image tooltip displayed on top left corner.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -312,6 +312,20 @@ export function initialize() {
                 $(instance.reference).parent().attr("aria-label") ||
                 $(instance.reference).parent().attr("href");
             instance.setContent(parse_html(render_message_inline_image_tooltip({title})));
+
+            const target_node = $(instance.reference)
+                .parents(".message_table.focused_table")
+                .get(0);
+            const config = {attributes: false, childList: true, subtree: false};
+            const nodes_to_check_for_removal = [
+                $(instance.reference).parents(".message_inline_image").get(0),
+            ];
+            hide_tooltip_if_reference_removed(
+                target_node,
+                config,
+                instance,
+                nodes_to_check_for_removal,
+            );
         },
         onHidden(instance) {
             instance.destroy();


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/tooltip.20in.20the.20wrong.20place

Spamming the `s` when hovered on an image can cause the tooltip
to be displayed at the top left corner. This is caused by original
reference of the tooltip being removed from DOM. The re-rendering
is happening so quickly that tippy is not able to hide the tooltip
in time.

Even if this fixes the issue, I feel like we should add some sort of throttle function to `s/S` hotkeys since they cause re-renders and spamming them for some time causes the app to freeze.