### PR TITLE
compose: Allow ctrl + enter to send in preview mode as well.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -268,9 +268,12 @@ export function send_message(request = create_message_object()) {
     }
 }
 
-export function enter_with_preview_open() {
-    if (user_settings.enter_sends) {
-        // If enter_sends is enabled, we attempt to send the message
+export function enter_with_preview_open(ctrl_pressed = false) {
+    if (
+        (user_settings.enter_sends && !ctrl_pressed) ||
+        (!user_settings.enter_sends && ctrl_pressed)
+    ) {
+        // If this enter should send, we attempt to send the message.
         finish();
     } else {
         // Otherwise, we return to the normal compose state.

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -273,8 +273,8 @@ export function enter_with_preview_open() {
         // If enter_sends is enabled, we attempt to send the message
         finish();
     } else {
-        // Otherwise, we return to the compose box and focus it
-        $("#compose-textarea").trigger("focus");
+        // Otherwise, we return to the normal compose state.
+        clear_preview_area();
     }
 }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -89,6 +89,7 @@ const keydown_unshift_mappings = {
 
 const keydown_ctrl_mappings = {
     219: {name: "escape", message_view_only: false}, // '['
+    13: {name: "ctrl_enter", message_view_only: true}, // enter
 };
 
 const keydown_cmd_or_ctrl_mappings = {
@@ -471,6 +472,16 @@ export function process_enter_key(e) {
     return true;
 }
 
+export function process_ctrl_enter_key() {
+    if ($("#preview_message_area").is(":visible")) {
+        const ctrl_pressed = true;
+        compose.enter_with_preview_open(ctrl_pressed);
+        return true;
+    }
+
+    return false;
+}
+
 export function process_tab_key() {
     // Returns true if we handled it, false if the browser should.
     // TODO: See if browsers like Safari can now handle tabbing correctly
@@ -566,6 +577,8 @@ export function process_hotkey(e, hotkey) {
             return process_escape_key(e);
         case "enter":
             return process_enter_key(e);
+        case "ctrl_enter":
+            return process_ctrl_enter_key(e);
         case "tab":
             return process_tab_key();
         case "shift_tab":


### PR DESCRIPTION
When the user chose to send the composebox message on pressing ctrl +
enter instead of just enter, it only worked in writing mode but not
the preview mode.

This change makes ctrl + enter send the message even in preview mode,
when that setting is chosen.

Fixes: #21670.

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
