### PR TITLE
puppeteer: Fix `subscribe_toogle.ts` long pending flake.

### DIFF
--- a/frontend_tests/puppeteer_tests/subscribe_toggle.ts
+++ b/frontend_tests/puppeteer_tests/subscribe_toggle.ts
@@ -9,16 +9,24 @@ async function test_subscription_button(page: Page): Promise<void> {
     const unsubscribed_selector = `${button_selector}:not(.checked)`;
 
     async function subscribed(): Promise<ElementHandle | null> {
+        await page.waitForFunction(
+            () => $(".stream_settings_header .sub_unsub_button").text().trim() === "Unsubscribe",
+        );
         return await page.waitForSelector(subscribed_selector, {visible: true});
     }
 
     async function unsubscribed(): Promise<ElementHandle | null> {
+        await page.waitForFunction(
+            () => $(".stream_settings_header .sub_unsub_button").text().trim() === "Subscribe",
+        );
         return await page.waitForSelector(unsubscribed_selector, {visible: true});
     }
 
     // Make sure that Venice is even in our list of streams.
     await page.waitForSelector(stream_selector, {visible: true});
     await page.waitForSelector(button_selector, {visible: true});
+
+    await page.click(stream_selector);
 
     // Note that we intentionally re-find the button after each click, since
     // the live-update code may replace the whole row.
@@ -28,20 +36,12 @@ async function test_subscription_button(page: Page): Promise<void> {
     // should happen immediately.
     button = await subscribed();
 
-    // Toggle subscriptions several times. This test code has been known
-    // to flake, so we add console statements. It appears that the console
-    // statements help prevent the flake, which is probably caused by some
-    // subtle race condition. We will hopefully diagnose the root cause of
-    // the flake, but I am confident that the test will mostly catch actual
-    // bugs in the real code, so as long as the console.info statements help
-    // here, we should just leave them in.
+    // Toggle subscriptions several times.
     for (let i = 0; i < 10; i += 1) {
-        console.info(`\n unsubscribe/subscribe loop ${i}\n\n`);
         await button!.click();
         button = await unsubscribed();
         await button!.click();
         button = await subscribed();
-        console.info(`\n end loop ${i}\n\n`);
     }
 }
 


### PR DESCRIPTION
The issue with the existing code is that we use the
`page.waitForSelector` function to detect if the element
is visible and interactable.

`page.waitForSelector` only ensures that the element is
visible and doesn't guarantees that the element is
interactable. Most of the time it is enough but sometimes
it is too fast and our test fails.

To fix this we change our approach to check the button
text on the stream settings page (`/#streams/stream_id`).
Either it could be `Subscribe` or `Unsubscribe`.

Tested the changes by running puppeteer 100 times in the [CI](https://github.com/Riken-Shah/zulip/runs/7854466120?check_suite_focus=true).

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
