### PR TITLE
compose: Refocus composebox when clearing prevew mode.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -898,6 +898,8 @@ test_ui("on_events", ({override, override_rewire}) => {
             stopPropagation: noop,
         };
 
+        override(compose_actions, "update_placeholder_text", noop);
+
         handler(event);
 
         assert.ok($("#compose-textarea").visible());

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -84,6 +84,7 @@ export function clear_private_stream_alert() {
 
 export function clear_preview_area() {
     $("#compose-textarea").show();
+    $("#compose-textarea").trigger("focus");
     $("#compose .undo_markdown_preview").hide();
     $("#compose .preview_message_area").hide();
     $("#compose .preview_content").empty();

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -681,6 +681,7 @@ export function initialize() {
         $("#compose-textarea").hide();
         $("#compose .markdown_preview").hide();
         $("#compose .undo_markdown_preview").show();
+        $("#compose .undo_markdown_preview").trigger("focus");
         $("#compose .preview_message_area").show();
 
         render_and_show_preview(


### PR DESCRIPTION
When switching back to writing mode after preview mode, the composebox
would be out of focus and so the the cursor would semingly get lost.

Now on clearing the preview mode, the composebox is focused and so the
cursor is seen blinking at it's original position.

Till now, switching back to writing mode after preview mode, needed
the user to first focus on the `Write` (unpreview) button by tabbing
to it (if using keyboard) and then select it.

To make things easier, especially when using keyboard, now the `Write`
button will be automatically focused on entering preview mode, so
going back to writing mode only needs one 'Enter` keystroke.

Fixes: [CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/preview.20mode.20and.20cursor/near/1419965)

**Screenshots and screen captures:**

Entering and exiting preview mode using keyboard:
https://user-images.githubusercontent.com/68962290/184899009-5997e5db-1e79-411d-9d95-e5b525a43e07.mp4

Unpreview button focused immediately after entering preview mode
![image](https://user-images.githubusercontent.com/68962290/184908894-738d2f05-eda5-4006-94c0-141802b0d4cf.png)

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
