### PR TITLE
puppeteer: Fix flake in `user-deactivation.ts`.

### DIFF
--- a/frontend_tests/puppeteer_tests/user-deactivation.ts
+++ b/frontend_tests/puppeteer_tests/user-deactivation.ts
@@ -79,9 +79,13 @@ async function test_deactivated_users_section(page: Page): Promise<void> {
     await page.waitForSelector(deactivated_users_section, {visible: true});
     await page.click(deactivated_users_section);
 
-    await page.waitForSelector(
-        "#admin_deactivated_users_table " + cordelia_user_row + " .reactivate",
-        {visible: true},
+    // Instead of waiting for reactivate button using the `waitForSelector` function,
+    // we wait until the input is focused because the `waitForSelector` function
+    // doesn't guarantee that element is interactable.
+    await page.waitForSelector("input[aria-label='Filter deactivated users']", {visible: true});
+    await page.click("input[aria-label='Filter deactivated users']");
+    await page.waitForFunction(
+        () => document.activeElement?.classList?.contains("search") === true,
     );
     await page.click("#admin_deactivated_users_table " + cordelia_user_row + " .reactivate");
 
@@ -134,7 +138,4 @@ async function user_deactivation_test(page: Page): Promise<void> {
 
 // Test temporarily disabled due to nondeterminsitic failures
 
-// eslint-disable-next-line no-constant-condition
-if (false) {
-    common.run_test(user_deactivation_test);
-}
+common.run_test(user_deactivation_test);


### PR DESCRIPTION
The reason for the flake was we were not waiting enough
time for the deactivation row to render.

To fix this, We are relying on the input from the user
deactivation screen to focus.

Tested the code by running in loop for 100 times in [CI](https://github.com/Riken-Shah/zulip/runs/7870252352?check_suite_focus=true).

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
