### PR TITLE
demo-orgs: Disable billing/upgrade pages for demo organizations.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2329,6 +2329,15 @@ class StripeTest(StripeTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual("/upgrade/", response["Location"])
 
+    def test_upgrade_page_for_demo_organizations(self) -> None:
+        user = self.example_user("iago")
+        user.realm.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(days=30)
+        user.realm.save()
+        self.login_user(user)
+
+        response = self.client_get("/billing/", follow=True)
+        self.assert_in_success_response(["cannot be upgraded"], response)
+
     def test_redirect_for_upgrade_page(self) -> None:
         user = self.example_user("iago")
         self.login_user(user)

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -276,6 +276,7 @@ def initial_upgrade(
             "annual_price": 8000,
             "monthly_price": 800,
             "percent_off": float(percent_off),
+            "demo_organization_scheduled_deletion_date": user.realm.demo_organization_scheduled_deletion_date,
         },
         "realm_org_type": user.realm.org_type,
         "sorted_org_types": sorted(
@@ -286,6 +287,7 @@ def initial_upgrade(
             ),
             key=lambda d: d[1]["display_order"],
         ),
+        "is_demo_organization": user.realm.demo_organization_scheduled_deletion_date is not None,
     }
     response = render(request, "corporate/upgrade.html", context=context)
     return response

--- a/static/js/bundles/portico.js
+++ b/static/js/bundles/portico.js
@@ -2,3 +2,4 @@ import "./common";
 import "../portico/header";
 import "../portico/google-analytics";
 import "../../styles/portico/portico_styles.css";
+import "tippy.js/dist/tippy.css";

--- a/static/js/portico/tippyjs.js
+++ b/static/js/portico/tippyjs.js
@@ -1,0 +1,18 @@
+import $ from "jquery";
+import tippy from "tippy.js";
+
+function initialize() {
+    tippy("[data-tippy-content]", {
+        // Same defaults as set in web app tippyjs module.
+        maxWidth: 300,
+        delay: [100, 20],
+        touch: ["hold", 750],
+        // Different default from web app tippyjs module.
+        animation: true,
+        placement: "bottom",
+    });
+}
+
+$(() => {
+    initialize();
+});

--- a/static/styles/portico/billing.css
+++ b/static/styles/portico/billing.css
@@ -177,6 +177,19 @@
 
     .invoice-button {
         font-size: 19px;
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+
+            &:hover {
+                pointer-events: all;
+            }
+        }
+    }
+
+    .upgrade-button-container {
+        display: inline-block;
     }
 
     #manual_license_count,

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -401,6 +401,33 @@ html {
         font-weight: 400;
     }
 
+    .demo-organization-warning {
+        position: relative;
+        display: block;
+        background-color: hsl(360, 100%, 93%);
+        border: 1px solid hsl(0, 0%, 80%);
+        border-radius: 4px;
+        padding: 10px;
+        margin: 10px 0;
+        font-size: 1rem;
+        font-weight: 500;
+        line-height: 1.5;
+        color: hsl(0, 0%, 27%);
+
+        a {
+            text-decoration: none;
+        }
+
+        &::before {
+            display: inline;
+            margin-right: 8px;
+
+            font-family: FontAwesome;
+            font-weight: 600;
+            content: "\f071";
+        }
+    }
+
     .alert {
         &:not(.alert-info) {
             padding: 0;

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -24,6 +24,16 @@
                 </div>
                 {% endif %}
 
+                {% if is_demo_organization %}
+                <div class="demo-organization-warning">
+                    Demo organizations cannot be directly upgraded to a paid plan. Please start by
+                    <a href="/help/demo-organizations#convert-a-demo-organization-to-a-permanent-organization">
+                    converting your demo organization
+                    </a>
+                    to a permanent organization.
+                </div>
+                {% endif %}
+
                 {% if error_message %}
                 <div class="alert alert-danger" id="upgrade-error-message-box">
                     {{ error_message }}
@@ -140,10 +150,14 @@
                                     <h4>Number of licenses (minimum {{ seat_count }})</h4>
                                     <input type="number" name="licenses" min="{{ seat_count }}" autocomplete="off" id="manual_license_count" required/><br />
                                 </div>
-
-                                <button id="add-card-button" class="stripe-button-el invoice-button">
-                                    <span id="add-card-button-span">Add card</span>
-                                </button>
+                                <!-- Disabled buttons do not fire any events, so we need a container div that isn't disabled for tippyjs to work -->
+                                <div class="upgrade-button-container" {% if is_demo_organization %}data-tippy-content="{% trans %}Convert demo organization before upgrading.{% endtrans %}"{% endif %}>
+                                    <button id="add-card-button" class="stripe-button-el invoice-button" {% if is_demo_organization %}disabled{% endif %}>
+                                        <span id="add-card-button-span">
+                                            Add card
+                                        </span>
+                                    </button>
+                                </div>
                             </form>
                         </div>
                         <div id="autopay-loading">
@@ -201,7 +215,12 @@
                                 <h4>Number of licenses (minimum {{ min_invoiced_licenses }})</h4>
                                 <input type="number" min="{{ min_invoiced_licenses }}" autocomplete="off"
                                   id="invoiced_licenses" name="licenses" required/><br />
-                                <button type="submit" id="invoice-button" class="stripe-button-el invoice-button">Buy Standard</button>
+                                <!-- Disabled buttons do not fire any events, so we need a container div that isn't disabled for tippyjs to work -->
+                                <div class="upgrade-button-container" {% if is_demo_organization %}data-tippy-content="{% trans %}Convert demo organization before upgrading.{% endtrans %}"{% endif %}>
+                                    <button type="submit" id="invoice-button" class="stripe-button-el invoice-button" {% if is_demo_organization %}disabled{% endif %}>
+                                        Buy Standard
+                                    </button>
+                                </div>
                             </form>
                         </div>
                         <div id="invoice-loading">
@@ -247,7 +266,12 @@
                                 <textarea name="description" style="width: 100%;" cols="100" rows="5" required></textarea>
                                 <br />
                                 <p id="sponsorship-discount-details"></p>
-                                <button type="submit" id="sponsorship-button" class="stripe-button-el invoice-button">Submit</button>
+                                <!-- Disabled buttons do not fire any events, so we need a container div that isn't disabled for tippyjs to work -->
+                                <div class="upgrade-button-container" {% if is_demo_organization %}data-tippy-content="{% trans %}Convert demo organization before upgrading.{% endtrans %}"{% endif %}>
+                                    <button type="submit" id="sponsorship-button" class="stripe-button-el invoice-button" {% if is_demo_organization %}disabled{% endif %}>
+                                        Submit
+                                    </button>
+                                </div>
                             </form>
                         </div>
                         <div id="sponsorship-loading">

--- a/templates/zerver/help/demo-organizations.md
+++ b/templates/zerver/help/demo-organizations.md
@@ -25,7 +25,7 @@ Other than those limitations, they work exactly like a normal Zulip
 organization; you can invite additional users, connect the mobile
 apps, etc.
 
-## Creating demo organizations
+## Create a demo organization
 
 {start_tabs}
 
@@ -39,7 +39,7 @@ apps, etc.
 
 {end_tabs}
 
-## Converting a demo organization to a regular organization
+## Convert a demo organization to a permanent organization
 
 {start_tabs}
 

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -17,6 +17,7 @@
     ],
     "upgrade": [
         "./static/js/bundles/portico",
+        "./static/js/portico/tippyjs",
         "./static/js/portico/landing-page",
         "./static/styles/portico/landing_page.css",
         "./static/js/billing/helpers",


### PR DESCRIPTION
Revision of the 2nd commit in #19741.

Prep for requiring demo organizations to convert to ~regular~ permanent organizations before upgrading to Zulip Cloud.

---

**Notes**:

- **1st commit**: Generally initializes tippy for tooltips in portico pages, see [this comment](https://github.com/zulip/zulip/pull/19741/commits/498c2d2cd637ba505e5845c578413582d61fd556#r790042280) in original PR.

- **2nd commit**: For demo organizations, adds a red banner to the billing/upgrade page and disables the submit buttons on the same page. Cleans up some of the shortened references to demo organizations (aka "demo-org" or "demo_org").

**Questions**:

- @amanagr would you be up for looking over the 1st commit since I haven't worked much with the tippy tooltips yet?

- @alya I believe the copy / visual appearance for the banner and the tooltip haven't yet been reviewed / confirmed, so it would be good to have your feedback on those (see screenshot below).

---

**Screenshots and screen captures:**

![Screenshot from 2022-08-05 22-40-47](https://user-images.githubusercontent.com/63245456/183429792-a3f0056c-9ccc-4daa-b49c-c89e37f599e6.png)

<details>
<summary>GIF of navigating to billing in demo organization</summary>

![Peek 2022-08-08 15-55](https://user-images.githubusercontent.com/63245456/183435142-f578cb40-bb8d-49a4-8885-38a05730ac58.gif)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
