### PR TITLE
portico: Fix title and description for /attribution.

### DIFF
--- a/templates/corporate/attribution.html
+++ b/templates/corporate/attribution.html
@@ -2,8 +2,11 @@
 {% set entrypoint = "landing-page" %}
 
 {% block title %}
-<title>Zulip: The best group chat for your business.</title>
+<title>Zulip attributions</title>
 {% endblock %}
+
+{% set OPEN_GRAPH_TITLE = 'Zulip website attributions' %}
+{% set OPEN_GRAPH_DESCRIPTION = '' %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -17,7 +20,7 @@
     <div class="hero empty-hero"></div>
     <div class="main">
         <div class="padded-content">
-            <h1>Attributions</h1>
+            <h1>Website attributions</h1>
             <ul>
                 <li>
                     <b>On <a href="/for/business">/for/business</a> page:</b>


### PR DESCRIPTION
This will help prevent search engines from accidentally leading visitors to this page.