### PR TITLE
support: Correctly show Unspecified org type at /activity/support.

### DIFF
--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -53,11 +53,9 @@
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
     <select name="org_type" id="org_type">
         {% for realm_type in sorted_realm_types %}
-            {% if not realm_type.hidden %}
             <option value="{{ realm_type.id }}" {% if realm.org_type == realm_type.id %}selected{% endif %}>
                 {{ _(realm_type.name) }}
             </option>
-            {% endif %}
         {% endfor %}
     </select>
     <button type="submit" class="btn btn-default support-submit-button">Update</button>


### PR DESCRIPTION
Because the org type is marked as "hidden", the HTML was being generated
for orgs with Unspecified .org_type with no `<option> `selected, meaning
it was displayed on the page using the first `<option>` in the list
(Business). The /support endpoint should ignore the "hidden" property,
since there's no reason not to - we only want to hide this org type from
regular users during Org registration.

Here's a screenshot showing how this was displayed in a misleading way in the case of an organization with no `.org_type` set;
![image](https://user-images.githubusercontent.com/45007152/181778701-f4307ebf-33e3-45a0-984d-d7f4f46da626.png)
