### PR TITLE
left-sidebar: Add `Log in to browse more streams` link.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -528,6 +528,12 @@ export function initialize() {
 
     // SIDEBARS
 
+    $(".left-sidebar #login-link").on("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        window.location.href = hash_util.build_login_link();
+    });
+
     $(".right-sidebar .login_button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -221,8 +221,8 @@ li.show-more-topics {
     }
 }
 
+#login-link,
 #subscribe-to-more-streams {
-    text-decoration: none;
     margin: 5px auto 5.5px 10px;
     margin-bottom: 25px;
 

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -93,4 +93,11 @@
             </div>
         </div>
     </div>
+    <div class="only-visible-for-spectators">
+        <a id="login-link">
+            <i class="fa fa-plus-circle" aria-hidden="true"></i>
+            {{~!-- squash whitespace --~}}
+            {{t "Log in to browse more streams" }}
+        </a>
+    </div>
 </div>


### PR DESCRIPTION
It can sometimes be unclear to logged out users why they
are not seeing all their subscribed streams in the left sidebar.

To reduce the chances of users being confused, we now add this another
link at the bottom of left sidebar regardless of whether or not
there are actually any additional streams left in the organization
to avoid leaking any information.

Fixes #22844.

<!-- Describe your pull request here.-->

Fixes: #22844 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="328" alt="image" src="https://user-images.githubusercontent.com/76561593/188002160-6535499e-3db4-45a9-893f-aa003f3bc21a.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x]  End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
