### PR TITLE
do_reactivate_realm: Noop if realm is already active.

### DIFF
--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -1,3 +1,4 @@
+import logging
 from email.headerregistry import Address
 from typing import Any, Dict, Literal, Optional
 
@@ -297,6 +298,10 @@ def do_deactivate_realm(realm: Realm, *, acting_user: Optional[UserProfile]) -> 
 
 
 def do_reactivate_realm(realm: Realm) -> None:
+    if not realm.deactivated:
+        logging.warning("Realm %s cannot be reactivated because it is already active.", realm.id)
+        return
+
     realm.deactivated = False
     with transaction.atomic():
         realm.save(update_fields=["deactivated"])

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -399,6 +399,8 @@ class RealmTest(ZulipTestCase):
 
     def test_do_send_realm_reactivation_email(self) -> None:
         realm = get_realm("zulip")
+        do_deactivate_realm(realm, acting_user=None)
+        self.assertEqual(realm.deactivated, True)
         iago = self.example_user("iago")
         do_send_realm_reactivation_email(realm, acting_user=iago)
         from django.core.mail import outbox


### PR DESCRIPTION
If the realm doesn't actually need re-activation, this should be a noop
rather than creating a confusing RealmAuditLog entry.
