### PR TITLE
message_edit: Use `disabled` instead of `readonly` to disable controls.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -507,8 +507,8 @@ function edit_message($row, raw_content) {
 
     switch (editability) {
         case editability_types.NO:
-            $message_edit_content.attr("readonly", "readonly");
-            $message_edit_topic.attr("readonly", "readonly");
+            $message_edit_content.prop("disabled", true);
+            $message_edit_topic.prop("disabled", true);
             create_copy_to_clipboard_handler($row, $copy_message[0], message.id);
             break;
         case editability_types.NO_LONGER:
@@ -516,12 +516,12 @@ function edit_message($row, raw_content) {
             // changes (e.g. if we stop allowing topics to be modified forever
             // in streams), then we'll need to disable
             // row.find('input.message_edit_topic') as well.
-            $message_edit_content.attr("readonly", "readonly");
+            $message_edit_content.prop("disabled", true);
             $message_edit_countdown_timer.text($t({defaultMessage: "View source"}));
             create_copy_to_clipboard_handler($row, $copy_message[0], message.id);
             break;
         case editability_types.TOPIC_ONLY:
-            $message_edit_content.attr("readonly", "readonly");
+            $message_edit_content.prop("disabled", true);
             // Hint why you can edit the topic but not the message content
             $message_edit_countdown_timer.text($t({defaultMessage: "Topic editing only"}));
             create_copy_to_clipboard_handler($row, $copy_message[0], message.id);
@@ -578,9 +578,9 @@ function edit_message($row, raw_content) {
             seconds_left -= 1;
             if (seconds_left <= 0) {
                 clearInterval(countdown_timer);
-                $message_edit_content.prop("readonly", "readonly");
+                $message_edit_content.prop("disabled", true);
                 if (message.type === "stream") {
-                    $message_edit_topic.prop("readonly", "readonly");
+                    $message_edit_topic.prop("disabled", true);
                     $message_edit_topic_propagate.hide();
                     $message_edit_breadcrumb_messages.hide();
                 }
@@ -892,7 +892,7 @@ export function save_message_row_edit($row) {
     show_message_edit_spinner($row);
 
     const $edit_content_input = $row.find(".message_edit_content");
-    const can_edit_content = $edit_content_input.attr("readonly") !== "readonly";
+    const can_edit_content = $edit_content_input.prop("disabled") !== true;
     if (can_edit_content) {
         new_content = $edit_content_input.val();
         content_changed = old_content !== new_content;
@@ -900,7 +900,7 @@ export function save_message_row_edit($row) {
     }
 
     const $edit_topic_input = $row.find(".message_edit_topic");
-    const can_edit_topic = message.is_stream && $edit_topic_input.attr("readonly") !== "readonly";
+    const can_edit_topic = message.is_stream && $edit_topic_input.prop("disabled") !== true;
     if (can_edit_topic) {
         new_topic = $edit_topic_input.val();
         topic_changed = new_topic !== old_topic && new_topic.trim() !== "";


### PR DESCRIPTION
Currently when a user does not have the permission to edit the topic/content
of a message, the edit UI/view source UI correctly shows a greyed
out topic/message-content input field, however these fields incorrectly have a
click behavior, so to fix this we now would want to use `disabled` prop instead
of `readonly` attribute as `readonly` controls can still function and are still
focusable whereas disabled controls can not receive focus and are unclickable.

Fixes #22565

<!-- Describe your pull request here.-->

Fixes: 22565.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
