### PR TITLE
Import: Validate emails of users while importing

### DIFF
--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -811,7 +811,7 @@ class RealmImportExportTest(ExportFile):
         self.export_realm(original_realm)
 
         with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"):
-            do_import_realm(os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip")
+            do_import_realm(get_output_dir(), "test-zulip")
 
         # Make sure our export/import didn't somehow leak info into the
         # original realm.
@@ -1220,7 +1220,7 @@ class RealmImportExportTest(ExportFile):
         self.export_realm(original_realm)
 
         with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"):
-            do_import_realm(os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip")
+            do_import_realm(get_output_dir(), "test-zulip")
 
         self.assertTrue(Realm.objects.filter(string_id="test-zulip").exists())
         imported_realm = Realm.objects.get(string_id="test-zulip")
@@ -1243,7 +1243,7 @@ class RealmImportExportTest(ExportFile):
         self.export_realm(realm)
 
         with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"):
-            do_import_realm(os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip")
+            do_import_realm(get_output_dir(), "test-zulip")
         imported_realm = Realm.objects.get(string_id="test-zulip")
 
         # Test attachments
@@ -1307,7 +1307,7 @@ class RealmImportExportTest(ExportFile):
         self.export_realm(realm)
 
         with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"):
-            do_import_realm(os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip")
+            do_import_realm(get_output_dir(), "test-zulip")
 
         imported_realm = Realm.objects.get(string_id="test-zulip")
         test_image_data = read_test_image_file("img.png")
@@ -1391,9 +1391,7 @@ class RealmImportExportTest(ExportFile):
         self.export_realm(realm)
 
         with self.settings(BILLING_ENABLED=True), self.assertLogs(level="INFO"):
-            realm = do_import_realm(
-                os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip-1"
-            )
+            realm = do_import_realm(get_output_dir(), "test-zulip-1")
             self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_LIMITED)
             self.assertEqual(realm.max_invites, 100)
             self.assertEqual(realm.upload_quota_gb, 5)
@@ -1404,9 +1402,7 @@ class RealmImportExportTest(ExportFile):
                 ).exists()
             )
         with self.settings(BILLING_ENABLED=False), self.assertLogs(level="INFO"):
-            realm = do_import_realm(
-                os.path.join(settings.TEST_WORKER_DIR, "test-export"), "test-zulip-2"
-            )
+            realm = do_import_realm(get_output_dir(), "test-zulip-2")
             self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_SELF_HOSTED)
             self.assertEqual(realm.max_invites, 100)
             self.assertEqual(realm.upload_quota_gb, None)

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -600,7 +600,7 @@ class TestSendCustomEmail(ZulipTestCase):
                 f"--path={path}",
                 f"-u={user.delivery_email}",
                 "--subject=Test email",
-                "--from-name=zulip@testserver.com",
+                "--from-name=zulip@zulip.example.com",
                 "--dry-run",
             )
             self.assertEqual(

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -853,7 +853,11 @@ class RocketChatImporter(ZulipTestCase):
         rocketchat_data_dir = self.fixture_file_name("", "rocketchat_fixtures")
         output_dir = self.make_import_output_dir("rocketchat")
 
-        with self.assertLogs(level="INFO") as info_log:
+        with self.assertLogs(level="INFO") as info_log, self.settings(
+            EXTERNAL_HOST="zulip.example.com"
+        ):
+            # We need to mock EXTERNAL_HOST to be a valid domain because rocketchat's importer
+            # uses it to generate email addresses for users without an email specified.
             do_convert_data(
                 rocketchat_data_dir=rocketchat_data_dir,
                 output_dir=output_dir,
@@ -900,7 +904,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(
             exported_user_emails,
             {
-                "rocket.cat-bot@testserver",
+                "rocket.cat-bot@zulip.example.com",
                 "priyansh3133@email.com",
                 "harrypotter@email.com",
                 "hermionegranger@email.com",
@@ -966,8 +970,8 @@ class RocketChatImporter(ZulipTestCase):
 
         realm = get_realm("hogwarts")
 
-        self.assertFalse(get_user("rocket.cat-bot@testserver", realm).is_mirror_dummy)
-        self.assertTrue(get_user("rocket.cat-bot@testserver", realm).is_bot)
+        self.assertFalse(get_user("rocket.cat-bot@zulip.example.com", realm).is_mirror_dummy)
+        self.assertTrue(get_user("rocket.cat-bot@zulip.example.com", realm).is_bot)
         self.assertFalse(get_user("harrypotter@email.com", realm).is_mirror_dummy)
         self.assertFalse(get_user("harrypotter@email.com", realm).is_bot)
         self.assertFalse(get_user("ronweasley@email.com", realm).is_mirror_dummy)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -487,10 +487,10 @@ class PasswordResetTest(ZulipTestCase):
                 result["Location"], "/accounts/go/?next=%2Faccounts%2Fpassword%2Freset%2F"
             )
 
-        mock_get_host.return_value = "www.testserver.com"
+        mock_get_host.return_value = "www.zulip.example.com"
         with self.settings(
             ROOT_DOMAIN_LANDING_PAGE=True,
-            EXTERNAL_HOST="www.testserver.com",
+            EXTERNAL_HOST="www.zulip.example.com",
         ):
             result = self.client_get("/accounts/password/reset/")
             self.assertEqual(result.status_code, 302)
@@ -519,8 +519,8 @@ class PasswordResetTest(ZulipTestCase):
         result = self.client_get("/accounts/password/reset/")
         self.assertEqual(result.status_code, 200)
 
-        mock_get_host.return_value = "www.testserver.com"
-        with self.settings(EXTERNAL_HOST="www.testserver.com", ROOT_SUBDOMAIN_ALIASES=[]):
+        mock_get_host.return_value = "www.zulip.example.com"
+        with self.settings(EXTERNAL_HOST="www.zulip.example.com", ROOT_SUBDOMAIN_ALIASES=[]):
             result = self.client_get("/accounts/password/reset/")
             self.assertEqual(result.status_code, 200)
 
@@ -5809,10 +5809,10 @@ class TestLoginPage(ZulipTestCase):
             self.assertEqual(result.status_code, 302)
             self.assertEqual(result["Location"], "/accounts/go/?next=%2Fupgrade%2F")
 
-        mock_get_host.return_value = "www.testserver.com"
+        mock_get_host.return_value = "www.zulip.example.com"
         with self.settings(
             ROOT_DOMAIN_LANDING_PAGE=True,
-            EXTERNAL_HOST="www.testserver.com",
+            EXTERNAL_HOST="www.zulip.example.com",
             ROOT_SUBDOMAIN_ALIASES=["test"],
         ):
             result = self.client_get("/en/login/")

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1107,7 +1107,9 @@ class SlackImporter(ZulipTestCase):
         ]
         mock_requests_get.return_value.raw = BytesIO(read_test_image_file("img.png"))
 
-        with self.assertLogs(level="INFO"):
+        with self.assertLogs(level="INFO"), self.settings(EXTERNAL_HOST="zulip.example.com"):
+            # We need to mock EXTERNAL_HOST to be a valid domain because Slack's importer
+            # uses it to generate email addresses for users without an email specified.
             do_convert_data(test_slack_zip_file, output_dir, token)
 
         self.assertTrue(os.path.exists(output_dir))


### PR DESCRIPTION
Having users with malformed email addresses in our database can lead to
hard to debug issues and we really should try to prevent that.