### PR TITLE
sharding: Support Tornado sharding by regexes

### DIFF
--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -43,7 +43,7 @@ class zulip::tornado_sharding {
 
   # The ports of Tornado processes to run on the server; defaults to
   # 9800.
-  $tornado_ports = zulipconf_keys('tornado_sharding')
+  $tornado_ports = unique(zulipconf_keys('tornado_sharding').map |$key| { regsubst($key, /_regex$/, '') })
 
   file { '/etc/nginx/zulip-include/tornado-upstreams':
     require => [Package[$zulip::common::nginx], Exec['stage_updated_sharding']],

--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -5,14 +5,21 @@ class zulip::tornado_sharding {
   # with the correct default content for the "only one shard" setup. For this
   # reason they use "replace => false", because the files are managed by
   # the sharding script afterwards and Puppet shouldn't overwrite them.
-  file { '/etc/zulip/nginx_sharding.conf':
+  file { '/etc/zulip/nginx_sharding_map.conf':
     ensure  => file,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     notify  => Service['nginx'],
-    content => "set \$tornado_server http://tornado;\n",
+    content => @(EOT),
+      map "" $tornado_server {
+          default http://tornado;
+      }
+      | EOT
     replace => false,
+  }
+  file { '/etc/zulip/nginx_sharding.conf':
+    ensure => absent,
   }
   file { '/etc/zulip/sharding.json':
     ensure  => file,
@@ -29,7 +36,7 @@ class zulip::tornado_sharding {
   exec { 'stage_updated_sharding':
     command   => "${::zulip_scripts_path}/lib/sharding.py",
     onlyif    => "${::zulip_scripts_path}/lib/sharding.py --errors-ok",
-    require   => [File['/etc/zulip/nginx_sharding.conf'], File['/etc/zulip/sharding.json']],
+    require   => [File['/etc/zulip/nginx_sharding_map.conf'], File['/etc/zulip/sharding.json']],
     logoutput => true,
     loglevel  => warning,
   }

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -13,6 +13,7 @@ server {
 <% end -%>
 
 include /etc/nginx/zulip-include/upstreams;
+include /etc/zulip/nginx_sharding_map.conf;
 
 server {
 <% if @nginx_http_only -%>
@@ -30,7 +31,6 @@ server {
         alias /home/zulip/local-static;
     }
 
-    include /etc/zulip/nginx_sharding.conf;
     include /etc/nginx/zulip-include/certbot;
     include /etc/nginx/zulip-include/app;
 }

--- a/puppet/zulip_ops/files/nginx/sites-available/zulip
+++ b/puppet/zulip_ops/files/nginx/sites-available/zulip
@@ -1,4 +1,5 @@
 include /etc/nginx/zulip-include/upstreams;
+include /etc/zulip/nginx_sharding_map.conf;
 
 server {
     listen 443 ssl http2;
@@ -15,6 +16,5 @@ server {
 
     server_name zulipchat.com *.zulipchat.com;
 
-    include /etc/zulip/nginx_sharding.conf;
     include /etc/nginx/zulip-include/app;
 }

--- a/puppet/zulip_ops/files/nginx/sites-available/zulip-staging
+++ b/puppet/zulip_ops/files/nginx/sites-available/zulip-staging
@@ -6,6 +6,7 @@ server {
 }
 
 include /etc/nginx/zulip-include/upstreams;
+include /etc/zulip/nginx_sharding_map.conf;
 
 server {
     listen 443 ssl http2;
@@ -22,6 +23,5 @@ server {
 
     server_name zulipstaging.com;
 
-    include /etc/zulip/nginx_sharding.conf;
     include /etc/nginx/zulip-include/app;
 }

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -593,7 +593,12 @@ def run_psql_as_postgres(
 def get_tornado_ports(config_file: configparser.RawConfigParser) -> List[int]:
     ports = []
     if config_file.has_section("tornado_sharding"):
-        ports = [int(port) for port in config_file.options("tornado_sharding")]
+        ports = sorted(
+            {
+                int(key[: -len("_regex")] if key.endswith("_regex") else key)
+                for key in config_file.options("tornado_sharding")
+            }
+        )
     if not ports:
         ports = [9800]
     return ports

--- a/scripts/refresh-sharding-and-restart
+++ b/scripts/refresh-sharding-and-restart
@@ -7,16 +7,16 @@ set -e
 SUPPRESS_SHARDING_NOTICE=1 "$(dirname "$0")/zulip-puppet-apply" -f
 
 # Verify, before we move them into place
-if ! [ -e /etc/zulip/nginx_sharding.conf.tmp ] || ! [ -e /etc/zulip/sharding.json.tmp ]; then
+if ! [ -e /etc/zulip/nginx_sharding_map.conf.tmp ] || ! [ -e /etc/zulip/sharding.json.tmp ]; then
     echo "No sharding updates found to apply."
     exit 1
 fi
 
-chown root:root /etc/zulip/nginx_sharding.conf.tmp
-chmod 644 /etc/zulip/nginx_sharding.conf.tmp
+chown root:root /etc/zulip/nginx_sharding_map.conf.tmp
+chmod 644 /etc/zulip/nginx_sharding_map.conf.tmp
 chown zulip:zulip /etc/zulip/sharding.json.tmp
 chmod 644 /etc/zulip/sharding.json.tmp
-mv /etc/zulip/nginx_sharding.conf.tmp /etc/zulip/nginx_sharding.conf
+mv /etc/zulip/nginx_sharding_map.conf.tmp /etc/zulip/nginx_sharding_map.conf
 mv /etc/zulip/sharding.json.tmp /etc/zulip/sharding.json
 
 # In the ordering of operations below, the crucial detail is that


### PR DESCRIPTION
One should now be able to configure a regex by appending `_regex` to the port number:

```
[tornado_sharding]
9802_regex = ^[l-p].*\.zulipchat\.com$
```

Tested on andersk.zulipdev.org.

Note that due to 8adf5304007b8e78ca421ca7654b6a7a62aa6001 (#16320), we’ll need to manually run `refresh-sharding-and-restart`.