### PR TITLE
message_send: Avoid setting service_queue_events on message objects.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -817,7 +817,7 @@ def do_send_messages(
 
             ums.extend(user_messages)
 
-            send_request.message.service_queue_events = get_service_bot_events(
+            send_request.service_queue_events = get_service_bot_events(
                 sender=send_request.message.sender,
                 service_bot_tuples=send_request.service_bot_tuples,
                 mentioned_user_ids=mentioned_user_ids,
@@ -982,7 +982,8 @@ def do_send_messages(
 
                 send_welcome_bot_response(send_request)
 
-        for queue_name, events in send_request.message.service_queue_events.items():
+        assert send_request.service_queue_events is not None
+        for queue_name, events in send_request.service_queue_events.items():
             for event in events:
                 queue_json_publish(
                     queue_name,

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -171,6 +171,7 @@ class SendMessageRequest:
     deliver_at: Optional[datetime.datetime] = None
     delivery_type: Optional[str] = None
     limit_unread_user_ids: Optional[Set[int]] = None
+    service_queue_events: Optional[Dict[str, List[Dict[str, Any]]]] = None
 
 
 # We won't try to fetch more unread message IDs from the database than


### PR DESCRIPTION
If not necessary, we should not monkey-patch attributes. This moves the
initialization of `service_queue_events` later in the function.

Affected errors:
```diff
16c16
< Found 104 errors in 34 files (checked 1406 source files)
---
> Found 102 errors in 33 files (checked 1406 source files)
21,22d20
< zerver/actions/message_send.py error "Message" has no attribute "service_queue_events"  [attr-defined]
< zerver/actions/message_send.py error "Message" has no attribute "service_queue_events"  [attr-defined]
```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
