### PR TITLE
demo-orgs: Create demo organization without setting an email.

### DIFF
--- a/templates/zerver/emails/confirm_demo_organization_email.html
+++ b/templates/zerver/emails/confirm_demo_organization_email.html
@@ -1,0 +1,14 @@
+{% extends "zerver/emails/email_base_default.html" %}
+
+{% block illustration %}
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+<p>{% trans %}Hi,{% endtrans %}</p>
+
+<p>{% trans realm_uri=macros.link_tag(realm_uri), new_email=macros.email_tag(new_email) %}We received a request to add the email address {{ new_email }} to your Zulip demo organization account on {{ realm_uri }}. To confirm this update and set a password for this account, please click below:{% endtrans %}
+    <a class="button" href="{{ activate_url }}">{{_('Confirm and set password') }}</a></p>
+
+<p>{% trans support_email=macros.email_tag(support_email) %}If you did not request this change, please contact us immediately at {{ support_email }}.{% endtrans %}</p>
+{% endblock %}

--- a/templates/zerver/emails/confirm_demo_organization_email.subject.txt
+++ b/templates/zerver/emails/confirm_demo_organization_email.subject.txt
@@ -1,0 +1,1 @@
+{{ _("Verify your new email address for your demo Zulip organization") }}

--- a/templates/zerver/emails/confirm_demo_organization_email.txt
+++ b/templates/zerver/emails/confirm_demo_organization_email.txt
@@ -1,0 +1,15 @@
+{% trans -%}
+Hi,
+{%- endtrans %}
+
+
+{% trans -%}
+We received a request to add the email address {{ new_email }} to your Zulip demo organization account on {{ realm_uri }}. To confirm this update and set a password for this account, please click below:
+{%- endtrans %}
+
+
+{{ activate_url }}
+
+{% trans -%}
+If you did not request this change, please contact us immediately at <{{ support_email }}>.
+{%- endtrans %}

--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -203,6 +203,7 @@ export function build_page() {
         allow_sorting_deactivated_users_list_by_email:
             settings_users.allow_sorting_deactivated_users_list_by_email(),
         has_bots: bot_data.get_all_bots_for_current_user().length > 0,
+        user_has_email_set: !settings_data.user_email_not_configured(),
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/web/src/invite.js
+++ b/web/src/invite.js
@@ -17,6 +17,7 @@ import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
 import * as scroll_util from "./scroll_util";
 import * as settings_config from "./settings_config";
+import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 import * as ui_report from "./ui_report";
@@ -265,6 +266,7 @@ function open_invite_user_modal(e) {
         streams: get_invite_streams(),
         notifications_stream: stream_data.get_notifications_stream(),
         show_select_default_streams_option: stream_data.get_default_stream_ids().length !== 0,
+        user_has_email_set: !settings_data.user_email_not_configured(),
     });
 
     function invite_user_modal_post_render() {
@@ -276,6 +278,8 @@ function open_invite_user_modal(e) {
             $("#generate_multiuse_invite_radio_container").addClass("control-label-disabled");
             $("#generate_multiuse_invite_radio_container").addClass("disabled_setting_tooltip");
         }
+
+        const user_has_email_set = !settings_data.user_email_not_configured();
 
         autosize($("#invitee_emails").trigger("focus"));
 
@@ -351,6 +355,10 @@ function open_invite_user_modal(e) {
         $("#invite_select_default_streams").on("change", () => {
             set_streams_to_join_list_visibility();
         });
+
+        if (!user_has_email_set) {
+            $("#invite-user-form :input").prop("disabled", !user_has_email_set);
+        }
     }
 
     function invite_users() {

--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -12,12 +12,14 @@ export const page_params: {
         percent_translated: number | undefined;
     }[];
     login_page: string;
+    delivery_email: string;
     is_admin: boolean;
     is_bot: boolean;
     is_guest: boolean;
     is_moderator: boolean;
     is_owner: boolean;
     is_spectator: boolean;
+    muted_users: {id: number; timestamp: number}[];
     needs_tutorial: boolean;
     page_load_time: number;
     promote_sponsoring_zulip: boolean;
@@ -64,7 +66,6 @@ export const page_params: {
     zulip_plan_is_not_limited: boolean;
     zulip_merge_base: string;
     zulip_version: string;
-    muted_users: {id: number; timestamp: number}[];
 } = $("#page-params").remove().data("params");
 const t2 = performance.now();
 export const page_params_parse_time = t2 - t1;

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -73,6 +73,13 @@ function get_parsed_date_of_joining() {
     );
 }
 
+function user_can_change_password() {
+    if (settings_data.user_email_not_configured()) {
+        return false;
+    }
+    return page_params.realm_email_auth_enabled;
+}
+
 export function build_page() {
     setup_settings_label();
 
@@ -119,6 +126,7 @@ export function build_page() {
         user_is_only_organization_owner: people.is_current_user_only_owner(),
         email_address_visibility_values: settings_config.email_address_visibility_values,
         owner_is_only_user_in_organization: people.get_active_human_count() === 1,
+        user_can_change_password: user_can_change_password(),
     });
 
     settings_bots.update_bot_settings_tip($("#personal-bot-settings-tip"), false);

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -127,6 +127,7 @@ export function build_page() {
         email_address_visibility_values: settings_config.email_address_visibility_values,
         owner_is_only_user_in_organization: people.get_active_human_count() === 1,
         user_can_change_password: user_can_change_password(),
+        user_has_email_set: !settings_data.user_email_not_configured(),
     });
 
     settings_bots.update_bot_settings_tip($("#personal-bot-settings-tip"), false);

--- a/web/src/settings_data.ts
+++ b/web/src/settings_data.ts
@@ -198,3 +198,10 @@ export function using_dark_theme(): boolean {
     }
     return false;
 }
+
+export function user_email_not_configured(): boolean {
+    // The following should also be true in the only circumstance
+    // under which we expect this condition to be possible:
+    // page_params.demo_organization_scheduled_deletion_date
+    return page_params.is_owner && page_params.delivery_email === "";
+}

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -19,6 +19,7 @@ import * as realm_icon from "./realm_icon";
 import * as realm_logo from "./realm_logo";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings_config from "./settings_config";
+import * as settings_data from "./settings_data";
 import * as settings_notifications from "./settings_notifications";
 import * as settings_realm_domains from "./settings_realm_domains";
 import * as settings_realm_user_settings_defaults from "./settings_realm_user_settings_defaults";
@@ -533,6 +534,16 @@ function sort_object_by_key(obj) {
     return new_obj;
 }
 
+function can_configure_auth_methods() {
+    if (settings_data.user_email_not_configured()) {
+        return false;
+    }
+    if (page_params.is_owner) {
+        return true;
+    }
+    return false;
+}
+
 export function populate_auth_methods(auth_methods) {
     if (!meta.loaded) {
         return;
@@ -544,7 +555,7 @@ export function populate_auth_methods(auth_methods) {
         rendered_auth_method_rows += render_settings_admin_auth_methods_list({
             method: auth_method,
             enabled: value,
-            is_owner: page_params.is_owner,
+            disable_configure_auth_method: !can_configure_auth_methods(),
             // The negated character class regexp serves as an allowlist - the replace() will
             // remove *all* symbols *but* digits (\d) and lowecase letters (a-z),
             // so that we can make assumptions on this string elsewhere in the code.

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -360,6 +360,17 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ["#api_key_button_container.disabled_setting_tooltip"],
+        content: $t({
+            defaultMessage: "You must configure your email to access this feature.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
         target: "#pm_tooltip_container",
         onShow(instance) {
             if ($(".private_messages_container").hasClass("zoom-in")) {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -360,7 +360,10 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: ["#api_key_button_container.disabled_setting_tooltip"],
+        target: [
+            "#api_key_button_container.disabled_setting_tooltip",
+            "#user_email_address_dropdown_container.disabled_setting_tooltip",
+        ],
         content: $t({
             defaultMessage: "You must configure your email to access this feature.",
         }),

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -174,7 +174,8 @@ h3,
 #change_email_button,
 #user_deactivate_account_button,
 .deactivate_realm_button,
-#api_key_button {
+#api_key_button,
+#user_email_address_visibility {
     &:disabled {
         pointer-events: none;
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -173,7 +173,8 @@ h3,
 
 #change_email_button,
 #user_deactivate_account_button,
-.deactivate_realm_button {
+.deactivate_realm_button,
+#api_key_button {
     &:disabled {
         pointer-events: none;
     }

--- a/web/templates/demo_organization_add_email_modal.hbs
+++ b/web/templates/demo_organization_add_email_modal.hbs
@@ -1,0 +1,11 @@
+<form id="demo_organization_add_email_form" class="new-style">
+    <div class="tip">{{t "If you haven't updated your name, it's a good idea to do so before inviting other users to join you!" }}</div>
+    <div class="input-group">
+        <label for="demo_organization_add_email">{{t "Email" }}</label>
+        <input id="demo_organization_add_email" type="text" name="email" class="modal_text_input" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+    </div>
+    <div class="input-group">
+        <label for="demo_organization_update_full_name">{{t "Full name" }}</label>
+        <input id="demo_organization_update_full_name" name="full_name" type="text" class="modal_text_input" value="{{full_name}}" maxlength="60" />
+    </div>
+</form>

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -2,6 +2,9 @@
     {{#if development_environment}}
     <div class="alert" id="dev_env_msg"></div>
     {{/if}}
+    {{#unless user_has_email_set }}
+    <div class="tip">{{t "You must add an email address to your account to be able to invite users to Zulip." }}</div>
+    {{/unless}}
     <div class="input-group">
         <label>{{t "How would you like to invite users?" }}</label>
         <div class="invite_type_radio_section prop-element" id="invite-user">
@@ -25,7 +28,7 @@
     </div>
     <div class="input-group">
         <label for="expires_in">{{t "Invitation expires after" }}</label>
-        <select id="expires_in" class="invite-expires-in bootstrap-focus-style">
+        <select id="expires_in" class="invite-expires-in modal_select bootstrap-focus-style">
             {{#each expires_in_options}}
                 <option {{#if this.default }}selected{{/if}} name="expires_in" value="{{this.value}}">{{this.description}}</option>
             {{/each}}
@@ -34,7 +37,7 @@
         <div id="custom-invite-expiration-time" class="dependent-settings-block">
             <label for="expires_in">{{t "Custom time" }}</label>
             <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-expiration-time inline-block" value="" maxlength="3"/>
-            <select class="custom-expiration-time bootstrap-focus-style" id="custom-expiration-time-unit">
+            <select class="custom-expiration-time modal_select bootstrap-focus-style" id="custom-expiration-time-unit">
                 {{#each time_choices}}
                     <option name="custom_time_choice" class="custom_time_choice" value="{{this}}">{{this}}</option>
                 {{/each}}
@@ -46,7 +49,7 @@
         <label for="invite_as">{{t "User(s) join as" }}
             {{> help_link_widget link="/help/roles-and-permissions" }}
         </label>
-        <select id="invite_as" class="invite-as bootstrap-focus-style">
+        <select id="invite_as" class="invite-as modal_select bootstrap-focus-style">
             <option name="invite_as" value="{{ invite_as_options.guest.code }}">{{t "Guests" }}</option>
             <option name="invite_as" selected="selected" value="{{ invite_as_options.member.code }}">{{t "Members" }}</option>
             {{#if is_admin}}

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -87,10 +87,12 @@
                 <label for="email_address_visibility" class="dropdown-title">{{t "Who can access your email address" }}
                     {{> ../help_link_widget link="/help/configure-email-visibility" }}
                 </label>
-                <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"
-                  id="user_email_address_visibility">
-                    {{> dropdown_options_widget option_values=email_address_visibility_values}}
-                </select>
+                <div id="user_email_address_dropdown_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">
+                    <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"
+                      id="user_email_address_visibility" {{#unless user_has_email_set}}disabled="disabled"{{/unless}}>
+                        {{> dropdown_options_widget option_values=email_address_visibility_values}}
+                    </select>
+                </div>
             </div>
         </div>
 

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -25,7 +25,7 @@
                 {{/if}}
 
                 <form class="password-change-form grid">
-                    {{#if page_params.realm_email_auth_enabled}}
+                    {{#if user_can_change_password}}
                     <div>
                         <label class="inline-block title">{{t "Password" }}</label>
                         <div class="input-group inline-block" id="pw_change_link">

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -110,7 +110,11 @@
                     the Zulip API, unless the task requires access to your account.
                     {{/tr}}
                 </p>
-                <button class="button rounded" id="api_key_button">{{t "Show/change your API key" }}</button>
+                <div id="api_key_button_container" class="inline-block {{#unless user_has_email_set}}disabled_setting_tooltip{{/unless}}">
+                    <button class="button rounded" id="api_key_button" {{#unless user_has_email_set}}disabled="disabled"{{/unless}}>
+                        {{t "Show/change your API key" }}
+                    </button>
+                </div>
             </div>
         </div>
         <!-- Render /settings/api_key_modal.hbs after #api_key_button is clicked

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -6,6 +6,7 @@
                 <h3 class="inline-block">{{t "Account" }}</h3>
                 <div class="alert-notification" id="account-settings-status"></div>
                 <form class="grid">
+                    {{#if user_has_email_set}}
                     <div class="input-group">
                         <label class="inline-block title">{{t "Email" }}</label>
                         <div id="change_email_button_container" class="inline-block {{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
@@ -15,6 +16,22 @@
                             </button>
                         </div>
                     </div>
+                    {{else}}
+                    {{! Demo organizations before the owner has configured an email address. }}
+                    <div class="input-group">
+                        <p>
+                            {{#tr}}
+                                Add your email to <z-link-invite-users-help>invite other users</z-link-invite-users-help>
+                                or <z-link-convert-demo-organization-help>convert to a permanent Zulip organization</z-link-convert-demo-organization-help>.
+                                {{#*inline "z-link-invite-users-help"}}<a href="/help/invite-new-users" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                                {{#*inline "z-link-convert-demo-organization-help"}}<a href="/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                            {{/tr}}
+                        </p>
+                        <button id="demo_organization_add_email_button" type="button" class="button rounded sea-green">
+                            {{t "Add email"}}
+                        </button>
+                    </div>
+                    {{/if}}
                 </form>
 
                 {{#if page_params.two_fa_enabled }}

--- a/web/templates/settings/admin_auth_methods_list.hbs
+++ b/web/templates/settings/admin_auth_methods_list.hbs
@@ -4,5 +4,5 @@
       prefix=prefix
       is_checked=enabled
       label=method
-      is_disabled=(not is_owner) }}
+      is_disabled=disable_configure_auth_method}}
 </div>

--- a/web/templates/settings/auth_methods_settings_admin.hbs
+++ b/web/templates/settings/auth_methods_settings_admin.hbs
@@ -2,6 +2,9 @@
     {{#unless is_owner}}
     <div class='tip'>{{t "Only organization owners can edit these settings."}}</div>
     {{/unless}}
+    {{#unless user_has_email_set}}
+    <div class='tip'>{{t "You must configure your email to access this feature."}}</div>
+    {{/unless}}
     <form class="admin-realm-form org-authentications-form">
         <div id="org-auth_settings" class="admin-table-wrapper settings-subsection-parent">
             <div class ="subsection-header">

--- a/web/tests/settings_data.test.js
+++ b/web/tests/settings_data.test.js
@@ -317,3 +317,17 @@ run_test("user_can_create_web_public_streams", () => {
     page_params.is_moderator = false;
     assert.equal(settings_data.user_can_create_web_public_streams(), false);
 });
+
+run_test("user_email_not_configured", () => {
+    const user_email_not_configured = settings_data.user_email_not_configured;
+
+    page_params.is_owner = false;
+    assert.equal(user_email_not_configured(), false);
+
+    page_params.is_owner = true;
+    page_params.delivery_email = "";
+    assert.equal(user_email_not_configured(), true);
+
+    page_params.delivery_email = "name@example.com";
+    assert.equal(user_email_not_configured(), false);
+});

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -280,7 +280,7 @@ def process_new_human_user(
     # from being sent after the user is created.
     clear_scheduled_invitation_emails(user_profile.delivery_email)
     if realm.send_welcome_emails:
-        enqueue_welcome_emails(user_profile)
+        enqueue_welcome_emails(user_profile, realm_creation)
 
     # Schedule an initial email with the user's
     # new account details and log-in information.

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -151,8 +151,20 @@ def do_start_email_change_process(user_profile: UserProfile, new_email: str) -> 
         activate_url=activation_url,
     )
     language = user_profile.default_language
+
+    email_template = "zerver/emails/confirm_new_email"
+
+    if old_email == "":
+        # The assertions here are to help document the only circumstance under which
+        # this condition should be possible.
+        assert (
+            user_profile.realm.demo_organization_scheduled_deletion_date is not None
+            and user_profile.is_realm_owner
+        )
+        email_template = "zerver/emails/confirm_demo_organization_email"
+
     send_email(
-        "zerver/emails/confirm_new_email",
+        template_prefix=email_template,
         to_emails=[new_email],
         from_name=FromAddress.security_email_from_name(language=language),
         from_address=FromAddress.tokenized_no_reply_address(),

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -767,6 +767,13 @@ def send_account_registered_email(user: UserProfile, realm_creation: bool = Fals
     # Imported here to avoid import cycles.
     from zerver.context_processors import common_context
 
+    if user.delivery_email == "":
+        # Do not attempt to enqueue welcome emails for users without an email address.
+        # The assertions here are to help document the only circumstance under which
+        # this condition should be possible.
+        assert user.realm.demo_organization_scheduled_deletion_date is not None and realm_creation
+        return
+
     from_name, from_address = welcome_sender_information()
     realm_url = user.realm.uri
 
@@ -811,9 +818,16 @@ def send_account_registered_email(user: UserProfile, realm_creation: bool = Fals
     )
 
 
-def enqueue_welcome_emails(user: UserProfile) -> None:
+def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> None:
     # Imported here to avoid import cycles.
     from zerver.context_processors import common_context
+
+    if user.delivery_email == "":
+        # Do not attempt to enqueue welcome emails for users without an email address.
+        # The assertions here are to help document the only circumstance under which
+        # this condition should be possible.
+        assert user.realm.demo_organization_scheduled_deletion_date is not None and realm_creation
+        return
 
     from_name, from_address = welcome_sender_information()
     other_account_count = (

--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -67,6 +67,16 @@ def get_device_os(user_agent: str) -> Optional[str]:
 def email_on_new_login(sender: Any, user: UserProfile, request: Any, **kwargs: Any) -> None:
     if not user.enable_login_emails:
         return
+
+    if user.delivery_email == "":
+        # Do not attempt to send new login emails for users without an email address.
+        # The assertions here are to help document the only circumstance under which
+        # this condition should be possible.
+        assert (
+            user.realm.demo_organization_scheduled_deletion_date is not None and user.is_realm_owner
+        )
+        return
+
     # We import here to minimize the dependencies of this module,
     # since it runs as part of `manage.py` initialization
     from zerver.context_processors import common_context

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3957,6 +3957,11 @@ class UserSignUpTest(ZulipTestCase):
         scheduled_email = ScheduledEmail.objects.filter(users=user_profile).last()
         assert scheduled_email is None
 
+        self.assertIn(realm.string_id, user_profile.email)
+        self.assertEqual(
+            user_profile.email_address_visibility, UserProfile.EMAIL_ADDRESS_VISIBILITY_NOBODY
+        )
+
         expected_deletion_date = realm.date_created + datetime.timedelta(
             days=settings.DEMO_ORG_DEADLINE_DAYS
         )

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3952,6 +3952,11 @@ class UserSignUpTest(ZulipTestCase):
         assert user_profile is not None
         self.assert_logged_in_user_id(user_profile.id)
 
+        # Demo organizations are created without setting an email address for the owner.
+        self.assertEqual(user_profile.delivery_email, "")
+        scheduled_email = ScheduledEmail.objects.filter(users=user_profile).last()
+        assert scheduled_email is None
+
         expected_deletion_date = realm.date_created + datetime.timedelta(
             days=settings.DEMO_ORG_DEADLINE_DAYS
         )

--- a/zerver/views/development/registration.py
+++ b/zerver/views/development/registration.py
@@ -94,6 +94,7 @@ def register_demo_development_realm(request: HttpRequest) -> HttpResponse:
     realm_name = generate_demo_realm_name()
     realm_type = Realm.ORG_TYPES["business"]["id"]
     realm_subdomain = realm_name
+    email_address_visibility = UserProfile.EMAIL_ADDRESS_VISIBILITY_NOBODY
     prereg_realm = create_preregistration_realm(email, realm_name, realm_subdomain, realm_type)
     activation_url = create_confirmation_link(
         prereg_realm, Confirmation.REALM_CREATION, realm_creation=True
@@ -105,6 +106,7 @@ def register_demo_development_realm(request: HttpRequest) -> HttpResponse:
         key=key,
         realm_name=realm_name,
         realm_type=realm_type,
+        email_address_visibility=email_address_visibility,
         full_name=name,
         password="test",
         realm_subdomain=realm_subdomain,

--- a/zerver/views/development/registration.py
+++ b/zerver/views/development/registration.py
@@ -88,9 +88,9 @@ def register_development_realm(request: HttpRequest) -> HttpResponse:
 
 @csrf_exempt
 def register_demo_development_realm(request: HttpRequest) -> HttpResponse:
-    count = UserProfile.objects.count()
-    name = f"user-{count}"
-    email = f"{name}@zulip.com"
+    # Demo organization owners are not required to provide a name or email.
+    name = "Your name"
+    email = ""
     realm_name = generate_demo_realm_name()
     realm_type = Realm.ORG_TYPES["business"]["id"]
     realm_subdomain = realm_name


### PR DESCRIPTION
Revision of the 1st commit in #19741, based on [Tim's review comment here](https://github.com/zulip/zulip/pull/19741/commits/f662b0834cb157e4ba161534ee88290a28fa55c3#r932756049).

Working specifically towards this part of #19523:
- We intend to allow you to initially create a demo organization without setting an email address, to make it feel super lightweight.

---

**Notes**:
- **1st commit**: Implements Tim's plan for not queuing welcome emails when the realm for the demo organization is being created since the owner's email is an empty string.

- **2nd commit**: I noted that without an email, key parts of the web-app in the new demo organization did not work, such as sending private messages to the welcome bot or to the new owner/user themself. I thought one option would be creating the realm with the email visibility already restricted, which is what this commit implements. But this may not be the route we want to take, which is why I kept it in a separate commit for now.

- **3rd commit**: I noted when doing some light manual testing in the development environment that the server was trying to send new login emails if I logged out/in of the new demo organization. I went ahead and added a similar restriction to 
`email_on_new_login` as in the first commit for `enqueue_welcome_emails`. I kept this as a separate commit in case there was some other implications for this change that I haven't yet considered.


**Questions**:

- In `accounts_register`, we validate email before doing much else, which we need to skip for demo organizations. I put in a check / assertion for the email being an empty string and `realm_creation` being true to skip the validation since that's how (at this point) we would ascertain that this is a demo organization. Is that enough to skip the validation? Or do we want a clearer marker that a demo organization is being created?

- The log-in page for the development environment uses the delivery email for input element value, so the button for the new owner of the demo realm is blank (see screenshot below) as it's an empty string. Maybe we could add labels with the user's full name for the owners? Or not worry about it?

--- 

**Screenshots and screen captures:**

<details>
<summary>Dev log-in screen for demo organization</summary>

### Note that because the delivery email is an empty string, there is no name/info in the button
![Screenshot from 2022-08-05 20-09-40](https://user-images.githubusercontent.com/63245456/183136755-f090cbb1-432d-4404-a5dd-cb148c48a307.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>