### PR TITLE
Billing: Fix a bug preventing organizations from adding guest users they're entitled to have

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -66,6 +66,10 @@ def get_latest_seat_count(realm: Realm) -> int:
     guests = UserProfile.objects.filter(
         realm=realm, is_active=True, is_bot=False, role=UserProfile.ROLE_GUEST
     ).count()
+
+    # This formula achieves the pricing of the first 5*N guests
+    # being free of charge (where N is the number of non-guests in the organization)
+    # and each consecutive one being worth 1/5 the non-guest price.
     return max(non_guests, math.ceil(guests / 5))
 
 

--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -58,14 +58,23 @@ STRIPE_API_VERSION = "2020-08-27"
 
 
 def get_latest_seat_count(realm: Realm) -> int:
+    return get_seat_count(realm, extra_non_guests_count=0, extra_guests_count=0)
+
+
+def get_seat_count(
+    realm: Realm, extra_non_guests_count: int = 0, extra_guests_count: int = 0
+) -> int:
     non_guests = (
         UserProfile.objects.filter(realm=realm, is_active=True, is_bot=False)
         .exclude(role=UserProfile.ROLE_GUEST)
         .count()
+    ) + extra_non_guests_count
+    guests = (
+        UserProfile.objects.filter(
+            realm=realm, is_active=True, is_bot=False, role=UserProfile.ROLE_GUEST
+        ).count()
+        + extra_guests_count
     )
-    guests = UserProfile.objects.filter(
-        realm=realm, is_active=True, is_bot=False, role=UserProfile.ROLE_GUEST
-    ).count()
 
     # This formula achieves the pricing of the first 5*N guests
     # being free of charge (where N is the number of non-guests in the organization)

--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -138,7 +138,14 @@ def do_invite_users(
     if settings.BILLING_ENABLED:
         from corporate.lib.registration import check_spare_licenses_available_for_inviting_new_users
 
-        check_spare_licenses_available_for_inviting_new_users(user_profile.realm, num_invites)
+        if invite_as == PreregistrationUser.INVITE_AS["GUEST_USER"]:
+            check_spare_licenses_available_for_inviting_new_users(
+                user_profile.realm, extra_guests_count=num_invites
+            )
+        else:
+            check_spare_licenses_available_for_inviting_new_users(
+                user_profile.realm, extra_non_guests_count=num_invites
+            )
 
     realm = user_profile.realm
     if not realm.invite_required:

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -167,6 +167,7 @@ class HomepageForm(forms.Form):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.realm = kwargs.pop("realm", None)
         self.from_multiuse_invite = kwargs.pop("from_multiuse_invite", False)
+        self.invited_as = kwargs.pop("invited_as", None)
         super().__init__(*args, **kwargs)
 
     def clean_email(self) -> str:
@@ -214,8 +215,9 @@ class HomepageForm(forms.Form):
             email_is_not_mit_mailing_list(email)
 
         if settings.BILLING_ENABLED:
+            role = self.invited_as if self.invited_as is not None else UserProfile.ROLE_MEMBER
             try:
-                check_spare_licenses_available_for_registering_new_user(realm, email)
+                check_spare_licenses_available_for_registering_new_user(realm, email, role=role)
             except LicenseLimitError:
                 raise ValidationError(
                     _(

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -211,7 +211,12 @@ def maybe_send_to_registration(
     else:
         invited_as = PreregistrationUser.INVITE_AS["MEMBER"]
 
-    form = HomepageForm({"email": email}, realm=realm, from_multiuse_invite=from_multiuse_invite)
+    form = HomepageForm(
+        {"email": email},
+        realm=realm,
+        from_multiuse_invite=from_multiuse_invite,
+        invited_as=invited_as,
+    )
     if form.is_valid():
         # If the email address is allowed to sign up for an account in
         # this organization, construct a PreregistrationUser and

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -219,7 +219,7 @@ def accounts_register(
 
         if settings.BILLING_ENABLED:
             try:
-                check_spare_licenses_available_for_registering_new_user(realm, email)
+                check_spare_licenses_available_for_registering_new_user(realm, email, role=role)
             except LicenseLimitError:
                 return render(request, "zerver/no_spare_licenses.html")
 
@@ -697,7 +697,12 @@ def accounts_home(
         invited_as = multiuse_object.invited_as
 
     if request.method == "POST":
-        form = HomepageForm(request.POST, realm=realm, from_multiuse_invite=from_multiuse_invite)
+        form = HomepageForm(
+            request.POST,
+            realm=realm,
+            from_multiuse_invite=from_multiuse_invite,
+            invited_as=invited_as,
+        )
         if form.is_valid():
             try:
                 rate_limit_request_by_ip(request, domain="sends_email_by_ip")


### PR DESCRIPTION
Guest accounts have special treatment for the purposes of calculating the "seat count" of an organization (https://zulip.com/help/zulip-cloud-billing#how-are-guest-accounts-billed-is-there-special-pricing). So when dealing with manual billing, this needs to be taken into account. Currently our checks applied when trying to invite a user (or when a user is signing up from an invitation) don't distinguish between guests and non-guests - so an organization with 50 licenses and all 50 of them used is unable to add a guest user, despite potentially being eligible for it (because this marginal guest might be free). 

This PR aims to fix that by making these checks correctly take the `role` of the user being added into account.