### PR TITLE
Change stream settings subscriptions buttons to match the UI of the m…

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -507,9 +507,11 @@ h4.stream_setting_subsection_title {
             opacity: 0.5;
         }
 
-        &.disabled {
-            pointer-events: none;
-            visibility: hidden;
+        &.unchecked.disabled svg {
+          pointer-events: none;
+          cursor: not-allowed;
+          fill: hsl(218, 14%, 33%);
+          opacity: 0.5;
         }
 
         .sub_unsub_status {
@@ -532,6 +534,19 @@ h4.stream_setting_subsection_title {
     .checked svg {
         fill: hsl(170, 48%, 54%);
     }
+
+    @media (prefers-color-scheme: light) {
+      .unchecked svg {
+        fill: hsla(0, 0%, 0%, 0.85);
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .unchecked svg {
+        fill: hsla(0, 0%, 100%, 0.85);
+      }
+    }
+
 
     .icon {
         width: 35px;
@@ -616,13 +631,13 @@ h4.stream_setting_subsection_title {
         vertical-align: top;
     }
 
-    &:hover .check:not(.checked) svg,
-    &.active:hover .check:not(.checked) svg {
+    &:hover .check:not(.checked):not(.disabled) svg,
+    &.active:hover .check:not(.checked):not(.disabled) svg {
         fill: hsl(0, 0%, 87%);
     }
 
-    .check:not(.checked):hover svg,
-    &.active .check:not(.checked):hover svg {
+    .check:not(.checked):not(.disabled):hover svg,
+    &.active .check:not(.checked):not(.disabled):hover svg {
         fill: hsl(0, 0%, 72%);
     }
 

--- a/static/templates/stream_settings/browse_streams_list_item.hbs
+++ b/static/templates/stream_settings/browse_streams_list_item.hbs
@@ -1,13 +1,22 @@
 {{! Client-side Mustache template for rendering subscriptions.}}
 {{#with this}}
+{{log this}}
 <div class="stream-row" data-stream-id="{{stream_id}}" data-stream-name="{{name}}">
-
-    <div class="check {{#if subscribed }}checked{{/if}} sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}}">
-        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
-            <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
-        </svg>
-        <div class='sub_unsub_status'></div>
-    </div>
+    {{#if subscribed}}
+      <div class="check checked sub_unsub_button">
+          <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+              <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
+          </svg>
+          <div class='sub_unsub_status'></div>
+      </div>
+    {{else}}
+      <div class="check unchecked sub_unsub_button tippy-zulip-tooltip {{#unless should_display_subscription_button}}disabled{{/unless}}" data-tippy-content={{#unless should_display_subscription_button}}"Cannot subscribe to stream. Stream {{name}} is private"{{else}}"Subscribe to {{name}}"{{/unless}}>
+          <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+             <path xmlns="http://www.w3.org/2000/svg" d="M468.433 210.554H301.446V43.567c0-17.164-13.914-31.079-31.079-31.079h-28.735c-17.164 0-31.079 13.914-31.079 31.079v166.987H43.567c-17.164 0-31.079 13.914-31.079 31.079v28.735c0 17.164 13.914 31.079 31.079 31.079h166.987v166.987c0 17.164 13.914 31.079 31.079 31.079h28.735c17.164 0 31.079-13.914 31.079-31.079V301.446h166.987c17.164 0 31.079-13.914 31.079-31.079v-28.735c-.001-17.164-13.916-31.078-31.08-31.078z"/>
+          </svg>
+          <div class='sub_unsub_status'></div>
+      </div>
+    {{/if}}
     {{> subscription_setting_icon }}
     <div class="sub-info-box">
         <div class="top-bar">

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -2,7 +2,7 @@
     <div class="tab-container"></div>
     {{#with sub}}
     <div class="button-group">
-        <div class="sub_unsub_button_wrapper inline-block">
+        <div class="sub_unsub_button_wrapper inline-block {{#unless should_display_subscription_button}}tippy-zulip-tooltip{{/unless}}" {{#unless should_display_subscription_button}}data-tippy-content="Cannot subscribe to stream. Stream #{{name}} is private."{{/unless}}>
             <button class="button small rounded subscribe-button sub_unsub_button {{#if should_display_subscription_button}}tippy-zulip-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}data-tippy-content="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
                 {{#if subscribed }}
                     {{#tr}}Unsubscribe{{/tr}}


### PR DESCRIPTION
…obile app. Subscribable streams now have a plus sign and private unsubscribed streams have a disabled plus. Also added more informative tooltips to these buttons.

Fix for issue 22217: changed the buttons for streams that are both private/public to which the user is not currently subscribed.

Fixes: (https://github.com/zulip/zulip/issues/22217)

Uploading Screen Recording 2022-08-25 at 9.20.48 AM.mov…

- [ X ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ X ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ X ] Each commit is a coherent idea.
- [ X ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ X ] Visual appearance of the changes.
- [ X ] Responsiveness and internationalization.
- [ X ] Strings and tooltips.
- [ X ] End-to-end functionality of buttons, interactions and flows.
- [ X ] Corner cases, error conditions, and easily imagined bugs.
