### PR TITLE
subscriptions: Send update events for `is_muted` property.

### DIFF
--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -120,12 +120,17 @@ test("update_property", ({override}) => {
         assert.equal(args.val, "blue");
     }
 
-    // Test in home view
+    // Test in home view (code coverage; until event/property removed)
+    {
+        stream_events.update_property(stream_id, "in_home_view", false);
+    }
+
+    // Test is muted
     {
         const stub = make_stub();
         override(stream_muting, "update_is_muted", stub.f);
         override(stream_list, "refresh_muted_or_unmuted_stream", noop);
-        stream_events.update_property(stream_id, "in_home_view", false);
+        stream_events.update_property(stream_id, "is_muted", true);
         assert.equal(stub.num_calls, 1);
         const args = stub.get_args("sub", "val");
         assert.equal(args.sub.stream_id, stream_id);

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -45,7 +45,11 @@ export function update_property(stream_id, property, value, other_values) {
             stream_color.update_stream_color(sub, value, {update_historical: true});
             break;
         case "in_home_view":
-            stream_muting.update_is_muted(sub, !value);
+            // Legacy in_home_view events are only sent as duplicates of
+            // modern is_muted events, which we handle below.
+            break;
+        case "is_muted":
+            stream_muting.update_is_muted(sub, value);
             stream_list.refresh_muted_or_unmuted_stream(sub);
             recent_topics_ui.complete_rerender();
             break;

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 139**
+
+* [`GET /get-events`](/api/get-events): When a user mutes or unmutes
+  their subscription to a stream, a `subscription` update event
+  is now sent for the `is_muted` property and for the deprecated
+  `in_home_view` property to support clients fully migrating to use the
+  `is_muted` property. Prior to this feature level, only one event was
+  sent to clients with the deprecated `in_home_view` property.
+
 **Feature level 138**
 
 * [`POST /register`](/api/register-queue), [`GET
@@ -228,7 +237,7 @@ No changes; feature level used for Zulip 5.0 release.
 
 **Feature level 111**
 
-* [`POST /subscriptions/properties`](/api/update-subscription-settings):
+* [`POST /users/me/subscriptions/properties`](/api/update-subscription-settings):
   Removed `subscription_data` from response object, replacing it with
   `ignored_parameters_unsupported`.
 
@@ -1137,7 +1146,8 @@ No changes; feature level used for Zulip 3.0 release.
   `demote_inactive_streams` display settings.
 * `enable_stream_sounds` was renamed to
   `enable_stream_audible_notifications`.
-* Deprecated `in_home_view`, replacing it with the more readable
+* [`POST /users/me/subscriptions/properties`](/api/update-subscription-settings):
+  Deprecated `in_home_view`, replacing it with the more readable
   `is_muted` (with the opposite meaning).
 * Custom profile fields: Added `EXTERNAL_ACCOUNT` field type.
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 138
+API_FEATURE_LEVEL = 139
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -697,8 +697,9 @@ paths:
                               description: |
                                 Event sent to a user's clients when a property of the user's
                                 subscription to a stream has been updated. This event is used
-                                only for personal properties like `is_muted`; see the `stream` event
-                                for global properties of a stream.
+                                only for personal properties like `is_muted` or `pin_to_top`.
+                                See the [stream update event](/api/get-events#stream-update)
+                                for updates to global properties of a stream.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -718,13 +719,19 @@ paths:
                                 property:
                                   type: string
                                   description: |
-                                    The property of the subscription which has changed. See
-                                    [/users/me/subscriptions/properties GET](/api/update-subscription-settings)
-                                    for details on the various properties of a stream.
+                                    The property of the subscription which has changed. For details on the
+                                    various subscription properties that a user can change, see
+                                    [POST /users/me/subscriptions/properties](/api/update-subscription-settings).
 
                                     Clients should generally handle an unknown property received here without
                                     crashing, since that will naturally happen when connecting to a Zulip
                                     server running a new version that adds a new subscription property.
+
+                                    **Changes**: As of Zulip 6.0 (feature level 139), updates to the `is_muted`
+                                    property or the deprecated `in_home_view` property will send two `subscription`
+                                    update events, one for each property, to support clients fully migrating to
+                                    use the `is_muted` property. Prior to this feature level, updates to either
+                                    property only sent one event with the deprecated `in_home_view` property.
                                 value:
                                   description: |
                                     The new value of the changed property.
@@ -8773,8 +8780,14 @@ paths:
                         - `"color"`: The hex value of the user's display color for the stream.
 
                         - `"is_muted"`: Whether the stream is [muted](/help/mute-a-stream).<br>
+                          **Changes**: As of Zulip 6.0 (feature level 139), updating either
+                          `"is_muted"` or `"in_home_view"` generates two [subscription update
+                          events](/api/get-events#subscription-update), one for each property,
+                          that are sent to clients. Prior to this feature level, updating either
+                          property only generated a subscription update event for
+                          `"in_home_view"`. <br>
                           **Changes**: Prior to Zulip 2.1.0, this feature was represented
-                          by the more confusingly named `in_home_view` (with the
+                          by the more confusingly named `"in_home_view"` (with the
                           opposite value: `in_home_view=!is_muted`); for
                           backwards-compatibility, modern Zulip still accepts that property.
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3016,7 +3016,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
         property_name = "is_muted"
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.tornado_redirected_to_list(events, expected_num_events=2):
             result = self.api_post(
                 test_user,
                 "/api/v1/users/me/subscriptions/properties",
@@ -3035,6 +3035,8 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(events[0]["event"]["property"], "in_home_view")
         self.assertEqual(events[0]["event"]["value"], False)
+        self.assertEqual(events[1]["event"]["property"], "is_muted")
+        self.assertEqual(events[1]["event"]["value"], True)
         sub = Subscription.objects.get(
             recipient__type=Recipient.STREAM,
             recipient__type_id=subs[0]["stream_id"],
@@ -3043,7 +3045,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         self.assertEqual(sub.is_muted, True)
 
         legacy_property_name = "in_home_view"
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.tornado_redirected_to_list(events, expected_num_events=2):
             result = self.api_post(
                 test_user,
                 "/api/v1/users/me/subscriptions/properties",
@@ -3062,6 +3064,8 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(events[0]["event"]["property"], "in_home_view")
         self.assertEqual(events[0]["event"]["value"], True)
+        self.assertEqual(events[1]["event"]["property"], "is_muted")
+        self.assertEqual(events[1]["event"]["value"], False)
         self.assert_json_success(result)
         sub = Subscription.objects.get(
             recipient__type=Recipient.STREAM,
@@ -3070,7 +3074,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         )
         self.assertEqual(sub.is_muted, False)
 
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.tornado_redirected_to_list(events, expected_num_events=2):
             result = self.api_post(
                 test_user,
                 "/api/v1/users/me/subscriptions/properties",
@@ -3089,6 +3093,8 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(events[0]["event"]["property"], "in_home_view")
         self.assertEqual(events[0]["event"]["value"], False)
+        self.assertEqual(events[1]["event"]["property"], "is_muted")
+        self.assertEqual(events[1]["event"]["value"], True)
 
         sub = Subscription.objects.get(
             recipient__type=Recipient.STREAM,


### PR DESCRIPTION
In Zulip 2.1.0, the `is_muted` stream subscription property was added and replaced the `in_home_view` property. But the server has still only been sending subscription update events with the `in_home_view` property.

Updates `do_change_subscription_property` to send a subscription update event for both `is_muted` and `in_home_view`, so that clients can fully migrate away from using `in_home_view` allowing us to eventually remove it completely.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/378-api-design/topic/in_home_view.20vs.20is_muted.20.28events.20only.3F.29/near/1411886).

**Notes**:

- I attempted to update `do_change_subscription_property` with the goal of making it simple to do the update to remove `in_home_view` from this function. For that final change, one should be able to remove the two `if` blocks and remove/replace all `database_property_name` / `database_value` instances to use the `property_name` and `value` parameters passed to the function.

- I thought about only sending the single event when `is_muted` was specified as the property name, but decided to always send both events so that we did not have to add extra temporary logic to `apply_event` in `events.py`. In fact, I believe that logic has been off since we haven't been sending any subscription update events with `is_muted` as the property. But since there wasn't a test in `test_events.py` for changing each subscription property name/value, it wasn't caught. Maybe a follow-up (or something to look at) would be to fill in that gap in the `test_events.py`? I did add a test for these changes and therefore for these two properties.

- Also, I made some small clean ups in the API changelog that are related to `in_home_view` or the `/update-subscription-settings` endpoint.

**Questions**:

- Did not add a **Changes** note to [/update-subscription-settings endpoint parameter](https://zulip.com/api/update-subscription-settings#parameter-subscription_data) because the change is focused on the events, but we might want to update the existing **Changes** note there for when `in_home_view` was deprecated in Zulip 2.1.0?

---

**Screenshots and screen captures:**

<details>
<summary>API changelog entry + clean-ups</summary>

![Screenshot from 2022-08-10 18-40-07](https://user-images.githubusercontent.com/63245456/183974763-30e488a1-cd71-4978-8f30-444522725d9f.png)

![Screenshot from 2022-08-10 19-35-23](https://user-images.githubusercontent.com/63245456/183979280-09d6131a-043d-46f9-ab39-f014fe284f2d.png)

![Screenshot from 2022-08-10 19-35-44](https://user-images.githubusercontent.com/63245456/183979287-9a1cc6a7-f067-4b7a-825a-96f9ce3e8a5e.png)


</details>

<details>
<summary>Update subscription event in `/get-events`</summary>

[Current documentation](https://zulip.com/api/get-events#subscription-update)
![Screenshot from 2022-08-10 18-40-40](https://user-images.githubusercontent.com/63245456/183974765-f2745937-b54c-4af0-bf2a-890b911e42d7.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
