### PR TITLE
recent-topics: Check topic exists before trying to revive focus.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -190,17 +190,20 @@ export function revive_current_focus() {
 
     if (is_table_focused()) {
         if (last_visited_topic) {
-            const topic_last_msg_id = topics.get(last_visited_topic).last_msg_id;
-            const current_list = topics_widget.get_current_list();
-            const last_visited_topic_index = current_list.findIndex(
-                (topic) => topic.last_msg_id === topic_last_msg_id,
-            );
-            if (last_visited_topic_index >= 0) {
-                row_focus = last_visited_topic_index;
+            // If the only message in the topic was deleted,
+            // then the topic will not be in recent topics data.
+            if (topics.get(last_visited_topic) !== undefined) {
+                const topic_last_msg_id = topics.get(last_visited_topic).last_msg_id;
+                const current_list = topics_widget.get_current_list();
+                const last_visited_topic_index = current_list.findIndex(
+                    (topic) => topic.last_msg_id === topic_last_msg_id,
+                );
+                if (last_visited_topic_index >= 0) {
+                    row_focus = last_visited_topic_index;
+                }
             }
             last_visited_topic = "";
         }
-
         set_table_focus(row_focus, col_focus);
         return true;
     }


### PR DESCRIPTION
When a message is deleted, if it was the only message in the topic and it was the previously focused topic in recent topics, then we cannot revive the focus if/when the user navigates back to the recent topics view.

Adds a check in `revive_current_focus` for this special case.

**Screenshots and screen captures:**

<details>
<summary>GIF before changes - show's how to reproduce error</summary>

![Peek 2022-08-19 23-04](https://user-images.githubusercontent.com/63245456/185707771-37835d3d-b854-4257-a508-c53414174798.gif)
</details>

<details>
<summary>GIF after changes</summary>

![Peek 2022-08-19 23-07](https://user-images.githubusercontent.com/63245456/185707791-82cb9390-301e-434f-b511-660895c4c5ff.gif)
</details>

@amanagr - Would appreciate your review on this update if you have time. I wasn't sure if we also wanted to do something with the scroll and/or focus in this case. Thanks!

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
