### PR TITLE
help-docs: Use `<kbd>` HTML elements for keyboard keys.

### DIFF
--- a/docs/documentation/helpcenter.md
+++ b/docs/documentation/helpcenter.md
@@ -226,18 +226,19 @@ and used liberally.
 
 ### Keyboard shortcuts
 
-Use backticks for each keyboard key in the shortcut (e.g. `Enter` or `R`).
-For shortcuts with more than one key, add a plus sign (+) surrounded by
-spaces in between the keys (e.g. `Ctrl` + `K`, instead of `Ctrl + K` or
-`Ctrl`+`K` or `Ctrl` `K`).
+Surround each keyboard key in the shortcut with `<kbd>` HTML element start and
+end tags (e.g., `<kbd>Enter</kbd>` or `<kbd>R</kbd>`).
+
+For shortcuts with more than one key, add a plus sign (+) surrounded by spaces
+in between the keys (e.g., `<kbd>Ctrl</kbd> + <kbd>K</kbd>`). Any shortcut for
+an arrow key (↑, ↓, ←, →) will also need the `"arrow-key"` CSS class included
+in the `<kbd>` start tag (e.g., ` <kbd class="arrow-key">↑</kbd>`).
 
 Use the labels one sees on the actual keyboard rather than the letter they
 produce when pressed (e.g. `R` and `Shift` + `R` rather than `r` and `R`).
-**Note**: The existing help center documentation is inconsistent about this
-([see this UI redesign issue](https://github.com/zulip/zulip/issues/21753)).
-Therefore, if there are already some keyboard shortcuts in the existing help
-center article, then it is more important to be consistent with those than
-with the global style.
+For symbols, such as `?` or `@`, that are produced through key combinations that
+change depending on the user's keyboard layout, you should use the symbol as it
+appears on a keyboard instead of any specific combination of keys.
 
 Use non-Mac keyboard keys; for example `Enter`, instead of `Return`. Zulip will
 automatically translate non-Mac keys to the Mac versions for users with a Mac
@@ -246,6 +247,13 @@ correctly when writing documentation in Windows or Linux, you can temporarily
 change `has_mac_keyboard` in `/static/js/common.ts` to always return `True`.
 Then when you view your documentation changes in the development environment,
 the keyboard shortcuts should be rendered with Mac keys where appropriate.
+
+If you're adding a tip to an article about a keyboard shortcut, you
+should use the more specific keyboard [tip macro](#tips-and-warnings),
+`!!! keyboard_tip ""`. In general, all keyboard shortcuts should be
+documented on the [keyboard
+shortcuts](https://zulip.com/help/keyboard-shortcuts) help center
+article.
 
 ## Markdown features
 
@@ -378,6 +386,15 @@ users.
     If you've forgotten your password, see the
     [Change your password](/help/change-your-password) page for
     instructions on how to reset it.
+```
+
+A **keyboard tip** is a note for users to let them know that the same action
+can also be accomplished via a [keyboard shortcut](#keyboard-shortcuts).
+
+```md
+!!! keyboard_tip ""
+
+    Use <kbd>D</kbd> to bring up your list of drafts.
 ```
 
 A **warning** is a note on what happens when there is some kind of problem.

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -89,9 +89,7 @@ run_test("adjust_mac_shortcuts non-mac", ({override}) => {
     common.adjust_mac_shortcuts("selector-that-does-not-exist");
 });
 
-// Test non-default value of adjust_mac_shortcuts boolean parameter:
-// `kbd_elem = false`.
-run_test("adjust_mac_shortcuts mac non-defaults", ({override}) => {
+run_test("adjust_mac_shortcuts mac", ({override}) => {
     const keys_to_test_mac = new Map([
         ["Backspace", "Delete"],
         ["Enter", "Return"],
@@ -101,64 +99,8 @@ run_test("adjust_mac_shortcuts mac non-defaults", ({override}) => {
         ["PgDn", "↓"],
         ["Ctrl", "⌘"],
         ["Alt", "⌘"],
-        ["X + Shift", "X + Shift"],
-        ["⌘ + Return", "⌘ + Return"],
-        ["Enter or Backspace", "Enter or Backspace"],
         ["#stream_name", "#stream_name"],
         ["Ctrl+K", "Ctrl+K"],
-    ]);
-
-    const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
-    const inserted_fn_key = "<code>Fn</code> + ";
-
-    override(navigator, "platform", "MacIntel");
-
-    const kbd_element = false;
-
-    const test_items = [];
-    let key_no = 1;
-
-    for (const [old_key, mac_key] of keys_to_test_mac) {
-        const test_item = {};
-        const $stub = $.create("hotkey_" + key_no);
-        $stub.text(old_key);
-        assert.equal($stub.hasClass("arrow-key"), false);
-        if (fn_shortcuts.has(old_key)) {
-            $stub.before = ($elem) => {
-                assert.equal($elem, inserted_fn_key);
-            };
-        }
-        test_item.$stub = $stub;
-        test_item.mac_key = mac_key;
-        test_item.adds_arrow_key = fn_shortcuts.has(old_key) && kbd_element;
-        test_items.push(test_item);
-        key_no += 1;
-    }
-
-    const children = test_items.map((test_item) => ({to_$: () => test_item.$stub}));
-
-    $.create(".markdown_content", {children});
-
-    common.adjust_mac_shortcuts(".markdown_content", kbd_element);
-
-    for (const test_item of test_items) {
-        assert.equal(test_item.$stub.text(), test_item.mac_key);
-        assert.equal(test_item.$stub.hasClass("arrow-key"), test_item.adds_arrow_key);
-    }
-});
-
-// Test default value of adjust_mac_shortcuts boolean parameter:
-// `kbd_elem = true`.
-run_test("adjust_mac_shortcuts mac defaults", ({override}) => {
-    const keys_to_test_mac = new Map([
-        ["Backspace", "Delete"],
-        ["Enter", "Return"],
-        ["Home", "←"],
-        ["End", "→"],
-        ["PgUp", "↑"],
-        ["PgDn", "↓"],
-        ["Ctrl", "⌘"],
-        ["Alt", "⌘"],
         ["[", "["],
         ["X", "X"],
     ]);
@@ -168,8 +110,6 @@ run_test("adjust_mac_shortcuts mac defaults", ({override}) => {
 
     override(navigator, "platform", "MacIntel");
 
-    const kbd_element = true;
-
     const test_items = [];
     let key_no = 1;
 
@@ -185,16 +125,16 @@ run_test("adjust_mac_shortcuts mac defaults", ({override}) => {
         }
         test_item.$stub = $stub;
         test_item.mac_key = mac_key;
-        test_item.adds_arrow_key = fn_shortcuts.has(old_key) && kbd_element;
+        test_item.adds_arrow_key = fn_shortcuts.has(old_key);
         test_items.push(test_item);
         key_no += 1;
     }
 
     const children = test_items.map((test_item) => ({to_$: () => test_item.$stub}));
 
-    $.create(".hotkeys_table kbd", {children});
+    $.create(".markdown kbd", {children});
 
-    common.adjust_mac_shortcuts(".hotkeys_table kbd");
+    common.adjust_mac_shortcuts(".markdown kbd");
 
     for (const test_item of test_items) {
         assert.equal(test_item.$stub.text(), test_item.mac_key);

--- a/static/js/common.ts
+++ b/static/js/common.ts
@@ -48,7 +48,7 @@ export function has_mac_keyboard(): boolean {
     return /mac/i.test(navigator.platform);
 }
 
-export function adjust_mac_shortcuts(key_elem_class: string, kbd_elem = true): void {
+export function adjust_mac_shortcuts(kbd_elem_class: string): void {
     if (!has_mac_keyboard()) {
         return;
     }
@@ -66,25 +66,12 @@ export function adjust_mac_shortcuts(key_elem_class: string, kbd_elem = true): v
 
     const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
 
-    $(key_elem_class).each(function () {
+    $(kbd_elem_class).each(function () {
         let key_text = $(this).text();
 
-        // There may be matches to `key_elem_class` that are not
-        // keyboard shortcuts. Since keyboard shortcuts should be an
-        // exact match to the text on a physical key of a keyboard,
-        // none of which have spaces, we check and return early for
-        // any matched element's text that contains whitespace.
-        if (/\s/.test(key_text)) {
-            return;
-        }
-
         if (fn_shortcuts.has(key_text)) {
-            if (kbd_elem) {
-                $(this).before("<kbd>Fn</kbd> + ");
-                $(this).addClass("arrow-key");
-            } else {
-                $(this).before("<code>Fn</code> + ");
-            }
+            $(this).before("<kbd>Fn</kbd> + ");
+            $(this).addClass("arrow-key");
         }
 
         const replace_key = keys_map.get(key_text);

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -58,7 +58,7 @@ function render_code_sections() {
 
     highlight_current_article();
 
-    common.adjust_mac_shortcuts(".markdown .content code", false);
+    common.adjust_mac_shortcuts(".markdown kbd");
 
     $("table").each(function () {
         $(this).addClass("table table-striped");

--- a/static/styles/portico/markdown.css
+++ b/static/styles/portico/markdown.css
@@ -327,6 +327,30 @@
         }
     }
 
+    kbd {
+        /* Same as kbd in app_components.css */
+        display: inline-block;
+        border: 1px solid hsl(0, 0%, 80%);
+        border-radius: 4px;
+        font-weight: 600;
+        white-space: nowrap;
+        background-color: hsl(0, 0%, 98%);
+        color: hsl(0, 0%, 20%);
+        text-shadow: 0 1px 0 hsl(0, 0%, 100%);
+        /* Different from app_components.css */
+        /* Removed margin setting */
+        font-size: 0.85em;
+        padding: 0 0.4em;
+
+        &.arrow-key {
+            /* Same as in informational_overlays.css */
+            line-height: 1;
+            padding: 0 0.2em 0.2em;
+            /* Different from informational_overlays.css */
+            font-size: 1.2em;
+        }
+    }
+
     code {
         /* Copied from rendered_markdown.css */
         font-size: 0.825em;

--- a/templates/zerver/help/configure-default-view.md
+++ b/templates/zerver/help/configure-default-view.md
@@ -11,8 +11,9 @@ The default views available in Zulip are
 on how to use these views.
 
 You can configure which view is set as your default, and whether
-the `Esc` key navigates to the default view. Also, you can always reach
-the default view by using the `Ctrl` + `[` shortcut.
+the <kbd>Esc</kbd> key navigates to the default view. Also, you can
+always reach the default view by using the <kbd>Ctrl</kbd> + <kbd>[</kbd>
+shortcut.
 
 ## Change default view
 
@@ -30,39 +31,41 @@ organization settings:
 
 {settings_tab|display-settings}
 
-2. Under **Advanced**, click on the **Default view** dropdown
-and select a view.
+1. Under **Advanced**, click on the **Default view** dropdown
+   and select a view.
 
 1. To see your changes in action, open a new Zulip tab, or use a keyboard
-shortcut twice to exit the settings and navigate to your default view
-(`Ctrl` + `[` or `Esc` if enabled).
+   shortcut twice to exit the settings and navigate to your default view
+   (<kbd>Ctrl</kbd> + <kbd>[</kbd> or <kbd>Esc</kbd> if enabled).
 
 [configure-esc]: /help/configure-default-view#set-whether-esc-navigates-to-the-default-view
 
 {end_tabs}
 
-## Set whether `Esc` navigates to the default view
+## Set whether <kbd>Esc</kbd> navigates to the default view
 
 Zulip has a number of [keyboard shortcuts](/help/keyboard-shortcuts)
 designed to enhance the user experience in the app.
 
-By default, the `Esc` key shortcut will ultimately navigate to your
-default view. You can disable this key binding if you would prefer.
-This will not disable other `Esc` key shortcuts used in Zulip,
-and will not affect the behavior of the `Ctrl` + `[` shortcut.
+By default, the <kbd>Esc</kbd> key shortcut will ultimately navigate to
+your default view. You can disable this key binding if you would prefer.
+This will not disable other <kbd>Esc</kbd> key shortcuts used in Zulip,
+and will not affect the behavior of the <kbd>Ctrl</kbd> + <kbd>[</kbd>
+shortcut.
 
-### Toggle whether `Esc` navigates to the default view
+### Toggle whether <kbd>Esc</kbd> navigates to the default view
 
 {start_tabs}
 
 {settings_tab|display-settings}
 
 1. Under **Advanced**, toggle **Escape key navigates to
-default view**, as desired.
+   default view**, as desired.
 
 {end_tabs}
 
 ## Related articles
+
 * [Reading strategies](/help/reading-strategies)
 * [Recent topics](/help/recent-topics)
 * [Keyboard shortcuts](/help/keyboard-shortcuts)

--- a/templates/zerver/help/enable-enter-to-send.md
+++ b/templates/zerver/help/enable-enter-to-send.md
@@ -1,26 +1,26 @@
-# Enable `Enter` to send
+# Enable Enter to send
 
-By default, the `Enter` key adds a new line to a message,
-and `Ctrl` + `Enter` sends the message.
+By default, the <kbd>Enter</kbd> key adds a new line to a message,
+and <kbd>Ctrl</kbd> + <kbd>Enter</kbd> sends the message.
 
 This is convenient for typing multi-line messages, which are more common in
 Zulip than in most other chat products. However, you can also configure
-Zulip so that `Enter` sends the message.
+Zulip so that <kbd>Enter</kbd> sends the message.
 
-## Enable `Enter` to send
+## Enable <kbd>Enter</kbd> to send
 
 {start_tabs}
 
 {!start-composing.md!}
 
-1. Select **`Ctrl` + `Enter` to send** below the **Send** button in
-   the compose box.
+1. Click **<kbd>Ctrl</kbd> + <kbd>Enter</kbd> to send** in the bottom right
+   corner of the compose box, just below the **Send** button.
 
-1. Toggle your preferred option.
+1. Select **<kbd>Enter</kbd> to send**.
 
 {end_tabs}
 
 !!! tip ""
 
-    `Shift` + `Enter` always adds a new line, regardless of whether
-    **`Enter` to send** is enabled.
+    <kbd>Shift</kbd> + <kbd>Enter</kbd> always adds a new line, regardless
+    of whether **<kbd>Enter</kbd> to send** is enabled.

--- a/templates/zerver/help/include/compose-and-send-message.md
+++ b/templates/zerver/help/include/compose-and-send-message.md
@@ -1,4 +1,6 @@
-1. Press `Tab` or click on the compose box to compose your message.
+1. Press <kbd>Tab</kbd> or click on the compose box to compose your
+   message.
 
-1. Click **Send**, or use `Enter` or `Ctrl` + `Enter` (depending on whether
-  the [**Press Enter to send** option](/help/enable-enter-to-send) is checked).
+1. Click **Send**, or use <kbd>Enter</kbd> or <kbd>Ctrl</kbd> +
+   <kbd>Enter</kbd> (depending on your settings. See
+  [enable enter to send](https://zulip.com/help/enable-enter-to-send)).

--- a/templates/zerver/help/include/how-to-start-a-new-topic.md
+++ b/templates/zerver/help/include/how-to-start-a-new-topic.md
@@ -1,19 +1,24 @@
 {start_tabs}
-{tab|stream}
-1. Click the **New topic** button at the bottom of the Zulip window, or type `c`.
 
-2. Enter a topic name. Auto-complete will provide suggestions for previously
+{tab|stream}
+
+1. Click the **New topic** button at the bottom of the Zulip window,
+   or type <kbd>C</kbd>.
+
+1. Enter a topic name. Auto-complete will provide suggestions for previously
    used topics.
 
 {!compose-and-send-message.md!}
 
 {tab|not-stream}
-1. Click the **New topic** button at the bottom of the Zulip window, or type `c`.
 
-2. Enter a stream name. Auto-complete will provide suggestions for streams you
+1. Click the **New topic** button at the bottom of the Zulip window, or
+   type <kbd>C</kbd>.
+
+1. Enter a stream name. Auto-complete will provide suggestions for streams you
    can send to.
 
-2. Enter a topic name. Auto-complete will provide suggestions for previously
+1. Enter a topic name. Auto-complete will provide suggestions for previously
    used topics.
 
 {!compose-and-send-message.md!}
@@ -21,6 +26,7 @@
 {end_tabs}
 
 !!! warn ""
+
     In Zulip, you can compose a message to a different place than the one you
     are viewing. In this situation, the message feed will fade to indicate
     what's going on.

--- a/templates/zerver/help/include/reading-pms.md
+++ b/templates/zerver/help/include/reading-pms.md
@@ -1,17 +1,20 @@
 {start_tabs}
+
 1. Click on **Private messages** in the left sidebar.
 
-2. Click on a conversation in the left sidebar under **Private messages**.
+1. Click on a conversation in the left sidebar under **Private messages**.
 
-3. Read the conversation, scrolling down with the mouse or by pressing `PgDn`.
+1. Read the conversation, scrolling down with the mouse or by pressing
+   <kbd>PgDn</kbd>.
 
-4. If the conversation is not of interest, you can
-   [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
-   to the end using the `End` key.
+1. If the conversation is not of interest, you can
+   [mark all messages as read](/help/marking-messages-as-read) or do so
+   by jumping to the end using the <kbd>End</kbd> key.
 
-5. Click on the next conversation in the left sidebar, or use the `p` key to go to the
-   next unread conversation.
+1. Click on the next conversation in the left sidebar, or use the
+   <kbd>P</kbd> key to go to the next unread conversation.
 
-6. To go to older unread conversations, use the `p` key or scroll down in the
-   **Private messages** section of the left sidebar to view.
+1. To go to older unread conversations, use the <kbd>P</kbd> key or scroll
+   down in the **Private messages** section of the left sidebar to view.
+
 {end_tabs}

--- a/templates/zerver/help/include/reading-topics.md
+++ b/templates/zerver/help/include/reading-topics.md
@@ -2,35 +2,40 @@
 
 {tab|via-recent-topics}
 
-1. Open **Recent topics** from the left sidebar or by pressing the `Esc` key.
+1. Open **Recent topics** from the left sidebar or by pressing the
+   <kbd>Esc</kbd> key.
 
 1. Click on the name of a topic in the **Topic** column.
 
-1. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
+1. Read the topic, scrolling down with the mouse or by pressing
+   <kbd>PgDn</kbd>.
 
 1. If the topic is not of interest, you can
-   [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
-   to the end using the `End` key.
+   [mark all messages as read](/help/marking-messages-as-read) or
+   do so by jumping to the end using the <kbd>End</kbd> key.
 
-1. You can then click on another topic in the left sidebar, use the `n` key to go to the
-   next unread topic, or go back to the **Recent topics** view.
+1. You can then click on another topic in the left sidebar, use the
+   <kbd>N</kbd> key to go to the next unread topic, or go back to the
+   **Recent topics** view.
 
 {tab|via-left-sidebar}
 
-1. Click on the name of a stream in the left sidebar. You will see a list of the
-   most recent unread topics in that stream.
+1. Click on the name of a stream in the left sidebar. You will see a
+   list of the most recent unread topics in that stream.
 
 1. Click on a topic in the left sidebar.
 
-1. Read the topic, scrolling down with the mouse or by pressing `PgDn`.
+1. Read the topic, scrolling down with the mouse or by pressing
+   <kbd>PgDn</kbd>.
 
 1. If the topic is not of interest, you can
-   [mark all messages as read](/help/marking-messages-as-read) or do so by jumping
-   to the end using the `End` key.
+   [mark all messages as read](/help/marking-messages-as-read) or do
+   so by jumping to the end using the <kbd>End</kbd> key.
 
-1. Click on the next topic in the left sidebar, or use the `n` key to go to the
-   next unread topic.
+1. Click on the next topic in the left sidebar, or use the <kbd>N</kbd>
+   key to go to the next unread topic.
 
-1. To go to older unread topics, use the `n` key or click **more topics** to view.
+1. To go to older unread topics, use the <kbd>N</kbd> key or click
+   **more topics** to view.
 
 {end_tabs}

--- a/templates/zerver/help/include/recent-topics.md
+++ b/templates/zerver/help/include/recent-topics.md
@@ -4,10 +4,11 @@ messages sent while you were away.
 
 {start_tabs}
 
-1. Open **Recent topics** from the left sidebar or by pressing the `Esc` key.
+1. Open **Recent topics** from the left sidebar or by pressing the
+   <kbd>Esc</kbd> key.
 
-1. The filters at the top help you quickly find relevant
-   conversations. For example, select **Participated** to narrow to
-   the topics you have sent messages to.
+1. The filters at the top help you quickly find relevant conversations.
+   For example, select **Participated** to narrow to the topics you
+   have sent messages to.
 
 {end_tabs}

--- a/templates/zerver/help/include/replying-to-messages.md
+++ b/templates/zerver/help/include/replying-to-messages.md
@@ -1,11 +1,12 @@
 To reply to an existing thread:
 
 {start_tabs}
+
 1. Click the **Message...** button at the bottom of the Zulip window.
 
 {!compose-and-send-message.md!}
 
 {end_tabs}
 
-You can also reply by clicking on a message, or using `r` or `Enter` to reply
-to the message in the blue box.
+You can also reply by clicking on a message, or using <kbd>R</kbd> or
+<kbd>Enter</kbd> to reply to the message in the blue box.

--- a/templates/zerver/help/include/set-up-your-account.md
+++ b/templates/zerver/help/include/set-up-your-account.md
@@ -1,18 +1,24 @@
 !!! tip ""
+
     If this is your first time using Zulip, we recommend starting with the web
     or desktop experience to set up your account and get oriented.
 
 - Get the [mobile and desktop apps](/apps). Zulip also works great in a browser.
+
 - [Add a profile picture](/help/change-your-profile-picture) and
   [edit your profile information](https://zulip.com/help/edit-your-profile) to tell others
   about yourself.
+
 - [Review your display settings](/help/review-your-settings#review-your-display-settings).
   You can [switch between light and dark theme](/help/dark-theme),
   [pick your favorite emoji theme](/help/emoji-and-emoticons#change-your-emoji-set),
   [change your language](/help/change-your-language), and make other tweaks to your Zulip experience.
+
 - [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams).
-- Decide whether you [want `Enter` to send your message](/help/enable-enter-to-send)
-  or add a new line.
+
+- Decide whether you want <kbd>Enter</kbd> [to send your message
+  or add a new line](/help/enable-enter-to-send).
+
 - [Configure your notifications](/#settings/notifications) to work the way
   you do. If you're joining a low traffic organization and aren't using the
   desktop app, consider sending all messages to email.

--- a/templates/zerver/help/include/starting-a-new-private-thread.md
+++ b/templates/zerver/help/include/starting-a-new-private-thread.md
@@ -1,8 +1,9 @@
 {start_tabs}
-1. Click the **New private message** button at the bottom of the Zulip window,
-   or type `x`.
 
-2. Type the names of one or more recipients. Auto-complete will provide
+1. Click the **New private message** button at the bottom of the Zulip
+   window, or type <kbd>X</kbd>.
+
+1. Type the names of one or more recipients. Auto-complete will provide
    suggestions for users you can message.
 
 {!compose-and-send-message.md!}
@@ -10,5 +11,6 @@
 {end_tabs}
 
 !!! tip ""
-    Rather than kicking off a group thread, consider starting the conversation in
-    a new topic to make it easier to browse later on.
+
+    Rather than kicking off a group thread, consider starting the
+    conversation in a new topic to make it easier to browse later on.

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -15,186 +15,203 @@ below, and add more to your repertoire as needed.
 
 ## The basics
 
-* **Reply to message**: `r` or `Enter` — Reply to the selected
-  message (outlined in blue).
+* **Reply to message**: <kbd>R</kbd> or <kbd>Enter</kbd> — Reply to the
+  selected message (outlined in blue).
 
-* **New stream message**: `c` — Start a new topic in the current stream.
+* **New stream message**: <kbd>C</kbd> — Start a new topic in the current
+  stream.
 
-* **New private message**: `x`
+* **New private message**: <kbd>X</kbd>
 
-* **Cancel compose and save draft**: `Esc` or `Ctrl` + `[` — Close the compose box and save
-  the unsent message as a draft.
+* **Cancel compose and save draft**: <kbd>Esc</kbd> or <kbd>Ctrl</kbd> +
+  <kbd>[</kbd> — Close the compose box and save the unsent message as a
+  draft.
 
-* **View drafts**: `d` — Use the arrow keys and `Enter` to restore a draft.
-  Press `d` again to close.
+* **View drafts**: <kbd>D</kbd> — Use the arrow keys and <kbd>Enter</kbd>
+  to restore a draft. Press <kbd>D</kbd> again to close.
 
-* **Next message**: `↓` or `j`
+* **Next message**: <kbd class="arrow-key">↓</kbd> or <kbd>J</kbd>
 
-* **Last message**: `End` or `G` — Also marks all messages in
-  the current view as read.
+* **Last message**: <kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd> —
+  Also marks all messages in the current view as read.
 
-* **Next unread topic**: `n`
+* **Next unread topic**: <kbd>N</kbd>
 
-* **Next unread private message**: `p`
+* **Next unread private message**: <kbd>P</kbd>
 
-* **Search messages**: `/`
+* **Search messages**: <kbd>/</kbd>
 
-* **Toggle keyboard shortcuts view**: `?`
+* **Toggle keyboard shortcuts view**: <kbd>?</kbd>
 
-* **Go to default view**: `Ctrl` + `[` (or `Esc`,
-  [if enabled][disable-escape])
+* **Go to default view**: <kbd>Ctrl</kbd> + <kbd>[</kbd> (or
+  <kbd>Esc</kbd>, [if enabled][disable-escape])
   until you are in the [default view](/help/configure-default-view).
 
 [disable-escape]: /help/configure-default-view#set-whether-esc-navigates-to-the-default-view
 ## Navigation
 
-* **Search messages**: `/` or `Ctrl` + `k`
+* **Search messages**: <kbd>/</kbd> or <kbd>Ctrl</kbd> + <kbd>K</kbd>
 
-* **Filter streams**: `q`
+* **Filter streams**: <kbd>Q</kbd>
 
-* **Search people**: `w`
+* **Search people**: <kbd>W</kbd>
 
-* **Last message**: `End` or `G` — Also marks all messages in
-  the current view as read.
+* **Last message**: <kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd> —
+  Also marks all messages in the current view as read.
 
-* **First message**: `Home`
+* **First message**: <kbd>Home</kbd>
 
-* **Previous message**: `↑` or `k`
+* **Previous message**: <kbd class="arrow-key">↑</kbd> or <kbd>K</kbd>
 
-* **Next message**: `↓` or `j`
+* **Next message**: <kbd class="arrow-key">↓</kbd> or <kbd>J</kbd>
 
-* **Scroll up**: `PgUp` or `K`
+* **Scroll up**: <kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd>
 
-* **Scroll down**: `PgDn`, `J`, or `Spacebar`
+* **Scroll down**: <kbd>PgDn</kbd>, <kbd>Shift</kbd> + <kbd>J</kbd>, or
+  <kbd>Spacebar</kbd>
 
-* **Go back through viewing history**: `Alt` + `←`
+* **Go back through viewing history**: <kbd>Alt</kbd> +
+  <kbd class="arrow-key">←</kbd>
 
-* **Go forward through viewing history**: `Alt` + `→`
+* **Go forward through viewing history**: <kbd>Alt</kbd> +
+  <kbd class="arrow-key">→</kbd>
 
 ## Narrowing
 
-* **Narrow to next unread topic**: `n`
+* **Narrow to next unread topic**: <kbd>N</kbd>
 
-* **Narrow to next unread private message**: `p`
+* **Narrow to next unread private message**: <kbd>P</kbd>
 
-* **Narrow to stream**: `s`
+* **Narrow to stream**: <kbd>S</kbd>
 
-* **Narrow to topic or PM conversation**: `S`
+* **Narrow to topic or PM conversation**: <kbd>Shift</kbd> + <kbd>S</kbd>
 
-* **Narrow to all private messages**: `P`
+* **Narrow to all private messages**: <kbd>Shift</kbd> + <kbd>P</kbd>
 
-* **Cycle between stream narrows**: `A` (previous) and `D` (next)
+* **Cycle between stream narrows**: <kbd>Shift</kbd> + <kbd>A</kbd>
+  (previous) and <kbd>Shift</kbd> + <kbd>D</kbd> (next)
 
-* **Narrow to all messages**: `a` — Shows all unmuted messages.
+* **Narrow to all messages**: <kbd>A</kbd> — Shows all unmuted messages.
 
-* **Narrow to current compose box recipient**: `Ctrl` + `.`
+* **Narrow to current compose box recipient**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
 
 ## Composing messages
 
-* **Reply to message**: `r` or `Enter` — Reply to the selected
-  message (outlined in blue). Same behavior as clicking on the message.
+* **Reply to message**: <kbd>R</kbd> or <kbd>Enter</kbd> — Reply to the
+  selected message (outlined in blue). Same behavior as clicking on the
+  message.
 
-* **Reply to message, mentioning author**: `@`
+* **Reply to message, mentioning author**: <kbd>@</kbd>
 
-* **Reply only to author**: `R`
+* **Reply only to author**: <kbd>Shift</kbd> + <kbd>R</kbd>
 
-* **Quote and reply to message**: `>`
+* **Quote and reply to message**: <kbd>></kbd>
 
-* **New stream message**: `c` — For starting a new topic in a stream.
+* **New stream message**: <kbd>C</kbd> — For starting a new topic in a
+  stream.
 
-* **New private message**: `x`
+* **New private message**: <kbd>X</kbd>
 
 ### In the compose box
 
-* **Send message**: `Enter`, `Tab` then `Enter`, and/or `Ctrl` + `Enter`,
+* **Send message**: <kbd>Enter</kbd>, <kbd>Tab</kbd> then <kbd>Enter</kbd>,
+  and/or <kbd>Ctrl</kbd> + <kbd>Enter</kbd>, depending on your settings. See
+  [enable enter to send](https://zulip.com/help/enable-enter-to-send).
+
+* **Insert new line**: <kbd>Enter</kbd>, or <kbd>Shift</kbd> + <kbd>Enter</kbd>,
   depending on your settings. See
   [enable enter to send](https://zulip.com/help/enable-enter-to-send).
 
-* **Insert new line**: `Enter`, or `Shift` + `Enter`, depending on your
-  settings. See
-  [enable enter to send](https://zulip.com/help/enable-enter-to-send).
+* **Insert italic text**: `*italic*` or <kbd>Ctrl</kbd> + <kbd>I</kbd>
 
-* **Insert italic text**: `*italic*` or `Ctrl` + `I`
-* **Insert bold text**: `**bold**` or `Ctrl` + `B`
-* **Insert link**: `[Zulip website](https://zulip.org)` or `Ctrl` + `Shift` + `L`
+* **Insert bold text**: `**bold**` or <kbd>Ctrl</kbd> + <kbd>B</kbd>
 
-* **Cancel compose and save draft**: `Esc` or `Ctrl` + `[` — Close the compose box and save
-  the unsent message as a draft.
+* **Insert link**: `[Zulip website](https://zulip.org)` or <kbd>Ctrl</kbd> +
+  <kbd>Shift</kbd> + <kbd>L</kbd>
+
+* **Cancel compose and save draft**: <kbd>Esc</kbd> or <kbd>Ctrl</kbd> +
+  <kbd>[</kbd> — Close the compose box and save the unsent message as a draft.
 
 ## Message actions
 
-* **Edit last message**: `←` — Open the last editable message in the current
-  view (if any).
+* **Edit last message**: <kbd class="arrow-key">←</kbd> — Open the last
+  editable message in the current view (if any).
 
 ### For a selected message (outlined in blue)
 
-* **Show sender's profile**: `u`
+* **Show sender's profile**: <kbd>U</kbd>
 
-* **View image**: `v`
+* **View image**: <kbd>V</kbd>
 
-* **Edit message**: `e`
+* **Edit message**: <kbd>E</kbd>
 
-* **Star message**: `Ctrl` + `s`
+* **Star message**: <kbd>Ctrl</kbd> + <kbd>S</kbd>
 
 * **React with <img alt=":thumbs_up:" class="emoji"
-src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
-title="thumbs up"/>**: `+`
+  src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
+  title="thumbs up"/>**: <kbd>+</kbd>
 
-* **Collapse/show message**: `-`
+* **Collapse/show message**: <kbd>-</kbd>
 
-* **Toggle topic mute**: `M` — Muted topics don't show up in any views
-  (including All messages), and don't contribute to unread counts. Read more about
-  [muting topics](/help/mute-a-topic).
+* **Toggle topic mute**: <kbd>Shift</kbd> + <kbd>M</kbd> — Muted topics
+  don't show up in any views (including All messages), and don't contribute
+  to unread counts. Read more about [muting topics](/help/mute-a-topic).
 
 ## Recent topics
 
-* **View recent topics**: `t`
-* **Search recent topics**: `t`
-* **Escape from recent topics search**: `Esc` or arrow keys
-* **Navigate recent topics**: Use arrow keys or vim keys (`j`, `k`, `l`, `h`).
+* **View recent topics**: <kbd>T</kbd>
 
-Use `Enter` to engage with elements.
+* **Search recent topics**: <kbd>T</kbd>
+
+* **Escape from recent topics search**: <kbd>Esc</kbd> or arrow keys
+
+* **Navigate recent topics**: Use arrow keys or vim keys (<kbd>J</kbd>,
+  <kbd>K</kbd>, <kbd>L</kbd>, <kbd>H</kbd>).
+
+Use <kbd>Enter</kbd> to engage with elements.
 
 ## Drafts
 
-* **Toggle drafts view**: `d`
+* **Toggle drafts view**: <kbd>D</kbd>
 
 ### Within the drafts view
 
-* **Edit selected draft**: `Enter`
+* **Edit selected draft**: <kbd>Enter</kbd>
 
-* **Delete selected draft**: `Backspace`
+* **Delete selected draft**: <kbd>Backspace</kbd>
 
 Keyboard navigation (e.g. arrow keys) works as expected.
 
 ## Menus
 
-* **Toggle shortcuts help**: `?`
+* **Toggle shortcuts help**: <kbd>?</kbd>
 
-* **Toggle gear menu**: `g`
+* **Toggle gear menu**: <kbd>G</kbd>
 
 ### For a selected message (outlined in blue)
 
-* **Toggle emoji reactions menu**: `:`
+* **Toggle emoji reactions menu**: <kbd>:</kbd>
 
-* **Toggle message actions menu**: `i`
+* **Toggle message actions menu**: <kbd>I</kbd>
 
 ## Streams settings page
 
-* **Scroll through streams**: `↑` and `↓`
+* **Scroll through streams**: <kbd class="arrow-key">↑</kbd> and
+  <kbd class="arrow-key">↓</kbd>
 
     !!! tip ""
 
-        Pressing `↑` from the first stream in the list moves
-        you to the **Filter streams** input.
+        Pressing <kbd class="arrow-key">↑</kbd> from the first stream
+        in the list moves you to the **Filter streams** input.
 
-* **Switch between tabs**: `←` and `→` — Switch between the
-**Subscribed** and **All streams** tabs.
+* **Switch between tabs**: <kbd class="arrow-key">←</kbd> and
+  <kbd class="arrow-key">→</kbd> — Switch between the **Subscribed**
+  and **All streams** tabs.
 
-* **Create new stream**: `n`
+* **Create new stream**: <kbd>N</kbd>
 
 ### For a selected stream
 
-* **View stream messages**: `V`
+* **View stream messages**: <kbd>Shift</kbd> + <kbd>V</kbd>
 
-* **Toggle subscription**: `S`
+* **Toggle subscription**: <kbd>Shift</kbd> + <kbd>S</kbd>

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -14,13 +14,13 @@ The easiest way to link to a stream or topic is:
 
 1. Type `#` followed by the one or more letters of the stream name.
 
-2. Choose the desired stream from the auto-complete menu. The link will be
+1. Choose the desired stream from the auto-complete menu. The link will be
    automatically formatted for you.
 
-3. If linking to a topic, type `>` after selecting a stream as described above,
-   followed by one or more letters of the topic name.
+1. If linking to a topic, type `>` after selecting a stream as
+   described above, followed by one or more letters of the topic name.
 
-4. Choose the desired topic from the auto-complete menu. The link will be
+1. Choose the desired topic from the auto-complete menu. The link will be
    automatically formatted for you.
 
 {end_tabs}
@@ -90,6 +90,7 @@ message](/help/quote-and-reply).
 {!topic-long-press-menu-tip.md!}
 
 {end_tabs}
+
 ### Get a link to a specific stream
 
 {start_tabs}

--- a/templates/zerver/help/marking-messages-as-read.md
+++ b/templates/zerver/help/marking-messages-as-read.md
@@ -12,17 +12,18 @@ There are two situations in which messages automatically get marked as read.
 * **Blue box**: Messages are marked as read when the blue box passes over
   them.
 
-You can move the blue box either with the keyboard (arrow keys, `End`, etc.)
-or by scrolling the feed with your mouse.
+You can move the blue box either with the keyboard (arrow keys, <kbd>End</kbd>,
+etc.) or by scrolling the feed with your mouse.
 
 You can also manually **mark all messages as read**, or **mark all messages in a
 stream or topic as read**.
 
 {start_tabs}
 
-1. Hover over a stream, topic, or All messages in the left sidebar.
+1. Hover over a stream, topic, or **All messages** in the left sidebar.
 
-1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) to the right.
+1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+   to the right.
 
 1. Click **Mark all messages as read**.
 

--- a/templates/zerver/help/mastering-the-compose-box.md
+++ b/templates/zerver/help/mastering-the-compose-box.md
@@ -14,8 +14,8 @@ To narrow the view to the conversation you're currently composing to,
 click on the **Go to conversation** (<i class="zulip-icon
    zulip-icon-arrow-left-circle"></i>) button in the compose box.
 
-You can also use the keyboard shortcut `Ctrl` + `.` to go to the conversation to
-which you are composing.
+You can also use the keyboard shortcut <kbd>Ctrl</kbd> + <kbd>.</kbd>
+to go to the conversation to which you are composing.
 
 While the button is only shown when composing to a stream, the keyboard shortcut
 will work in both stream messages and private messages.

--- a/templates/zerver/help/open-the-compose-box.md
+++ b/templates/zerver/help/open-the-compose-box.md
@@ -14,20 +14,22 @@ space for the message feed. There are a number of ways to open the compose box.
 
 All replies are to the message in the **blue box**.
 
-* **Reply**: `r` or `Enter`
+* **Reply**: <kbd>R</kbd> or <kbd>Enter</kbd>
 
-* **New topic**: `c`
+* **New topic**: <kbd>C</kbd>
 
-* **New private message**: `x`
+* **New private message**: <kbd>X</kbd>
 
-You can move the blue box around using the **arrow keys**, `j`, or `k`. You
-can close the compose box using `Esc`, or up/down arrow if the box is empty.
+You can move the blue box around using the **arrow keys**, <kbd>J</kbd>, or
+<kbd>K</kbd>. You can close the compose box using <kbd>Esc</kbd>, or up/down
+arrow if the box is empty.
 
 !!! tip ""
-    Zulip offers handy
-    one-character [keyboard shortcuts](/help/keyboard-shortcuts) for
+
+    Zulip offers handy one-character
+    [keyboard shortcuts](/help/keyboard-shortcuts) for
     [reading messages](/help/reading-strategies). With the compose
-    box closed, there is no need to use the `Ctrl` key all the time.
+    box closed, there is no need to use the <kbd>Ctrl</kbd> key all the time.
 
 ## Related articles
 

--- a/templates/zerver/help/private-messages.md
+++ b/templates/zerver/help/private-messages.md
@@ -13,21 +13,21 @@ Note that group PMs are not the same as [user groups](/help/user-groups) or
 private streams. PMs and group PMs do not have [topics](/help/streams-and-topics)
 and do not appear in your list of streams.
 
-### Send a PM
+## Send a PM
 
 {start_tabs}
 
 {tab|desktop-web}
 
 1. Click the **New private message** button at the bottom of the app, or
-use the `x` keyboard shortcut.
+   use the <kbd>X</kbd> keyboard shortcut.
 
 1. Start typing the name of the person you want to message, and
-select their name from the list of suggestions.
+   select their name from the list of suggestions.
 
 1. Compose your message, and click **Send**.
 
-!!! Tip ""
+!!! tip ""
 
     You can also click on any user in the right sidebar, or click on a
     user's profile picture or name, and select **Send private message**.
@@ -35,73 +35,76 @@ select their name from the list of suggestions.
 {tab|mobile}
 
 1. Tap the private messages
-( <img src="/static/images/help/mobile-pm-tab-icon.svg" alt="private messages" class="mobile-icon"/> )
-tab at the bottom of the app.
+   ( <img src="/static/images/help/mobile-pm-tab-icon.svg" alt="private messages" class="mobile-icon"/> )
+   tab at the bottom of the app.
 
 1. Tap the **New PM** button at the top of the app.
 
 1. Start typing the name of the person you want to message, and
-select their name from the list of suggestions.
+   select their name from the list of suggestions.
 
 1. Compose your message, and tap the send
-(<img src="/static/images/help/mobile-send-circle-icon.svg" alt="send" class="mobile-icon"/>)
-button in the bottom right corner of the app.
+   (<img src="/static/images/help/mobile-send-circle-icon.svg" alt="send" class="mobile-icon"/>)
+   button in the bottom right corner of the app.
 
-!!! Tip ""
+!!! tip ""
 
     You can also tap on a user's profile picture or name, and tap the
     **Send private message** button at the bottom of the app.
 
 {end_tabs}
 
-### Send a group PM
+## Send a group PM
 
 {start_tabs}
 
 {tab|desktop-web}
 
 1. Click the **New private message** button at the bottom of the app, or
-use the `x` keyboard shortcut.
+   use the <kbd>X</kbd> keyboard shortcut.
 
 1. Start typing the name of the person you want to message, and
-select their name from the list of suggestions. You can continue
-adding as many message recipients as you like.
+   select their name from the list of suggestions. You can continue
+   adding as many message recipients as you like.
 
 1. Compose your message, and click **Send**.
 
 {tab|mobile}
 
 1. Tap the private messages
-( <img src="/static/images/help/mobile-pm-tab-icon.svg" alt="private messages" class="mobile-icon"/> )
-tab at the bottom of the app.
+   ( <img src="/static/images/help/mobile-pm-tab-icon.svg" alt="private messages" class="mobile-icon"/> )
+   tab at the bottom of the app.
 
 1. Tap the **New group PM** button at the top of the app.
 
 1. Start typing the name of the person you want to message, and
-select their name from the list of suggestions. You can continue
-adding as many message recipients as you like.
+   select their name from the list of suggestions. You can continue
+   adding as many message recipients as you like.
 
 1. Approve by tapping the checkmark
-(<img src="/static/images/help/mobile-check-circle-icon.svg" alt="checkmark" class="mobile-icon"/>)
-button in the bottom right corner of the app.
+   (<img src="/static/images/help/mobile-check-circle-icon.svg" alt="checkmark" class="mobile-icon"/>)
+   button in the bottom right corner of the app.
 
 1. Compose your message, and tap the send
-(<img src="/static/images/help/mobile-send-circle-icon.svg" alt="send" class="mobile-icon"/>)
-button in the bottom right corner of the app.
+   (<img src="/static/images/help/mobile-send-circle-icon.svg" alt="send" class="mobile-icon"/>)
+   button in the bottom right corner of the app.
 
 {end_tabs}
 
-### Access a PM or group PM
+## Access a PM or group PM
 
 If using Zulip in a browser or desktop, there are several ways to access an existing PM or group PM.
 
 * Click on **Private messages** near the top of the left sidebar to access
   recent conversations.
+
 * Click on any user in the right sidebar.
+
 * Start typing a user's name in the [search](/help/search-for-messages) bar.
   You'll be able to select PMs or group PMs with that user.
+
 * Open the compose box, and enter a list of users on the **To:**
-  line. Type `Ctrl` + `.` to open that conversation.
+  line. Type <kbd>Ctrl</kbd> + <kbd>.</kbd> to open that conversation.
 
 ## Related articles
 

--- a/templates/zerver/help/quote-and-reply.md
+++ b/templates/zerver/help/quote-and-reply.md
@@ -3,29 +3,40 @@
 You can quote a previous message, either replying within a topic or to
 start a new topic.
 
+The first line of the reply contains a [permanent link][link-to-message]
+to the quoted message. Zulip automatically turns mentions in the quoted text
+into [silent mentions](/help/mention-a-user-or-group#silently-mention-a-user)
+to avoid unnecessarily mentioning someone twice.
+
+!!! tip ""
+
+    You can use [quote blocks](/help/format-your-message-using-markdown#quotes)
+    when quoting emails or other non-Zulip content.
+
+## Quote and reply
+
 {start_tabs}
 
 {!message-actions-menu.md!}
 
 1. Click **Quote and reply**.
 
-1. (optional) Delete paragraphs not relevant to your reply, just like
-   when replying to a multi-paragraph email.
+1. *(optional)* Delete any parts of the quoted message that are not
+   relevant to your reply.
 
 1. Send your message.
 
 {end_tabs}
 
-You can also use the keyboard shortcut `>` to initiate quote-and-reply.
+!!! keyboard_tip ""
+
+    You can also use <kbd>></kbd> to **quote and reply** to the
+    selected message.
 
 ## Related articles
 
-* The first line of the reply contains a [permanent
-  link](/help/link-to-a-message-or-conversation) to the quoted
-  message.
-* Zulip automatically turns mentions in quoted text into [silent
-  mentions](/help/mention-a-user-or-group#silently-mention-a-user) to
-  avoid unnecessarily mentioning someone twice.
-* You can use [quote
-  blocks](/help/format-your-message-using-markdown#quotes) when
-  quoting emails or other non-Zulip content.
+* [Format your message using markdown](/help/format-your-message-using-markdown)
+* [Link to a message or conversation][link-to-message]
+* [Mention a user or group](/help/mention-a-user-or-group)
+
+[link-to-message]: /help/link-to-a-message-or-conversation

--- a/templates/zerver/help/reading-strategies.md
+++ b/templates/zerver/help/reading-strategies.md
@@ -10,7 +10,8 @@ in Zulip.
 
 ## Topic by topic
 
-Like your email inbox, for most users, Zulip works best if you read it topic-by-topic.
+Like your email inbox, for most users, Zulip works best if you read it
+topic-by-topic.
 
 ### Finding a topic to read
 
@@ -33,12 +34,12 @@ especially in situations where you just want a general idea of what's going
 on.
 
 * Click on a stream name in the left sidebar, and scroll using your mouse,
-  the arrow keys, `End`, or page up/down.
+  the arrow keys, <kbd>End</kbd>, or page up/down.
 
 * Click on a topic to narrow to messages from that topic.
 
 You can also search for a stream by clicking on **STREAMS** in the
-left sidebar, or using the `q` [keyboard
+left sidebar, or using the <kbd>Q</kbd> [keyboard
 shortcut](/help/keyboard-shortcuts).
 
 ## All messages
@@ -46,10 +47,12 @@ shortcut](/help/keyboard-shortcuts).
 If you're all caught up, it can be useful to have a single place to keep
 track of all messages coming in.
 
-* Click on **All messages** near the top left corner of the app, or hit `a`.
+* Click on **All messages** near the top left corner of the app, or hit
+  <kbd>A</kbd>.
 
-* You can use `s` (narrow to stream) or `S` (narrow to topic) to zoom in,
-  and `a` to get back to All messages.
+* You can use <kbd>S</kbd> (narrow to stream) or <kbd>Shift</kbd> +
+  <kbd>S</kbd> (narrow to topic) to zoom in, and <kbd>A</kbd> to get back
+  to All messages.
 
 ## Starring messages for later
 

--- a/templates/zerver/help/recent-topics.md
+++ b/templates/zerver/help/recent-topics.md
@@ -2,9 +2,10 @@
 
 {!recent-topics.md!}
 
-!!! tip ""
-    The arrows keys and vim navigation keys (`j`, `k`, `l`, `h`) can be
-    used to move between elements.
+!!! keyboard_tip ""
+
+    The arrow keys and vim navigation keys (<kbd>J</kbd>, <kbd>K</kbd>,
+    <kbd>L</kbd>, <kbd>H</kbd>) can be used to move between elements.
 
 ## Related articles
 * [Finding a topic to read](/help/finding-a-topic-to-read)

--- a/templates/zerver/help/start-a-new-topic.md
+++ b/templates/zerver/help/start-a-new-topic.md
@@ -3,29 +3,24 @@
 Topics are a lightweight tool to keep conversations organized. You should
 start a new topic whenever you're not replying to an existing message.
 
-### Start a new topic
+## Start a new topic
 
 {start_tabs}
 
 1. Click on a stream in the left sidebar.
 
-1. Click **New topic** at the bottom of the app.
-
-!!! warn ""
-
-    **Keyboard tip**: Use `c` to start a new topic.
+1. Click **New topic** at the bottom of the app, or type <kbd>C</kbd>.
 
 {end_tabs}
 
 Don't worry about picking the perfect topic. The first 2-4 words that come
 to mind are great.
 
-Note that topics are not available for [private messages (PMs)](/help/private-messages). If you find
-yourself wanting topics in a PM, we recommend
+Note that topics are not available for [private messages](/help/private-messages).
+If you find yourself wanting topics in a PM, we recommend
 [creating a private stream](/help/create-a-stream).
 
 ## Related articles
 
 * [Rename a topic](/help/rename-a-topic)
-
 * [Require topics](/help/require-topics) for all stream messages

--- a/templates/zerver/help/view-and-browse-images.md
+++ b/templates/zerver/help/view-and-browse-images.md
@@ -24,9 +24,9 @@ Exit the image viewer by clicking anywhere outside the image.
 
 !!! keyboard_tip ""
 
-    Use `v` to **open** the image viewer. Use `Z` and `z` to
-    zoom in and out of the image. Use `v` or `Esc` to **close**
-    the image viewer.
+    Use <kbd>V</kbd> to **open** the image viewer. Use <kbd>Shift</kbd> +
+    <kbd>Z</kbd> and <kbd>Z</kbd> to zoom in and out of the image. Use
+    <kbd>V</kbd> or <kbd>Esc</kbd> to **close** the image viewer.
 
 ## Troubleshooting
 

--- a/templates/zerver/help/view-and-edit-your-message-drafts.md
+++ b/templates/zerver/help/view-and-edit-your-message-drafts.md
@@ -14,7 +14,7 @@ so that you never lose your work. Drafts are saved for 30 days.
 
 {tab|desktop-web}
 
-Simply close the compose box. You can hit `Esc`, click
+Simply close the compose box. You can hit <kbd>Esc</kbd>, click
 the <i class="fa fa-remove"></i> in the top right corner of the
 compose box, or click on an empty part of the app.
 
@@ -31,7 +31,7 @@ From there, you can delete or restore any of your drafts.
 
 {end_tabs}
 
-!!! tip ""
+!!! keyboard_tip ""
 
-    Use `d` to bring up the list of drafts. Check out other keyboard shortcuts
-    related to drafts [here](/help/keyboard-shortcuts#drafts)
+    Use <kbd>D</kbd> to bring up your list of drafts. Check out other
+    keyboard shortcuts related to drafts [here](/help/keyboard-shortcuts#drafts)


### PR DESCRIPTION
Updates references to keyboard keys in the help center docs to use `<kbd>` HTML elements, which also means updating them to be as the key would appear on a keyboard. Previously, uppercase and lowercase letters were used to indicate when/if the `Shift` key was being used, and even that was not consistent throughout the documentation.

Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/format.20of.20keyboard.20shortcuts.20in.20help.20center.20docs/near/1424923).

[Diff](https://pastebin.com/8piPjTVr) with current help center documentation in main branch.

**Notes**:

- For CSS styling, adds a similar rule for `<kbd>` elements that is used in `/static/styles/app_components.css`. And updates the CSS class used in `/static/js/portico/help.js` for `adjust_mac_shortcuts` accordingly. Also, takes into account "arrow-key" CSS rule in `/static/styles/informational_overlays.css`.

- In 2nd commit, updates the tutorial in "Writing help center articles: Writing style" for using `<kbd>` HTML elements when documenting keyboard shortcuts in help center articles.

- In 3rd, commit, since we are updating the help center documentation to use `<kbd>` HTML elements when documenting keyboard keys and shortcuts, we no longer need to support `<code>` HTML elements in `adjust_mac_shortcuts`.

- In 1st commit, takes advantage of revising these pages for making small updates for current help center documentation practices. Changes to note are:
  - Updates [Enable Enter to send](https://zulip.com/help/enable-enter-to-send) to not use backticks in the title, see [this CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/Enable.20Enter.20to.20send.20article.20title/near/1425474).
  - Substantially revises [Quote and reply](https://zulip.com/help/quote-and-reply), see screenshot below.

**Questions**:

- I did not update the following pages as the instructions / text seemed to be directions for what to type and not a reference to a keyboard key. Does that seem correct?
  - https://zulip.com/help/mention-a-user-or-group
  - https://zulip.com/help/emoji-and-emoticons
  - https://zulip.com/help/link-to-a-message-or-conversation

- For shortcuts that were referenced as `@`, `?`, etc., I used the format `<kbd>Shift</kbd> + ...` for consistency. The main instances for those are below. Is that how we want those referenced?
  - `@` = `Shift` + `2`
  - `:` = `Shift` + `;`
  - `>` = `Shift` + `.`
  - `?` = `Shift` + `/`
  - `+` = `Shift` + `=`

- There is a CSS class for a "keyboard_tip" that was only being used in [View and browse images](https://zulip.com/help/view-and-browse-images). I extended that to be used in 3 additional pages where appropriate. Do we want to keep and use that type of tip syntax? Or do we want to have all tips be the same generic format?

---

**Screenshots and screen captures:**
*Note these are not all the articles updated by this change.*

<details>
<summary>Writing help articles tutorial update</summary>

[Current documentation](https://zulip.readthedocs.io/en/latest/documentation/helpcenter.html#keyboard-shortcuts)
![Screenshot from 2022-08-29 17-17-39](https://user-images.githubusercontent.com/63245456/187480952-41966620-01fc-455c-9e78-ed3bf759dc85.png)
</details>

<details>
<summary>Keyboard shortcuts</summary>

**Note that the current documentation does not have the go back/forward viewing shortcuts in the Navigation section**
[Current documentation](https://zulip.com/help/keyboard-shortcuts)
![Screenshot from 2022-08-30 17-45-12](https://user-images.githubusercontent.com/63245456/187481960-7cd6a5a4-598d-4042-99eb-f8b75c80c196.png)
![Screenshot from 2022-08-30 17-45-34](https://user-images.githubusercontent.com/63245456/187481968-6e92dfca-ee61-4e0f-9dda-61013e418885.png)
![Screenshot from 2022-08-30 17-45-52](https://user-images.githubusercontent.com/63245456/187481970-b8e2775d-81de-4742-8470-eb5453839220.png)
![Screenshot from 2022-08-30 17-46-08](https://user-images.githubusercontent.com/63245456/187481973-08a6b02d-0f9e-4641-bd5f-d5b7006478a9.png)
</details>

<details>
<summary>Quote and reply</summary>

[Current documentation](https://zulip.com/help/quote-and-reply)
![Screenshot from 2022-08-30 17-47-47](https://user-images.githubusercontent.com/63245456/187482332-b4ff8c03-d42c-404d-90c9-fdd27520ce14.png)
</details>

<details>
<summary>Enable Enter to send</summary>

[Current documentation](https://zulip.com/help/enable-enter-to-send)
**Non Mac user**
![Screenshot from 2022-08-30 17-49-05](https://user-images.githubusercontent.com/63245456/187482613-5061a8b8-7639-4364-9d43-4658eede08d3.png)
**Mac user**
![Screenshot from 2022-08-30 17-49-59](https://user-images.githubusercontent.com/63245456/187482894-c3cd9a1f-cf4c-47a6-83dd-4ea8c7456443.png)
</details>

<details>
<summary>Starting a new topic</summary>

[Current documentation](https://zulip.com/help/starting-a-new-topic)
![Screenshot from 2022-08-30 17-52-30](https://user-images.githubusercontent.com/63245456/187483755-532e6a1d-bc61-4db3-bf00-a9d903c8d2bc.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
