### PR TITLE
Refer to automated notification bot messages as notices.

### DIFF
--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -26,12 +26,12 @@
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
                 <span></span>
-                {{t "Send notification to new topic" }}
+                {{t "Send automated notice to new topic" }}
             </label>
             <label class="checkbox">
                 <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                 <span></span>
-                {{t "Send notification to old topic" }}
+                {{t "Send automated notice to old topic" }}
             </label>
         </div>
     </div>

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -16,12 +16,12 @@
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
                 <span></span>
-                {{t "Send notification to new topic" }}
+                {{t "Send automated notice to new topic" }}
             </label>
             <label class="checkbox">
                 <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
                 <span></span>
-                {{t "Send notification to old topic" }}
+                {{t "Send automated notice to old topic" }}
             </label>
         </div>
     </div>

--- a/templates/zerver/help/change-the-privacy-of-a-stream.md
+++ b/templates/zerver/help/change-the-privacy-of-a-stream.md
@@ -30,7 +30,7 @@ public.
 
 {end_tabs}
 
-{!update-stream-auto-notification.md!}
+{!automated-notice-stream-event.md!}
 
 !!! warn ""
 

--- a/templates/zerver/help/change-the-stream-description.md
+++ b/templates/zerver/help/change-the-stream-description.md
@@ -25,6 +25,6 @@ previews are disabled.
 
 {end_tabs}
 
-{!update-stream-auto-notification.md!}
+{!automated-notice-stream-event.md!}
 
 [markdown-formatting]: /help/format-your-message-using-markdown

--- a/templates/zerver/help/configure-notification-bot.md
+++ b/templates/zerver/help/configure-notification-bot.md
@@ -16,6 +16,10 @@ The notification bot also generates automated private messages to
 individual users for some user specific events, such as [being
 subscribed to a stream][add-users-to-stream] by another user.
 
+Additionally, when [moving messages to a another stream][move-messages],
+users can have the notification bot send automated notices to help
+others find the moved content.
+
 Organization administrators can configure where (and whether)
 [new stream](#new-stream-announcements) and
 [new user](#new-user-announcements) announcement messages are sent.
@@ -74,3 +78,4 @@ these messages is "signups".
 [api-create-user]: https://zulip.com/api/create-user
 [new-stream-options]: /help/create-a-stream#stream-options
 [org-lang]: /help/change-the-default-language-for-your-organization
+[move-messages]: /help/move-content-to-another-stream

--- a/templates/zerver/help/include/automated-notice-stream-event.md
+++ b/templates/zerver/help/include/automated-notice-stream-event.md
@@ -1,0 +1,7 @@
+!!! warn ""
+
+    **Note**: This sends an automated notice from [notification
+    bot][notification-bot] to the "stream events" topic in the
+    modified stream.
+
+[notification-bot]: /help/configure-notification-bot

--- a/templates/zerver/help/include/update-stream-auto-notification.md
+++ b/templates/zerver/help/include/update-stream-auto-notification.md
@@ -1,4 +1,0 @@
-!!! warn ""
-
-    **Note**: This sends an automated notification to the **stream
-    events** topic in the modified stream.

--- a/templates/zerver/help/message-retention-policy.md
+++ b/templates/zerver/help/message-retention-policy.md
@@ -56,7 +56,7 @@ Standard hosting.
 
 {end_tabs}
 
-{!update-stream-auto-notification.md!}
+{!automated-notice-stream-event.md!}
 
 ## Important details
 

--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -1,13 +1,13 @@
 # Move content to another stream
 
-Zulip makes it possible to move messages or an entire topic to another stream.
-Organizations can [configure][move-permission-setting] which
-[roles](/help/roles-and-permissions) have permission to move messages between
-streams.
+Zulip makes it possible to move messages, or an entire topic, to another
+stream. Organizations can [configure][move-permission-setting] which
+[roles](/help/roles-and-permissions) have permission to move messages
+between streams.
 
-To help others find moved content, you can have Zulip send automated
-notification messages to the source topic, the destination topic, or
-both. These notifications include:
+To help others find moved content, you can have the [notification
+bot][notification-bot] send automated notices to the source topic, the
+destination topic, or both. These notices include:
 
 * A link to the source or destination topic.
 * How many messages were moved, or whether the whole topic was moved.
@@ -28,7 +28,7 @@ destination streams.
 
 1. (optional) Change the topic.
 
-1. Toggle whether automated notification messages should be sent.
+1. Toggle whether automated notices should be sent.
 
 1. Click **Confirm**.
 
@@ -55,7 +55,7 @@ destination streams.
 
 1. (optional) Change the topic.
 
-1. Toggle whether automated notification messages should be sent.
+1. Toggle whether automated notices should be sent.
 
 1. From the dropdown menu, select which messages to move.
 
@@ -85,10 +85,10 @@ will only be accessible to users who both:
 In [private streams with protected history](/help/stream-permissions),
 Zulip determines whether to treat the entire topic as moved using the
 access permissions of the user requesting the topic move. This means
-that the automated notifications will report that the entire topic was
-moved if the requesting user moved every message in the topic that
-they can access, regardless of whether older messages exist that
-they cannot access.
+that the automated notices sent by the notification bot will report
+that the entire topic was moved if the requesting user moved every
+message in the topic that they can access, regardless of whether older
+messages exist that they cannot access.
 
 Similarly, [muted topics](/help/mute-a-topic) will be migrated to the
 new stream and topic if the requesting user moved every message in the
@@ -105,3 +105,4 @@ that one does not have permission to access.
 * [Configure message editing and deletion](/help/configure-message-editing-and-deletion)
 
 [move-permission-setting]: /help/configure-message-editing-and-deletion#configure-who-can-move-topics-between-streams
+[notification-bot]: /help/configure-notification-bot

--- a/templates/zerver/help/rename-a-stream.md
+++ b/templates/zerver/help/rename-a-stream.md
@@ -17,4 +17,4 @@
 
 {end_tabs}
 
-{!update-stream-auto-notification.md!}
+{!automated-notice-stream-event.md!}

--- a/templates/zerver/help/resolve-a-topic.md
+++ b/templates/zerver/help/resolve-a-topic.md
@@ -2,21 +2,23 @@
 
 Zulip's [topics](/help/streams-and-topics) are very
 helpful for customer support, answering questions, investigating
-issues and production errors, and other workflows.
-
+issues and production errors, as well as other workflows.
 Resolving topics makes it easy to track the status of each question,
-investigation, or notification. Marking a topic as resolved:
+investigation, or notification.
+
+Marking a topic as resolved:
 
 * Puts a ✔ at the beginning of the topic name, e.g. `example topic`
   becomes `✔ example topic`.
-* Triggers an automated message from Notification Bot indicating that
+* Triggers an automated notice from the [notification
+  bot](/help/configure-notification-bot) indicating that
   you resolved the topic. This message will be marked as unread
   only for users who had participated in the topic.
 * Changes whether the topic appears when using the `is:resolved` and
   `-is:resolved` [search operators](/help/search-for-messages).
 
-Marking a topic as unresolved removes the ✔ and also triggers a
-Notification Bot message.
+Marking a topic as unresolved removes the ✔ and also triggers an
+automated notice from the notification bot.
 
 It's often helpful to define a policy for when to resolve topics that
 fits how topics are used in a given stream. Here are some common
@@ -28,7 +30,7 @@ approaches for deciding when to mark a topic as resolved:
 * **Issues, errors and production incidents**: When investigation or
   incident response is complete, and any follow-up work has been
   transferred to the appropriate tracker.
-* **Workflow management**: What the work described in the topic is
+* **Workflow management**: When the work described in the topic is
   complete and any follow-ups have been transcribed.
 * **Answering questions**: When the question has been fully answered,
   and follow-ups would be best discussed in a new topic.

--- a/templates/zerver/help/stream-sending-policy.md
+++ b/templates/zerver/help/stream-sending-policy.md
@@ -24,4 +24,4 @@ certain users can send messages.
 
 {end_tabs}
 
-{!update-stream-auto-notification.md!}
+{!automated-notice-stream-event.md!}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6200,7 +6200,7 @@ paths:
         - name: send_notification_to_old_thread
           in: query
           description: |
-            Whether to send breadcrumb message to the old thread to
+            Whether to send an automated message to the old thread to
             notify users where the messages were moved to.
 
             **Changes**: New in Zulip 3.0 (feature level 9).
@@ -6211,7 +6211,7 @@ paths:
         - name: send_notification_to_new_thread
           in: query
           description: |
-            Whether to send a notification message to the new thread to
+            Whether to send an automated message to the new thread to
             notify users where the messages came from.
 
             **Changes**: New in Zulip 3.0 (feature level 9).


### PR DESCRIPTION
Updates in-app and documentation references to automated messages sent by the Zulip notification bot as 'notices' (or 'automated messages' where more appropriate/clear).

Also, makes some small related revisions / general clean ups to `resolve-a-topic.md`.

Fixes #22188. Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/notification.20options.20when.20moving.20messages/near/1384173).

**Notes**:
- Renamed the shared `/help/include/update-stream-auto-notifications.md` to be `update-stream-auto-notice.md` to help with using `git-grep` in the help center markdown files for this terminology.
- Went ahead and made references to a specific topic use quotation marks instead of bold to be consistent with the current [notification bot](https://zulip.com/help/configure-notification-bot) help center article.
- Noticed the API documentation uses the term 'thread' instead of 'topic', but didn't change it in this PR.
- Did an audit of the `/static` and `/templates` directories for 'notification'. Did not really audit the integrations / webhooks documentation. That seemed beyond the scope / intention of the issue, which is about updating the terminology used for the Zulip notification bot automated messages.

---

**Screenshots and screen captures:**

#### In-app updates

<details>
<summary>Move topic</summary>

![Screenshot from 2022-07-28 16-51-43](https://user-images.githubusercontent.com/63245456/181568245-90630793-2dec-46b5-af4b-971ebbe62cee.png)
</details>

<details>
<summary>Move message(s)</summary>

![Screenshot from 2022-07-28 16-52-32](https://user-images.githubusercontent.com/63245456/181568251-0fb55749-4db4-424f-ab7c-2c5a61fca732.png)
</details>

#### Documentation updates

<details>
<summary>Move content to another stream</summary>

[Current documentation](https://zulip.com/help/move-content-to-another-stream)
![Screenshot from 2022-07-28 16-56-47](https://user-images.githubusercontent.com/63245456/181571701-be65331d-9553-4565-ba15-53c9be6c4c6e.png)
![Screenshot from 2022-07-28 16-57-18](https://user-images.githubusercontent.com/63245456/181571705-73451ff8-ace9-48bb-991d-e88bbf02b94b.png)
</details>

<details>
<summary>Resolve topic</summary>

[Current documentation](https://zulip.com/help/resolve-a-topic)
![Screenshot from 2022-07-28 16-58-11](https://user-images.githubusercontent.com/63245456/181571711-2f4b7967-af21-4291-8c2f-db6d49a84fbf.png)
</details>

<details>
<summary>Example of note about automated notices sent by notification bot</summary>

[Current documentation](https://zulip.com/help/rename-a-stream)
![Screenshot from 2022-07-28 16-59-04](https://user-images.githubusercontent.com/63245456/181571713-558519a2-1893-4f00-a1f0-634d9662cd3b.png)
</details>

<details>
<summary>API updates to 'Edit a message'</summary>

[Current documentation](https://zulip.com/api/update-message)
![Screenshot from 2022-07-28 17-03-06](https://user-images.githubusercontent.com/63245456/181571718-97998f60-f00d-423a-87c1-48b56bd504bc.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
