### PR TITLE
portico: Remove usage of `control-group` and `control-label` class.

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -42,16 +42,6 @@ $(() => {
         "#id_new_password2 ~ .password_visibility_toggle",
     );
 
-    function highlight(class_to_add) {
-        // Set a class on the enclosing control group.
-        return function (element) {
-            $(element)
-                .closest(".control-group")
-                .removeClass("success error")
-                .addClass(class_to_add);
-        };
-    }
-
     $("#registration, #password_reset").validate({
         rules: {
             password: "password_strength",
@@ -71,8 +61,6 @@ $(() => {
                 $error.insertAfter($element).addClass("help-inline alert alert-error");
             }
         },
-        highlight: highlight("error"),
-        unhighlight: highlight("success"),
     });
 
     if ($("#registration").length > 0) {

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -854,11 +854,7 @@ input.new-organization-button {
 
 .login-form,
 .register-form {
-    .control-label {
-        margin-bottom: 2px;
-    }
-
-    .control-group {
+    .controls {
         margin-right: 10px;
     }
 }
@@ -922,10 +918,6 @@ input.new-organization-button {
     #pw_strength {
         width: 328px;
         margin-top: 20px;
-    }
-
-    .control-group .control-label {
-        display: block;
     }
 
     .pitch {
@@ -1018,6 +1010,17 @@ input.new-organization-button {
     text-align: center;
 }
 
+#registration-email {
+    label {
+        float: left;
+        padding-top: 5px;
+        width: 100%;
+        display: block;
+        margin: 0;
+        text-align: left;
+    }
+}
+
 .center-block {
     text-align: left;
     display: inline-block;
@@ -1027,20 +1030,9 @@ input.new-organization-button {
         margin-bottom: 20px;
     }
 
-    .control-group {
-        margin-bottom: 10px;
-
-        label {
-            width: 100%;
-            display: block;
-            margin: 0;
-            text-align: left;
-        }
-
-        .controls {
-            margin: 0;
-            text-align: left;
-        }
+    .controls {
+        margin: 0;
+        text-align: left;
     }
 
     #send_confirm input[type="text"] {

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -303,7 +303,7 @@ html {
     .center-block {
         max-width: 800px;
 
-        .control-group {
+        .controls {
             margin-bottom: 5px;
         }
     }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1746,15 +1746,15 @@ input[type="checkbox"] {
         margin: auto;
     }
 
-    #linkifier-settings .new-linkifier-form,
-    #playground-settings .new-playground-form,
-    #profile-field-settings .new-profile-field-form {
-        width: 100%;
+    #linkifier-settings .new-linkifier-form input,
+    #playground-settings .new-playground-form input,
+    #profile-field-settings .new-profile-field-form input {
+        width: calc(100% - 20px) !important;
     }
 
-    #linkifier-settings .new-linkifier-form .control-label,
-    #playground-settings .new-playground-form .control-label,
-    #profile-field-settings .new-profile-field-form .control-label {
+    #linkifier-settings .new-linkifier-form label,
+    #playground-settings .new-playground-form label,
+    #profile-field-settings .new-profile-field-form label {
         display: block;
         width: 120px;
         padding: 0;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1764,13 +1764,6 @@ input[type="checkbox"] {
         float: none;
     }
 
-    #linkifier-settings .new-linkifier-form .controls,
-    #playground-settings .new-playground-form .controls,
-    #profile-field-settings .new-profile-field-form .controls {
-        margin: auto;
-        text-align: center;
-    }
-
     #settings_page .save-button-controls {
         display: block;
         margin: 10px 0 0;

--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -16,8 +16,8 @@ the registration flow has its own (nearly identical) copy of the fields below in
         <div class="form-horizontal white-box">
             <form method="post" class="form-horizontal" id="registration" action="{{ url('accept_terms') }}">
                 {{ csrf_input }}
-                <div class="control-group">
-                    <label for="id_email" class="control-label">{{ _("Email") }}</label>
+                <div id="registration-email">
+                    <label for="id_email">{{ _("Email") }}</label>
                     <div class="controls fakecontrol">
                         <p>{{ email }}</p>
                     </div>
@@ -52,11 +52,9 @@ the registration flow has its own (nearly identical) copy of the fields below in
                         {% endfor %}
                     {% endif %}
                 </div>
-                <div class="control-group">
-                    <div class="controls">
-                        <button id="accept_tos_button" type="submit">{{ _('Accept') }}</button>
-                        <input type="hidden" name="next" value="{{ next }}" />
-                    </div>
+                <div class="controls">
+                    <button id="accept_tos_button" type="submit">{{ _('Accept') }}</button>
+                    <input type="hidden" name="next" value="{{ next }}" />
                 </div>
             </form>
         </div>

--- a/templates/zerver/development/dev_login.html
+++ b/templates/zerver/development/dev_login.html
@@ -16,75 +16,73 @@ page can be easily identified in it's respective JavaScript file -->
         <p class="devlogin_subheader">(Or visit the <a href="/login/">normal login page</a>.)</p>
         <form name="direct_login_form" id="direct_login_form" method="post" class="login-form">
             <input type="hidden" name="next" value="{{ next }}" />
-            <div class="control-group">
-                <div class="controls">
-                    <div class="group">
-                        {% if realm_web_public_access_enabled %}
-                        <h2>{{_('Anonymous user') }}</h2>
+            <div class="controls">
+                <div class="group">
+                    {% if realm_web_public_access_enabled %}
+                    <h2>{{_('Anonymous user') }}</h2>
+                    <p>
+                        <input type="submit" formaction="{{ current_realm.uri }}{{ url('login-local') }}"
+                          name="prefers_web_public_view" class="btn-direct btn-admin" value="Anonymous login" />
+                    </p>
+                    {% endif %}
+                    <h2>{{_('Owners') }}</h2>
+                    {% if direct_owners %}
+                        {% for direct_owner in direct_owners %}
                         <p>
-                            <input type="submit" formaction="{{ current_realm.uri }}{{ url('login-local') }}"
-                              name="prefers_web_public_view" class="btn-direct btn-admin" value="Anonymous login" />
+                            <input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('login-local') }}"
+                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_owner.delivery_email }}" />
                         </p>
-                        {% endif %}
-                        <h2>{{_('Owners') }}</h2>
-                        {% if direct_owners %}
-                            {% for direct_owner in direct_owners %}
-                            <p>
-                                <input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('login-local') }}"
-                                  name="direct_email" class="btn-direct btn-admin" value="{{ direct_owner.delivery_email }}" />
-                            </p>
-                            {% endfor %}
-                        {% else %}
-                            <p>No owners found in this realm</p>
-                        {% endif %}
-                        <h2>{{ _('Administrators') }}</h2>
-                        {% if direct_admins %}
-                            {% for direct_admin in direct_admins %}
-                            <p>
-                                <input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('login-local') }}"
-                                  name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.delivery_email }}" />
-                            </p>
-                            {% endfor %}
-                        {% else %}
-                            <p>No administrators found in this realm</p>
-                        {% endif %}
-                        <h2>{{ _('Moderators') }}</h2>
-                        {% if direct_moderators %}
-                            {% for direct_moderator in direct_moderators %}
-                            <p>
-                                <input type="submit" formaction="{{ direct_moderator.realm.uri }}{{ url('login-local') }}"
-                                  name="direct_email" class="btn-direct btn-admin" value="{{ direct_moderator.delivery_email }}" />
-                            </p>
-                            {% endfor %}
-                        {% else %}
-                            <p>No moderators found in this realm</p>
-                        {% endif %}
-                        <h2>{{ _('Guest users') }}</h2>
-                        {% if guest_users %}
-                            {% for guest_user in guest_users %}
-                            <p>
-                                <input type="submit" formaction="{{ guest_user.realm.uri }}{{ url('login-local') }}"
-                                  name="direct_email" class="btn-direct btn-admin" value="{{ guest_user.delivery_email }}" />
-                            </p>
-                            {% endfor %}
-                        {% else %}
-                            <p>No guest users found in this realm</p>
-                        {% endif %}
-                    </div>
+                        {% endfor %}
+                    {% else %}
+                        <p>No owners found in this realm</p>
+                    {% endif %}
+                    <h2>{{ _('Administrators') }}</h2>
+                    {% if direct_admins %}
+                        {% for direct_admin in direct_admins %}
+                        <p>
+                            <input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('login-local') }}"
+                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.delivery_email }}" />
+                        </p>
+                        {% endfor %}
+                    {% else %}
+                        <p>No administrators found in this realm</p>
+                    {% endif %}
+                    <h2>{{ _('Moderators') }}</h2>
+                    {% if direct_moderators %}
+                        {% for direct_moderator in direct_moderators %}
+                        <p>
+                            <input type="submit" formaction="{{ direct_moderator.realm.uri }}{{ url('login-local') }}"
+                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_moderator.delivery_email }}" />
+                        </p>
+                        {% endfor %}
+                    {% else %}
+                        <p>No moderators found in this realm</p>
+                    {% endif %}
+                    <h2>{{ _('Guest users') }}</h2>
+                    {% if guest_users %}
+                        {% for guest_user in guest_users %}
+                        <p>
+                            <input type="submit" formaction="{{ guest_user.realm.uri }}{{ url('login-local') }}"
+                              name="direct_email" class="btn-direct btn-admin" value="{{ guest_user.delivery_email }}" />
+                        </p>
+                        {% endfor %}
+                    {% else %}
+                        <p>No guest users found in this realm</p>
+                    {% endif %}
+                </div>
 
-                    <div class="group">
-                        <h2>{{ _('Normal users') }}</h2>
-                        {% if direct_users %}
-                            {% for direct_user in direct_users %}
-                            <p>
-                                <input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('login-local') }}"
-                                  name="direct_email" class="btn-direct btn-admin" value="{{ direct_user.delivery_email }}" />
-                            </p>
-                            {% endfor %}
-                        {% else %}
-                            <p>No normal users found in this realm</p>
-                        {% endif %}
-                    </div>
+                <div class="group">
+                    <h2>{{ _('Normal users') }}</h2>
+                    {% if direct_users %}
+                        {% for direct_user in direct_users %}
+                        <p>
+                            <input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('login-local') }}"
+                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_user.delivery_email }}" />
+                        </p>
+                        {% endfor %}
+                    {% else %}
+                        <p>No normal users found in this realm</p>
+                    {% endif %}
                 </div>
             </div>
         </form>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -90,7 +90,7 @@ page can be easily identified in it's respective JavaScript file. -->
                                 <input id="id_password" name="password" class="required" type="password" autocomplete="off"
                                   {% if email %} autofocus {% endif %}
                                   required />
-                                <label for="id_password" class="control-label">{{ _('Password') }}</label>
+                                <label for="id_password">{{ _('Password') }}</label>
                                 <i class="fa fa-eye-slash password_visibility_toggle" role="button"></i>
                             </div>
                             {% else %}


### PR DESCRIPTION
Visually, the UI still looks the same.