### PR TITLE
Fix authentication_methods import and make Gitter-imported orgs start with only GitHub auth enabled

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -587,9 +587,14 @@ def fix_bitfield_keys(data: TableData, table: TableName, field_name: Field) -> N
 
 
 def fix_realm_authentication_bitfield(data: TableData, table: TableName, field_name: Field) -> None:
-    """Used to fixup the authentication_methods bitfield to be a string"""
+    """Used to fixup the authentication_methods bitfield to be an integer."""
     for item in data[table]:
-        values_as_bitstring = "".join("1" if field[1] else "0" for field in item[field_name])
+        # The ordering of bits here is important for the imported value
+        # to end up as expected.
+        charlist = ["1" if field[1] else "0" for field in item[field_name]]
+        charlist.reverse()
+
+        values_as_bitstring = "".join(charlist)
         values_as_int = int(values_as_bitstring, 2)
         item[field_name] = values_as_int
 

--- a/zerver/tests/test_gitter_importer.py
+++ b/zerver/tests/test_gitter_importer.py
@@ -7,7 +7,8 @@ import orjson
 from zerver.data_import.gitter import do_convert_data, get_usermentions
 from zerver.lib.import_realm import do_import_realm
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import Message, UserProfile, get_realm
+from zerver.models import Message, Realm, UserProfile, get_realm
+from zproject.backends import GitHubAuthBackend, auth_enabled_helper, github_auth_enabled
 
 
 class GitterImporter(ZulipTestCase):
@@ -98,6 +99,13 @@ class GitterImporter(ZulipTestCase):
         messages = Message.objects.filter(sender__in=realm_users)
         for message in messages:
             self.assertIsNotNone(message.rendered_content, None)
+
+        self.assertTrue(github_auth_enabled(realm))
+        for auth_backend_name in Realm.AUTHENTICATION_FLAGS:
+            if auth_backend_name == GitHubAuthBackend.auth_backend_name:
+                continue
+
+            self.assertFalse(auth_enabled_helper([auth_backend_name], realm))
 
     def test_get_usermentions(self) -> None:
         user_map = {"57124a4": 3, "57124b4": 5, "57124c4": 8}


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/343-kandra-errors/topic/Exception.3A.20Output.20directory.20should.20be.20empty!/near/1383886 has the background discussion, but the commits should be self-explanatory with their comments