### PR TITLE
markdown: Add icons before links for common file types.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -298,6 +298,61 @@
         }
     }
 
+    /* setup for icons before links of common file types */
+    a::before {
+        font-family: FontAwesome;
+        margin-left: 5px;
+        margin-right: 3px;
+    }
+
+    /* external link icon */
+    a[target="_blank"]::before {
+        content: "\f08e";
+    }
+
+    /* pdf file icon */
+    a[href$=".pdf"]::before {
+        content: "\f1c1";
+    }
+
+    /* image file icon */
+    a[href$=".png"]::before,
+    a[href$=".jpeg"]::before,
+    a[href$=".jpg"]::before,
+    a[href$=".gif"]::before {
+        content: "\f03e";
+    }
+
+    /* video file icon */
+    a[href$=".mp4"]::before,
+    a[href$=".mov"]::before {
+        content: "\f1c8";
+    }
+
+    /* audio file icon */
+    a[href$=".mp3"]::before {
+        content: "\f1c7";
+    }
+
+    /* text file icon */
+    a[href$=".txt"]::before,
+    a[href$=".doc"]::before,
+    a[href$=".docx"]::before {
+        content: "\f1c2";
+    }
+
+    /* ppt file icon */
+    a[href$=".ppt"]::before,
+    a[href$=".pptx"]::before {
+        content: "\f1c4";
+    }
+
+    /* compressed file icon */
+    a[href$=".zip"]::before,
+    a[href$=".tar"]::before {
+        content: "\f1c6";
+    }
+
     /* embedded link previews */
     .message_inline_image_title {
         font-weight: bold;
@@ -349,6 +404,11 @@
             display: block;
             height: 100%;
             width: 100%;
+
+            /* do not show icon in preview */
+            &::before {
+                display: none;
+            }
         }
     }
 


### PR DESCRIPTION
markdown: Add icons before links for common file types.

When links (usually in form of list of files) are one after the other
in a message, it gets hard to distinguish one from the other, since the
beginnings are not well defined.

Now every attachment of a common file type will have a file type based
icon preceding it, and other external links will have an external link
icon. This way it will now be easier to distinguish multiple links /
attachments, and as an added benefit, also gauge their type visually.

Fixes: #21603.

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/68962290/187545058-56e8ef62-164d-49a6-8ce5-ebfe0e61acde.png)

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
