### PR TITLE
forms: Fix 500 error on realm creation with invalid email

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -239,7 +239,12 @@ def email_not_system_bot(email: str) -> None:
 
 
 def email_is_not_disposable(email: str) -> None:
-    if is_disposable_domain(Address(addr_spec=email).domain):
+    try:
+        domain = Address(addr_spec=email).domain
+    except ValueError:
+        raise ValidationError(_("Please use your real email address."))
+
+    if is_disposable_domain(domain):
         raise ValidationError(_("Please use your real email address."))
 
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3763,6 +3763,11 @@ class RealmCreationTest(ZulipTestCase):
         self.assertEqual(PreregistrationUser.objects.filter(email=email, status=0).count(), 0)
 
     @override_settings(OPEN_REALM_CREATION=True)
+    def test_invalid_email_signup(self) -> None:
+        result = self.client_post("/new/", {"email": "foo\x00bar"})
+        self.assert_in_response("Please use your real email address.", result)
+
+    @override_settings(OPEN_REALM_CREATION=True)
     def test_mailinator_signup(self) -> None:
         result = self.client_post("/new/", {"email": "hi@mailinator.com"})
         self.assert_in_response("Please use your real email address.", result)


### PR DESCRIPTION
Commit b945aa3443110cac98736ba33c32ff5899e0b237 (#22604) incorrectly assumed that Django would run the extra `EmailField` validators if basic email address validation passed. Actually, it runs all validators unconditionally and collects all failures. So `email_is_not_disposable` needs to catch email address parsing errors.