### PR TITLE
unread_ops: Don't mark all msgs as read when msg_list is rendering.

### DIFF
--- a/frontend_tests/node_tests/example7.js
+++ b/frontend_tests/node_tests/example7.js
@@ -56,7 +56,7 @@ const message_viewport = mock_esm("../../static/js/message_viewport");
 const notifications = mock_esm("../../static/js/notifications");
 const unread_ui = mock_esm("../../static/js/unread_ui");
 
-message_lists.current = {};
+message_lists.current = {view: () => {}};
 message_lists.home = {};
 
 const message_store = zrequire("message_store");
@@ -106,7 +106,7 @@ run_test("unread_ops", ({override}) => {
     message_list.narrowed = undefined;
 
     // Set message_lists.current containing messages that can be marked read
-    override(message_lists.current, "all_messages", () => test_messages);
+    override(message_lists.current.view, "get_rendered_message_ids", () => test_messages);
 
     // Ignore these interactions for now:
     override(message_lists.home, "show_message_as_read", () => {});

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1343,6 +1343,10 @@ export class MessageListView {
         return $row;
     }
 
+    get_rendered_message_ids() {
+        return [...this._rows.keys()].map((id) => message_store.get(id));
+    }
+
     clear_trailing_bookend() {
         const $trailing_bookend = rows.get_table(this.table_name).find(".trailing_bookend");
         $trailing_bookend.remove();

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -157,7 +157,7 @@ export function notify_server_message_read(message, options) {
 
 export function process_scrolled_to_bottom() {
     if (message_lists.current.can_mark_messages_read()) {
-        mark_current_list_as_read();
+        mark_rendered_messages_as_read();
         return;
     }
 
@@ -177,8 +177,11 @@ export function process_visible() {
     }
 }
 
-export function mark_current_list_as_read(options) {
-    notify_server_messages_read(message_lists.current.all_messages(), options);
+export function mark_rendered_messages_as_read(options) {
+    // Only marking rendered messages as read avoids the race between new messages being fetched in the data and
+    // user reaching the bottom of the rendered message list. If we mark mark all messages in the list as read
+    // here, we may have marked messages as read without even rendering them to the user.
+    notify_server_messages_read(message_lists.current.view.get_rendered_message_ids(), options);
 }
 
 export function mark_stream_as_read(stream_id, cont) {


### PR DESCRIPTION
It is possible to mark messages not seen by the user as read if
msg_list.data was populated with the messages, but they are not
rendered yet and user hit the bottom of the msg_list.

We fix this by not marking all messages as read when more messages
are being appended to the message list.

Discussion: https://chat.zulip.org/#narrow/stream/137-feedback/topic/scrolling.20to.20the.20reload.20point.20causes.20mark-all-as-read

How to reproduce: This is hard to reproduce. The only way I was able to reproduce this was on 5k unread message with network throttled to fast 3g. Just keep scrolling after pressing `G` until messages that are rendered after the selected message are already read. The bug happens just before the last batch of unread messages are rendered.

We cannot rely on fetch status here too, since fetch status is synchronous to the data and not with what is rendered.