### PR TITLE
message_edit: Repair incorrectly moved with_first_message_id function

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -1237,6 +1237,6 @@ export function with_first_message_id(stream_id, topic_name, success_cb, error_c
             const message_id = data.messages[0].id;
             success_cb(message_id);
         },
-        error_cb,
+        error: error_cb,
     });
 }


### PR DESCRIPTION
Commit 9aa5082d63e9d2f36c1055c5a855ea2fc1f61123 (#20673) incorrectly changed the name of the error callback passed to `channel.get`. This prevented reporting of errors while moving a topic. Fix it.

Cc @Signior-X @nikhilmaske-2001