### PR TITLE
documentation: Add delete a user group instruction.

### DIFF
--- a/templates/zerver/help/user-groups.md
+++ b/templates/zerver/help/user-groups.md
@@ -33,6 +33,24 @@ trying to send a message to a group of people, you'll want to either
 
 {end_tabs}
 
+### Delete a user group
+
+{start_tabs}
+
+{settings_tab|user-groups-admin}
+
+1. Find the group.
+
+1. Click on the trash (<i class="fa fa-trash-o"></i>) icon in the top
+   right corner of the user group.
+
+1. Approve by clicking **Confirm**.
+
+!!! warn ""
+    **Note**: Deleting a user group cannot be undone by anyone.
+
+{end_tabs}
+
 ### Configure who can create and manage user groups
 
 {!admin-only.md!}


### PR DESCRIPTION
<!-- Describe your pull request here.--> 
There was no documentation on how to delete a user group, therefore I added the instructions.

Fixes: #22591 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-07-31 15-53-43](https://user-images.githubusercontent.com/32341580/182041075-f755f8e9-9860-44fc-9623-6db0c1afdb41.png)

