### PR TITLE
docs: Add warning about SAML on Cloud requiring the Plus plan.

### DIFF
--- a/templates/zerver/help/saml-authentication.md
+++ b/templates/zerver/help/saml-authentication.md
@@ -1,5 +1,13 @@
 # SAML authentication
 
+!!! warn ""
+
+    If your organization is hosted on Zulip Cloud, please note that
+    due to requiring manual configuration on our side,
+    we currently cannot offer SAML for customers on the Free or Standard plan and
+    purchasing the Plus plan is required.
+    Contact [support@zulip.com](mailto:support@zulip.com) for more details.
+
 Zulip supports using SAML authentication for single sign-on, both when
 self-hosting or on the Zulip Cloud Plus plan.
 


### PR DESCRIPTION
The page is not clear enough in its current state about the **Plus** plan being required and Cloud users sometimes don't realize it and end up sending us all the detail for SAML set up just to find out they can't use it. So a warning on top of the help page seems important to add.

![image](https://user-images.githubusercontent.com/45007152/183477369-ac4eaa08-ca80-4a67-8480-74033583afe7.png)