### PR TITLE
migration: Tweak migration 0401 to exit early on most servers.

### DIFF
--- a/zerver/migrations/0401_migrate_old_realm_reactivation_links.py
+++ b/zerver/migrations/0401_migrate_old_realm_reactivation_links.py
@@ -26,8 +26,8 @@ def fix_old_realm_reactivation_confirmations(
     Confirmation = apps.get_model("confirmation", "Confirmation")
     ContentType = apps.get_model("contenttypes", "ContentType")
 
-    if not Confirmation.objects.exists():
-        # No Confirmations so nothing to do, and the database may actually
+    if not Confirmation.objects.filter(type=REALM_REACTIVATION).exists():
+        # No relevant Confirmations so nothing to do, and the database may actually
         # no be provisioned yet, which would make the code below break.
         return
 


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/31-production-help/topic/Failed.20to.20run.20upgrade.20from.20git/near/1411990

I'm actually unable to reproduce this when upgrading my own production server, so not sure why
`ContentType.objects.get(model="realmreactivationstatus", app_label="zerver")` fails for the user. Perhaps it can be debugged after they successfully upgrade. 

Before doing the migration on Zulip Cloud we can first apply migration `0400` and then run  `ContentType.objects.get(model="realmreactivationstatus", app_label="zerver")` in the shell to ensure the `ContentType` row exists before applying `0401` to avoid failures.


A user ran into an issue while upgrading where
ContentType.objects.get(model="realmreactivationstatus",
app_label="zerver") fails due to the object being missing. The reason
for that is to be yet figured out, but the immediate solution is clear
in the sense that the migration can just quit early
if not Confirmation.objects.filter(type=REALM_REACTIVATION).exists() and
that'll effectively skip it for almost all servers (because realm
reactivations links are something that's really only useful on Zulip
Cloud).
