### PR TITLE
rest: Extract remote_server_path from rest_path

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -4,7 +4,18 @@ import logging
 import urllib
 from functools import wraps
 from io import BytesIO
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, TypeVar, Union, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 import django_otp
 from django.conf import settings
@@ -711,6 +722,33 @@ def authenticated_uploads_api_view(
     return _wrapped_view_func
 
 
+def get_basic_credentials(
+    request: HttpRequest, beanstalk_email_decode: bool = False
+) -> Tuple[str, str]:
+    """
+    Extracts the role and API key as a tuple from the Authorization header
+    for HTTP basic authentication.
+    """
+    try:
+        # Grab the base64-encoded authentication string, decode it, and split it into
+        # the email and API key
+        auth_type, credentials = request.headers["Authorization"].split()
+        # case insensitive per RFC 1945
+        if auth_type.lower() != "basic":
+            raise JsonableError(_("This endpoint requires HTTP basic authentication."))
+        role, api_key = base64.b64decode(credentials).decode().split(":")
+        if beanstalk_email_decode:
+            # Beanstalk's web hook UI rejects URL with a @ in the username section
+            # So we ask the user to replace them with %40
+            role = role.replace("%40", "@")
+    except ValueError:
+        raise UnauthorizedError(_("Invalid authorization header for basic auth"))
+    except KeyError:
+        raise UnauthorizedError(_("Missing authorization header for basic auth"))
+
+    return role, api_key
+
+
 # A more REST-y authentication decorator, using, in particular, HTTP basic
 # authentication.
 #
@@ -737,23 +775,9 @@ def authenticated_rest_api_view(
         def _wrapped_func_arguments(
             request: HttpRequest, /, *args: ParamT.args, **kwargs: ParamT.kwargs
         ) -> HttpResponse:
-            # First try block attempts to get the credentials we need to do authentication
-            try:
-                # Grab the base64-encoded authentication string, decode it, and split it into
-                # the email and API key
-                auth_type, credentials = request.headers["Authorization"].split()
-                # case insensitive per RFC 1945
-                if auth_type.lower() != "basic":
-                    raise JsonableError(_("This endpoint requires HTTP basic authentication."))
-                role, api_key = base64.b64decode(credentials).decode().split(":")
-                if beanstalk_email_decode:
-                    # Beanstalk's web hook UI rejects URL with a @ in the username section
-                    # So we ask the user to replace them with %40
-                    role = role.replace("%40", "@")
-            except ValueError:
-                raise UnauthorizedError(_("Invalid authorization header for basic auth"))
-            except KeyError:
-                raise UnauthorizedError(_("Missing authorization header for basic auth"))
+            role, api_key = get_basic_credentials(
+                request, beanstalk_email_decode=beanstalk_email_decode
+            )
 
             # Now we try to do authentication or die
             try:

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -41,30 +41,24 @@ def default_never_cache_responses(view_func: ViewFuncT) -> ViewFuncT:
     return cast(ViewFuncT, _wrapped_view_func)  # https://github.com/python/mypy/issues/1927
 
 
-@default_never_cache_responses
-@csrf_exempt
-def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
-    """Dispatch to a REST API endpoint.
+def get_target_view_function_or_response(
+    request: HttpRequest, rest_dispatch_kwargs: Dict[str, Any]
+) -> Union[Tuple[Callable[..., HttpResponse], Set[str]], HttpResponse]:
+    """Helper for REST API request dispatch. The rest_dispatch_kwargs
+    parameter is expected to be a dictionary mapping HTTP methods to
+    a mix of view functions and (view_function, {view_flags}) tuples.
 
-    Unauthenticated endpoints should not use this, as authentication is verified
-    in the following ways:
-        * for paths beginning with /api, HTTP basic auth
-        * for paths beginning with /json (used by the web client), the session token
+    * Returns an error HttpResponse for unsupported HTTP methods.
 
-    This calls the function named in kwargs[request.method], if that request
-    method is supported, and after wrapping that function to:
+    * Otherwise, returns a tuple containing the view function
+      corresponding to the request's HTTP method, as well as the
+      appropriate set of view flags.
 
-        * protect against CSRF (if the user is already authenticated through
-          a Django session)
-        * authenticate via an API key (otherwise)
-        * coerce PUT/PATCH/DELETE into having POST-like semantics for
-          retrieving variables
+    HACK: Mutates the passed rest_dispatch_kwargs, removing the HTTP
+    method details but leaving any other parameters for the caller to
+    pass directly to the view function. We should see if we can remove
+    this feature; it's not clear it's actually used.
 
-    Any keyword args that are *not* HTTP methods are passed through to the
-    target function.
-
-    Never make a urls.py pattern put user input into a variable called GET, POST,
-    etc, as that is where we route HTTP verbs to target functions.
     """
     supported_methods: Dict[str, Any] = {}
     request_notes = RequestNotes.get_notes(request)
@@ -73,11 +67,12 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
         # view function logic and just return the response.
         return request_notes.saved_response
 
-    # duplicate kwargs so we can mutate the original as we go
-    for arg in list(kwargs):
+    # The list() duplicates rest_dispatch_kwargs, since this loop
+    # mutates the original.
+    for arg in list(rest_dispatch_kwargs):
         if arg in METHODS:
-            supported_methods[arg] = kwargs[arg]
-            del kwargs[arg]
+            supported_methods[arg] = rest_dispatch_kwargs[arg]
+            del rest_dispatch_kwargs[arg]
 
     if "GET" in supported_methods:
         supported_methods.setdefault("HEAD", supported_methods["GET"])
@@ -95,77 +90,108 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
     if method_to_use in supported_methods:
         entry = supported_methods[method_to_use]
         if isinstance(entry, tuple):
-            target_function, view_flags = entry
-        else:
-            target_function = supported_methods[method_to_use]
-            view_flags = set()
-
-        # Set request_notes.query for update_activity_user(), which is called
-        # by some of the later wrappers.
-        request_notes.query = target_function.__name__
-
-        # We want to support authentication by both cookies (web client)
-        # and API keys (API clients). In the former case, we want to
-        # do a check to ensure that CSRF etc is honored, but in the latter
-        # we can skip all of that.
-        #
-        # Security implications of this portion of the code are minimal,
-        # as we should worst-case fail closed if we miscategorize a request.
-
-        # for some special views (e.g. serving a file that has been
-        # uploaded), we support using the same URL for web and API clients.
-        if "override_api_url_scheme" in view_flags and "Authorization" in request.headers:
-            # This request uses standard API based authentication.
-            # For override_api_url_scheme views, we skip our normal
-            # rate limiting, because there are good reasons clients
-            # might need to (e.g.) request a large number of uploaded
-            # files or avatars in quick succession.
-            target_function = authenticated_rest_api_view(skip_rate_limiting=True)(target_function)
-        elif "override_api_url_scheme" in view_flags and request.GET.get("api_key") is not None:
-            # This request uses legacy API authentication.  We
-            # unfortunately need that in the React Native mobile apps,
-            # because there's no way to set the Authorization header in
-            # React Native.  See last block for rate limiting notes.
-            target_function = authenticated_uploads_api_view(skip_rate_limiting=True)(
-                target_function
-            )
-        # /json views (web client) validate with a session token (cookie)
-        elif not request.path.startswith("/api") and request.user.is_authenticated:
-            # Authenticated via sessions framework, only CSRF check needed
-            auth_kwargs = {}
-            if "override_api_url_scheme" in view_flags:
-                auth_kwargs["skip_rate_limiting"] = True
-            target_function = csrf_protect(authenticated_json_view(target_function, **auth_kwargs))
-
-        # most clients (mobile, bots, etc) use HTTP basic auth and REST calls, where instead of
-        # username:password, we use email:apiKey
-        elif "Authorization" in request.headers:
-            # Wrap function with decorator to authenticate the user before
-            # proceeding
-            target_function = authenticated_rest_api_view(
-                allow_webhook_access="allow_incoming_webhooks" in view_flags,
-            )(target_function)
-        elif (
-            request.path.startswith(("/json", "/avatar", "/user_uploads", "/thumbnail"))
-            and "allow_anonymous_user_web" in view_flags
-        ):
-            # For endpoints that support anonymous web access, we do that.
-            # TODO: Allow /api calls when this is stable enough.
-            target_function = csrf_protect(public_json_view(target_function))
-        else:
-            # Otherwise, throw an authentication error; our middleware
-            # will generate the appropriate HTTP response.
-            raise MissingAuthenticationError()
-
-        if request.method in ["DELETE", "PATCH", "PUT"]:
-            # process_as_post needs to be the outer decorator, because
-            # otherwise we might access and thus cache a value for
-            # request.POST.
-            target_function = process_as_post(target_function)
-
-        return target_function(request, **kwargs)
+            return entry
+        return supported_methods[method_to_use], set()
 
     return json_method_not_allowed(list(supported_methods.keys()))
+
+
+@default_never_cache_responses
+@csrf_exempt
+def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
+    """Dispatch to a REST API endpoint.
+
+    Authentication is verified in the following ways:
+        * for paths beginning with /api, HTTP basic auth
+        * for paths beginning with /json (used by the web client), the session token
+
+    Unauthenticated requests may use this endpoint only with the
+    allow_anonymous_user_web view flag.
+
+    This calls the function named in kwargs[request.method], if that request
+    method is supported, and after wrapping that function to:
+
+        * protect against CSRF (if the user is already authenticated through
+          a Django session)
+        * authenticate via an API key (otherwise)
+        * coerce PUT/PATCH/DELETE into having POST-like semantics for
+          retrieving variables
+
+    Any keyword args that are *not* HTTP methods are passed through to the
+    target function.
+
+    Never make a urls.py pattern put user input into a variable called GET, POST,
+    etc, as that is where we route HTTP verbs to target functions.
+
+    """
+    result = get_target_view_function_or_response(request, kwargs)
+    if isinstance(result, HttpResponse):
+        return result
+    target_function, view_flags = result
+    request_notes = RequestNotes.get_notes(request)
+
+    # Set request_notes.query for update_activity_user(), which is called
+    # by some of the later wrappers.
+    request_notes.query = target_function.__name__
+
+    # We want to support authentication by both cookies (web client)
+    # and API keys (API clients). In the former case, we want to
+    # do a check to ensure that CSRF etc is honored, but in the latter
+    # we can skip all of that.
+    #
+    # Security implications of this portion of the code are minimal,
+    # as we should worst-case fail closed if we miscategorize a request.
+
+    # for some special views (e.g. serving a file that has been
+    # uploaded), we support using the same URL for web and API clients.
+    if "override_api_url_scheme" in view_flags and "Authorization" in request.headers:
+        # This request uses standard API based authentication.
+        # For override_api_url_scheme views, we skip our normal
+        # rate limiting, because there are good reasons clients
+        # might need to (e.g.) request a large number of uploaded
+        # files or avatars in quick succession.
+        target_function = authenticated_rest_api_view(skip_rate_limiting=True)(target_function)
+    elif "override_api_url_scheme" in view_flags and request.GET.get("api_key") is not None:
+        # This request uses legacy API authentication.  We
+        # unfortunately need that in the React Native mobile apps,
+        # because there's no way to set the Authorization header in
+        # React Native.  See last block for rate limiting notes.
+        target_function = authenticated_uploads_api_view(skip_rate_limiting=True)(target_function)
+    # /json views (web client) validate with a session token (cookie)
+    elif not request.path.startswith("/api") and request.user.is_authenticated:
+        # Authenticated via sessions framework, only CSRF check needed
+        auth_kwargs = {}
+        if "override_api_url_scheme" in view_flags:
+            auth_kwargs["skip_rate_limiting"] = True
+        target_function = csrf_protect(authenticated_json_view(target_function, **auth_kwargs))
+
+    # most clients (mobile, bots, etc) use HTTP basic auth and REST calls, where instead of
+    # username:password, we use email:apiKey
+    elif "Authorization" in request.headers:
+        # Wrap function with decorator to authenticate the user before
+        # proceeding
+        target_function = authenticated_rest_api_view(
+            allow_webhook_access="allow_incoming_webhooks" in view_flags,
+        )(target_function)
+    elif (
+        request.path.startswith(("/json", "/avatar", "/user_uploads", "/thumbnail"))
+        and "allow_anonymous_user_web" in view_flags
+    ):
+        # For endpoints that support anonymous web access, we do that.
+        # TODO: Allow /api calls when this is stable enough.
+        target_function = csrf_protect(public_json_view(target_function))
+    else:
+        # Otherwise, throw an authentication error; our middleware
+        # will generate the appropriate HTTP response.
+        raise MissingAuthenticationError()
+
+    if request.method in ["DELETE", "PATCH", "PUT"]:
+        # process_as_post needs to be the outer decorator, because
+        # otherwise we might access and thus cache a value for
+        # request.POST.
+        target_function = process_as_post(target_function)
+
+    return target_function(request, **kwargs)
 
 
 def rest_path(

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -2015,6 +2015,11 @@ class RestAPITest(ZulipTestCase):
         self.assertEqual(result.status_code, 405)
         self.assert_in_response("Method Not Allowed", result)
 
+        with self.settings(ZILENCER_ENABLED=True):
+            result = self.client_patch("/json/remotes/push/register")
+            self.assertEqual(result.status_code, 405)
+            self.assert_in_response("Method Not Allowed", result)
+
     def test_options_method(self) -> None:
         self.login("hamlet")
         result = self.client_options("/json/users")

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2184,7 +2184,7 @@ class TestSendToPushBouncer(ZulipTestCase):
 
     @responses.activate
     def test_400_error_invalid_server_key(self) -> None:
-        from zerver.decorator import InvalidZulipServerError
+        from zilencer.auth import InvalidZulipServerError
 
         # This is the exception our decorator uses for an invalid Zulip server
         error_response = json_response_from_error(InvalidZulipServerError("testRole"))

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -205,22 +205,6 @@ class PushBouncerNotificationTest(BouncerTestCase):
 
         hamlet = self.example_user("hamlet")
 
-        with self.assertLogs(level="WARNING") as warn_log:
-            result = self.api_post(
-                hamlet,
-                endpoint,
-                dict(user_id=user_id, token_kin=token_kind, token=token),
-            )
-        self.assertEqual(
-            warn_log.output,
-            [
-                "WARNING:root:User hamlet@zulip.com (zulip) attempted to access API on wrong subdomain ()"
-            ],
-        )
-        self.assert_json_error(
-            result, "Account is not associated with this subdomain", status_code=401
-        )
-
         # We need the root ('') subdomain to be in use for this next
         # test, since the push bouncer API is only available there:
         realm = get_realm("zulip")

--- a/zilencer/auth.py
+++ b/zilencer/auth.py
@@ -1,0 +1,50 @@
+from django.http import HttpRequest
+from django.utils.crypto import constant_time_compare
+from django.utils.translation import gettext as _
+
+from zerver.decorator import process_client
+from zerver.lib.exceptions import ErrorCode, JsonableError, RemoteServerDeactivatedError
+from zerver.lib.request import RequestNotes
+from zerver.lib.subdomains import get_subdomain
+from zerver.models import Realm
+from zilencer.models import RemoteZulipServer, get_remote_server_by_uuid
+
+
+class InvalidZulipServerError(JsonableError):
+    code = ErrorCode.INVALID_ZULIP_SERVER
+    data_fields = ["role"]
+
+    def __init__(self, role: str) -> None:
+        self.role: str = role
+
+    @staticmethod
+    def msg_format() -> str:
+        return "Zulip server auth failure: {role} is not registered -- did you run `manage.py register_server`?"
+
+
+class InvalidZulipServerKeyError(InvalidZulipServerError):
+    @staticmethod
+    def msg_format() -> str:
+        return "Zulip server auth failure: key does not match role {role}"
+
+
+def validate_remote_server(
+    request: HttpRequest,
+    role: str,
+    api_key: str,
+) -> RemoteZulipServer:
+    try:
+        remote_server = get_remote_server_by_uuid(role)
+    except RemoteZulipServer.DoesNotExist:
+        raise InvalidZulipServerError(role)
+    if not constant_time_compare(api_key, remote_server.api_key):
+        raise InvalidZulipServerKeyError(role)
+
+    if remote_server.deactivated:
+        raise RemoteServerDeactivatedError()
+
+    if get_subdomain(request) != Realm.SUBDOMAIN_FOR_ROOT_DOMAIN:
+        raise JsonableError(_("Invalid subdomain for push notifications bouncer"))
+    RequestNotes.get_notes(request).remote_server = remote_server
+    process_client(request)
+    return remote_server

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.conf.urls import include
 from django.urls import path
 
-from zerver.lib.rest import rest_path
+from zilencer.auth import remote_server_path
 from zilencer.views import (
     deactivate_remote_server,
     register_remote_push_device,
@@ -19,16 +19,16 @@ i18n_urlpatterns: Any = []
 
 # Zilencer views following the REST API style
 v1_api_and_json_patterns = [
-    rest_path("remotes/push/register", POST=register_remote_push_device),
-    rest_path("remotes/push/unregister", POST=unregister_remote_push_device),
-    rest_path("remotes/push/unregister/all", POST=unregister_all_remote_push_devices),
-    rest_path("remotes/push/notify", POST=remote_server_notify_push),
+    remote_server_path("remotes/push/register", POST=register_remote_push_device),
+    remote_server_path("remotes/push/unregister", POST=unregister_remote_push_device),
+    remote_server_path("remotes/push/unregister/all", POST=unregister_all_remote_push_devices),
+    remote_server_path("remotes/push/notify", POST=remote_server_notify_push),
     # Push signup doesn't use the REST API, since there's no auth.
     path("remotes/server/register", register_remote_server),
-    rest_path("remotes/server/deactivate", POST=deactivate_remote_server),
+    remote_server_path("remotes/server/deactivate", POST=deactivate_remote_server),
     # For receiving table data used in analytics and billing
-    rest_path("remotes/server/analytics", POST=remote_server_post_analytics),
-    rest_path("remotes/server/analytics/status", GET=remote_server_check_analytics),
+    remote_server_path("remotes/server/analytics", POST=remote_server_post_analytics),
+    remote_server_path("remotes/server/analytics/status", GET=remote_server_check_analytics),
 ]
 
 urlpatterns = [

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -16,7 +16,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from analytics.lib.counts import COUNT_STATS
 from corporate.lib.stripe import do_deactivate_remote_server
-from zerver.decorator import InvalidZulipServerKeyError, require_post
+from zerver.decorator import require_post
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.push_notifications import (
     UserPushIndentityCompat,
@@ -38,6 +38,7 @@ from zerver.lib.validator import (
 )
 from zerver.models import UserProfile
 from zerver.views.push_notifications import validate_token
+from zilencer.auth import InvalidZulipServerKeyError
 from zilencer.models import (
     RemoteInstallationCount,
     RemotePushDeviceToken,


### PR DESCRIPTION
This is a follow-up to #22647 and #22646 (this PR is rebased onto them, only the last 5 commits should be reviewed), which wraps up this series of refactorings to settle typing issues revolving around `RemoteZulipServer` and `UserProfile`.

We extract `validate_remote_server` from `validate_api_key`, `remote_server_path` from `rest_path`, to isolate the bouncer views from regular authenticated json views that expect a `UserProfile`.

Affected errors:
```diff
5c5
< Found 79 errors in 25 files (checked 1406 source files)
---
> Found 76 errors in 25 files (checked 1406 source files)
14,16d13
< zerver/decorator.py error Argument 2 to "rate_limit_user" has incompatible type "Union[UserProfile, RemoteZulipServer]"; expected "UserProfile"  [arg-type]
< zerver/decorator.py error Argument 1 to "notify_bot_owner_about_invalid_json" has incompatible type "Union[UserProfile, RemoteZulipServer]"; expected "UserProfile"  [arg-type]
< zerver/decorator.py error Argument 2 has incompatible type "Union[UserProfile, RemoteZulipServer]"; expected "UserProfile"  [arg-type]
```

TODO:

In future PRs, we should:

- Replace `ViewFuncT` with `ParamSpec` and `Concatenate`.
- Further split up `rest_dispatch`.
- Replace `get_target_view_function_or_response` with Django's class-based decorators for paths that support multiple HTTP methods.

See [chat](https://chat.zulip.org/#narrow/stream/3-backend/topic/Breaking.20down.20rest_dispatch) for more context and further discussions.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
