### PR TITLE
user_topics: Use user_topics page_param instead of muted_topics in the web app.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -274,14 +274,14 @@ run_test("invites_changed", ({override}) => {
 });
 
 run_test("muted_topics", ({override}) => {
-    const event = event_fixtures.muted_topics;
+    const event = event_fixtures.user_topic;
 
     const stub = make_stub();
     override(muted_topics_ui, "handle_topic_updates", stub.f);
     dispatch(event);
     assert.equal(stub.num_calls, 1);
-    const args = stub.get_args("muted_topics");
-    assert_same(args.muted_topics, event.muted_topics);
+    const args = stub.get_args("user_topic");
+    assert_same(args.user_topic, event);
 });
 
 run_test("muted_users", ({override}) => {

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -171,14 +171,6 @@ exports.fixtures = {
         type: "invites_changed",
     },
 
-    muted_topics: {
-        type: "muted_topics",
-        muted_topics: [
-            ["devel", "js", fake_then],
-            ["lunch", "burritos", fake_now],
-        ],
-    },
-
     muted_users: {
         type: "muted_users",
         muted_users: [
@@ -947,5 +939,13 @@ exports.fixtures = {
         type: "user_status",
         user_id: test_user.user_id,
         status_text: "out to lunch",
+    },
+
+    user_topic: {
+        type: "user_topic",
+        stream_id: 101,
+        topic_name: "js",
+        last_updated: fake_now,
+        visibility_policy: 1,
     },
 };

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -165,36 +165,12 @@ test("get_mutes", () => {
 });
 
 test("unknown streams", () => {
-    blueslip.expect("warn", "Unknown stream in set_muted_topics: BOGUS STREAM");
-
-    page_params.muted_topics = [
-        ["social", "breakfast", 1577836800],
-        ["design", "typography", 1577836800],
-        ["BOGUS STREAM", "whatever", 1577836800],
-    ];
     page_params.muted_users = [
         {id: 3, timestamp: 1577836800},
         {id: 2, timestamp: 1577836800},
     ];
-    user_topics.initialize();
-    muted_users.initialize();
 
-    assert.deepEqual(user_topics.get_muted_topics().sort(), [
-        {
-            date_muted: 1577836800000,
-            date_muted_str: "Jan\u00A001,\u00A02020",
-            stream: social.name,
-            stream_id: social.stream_id,
-            topic: "breakfast",
-        },
-        {
-            date_muted: 1577836800000,
-            date_muted_str: "Jan\u00A001,\u00A02020",
-            stream: design.name,
-            stream_id: design.stream_id,
-            topic: "typography",
-        },
-    ]);
+    muted_users.initialize();
 
     assert.deepEqual(muted_users.get_muted_users().sort(), [
         {
@@ -217,7 +193,7 @@ test("set_user_topics", () => {
     assert.ok(!user_topics.is_topic_muted(social.stream_id, "breakfast"));
     assert.ok(!user_topics.is_topic_muted(design.stream_id, "typography"));
 
-    const user_topic_events = [
+    page_params.user_topics = [
         {
             stream_id: social.stream_id,
             topic_name: "breakfast",
@@ -238,9 +214,7 @@ test("set_user_topics", () => {
         },
     ];
 
-    for (const user_topic of user_topic_events) {
-        user_topics.set_user_topic(user_topic);
-    }
+    user_topics.initialize();
 
     assert.deepEqual(user_topics.get_muted_topics().sort(), [
         {
@@ -271,7 +245,14 @@ test("set_user_topics", () => {
 test("case_insensitivity", () => {
     user_topics.set_muted_topics([]);
     assert.ok(!user_topics.is_topic_muted(social.stream_id, "breakfast"));
-    user_topics.set_muted_topics([["SOCial", "breakfast"]]);
+    user_topics.set_muted_topics([
+        {
+            stream_id: social.stream_id,
+            topic_name: "breakfast",
+            last_updated: "1577836800",
+            visibility_policy: visibility_policy.MUTED,
+        },
+    ]);
     assert.ok(user_topics.is_topic_muted(social.stream_id, "breakfast"));
     assert.ok(user_topics.is_topic_muted(social.stream_id, "breakFAST"));
 });

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -44,7 +44,7 @@ stream_data.add_sub(social);
 
 function test(label, f) {
     run_test(label, ({override}) => {
-        user_topics.set_muted_topics([]);
+        user_topics.set_user_topics([]);
         muted_users.set_muted_users([]);
         f({override});
     });
@@ -189,7 +189,7 @@ test("unknown streams", () => {
 test("set_user_topics", () => {
     blueslip.expect("warn", "Unknown stream ID in set_user_topic: 999");
 
-    user_topics.set_muted_topics([]);
+    user_topics.set_user_topics([]);
     assert.ok(!user_topics.is_topic_muted(social.stream_id, "breakfast"));
     assert.ok(!user_topics.is_topic_muted(design.stream_id, "typography"));
 
@@ -243,9 +243,9 @@ test("set_user_topics", () => {
 });
 
 test("case_insensitivity", () => {
-    user_topics.set_muted_topics([]);
+    user_topics.set_user_topics([]);
     assert.ok(!user_topics.is_topic_muted(social.stream_id, "breakfast"));
-    user_topics.set_muted_topics([
+    user_topics.set_user_topics([
         {
             stream_id: social.stream_id,
             topic_name: "breakfast",

--- a/frontend_tests/node_tests/pm_conversations.js
+++ b/frontend_tests/node_tests/pm_conversations.js
@@ -23,7 +23,7 @@ const params = {
 function test(label, f) {
     run_test(label, ({override}) => {
         pmc.clear_for_testing();
-        user_topics.set_muted_topics([]);
+        user_topics.set_user_topics([]);
         muted_users.set_muted_users([]);
         people.initialize_current_user(15);
         f({override});

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -57,7 +57,7 @@ function test_notifiable_count(home_unread_messages, expected_notifiable_count) 
 function test(label, f) {
     run_test(label, (helpers) => {
         unread.declare_bankruptcy();
-        user_topics.set_muted_topics([]);
+        user_topics.set_user_topics([]);
         f(helpers);
     });
 }

--- a/static/js/muted_topics_ui.js
+++ b/static/js/muted_topics_ui.js
@@ -36,9 +36,9 @@ export function rerender_for_muted_topic(old_muted_topics) {
     }
 }
 
-export function handle_topic_updates(muted_topics_list) {
+export function handle_topic_updates(user_topic) {
     const old_muted_topics = user_topics.get_muted_topics();
-    user_topics.set_muted_topics(muted_topics_list);
+    user_topics.set_user_topic(user_topic);
     stream_popover.hide_topic_popover();
     unread_ui.update_unread_counts();
     rerender_for_muted_topic(old_muted_topics);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -141,8 +141,8 @@ export function dispatch_normal_event(event) {
             }
             break;
 
-        case "muted_topics":
-            muted_topics_ui.handle_topic_updates(event.muted_topics);
+        case "user_topic":
+            muted_topics_ui.handle_topic_updates(event);
             break;
 
         case "muted_users":

--- a/static/js/user_topics.js
+++ b/static/js/user_topics.js
@@ -80,25 +80,14 @@ export function set_user_topic(user_topic) {
     }
 }
 
-export function set_muted_topics(tuples) {
+export function set_muted_topics(user_topics) {
     muted_topics.clear();
 
-    for (const tuple of tuples) {
-        const stream_name = tuple[0];
-        const topic = tuple[1];
-        const date_muted = tuple[2];
-
-        const stream_id = stream_data.get_stream_id(stream_name);
-
-        if (!stream_id) {
-            blueslip.warn("Unknown stream in set_muted_topics: " + stream_name);
-            continue;
-        }
-
-        add_muted_topic(stream_id, topic, date_muted);
+    for (const user_topic of user_topics) {
+        set_user_topic(user_topic);
     }
 }
 
 export function initialize() {
-    set_muted_topics(page_params.muted_topics);
+    set_muted_topics(page_params.user_topics);
 }

--- a/static/js/user_topics.js
+++ b/static/js/user_topics.js
@@ -80,7 +80,7 @@ export function set_user_topic(user_topic) {
     }
 }
 
-export function set_muted_topics(user_topics) {
+export function set_user_topics(user_topics) {
     muted_topics.clear();
 
     for (const user_topic of user_topics) {
@@ -89,5 +89,5 @@ export function set_muted_topics(user_topics) {
 }
 
 export function initialize() {
-    set_muted_topics(page_params.user_topics);
+    set_user_topics(page_params.user_topics);
 }

--- a/static/js/user_topics.js
+++ b/static/js/user_topics.js
@@ -7,6 +7,13 @@ import {get_time_from_date_muted} from "./util";
 
 const muted_topics = new Map();
 
+export const visibility_policy = {
+    VISIBILITY_POLICY_INHERIT: 0,
+    MUTED: 1,
+    UNMUTED: 2,
+    FOLLOWED: 3,
+};
+
 export function add_muted_topic(stream_id, topic, date_muted) {
     let sub_dict = muted_topics.get(stream_id);
     if (!sub_dict) {
@@ -49,6 +56,28 @@ export function get_muted_topics() {
         }
     }
     return topics;
+}
+
+export function set_user_topic(user_topic) {
+    const stream_id = user_topic.stream_id;
+    const topic = user_topic.topic_name;
+    const date_muted = user_topic.last_updated;
+
+    const stream_name = stream_data.maybe_get_stream_name(stream_id);
+
+    if (!stream_name) {
+        blueslip.warn("Unknown stream ID in set_user_topic: " + stream_id);
+        return;
+    }
+
+    switch (user_topic.visibility_policy) {
+        case visibility_policy.MUTED:
+            add_muted_topic(stream_id, topic, date_muted);
+            break;
+        case visibility_policy.VISIBILITY_POLICY_INHERIT:
+            remove_muted_topic(stream_id, topic);
+            break;
+    }
 }
 
 export function set_muted_topics(tuples) {


### PR DESCRIPTION
This PR aims to replace the usage of the `muted_topics` page_param with the newer `user_topics` page_param and the  `user_topic` event.

I took the liberty to add a new helper function `set_user_topic` that will be used to initialize the `muted_topics` map as well as set an incoming `user_topic` event (from `server_events_dispatch.js`) accordingly in the `muted_topics` map ( or a `user_topics` map in the future).

