### PR TITLE
UI redesign: change font & color of timestamp in a message

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -245,8 +245,7 @@ body.dark-theme {
     /* these are converting grey things to "new grey" */
     :disabled,
     input:not([type="radio"]):read-only,
-    textarea:read-only,
-    .recipient_row_date {
+    textarea:read-only {
         color: inherit;
         opacity: 0.5;
     }
@@ -376,11 +375,6 @@ body.dark-theme {
         &:hover {
             border-color: hsl(236, 33%, 90%);
         }
-    }
-
-    /* Disable blue link styling for the message timestamp link. */
-    .message_time {
-        color: hsl(236, 33%, 90%);
     }
 
     .emoji-popover .reaction:focus {

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -555,6 +555,8 @@ body.dark-theme {
         color: hsl(236, 33%, 80%);
     }
 
+    .messagebox-content .message_time,
+    .recipient_row_date,
     #message_edit_tooltip:hover,
     .clear_search_button:hover {
         color: hsl(0, 0%, 100%);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -40,6 +40,14 @@ body {
     font-size: 14px;
     line-height: calc(20 / 14);
     font-family: "Source Sans 3", sans-serif;
+
+    --color-message-time: hsl(0, 0%, 20%);
+    --color-recipient-row-date: hsl(0, 0%, 53%);
+}
+
+body.dark-theme {
+    --color-message-time: hsl(236, 33%, 90%);
+    --color-recipient-row-date: hsl(236, 33%, 90%);
 }
 
 /* Common background color */
@@ -1009,7 +1017,7 @@ td.pointer {
     line-height: 20px;
     text-align: right;
     /* Disable blue link styling for the message timestamp link. */
-    color: hsl(0, 0%, 20%);
+    color: var(--color-message-time);
     transition: background-color 1.5s ease-in, color 1.5s ease-in;
 
     a& {
@@ -1265,7 +1273,7 @@ td.pointer {
 }
 
 .recipient_row_date {
-    color: hsl(0, 0%, 53%);
+    color: var(--color-recipient-row-date);
     font-size: 12px;
     font-weight: 600;
     padding: 3px 11px 2px 10px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -41,13 +41,11 @@ body {
     line-height: calc(20 / 14);
     font-family: "Source Sans 3", sans-serif;
 
-    --color-message-time: hsl(0, 0%, 20%);
-    --color-recipient-row-date: hsl(0, 0%, 53%);
+    --color-default-text: hsl(0, 0%, 15%);
 }
 
 body.dark-theme {
-    --color-message-time: hsl(236, 33%, 90%);
-    --color-recipient-row-date: hsl(236, 33%, 90%);
+    --color-default-text: hsl(0, 0%, 100%);
 }
 
 /* Common background color */
@@ -1008,19 +1006,20 @@ td.pointer {
 
 .messagebox-content .message_time {
     display: block;
-    font-size: 12px;
-    opacity: 0.4;
+    font-size: calc(15em / 14);
     padding: 1px;
     font-weight: 400;
+    font-variant: all-small-caps;
     position: absolute;
     right: -105px;
-    line-height: 20px;
+    line-height: 18px;
     text-align: right;
-    color: var(--color-message-time);
+    opacity: 0.5;
+    color: var(--color-default-text);
     /* Disable blue link styling for the message timestamp link. */
     &:hover {
         text-decoration: none;
-        color: var(--color-message-time);
+        color: var(--color-default-text);
     }
 
     a& {
@@ -1276,12 +1275,14 @@ td.pointer {
 }
 
 .recipient_row_date {
-    color: var(--color-recipient-row-date);
-    font-size: 12px;
-    font-weight: 600;
+    color: var(--color-default-text);
+    opacity: 0.75;
+    font-size: calc(15em / 14);
+    font-weight: 400;
     padding: 3px 11px 2px 10px;
-    height: 17px;
-    line-height: 17px;
+    line-height: 18px;
+    text-align: right;
+    font-variant: all-small-caps;
 
     &.hide-date {
         display: none;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1006,7 +1006,7 @@ td.pointer {
     overflow-x: clip;
 }
 
-.message_time {
+.messagebox-content .message_time {
     display: block;
     font-size: 12px;
     opacity: 0.4;
@@ -1016,9 +1016,12 @@ td.pointer {
     right: -105px;
     line-height: 20px;
     text-align: right;
-    /* Disable blue link styling for the message timestamp link. */
     color: var(--color-message-time);
-    transition: background-color 1.5s ease-in, color 1.5s ease-in;
+    /* Disable blue link styling for the message timestamp link. */
+    &:hover {
+        text-decoration: none;
+        color: var(--color-message-time);
+    }
 
     a& {
         z-index: 1;


### PR DESCRIPTION
Fixes #21752
<img width="782" alt="Screenshot 2022-08-04 190138" src="https://user-images.githubusercontent.com/25124304/182870004-679d0de5-3b77-4f41-ae5d-b8ba51792a19.png">
