### PR TITLE
import: Fix timestamp check in long_term_idle_helper.

### DIFF
--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -776,7 +776,7 @@ def long_term_idle_helper(
         if user in recent_senders:
             continue
 
-        if NOW - timestamp < 60:
+        if NOW - timestamp < 60 * 24 * 60 * 60:
             recent_senders.add(user)
 
         sender_counts[user] += 1

--- a/zerver/tests/test_gitter_importer.py
+++ b/zerver/tests/test_gitter_importer.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 from typing import Any
 from unittest import mock
 
@@ -27,7 +28,8 @@ class GitterImporter(ZulipTestCase):
             gitter_data = orjson.loads(f.read())
         sent_datetime = dateutil.parser.parse(gitter_data[1]["sent"])
         with self.assertLogs(level="INFO"), mock.patch(
-            "zerver.data_import.import_util.timezone_now", return_value=sent_datetime
+            "zerver.data_import.import_util.timezone_now",
+            return_value=sent_datetime + timedelta(days=1),
         ):
             do_convert_data(gitter_file, output_dir)
 


### PR DESCRIPTION
Caught  by @timabbott in https://github.com/zulip/zulip/pull/22170#issuecomment-1230666170 