### PR TITLE
compose_box: Make "To" in compose window clickable to narrow conversation.

### DIFF
--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -18,6 +18,7 @@ let pills = {
 
 run_test("pills", ({override}) => {
     override(compose_actions, "update_placeholder_text", () => {});
+    override(compose_actions, "update_narrow_to_recipient_visibility", () => {});
 
     const othello = {
         user_id: 1,

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -141,8 +141,18 @@ function composing_to_current_topic_narrow() {
     );
 }
 
+function composing_to_current_pm_narrow() {
+    const compose_recipients = util.extract_pm_recipients(
+        compose_state.private_message_recipient() || "",
+    );
+    const narrow_recipients = util.extract_pm_recipients(narrow_state.pm_emails_string() || "");
+
+    return util.lower_same(JSON.stringify(compose_recipients), JSON.stringify(narrow_recipients));
+}
+
 export function update_narrow_to_recipient_visibility() {
     const message_type = compose_state.get_message_type();
+
     if (message_type === "stream") {
         const stream_name = compose_state.stream_name();
         const stream_exists = Boolean(stream_data.get_stream_id(stream_name));
@@ -152,11 +162,21 @@ export function update_narrow_to_recipient_visibility() {
             !composing_to_current_topic_narrow() &&
             !compose_state.is_topic_field_empty()
         ) {
-            $(".narrow_to_compose_recipients").show();
+            $("#stream-message .narrow_to_compose_recipients").show();
             return;
         }
+        $("#stream-message .narrow_to_compose_recipients").hide();
+        return;
+    } else if (message_type === "private") {
+        const $to_text = $("#private-message .to_text");
+
+        if (compose_state.private_message_recipient() === "" || composing_to_current_pm_narrow()) {
+            $to_text.removeClass("narrow_to_compose_recipients");
+            return;
+        }
+        $to_text.addClass("narrow_to_compose_recipients");
+        return;
     }
-    $(".narrow_to_compose_recipients").hide();
 }
 
 export function complete_starting_tasks(msg_type, opts) {

--- a/static/js/compose_pm_pill.js
+++ b/static/js/compose_pm_pill.js
@@ -34,6 +34,7 @@ export function initialize() {
 
     widget.onPillRemove(() => {
         compose_actions.update_placeholder_text();
+        compose_actions.update_narrow_to_recipient_visibility();
     });
 }
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -135,8 +135,15 @@
 
     #private-message .to_text {
         vertical-align: middle;
-
         font-weight: 600;
+        color: inherit;
+        opacity: 0.7;
+        cursor: default;
+
+        &.narrow_to_compose_recipients:hover {
+            cursor: pointer;
+            opacity: 1;
+        }
     }
 
     #compose-lock-icon,


### PR DESCRIPTION
Fixes #22756.

Edited with new description and behavior

Make the word "To" in the compose box a clickable element to narrow conversation view to recipients in the to field.

This is a first pass at making the word "To" clickable as a "narrow view" button, this is intentionally inconsistent with the narrow stream UX which relies on a separate button.

![pm-to-narrow](https://user-images.githubusercontent.com/3621543/187133101-6b98b77d-b500-4659-a644-f198d3f04f17.gif)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
