### PR TITLE
api-docs: Remove incorrect schema reference in `unread_msgs` object.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9744,8 +9744,6 @@ paths:
                           to.
                       unread_msgs:
                         type: object
-                        items:
-                          $ref: "#/components/schemas/BasicStream"
                         description: |
                           Present if `message` and `update_message_flags` are both present in
                           `event_types`.


### PR DESCRIPTION
Removes an extraneous `BasicStream` schema reference in the `unread_msgs` object returned by the `/register-queue` endpoint.

[Current documentation](https://zulip.com/api/register-queue) - find on page "unread_msgs"

<details>
<summary>API documentation diff</summary>

```diff
diff -r -B -u current_api_html/register-queue.html new_api_html/register-queue.html
--- current_api_html/register-queue.html	2022-08-08 11:17:52.404009817 +0200
+++ new_api_html/register-queue.html	2022-08-08 11:17:18.551780006 +0200
@@ -1614,7 +1614,7 @@
 </ul>
 </li>
 <li>
-<p><code>unread_msgs</code>: <span class="api-field-type">(object)[]</span></p>
+<p><code>unread_msgs</code>: <span class="api-field-type">object</span></p>
 <p>Present if <code>message</code> and <code>update_message_flags</code> are both present in
 <code>event_types</code>.</p>
 <p>A set of data structures describing the conversations containing
@@ -1712,90 +1712,6 @@
 unread messages.</p>
 <p><strong>Changes</strong>: New in Zulip 4.0 (feature level 44).</p>
 </li>
-<li>
-<p><code>stream_id</code>: <span class="api-field-type">integer</span></p>
-<p>The unique ID of the stream.</p>
-</li>
-<li>
-<p><code>name</code>: <span class="api-field-type">string</span></p>
-<p>The name of the stream.</p>
-</li>
-<li>
-<p><code>description</code>: <span class="api-field-type">string</span></p>
-<p>The short description of the stream in text/markdown format,
-intended to be used to prepopulate UI for editing a stream's
-description.</p>
-</li>
-<li>
-<p><code>date_created</code>: <span class="api-field-type">integer</span></p>
-<p>The UNIX timestamp for when the stream was created, in UTC seconds.</p>
-<p><strong>Changes</strong>: New in Zulip 4.0 (feature level 30).</p>
-</li>
-<li>
-<p><code>invite_only</code>: <span class="api-field-type">boolean</span></p>
-<p>Specifies whether the stream is private or not.
-Only people who have been invited can access a private stream.</p>
-</li>
-<li>
-<p><code>rendered_description</code>: <span class="api-field-type">string</span></p>
-<p>The short description of the stream rendered as HTML, intended to
-be used when displaying the stream description in a UI.</p>
-<p>One should use the standard Zulip rendered_markdown CSS when
-displaying this content so that emoji, LaTeX, and other syntax
-work correctly. And any client-side security logic for
-user-generated message content should be applied when displaying
-this HTML as though it were the body of a Zulip message.</p>
-</li>
-<li>
-<p><code>is_web_public</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the stream has been configured to allow unauthenticated
-access to its message history from the web.</p>
-</li>
-<li>
-<p><code>stream_post_policy</code>: <span class="api-field-type">integer</span></p>
-<p><a href="/api/roles-and-permissions#permission-levels">Policy</a> for which users can post messages to the stream.</p>
-<ul>
-<li>1 =&gt; Any user can post.</li>
-<li>2 =&gt; Only administrators can post.</li>
-<li>3 =&gt; Only <a href="/api/roles-and-permissions#determining-if-a-user-is-a-full-member">full members</a> can post.</li>
-<li>4 =&gt; Only moderators can post.</li>
-</ul>
-<p><strong>Changes</strong>: New in Zulip 3.0 (feature level 1), replacing the previous
-<code>is_announcement_only</code> boolean.</p>
-</li>
-<li>
-<li><code>null</code>, the default, means the stream will inherit the organization
-  level setting.</li>
-<li><code>-1</code> encodes retaining messages in this stream forever.</li>
-</ul>
-<p><strong>Changes</strong>: New in Zulip 3.0 (feature level 17).</p>
-</li>
-<li>
-<p><code>history_public_to_subscribers</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the history of the stream is public to its subscribers.</p>
-<p>Currently always true for public streams (i.e. invite_only=False implies
-history_public_to_subscribers=True), but clients should not make that
-assumption, as we may change that behavior in the future.</p>
-</li>
-<li>
-<p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
-<p>Intended to help clients determine whether they need to display
-UI like the "more topics" widget that would suggest the stream
-has older history that can be accessed.</p>
-<p>Null is used for streams with no message history.</p>
-</li>
-<li>
-<p><code>is_announcement_only</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the given stream is announcement only or not.</p>
-<p><strong>Changes</strong>: Deprecated in Zulip 3.0 (feature level 1). Clients
-should use <code>stream_post_policy</code> instead.</p>
-</li>
-</ul>
-</li>
-<li><p><code>message_retention_days</code>: <span class="api-field-type">integer | null</span></p>
-<p>Number of days that messages sent to this stream will be stored
-before being automatically deleted by the <a href="/help/message-retention-policy">message retention
-policy</a>. There are two special values:</p>
-<ul>
-<li><code>null</code>, the default, means the stream will inherit the organization
-  level setting.</li>
-<li><code>-1</code> encodes retaining messages in this stream forever.</li>
-</ul>
-<p><strong>Changes</strong>: New in Zulip 3.0 (feature level 17).</p>
-</li>
-<li>
-<p><code>history_public_to_subscribers</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the history of the stream is public to its subscribers.</p>
-<p>Currently always true for public streams (i.e. invite_only=False implies
-history_public_to_subscribers=True), but clients should not make that
-assumption, as we may change that behavior in the future.</p>
-</li>
-<li>
-<p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
-<p>Intended to help clients determine whether they need to display
-UI like the "more topics" widget that would suggest the stream
-has older history that can be accessed.</p>
-<p>Null is used for streams with no message history.</p>
-</li>
-<li>
-<p><code>is_announcement_only</code>: <span class="api-field-type">boolean</span></p>
-<p>Whether the given stream is announcement only or not.</p>
-<p><strong>Changes</strong>: Deprecated in Zulip 3.0 (feature level 1). Clients
-should use <code>stream_post_policy</code> instead.</p>
-</li>
 </ul>
 </li>
 <li>
```
</details>

<details>
<summary>Screenshot of updated `unread_msgs` object in register response doc</summary>

![Screenshot from 2022-08-08 11-29-27](https://user-images.githubusercontent.com/63245456/183386760-442ee3a6-b08a-4140-b903-01fa6e14f453.png)
![Screenshot from 2022-08-08 11-29-53](https://user-images.githubusercontent.com/63245456/183386765-0b6758b5-c16f-4d7b-8ccb-80f642561043.png)

</details>

<details>
<summary>Register response in dev environment (via curl)</summary>

**Note**: with event types "messages" and "update_message_flags"
```json
{
   "last_event_id" : -1,
   "max_message_id" : 99,
   "msg" : "",
   "queue_id" : "1659950209:0",
   "result" : "success",
   "unread_msgs" : {
      "count" : 0,
      "huddles" : [],
      "mentions" : [],
      "old_unreads_missing" : false,
      "pms" : [],
      "streams" : []
   },
   "zulip_feature_level" : 135,
   "zulip_merge_base" : "",
   "zulip_version" : "6.0-dev+git"
}
```
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
