### PR TITLE
Add padding between link text and external-link Icon

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -433,6 +433,9 @@ input[type="checkbox"] {
 
 #id_org_profile_preview {
     margin-bottom: 20px;
+    display: inline-flex;
+    justify-content: space-evenly;
+    align-items: center;
 }
 
 .inline-block.organization-permissions-parent div:first-of-type {


### PR DESCRIPTION
Fixes: [<!-- Issue link, or clear description.-->](https://github.com/zulip/zulip/issues/22743)

Before:
![image](https://user-images.githubusercontent.com/79783828/185734797-0971fa8c-bbca-4eab-8702-3b8f9d616d1f.png)

After:
![image](https://user-images.githubusercontent.com/79783828/185734811-3d77c882-6b62-473a-b164-9bd5f69fc9fe.png)

