### PR TITLE
unread: Make the `n` key respect the left sidebar filter.

### DIFF
--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -2,32 +2,74 @@ import * as pm_conversations from "./pm_conversations";
 import * as stream_data from "./stream_data";
 import * as stream_sort from "./stream_sort";
 import * as stream_topic_history from "./stream_topic_history";
+import * as topic_list from "./topic_list";
+import * as topic_list_data from "./topic_list_data";
 import * as unread from "./unread";
 import * as user_topics from "./user_topics";
 
 export function next_topic(streams, get_topics, has_unread_messages, curr_stream, curr_topic) {
+    // curr_stream_widget_id is used only for the TopicListWidget associated with left-sidebar filter
+    const curr_stream_widget_id = topic_list.active_stream_id();
     const curr_stream_index = streams.indexOf(curr_stream); // -1 if not found
 
     if (curr_stream_index >= 0) {
+        // Use 2 pass approach. First pass (filtered_topics_in_stream) iterates all topics that match
+        // the left-sidebar filter. Second pass (all_topics_in_stream) iterates all topics in the
+        // entire unfiltered stream. This 2 pass approach was made for users to jump to the next
+        // unread topic (with respect to the left-sidebar filter) in a stream using 'n' hotkey aka
+        // 'n_key', rather than jumping to the next unread topic overall, which disregards a filter.
         const stream = streams[curr_stream_index];
-        const topics = get_topics(stream);
-        const curr_topic_index = topics.indexOf(curr_topic); // -1 if not found
+        const filtered_topics_in_stream = topic_list_data.get_list_info(
+            curr_stream_widget_id,
+            true,
+        ).items;
+        const all_topics_in_stream = get_topics(stream);
+        // first "pass" --> check all filtered topics first for unread topics. Return topic if found.
+        if (filtered_topics_in_stream.length > 0) {
+            let curr_topic_index = -1; // assume topic not found intitially
+            for (const [i, element] of filtered_topics_in_stream.entries()) {
+                if (element.topic_name === curr_topic) {
+                    curr_topic_index = i;
+                }
+            }
 
-        for (let i = curr_topic_index + 1; i < topics.length; i += 1) {
-            const topic = topics[i];
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+            for (let i = curr_topic_index + 1; i < filtered_topics_in_stream.length; i += 1) {
+                const topic = filtered_topics_in_stream[i].topic_name;
+                if (has_unread_messages(stream, topic)) {
+                    return {stream, topic};
+                }
+            }
+
+            for (let i = 0; i < curr_topic_index; i += 1) {
+                const topic = filtered_topics_in_stream[i].topic_name;
+                if (has_unread_messages(stream, topic)) {
+                    return {stream, topic};
+                }
             }
         }
+        // Second "pass" --> Check all topics in current stream for unread topics. All filtered
+        // messages should be read by this point, so this if statement will return the
+        // next unread unfiltered topic in this stream.
+        if (all_topics_in_stream.length > 0) {
+            const curr_topic_index = all_topics_in_stream.indexOf(curr_topic); // -1 if not found
+            for (let i = curr_topic_index + 1; i < all_topics_in_stream.length; i += 1) {
+                const topic = all_topics_in_stream[i];
+                if (has_unread_messages(stream, topic)) {
+                    return {stream, topic};
+                }
+            }
 
-        for (let i = 0; i < curr_topic_index; i += 1) {
-            const topic = topics[i];
-            if (has_unread_messages(stream, topic)) {
-                return {stream, topic};
+            for (let i = 0; i < curr_topic_index; i += 1) {
+                const topic = all_topics_in_stream[i];
+                if (has_unread_messages(stream, topic)) {
+                    return {stream, topic};
+                }
             }
         }
     }
 
+    // Find next unread message in all other streams. No left-sidebar topic filters are
+    // applied to other streams since topic filters are stream-specific.
     for (let i = curr_stream_index + 1; i < streams.length; i += 1) {
         const stream = streams[i];
         for (const topic of get_topics(stream)) {


### PR DESCRIPTION
When going to the next unread message we should restrict
the streams according to the stream filter, if it is filled in.
And similarly for the topic filter, if you're currently
viewing "more topics".

So, modified the algorithm to iterate through the unread
actively-filtered topics first, then the other unread
topics in the stream, and then all the unfiltered
topics of other streams (no filters applied for any of those).

Fixes #21437.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
