### PR TITLE
rate_limit: Remove rate_limit.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -744,7 +744,7 @@ def authenticated_rest_api_view(
 
             # Now we try to do authentication or die
             try:
-                profile = validate_api_key(
+                user_profile = validate_api_key(
                     request,
                     role,
                     api_key,
@@ -755,8 +755,8 @@ def authenticated_rest_api_view(
                 raise UnauthorizedError(e.msg)
             try:
                 if not skip_rate_limiting:
-                    rate_limit_user(request, profile, domain="api_by_user")
-                return view_func(request, profile, *args, **kwargs)
+                    rate_limit_user(request, user_profile, domain="api_by_user")
+                return view_func(request, user_profile, *args, **kwargs)
             except Exception as err:
                 if not webhook_client_name:
                     raise err

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Type, cast
+from typing import Dict, List, Optional, Set, Tuple, Type, cast
 
 import orjson
 import redis
@@ -15,9 +15,6 @@ from zerver.lib.exceptions import RateLimited
 from zerver.lib.redis_utils import get_redis_client
 from zerver.lib.utils import statsd
 from zerver.models import UserProfile
-
-if TYPE_CHECKING:
-    from zilencer.models import RemoteZulipServer
 
 # Implement a rate-limiting scheme inspired by the one described here, but heavily modified
 # https://www.domaintools.com/resources/blog/rate-limiting-with-redis
@@ -618,18 +615,6 @@ def rate_limit_request_by_ip(request: HttpRequest, domain: str) -> None:
         logger.warning("Failed to fetch TOR exit node list: %s", err)
         pass
     rate_limit_ip(request, ip_addr, domain=domain)
-
-
-def rate_limit_remote_server(
-    request: HttpRequest, remote_server: "RemoteZulipServer", domain: str
-) -> None:
-    if settings.ZILENCER_ENABLED:
-        from zilencer.models import RateLimitedRemoteZulipServer
-    try:
-        RateLimitedRemoteZulipServer(remote_server, domain=domain).rate_limit_request(request)
-    except RateLimited as e:
-        logger.warning("Remote server %s exceeded rate limits on domain %s", remote_server, domain)
-        raise e
 
 
 def should_rate_limit(request: HttpRequest) -> bool:

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -632,11 +632,18 @@ def rate_limit_remote_server(
         raise e
 
 
-def rate_limit(request: HttpRequest) -> None:
+def should_rate_limit(request: HttpRequest) -> bool:
     if not settings.RATE_LIMITING:
-        return
+        return False
 
     if client_is_exempt_from_rate_limiting(request):
+        return False
+
+    return True
+
+
+def rate_limit(request: HttpRequest) -> None:
+    if not should_rate_limit(request):
         return
 
     from zerver.lib.request import RequestNotes

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -646,14 +646,9 @@ def rate_limit(request: HttpRequest) -> None:
     if not should_rate_limit(request):
         return
 
-    from zerver.lib.request import RequestNotes
-
     user = request.user
-    remote_server = RequestNotes.get_notes(request).remote_server
 
-    if settings.ZILENCER_ENABLED and remote_server is not None:
-        rate_limit_remote_server(request, remote_server, domain="api_by_remote_server")
-    elif not user.is_authenticated:
+    if not user.is_authenticated:
         rate_limit_request_by_ip(request, domain="api_by_ip")
     else:
         assert isinstance(user, UserProfile)

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -588,10 +588,6 @@ def rate_limit_user(request: HttpRequest, user: UserProfile, domain: str) -> Non
     RateLimitedUser(user, domain=domain).rate_limit_request(request)
 
 
-def rate_limit_ip(request: HttpRequest, ip_addr: str, domain: str) -> None:
-    RateLimitedIPAddr(ip_addr, domain=domain).rate_limit_request(request)
-
-
 def rate_limit_request_by_ip(request: HttpRequest, domain: str) -> None:
     if not should_rate_limit(request):
         return
@@ -619,7 +615,7 @@ def rate_limit_request_by_ip(request: HttpRequest, domain: str) -> None:
         # service doesn't silently remove this functionality.
         logger.warning("Failed to fetch TOR exit node list: %s", err)
         pass
-    rate_limit_ip(request, ip_addr, domain=domain)
+    RateLimitedIPAddr(ip_addr, domain=domain).rate_limit_request(request)
 
 
 def should_rate_limit(request: HttpRequest) -> bool:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1133,7 +1133,7 @@ Output:
         self.assertIn(substring, response.content.decode())
 
     def assert_in_success_response(
-        self, substrings: List[str], response: "TestHttpResponse"
+        self, substrings: List[str], response: Union["TestHttpResponse", HttpResponse]
     ) -> None:
         self.assertEqual(response.status_code, 200)
         decoded = response.content.decode()
@@ -1141,7 +1141,7 @@ Output:
             self.assertIn(substring, decoded)
 
     def assert_not_in_success_response(
-        self, substrings: List[str], response: "TestHttpResponse"
+        self, substrings: List[str], response: Union["TestHttpResponse", HttpResponse]
     ) -> None:
         self.assertEqual(response.status_code, 200)
         decoded = response.content.decode()

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -642,17 +642,6 @@ class RateLimitTestCase(ZulipTestCase):
     def ratelimited_web_view(req: HttpRequest) -> HttpResponse:
         return HttpResponse("some value")
 
-    def errors_disallowed(self) -> Any:
-        # Due to what is probably a hack in rate_limit(),
-        # some tests will give a false positive (or succeed
-        # for the wrong reason), unless we complain
-        # about logging errors.  There might be a more elegant way
-        # make logging errors fail than what I'm doing here.
-        class TestLoggingErrorException(Exception):
-            pass
-
-        return mock.patch("logging.error", side_effect=TestLoggingErrorException)
-
     def check_rate_limit_public_or_user_views(
         self,
         remote_addr: str,
@@ -669,7 +658,7 @@ class RateLimitTestCase(ZulipTestCase):
             "zerver.lib.rate_limiter.RateLimitedUser"
         ) as rate_limit_user_mock, mock.patch(
             "zerver.lib.rate_limiter.rate_limit_ip"
-        ) as rate_limit_ip_mock, self.errors_disallowed():
+        ) as rate_limit_ip_mock:
             self.assert_in_success_response(["some value"], view_func(request))
         self.assertEqual(rate_limit_ip_mock.called, expect_rate_limit)
         self.assertFalse(rate_limit_user_mock.called)
@@ -685,7 +674,7 @@ class RateLimitTestCase(ZulipTestCase):
             "zerver.lib.rate_limiter.RateLimitedUser"
         ) as rate_limit_user_mock, mock.patch(
             "zerver.lib.rate_limiter.rate_limit_ip"
-        ) as rate_limit_ip_mock, self.errors_disallowed():
+        ) as rate_limit_ip_mock:
             self.assert_in_success_response(["some value"], view_func(request))
         self.assertEqual(rate_limit_user_mock.called, expect_rate_limit)
         self.assertFalse(rate_limit_ip_mock.called)

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -718,7 +718,7 @@ class RateLimitTestCase(ZulipTestCase):
         server.save()
 
         with self.settings(RATE_LIMITING=True), mock.patch(
-            "zerver.lib.rate_limiter.rate_limit_remote_server"
+            "zilencer.auth.rate_limit_remote_server"
         ) as rate_limit_mock:
             result = self.uuid_post(
                 server_uuid,

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -657,7 +657,7 @@ class RateLimitTestCase(ZulipTestCase):
         with mock.patch(
             "zerver.lib.rate_limiter.RateLimitedUser"
         ) as rate_limit_user_mock, mock.patch(
-            "zerver.lib.rate_limiter.rate_limit_ip"
+            "zerver.lib.rate_limiter.RateLimitedIPAddr"
         ) as rate_limit_ip_mock:
             self.assert_in_success_response(["some value"], view_func(request))
         self.assertEqual(rate_limit_ip_mock.called, expect_rate_limit)
@@ -673,7 +673,7 @@ class RateLimitTestCase(ZulipTestCase):
         with mock.patch(
             "zerver.lib.rate_limiter.RateLimitedUser"
         ) as rate_limit_user_mock, mock.patch(
-            "zerver.lib.rate_limiter.rate_limit_ip"
+            "zerver.lib.rate_limiter.RateLimitedIPAddr"
         ) as rate_limit_ip_mock:
             self.assert_in_success_response(["some value"], view_func(request))
         self.assertEqual(rate_limit_user_mock.called, expect_rate_limit)

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -430,12 +430,12 @@ class RateLimitTests(ZulipTestCase):
             self.DEFAULT_SUBDOMAIN = ""
 
             RateLimitedRemoteZulipServer(server).clear_history()
-            with self.assertLogs("zerver.lib.rate_limiter", level="WARNING") as m:
+            with self.assertLogs("zilencer.auth", level="WARNING") as m:
                 self.do_test_hit_ratelimits(lambda: self.uuid_post(server_uuid, endpoint, payload))
             self.assertEqual(
                 m.output,
                 [
-                    f"WARNING:zerver.lib.rate_limiter:Remote server <RemoteZulipServer demo.example.com {server_uuid[:12]}> exceeded rate limits on domain api_by_remote_server"
+                    f"WARNING:zilencer.auth:Remote server <RemoteZulipServer demo.example.com {server_uuid[:12]}> exceeded rate limits on domain api_by_remote_server"
                 ],
             )
         finally:

--- a/zilencer/auth.py
+++ b/zilencer/auth.py
@@ -15,7 +15,7 @@ from zerver.lib.exceptions import (
     RemoteServerDeactivatedError,
     UnauthorizedError,
 )
-from zerver.lib.rate_limiter import rate_limit
+from zerver.lib.rate_limiter import rate_limit_remote_server, should_rate_limit
 from zerver.lib.request import RequestNotes
 from zerver.lib.rest import get_target_view_function_or_response
 from zerver.lib.subdomains import get_subdomain
@@ -80,7 +80,8 @@ def authenticated_remote_server_view(
         except JsonableError as e:
             raise UnauthorizedError(e.msg)
 
-        rate_limit(request)
+        if should_rate_limit(request):
+            rate_limit_remote_server(request, remote_server, domain="api_by_remote_server")
         return view_func(request, remote_server, *args, **kwargs)
 
     return _wrapped_view_func


### PR DESCRIPTION
By using inlined calls to rate limit functions like `rate_limit_request_by_ip` in the corresponding view decorators,
we can remove the all-in-one `rate_limit` function.

As a part of this change, `rate_limit_by_remote_server` is now an internal part of `zilencer`, such that `zerver.lib.rate_limiter`
no longer depends on it.

Inlining the rate limit checks also leads to a complete rework of the `RateLimitTestCase`.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
