### PR TITLE
custom_profile_fields: Some improvements in settings > custom profile fields.

### DIFF
--- a/frontend_tests/puppeteer_tests/custom-profile.ts
+++ b/frontend_tests/puppeteer_tests/custom-profile.ts
@@ -63,6 +63,18 @@ async function test_edit_profile_field(page: Page): Promise<void> {
 
 async function test_delete_custom_profile_field(page: Page): Promise<void> {
     await page.click(`${profile_field_row} button.delete`);
+    await common.wait_for_micromodal_to_open(page);
+    assert.strictEqual(
+        await common.get_text_from_selector(page, ".dialog_heading"),
+        "Delete custom profile field?",
+    );
+    assert.strictEqual(
+        await common.get_text_from_selector(page, "#dialog_widget_modal .dialog_submit_button"),
+        "Confirm",
+    );
+    await page.click("#dialog_widget_modal .dialog_submit_button");
+    await common.wait_for_micromodal_to_close(page);
+
     await page.waitForSelector("#admin-profile-field-status img", {visible: true});
     assert.strictEqual(
         await common.get_text_from_selector(page, "div#admin-profile-field-status"),

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -313,8 +313,12 @@ function show_modal_for_deleting_options(field, deleted_values, update_profile_f
         field_name: field.name,
     });
 
+    let modal_heading_text = "Delete this option?";
+    if (Object.keys(deleted_values).length !== 1) {
+        modal_heading_text = "Delete these options?";
+    }
     confirm_dialog.launch({
-        html_heading: $t_html({defaultMessage: "Delete option"}),
+        html_heading: $t_html({defaultMessage: "{modal_heading_text}"}, {modal_heading_text}),
         html_body,
         on_click: update_profile_field,
     });

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -15,10 +15,18 @@ import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as settings_ui from "./settings_ui";
+import * as ui_report from "./ui_report";
 
 const meta = {
     loaded: false,
 };
+
+function display_success_status() {
+    const $spinner = $("#admin-profile-field-status").expectOne();
+    const success_msg_html = settings_ui.strings.success_html;
+    ui_report.success(success_msg_html, $spinner, 1000);
+    settings_ui.display_checkmark($spinner);
+}
 
 export function maybe_disable_widgets() {
     if (page_params.is_admin) {
@@ -222,7 +230,12 @@ function open_custom_profile_field_form_modal() {
             field_data: JSON.stringify(field_data),
         };
         const url = "/json/realm/profile_fields";
-        dialog_widget.submit_api_request(channel.post, url, data);
+        const opts = {
+            success_continuation() {
+                display_success_status();
+            },
+        };
+        dialog_widget.submit_api_request(channel.post, url, data, opts);
     }
 
     function set_up_form_fields() {
@@ -410,7 +423,12 @@ function open_edit_form_modal(e) {
 
         function update_profile_field() {
             const url = "/json/realm/profile_fields/" + field_id;
-            dialog_widget.submit_api_request(channel.patch, url, data);
+            const opts = {
+                success_continuation() {
+                    display_success_status();
+                },
+            };
+            dialog_widget.submit_api_request(channel.patch, url, data, opts);
         }
 
         if (field.type === field_types.SELECT.id) {

--- a/static/templates/confirm_dialog/confirm_delete_profile_field.hbs
+++ b/static/templates/confirm_dialog/confirm_delete_profile_field.hbs
@@ -1,0 +1,12 @@
+{{#if (eq count 1)}}
+    {{#tr}}
+        This will delete the <z-profile-field-name></z-profile-field-name> profile field for 1 user.
+        {{#*inline "z-profile-field-name"}}<strong>{{profile_field_name}}</strong>{{/inline}}
+    {{/tr}}
+{{else}}
+    {{#tr}}
+        This will delete the <z-profile-field-name></z-profile-field-name> profile field for <z-count></z-count> users.
+        {{#*inline "z-count"}}{{count}}{{/inline}}
+        {{#*inline "z-profile-field-name"}}<strong>{{profile_field_name}}</strong>{{/inline}}
+    {{/tr}}
+{{/if}}

--- a/static/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
+++ b/static/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
@@ -1,12 +1,28 @@
-{{#if (eq count 1)}}
-    {{#tr}}
-        This will clear the <z-field-name></z-field-name> profile field for 1 user.
-        {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
-    {{/tr}}
-{{else}}
-    {{#tr}}
-        This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
-        {{#*inline "z-count"}}{{count}}{{/inline}}
-        {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
-    {{/tr}}
-{{/if}}
+<p>
+    {{#if (eq count 1)}}
+        {{#tr}}
+            This will clear the <z-field-name></z-field-name> profile field for 1 user.
+            {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+        {{/tr}}
+    {{else}}
+        {{#tr}}
+            This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
+            {{#*inline "z-count"}}{{count}}{{/inline}}
+            {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
+        {{/tr}}
+    {{/if}}
+</p>
+<p>
+    <div>
+        {{#if (eq deleted_options_count 1)}}
+            {{#tr}}Deleted option:{{/tr}}
+        {{else}}
+            {{#tr}}Deleted options:{{/tr}}
+        {{/if}}
+    </div>
+    <ul>
+        {{#each deleted_values}}
+            <li>{{this}}</li>
+        {{/each}}
+    </ul>
+</p>

--- a/static/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
+++ b/static/templates/confirm_dialog/confirm_delete_profile_field_option.hbs
@@ -1,11 +1,11 @@
 {{#if (eq count 1)}}
     {{#tr}}
-        Are you sure you want to delete these options? This will clear the <z-field-name></z-field-name> profile field for 1 user.
+        This will clear the <z-field-name></z-field-name> profile field for 1 user.
         {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
     {{/tr}}
 {{else}}
     {{#tr}}
-        Are you sure you want to delete these options? This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
+        This will clear the <z-field-name></z-field-name> profile field for <z-count></z-count> users.
         {{#*inline "z-count"}}{{count}}{{/inline}}
         {{#*inline "z-field-name"}}<strong>{{field_name}}</strong>{{/inline}}
     {{/tr}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
**Display success status after add/edit fields.**
Display success status "Saved" for consistency in settings UI, after
a successful request of Add or Edit custom profile fields.

**Confirmation modal for delete profile field.**

**Display deleted options in the confirmation modal.**
While editing custom profile fields, when the user delete option(s) of
select the type profile field, display that deleted option(s) in delete
option confirmation modal.


Follow-up: #21878 <!-- Issue link, or clear description.-->
[CZO
](https://chat.zulip.org/#narrow/stream/101-design/topic/Make.20.22Add.20and.20Edit.20custom.20profile.20field.22.20a.20modal.20.2321634/near/1415879)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>

**<summary>Screenshots and screen captures:</summary>**

![success_status](https://user-images.githubusercontent.com/41695888/187473269-089f0fab-424d-437f-84dd-c9ed9dbef1d8.gif)


![delete_profile_field_confirmation_modal](https://user-images.githubusercontent.com/41695888/187472597-fb9e2dfd-5749-4c81-a268-624a90c59247.png)

![0_users](https://user-images.githubusercontent.com/41695888/187472469-41db2945-6879-4949-a1e2-8f826707c53b.png)
![confirmation_modal_delete_option](https://user-images.githubusercontent.com/41695888/187472474-506b0d99-f957-4f49-ad87-ed0a319a5cf5.png)

</details>

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
