### PR TITLE
user-settings: Make default `None` for name, email and password changes.

### DIFF
--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -244,11 +244,13 @@ class EmailChangeTestCase(ZulipTestCase):
         )
 
     def test_post_invalid_email(self) -> None:
-        data = {"email": "hamlet-new"}
-        self.login("hamlet")
-        url = "/json/settings"
-        result = self.client_patch(url, data)
-        self.assert_in_response("Invalid address", result)
+        invalid_emails = ["", "hamlet-new"]
+        for email in invalid_emails:
+            data = {"email": email}
+            self.login("hamlet")
+            url = "/json/settings"
+            result = self.client_patch(url, data)
+            self.assert_in_response("Invalid address", result)
 
     def test_post_same_email(self) -> None:
         data = {"email": self.example_email("hamlet")}

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -121,9 +121,11 @@ class ChangeSettingsTest(ZulipTestCase):
         json_result = self.client_patch("/json/settings", dict(full_name="x" * 1000))
         self.assert_json_error(json_result, "Name too long!")
 
-        # Now try a too-short name
-        json_result = self.client_patch("/json/settings", dict(full_name="x"))
-        self.assert_json_error(json_result, "Name too short!")
+        # Now try too-short names
+        short_names = ["", "x"]
+        for name in short_names:
+            json_result = self.client_patch("/json/settings", dict(full_name=name))
+            self.assert_json_error(json_result, "Name too short!")
 
     def test_illegal_characters_in_name_changes(self) -> None:
         self.login("hamlet")


### PR DESCRIPTION
Updates `json_change_settings` so that the default values for the `email`, `full_name`, `new_password` and `old_password` parameters is `None` instead of an empty string, which also makes the type annotation `Optional[str]`.

[Relevant CZO conversation](https://chat.zulip.org/#narrow/stream/9-issues/topic/change.20email.20setting.20bug/near/1415310)

Also, updates tests for email and full name changes to include an empty string as one of the tested invalid values. For email, an empty string shouldn't pass the email validation check. For full name, an empty string does not meet the minimum length requirement for names in Zulip and therefore not pass the name check.

**Note**: I didn't think it made sense to add an explicit backend test for a new password that was an empty string, but could add one if we want a particular behavior on the server side for that value.

---

Current response in dev environment for `full_name` update to `""`:
```console
{
   "msg" : "",
   "result" : "success"
}
```

Updated response in dev environment for `full_name` update to `""`:
```console
{
   "code" : "BAD_REQUEST",
   "msg" : "Name too short!",
   "result" : "error"
}
```

---

**Screenshots and screen captures:**

<details>
<summary>Change email to blank field - current behavior</summary>

![Screenshot from 2022-08-08 13-27-08](https://user-images.githubusercontent.com/63245456/183407990-7865d287-f8cd-47d1-832a-f3720c58e350.png)
</details>

<details>
<summary>Change email to blank field - new behavior</summary>

![Screenshot from 2022-08-08 13-26-21](https://user-images.githubusercontent.com/63245456/183408014-794edb4c-a147-472d-8c89-febb6eef8cbc.png)
</details>

<details>
<summary>GIF update email with empty field - new behavior</summary>

**Note**: Sending the same email address still sends a success response as expected
![Peek 2022-08-08 13-22](https://user-images.githubusercontent.com/63245456/183407576-beaac138-c023-4cbd-8c38-c725d4de4936.gif)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
