### PR TITLE
settings: Move custom input div inside the main setting div.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -364,10 +364,6 @@ td .button {
     }
 }
 
-.dependent-block {
-    margin: -5px 0 15px 23px;
-}
-
 .dependent-inline-block {
     display: inline-block;
     margin: 0 0 0 10px !important;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -843,6 +843,11 @@ li.actual-dropdown-menu i {
     padding: 6px 12px;
 }
 
+#settings_content .dependent-block,
+#invite-user .dependent-block {
+    margin: 15px 0 -5px 23px;
+}
+
 .message_area_padder {
     /* The height of the header and the message_view_header plus a small gap */
     margin-top: 57px;

--- a/static/templates/invite_user.hbs
+++ b/static/templates/invite_user.hbs
@@ -39,16 +39,16 @@
                         </select>
                     </div>
                     <p id="expires_on"></p>
-                </div>
-                <div id="custom-invite-expiration-time" class="dependent-block">
-                    <label for="expires_in">{{t "Custom time" }}</label>
-                    <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-expiration-time inline-block" value="{{time_input}}" maxlength="3"/>
-                    <select class="custom-expiration-time" id="custom-expiration-time-unit">
-                        {{#each time_choices}}
-                            <option name="custom_time_choice" class="custom_time_choice" value="{{this}}">{{this}}</option>
-                        {{/each}}
-                    </select>
-                    <p id="custom_expires_on"></p>
+                    <div id="custom-invite-expiration-time" class="dependent-block">
+                        <label for="expires_in">{{t "Custom time" }}</label>
+                        <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-expiration-time inline-block" value="{{time_input}}" maxlength="3"/>
+                        <select class="custom-expiration-time" id="custom-expiration-time-unit">
+                            {{#each time_choices}}
+                                <option name="custom_time_choice" class="custom_time_choice" value="{{this}}">{{this}}</option>
+                            {{/each}}
+                        </select>
+                        <p id="custom_expires_on"></p>
+                    </div>
                 </div>
                 <div class="input-group">
                     <label for="invite_as">{{t "User(s) join as" }}

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -129,17 +129,17 @@
                     <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}
             </select>
-        </div>
-        <div class="dependent-block">
-            <label for="email_notification_batching_period_edit_minutes" class="inline-block">
-                {{t 'Delay period (minutes)' }}:
-            </label>
-            <input type="text"
-              name="email_notification_batching_period_edit_minutes"
-              class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input prop-element"
-              data-setting-widget-type="number"
-              autocomplete="off"
-              id="{{prefix}}email_notification_batching_period_edit_minutes"/>
+            <div class="dependent-block">
+                <label for="email_notification_batching_period_edit_minutes" class="inline-block">
+                    {{t 'Delay period (minutes)' }}:
+                </label>
+                <input type="text"
+                  name="email_notification_batching_period_edit_minutes"
+                  class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input prop-element"
+                  data-setting-widget-type="number"
+                  autocomplete="off"
+                  id="{{prefix}}email_notification_batching_period_edit_minutes"/>
+            </div>
         </div>
 
         {{#each notification_settings.email_message_notification_settings}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -28,12 +28,12 @@
                         <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
                         <option value="only_selected_domain">{{t "Restrict to a list of domains" }}</option>
                     </select>
-                </div>
-                <div class="dependent-block">
-                    <p id="allowed_domains_label" class="inline-block"></p>
-                    {{#if is_admin }}
-                    <a id="show_realm_domains_modal" role="button">{{t "[Configure]" }}</a>
-                    {{/if}}
+                    <div class="dependent-block">
+                        <p id="allowed_domains_label" class="inline-block"></p>
+                        {{#if is_admin }}
+                        <a id="show_realm_domains_modal" role="button">{{t "[Configure]" }}</a>
+                        {{/if}}
+                    </div>
                 </div>
                 <div class="input-group">
                     <label for="realm_waiting_period_setting" class="dropdown-title">
@@ -45,14 +45,14 @@
                         <option value="three_days">{{t "3 days" }}</option>
                         <option value="custom_days">{{t "Custom" }}</option>
                     </select>
-                </div>
-                {{!-- This setting is hidden unless `custom_days` --}}
-                <div class="dependent-block">
-                    <label for="id_realm_waiting_period_threshold" class="inline-block">{{t "Waiting period (days)" }}:</label>
-                    <input type="text" id="id_realm_waiting_period_threshold"
-                      name="realm_waiting_period_threshold"
-                      class="admin-realm-time-limit-input prop-element"
-                      value="{{ realm_waiting_period_threshold }}"/>
+                    {{!-- This setting is hidden unless `custom_days` --}}
+                    <div class="dependent-block">
+                        <label for="id_realm_waiting_period_threshold" class="inline-block">{{t "Waiting period (days)" }}:</label>
+                        <input type="text" id="id_realm_waiting_period_threshold"
+                          name="realm_waiting_period_threshold"
+                          class="admin-realm-time-limit-input prop-element"
+                          value="{{ realm_waiting_period_threshold }}"/>
+                    </div>
                 </div>
             </div>
         </div>
@@ -161,17 +161,17 @@
                             <option value="{{0}}">{{1.text}}</option>
                         {{/each}}
                     </select>
-                </div>
-                <div class="dependent-block">
-                    <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
-                        {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
-                    </label>
-                    <input type="text" id="id_realm_message_content_edit_limit_minutes"
-                      name="realm_message_content_edit_limit_minutes"
-                      class="admin-realm-time-limit-input prop-element"
-                      autocomplete="off"
-                      value="{{ realm_message_content_edit_limit_minutes }}"
-                      {{#unless realm_allow_message_editing}}disabled{{/unless}}/>
+                    <div class="dependent-block">
+                        <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
+                            {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
+                        </label>
+                        <input type="text" id="id_realm_message_content_edit_limit_minutes"
+                          name="realm_message_content_edit_limit_minutes"
+                          class="admin-realm-time-limit-input prop-element"
+                          autocomplete="off"
+                          value="{{ realm_message_content_edit_limit_minutes }}"
+                          {{#unless realm_allow_message_editing}}disabled{{/unless}}/>
+                    </div>
                 </div>
 
                 <div class="input-group">
@@ -208,16 +208,16 @@
                             <option value="{{0}}">{{1.text}}</option>
                         {{/each}}
                     </select>
-                </div>
-                <div class="dependent-block">
-                    <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
-                        {{t "Duration deletion is allowed after posting (minutes)" }}:
-                    </label>
-                    <input type="text" id="id_realm_message_content_delete_limit_minutes"
-                      name="realm_message_content_delete_limit_minutes"
-                      class="admin-realm-time-limit-input prop-element"
-                      autocomplete="off"
-                      value="{{ realm_message_content_delete_limit_minutes }}"/>
+                    <div class="dependent-block">
+                        <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
+                            {{t "Duration deletion is allowed after posting (minutes)" }}:
+                        </label>
+                        <input type="text" id="id_realm_message_content_delete_limit_minutes"
+                          name="realm_message_content_delete_limit_minutes"
+                          class="admin-realm-time-limit-input prop-element"
+                          autocomplete="off"
+                          value="{{ realm_message_content_delete_limit_minutes }}"/>
+                    </div>
                 </div>
 
                 <div class="input-group">


### PR DESCRIPTION
This PR moves "dependent-block" div inside the main
setting "input-group" div as the custom input is part of
that setting only. Also this will help in further refactoring
of settings code which will be done in next couple of PRs.

There are no changes visually, the space between settings   
and inputs remain same.
<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
