### PR TITLE
rest: Remove kwargs from rest_path.

### DIFF
--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, Dict, Mapping, Set, Tuple, Union, cast
+from typing import Any, Callable, Dict, Set, Tuple, Union, cast
 
 from django.http import HttpRequest, HttpResponse
 from django.urls import path
@@ -199,7 +199,6 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
 
 def rest_path(
     route: str,
-    kwargs: Mapping[str, object] = {},
     **handlers: Union[Callable[..., HttpResponse], Tuple[Callable[..., HttpResponse], Set[str]]],
 ) -> URLPattern:
-    return path(route, rest_dispatch, {**kwargs, **handlers})
+    return path(route, rest_dispatch, handlers)

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, Dict, Set, Tuple, Union, cast
+from typing import Callable, Dict, Set, Tuple, Union, cast
 
 from django.http import HttpRequest, HttpResponse
 from django.urls import path
@@ -42,7 +42,7 @@ def default_never_cache_responses(view_func: ViewFuncT) -> ViewFuncT:
 
 
 def get_target_view_function_or_response(
-    request: HttpRequest, rest_dispatch_kwargs: Dict[str, Any]
+    request: HttpRequest, rest_dispatch_kwargs: Dict[str, object]
 ) -> Union[Tuple[Callable[..., HttpResponse], Set[str]], HttpResponse]:
     """Helper for REST API request dispatch. The rest_dispatch_kwargs
     parameter is expected to be a dictionary mapping HTTP methods to
@@ -60,7 +60,7 @@ def get_target_view_function_or_response(
     this feature; it's not clear it's actually used.
 
     """
-    supported_methods: Dict[str, Any] = {}
+    supported_methods: Dict[str, object] = {}
     request_notes = RequestNotes.get_notes(request)
     if request_notes.saved_response is not None:
         # For completing long-polled Tornado requests, we skip the
@@ -94,14 +94,15 @@ def get_target_view_function_or_response(
             assert callable(handler)
             assert isinstance(view_flags, set)
             return handler, view_flags
-        return supported_methods[method_to_use], set()
+        assert callable(entry)
+        return entry, set()
 
     return json_method_not_allowed(list(supported_methods.keys()))
 
 
 @default_never_cache_responses
 @csrf_exempt
-def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
+def rest_dispatch(request: HttpRequest, **kwargs: object) -> HttpResponse:
     """Dispatch to a REST API endpoint.
 
     Authentication is verified in the following ways:

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -324,6 +324,12 @@ def avatar(
     return redirect(url)
 
 
+def avatar_medium(
+    request: HttpRequest, maybe_user_profile: Union[UserProfile, AnonymousUser], email_or_id: str
+) -> HttpResponse:
+    return avatar(request, maybe_user_profile, email_or_id, medium=True)
+
+
 def get_stream_name(stream: Optional[Stream]) -> Optional[str]:
     if stream:
         return stream.name

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -195,6 +195,7 @@ from zerver.views.user_settings import (
 from zerver.views.users import (
     add_bot_backend,
     avatar,
+    avatar_medium,
     create_user_backend,
     deactivate_bot_backend,
     deactivate_user_backend,
@@ -725,8 +726,10 @@ urls += [
     ),
     rest_path(
         "avatar/<email_or_id>/medium",
-        {"medium": True},
-        GET=(avatar, {"override_api_url_scheme", "allow_anonymous_user_web"}),
+        GET=(
+            avatar_medium,
+            {"override_api_url_scheme", "allow_anonymous_user_web"},
+        ),
     ),
 ]
 


### PR DESCRIPTION
The only caller that passes the `kwargs` argument is the `avatar` rest path.
The application of `kwargs` can be rewritten inline with `functools`.


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
