### PR TITLE
help-docs: Note automated PMs sent when subscribing users to streams.

### DIFF
--- a/templates/zerver/help/add-or-remove-users-from-a-stream.md
+++ b/templates/zerver/help/add-or-remove-users-from-a-stream.md
@@ -31,6 +31,8 @@ to a stream][configure-invites].
       To add users in bulk, you can copy members from an
       existing stream or [user group](/help/user-groups).
 
+{!automated-pm-stream-subscription.md!}
+
 ### Mentioning a user in the compose box (alternate method)
 
 When you [mention a user](/help/mention-a-user-or-group) while composing

--- a/templates/zerver/help/configure-notification-bot.md
+++ b/templates/zerver/help/configure-notification-bot.md
@@ -12,9 +12,9 @@ various organization level events, including:
 * New public stream announcements (private streams are not announced)
 * New user announcements
 
-The notification bot also generates messages to individual users
-for some user specific events, such as [being subscribed to a
-stream][add-users-to-stream] by another user.
+The notification bot also generates automated private messages to
+individual users for some user specific events, such as [being
+subscribed to a stream][add-users-to-stream] by another user.
 
 Organization administrators can configure where (and whether)
 [new stream](#new-stream-announcements) and
@@ -23,8 +23,8 @@ Organization administrators can configure where (and whether)
 Stream messages sent by the notification bot (including the topic)
 are translated into the language that the organization has configured
 as the [organization language for automated messages and invitation
-emails][org-lang]. Notification bot messages sent to a single user will
-use [their preferred language](/help/change-your-language).
+emails][org-lang]. Private messages sent by the notification bot to
+a user will use [their preferred language](/help/change-your-language).
 
 ## Configure notification bot
 

--- a/templates/zerver/help/include/automated-pm-stream-subscription.md
+++ b/templates/zerver/help/include/automated-pm-stream-subscription.md
@@ -1,0 +1,6 @@
+!!! warn ""
+
+      **Note**: Subscribing someone else to a stream sends them an
+      automated private message from [notification bot][notification-bot].
+
+[notification-bot]: /help/configure-notification-bot

--- a/templates/zerver/help/manage-user-stream-subscriptions.md
+++ b/templates/zerver/help/manage-user-stream-subscriptions.md
@@ -4,7 +4,7 @@
 
 !!! warn ""
 
-      Note that the list of a user's **Subscribed streams** will be limited to
+      **Note**: The list of a user's **Subscribed streams** will be limited to
       streams for which [you can see all subscribers](/help/stream-permissions).
 
 {start_tabs}
@@ -34,6 +34,8 @@ other users to a stream][configure-invites].
 1. Click **Add**.
 
 {end_tabs}
+
+{!automated-pm-stream-subscription.md!}
 
 ## Unsubscribe a user from stream(s)
 


### PR DESCRIPTION
Adds a note to both help center articles with sections on subscribing users to streams, documenting that an automated private message (from the Zulip notification bot) is sent to each user when subscribed in this way.

Also, makes a small formatting change to the existing note [here](https://zulip.com/help/manage-user-stream-subscriptions#view-a-users-stream-subscriptions), see 3rd screenshot below.

Noted while working on #22612.

**Screenshots and screen captures:**

[Current documentation](https://zulip.com/help/manage-user-stream-subscriptions#subscribe-a-user-to-a-stream)
![Screenshot from 2022-07-28 16-44-37](https://user-images.githubusercontent.com/63245456/181749367-2cd0a4e7-f659-4365-95e8-f228d46d3d04.png)

[Current documentation](https://zulip.com/help/add-or-remove-users-from-a-stream#add-users-to-a-stream)
![Screenshot from 2022-07-28 16-44-53](https://user-images.githubusercontent.com/63245456/181749372-62b7a311-320c-4b4c-bc4c-e529b8ba5b71.png)

[Current documentation](https://zulip.com/help/manage-user-stream-subscriptions#view-a-users-stream-subscriptions)
![Screenshot from 2022-07-29 13-30-44](https://user-images.githubusercontent.com/63245456/181750086-87c48a4e-822f-4617-86fd-a2535529e473.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
