### PR TITLE
help: Document "import personal settings" feature.

### DIFF
--- a/templates/zerver/help/import-your-settings.md
+++ b/templates/zerver/help/import-your-settings.md
@@ -1,0 +1,39 @@
+# Import your settings
+
+When you create a Zulip account using an email address already associated with
+an account in another Zulip organization, on Zulip Cloud or the same self-hosted
+Zulip installation, you can import your user settings from an existing account.
+It's a convenient way to preserve the user settings that you've already customized.
+
+!!! tip ""
+
+    Settings that may not apply to all organizations, such as custom profile
+    fields, will not be imported.
+
+The import will include your:
+
+- [Name and avatar](/#settings/profile)
+- [Privacy settings](/#settings/account-and-privacy)
+- [Display settings](/#settings/display-settings)
+- [Notification settings](/#settings/notifications)
+- Tutorial completion status.
+
+### Import your settings
+
+{start_tabs}
+
+1. Follow the instructions for [joining a Zulip organization](/help/join-a-zulip-organization).
+
+1. From the dropdown list under **Import settings from an existing Zulip account**,
+   select the account from which you would like to import your settings.
+
+1. Complete the registration form, and click **Sign up**.
+
+1. _(recommended)_ [Review your settings](/help/review-your-settings).
+
+{end_tabs}
+
+## Related articles
+
+* [Joining a Zulip organization](/help/join-a-zulip-organization)
+* [Review your settings](/help/review-your-settings)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -40,6 +40,7 @@
 * [Logging in](/help/logging-in)
 * [Logging out](/help/logging-out)
 * [Switching between organizations](/help/switching-between-organizations)
+* [Import your settings](/help/import-your-settings)
 * [Deactivate your account](/help/deactivate-your-account)
 
 ## Display settings

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -97,5 +97,6 @@ for invitations for the organization owners role.
 * [Configure default new user settings](/help/configure-default-new-user-settings)
 * [Configure organization language for automated messages and invitation emails][org-lang]
 * [Roles and permissions](/help/roles-and-permissions)
+* [Joining a Zulip organization](/help/join-a-zulip-organization)
 
 [org-lang]: /help/configure-organization-language

--- a/templates/zerver/help/join-a-zulip-organization.md
+++ b/templates/zerver/help/join-a-zulip-organization.md
@@ -53,3 +53,10 @@ link via another method.
   these instructions may not apply. Try going to your company's Zulip URL
   to see if there are instructions there; otherwise contact your manager
   or IT department for company-specific instructions.
+
+
+## Related articles
+
+* [Invite new users](/help/invite-new-users)
+* [Switching between organizations](/help/switching-between-organizations)
+* [Import your settings](/help/import-your-settings)

--- a/templates/zerver/help/review-your-settings.md
+++ b/templates/zerver/help/review-your-settings.md
@@ -23,3 +23,7 @@ you use Zulip.
 1. Click on the **Display settings** tab on the left.
 
 {end_tabs}
+
+## Related articles
+
+* [Import your settings](/help/import-your-settings)

--- a/templates/zerver/help/switching-between-organizations.md
+++ b/templates/zerver/help/switching-between-organizations.md
@@ -33,3 +33,4 @@ an organization from the **Window** menu in the top menu bar.
 * [Logging out](logging-out)
 * [Deactivate your account](deactivate-your-account)
 * [Create your organization profile](create-your-organization-profile)
+* [Joining a Zulip organization](/help/join-a-zulip-organization)

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -119,7 +119,9 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
 
                 {% if accounts %}
                 <div class="input-box">
-                    <label for="source_realm_id" class="inline-block">{{ _('Import settings from existing Zulip account') }}</label>
+                    <label for="source_realm_id" class="inline-block">{{ _('Import settings from existing Zulip account') }}
+                        <a href="{{ root_domain_uri }}/help/import-your-settings"><i class="fa fa-question-circle"></i></a>
+                    </label>
                 </div>
                 <div id="source_realm_select_section" class="input-group m-10 inline-block">
                     <select class="select" name="source_realm_id" id="source_realm_select">


### PR DESCRIPTION
When a user whose email is already associated with a Zulip account creates an account with another organization, the registration form offers to import settings from the existing account.

Adds a new page titled "Import your settings" in the "Account basics" section to document which settings get imported.

Adds a question mark (?) icon linking to this help page from the registration form when the import settings option is available.

Adds cross-links on related articles.

Fixes: #20918.

**Screenshots and screen captures:**

**Sidebar index**
<img width="251" alt="image" src="https://user-images.githubusercontent.com/2343554/186077656-b3661337-2174-44bb-b2cc-a4df29198ba1.png">

**New page**
<img width="784" alt="image" src="https://user-images.githubusercontent.com/2343554/187316924-e98debbd-b581-491b-81e1-19339e2930d0.png">

**Updated text label in the registration form**
<img width="345" alt="image" src="https://user-images.githubusercontent.com/2343554/186077591-8b381ae8-d20d-4c03-8914-a8c157d0eb2f.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>