### PR TITLE
decorator: Refactor `has_request_variables` and friends

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -131,7 +131,7 @@ def get_chart_data_for_realm(
     except Realm.DoesNotExist:
         raise JsonableError(_("Invalid organization"))
 
-    return get_chart_data(request, user_profile=user_profile, realm=realm, **kwargs)
+    return get_chart_data(request, user_profile, realm=realm, **kwargs)
 
 
 @require_server_admin_api
@@ -148,7 +148,7 @@ def get_chart_data_for_remote_realm(
     server = RemoteZulipServer.objects.get(id=remote_server_id)
     return get_chart_data(
         request,
-        user_profile=user_profile,
+        user_profile,
         server=server,
         remote=True,
         remote_realm_id=int(remote_realm_id),
@@ -179,7 +179,7 @@ def stats_for_remote_installation(request: HttpRequest, remote_server_id: int) -
 def get_chart_data_for_installation(
     request: HttpRequest, /, user_profile: UserProfile, chart_name: str = REQ(), **kwargs: Any
 ) -> HttpResponse:
-    return get_chart_data(request, user_profile=user_profile, for_installation=True, **kwargs)
+    return get_chart_data(request, user_profile, for_installation=True, **kwargs)
 
 
 @require_server_admin_api
@@ -196,7 +196,7 @@ def get_chart_data_for_remote_installation(
     server = RemoteZulipServer.objects.get(id=remote_server_id)
     return get_chart_data(
         request,
-        user_profile=user_profile,
+        user_profile,
         for_installation=True,
         remote=True,
         server=server,

--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -131,7 +131,7 @@ def get_chart_data_for_realm(
     except Realm.DoesNotExist:
         raise JsonableError(_("Invalid organization"))
 
-    return get_chart_data(request=request, user_profile=user_profile, realm=realm, **kwargs)
+    return get_chart_data(request, user_profile=user_profile, realm=realm, **kwargs)
 
 
 @require_server_admin_api
@@ -147,7 +147,7 @@ def get_chart_data_for_remote_realm(
     assert settings.ZILENCER_ENABLED
     server = RemoteZulipServer.objects.get(id=remote_server_id)
     return get_chart_data(
-        request=request,
+        request,
         user_profile=user_profile,
         server=server,
         remote=True,
@@ -179,9 +179,7 @@ def stats_for_remote_installation(request: HttpRequest, remote_server_id: int) -
 def get_chart_data_for_installation(
     request: HttpRequest, /, user_profile: UserProfile, chart_name: str = REQ(), **kwargs: Any
 ) -> HttpResponse:
-    return get_chart_data(
-        request=request, user_profile=user_profile, for_installation=True, **kwargs
-    )
+    return get_chart_data(request, user_profile=user_profile, for_installation=True, **kwargs)
 
 
 @require_server_admin_api
@@ -197,7 +195,7 @@ def get_chart_data_for_remote_installation(
     assert settings.ZILENCER_ENABLED
     server = RemoteZulipServer.objects.get(id=remote_server_id)
     return get_chart_data(
-        request=request,
+        request,
         user_profile=user_profile,
         for_installation=True,
         remote=True,

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -364,7 +364,7 @@ def webhook_view(
         @has_request_variables
         @wraps(view_func)
         def _wrapped_func_arguments(
-            request: HttpRequest, api_key: str = REQ(), *args: object, **kwargs: object
+            request: HttpRequest, /, api_key: str = REQ(), *args: object, **kwargs: object
         ) -> HttpResponse:
             user_profile = validate_api_key(
                 request,
@@ -677,7 +677,7 @@ def authenticated_uploads_api_view(
         @has_request_variables
         @wraps(view_func)
         def _wrapped_func_arguments(
-            request: HttpRequest, api_key: str = REQ(), *args: object, **kwargs: object
+            request: HttpRequest, /, api_key: str = REQ(), *args: object, **kwargs: object
         ) -> HttpResponse:
             user_profile = validate_api_key(request, None, api_key, False)
             if not skip_rate_limiting:

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -142,52 +142,76 @@ def require_post(
     return wrapper
 
 
-def require_realm_owner(func: ViewFuncT) -> ViewFuncT:
+def require_realm_owner(
+    func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
     @wraps(func)
     def wrapper(
-        request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if not user_profile.is_realm_owner:
             raise OrganizationOwnerRequired()
         return func(request, user_profile, *args, **kwargs)
 
-    return cast(ViewFuncT, wrapper)  # https://github.com/python/mypy/issues/1927
+    return wrapper
 
 
-def require_realm_admin(func: ViewFuncT) -> ViewFuncT:
+def require_realm_admin(
+    func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
     @wraps(func)
     def wrapper(
-        request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if not user_profile.is_realm_admin:
             raise OrganizationAdministratorRequired()
         return func(request, user_profile, *args, **kwargs)
 
-    return cast(ViewFuncT, wrapper)  # https://github.com/python/mypy/issues/1927
+    return wrapper
 
 
-def require_organization_member(func: ViewFuncT) -> ViewFuncT:
+def require_organization_member(
+    func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
     @wraps(func)
     def wrapper(
-        request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if user_profile.role > UserProfile.ROLE_MEMBER:
             raise OrganizationMemberRequired()
         return func(request, user_profile, *args, **kwargs)
 
-    return cast(ViewFuncT, wrapper)  # https://github.com/python/mypy/issues/1927
+    return wrapper
 
 
-def require_billing_access(func: ViewFuncT) -> ViewFuncT:
+def require_billing_access(
+    func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
     @wraps(func)
     def wrapper(
-        request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if not user_profile.has_billing_access:
             raise JsonableError(_("Must be a billing administrator or an organization owner"))
         return func(request, user_profile, *args, **kwargs)
 
-    return cast(ViewFuncT, wrapper)  # https://github.com/python/mypy/issues/1927
+    return wrapper
 
 
 def process_client(
@@ -627,22 +651,34 @@ def require_server_admin_api(
     return _wrapped_view_func
 
 
-def require_non_guest_user(view_func: ViewFuncT) -> ViewFuncT:
+def require_non_guest_user(
+    view_func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
     @wraps(view_func)
     def _wrapped_view_func(
-        request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if user_profile.is_guest:
             raise JsonableError(_("Not allowed for guest users"))
         return view_func(request, user_profile, *args, **kwargs)
 
-    return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927
+    return _wrapped_view_func
 
 
-def require_member_or_admin(view_func: ViewFuncT) -> ViewFuncT:
+def require_member_or_admin(
+    view_func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
     @wraps(view_func)
     def _wrapped_view_func(
-        request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if user_profile.is_guest:
             raise JsonableError(_("Not allowed for guest users"))
@@ -650,20 +686,26 @@ def require_member_or_admin(view_func: ViewFuncT) -> ViewFuncT:
             raise JsonableError(_("This endpoint does not accept bot requests."))
         return view_func(request, user_profile, *args, **kwargs)
 
-    return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927
+    return _wrapped_view_func
 
 
-def require_user_group_edit_permission(view_func: ViewFuncT) -> ViewFuncT:
+def require_user_group_edit_permission(
+    view_func: Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]
+) -> Callable[Concatenate[HttpRequest, UserProfile, ParamT], HttpResponse]:
     @require_member_or_admin
     @wraps(view_func)
     def _wrapped_view_func(
-        request: HttpRequest, user_profile: UserProfile, *args: object, **kwargs: object
+        request: HttpRequest,
+        user_profile: UserProfile,
+        /,
+        *args: ParamT.args,
+        **kwargs: ParamT.kwargs,
     ) -> HttpResponse:
         if not user_profile.can_edit_user_groups():
             raise JsonableError(_("Insufficient permission"))
         return view_func(request, user_profile, *args, **kwargs)
 
-    return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927
+    return _wrapped_view_func
 
 
 # This API endpoint is used only for the mobile apps.  It is part of a

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -754,6 +754,7 @@ class TwoFactorLoginView(BaseTwoFactorLoginView):
 @has_request_variables
 def login_page(
     request: HttpRequest,
+    /,
     next: str = REQ(default="/"),
     **kwargs: Any,
 ) -> HttpResponse:

--- a/zerver/views/development/integrations.py
+++ b/zerver/views/development/integrations.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import orjson
 from django.http import HttpRequest, HttpResponse
+from django.http.response import HttpResponseBase
 from django.shortcuts import render
 from django.test import Client
 
@@ -110,7 +111,7 @@ def check_send_webhook_fixture_message(
     body: str = REQ(),
     is_json: bool = REQ(json_validator=check_bool),
     custom_headers: str = REQ(),
-) -> HttpResponse:
+) -> HttpResponseBase:
     try:
         custom_headers_dict = orjson.loads(custom_headers)
     except orjson.JSONDecodeError as ve:


### PR DESCRIPTION
This makes `has_request_variables` more generic, in the sense of the return
value, and also makes it more accurate, in the sense of requiring the
first parameter of the decorated function to be `HttpRequest`, and
preserving the function signature without using `cast`.

This affects some callers of `has_request_variables` or the callers of its
decorated functions in the following manners:

- Decorated non-view functions called directly in other functions cannot
use `request` as a keyword argument. Becasue `Concatenate` turns the
concatenated parameters (`request: HttpRequest` in this case) into
positional-only parameters. Callers of `get_chart_data` are thus
refactored.

- Functions to be decorated that accept variadic keyword arguments must
define `request: HttpRequest` as positional-only. Mypy in strict mode
rejects such functions otherwise because it is possibly for the caller to
pass a keyword argument that has the same name as `request` for `**kwargs`.
No defining `request: HttpRequest` as positional-only breaks type safety
because function with positional-or-keyword parameters cannot be considered
a subtype of a function with the same parameters in which some of them are
positional-only.

Consider `f(x: int, /, **kwargs: object) -> int` and `g(x: int,
**kwargs: object) -> int`. `f(12, x="asd")` is valid but `g(12, x="asd")` is not.

Along with this change, we modify other decorators that expect `UserProfile` as
the second positional-only argument. The combined effect is that functions like
`get_chart_data` that gets decorated by both `require_non_guest_user` and 
`has_request_variables` now have accurate type annotation during type checking, 
with the first two parameters turned into positional-only. So we further update the
caller of `get_chart_data` to drop the keyword argument `"user_profile"` and pass it
as a positional argument.

This change also allows us to fix the return type annotation `check_send_webhook_fixture_message`,
since it is not restricted to `HttpResponse` anymore, and other use cases in which we use
`has_request_variables` in helper functions (`zerver.decorator.authenticate_notify` for example) without
additional refactorings.

It is also worth noting that we have now removed `ViewFuncT` from `zerver.decorator`. Eventually `ViewFuncT` shouldn't be necessary.

Affected errors:
```diff
5c5
< Found 82 errors in 27 files (checked 1406 source files)
---
> Found 78 errors in 25 files (checked 1406 source files)
16d15
< zerver/decorator.py error Value of type variable "ViewFuncT" of "has_request_variables" cannot be "Callable[[HttpRequest, str], bool]"  [type-var]
53d51
< zerver/lib/webhooks/common.py error Value of type variable "ViewFuncT" of "has_request_variables" cannot be "Callable[[HttpRequest, UserProfile, str, str, Optional[str], Optional[str], Optional[str], Optional[List[str]], Optional[List[str]], bool], None]"  [type-var]
56d53
< zerver/middleware.py error Value of type variable "ViewFuncT" of "has_request_variables" cannot be "Callable[[HttpRequest, Optional[str]], Tuple[str, Optional[str]]]"  [type-var]
81d78
< zerver/views/development/integrations.py error Incompatible return value type (got "_MonkeyPatchedWSGIResponse", expected "HttpResponse")  [return-value]
```

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
