### PR TITLE
import: Remove dead do_import_system_bots code.

### DIFF
--- a/zerver/management/commands/import.py
+++ b/zerver/management/commands/import.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 from zerver.forms import check_subdomain_available
-from zerver.lib.import_realm import do_import_realm, do_import_system_bots
+from zerver.lib.import_realm import do_import_realm
 
 
 class Command(BaseCommand):
@@ -96,6 +96,4 @@ import a database dump from one or more JSON files."""
 
         for path in paths:
             print(f"Processing dump: {path} ...")
-            realm = do_import_realm(path, subdomain, num_processes)
-            print("Checking the system bots.")
-            do_import_system_bots(realm)
+            do_import_realm(path, subdomain, num_processes)


### PR DESCRIPTION
This code is actually a noop (and would be a bug if it wasn't a noop),
because when this runs the server is already initialized, meaning the
internal realm exists and the system bots have been created, so
UserProfile.objects.filter(email=email) is always truthy. Also, system
bots are supposed to live in the internal realm, not in the realm being
imported so this code doesn't make sense currently.

https://chat.zulip.org/#narrow/stream/3-backend/topic/do_import_system_bots