### PR TITLE
Fix bugs in message edit section of organization settings.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1148,6 +1148,35 @@ export function build_page() {
 
     register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
 
+    function update_save_button_state(e) {
+        const edit_limit_value = Number.parseInt(
+            $("#id_realm_message_content_edit_limit_minutes").val(),
+            10,
+        );
+        const delete_limit_value = Number.parseInt(
+            $("#id_realm_message_content_delete_limit_minutes").val(),
+            10,
+        );
+
+        const msg_edit_limit_dropdown_value = $("#id_realm_msg_edit_limit_setting").val();
+        const edit_limit_custom_value_invalid =
+            msg_edit_limit_dropdown_value === "custom_limit" &&
+            (edit_limit_value <= 0 || Number.isNaN(edit_limit_value));
+
+        const msg_delete_limit_dropdown_value = $("#id_realm_msg_delete_limit_setting").val();
+        const delete_limit_custom_value_invalid =
+            msg_delete_limit_dropdown_value === "custom_limit" &&
+            (delete_limit_value <= 0 || Number.isNaN(delete_limit_value));
+
+        const disable_save_btn =
+            edit_limit_custom_value_invalid || delete_limit_custom_value_invalid;
+
+        $(e.target)
+            .closest(".org-subsection-parent")
+            .find(".subsection-changes-save button")
+            .prop("disabled", disable_save_btn);
+    }
+
     $(".org-subsection-parent").on("keydown", "input", (e) => {
         e.stopPropagation();
         if (e.key === "Enter") {
@@ -1249,32 +1278,7 @@ export function build_page() {
     });
 
     $("#org-msg-editing").on("input", ".admin-realm-time-limit-input", (e) => {
-        const edit_limit_value = Number.parseInt(
-            $("#id_realm_message_content_edit_limit_minutes").val(),
-            10,
-        );
-        const delete_limit_value = Number.parseInt(
-            $("#id_realm_message_content_delete_limit_minutes").val(),
-            10,
-        );
-
-        const msg_edit_limit_dropdown_value = $("#id_realm_msg_edit_limit_setting").val();
-        const edit_limit_custom_value_invalid =
-            msg_edit_limit_dropdown_value === "custom_limit" &&
-            (edit_limit_value <= 0 || Number.isNaN(edit_limit_value));
-
-        const msg_delete_limit_dropdown_value = $("#id_realm_msg_delete_limit_setting").val();
-        const delete_limit_custom_value_invalid =
-            msg_delete_limit_dropdown_value === "custom_limit" &&
-            (delete_limit_value <= 0 || Number.isNaN(delete_limit_value));
-
-        const disable_save_btn =
-            edit_limit_custom_value_invalid || delete_limit_custom_value_invalid;
-
-        $(e.target)
-            .closest(".org-subsection-parent")
-            .find(".subsection-changes-save button")
-            .prop("disabled", disable_save_btn);
+        update_save_button_state(e);
     });
 
     $("#show_realm_domains_modal").on("click", (e) => {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -794,6 +794,16 @@ function check_property_changed(elem, for_realm_default_settings) {
             changed_val = get_email_notification_batching_setting_element_value();
             break;
         }
+        case "realm_message_content_edit_limit_minutes":
+        case "realm_message_content_delete_limit_minutes": {
+            const input_val = Number.parseInt($(`#id_${CSS.escape(property_name)}`).val(), 10);
+            if (Number.isNaN(input_val)) {
+                changed_val = null;
+                break;
+            }
+            changed_val = input_val.toString();
+            break;
+        }
         case "realm_default_language":
             changed_val = $(
                 "#org-notifications .language_selection_widget .language_selection_button span",

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1190,19 +1190,38 @@ export function build_page() {
 
     $("#id_realm_msg_edit_limit_setting").on("change", (e) => {
         const msg_edit_limit_dropdown_value = e.target.value;
+        const show_custom_limit_input = msg_edit_limit_dropdown_value === "custom_limit";
         change_element_block_display_property(
             "id_realm_message_content_edit_limit_minutes",
-            msg_edit_limit_dropdown_value === "custom_limit",
+            show_custom_limit_input,
         );
+
+        if (!show_custom_limit_input) {
+            // Set the input value to the original setting value if hiding the input box
+            // so that the save-discard widget is hidden again if we change the setting
+            // again to original input.
+            const setting_value = get_property_value("realm_message_content_edit_limit_minutes");
+            $("#id_realm_message_content_edit_limit_minutes").val(setting_value);
+        }
+
         update_save_button_state(e);
     });
 
     $("#id_realm_msg_delete_limit_setting").on("change", (e) => {
         const msg_delete_limit_dropdown_value = e.target.value;
+        const show_custom_limit_input = msg_delete_limit_dropdown_value === "custom_limit";
         change_element_block_display_property(
             "id_realm_message_content_delete_limit_minutes",
-            msg_delete_limit_dropdown_value === "custom_limit",
+            show_custom_limit_input,
         );
+
+        if (!show_custom_limit_input) {
+            // Set the input value to the original setting value if hiding the input box
+            // so that the save-discard widget is hidden again if we change the setting
+            // again to original input.
+            const setting_value = get_property_value("realm_message_content_delete_limit_minutes");
+            $("#id_realm_message_content_delete_limit_minutes").val(setting_value);
+        }
 
         update_save_button_state(e);
     });

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1258,11 +1258,19 @@ export function build_page() {
             10,
         );
 
+        const msg_edit_limit_dropdown_value = $("#id_realm_msg_edit_limit_setting").val();
+        const edit_limit_custom_value_invalid =
+            msg_edit_limit_dropdown_value === "custom_limit" &&
+            (edit_limit_value <= 0 || Number.isNaN(edit_limit_value));
+
+        const msg_delete_limit_dropdown_value = $("#id_realm_msg_delete_limit_setting").val();
+        const delete_limit_custom_value_invalid =
+            msg_delete_limit_dropdown_value === "custom_limit" &&
+            (delete_limit_value <= 0 || Number.isNaN(delete_limit_value));
+
         const disable_save_btn =
-            edit_limit_value <= 0 ||
-            delete_limit_value <= 0 ||
-            Number.isNaN(edit_limit_value) ||
-            Number.isNaN(delete_limit_value);
+            edit_limit_custom_value_invalid || delete_limit_custom_value_invalid;
+
         $(e.target)
             .closest(".org-subsection-parent")
             .find(".subsection-changes-save button")

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1194,15 +1194,7 @@ export function build_page() {
             "id_realm_message_content_edit_limit_minutes",
             msg_edit_limit_dropdown_value === "custom_limit",
         );
-        if (msg_edit_limit_dropdown_value === "custom_limit") {
-            const val = get_property_value("realm_message_content_edit_limit_minutes");
-            if (val === null) {
-                $("#id_realm_message_content_edit_limit_minutes")
-                    .closest(".org-subsection-parent")
-                    .find(".subsection-changes-save button")
-                    .prop("disabled", true);
-            }
-        }
+        update_save_button_state(e);
     });
 
     $("#id_realm_msg_delete_limit_setting").on("change", (e) => {
@@ -1212,15 +1204,7 @@ export function build_page() {
             msg_delete_limit_dropdown_value === "custom_limit",
         );
 
-        if (msg_delete_limit_dropdown_value === "custom_limit") {
-            const val = get_property_value("realm_message_content_delete_limit_minutes");
-            if (val === null) {
-                $("#id_realm_message_content_delete_limit_minutes")
-                    .closest(".org-subsection-parent")
-                    .find(".subsection-changes-save button")
-                    .prop("disabled", true);
-            }
-        }
+        update_save_button_state(e);
     });
 
     $("#id_realm_message_retention_setting").on("change", (e) => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes bugs in changing message edit and delete limit setting introduced in #21837.

- First commit is to fix the bug of the save-discard widget not hiding when changing edit/delete limit setting in the following order- Any time -> Any other option -> Anytime.
- Second commit is to fix the bug of save button being disabled even after custom input having valid value when changing the setting from Any time to custom.
- Third and fourth commit is save button not being re-enabled when changing setting in following order - Any time -> Custom -> Any option other than above two.
- Last commit is to set the custom input box to the original setting value when hiding it.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
