### PR TITLE
frontend: add stream context to PM suggestions

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -442,6 +442,8 @@ export function filter_and_sort_mentions(is_silent, query, opts) {
 
 export function get_pm_people(query) {
     const opts = {
+        stream: compose_state.stream_name(),
+        topic: compose_state.topic(),
         want_broadcast: false,
         filter_pills: true,
     };


### PR DESCRIPTION
This PR attempts to fix #21645 by including the stream context when generating PM typeahead suggestions. The To: typeahead calls `get_stream_topic_data()` to include the message view context when generating suggestions, so I modified `get_pm_people` to also call this function.

Currently, this PR breaks the `initialize` test of `composebox_typeahead`. It also does not yet have a test to catch regressions.

Attempts to fix: #21645

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
