### PR TITLE
computed_settings: Set STATICFILES_DIRS to an existing absolute path

### DIFF
--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -16,6 +16,7 @@ from tools.lib import sanity_check
 sanity_check.check_venv(__file__)
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "zproject.settings"
+os.environ["ZULIP_COLLECTING_STATIC"] = "1"
 from django.conf import settings
 
 from scripts.lib.node_cache import setup_node_modules

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -607,7 +607,8 @@ LOCALE_PATHS = (os.path.join(DEPLOY_ROOT, "locale"),)
 # We want all temporary uploaded files to be stored on disk.
 FILE_UPLOAD_MAX_MEMORY_SIZE = 0
 
-STATICFILES_DIRS = ["static/"]
+if DEVELOPMENT or "ZULIP_COLLECTING_STATIC" in os.environ:
+    STATICFILES_DIRS = [os.path.join(DEPLOY_ROOT, "static")]
 
 if DEBUG:
     WEBPACK_BUNDLES = "../webpack/"


### PR DESCRIPTION
Django has always expected this, but Django 4.0 added a system check that spews warnings in production.