### PR TITLE
Release script tweaks from working on the 5.6 release

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -105,7 +105,6 @@ remote="$(git config zulip.zulipRemote)" || remote=upstream
 git push "$remote" "$branch:$branch"
 
 OUTPUT_DIR=$(mktemp -d)
-trap 'rm -r "$OUTPUT_DIR"' EXIT
 export OUTPUT_DIR
 
 ./tools/build-release-tarball "$version"

--- a/tools/release
+++ b/tools/release
@@ -118,7 +118,7 @@ fi
 
 ./tools/upload-release "$TARBALL"
 
-git push "$version"
+git push "$remote" "$version"
 
 # Upload to Github
 gh release create "$version" \


### PR DESCRIPTION
commit 288f4544a02db27d1f5384ea1f408d63341b60d5 (HEAD -> main, tabbott/release-script-tweaks)
Author: Tim Abbott <tabbott@zulip.com>
Date:   Wed Aug 24 17:03:19 2022 -0700

    release: Don't remove OUTPUT_DIR on exit.
    
    This ends up deleting your local copy of the release tarball, which
    can be annoying if you need to upload it manually to the GitHub
    releases page.

commit 040eece9720bbb42b14f1418354697ab98c40797
Author: Tim Abbott <tabbott@zulip.com>
Date:   Wed Aug 24 17:03:02 2022 -0700

    release: Fix pushing new release tags.
