### PR TITLE
settings_config: Fix conversion between names of stream-specific and default notification settings

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -730,8 +730,9 @@ export function handle_global_notification_updates(notification_name, setting) {
     }
 
     if (settings_config.stream_notification_settings.includes(notification_name)) {
-        [, notification_name] = /^enable_stream_(.*)$/.exec(notification_name);
-        stream_ui_updates.update_notification_setting_checkbox(notification_name);
+        stream_ui_updates.update_notification_setting_checkbox(
+            settings_config.specialize_stream_notification_setting[notification_name],
+        );
     }
 
     if (notification_name === "notification_sound") {

--- a/static/js/realm_user_settings_defaults.ts
+++ b/static/js/realm_user_settings_defaults.ts
@@ -1,4 +1,4 @@
-export type RealmDefaultSettingsType = {
+export type RealmDefaultSettings = {
     color_scheme: number;
     default_language: string;
     default_view: string;
@@ -37,8 +37,8 @@ export type RealmDefaultSettingsType = {
     wildcard_mentions_notify: boolean;
 };
 
-export let realm_user_settings_defaults = {} as RealmDefaultSettingsType;
+export let realm_user_settings_defaults = {} as RealmDefaultSettings;
 
-export function initialize(params: Record<string, RealmDefaultSettingsType>): void {
+export function initialize(params: Record<string, RealmDefaultSettings>): void {
     realm_user_settings_defaults = params.realm_user_settings_defaults;
 }

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -584,6 +584,17 @@ export const stream_notification_settings: (keyof StreamNotificationSettings)[] 
     "wildcard_mentions_notify",
 ];
 
+export const generalize_stream_notification_setting: Record<
+    keyof StreamSpecificNotificationSettings,
+    keyof StreamNotificationSettings
+> = {
+    desktop_notifications: "enable_stream_desktop_notifications",
+    audible_notifications: "enable_stream_audible_notifications",
+    push_notifications: "enable_stream_push_notifications",
+    email_notifications: "enable_stream_email_notifications",
+    wildcard_mentions_notify: "wildcard_mentions_notify",
+};
+
 export const pm_mention_notification_settings: (keyof PmNotificationSettings)[] = [
     "enable_desktop_notifications",
     "enable_sounds",

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -2,8 +2,8 @@ import Handlebars from "handlebars/runtime";
 
 import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
-import type {RealmDefaultSettingsType} from "./realm_user_settings_defaults";
-import type {UserSettingsType} from "./user_settings";
+import type {RealmDefaultSettings} from "./realm_user_settings_defaults";
+import type {UserSettings} from "./user_settings";
 
 /*
     This file contains translations between the integer values used in
@@ -571,8 +571,8 @@ export const stream_specific_notification_settings = [
     "wildcard_mentions_notify",
 ];
 
-type SettingsObjectType = UserSettingsType | RealmDefaultSettingsType;
-type PageParamsItem = keyof SettingsObjectType;
+type Settings = UserSettings | RealmDefaultSettings;
+type PageParamsItem = keyof Settings;
 export const stream_notification_settings: PageParamsItem[] = [
     "enable_stream_desktop_notifications",
     "enable_stream_audible_notifications",
@@ -667,7 +667,7 @@ type NotificationSettingCheckbox = {
 
 export function get_notifications_table_row_data(
     notify_settings: PageParamsItem[],
-    settings_object: SettingsObjectType,
+    settings_object: Settings,
 ): NotificationSettingCheckbox[] {
     return general_notifications_table_labels.realm.map((column, index) => {
         const setting_name = notify_settings[index];
@@ -710,7 +710,7 @@ export interface AllNotifications {
     };
 }
 
-export const all_notifications = (settings_object: SettingsObjectType): AllNotifications => ({
+export const all_notifications = (settings_object: Settings): AllNotifications => ({
     general_settings: [
         {
             label: $t({defaultMessage: "Streams"}),

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -595,6 +595,17 @@ export const generalize_stream_notification_setting: Record<
     wildcard_mentions_notify: "wildcard_mentions_notify",
 };
 
+export const specialize_stream_notification_setting: Record<
+    keyof StreamNotificationSettings,
+    keyof StreamSpecificNotificationSettings
+> = {
+    enable_stream_desktop_notifications: "desktop_notifications",
+    enable_stream_audible_notifications: "audible_notifications",
+    enable_stream_push_notifications: "push_notifications",
+    enable_stream_email_notifications: "email_notifications",
+    wildcard_mentions_notify: "wildcard_mentions_notify",
+};
+
 export const pm_mention_notification_settings: (keyof PmNotificationSettings)[] = [
     "enable_desktop_notifications",
     "enable_sounds",

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -3,7 +3,11 @@ import Handlebars from "handlebars/runtime";
 import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults";
-import type {UserSettings} from "./user_settings";
+import type {
+    PmNotificationSettings,
+    StreamNotificationSettings,
+    UserSettings,
+} from "./user_settings";
 
 /*
     This file contains translations between the integer values used in
@@ -571,9 +575,7 @@ export const stream_specific_notification_settings = [
     "wildcard_mentions_notify",
 ];
 
-type Settings = UserSettings | RealmDefaultSettings;
-type PageParamsItem = keyof Settings;
-export const stream_notification_settings: PageParamsItem[] = [
+export const stream_notification_settings: (keyof StreamNotificationSettings)[] = [
     "enable_stream_desktop_notifications",
     "enable_stream_audible_notifications",
     "enable_stream_push_notifications",
@@ -581,7 +583,7 @@ export const stream_notification_settings: PageParamsItem[] = [
     "wildcard_mentions_notify",
 ];
 
-export const pm_mention_notification_settings: PageParamsItem[] = [
+export const pm_mention_notification_settings: (keyof PmNotificationSettings)[] = [
     "enable_desktop_notifications",
     "enable_sounds",
     "enable_offline_push_notifications",
@@ -659,6 +661,8 @@ export const all_notification_settings = other_notification_settings.concat(
     stream_notification_settings,
 );
 
+type Settings = UserSettings | RealmDefaultSettings;
+type PageParamsItem = keyof Settings;
 type NotificationSettingCheckbox = {
     setting_name: string;
     is_disabled: boolean;

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -3,6 +3,7 @@ import Handlebars from "handlebars/runtime";
 import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
 import type {RealmDefaultSettings} from "./realm_user_settings_defaults";
+import type {StreamSpecificNotificationSettings} from "./sub_store";
 import type {
     PmNotificationSettings,
     StreamNotificationSettings,
@@ -567,7 +568,7 @@ export const general_notifications_table_labels = {
     },
 };
 
-export const stream_specific_notification_settings = [
+export const stream_specific_notification_settings: (keyof StreamSpecificNotificationSettings)[] = [
     "desktop_notifications",
     "audible_notifications",
     "push_notifications",

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -468,10 +468,7 @@ export function receives_notifications(stream_id, notification_name) {
     if (sub[notification_name] !== null) {
         return sub[notification_name];
     }
-    if (notification_name === "wildcard_mentions_notify") {
-        return user_settings[notification_name];
-    }
-    return user_settings["enable_stream_" + notification_name];
+    return user_settings[settings_config.generalize_stream_notification_setting[notification_name]];
 }
 
 export function all_subscribed_streams_are_in_home_view() {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -330,11 +330,8 @@ export function stream_setting_changed(e, from_notification_settings) {
         return;
     }
     if (is_notification_setting(setting) && sub[setting] === null) {
-        if (setting === "wildcard_mentions_notify") {
-            sub[setting] = user_settings[setting];
-        } else {
-            sub[setting] = user_settings["enable_stream_" + setting];
-        }
+        sub[setting] =
+            user_settings[settings_config.generalize_stream_notification_setting[setting]];
     }
     set_stream_property(sub, setting, e.target.checked, status_element);
 }

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -60,9 +60,10 @@ export function get_unmatched_streams_for_notification_settings() {
         const settings_values = {};
         let make_table_row = false;
         for (const notification_name of settings_config.stream_specific_notification_settings) {
-            const prepend =
-                notification_name === "wildcard_mentions_notify" ? "" : "enable_stream_";
-            const default_setting = user_settings[prepend + notification_name];
+            const default_setting =
+                user_settings[
+                    settings_config.generalize_stream_notification_setting[notification_name]
+                ];
             const stream_setting = stream_data.receives_notifications(
                 row.stream_id,
                 notification_name,

--- a/static/js/sub_store.ts
+++ b/static/js/sub_store.ts
@@ -22,19 +22,22 @@ export type Stream = {
     stream_post_policy: StreamPostPolicy;
 };
 
-export type StreamSubscription = Stream & {
+export type StreamSpecificNotificationSettings = {
     audible_notifications: boolean | null;
-    color: string;
     desktop_notifications: boolean | null;
-    email_address: string;
     email_notifications: boolean | null;
+    push_notifications: boolean | null;
+    wildcard_mentions_notify: boolean | null;
+};
+
+export type StreamSubscription = (Stream & StreamSpecificNotificationSettings) & {
+    color: string;
+    email_address: string;
     in_home_view: boolean;
     is_muted: boolean;
     pin_to_top: boolean;
-    push_notifications: boolean | null;
     stream_weekly_traffic: number | null;
     subscribers?: number[];
-    wildcard_mentions_notify: boolean | null;
 };
 
 const subs_by_stream_id = new Map<number, StreamSubscription>();

--- a/static/js/user_settings.ts
+++ b/static/js/user_settings.ts
@@ -1,4 +1,19 @@
-export type UserSettings = {
+export type StreamNotificationSettings = {
+    enable_stream_audible_notifications: boolean;
+    enable_stream_desktop_notifications: boolean;
+    enable_stream_email_notifications: boolean;
+    enable_stream_push_notifications: boolean;
+    wildcard_mentions_notify: boolean;
+};
+
+export type PmNotificationSettings = {
+    enable_desktop_notifications: boolean;
+    enable_sounds: boolean;
+    enable_offline_push_notifications: boolean;
+    enable_offline_email_notifications: boolean;
+};
+
+export type UserSettings = (StreamNotificationSettings & PmNotificationSettings) & {
     color_scheme: number;
     default_language: string;
     default_view: string;
@@ -7,19 +22,11 @@ export type UserSettings = {
     dense_mode: boolean;
     email_notifications_batching_period_seconds: number;
     emojiset: string;
-    enable_desktop_notifications: boolean;
     enable_digest_emails: boolean;
     enable_drafts_synchronization: boolean;
     enable_login_emails: boolean;
     enable_marketing_emails: boolean;
-    enable_offline_push_notifications: boolean;
-    enable_offline_email_notifications: boolean;
     enable_online_push_notifications: boolean;
-    enable_sounds: boolean;
-    enable_stream_audible_notifications: boolean;
-    enable_stream_desktop_notifications: boolean;
-    enable_stream_email_notifications: boolean;
-    enable_stream_push_notifications: boolean;
     enter_sends: boolean;
     escape_navigates_to_default_view: boolean;
     fluid_layout_width: boolean;
@@ -34,7 +41,6 @@ export type UserSettings = {
     translate_emoticons: boolean;
     display_emoji_reaction_users: boolean;
     twenty_four_hour_time: boolean;
-    wildcard_mentions_notify: boolean;
     send_stream_typing_notifications: boolean;
     send_private_typing_notifications: boolean;
     send_read_receipts: boolean;

--- a/static/js/user_settings.ts
+++ b/static/js/user_settings.ts
@@ -1,4 +1,4 @@
-export type UserSettingsType = {
+export type UserSettings = {
     color_scheme: number;
     default_language: string;
     default_view: string;
@@ -40,8 +40,8 @@ export type UserSettingsType = {
     send_read_receipts: boolean;
 };
 
-export let user_settings = {} as UserSettingsType;
+export let user_settings = {} as UserSettings;
 
-export function initialize_user_settings(params: Record<string, UserSettingsType>): void {
+export function initialize_user_settings(params: Record<string, UserSettings>): void {
     user_settings = params.user_settings;
 }


### PR DESCRIPTION
This fixes a bug in commit 513207523cd51364dc2cca9d15d08b5218177bc0 (#21284) where `handle_global_notification_updates` would throw an error on `wildcard_mentions_notify` because our API isn’t as symmetric as it should be.