### PR TITLE
compose_validate: Convert deprecated synchronous XHR to async

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -278,7 +278,7 @@ test_ui("send_message", ({override, override_rewire}) => {
     })();
 });
 
-test_ui("enter_with_preview_open", ({override, override_rewire}) => {
+test_ui("enter_with_preview_open", async ({override, override_rewire}) => {
     override(notifications, "clear_compose_notifications", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
@@ -304,7 +304,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     override_rewire(compose, "send_message", () => {
         send_message_called = true;
     });
-    compose.enter_with_preview_open();
+    await compose.enter_with_preview_open();
     assert.ok($("#compose-textarea").visible());
     assert.ok(!$("#compose .undo_markdown_preview").visible());
     assert.ok(!$("#compose .preview_message_area").visible());
@@ -314,7 +314,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
 
     user_settings.enter_sends = false;
     $("#compose-textarea").trigger("blur");
-    compose.enter_with_preview_open();
+    await compose.enter_with_preview_open();
     assert.ok($("#compose-textarea").is_focused());
 
     // Test sending a message without content.
@@ -322,11 +322,11 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     $("#compose .preview_message_area").show();
     user_settings.enter_sends = true;
 
-    compose.enter_with_preview_open();
+    await compose.enter_with_preview_open();
     assert.equal($("#compose-error-msg").html(), "never-been-set");
 });
 
-test_ui("finish", ({override, override_rewire}) => {
+test_ui("finish", async ({override, override_rewire}) => {
     override(notifications, "clear_compose_notifications", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
@@ -336,14 +336,14 @@ test_ui("finish", ({override, override_rewire}) => {
         show_button_spinner_called = true;
     });
 
-    (function test_when_compose_validation_fails() {
+    await (async function test_when_compose_validation_fails() {
         $("#compose_invite_users").show();
         $("#compose-send-button").prop("disabled", false);
         $("#compose-send-button").trigger("focus");
         $("#compose-send-button .loader").hide();
         $("#compose-textarea").off("select");
         $("#compose-textarea").val("");
-        const res = compose.finish();
+        const res = await compose.finish();
         assert.equal(res, false);
         assert.ok(!$("#compose_invite_users").visible());
         assert.ok(!$("#compose-send-button .loader").visible());
@@ -354,7 +354,7 @@ test_ui("finish", ({override, override_rewire}) => {
         assert.ok(show_button_spinner_called);
     })();
 
-    (function test_when_compose_validation_succeed() {
+    await (async function test_when_compose_validation_succeed() {
         // Testing successfully sending of a message.
         $("#compose .undo_markdown_preview").show();
         $("#compose .preview_message_area").show();
@@ -372,7 +372,7 @@ test_ui("finish", ({override, override_rewire}) => {
         override_rewire(compose, "send_message", () => {
             send_message_called = true;
         });
-        assert.ok(compose.finish());
+        assert.ok(await compose.finish());
         assert.ok($("#compose-textarea").visible());
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());
@@ -394,7 +394,7 @@ test_ui("finish", ({override, override_rewire}) => {
             schedule_message = true;
         });
         reminder.is_deferred_delivery = () => true;
-        assert.ok(compose.finish());
+        assert.ok(await compose.finish());
         assert.ok($("#compose-textarea").visible());
         assert.ok(!$("#compose .undo_markdown_preview").visible());
         assert.ok(!$("#compose .preview_message_area").visible());

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -268,20 +268,20 @@ export function send_message(request = create_message_object()) {
     }
 }
 
-export function enter_with_preview_open(ctrl_pressed = false) {
+export async function enter_with_preview_open(ctrl_pressed = false) {
     if (
         (user_settings.enter_sends && !ctrl_pressed) ||
         (!user_settings.enter_sends && ctrl_pressed)
     ) {
         // If this enter should send, we attempt to send the message.
-        finish();
+        await finish();
     } else {
         // Otherwise, we return to the normal compose state.
         clear_preview_area();
     }
 }
 
-export function finish() {
+export async function finish() {
     clear_preview_area();
     clear_invites();
     clear_private_stream_alert();
@@ -300,7 +300,7 @@ export function finish() {
 
     compose_ui.show_compose_spinner();
 
-    if (!compose_validate.validate()) {
+    if (!(await compose_validate.validate())) {
         // If the message failed validation, hide compose spinner.
         compose_ui.hide_compose_spinner();
         return false;
@@ -427,7 +427,7 @@ export function initialize() {
 
     $("#compose form").on("submit", (e) => {
         e.preventDefault();
-        finish();
+        void finish();
     });
 
     resize.watch_manual_resize("#compose-textarea");
@@ -447,7 +447,7 @@ export function initialize() {
         $(event.target).parents(".compose-all-everyone").remove();
         compose_validate.set_user_acknowledged_all_everyone_flag(true);
         compose_validate.clear_all_everyone_warnings();
-        finish();
+        void finish();
     });
 
     $("#compose-send-status").on("click", ".sub_unsub_button", (event) => {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -233,7 +233,7 @@ function handle_keydown(e) {
                         !$("#compose-send-button").prop("disabled")
                     ) {
                         $("#compose-send-button").prop("disabled", true);
-                        compose.finish();
+                        void compose.finish();
                     }
                     return;
                 }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -461,7 +461,7 @@ export function process_enter_key(e) {
     }
 
     if ($("#preview_message_area").is(":visible")) {
-        compose.enter_with_preview_open();
+        void compose.enter_with_preview_open();
         return true;
     }
 
@@ -475,7 +475,7 @@ export function process_enter_key(e) {
 export function process_ctrl_enter_key() {
     if ($("#preview_message_area").is(":visible")) {
         const ctrl_pressed = true;
-        compose.enter_with_preview_open(ctrl_pressed);
+        void compose.enter_with_preview_open(ctrl_pressed);
         return true;
     }
 

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -153,7 +153,7 @@ export function initialize() {
                 draft_id: vars.draft_id || "",
             });
             if (send_now) {
-                compose.finish();
+                void compose.finish();
             }
         } catch (error) {
             // We log an error if we can't open the compose box, but otherwise


### PR DESCRIPTION
Fixes #4650, although not in the way it suggests. Rather than adding new support to the backend, we just convert the entire existing call chain to `async`.

(Not sure if this is the way we want to do this. An alternative would be to try reviving #8226. We should do something though.)