### PR TITLE
typeahead: 2 highlighting bugs fixed

### DIFF
--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -29,16 +29,24 @@ export function build_highlight_regex(query) {
 }
 
 export function highlight_with_escaping_and_regex(regex, item) {
+    // if regex is empty return entire item highlighted and escaped
+    if (regex.source === "()") {
+        return "<strong>" + Handlebars.Utils.escapeExpression(item) + "</strong>";
+    }
+
     // We need to assemble this manually (as opposed to doing 'join') because we need to
     // (1) escape all the pieces and (2) the regex is case-insensitive, and we need
     // to know the case of the content we're replacing (you can't just use a bolded
     // version of 'query')
 
-    const pieces = item.split(regex);
+    const pieces = item.split(regex).filter(Boolean);
     let result = "";
 
-    for (const piece of pieces) {
-        if (regex.test(piece)) {
+    for (let i = 0; i < pieces.length; i += 1) {
+        const piece = pieces[i];
+        if (regex.test(piece) && (i === 0 || pieces[i - 1].endsWith(" "))) {
+            // only highlight if the matching part is a word prefix, ie
+            // if it is the 1st piece or if there was a space before it
             result += "<strong>" + Handlebars.Utils.escapeExpression(piece) + "</strong>";
         } else {
             result += Handlebars.Utils.escapeExpression(piece);

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -57,21 +57,12 @@ export function highlight_with_escaping_and_regex(regex, item) {
 }
 
 export function make_query_highlighter(query) {
-    let i;
     query = query.toLowerCase();
 
     const regex = build_highlight_regex(query);
 
     return function (phrase) {
-        let result = "";
-        const parts = phrase.split(" ");
-        for (i = 0; i < parts.length; i += 1) {
-            if (i > 0) {
-                result += " ";
-            }
-            result += highlight_with_escaping_and_regex(regex, parts[i]);
-        }
-        return result;
+        return highlight_with_escaping_and_regex(regex, phrase);
     };
 }
 

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -671,6 +671,12 @@ test("highlight_with_escaping", () => {
     expected = "<strong>development h</strong>elp";
     result = highlight(query, item);
     assert.equal(result, expected);
+
+    item = "Prefix notprefix prefix";
+    query = "pre";
+    expected = "<strong>Pre</strong>fix notprefix <strong>pre</strong>fix";
+    result = highlight(query, item);
+    assert.equal(result, expected);
 });
 
 test("render_person when emails hidden", ({mock_template}) => {


### PR DESCRIPTION
Earlier mid word parts matching with the search query were also
highlighted (made bold), but since actual matching for showing search
suggestions is based on prefix matching, this highlighting logic is
now made to be in sync with the search suggestions matching logic.

---------------------------------------------------------------------------

`make_query_highlighter` called `highlight_with_escaping_and_regex`
once for each word in the phrase, due to which only 1 word searches
could be highlighted. For example searching for `two wo` resulted
in no highlighting at all in `two words`.

One call per word in the phrase was also redundant since the called
function can handle a multi word query. So now the entire phrase is
passed to the called function just once.

Follow up to https://github.com/zulip/zulip/pull/22307#discussion_r947261493


**Screenshots and screen captures:**

Note the mid word `o`s are not highlighted:
![image](https://user-images.githubusercontent.com/68962290/185229882-81237896-b6cc-4454-a072-5b4adfa8663d.png)

![image](https://user-images.githubusercontent.com/68962290/185229998-c9ff4752-4e61-4982-9fcb-5082ee3bd47b.png)

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
