### PR TITLE
docs: Update documentation for secrets related settings.

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -62,8 +62,8 @@ The Vagrant setup process runs this for you.
 ## Secrets
 
 Please don't put any passwords, secret access keys, etc. inline in the
-code. Instead, use the `get_secret` function in `zproject/config.py`
-to read secrets from `/etc/zulip/secrets.conf`.
+code. Instead, use the `get_secret` function or the `get_mandatory_secret`
+function in `zproject/config.py` to read secrets from `/etc/zulip/secrets.conf`.
 
 ## Dangerous constructs
 

--- a/docs/subsystems/settings.md
+++ b/docs/subsystems/settings.md
@@ -71,9 +71,12 @@ In a production environment, we have:
   using the [standard Python
   `RawConfigParser`](https://docs.python.org/3/library/configparser.html#configparser.RawConfigParser),
   and accessed in `zproject/computed_settings.py` by the `get_secret`
-  function. All secrets/API keys/etc. used by the Zulip Django
-  application should be stored here, and read using the `get_secret`
-  function in `zproject/config.py`.
+  or `get_mandatory_secret` function defined in `zproject/config.py`.
+  All secrets/API keys/etc. used by the Zulip Django application should
+  be stored here. The secrets mandatory to start the Zulip Django app
+  are read using `get_mandatory_secret` and the others are read with
+  `get_secret`. If any of the mandatory secrets is missing, a
+  `ZulipSettingsError` is raised.
 
 - `zproject/settings.py` is the main Django settings file for Zulip.
   It imports everything from `zproject/configured_settings.py` and
@@ -121,7 +124,8 @@ in two or three places:
   for production environments.
 
 - If the settings has a secret key,
-  you'll add a `get_secret` call in `zproject/computed_settings.py` (and the
+  you'll add a `get_secret` or `get_mandatory_secret` call in
+  `zproject/computed_settings.py` (and the
   user will add the value when they configure the feature).
 
 - In an appropriate section of `zproject/prod_settings_template.py`,


### PR DESCRIPTION
This is a follow-up to #22699 to document the new `get_mandatory_secret`
helper.

Signed-off-by: Zixuan James Li <p359101898@gmail.com>

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
