### PR TITLE
integrations_dev_panel: Remove unused idempotent flag

### DIFF
--- a/static/js/portico/integrations_dev_panel.js
+++ b/static/js/portico/integrations_dev_panel.js
@@ -223,8 +223,6 @@ function get_fixtures(integration_name) {
     // /devtools/integrations/<integration_name>/fixtures
     channel.get({
         url: "/devtools/integrations/" + integration_name + "/fixtures",
-        // Since the user may add or modify fixtures as they edit.
-        idempotent: false,
         success(response) {
             loaded_fixtures.set(integration_name, response.fixtures);
             load_fixture_options(integration_name);


### PR DESCRIPTION
Followup to commit fde9b1d366dc377cc40666d378232a2ab2410ae6 (#22753).

(This was a misuse of “idempotent”. “Idempotent” means that performing the request more than once in a row has the same effect as performing it once; it says nothing about whether the response is cacheable.)