### PR TITLE
compose: Clear preview area when compose box switches recipient.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -44,7 +44,6 @@ function hide_box() {
     compose_fade.clear_compose();
     $(".message_comp").hide();
     $("#compose_controls").show();
-    compose.clear_preview_area();
 }
 
 function get_focus_area(msg_type, opts) {
@@ -111,6 +110,7 @@ function clear_box() {
     compose.clear_private_stream_alert();
     compose_validate.set_user_acknowledged_all_everyone_flag(undefined);
 
+    compose.clear_preview_area();
     clear_textarea();
     compose_validate.check_overflow_text();
     $("#compose-textarea").removeData("draft-id");


### PR DESCRIPTION
Fix for the message preview not clearing when clicking on a new topic and message. Added a call to "clear_preview_area()" in compose_actions.js which also changes the message area state to the compose state instead of the preview state.
Fixes: ([zulip#22703](https://github.com/zulip/zulip/issues/22703))
Screencap: https://user-images.githubusercontent.com/21269876/185985793-3fcf312b-bbcc-46fa-8bb9-d837d5a367a2.mov
* [ X ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
Communicate decisions, questions, and potential concerns.
* 		  Explains differences from previous plans (e.g., issue description).
* 		  Highlights technical choices and bugs encountered.
* 		  Calls out remaining decisions and concerns.
* 		  Automated tests verify logic where appropriate.
Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).
* [ X ] Each commit is a coherent idea.
* [ X ] Commit message(s) explain reasoning and motivation for changes.
Completed manual review and testing of the following:
* [ X ] Visual appearance of the changes.
* [ X ] Responsiveness and internationalization.
* [ X ] Strings and tooltips.
* [ X ] End-to-end functionality of buttons, interactions and flows.
* [ X ] Corner cases, error conditions, and easily imagined bugs.