### PR TITLE
recent_topics: Provide `participated` filter with relevant data.

### DIFF
--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -27,6 +27,7 @@ const consts = {
     num_before_home_anchor: 200,
     num_after_home_anchor: 200,
     recent_topics_initial_fetch_size: 400,
+    sent_by_user_fetch_size: 1000,
     backward_batch_size: 100,
     forward_batch_size: 100,
     catch_up_batch_size: 1000,
@@ -517,5 +518,15 @@ export function initialize(home_view_loaded) {
         num_after: 0,
         msg_list: recent_topics_message_list,
         cont: recent_topics_ui.hide_loading_indicator,
+    });
+    const sent_by_user_message_list = new message_list.MessageList({
+        filter: new Filter([{operator: "sender", operand: "me"}]),
+        excludes_muted_topics: false,
+    });
+    load_messages({
+        anchor: "newest",
+        num_before: consts.sent_by_user_fetch_size,
+        num_after: 0,
+        msg_list: sent_by_user_message_list,
     });
 }


### PR DESCRIPTION
To make sure `participated` filter has topics in which user
recently sent messages, we fetch some messages sent by the user
at when initializing.

This avoids users being confused by why topics they participated
in are not present in the participated filter.

Fixes #17903

discussion: https://chat.zulip.org/#narrow/stream/2-general/topic/recent.20topics.20load.20more.20.2319151/near/1413828