### PR TITLE
typeahead: Fix thin blue line bug when there is space after `>`.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -723,6 +723,12 @@ export function get_candidates(query) {
             if (tokens[1]) {
                 const stream_name = tokens[1];
                 this.token = tokens[2] || "";
+
+                // Don't autocomplete if there is a space following '>'
+                if (this.token[0] === " ") {
+                    return false;
+                }
+
                 const topic_list = topics_seen_for(stream_name);
                 if (should_show_custom_query(this.token, topic_list)) {
                     topic_list.push(this.token);


### PR DESCRIPTION
When the user added space/s right after the topic typehead symbol `>`,
a thin blue line would be selected at the top of the typeahead menu.

To avoid this and to make stream and topic typeaheads' behaviour more
consistent with each other, space/s right after `>` is not allowed,
like it is not allowed right after `#`.

Fixes: #19124.

**Screenshots and screen captures:**
(no typeahead menu visible when there is a space immediately after `>`)
![image](https://user-images.githubusercontent.com/68962290/184433753-0bbd147f-1407-48e1-9972-aa8c40f1cea2.png)


**Self-review checklist**


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
