### PR TITLE
requirements: Upgrade types-stripe to 3.5.1.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2168,9 +2168,9 @@ types-six==1.16.18 \
     # via
     #   -r requirements/mypy.in
     #   types-boto
-types-stripe==3.5.0 \
-    --hash=sha256:1eaf4d147f5d572158cc01217490dd2d13607c5bbb028cc34498ee0952c1604b \
-    --hash=sha256:2220b675422daf1fc49a2be1ca634dbe74803c23067f968043c2f90697da3566
+types-stripe==3.5.1 \
+    --hash=sha256:2fb2d9eab532e3b382253596cc7a1027a907a1c9f7a91bc27296e41e655ba888 \
+    --hash=sha256:9bad37c88c9eb9bf70bb096d92aa71f366f2f642d42510ab657b63d82a0dcd1b
     # via -r requirements/mypy.in
 types-urllib3==1.26.17 \
     --hash=sha256:0d027fcd27dbb3cb532453b4d977e05bc1e13aefd70519866af211b3003d895d \

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -267,9 +267,9 @@ types-six==1.16.18 \
     # via
     #   -r requirements/mypy.in
     #   types-boto
-types-stripe==3.5.0 \
-    --hash=sha256:1eaf4d147f5d572158cc01217490dd2d13607c5bbb028cc34498ee0952c1604b \
-    --hash=sha256:2220b675422daf1fc49a2be1ca634dbe74803c23067f968043c2f90697da3566
+types-stripe==3.5.1 \
+    --hash=sha256:2fb2d9eab532e3b382253596cc7a1027a907a1c9f7a91bc27296e41e655ba888 \
+    --hash=sha256:9bad37c88c9eb9bf70bb096d92aa71f366f2f642d42510ab657b63d82a0dcd1b
     # via -r requirements/mypy.in
 types-urllib3==1.26.17 \
     --hash=sha256:0d027fcd27dbb3cb532453b4d977e05bc1e13aefd70519866af211b3003d895d \

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 136
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (197, 0)
+PROVISION_VERSION = (197, 1)


### PR DESCRIPTION
This includes the change from https://github.com/python/typeshed/commit/28fde2ee2738e44bf6339460e6bdeb6ff255cca3.
Only a minor bump is required because it has no effect on type
checking yet before django-stubs gets integrated.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
