### PR TITLE
message_edit: Don't send content to server if msg edit is disabled.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -864,12 +864,9 @@ export function save_message_row_edit($row) {
     const msg_list = message_lists.current;
     let message_id = rows.id($row);
     const message = message_lists.current.get(message_id);
-    const can_edit_stream =
-        message.is_stream && settings_data.user_can_move_messages_between_streams();
     let changed = false;
     let edit_locally_echoed = false;
 
-    const $edit_content_input = $row.find(".message_edit_content");
     let content_changed = false;
     let new_content;
     const old_content = message.raw_content;
@@ -884,22 +881,29 @@ export function save_message_row_edit($row) {
 
     show_message_edit_spinner($row);
 
-    if ($edit_content_input.attr("readonly") !== "readonly") {
+    const $edit_content_input = $row.find(".message_edit_content");
+    const can_edit_content = $edit_content_input.attr("readonly") !== "readonly";
+    if (can_edit_content) {
         new_content = $edit_content_input.val();
         content_changed = old_content !== new_content;
         changed = content_changed;
     }
 
-    if (message.type === "stream") {
-        new_topic = $row.find(".message_edit_topic").val();
+    const $edit_topic_input = $row.find(".message_edit_topic");
+    const can_edit_topic = message.is_stream && $edit_topic_input.attr("readonly") !== "readonly";
+    if (can_edit_topic) {
+        new_topic = $edit_topic_input.val();
         topic_changed = new_topic !== old_topic && new_topic.trim() !== "";
-
-        if (can_edit_stream) {
-            const $dropdown_list_widget_value_elem = $(`#id_select_move_stream_${message_id}`);
-            new_stream_id = Number.parseInt($dropdown_list_widget_value_elem.data("value"), 10);
-            stream_changed = new_stream_id !== old_stream_id;
-        }
     }
+
+    const can_edit_stream =
+        message.is_stream && settings_data.user_can_move_messages_between_streams();
+    if (can_edit_stream) {
+        const $edit_stream_input = $(`#id_select_move_stream_${message_id}`);
+        new_stream_id = Number.parseInt($edit_stream_input.data("value"), 10);
+        stream_changed = new_stream_id !== old_stream_id;
+    }
+
     // Editing a not-yet-acked message (because the original send attempt failed)
     // just results in the in-memory message being changed
     if (message.locally_echoed) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -869,7 +869,11 @@ export function save_message_row_edit($row) {
     let changed = false;
     let edit_locally_echoed = false;
 
-    const new_content = $row.find(".message_edit_content").val();
+    const $edit_content_input = $row.find(".message_edit_content");
+    let content_changed = false;
+    let new_content;
+    const old_content = message.raw_content;
+
     let topic_changed = false;
     let new_topic;
     const old_topic = message.topic;
@@ -879,6 +883,12 @@ export function save_message_row_edit($row) {
     const old_stream_id = message.stream_id;
 
     show_message_edit_spinner($row);
+
+    if ($edit_content_input.attr("readonly") !== "readonly") {
+        new_content = $edit_content_input.val();
+        content_changed = old_content !== new_content;
+        changed = content_changed;
+    }
 
     if (message.type === "stream") {
         new_topic = $row.find(".message_edit_topic").val();
@@ -931,9 +941,8 @@ export function save_message_row_edit($row) {
     if (stream_changed) {
         request.stream_id = new_stream_id;
     }
-    if (new_content !== message.raw_content) {
+    if (content_changed) {
         request.content = new_content;
-        changed = true;
     }
 
     if (!changed) {


### PR DESCRIPTION
We ensure that if message edit is disabled, then we don't send
content in request to the server.

This will also help us avoid bugs where a content containing some
character that is parsed differently by browser than the sender
ends get send to the server even if no content was edited by the user.

Discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/cannot.20change.20message.20content.20while.20changing.20stream


We don't trim whitespace or do any process before comparing `message.raw_content` and `new_content` in the frontend. Also, if the content was found to be different in frontend and sent to backend, I don't think backend should process it any differently.

I even tried playing with some weird characters like https://en.wikipedia.org/wiki/Whitespace_character, but was not able to reproduce the bug.