### PR TITLE
django-stubs: Fix Promise related typing errors.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, Iterable, List, Optional, Set, TypedDict
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, TypedDict
 
 from django.conf import settings
 from django.db import transaction
@@ -65,6 +65,9 @@ from zerver.models import (
     get_system_bot,
 )
 from zerver.tornado.django_api import send_event
+
+if TYPE_CHECKING:
+    from django.utils.functional import _StrPromise as StrPromise
 
 
 def subscriber_info(user_id: int) -> Dict[str, Any]:
@@ -198,10 +201,10 @@ def send_message_moved_breadcrumbs(
     user_profile: UserProfile,
     old_stream: Stream,
     old_topic: str,
-    old_thread_notification_string: Optional[str],
+    old_thread_notification_string: Optional["StrPromise"],
     new_stream: Stream,
     new_topic: Optional[str],
-    new_thread_notification_string: Optional[str],
+    new_thread_notification_string: Optional["StrPromise"],
     changed_messages_count: int,
 ) -> None:
     # Since moving content between streams is highly disruptive,

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -844,7 +844,7 @@ def send_change_stream_permission_notification(
             new_policy=new_policy_name,
         )
         internal_send_stream_message(
-            sender, stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC, notification_string
+            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC), notification_string
         )
 
 
@@ -1030,7 +1030,7 @@ def send_change_stream_post_policy_notification(
             new_policy=Stream.POST_POLICIES[new_post_policy],
         )
         internal_send_stream_message(
-            sender, stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC, notification_string
+            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC), notification_string
         )
 
 
@@ -1153,7 +1153,7 @@ def do_rename_stream(stream: Stream, new_name: str, user_profile: UserProfile) -
         internal_send_stream_message(
             sender,
             stream,
-            Realm.STREAM_EVENTS_NOTIFICATION_TOPIC,
+            str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC),
             _("{user_name} renamed stream {old_stream_name} to {new_stream_name}.").format(
                 user_name=silent_mention_syntax_for_user(user_profile),
                 old_stream_name=f"**{old_name}**",
@@ -1190,7 +1190,7 @@ def send_change_stream_description_notification(
         )
 
         internal_send_stream_message(
-            sender, stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC, notification_string
+            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC), notification_string
         )
 
 
@@ -1276,7 +1276,7 @@ def send_change_stream_message_retention_days_notification(
             summary_line=summary_line,
         )
         internal_send_stream_message(
-            sender, stream, Realm.STREAM_EVENTS_NOTIFICATION_TOPIC, notification_string
+            sender, stream, str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC), notification_string
         )
 
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -140,7 +140,7 @@ class RegistrationForm(forms.Form):
         if self.fields["password"].required and not check_password_strength(password):
             # The frontend code tries to stop the user from submitting the form with a weak password,
             # but if the user bypasses that protection, this error code path will run.
-            raise ValidationError(PASSWORD_TOO_WEAK_ERROR)
+            raise ValidationError(str(PASSWORD_TOO_WEAK_ERROR))
 
         return password
 
@@ -275,7 +275,7 @@ class LoggingSetPasswordForm(SetPasswordForm):
         if not check_password_strength(new_password):
             # The frontend code tries to stop the user from submitting the form with a weak password,
             # but if the user bypasses that protection, this error code path will run.
-            raise ValidationError(PASSWORD_TOO_WEAK_ERROR)
+            raise ValidationError(str(PASSWORD_TOO_WEAK_ERROR))
 
         return new_password
 

--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -1,14 +1,16 @@
 # See https://zulip.readthedocs.io/en/latest/subsystems/hotspots.html
 # for documentation on this subsystem.
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List
 
 from django.conf import settings
-from django.utils.functional import Promise
 from django.utils.translation import gettext_lazy
 
 from zerver.models import UserHotspot, UserProfile
 
-INTRO_HOTSPOTS: Dict[str, Dict[str, Promise]] = {
+if TYPE_CHECKING:
+    from django.utils.functional import _StrPromise as StrPromise
+
+INTRO_HOTSPOTS: Dict[str, Dict[str, "StrPromise"]] = {
     "intro_streams": {
         "title": gettext_lazy("Catch up on a stream"),
         "description": gettext_lazy(
@@ -42,7 +44,7 @@ INTRO_HOTSPOTS: Dict[str, Dict[str, Promise]] = {
 # We would most likely implement new hotspots in the future that aren't
 # a part of the initial tutorial. To that end, classifying them into
 # categories which are aggregated in ALL_HOTSPOTS, seems like a good start.
-ALL_HOTSPOTS: Dict[str, Dict[str, Promise]] = {
+ALL_HOTSPOTS: Dict[str, Dict[str, "StrPromise"]] = {
     **INTRO_HOTSPOTS,
 }
 

--- a/zerver/lib/integrations.py
+++ b/zerver/lib/integrations.py
@@ -1,14 +1,16 @@
 import os
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import URLResolver, path
-from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy
 
 from zerver.lib.storage import static_path
+
+if TYPE_CHECKING:
+    from django.utils.functional import _StrPromise as StrPromise
 
 """This module declares all of the (documented) integrations available
 in the Zulip server.  The Integration class is used as part of
@@ -31,7 +33,7 @@ features for writing and configuring integrations efficiently.
 
 OptionValidator = Callable[[str, str], Optional[str]]
 
-CATEGORIES: Dict[str, Promise] = {
+CATEGORIES: Dict[str, "StrPromise"] = {
     "meta-integration": gettext_lazy("Integration frameworks"),
     "continuous-integration": gettext_lazy("Continuous integration"),
     "customer-support": gettext_lazy("Customer support"),

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -1,9 +1,22 @@
 import datetime
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
-from django.utils.functional import Promise
 from typing_extensions import NotRequired
+
+if TYPE_CHECKING:
+    from django.utils.functional import _StrPromise as StrPromise
 
 # See zerver/lib/validator.py for more details of Validators,
 # including many examples
@@ -37,9 +50,11 @@ class ProfileDataElementUpdateDict(TypedDict):
 
 ProfileData = List[ProfileDataElement]
 
-FieldElement = Tuple[int, Promise, Validator[ProfileDataElementValue], Callable[[Any], Any], str]
-ExtendedFieldElement = Tuple[int, Promise, ExtendedValidator, Callable[[Any], Any], str]
-UserFieldElement = Tuple[int, Promise, RealmUserValidator, Callable[[Any], Any], str]
+FieldElement = Tuple[
+    int, "StrPromise", Validator[ProfileDataElementValue], Callable[[Any], Any], str
+]
+ExtendedFieldElement = Tuple[int, "StrPromise", ExtendedValidator, Callable[[Any], Any], str]
+UserFieldElement = Tuple[int, "StrPromise", RealmUserValidator, Callable[[Any], Any], str]
 
 ProfileFieldData = Dict[str, Union[Dict[str, str], str]]
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -907,7 +907,7 @@ class Realm(models.Model):
 
     def ensure_not_on_limited_plan(self) -> None:
         if self.plan_type == Realm.PLAN_TYPE_LIMITED:
-            raise JsonableError(self.UPGRADE_TEXT_STANDARD)
+            raise JsonableError(str(self.UPGRADE_TEXT_STANDARD))
 
     @property
     def subdomain(self) -> str:
@@ -1872,7 +1872,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):
     }
 
     def get_role_name(self) -> str:
-        return self.ROLE_ID_TO_NAME_MAP[self.role]
+        return str(self.ROLE_ID_TO_NAME_MAP[self.role])
 
     def profile_data(self) -> ProfileData:
         values = CustomProfileFieldValue.objects.filter(user_profile=self)
@@ -4505,7 +4505,9 @@ class CustomProfileField(models.Model):
     FIELD_CONVERTERS: Dict[int, Callable[[Any], Any]] = {
         item[0]: item[3] for item in ALL_FIELD_TYPES
     }
-    FIELD_TYPE_CHOICES: List[Tuple[int, Promise]] = [(item[0], item[1]) for item in ALL_FIELD_TYPES]
+    FIELD_TYPE_CHOICES: List[Tuple[int, "StrPromise"]] = [
+        (item[0], item[1]) for item in ALL_FIELD_TYPES
+    ]
 
     field_type: int = models.PositiveSmallIntegerField(
         choices=FIELD_TYPE_CHOICES,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -46,7 +46,6 @@ from django.db.models.functions import Upper
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_delete, post_save, pre_delete
 from django.db.models.sql.compiler import SQLCompiler
-from django.utils.functional import Promise
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -120,6 +119,7 @@ if TYPE_CHECKING:
     # We use ModelBackend only for typing. Importing it otherwise causes circular dependency.
     from django.contrib.auth.backends import ModelBackend
     from django.db.models.query import _QuerySet as ValuesQuerySet
+    from django.utils.functional import _StrPromise as StrPromise
 
 
 class EmojiInfo(TypedDict):
@@ -2452,7 +2452,7 @@ class Stream(models.Model):
 
     # Who in the organization has permission to send messages to this stream.
     stream_post_policy: int = models.PositiveSmallIntegerField(default=STREAM_POST_POLICY_EVERYONE)
-    POST_POLICIES: Dict[int, str] = {
+    POST_POLICIES: Dict[int, "StrPromise"] = {
         # These strings should match the strings in the
         # stream_post_policy_values object in stream_data.js.
         STREAM_POST_POLICY_EVERYONE: gettext_lazy("All stream members can post"),

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -740,7 +740,7 @@ def send_messages_for_new_subscribers(
                     internal_prep_stream_message(
                         sender=sender,
                         stream=stream,
-                        topic=Realm.STREAM_EVENTS_NOTIFICATION_TOPIC,
+                        topic=str(Realm.STREAM_EVENTS_NOTIFICATION_TOPIC),
                         content=_(
                             "**{policy}** stream created by {user_name}. **Description:**"
                         ).format(

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -719,7 +719,7 @@ def create_user_backend(
         pass
 
     if not check_password_strength(password):
-        raise JsonableError(PASSWORD_TOO_WEAK_ERROR)
+        raise JsonableError(str(PASSWORD_TOO_WEAK_ERROR))
 
     target_user = do_create_user(
         email,


### PR DESCRIPTION
This discussion for this solution can be found [here](https://chat.zulip.org/#narrow/stream/3-backend/topic/The.20proper.20way.20to.20deal.20with.20.60Promise.60.20objects).

`gettext_lazy` returns `Promise` objects that is actually different from `str`. Methods that are present on `str` can also be accessed  on such objects. And it behaves like a `str` except that it is not an instance of `str`.

Affected errors:
```diff
3c3
< Found 86 errors in 31 files (checked 1406 source files)
---
> Found 48 errors in 24 files (checked 1406 source files)
5,6d4
< corporate/lib/stripe.py error "Promise" has no attribute "format"  [attr-defined]
< corporate/lib/stripe_event_handler.py error "Promise" has no attribute "format"  [attr-defined]
8,15d5
< corporate/views/upgrade.py error "Promise" has no attribute "format"  [attr-defined]
< zerver/actions/message_edit.py error Argument 4 to "send_message_moved_breadcrumbs" has incompatible type "Optional[Promise]"; expected "Optional[str]"  [arg-type]
< zerver/actions/message_edit.py error Argument 7 to "send_message_moved_breadcrumbs" has incompatible type "Optional[Promise]"; expected "Optional[str]"  [arg-type]
< zerver/actions/streams.py error Argument 3 to "internal_send_stream_message" has incompatible type "Promise"; expected "str"  [arg-type]
< zerver/actions/streams.py error Argument 3 to "internal_send_stream_message" has incompatible type "Promise"; expected "str"  [arg-type]
< zerver/actions/streams.py error Argument 3 to "internal_send_stream_message" has incompatible type "Promise"; expected "str"  [arg-type]
< zerver/actions/streams.py error Argument 3 to "internal_send_stream_message" has incompatible type "Promise"; expected "str"  [arg-type]
< zerver/actions/streams.py error Argument 3 to "internal_send_stream_message" has incompatible type "Promise"; expected "str"  [arg-type]
21,23d10
< zerver/forms.py error Argument 1 to "ValidationError" has incompatible type "Promise"; expected "Union[str, ValidationError, Dict[str, Any], List[Any]]"  [arg-type]
< zerver/forms.py error Argument 1 to "ValidationError" has incompatible type "Promise"; expected "Union[str, ValidationError, Dict[str, Any], List[Any]]"  [arg-type]
< zerver/forms.py error "Promise" has no attribute "format"  [attr-defined]
57d28
< zerver/models.py error Argument "message" to "RegexValidator" has incompatible type "Promise"; expected "Optional[str]"  [arg-type]
61d31
< zerver/models.py error Incompatible return value type (got "Promise", expected "str")  [return-value]
65,68d34
< zerver/models.py error Dict entry 0 has incompatible type "int" "Promise"; expected "int" "str"  [dict-item]
< zerver/models.py error Dict entry 1 has incompatible type "int" "Promise"; expected "int" "str"  [dict-item]
< zerver/models.py error Dict entry 2 has incompatible type "int" "Promise"; expected "int" "str"  [dict-item]
< zerver/models.py error Dict entry 3 has incompatible type "int" "Promise"; expected "int" "str"  [dict-item]
71d36
< zerver/models.py error Argument 1 to "JsonableError" has incompatible type "Promise"; expected "str"  [arg-type]
81d45
< zerver/views/auth.py error "Promise" has no attribute "format"  [attr-defined]
84,85d47
< zerver/views/streams.py error Argument "topic" to "internal_prep_stream_message" has incompatible type "Promise"; expected "str"  [arg-type]
< zerver/views/users.py error Argument 1 to "JsonableError" has incompatible type "Promise"; expected "str"  [arg-type]
```

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
