### PR TITLE
help center: Create documentation for read receipts.

### DIFF
--- a/templates/zerver/help/configure-default-new-user-settings.md
+++ b/templates/zerver/help/configure-default-new-user-settings.md
@@ -12,6 +12,9 @@ users will be able to customize their own settings once they
 join. Administrators can customize defaults for all personal
 preference settings, including the following:
 
+* Privacy settings, including:
+    * [Displaying availability to other users](/help/status-and-availability)
+    * [Allowing others to see when the user has read messages](/help/read-receipts)
 * Display settings, including:
     * Default view ([Recent topics](/help/recent-topics) vs. [All messages](/help/reading-strategies#all-messages))
     * [Light theme vs. dark theme](/help/dark-theme)
@@ -28,7 +31,7 @@ preference settings, including the following:
 
 {settings_tab|default-user-settings}
 
-2. Review all settings and adjust as needed.
+1. Review all settings and adjust as needed.
 
 {end_tabs}
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -88,6 +88,7 @@
 * [View when message was sent](/help/view-the-exact-time-a-message-was-sent)
 * [View a message's edit history](/help/view-a-messages-edit-history)
 * [Collapse a message](/help/collapse-a-message)
+* [Read receipts](/help/read-receipts)
 
 ## People
 * [Status and availability](/help/status-and-availability)

--- a/templates/zerver/help/read-receipts.md
+++ b/templates/zerver/help/read-receipts.md
@@ -1,0 +1,85 @@
+# Read receipts
+
+Read receipts let you check who has read a message. You can see read receipts
+for any message, including both [stream messages](/help/streams-and-topics) and
+[private messages](/help/private-messages).
+
+With privacy in mind, Zulip lets you [control][configure-personal-read-recipts]
+whether your read receipts are shared, and administrators can
+[choose][configure-organization-read-recipts] whether to enable read receipts in
+their organization.
+
+!!! tip ""
+    Read receipts reflect whether or not someone has marked a message as read,
+    whether by viewing it, or [by marking messages as read in
+    bulk](/help/marking-messages-as-read).
+
+## View who has read a message
+
+{start_tabs}
+
+{!message-actions-menu.md!}
+
+3. Click **View read receipts**.
+
+!!! tip ""
+    In addition to a list of names, you will see how many people have read
+    the message.
+
+{end_tabs}
+
+## Configure whether Zulip lets others see when you've read messages
+
+Zulip supports the privacy option of never sharing whether or not you have read
+a message. If this setting is turned off, your name will never appear in the
+list of read receipts.
+
+{start_tabs}
+
+{settings_tab|account-and-privacy}
+
+1. Under **Privacy**, toggle **Let others see when I've read messages**.
+
+{end_tabs}
+
+## Configure read receipts for your organization
+
+{!admin-only.md!}
+
+You can configure:
+
+* Whether read receipts are enabled in your organization.
+* Whether new users will allow others to view read receipts by default. (Note
+  that users [can always change this setting][configure-personal-read-recipts]
+  once they join.)
+
+### Configure whether read receipts are enabled in your organization
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Other settings**, toggle **Enable read receipts**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+### Configure default read receipt sharing settings for new users
+
+{start_tabs}
+
+{settings_tab|default-user-settings}
+
+1. Under **Privacy settings**, toggle **Allow other users to view read receipts**.
+
+{end_tabs}
+
+## Related articles
+
+* [Status and availability](/help/status-and-availability)
+* [Typing notifications](/help/typing-notifications)
+
+[configure-personal-read-recipts]: /help/read-receipts#configure-whether-zulip-lets-others-see-when-youve-read-messages
+[configure-organization-read-recipts]:
+    /help/read-receipts#configure-whether-read-receipts-are-enabled-in-your-organization

--- a/templates/zerver/help/status-and-availability.md
+++ b/templates/zerver/help/status-and-availability.md
@@ -123,3 +123,4 @@ minutes after disabling updates to your availability.
 ## Related articles
 
 * [Typing notifications](/help/typing-notifications)
+* [Read receipts](/help/read-receipts)

--- a/templates/zerver/help/typing-notifications.md
+++ b/templates/zerver/help/typing-notifications.md
@@ -27,3 +27,4 @@ configure Zulip to not send typing notifications.
 
 * [Private messages](/help/private-messages)
 * [Status and availability](/help/status-and-availability)
+* [Read receipts](/help/read-receipts)


### PR DESCRIPTION
This PR adds documentation for the new read receipts feature.

Other changes:
- Cross-links on related articles
- Added privacy settings to instructions for configuring default settings for new users.

Questions to consider:
- Is this article in the right place in the sidebar, or would somewhere else be better?
- Are there any intro/guide pages where this feature should be mentioned?

Screenshots:

<details>
<summary>Read receipts</summary>

![Screen Shot 2022-08-29 at 3 18 49 PM](https://user-images.githubusercontent.com/2090066/187309578-6d013fbc-604c-4366-ba03-4dcd4b95eb3d.png)
</details>

<details>
<summary>Configure default settings for new users (exerpt)</summary>

Current: http://zulip.com/help/configure-default-new-user-settings

![Screen Shot 2022-08-29 at 3 20 42 PM](https://user-images.githubusercontent.com/2090066/187309722-f80b8ca1-2e6a-469f-95fc-77267675e87c.png)

</details>
