### PR TITLE
left_sidebar: Remove outline from streams scrolling container.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -199,6 +199,10 @@ li.show-more-topics {
     width: 100%;
 }
 
+#stream-filters-container .simplebar-content-wrapper {
+    outline: none;
+}
+
 #private-container {
     max-height: 210px;
 


### PR DESCRIPTION
Simplebar sets tabindex for `simplebar-content-wrapper` which
makes it focusable. The outline which comes with it when focused
is annoying, so we remove the outline.
<img width="1317" alt="Screenshot 2022-08-31 at 10 29 19 AM" src="https://user-images.githubusercontent.com/25124304/187596359-9420b148-2dcb-4b20-86a2-60fae1158dde.png">

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20list.20focus.20outline