### PR TITLE
ts: Convert util.js to TypeScript.

### DIFF
--- a/static/js/types.ts
+++ b/static/js/types.ts
@@ -1,3 +1,20 @@
+export type MessageType = "private" | "stream";
+
+export type RawMessage = {
+    sender_email: string;
+    stream_id: number;
+    type: MessageType;
+};
+
+export type Message = RawMessage & {
+    match_content: string;
+    match_subject: string;
+    orig_subject: string;
+    subject: string;
+    to_user_ids: string;
+    topic: string;
+};
+
 // TODO/typescript: Move this to server_events_dispatch
 export type UserGroupUpdateEvent = {
     id: number;

--- a/static/js/util.ts
+++ b/static/js/util.ts
@@ -1,7 +1,8 @@
 import {$t} from "./i18n";
+import type {Message, RawMessage} from "./types";
 
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
-export function random_int(min, max) {
+export function random_int(min: number, max: number): number {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
@@ -15,7 +16,11 @@ export function random_int(min, max) {
 // for some i and false otherwise.
 //
 // Usage: lower_bound(array, value, less)
-export function lower_bound(array, value, less) {
+export function lower_bound<T>(
+    array: T[],
+    value: T,
+    less: (item: T, value: T, middle: number) => boolean,
+): number {
     let first = 0;
     const last = array.length;
 
@@ -36,25 +41,28 @@ export function lower_bound(array, value, less) {
     return first;
 }
 
-export const lower_same = function lower_same(a, b) {
+export const lower_same = function lower_same(a: string, b: string): boolean {
     return a.toLowerCase() === b.toLowerCase();
 };
 
-export const same_stream_and_topic = function util_same_stream_and_topic(a, b) {
+export const same_stream_and_topic = function util_same_stream_and_topic(
+    a: Message,
+    b: Message,
+): boolean {
     // Streams and topics are case-insensitive.
     return a.stream_id === b.stream_id && lower_same(a.topic, b.topic);
 };
 
-export function is_pm_recipient(user_id, message) {
+export function is_pm_recipient(user_id: number, message: Message): boolean {
     const recipients = message.to_user_ids.split(",");
     return recipients.includes(user_id.toString());
 }
 
-export function extract_pm_recipients(recipients) {
+export function extract_pm_recipients(recipients: string): string[] {
     return recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");
 }
 
-export const same_recipient = function util_same_recipient(a, b) {
+export const same_recipient = function util_same_recipient(a: Message, b: Message): boolean {
     if (a === undefined || b === undefined) {
         return false;
     }
@@ -71,7 +79,7 @@ export const same_recipient = function util_same_recipient(a, b) {
     return false;
 };
 
-export const same_sender = function util_same_sender(a, b) {
+export const same_sender = function util_same_sender(a: RawMessage, b: RawMessage): boolean {
     return (
         a !== undefined &&
         b !== undefined &&
@@ -79,7 +87,7 @@ export const same_sender = function util_same_sender(a, b) {
     );
 };
 
-export function normalize_recipients(recipients) {
+export function normalize_recipients(recipients: string): string {
     // Converts a string listing emails of message recipients
     // into a canonical formatting: emails sorted ASCIIbetically
     // with exactly one comma and no spaces between each.
@@ -95,7 +103,7 @@ export function normalize_recipients(recipients) {
 // one by one until the decode succeeds.  This makes sense if
 // we are decoding input that the user is in the middle of
 // typing.
-export function robust_uri_decode(str) {
+export function robust_uri_decode(str: string): string {
     let end = str.length;
     while (end > 0) {
         try {
@@ -114,22 +122,23 @@ export function robust_uri_decode(str) {
 // doesn't support the ECMAScript Internationalization API
 // Specification, do a dumb string comparison because
 // String.localeCompare is really slow.
-export function make_strcmp() {
+export function make_strcmp(): (x: string, y: string) => number {
     try {
         const collator = new Intl.Collator();
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         return collator.compare;
     } catch {
         // continue regardless of error
     }
 
-    return function util_strcmp(a, b) {
+    return function util_strcmp(a: string, b: string): number {
         return a < b ? -1 : a > b ? 1 : 0;
     };
 }
 
 export const strcmp = make_strcmp();
 
-export const array_compare = function util_array_compare(a, b) {
+export const array_compare = function util_array_compare<T>(a: T[], b: T[]): boolean {
     if (a.length !== b.length) {
         return false;
     }
@@ -149,27 +158,29 @@ export const array_compare = function util_array_compare(a, b) {
  * You must supply a option to the constructor called compute_value
  * which should be a function that computes the uncached value.
  */
-const unassigned_value_sentinel = Symbol("unassigned_value_sentinel");
-export class CachedValue {
-    _value = unassigned_value_sentinel;
+const unassigned_value_sentinel: unique symbol = Symbol("unassigned_value_sentinel");
+export class CachedValue<T> {
+    _value: T | typeof unassigned_value_sentinel = unassigned_value_sentinel;
 
-    constructor(opts) {
+    private compute_value: () => T;
+
+    constructor(opts: {compute_value: () => T}) {
         this.compute_value = opts.compute_value;
     }
 
-    get() {
+    get(): T {
         if (this._value === unassigned_value_sentinel) {
             this._value = this.compute_value();
         }
         return this._value;
     }
 
-    reset() {
+    reset(): void {
         this._value = unassigned_value_sentinel;
     }
 }
 
-export function find_wildcard_mentions(message_content) {
+export function find_wildcard_mentions(message_content: string): string | null {
     const mention = message_content.match(/(^|\s)(@\*{2}(all|everyone|stream)\*{2})($|\s)/);
     if (mention === null) {
         return null;
@@ -177,13 +188,13 @@ export function find_wildcard_mentions(message_content) {
     return mention[3];
 }
 
-export const move_array_elements_to_front = function util_move_array_elements_to_front(
-    array,
-    selected,
-) {
+export const move_array_elements_to_front = function util_move_array_elements_to_front<T>(
+    array: T[],
+    selected: T[],
+): T[] {
     const selected_hash = new Set(selected);
-    const selected_elements = [];
-    const unselected_elements = [];
+    const selected_elements: T[] = [];
+    const unselected_elements: T[] = [];
     for (const element of array) {
         (selected_hash.has(element) ? selected_elements : unselected_elements).push(element);
     }
@@ -191,12 +202,12 @@ export const move_array_elements_to_front = function util_move_array_elements_to
 };
 
 // check by the userAgent string if a user's client is likely mobile.
-export function is_mobile() {
+export function is_mobile(): boolean {
     const regex = "Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini";
     return new RegExp(regex, "i").test(window.navigator.userAgent);
 }
 
-export function sorted_ids(ids) {
+export function sorted_ids(ids: string[]): number[] {
     // This mapping makes sure we are using ints, and
     // it also makes sure we don't mutate the list.
     let id_list = ids.map((s) => Number.parseInt(s, 10));
@@ -206,28 +217,28 @@ export function sorted_ids(ids) {
     return id_list;
 }
 
-export function set_match_data(target, source) {
+export function set_match_data(target: Message, source: Message): void {
     target.match_subject = source.match_subject;
     target.match_content = source.match_content;
 }
 
-export function get_match_topic(obj) {
+export function get_match_topic(obj: Message): string | undefined {
     return obj.match_subject;
 }
 
-export function get_draft_topic(obj) {
+export function get_draft_topic(obj: Message): string {
     // We will need to support subject for old drafts.
     return obj.topic || obj.subject || "";
 }
 
-export function get_reload_topic(obj) {
+export function get_reload_topic(obj: Message): string {
     // When we first upgrade to releases that have
     // topic=foo in the code, the user's reload URL
     // may still have subject=foo from the prior version.
     return obj.topic || obj.subject || "";
 }
 
-export function get_edit_event_topic(obj) {
+export function get_edit_event_topic(obj: Message): string | undefined {
     if (obj.topic === undefined) {
         return obj.subject;
     }
@@ -237,23 +248,23 @@ export function get_edit_event_topic(obj) {
     return obj.topic;
 }
 
-export function get_edit_event_orig_topic(obj) {
+export function get_edit_event_orig_topic(obj: Message): string | undefined {
     return obj.orig_subject;
 }
 
-export function is_topic_synonym(operator) {
+export function is_topic_synonym(operator: string): boolean {
     return operator === "subject";
 }
 
-export function convert_message_topic(message) {
+export function convert_message_topic(message: Message): void {
     if (message.topic === undefined) {
         message.topic = message.subject;
     }
 }
 
-export function clean_user_content_links(html) {
+export function clean_user_content_links(html: string): string {
     const content = new DOMParser().parseFromString(html, "text/html").body;
-    for (const elt of content.querySelectorAll("a")) {
+    for (const elt of Array.from(content.querySelectorAll("a"))) {
         // Ensure that all external links have target="_blank"
         // rel="opener noreferrer".  This ensures that external links
         // never replace the Zulip web app while also protecting
@@ -264,6 +275,9 @@ export function clean_user_content_links(html) {
         // Zulip web app using our hashchange system, do not require
         // these attributes.
         const href = elt.getAttribute("href");
+        if (href === null) {
+            continue;
+        }
         let url;
         try {
             url = new URL(href, window.location.href);
@@ -295,15 +309,16 @@ export function clean_user_content_links(html) {
         if (is_inline_image) {
             // For inline images we want to handle the tooltips explicitly, and disable
             // the browser's built in handling of the title attribute.
-            if (elt.getAttribute("title")) {
-                elt.setAttribute("aria-label", elt.getAttribute("title"));
+            const title = elt.getAttribute("title");
+            if (title !== null) {
+                elt.setAttribute("aria-label", title);
                 elt.removeAttribute("title");
             }
         } else {
             // For non-image user uploads, the following block ensures that the title
             // attribute always displays the filename as a security measure.
-            let title;
-            let legacy_title;
+            let title: string;
+            let legacy_title: string;
             if (
                 url.origin === window.location.origin &&
                 url.pathname.startsWith("/user_uploads/")
@@ -317,7 +332,7 @@ export function clean_user_content_links(html) {
                     {filename: url.pathname.slice(url.pathname.lastIndexOf("/") + 1)},
                 );
             } else {
-                title = url;
+                title = url.toString();
                 legacy_title = href;
             }
             elt.setAttribute(
@@ -329,7 +344,11 @@ export function clean_user_content_links(html) {
     return content.innerHTML;
 }
 
-export function filter_by_word_prefix_match(items, search_term, item_to_text) {
+export function filter_by_word_prefix_match<T>(
+    items: T[],
+    search_term: string,
+    item_to_text: (item: T) => string,
+): T[] {
     if (search_term === "") {
         return items;
     }
@@ -349,7 +368,7 @@ export function filter_by_word_prefix_match(items, search_term, item_to_text) {
     return filtered_items;
 }
 
-export function get_time_from_date_muted(date_muted) {
+export function get_time_from_date_muted(date_muted: number | undefined): number {
     if (date_muted === undefined) {
         return Date.now();
     }

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -112,7 +112,7 @@ js_rules = RuleList(
     rules=[
         {
             "pattern": "subject|SUBJECT",
-            "exclude": {"static/js/util.js", "frontend_tests/"},
+            "exclude": {"static/js/types.ts", "static/js/util.ts", "frontend_tests/"},
             "exclude_pattern": "emails",
             "description": "avoid subject in JS code",
             "good_lines": ["topic_name"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,10 @@
     "compilerOptions": {
         "baseUrl": ".",
         "paths": {
-            "*": ["static/js/types/*"],
+            "*": ["static/js/types/*", "static/js/*.ts"],
         },
         "types": [],
+        "lib": ["dom", "es5"],
 
         /* TypeScript 3.4 added the --incremental flag but its API is not
          * currently public so ts-loader cannot use it yet.


### PR DESCRIPTION
This commit converts `util.js` to TypeScript. In order to do this, it adds a `Message` type in `types.ts`. It also updates the linting logic which forbids `subject`: trivially to ignore `util.ts` instead of `util.js`, but also to ignore `types.ts` due to the `match_subject` property of `Message`.

This was mostly straightforward, but in a few places I had to add non-null assertions or explicit casts due to the existing code not being type-safe.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
