### PR TITLE
typing: Broaden parameter type for bulk_regenerate_api_keys.

### DIFF
--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Optional, Union
+from typing import Iterable, Optional, Union
 
 import orjson
 from django.db import transaction
@@ -247,7 +247,7 @@ def do_regenerate_api_key(user_profile: UserProfile, acting_user: UserProfile) -
     return new_api_key
 
 
-def bulk_regenerate_api_keys(user_profile_ids: List[int]) -> None:
+def bulk_regenerate_api_keys(user_profile_ids: Iterable[int]) -> None:
     for user_profile_id in user_profile_ids:
         user_profile = get_user_profile_by_id(user_profile_id)
         do_regenerate_api_key(user_profile, user_profile)


### PR DESCRIPTION
In zerver.management.commands.logout_all_users,
we pass a values queryset containing the ids into
this function, which is not actually a list. This
broadens the type annotation so that the ValuesQuerySet
is accepted.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
