### PR TITLE
tornado: Add None check for SHARED_SECRET.

### DIFF
--- a/scripts/setup/generate_secrets.py
+++ b/scripts/setup/generate_secrets.py
@@ -11,6 +11,7 @@ from scripts.lib.zulip_tools import get_config, get_config_file
 
 setup_path()
 
+os.environ["DISABLE_MANDATORY_SECRET_CHECK"] = "True"
 os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
 
 import argparse

--- a/zerver/lib/avatar_hash.py
+++ b/zerver/lib/avatar_hash.py
@@ -24,7 +24,6 @@ def user_avatar_hash(uid: str) -> str:
     # The salt probably doesn't serve any purpose now.  In the past we
     # used a hash of the email address, not the user ID, and we salted
     # it in order to make the hashing scheme different from Gravatar's.
-    assert settings.AVATAR_SALT is not None
     user_key = uid + settings.AVATAR_SALT
     return make_safe_digest(user_key, hashlib.sha1)
 

--- a/zerver/migrations/0032_verify_all_medium_avatar_images.py
+++ b/zerver/migrations/0032_verify_all_medium_avatar_images.py
@@ -19,7 +19,6 @@ from zerver.models import UserProfile
 # since we rearranged the avatars in Zulip 1.6.
 def patched_user_avatar_path(user_profile: UserProfile) -> str:
     email = user_profile.email
-    assert settings.AVATAR_SALT is not None
     user_key = email.lower() + settings.AVATAR_SALT
     return make_safe_digest(user_key, hashlib.sha1)
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1392,7 +1392,6 @@ class TestScriptMTA(ZulipTestCase):
 
         mail_template = self.fixture_data("simple.txt", type="email")
         mail = mail_template.format(stream_to_address=stream_to_address, sender=sender)
-        assert settings.SHARED_SECRET is not None
         subprocess.run(
             [script, "-r", stream_to_address, "-s", settings.SHARED_SECRET, "-t"],
             input=mail,
@@ -1408,7 +1407,6 @@ class TestScriptMTA(ZulipTestCase):
         stream_to_address = encode_email_address(stream)
         mail_template = self.fixture_data("simple.txt", type="email")
         mail = mail_template.format(stream_to_address=stream_to_address, sender=sender)
-        assert settings.SHARED_SECRET is not None
         p = subprocess.run(
             [script, "-s", settings.SHARED_SECRET, "-t"],
             input=mail,

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -220,7 +220,6 @@ class EventsEndpointTest(ZulipTestCase):
         self.assertEqual(str(access_denied_error.exception), "Access denied")
         self.assertEqual(access_denied_error.exception.http_status_code, 403)
 
-        assert settings.SHARED_SECRET is not None
         post_data["secret"] = settings.SHARED_SECRET
         req = HostRequestMock(post_data, tornado_handler=dummy_handler)
         req.META["REMOTE_ADDR"] = "127.0.0.1"

--- a/zerver/tests/test_server_settings.py
+++ b/zerver/tests/test_server_settings.py
@@ -1,0 +1,20 @@
+import os
+from unittest import mock
+
+from zerver.lib.test_classes import ZulipTestCase
+from zproject import config
+
+
+class ConfigTest(ZulipTestCase):
+    def test_get_mandatory_secret_succeed(self) -> None:
+        secret = config.get_mandatory_secret("shared_secret")
+        self.assertGreater(len(secret), 0)
+
+    def test_get_mandatory_secret_failed(self) -> None:
+        with self.assertRaisesRegex(config.ZulipSettingsError, "nonexistent"):
+            config.get_mandatory_secret("nonexistent")
+
+    def test_disable_mandatory_secret_check(self) -> None:
+        with mock.patch.dict(os.environ, {"DISABLE_MANDATORY_SECRET_CHECK": "True"}):
+            secret = config.get_mandatory_secret("nonexistent")
+        self.assertEqual(secret, "")

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -73,7 +73,7 @@ from .configured_settings import (
 ########################################################################
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = get_secret("secret_key")
+SECRET_KEY = get_mandatory_secret("secret_key")
 
 # A shared secret, used to authenticate different parts of the app to each other.
 SHARED_SECRET = get_mandatory_secret("shared_secret")

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -82,7 +82,7 @@ SHARED_SECRET = get_mandatory_secret("shared_secret")
 # avatar.  If this salt is discovered, attackers will only be able to determine
 # that the owner of an email account has uploaded an avatar to Zulip, which isn't
 # the end of the world.  Don't use the salt where there is more security exposure.
-AVATAR_SALT = get_secret("avatar_salt")
+AVATAR_SALT = get_mandatory_secret("avatar_salt")
 
 # SERVER_GENERATION is used to track whether the server has been
 # restarted for triggering browser clients to reload.

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -19,6 +19,7 @@ from .config import (
     config_file,
     get_config,
     get_from_file_if_exists,
+    get_mandatory_secret,
     get_secret,
 )
 from .configured_settings import (
@@ -75,7 +76,7 @@ from .configured_settings import (
 SECRET_KEY = get_secret("secret_key")
 
 # A shared secret, used to authenticate different parts of the app to each other.
-SHARED_SECRET = get_secret("shared_secret")
+SHARED_SECRET = get_mandatory_secret("shared_secret")
 
 # We use this salt to hash a user's email into a filename for their user-uploaded
 # avatar.  If this salt is discovered, attackers will only be able to determine

--- a/zproject/config.py
+++ b/zproject/config.py
@@ -2,6 +2,13 @@ import configparser
 import os
 from typing import Optional, overload
 
+from django.core.exceptions import ImproperlyConfigured
+
+
+class ZulipSettingsError(ImproperlyConfigured):
+    pass
+
+
 DEPLOY_ROOT = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
 config_file = configparser.RawConfigParser()
@@ -10,7 +17,6 @@ config_file.read("/etc/zulip/zulip.conf")
 # Whether this instance of Zulip is running in a production environment.
 PRODUCTION = config_file.has_option("machine", "deploy_type")
 DEVELOPMENT = not PRODUCTION
-
 secrets_file = configparser.RawConfigParser()
 if PRODUCTION:
     secrets_file.read("/etc/zulip/zulip-secrets.conf")
@@ -36,6 +42,15 @@ def get_secret(
     if development_only and PRODUCTION:
         return default_value
     return secrets_file.get("secrets", key, fallback=default_value)
+
+
+def get_mandatory_secret(key: str) -> str:
+    secret = get_secret(key)
+    if secret is None:
+        if os.environ.get("DISABLE_MANDATORY_SECRET_CHECK") == "True":
+            return ""
+        raise ZulipSettingsError(f'Mandatory secret "{key}" is not set')
+    return secret
 
 
 @overload


### PR DESCRIPTION
Secrets like SHARED_SECRET are not intended to be `None`. We add a helper get_mandatory_secret to ensure that the reuquired secrets are set.

This check needs to be disabled when generating secrets with an environment variable.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
