### PR TITLE
typing: Remove ViewFuncT.

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -4,7 +4,6 @@ import re
 import sys
 import time
 from contextlib import contextmanager
-from functools import wraps
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -722,17 +721,3 @@ def mock_queue_publish(
 
     with mock.patch(method_to_patch, side_effect=verify_serialize):
         yield inner
-
-
-def patch_queue_publish(
-    method_to_patch: str,
-) -> Callable[[Callable[..., None]], Callable[..., None]]:
-    def inner(func: Callable[..., None]) -> Callable[..., None]:
-        @wraps(func)
-        def _wrapped(*args: object, **kwargs: object) -> None:
-            with mock_queue_publish(method_to_patch) as m:
-                func(*args, m, **kwargs)
-
-        return _wrapped
-
-    return inner

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -2,11 +2,8 @@ import datetime
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, TypeVar, Union
 
-from django.http import HttpResponse
 from django.utils.functional import Promise
 from typing_extensions import NotRequired
-
-ViewFuncT = TypeVar("ViewFuncT", bound=Callable[..., HttpResponse])
 
 # See zerver/lib/validator.py for more details of Validators,
 # including many examples

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -22,6 +22,7 @@ from django_scim.middleware import SCIMAuthCheckMiddleware
 from django_scim.settings import scim_settings
 from sentry_sdk import capture_exception
 from sentry_sdk.integrations.logging import ignore_logger
+from typing_extensions import Concatenate, ParamSpec
 
 from zerver.lib.cache import get_remote_cache_requests, get_remote_cache_time
 from zerver.lib.db import reset_queries
@@ -38,11 +39,11 @@ from zerver.lib.response import (
     json_unauthorized,
 )
 from zerver.lib.subdomains import get_subdomain
-from zerver.lib.types import ViewFuncT
 from zerver.lib.user_agent import parse_user_agent
 from zerver.lib.utils import statsd
 from zerver.models import Realm, SCIMClient, flush_per_request_caches, get_realm
 
+ParamT = ParamSpec("ParamT")
 logger = logging.getLogger("zulip.requests")
 slow_query_logger = logging.getLogger("zulip.slow_queries")
 
@@ -368,8 +369,8 @@ class LogRequests(MiddlewareMixin):
     def process_view(
         self,
         request: HttpRequest,
-        view_func: ViewFuncT,
-        args: List[str],
+        view_func: Callable[Concatenate[HttpRequest, ParamT], HttpResponseBase],
+        args: List[object],
         kwargs: Dict[str, Any],
     ) -> None:
         request_notes = RequestNotes.get_notes(request)
@@ -475,7 +476,11 @@ class JsonErrorHandler(MiddlewareMixin):
 
 class TagRequests(MiddlewareMixin):
     def process_view(
-        self, request: HttpRequest, view_func: ViewFuncT, args: List[str], kwargs: Dict[str, Any]
+        self,
+        request: HttpRequest,
+        view_func: Callable[Concatenate[HttpRequest, ParamT], HttpResponseBase],
+        args: List[object],
+        kwargs: Dict[str, Any],
     ) -> None:
         self.process_request(request)
 

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -434,12 +434,17 @@ def for_all_bot_types(
 
 def patch_queue_publish(
     method_to_patch: str,
-) -> Callable[[Callable[..., None]], Callable[..., None]]:
-    def inner(func: Callable[..., None]) -> Callable[..., None]:
+) -> Callable[
+    [Callable[["TestServiceBotEventTriggers", mock.Mock], None]],
+    Callable[["TestServiceBotEventTriggers"], None],
+]:
+    def inner(
+        func: Callable[["TestServiceBotEventTriggers", mock.Mock], None]
+    ) -> Callable[["TestServiceBotEventTriggers"], None]:
         @wraps(func)
-        def _wrapped(*args: object, **kwargs: object) -> None:
+        def _wrapped(self: "TestServiceBotEventTriggers") -> None:
             with mock_queue_publish(method_to_patch) as m:
-                func(*args, m, **kwargs)
+                func(self, m)
 
         return _wrapped
 


### PR DESCRIPTION
This removes ViewFuncT and all the associated type casts with ParamSpec
and Concatenate. This provides more accurate type annotation for
decorators at the cost of making the concatenated parameters
positional-only. This change does not intend to introduce any other
behavioral difference.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
