### PR TITLE
settings: Refactor out settings from test_extra_settings.

### DIFF
--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -26,6 +26,7 @@ from scripts.lib.zulip_tools import (
     write_new_digest,
 )
 
+BACKEND_DATABASE_TEMPLATE = "zulip_test_template"
 UUID_VAR_DIR = get_dev_uuid_var_path()
 
 IMPORTANT_FILES = [
@@ -413,7 +414,7 @@ def reset_zulip_test_database() -> None:
 
     destroy_test_databases()
     # Pointing default database to test database template, so we can instantly clone it.
-    settings.DATABASES["default"]["NAME"] = settings.BACKEND_DATABASE_TEMPLATE
+    settings.DATABASES["default"]["NAME"] = BACKEND_DATABASE_TEMPLATE
     connection = connections["default"]
     clone_database_suffix = "clone"
     connection.creation.clone_test_db(

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -22,6 +22,7 @@ from scripts.lib.zulip_tools import (
 )
 from zerver.lib import test_helpers
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
+from zerver.lib.test_fixtures import BACKEND_DATABASE_TEMPLATE
 from zerver.lib.test_helpers import append_instrumentation_data, write_instrumentation_reports
 
 # We need to pick an ID for this test-backend invocation, and store it
@@ -289,7 +290,7 @@ class Runner(DiscoverRunner):
         return self.shallow_tested_templates
 
     def setup_test_environment(self, *args: Any, **kwargs: Any) -> Any:
-        settings.DATABASES["default"]["NAME"] = settings.BACKEND_DATABASE_TEMPLATE
+        settings.DATABASES["default"]["NAME"] = BACKEND_DATABASE_TEMPLATE
         # We create/destroy the test databases in run_tests to avoid
         # duplicate work when running in parallel mode.
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -156,9 +156,15 @@ from zproject.backends import (
     saml_auth_enabled,
     sync_user_from_ldap,
 )
+from zproject.config import get_from_file_if_exists
 
 if TYPE_CHECKING:
     from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
+
+APPLE_ID_TOKEN_GENERATION_KEY = get_from_file_if_exists(
+    "zerver/tests/fixtures/apple/token_gen_private_key"
+)
+EXAMPLE_JWK = get_from_file_if_exists("zerver/tests/fixtures/example_jwk")
 
 
 class AuthBackendTest(ZulipTestCase):
@@ -2957,7 +2963,7 @@ class AppleAuthMixin:
             payload["aud"] = audience
 
         headers = {"kid": "SOMEKID"}
-        private_key = settings.APPLE_ID_TOKEN_GENERATION_KEY
+        private_key = APPLE_ID_TOKEN_GENERATION_KEY
 
         id_token = jwt.encode(payload, private_key, algorithm="RS256", headers=headers)
 
@@ -3011,7 +3017,7 @@ class AppleIdAuthBackendTest(AppleAuthMixin, SocialAuthBase):
             requests_mock.GET,
             self.BACKEND_CLASS.JWK_URL,
             status=200,
-            json=json.loads(settings.EXAMPLE_JWK),
+            json=json.loads(EXAMPLE_JWK),
         )
 
     def generate_access_token_url_payload(self, account_data_dict: Dict[str, str]) -> str:
@@ -3209,7 +3215,7 @@ class AppleAuthBackendNativeFlowTest(AppleAuthMixin, SocialAuthBase):
                 requests_mock.GET,
                 self.BACKEND_CLASS.JWK_URL,
                 status=200,
-                json=json.loads(settings.EXAMPLE_JWK),
+                json=json.loads(EXAMPLE_JWK),
             )
             yield
 
@@ -3386,7 +3392,7 @@ class GenericOpenIdConnectTest(SocialAuthBase):
             requests_mock.GET,
             self.JWKS_URL,
             status=200,
-            json=json.loads(settings.EXAMPLE_JWK),
+            json=json.loads(EXAMPLE_JWK),
         )
 
     def generate_access_token_url_payload(self, account_data_dict: Dict[str, str]) -> str:

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -570,9 +570,8 @@ if STATSD_HOST != "":
 # CAMO HTTPS CACHE CONFIGURATION
 ########################################################################
 
-if CAMO_URI != "":
-    # This needs to be synced with the Camo installation
-    CAMO_KEY = get_secret("camo_key")
+# This needs to be synced with the Camo installation
+CAMO_KEY = get_secret("camo_key") if CAMO_URI != "" else None
 
 ########################################################################
 # STATIC CONTENT AND MINIFICATION SETTINGS

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -111,6 +111,8 @@ RUNNING_OPENAPI_CURL_TEST = False
 GENERATE_STRIPE_FIXTURES = False
 # This is overridden in test_settings.py for the test suites
 BAN_CONSOLE_OUTPUT = False
+# This is overridden in test_settings.py for the test suites
+TEST_WORKER_DIR = ""
 
 # These are the settings that we will check that the user has filled in for
 # production deployments before starting the app.  It consists of a series

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -26,9 +26,6 @@ FAKE_EMAIL_DOMAIN = "zulip.testserver"
 # Clear out the REALM_HOSTS set in dev_settings.py
 REALM_HOSTS: Dict[str, str] = {}
 
-# Used to clone DBs in backend tests.
-BACKEND_DATABASE_TEMPLATE = "zulip_test_template"
-
 DATABASES["default"] = {
     "NAME": os.getenv("ZULIP_DB_NAME", "zulip_test"),
     "USER": "zulip_test",

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -146,8 +146,7 @@ if not PUPPETEER_TESTS:
 # Enable file:/// hyperlink support by default in tests
 ENABLE_FILE_LINKS = True
 
-# These settings are set dynamically in `zerver/lib/test_runner.py`:
-TEST_WORKER_DIR = ""
+# This is set dynamically in `zerver/lib/test_runner.py`.
 # Allow setting LOCAL_UPLOADS_DIR in the environment so that the
 # frontend/API tests in test_server.py can control this.
 if "LOCAL_UPLOADS_DIR" in os.environ:

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -185,10 +185,6 @@ SOCIAL_AUTH_APPLE_KEY = "KEYISKEY"
 SOCIAL_AUTH_APPLE_TEAM = "TEAMSTRING"
 SOCIAL_AUTH_APPLE_SECRET = get_from_file_if_exists("zerver/tests/fixtures/apple/private_key.pem")
 
-EXAMPLE_JWK = get_from_file_if_exists("zerver/tests/fixtures/example_jwk")
-APPLE_ID_TOKEN_GENERATION_KEY = get_from_file_if_exists(
-    "zerver/tests/fixtures/apple/token_gen_private_key"
-)
 
 SOCIAL_AUTH_OIDC_ENABLED_IDPS: Dict[str, OIDCIdPConfigDict] = {
     "testoidc": {


### PR DESCRIPTION
Because our test suites rely on some settings that only present on (or whose types are inferrable from) `zproject.test_extra_settings`, `mypy_django_plugin` might not be able to find out their types.

This eliminates those settings that aren't necessary as settings, and moves definitions into `zproject.computed_settings` if needed.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
