### PR TITLE
Updated: document /realm/presence endpoint.

### DIFF
--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -54,7 +54,7 @@
 * [Deactivate own user](/api/deactivate-own-user)
 * [Set "typing" status](/api/set-typing-status)
 * [Get user presence](/api/get-user-presence)
-* [Get presence of all the users](/api/get-presence)
+* [Get presence of all users](/api/get-presence)
 * [Get attachments](/api/get-attachments)
 * [Delete an attachment](/api/remove-attachment)
 * [Update settings](/api/update-settings)

--- a/templates/zerver/help/include/rest-endpoints.md
+++ b/templates/zerver/help/include/rest-endpoints.md
@@ -54,6 +54,7 @@
 * [Deactivate own user](/api/deactivate-own-user)
 * [Set "typing" status](/api/set-typing-status)
 * [Get user presence](/api/get-user-presence)
+* [Get presence of all the users](/api/get-presence)
 * [Get attachments](/api/get-attachments)
 * [Delete an attachment](/api/remove-attachment)
 * [Update settings](/api/update-settings)

--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -160,11 +160,24 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
                 elif return_values[return_value]["additionalProperties"].get(
                     "additionalProperties", False
                 ):
+                    data_type = generate_data_type(
+                        return_values[return_value]["additionalProperties"]["additionalProperties"]
+                    )
+                    ans.append(
+                        self.render_desc(
+                            return_values[return_value]["additionalProperties"][
+                                "additionalProperties"
+                            ]["description"],
+                            spacing + 8,
+                            data_type,
+                        )
+                    )
+
                     ans += self.render_table(
                         return_values[return_value]["additionalProperties"]["additionalProperties"][
                             "properties"
                         ],
-                        spacing + 8,
+                        spacing + 12,
                     )
             if (
                 "items" in return_values[return_value]

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -144,6 +144,16 @@ def test_authorization_errors_fatal(client: Client, nonadmin_client: Client) -> 
     validate_against_openapi_schema(result, "/users/me/subscriptions", "post", "400")
 
 
+@openapi_test_function("/realm/presence:get")
+def get_presence(client: Client) -> None:
+
+    # {code_example|start}
+    # Get presence information of all the users in an organization.
+    result = client.get_realm_presence()
+    # {code_example|end}
+    validate_against_openapi_schema(result, "/realm/presence", "get", "200")
+
+
 @openapi_test_function("/users/{user_id_or_email}/presence:get")
 def get_user_presence(client: Client) -> None:
 
@@ -1489,6 +1499,7 @@ def test_users(client: Client, owner_client: Client) -> None:
     set_typing_status(client)
     update_presence(client)
     get_user_presence(client)
+    get_presence(client)
     create_user_group(client)
     user_group_id = get_user_groups(client)
     update_user_group(client, user_group_id)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1005,10 +1005,12 @@ paths:
                             - type: object
                               description: |
                                 Event sent to all users in an organization when a user comes
-                                back online after being long offline. While most presence updates happen
-                                done via polling the main presence endpoint, this event is important
-                                to avoid confusing users when someone comes online and then immediately sends
-                                a message (one wouldn't want them to still appear offline at that point!).
+                                back online after being offline for a while. While most presence
+                                updates are done via polling the [main presence
+                                endpoint](/api/get-presence), this event is important to avoid
+                                confusing users when someone comes online and immediately sends
+                                a message (one wouldn't want them to still appear offline at
+                                that point!).
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -1020,7 +1022,7 @@ paths:
                                 user_id:
                                   type: integer
                                   description: |
-                                    The ID of modified user.
+                                    The ID of the modified user.
                                 email:
                                   type: string
                                   description: |
@@ -1037,10 +1039,37 @@ paths:
                                 presence:
                                   type: object
                                   description: |
-                                    An object contatining a set of objects which describe the
-                                    the user's presence on various platforms.
+                                    Object containing the details of the user's most recent presence.
                                   additionalProperties:
-                                    $ref: "#/components/schemas/Presence"
+                                    type: object
+                                    description: |
+                                      `{client_name}`: Object containing the details of the user's
+                                      presence on a particular platform. The object key is the client's
+                                      platform name, for example `website` or `ZulipDesktop`.
+                                    additionalProperties: false
+                                    properties:
+                                      client:
+                                        type: string
+                                        description: |
+                                          The client's platform name.
+                                      status:
+                                        type: string
+                                        enum:
+                                          - idle
+                                          - active
+                                        description: |
+                                          The status of the user on this client. Will be either `idle`
+                                          or `active`.
+                                      timestamp:
+                                        type: integer
+                                        description: |
+                                          The UNIX timestamp of when this client sent the user's presence
+                                          to the server with the precision of a second.
+                                      pushable:
+                                        type: boolean
+                                        description: |
+                                          Whether the client is capable of showing mobile/push notifications
+                                          to the user.
                               additionalProperties: false
                               example:
                                 {
@@ -6386,19 +6415,20 @@ paths:
         Get the presence status for a specific user.
 
         This endpoint is most useful for embedding data about a user's
-        presence status in other sites (E.g. an employee directory). Full
-        Zulip clients like mobile/desktop apps will want to use the main
-        presence endpoint, which returns data for all active users in the
-        organization, instead.
+        presence status in other sites (e.g. an employee directory). Full
+        Zulip clients like mobile/desktop apps will want to use the [main
+        presence endpoint](/api/get-presence), which returns data for all
+        active users in the organization, instead.
 
-        See
-        [Zulip's developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/presence.html)
+        See [Zulip's developer documentation][subsystems-presence]
         for details on the data model for presence in Zulip.
+
+        [subsystems-presence]: https://zulip.readthedocs.io/en/latest/subsystems/presence.html
       parameters:
         - name: user_id_or_email
           in: path
           description: |
-            The user_id or Zulip display email address of the user whose presence you want to fetch.
+            The ID or Zulip display email address of the user whose presence you want to fetch.
 
             **Changes**: New in Zulip 4.0 (feature level 43). Previous versions only supported
             identifying the user by Zulip display email.
@@ -6431,24 +6461,26 @@ paths:
                             timestamp:
                               type: integer
                               description: |
-                                when this update was received; if the timestamp
+                                When this update was received. If the timestamp
                                 is more than a few minutes in the past, the user is offline.
                             status:
                               type: string
                               description: |
-                                either `active` or `idle`: whether the user had
-                                recently interacted with Zulip at the time in the timestamp
-                                (this distinguishes orange vs. green dots in the Zulip web
-                                UI; orange/idle means we don't know whether the user is
-                                actually at their computer or just left the Zulip app open
-                                on their desktop).
+                                Whether the user had recently interacted with Zulip at the time
+                                of the timestamp.
+
+                                Will be either `active` or `idle`
                           description: |
-                            `{client_name}` or `aggregated`: the keys for these objects are
-                            the names of the different clients where this user is logged in,
-                            like `website`, `ZulipDesktop`, `ZulipTerminal`, or
-                            `ZulipMobile`. There is also an `aggregated` key, which matches
-                            the contents of the object that has been updated most
-                            recently. For most applications, you'll just want to look at the
+                            `{client_name}` or `aggregated`: Object containing the details of the user's
+                            presence on a particular platform.
+
+                            Generally, the keys for these objects are the names of the different clients
+                            where this user is logged in, for example `website` or `ZulipDesktop`.
+
+                            There is also an `aggregated` key, which matches the contents of the object
+                            that has been updated most recently.
+
+                            For most applications, you'll just want to look at the
                             `aggregated` key.
                     example:
                       {
@@ -7650,14 +7682,15 @@ paths:
   /realm/presence:
     get:
       operationId: get-presence
-      summary: Get presence of all the users
+      summary: Get presence of all users
       tags: ["server_and_organizations"]
       description: |
         Get the presence information of all the users in an organization.
 
-        See
-        [Zulip's developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/presence.html)
+        See [Zulip's developer documentation][subsystems-presence]
         for details on the data model for presence in Zulip.
+
+        [subsystems-presence]: https://zulip.readthedocs.io/en/latest/subsystems/presence.html
       responses:
         "200":
           description: Success.
@@ -7679,15 +7712,14 @@ paths:
                       presences:
                         type: object
                         description: |
-                          An object that contains `presence` objects for all the users,
-                          each identified by user email as the key.
+                          A dictionary where each entry describes the presence details
+                          of a user in the Zulip organization.
                         additionalProperties:
                           type: object
                           description: |
-                            `{user_email}`: Object containing details of a user's presence
-                            on every client the user is logged into. The keys for these
-                            objects are the emails of the different users whose presence
-                            data is included.
+                            `{user_email}`: Object containing the details of a user's presence
+                            on every client the user is logged into. The object's key is the
+                            user's email.
                           additionalProperties:
                             $ref: "#/components/schemas/Presence"
                     example:
@@ -9346,16 +9378,16 @@ paths:
                         description: |
                           Present if `presence` is present in `fetch_event_types`.
 
-                          A dictionary where each entry describes the presence details for another
+                          A dictionary where each entry describes the presence details of a
                           user in the Zulip organization.
 
                           Users who have been offline for multiple weeks may not appear in this object.
                         additionalProperties:
                           type: object
                           description: |
-                            `{user_id} or {user_email}`: Depending on the value of `slim_presence`.
-                            Each entry contains the details of the presence of the user with the specific
-                            id or email.
+                            `{user_id}` or `{user_email}`: Object containing the details of a user's
+                            presence on every client the user is logged into. Depending on the value
+                            of `slim_presence`, the object's key is either the user's ID or email.
                           additionalProperties:
                             $ref: "#/components/schemas/Presence"
                       server_timestamp:
@@ -15566,9 +15598,15 @@ components:
     Presence:
       type: object
       description: |
-        `{client_name}`: Object containing the details of the user's
-        presence on a particular platform with the client's platform
-        name being the object key.
+        `{client_name}` or `aggregated`: Object containing the details of the user's
+        presence on a particular platform.
+
+        Generally, the keys for these objects are the names of the different clients
+        where this user is logged in, for example `website` or `ZulipDesktop`.
+
+        There is also an `aggregated` key, which matches the contents of the object
+        that has been updated most recently (except for the `pushable` value which is
+        not present).
       additionalProperties: false
       properties:
         client:
@@ -15581,7 +15619,7 @@ components:
             - idle
             - active
           description: |
-            The status of the user on this client. It is either `idle`
+            The status of the user on this client. Will be either `idle`
             or `active`.
         timestamp:
           type: integer
@@ -15593,6 +15631,8 @@ components:
           description: |
             Whether the client is capable of showing mobile/push notifications
             to the user.
+
+            Not present in objects with the `aggregated` key.
     Draft:
       type: object
       description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7647,6 +7647,74 @@ paths:
                               },
                           },
                       }
+  /realm/presence:
+    get:
+      operationId: get-presence
+      summary: Get presence of all the users
+      tags: ["server_and_organizations"]
+      description: |
+        Get the presence information of all the users in an organization.
+
+        See
+        [Zulip's developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/presence.html)
+        for details on the data model for presence in Zulip.
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      server_timestamp:
+                        type: number
+                        description: |
+                          The time when the server fetched the `presences` data included
+                          in the response.
+                      presences:
+                        type: object
+                        description: |
+                          An object that contains `presence` objects for all the users,
+                          each identified by user email as the key.
+                        additionalProperties:
+                          type: object
+                          description: |
+                            `{user_email}`: Object containing details of a user's presence
+                            on every client the user is logged into. The keys for these
+                            objects are the emails of the different users whose presence
+                            data is included.
+                          additionalProperties:
+                            $ref: "#/components/schemas/Presence"
+                    example:
+                      {
+                        "msg": "",
+                        "presences":
+                          {
+                            "iago@zulip.com":
+                              {
+                                "ZulipPython":
+                                  {
+                                    "client": "ZulipPython",
+                                    "pushable": false,
+                                    "status": "active",
+                                    "timestamp": 1656958485,
+                                  },
+                                "aggregated":
+                                  {
+                                    "client": "ZulipPython",
+                                    "status": "active",
+                                    "timestamp": 1656958485,
+                                  },
+                              },
+                          },
+                        "result": "success",
+                        "server_timestamp": 1656958539.6287155,
+                      }
   /realm/profile_fields:
     get:
       operationId: get-custom-profile-fields

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -205,7 +205,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
     checked_endpoints: Set[str] = set()
     pending_endpoints = {
         #### TODO: These endpoints are a priority to document:
-        "/realm/presence",
         "/users/me/presence",
         "/users/me/alert_words",
         # These are a priority to document but don't match our normal URL schemes


### PR DESCRIPTION
Updated version of #22509. Revises areas of documentation re: user presence objects.

Updates documentation to include information about user presence objects with `aggregated` key (instead of the user's email) where appropriate.

Also, cleans up spelling, grammar and formatting errors in the descriptive text for these objects / endpoints.

**Notes**:
- Because the `presence` event sent to the `/get-events` endpoint will never include the `aggregated` key object, these changes create some duplication in the documentation. I'm not sure if there is a good way to avoid that and cleanly validate the api documentation.
- There were existing references to the "main presence endpoint" (in the [`/get-events` `presence` event](https://zulip.com/api/get-events#presence) and the main description for the [`/get-user-presence` endpoint](https://zulip.com/api/get-user-presence), which I took to mean the `realm/presence` endpoint being documented here, so I added links in those parts of the documentation.

@akashaviator - Would you be up for looking over these updates and seeing if everything is accurate and if there is a way to deduplicate any information in the OpenAPI documentation between these endpoints / objects?

---

**Screenshots and screen captures:**

<details>
<summary>New get presence of all users endpoint doc</summary>

![Screenshot from 2022-08-01 13-41-09](https://user-images.githubusercontent.com/63245456/182167476-92a6043e-860f-4701-aa0e-e47bc600b43f.png)
</details>

<details>
<summary>Get presence of single user</summary>

[Current documentation](https://zulip.com/api/get-user-presence)
![Screenshot from 2022-08-01 13-41-26](https://user-images.githubusercontent.com/63245456/182167628-85766f91-c3c2-4e16-a00a-b4c68dc06631.png)
</details>

<details>
<summary>Register queue `presences` object</summary>

[Current documentation](https://zulip.com/api/register-queue) : search in page for "presences"
![Screenshot from 2022-08-01 13-42-53](https://user-images.githubusercontent.com/63245456/182167769-32016d68-0f7c-46d3-9f97-fc63045c432b.png)
</details>

<details>
<summary>Get events `presence` event</summary>

[Current documentation](https://zulip.com/api/get-events#presence)
![Screenshot from 2022-08-01 13-42-25](https://user-images.githubusercontent.com/63245456/182167727-6246ad3e-fb9a-4af1-ab32-044f6a8d3cdc.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
