### PR TITLE
realm: Don't allow changing `enable_spectator_access` to True on limited plan realms.

### DIFF
--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1373,6 +1373,16 @@ class RealmAPITest(ZulipTestCase):
         realm = get_realm("zulip")
         self.assertEqual(realm.invite_to_realm_policy, Realm.POLICY_ADMINS_ONLY)
 
+    def test_enable_spectator_access_for_limited_plan_realms(self) -> None:
+        self.login("iago")
+        realm = get_realm("zulip")
+        do_change_realm_plan_type(realm, Realm.PLAN_TYPE_LIMITED, acting_user=None)
+        self.assertFalse(realm.enable_spectator_access)
+
+        req = {"enable_spectator_access": orjson.dumps(True).decode()}
+        result = self.client_patch("/json/realm", req)
+        self.assert_json_error(result, "Available on Zulip Cloud Standard. Upgrade to access.")
+
 
 class ScrubRealmTest(ZulipTestCase):
     def test_scrub_realm(self) -> None:

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -179,6 +179,9 @@ def update_realm(
     if invite_to_realm_policy is not None and not user_profile.is_realm_owner:
         raise OrganizationOwnerRequired()
 
+    if enable_spectator_access:
+        realm.ensure_not_on_limited_plan()
+
     data: Dict[str, Any] = {}
 
     message_content_delete_limit_seconds: Optional[int] = None


### PR DESCRIPTION
We do not allow changing enable_spectator_access to True using API on
limited plan realms. Frontend changes have been done previously.

This is a follow-up of #22179.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
