### PR TITLE
email_mirror: Replace disallowed characters in incoming email subject.

### DIFF
--- a/zerver/lib/string_validation.py
+++ b/zerver/lib/string_validation.py
@@ -16,12 +16,19 @@ unicode_non_chars = {
 }
 
 
+def is_character_printable(char: str) -> bool:
+    unicode_category = unicodedata.category(char)
+    if (unicode_category in ["Cc", "Cs"]) or char in unicode_non_chars:
+        return False
+
+    return True
+
+
 def check_string_is_printable(var: str) -> Optional[int]:
     # Return position (1-indexed!) of the character which is not
     # printable, None if no such character is present.
     for i, char in enumerate(var):
-        unicode_character = unicodedata.category(char)
-        if (unicode_character in ["Cc", "Cs"]) or char in unicode_non_chars:
+        if not is_character_printable(char):
             return i + 1
     return None
 


### PR DESCRIPTION
These characters are not allowed and trying to create a Zulip message
with those characters throws a JsonableError in check_stream_topic.

We don't want to reject emails with those chars in the subject, so
it's best to just modify it appropriately.
