### PR TITLE
message_edit: Close message edit UI after message is moved.

### DIFF
--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -88,10 +88,6 @@ run_test("update_messages", () => {
         },
     ];
 
-    message_lists.current.get_row = (message_id) => {
-        assert.equal(message_id, 111);
-        return ["row-stub"];
-    };
     message_lists.current.view = {};
 
     let rendered_mgs;
@@ -103,7 +99,7 @@ run_test("update_messages", () => {
 
     const side_effects = [
         [condense, "un_cache_message_content_height"],
-        [message_edit, "end_message_row_edit"],
+        [message_edit, "end_message_edit"],
         [notifications, "received_messages"],
         [unread_ui, "update_unread_counts"],
         [stream_list, "update_streams_sidebar"],

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -805,6 +805,17 @@ export function end_message_row_edit($row) {
     $row.find("input.message_edit_topic").trigger("blur");
 }
 
+export function end_message_edit(message_id) {
+    const $row = message_lists.current.get_row(message_id);
+    if ($row.length > 0) {
+        end_message_row_edit($row);
+    } else if (currently_editing_messages.has(message_id)) {
+        // We should delete the message_id from currently_editing_messages
+        // if it exists there but we cannot find the row.
+        currently_editing_messages.delete(message_id);
+    }
+}
+
 export function save_inline_topic_edit($row) {
     const msg_list = message_lists.current;
     let message_id = rows.id_for_recipient_row($row);

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -175,10 +175,8 @@ export function update_messages(events) {
             msg.is_me_message = event.is_me_message;
         }
 
-        const $row = message_lists.current.get_row(event.message_id);
-        if ($row.length > 0) {
-            message_edit.end_message_row_edit($row);
-        }
+        // mark the current message edit attempt as complete.
+        message_edit.end_message_edit(event.message_id);
 
         const new_topic = util.get_edit_event_topic(event);
 


### PR DESCRIPTION
Currently, if we navigate to some other topic/stream
while the message is being moved, the message edit UI
still remains open as we do not get its `row` in
`message_lists.current` since the message has not moved yet
to the stream/topic we navigated.

Hence the correct thing to do would be to delete
the message_id from `currently_editing_messages` if it
exists there but we cannot find the row.

Fixes #21724.

<!-- Describe your pull request here.-->

Fixes: #21724 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
