### PR TITLE
Fedora 36 support.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-20.04"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/srv/zulip"
+  config.vm.synced_folder ".", "/srv/zulip", docker_consistency: "z"
 
   vagrant_config_file = ENV["HOME"] + "/.zulip-vagrant-config"
   if File.file?(vagrant_config_file)

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -51,13 +51,13 @@ a proxy to access the internet.)
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
 - **Ubuntu LTS**: 20.04 or 22.04
 - **Debian**: 11
+- **Fedora**: tested for 36
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
   virtualization enabled (VT-x or AMD-V), administrator access.
 
 Other Linux distributions work great too, but we don't maintain
 documentation for installing Vagrant and Docker on those systems, so
-you'll need to find a separate guide and crib from the Debian/Ubuntu
-docs.
+you'll need to find a separate guide and crib from these docs.
 
 ### Step 0: Set up Git & GitHub
 
@@ -77,6 +77,7 @@ Jump to:
 - [macOS](#macos)
 - [Ubuntu](#ubuntu)
 - [Debian](#debian)
+- [Fedora](#fedora)
 - [Windows](#windows-10)
 
 #### macOS
@@ -144,6 +145,16 @@ Now you are ready for [Step 2: Get Zulip code](#step-2-get-zulip-code).
 #### Debian
 
 The setup for Debian is the same as that [for Ubuntu above](#ubuntu).
+
+#### Fedora
+
+The setup for Fedora is mostly equivalent to the [setup for Ubuntu](#ubuntu).
+The only difference is the installation of Docker. Fedora does not include the
+official `docker-ce` package (named `docker.io` in the
+[setup for Ubuntu](#ubuntu)) in their repositories. They provide the package
+`moby-engine` which you can choose instead. In case you prefer the official
+docker distribution, you can follow
+[their documentation to install Docker on Fedora](https://docs.docker.com/engine/install/fedora/).
 
 #### Windows 10
 


### PR DESCRIPTION
Hi :) This PR fixes the Fedora 36 support, as discussed [here](https://chat.zulip.org/#narrow/stream/21-provision-help/topic/Bind.20mounts.20selinux.20context).

The current enhancements:
- Add documentation for the vagrant setup on Fedora.
- Fix the container setup by adding the `:z` label to the bind mounts so that the selinux context allows sharing. This is according to the official docker documentation: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
The error fixed by this happened during execution of `vagrant up --provider=docker`:
```
    default: build_emoji: Using cached emojis from /srv/zulip-emoji-cache/8104e7a3afb8a0bac60d1aacfefcd3aedfdbdbc2/emoji
    default: Traceback (most recent call last):
    default:   File "tools/setup/emoji/build_emoji", line 378, in <module>
    default:     main()
    default:   File "tools/setup/emoji/build_emoji", line 111, in main
    default:     shutil.copy2(os.path.join(source_emoji_dump, filename), TARGET_EMOJI_STYLES)
    default:   File "/usr/lib/python3.8/shutil.py", line 435, in copy2
    default:     copyfile(src, dst, follow_symlinks=follow_symlinks)
    default:   File "/usr/lib/python3.8/shutil.py", line 264, in copyfile
    default:     with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
    default: PermissionError: [Errno 13] Permission denied: '/srv/zulip/tools/setup/emoji/../../../static/generated/emoji-styles/google-blob-sprite.css'
    default: 
    default: Error running a subcommand of /srv/zulip/tools/lib/provision_inner.py: tools/setup/emoji/build_emoji
    default: Actual error output for the subcommand is just above this.
    default: 
    default: 
    default: Provisioning failed (exit code 1)!
    default: 
    default: * Look at the traceback(s) above to find more about the errors.
    default: * Resolve the errors or get help on chat.
    default: * If you can fix this yourself, you can re-run tools/provision at any time.
    default: * Logs are here: zulip/var/log/provision.log
    default: 
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

With these changes, it is possible to use the Zulip Vagrant environment on Fedora 36.