### PR TITLE
scim: Upgrade scim2-filter-parser to 0.4.0 to fix case-sensitivity.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1827,8 +1827,9 @@ s3transfer==0.6.0 \
     --hash=sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd \
     --hash=sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947
     # via boto3
-scim2-filter-parser==0.3.9 \
-    --hash=sha256:10873af0dbe279acaaaf176b1506b3d2c2730bd74c02e8753acfa0515b8f0f70
+scim2-filter-parser==0.4.0 \
+    --hash=sha256:7171e8cc4e110928bfdb83e5f0a19781d2d8b21f31e5905d92243c5067f2cf59 \
+    --hash=sha256:ca6e08c167a559d75081a044315c0dd34941c5d61d54aad04e9f6cefc1b929be
     # via django-scim2
 scrapy==2.6.2 \
     --hash=sha256:53528bcaf8c2c77aca359af11f349dec5dad98845a13d4c0bb9abd07f302298d \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1253,8 +1253,9 @@ s3transfer==0.6.0 \
     --hash=sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd \
     --hash=sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947
     # via boto3
-scim2-filter-parser==0.3.9 \
-    --hash=sha256:10873af0dbe279acaaaf176b1506b3d2c2730bd74c02e8753acfa0515b8f0f70
+scim2-filter-parser==0.4.0 \
+    --hash=sha256:7171e8cc4e110928bfdb83e5f0a19781d2d8b21f31e5905d92243c5067f2cf59 \
+    --hash=sha256:ca6e08c167a559d75081a044315c0dd34941c5d61d54aad04e9f6cefc1b929be
     # via django-scim2
 sentry-sdk==1.9.0 \
     --hash=sha256:60b13757d6344a94bf0ccb3c0a006c4de77daab09871b30fbbd05d5ec24e54fb \

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 140
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (198, 1)
+PROVISION_VERSION = (199, 0)

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -170,6 +170,33 @@ class TestSCIMUser(SCIMTestCase):
 
         self.assertEqual(output_data, expected_empty_results_response_schema)
 
+    def test_get_basic_filter_by_username_case_insensitive(self) -> None:
+        """
+        Verifies that the "userName eq XXXX" syntax is case-insensitive.
+        """
+
+        hamlet = self.example_user("hamlet")
+
+        # The assumption for the test to make sense is that these two are not the same:
+        self.assertNotEqual(hamlet.delivery_email.upper(), hamlet.delivery_email)
+
+        expected_response_schema = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            "totalResults": 1,
+            "itemsPerPage": 50,
+            "startIndex": 1,
+            "Resources": [self.generate_user_schema(hamlet)],
+        }
+
+        result = self.client_get(
+            f'/scim/v2/Users?filter=userName eq "{hamlet.delivery_email.upper()}"',
+            {},
+            **self.scim_headers(),
+        )
+        self.assertEqual(result.status_code, 200)
+        output_data = orjson.loads(result.content)
+        self.assertEqual(output_data, expected_response_schema)
+
     def test_get_all_with_pagination(self) -> None:
         realm = get_realm("zulip")
 


### PR DESCRIPTION
userName lookups are supposed to be case-insensitive per the SCIM2 RFC
and this was fixed upstream in
https://github.com/15five/scim2-filter-parser/pull/31
and included in 0.4.0 release.

This replaces the old hacky PR https://github.com/zulip/zulip/pull/22398