### PR TITLE
help center: Clean up "Deactivate or reactivate a user" help page, with minor tweaks to related pages.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -464,7 +464,7 @@ export function confirm_deactivation(user_id, handle_confirm, loading_spinner) {
                     {defaultMessage: "Deactivate {name}?"},
                     {name: user.full_name},
                 ),
-                help_link: "/help/deactivate-or-reactivate-a-user#deactivate-ban-a-user",
+                help_link: "/help/deactivate-or-reactivate-a-user#deactivating-a-user",
                 html_body,
                 html_submit_button: $t_html({defaultMessage: "Deactivate"}),
                 id: "deactivate-user-modal",
@@ -528,7 +528,7 @@ export function confirm_reactivation(user_id, handle_confirm, loading_spinner) {
 
     confirm_dialog.launch({
         html_heading: $t_html({defaultMessage: "Reactivate {name}"}, {name: user.full_name}),
-        help_link: "/help/deactivate-or-reactivate-a-user#reactivate-a-user",
+        help_link: "/help/deactivate-or-reactivate-a-user#reactivating-a-user",
         html_body,
         on_click: handle_confirm,
         loading_spinner,

--- a/templates/zerver/help/change-a-users-name.md
+++ b/templates/zerver/help/change-a-users-name.md
@@ -14,12 +14,7 @@ Organization administrators can always change any user's name.
 
 {tab|via-user-profile}
 
-1. Hover over a user's name in the right sidebar.
-
-1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
-   to the right of their name.
-
-1. Click **Manage this user**.
+{!manage-this-user.md!}
 
 1. Under **Full name**, enter a new name.
 
@@ -37,3 +32,8 @@ Organization administrators can always change any user's name.
 {!save-changes.md!}
 
 {end_tabs}
+
+## Related articles
+
+* [Change a user's role](/help/change-a-users-role)
+* [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)

--- a/templates/zerver/help/change-a-users-role.md
+++ b/templates/zerver/help/change-a-users-role.md
@@ -21,12 +21,7 @@ organization](/help/deactivate-your-organization) instead).
 
 {tab|via-user-profile}
 
-1. Hover over a user's name in the right sidebar.
-
-1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
-   to the right of their name.
-
-1. Click **Manage this user**.
+{!manage-this-user.md!}
 
 1. Under **User role**, select a [role](/help/roles-and-permissions).
 
@@ -44,3 +39,8 @@ organization](/help/deactivate-your-organization) instead).
 1. Click **Save changes**. The new permissions will take effect immediately.
 
 {end_tabs}
+
+## Related articles
+
+* [Change a user's name](/help/change-a-users-name)
+* [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)

--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -1,29 +1,45 @@
 # Deactivate or reactivate a user
 
+## Deactivating a user
+
 {!admin-only.md!}
 
-## Deactivate (ban) a user
+When you deactivate a user:
 
-To properly remove a user’s access to a Zulip organization, it does not
-suffice to change their password or deactivate their account in an external
-email system, since the user’s API key and bot API keys will still be
-active. Instead, you need to deactivate the user’s account using the Zulip
-administrative interface.
+* The user will be immediately logged out of all Zulip sessions, including
+  desktop, web and mobile apps.
 
-Note that organization administrators cannot deactivate organization owners.
+* The user's credentials for logging in will no longer work, including password
+  login and [any other login options](/help/configure-authentication-methods)
+  enabled in your organization.
+
+* The user's [bots](/help/bots-and-integrations) will be deactivated.
+
+* [Email invitations and invite links](/help/invite-new-users) created by the
+  user will be disabled.
+
+* Even if your organization [allows users to join without an
+  invitation](/help/restrict-account-creation#set-whether-invitations-are-required-to-join),
+  this user will not be able to rejoin with the same email account.
+
+!!! warn ""
+    You must go through the deactivation process below to fully remove a user's
+    access to your Zulip organization. Changing a user's password or removing
+    their single sign-on account will not log them out of their open Zulip
+    sessions, or disable their API keys.
+
+### Deactivate a user
 
 {start_tabs}
 
 {tab|via-user-profile}
 
-1. Hover over a user's name in the right sidebar.
+{!manage-this-user.md!}
 
-1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
-   to the right of their name.
+1. Click **Deactivate user** at the bottom of the **Manage user** menu.
 
-1. Click **Manage this user**.
-
-1. Click the **Deactivate user** button at the bottom.
+1. *(optional)* Select **Notify this user by email?** if desired, and enter a
+   custom comment to include in the notification email.
 
 1. Approve by clicking **Deactivate**.
 
@@ -31,54 +47,36 @@ Note that organization administrators cannot deactivate organization owners.
 
 {settings_tab|user-list-admin}
 
-1. Click the **Deactivate** button to the right of the user account that you
-   want to deactivate.
+1. In the **Actions** column, click the **deactivate** (<i class="fa
+   fa-user-times"></i>) icon for the user you want to deactivate.
 
-1. Approve by clicking **Deactivate**.
+2. *(optional)* Select **Notify this user by email?** if desired, and enter a
+   custom comment to include in the notification email.
 
-{end_tabs}
-
-The user will be logged out immediately and not be able to log back in. The
-user's bots will also be deactivated. Lastly, the user will be unable to
-create a new Zulip account in your organization using their deactivated
-email address.
-
-### Notify users of their deactivation
-
-Zulip can optionally send the user an email notification that their account was deactivated.
-
-{start_tabs}
-
-{settings_tab|user-list-admin}
-
- 2. Click the **Deactivate** button to the right of the user account that you
-want to deactivate.
-
- 3. Check the checkbox labeled **"Notify this user by email?"**.
-
- 4. Optional: Enter a custom message for the user in the provided textbox.
-
- 3. Approve by clicking **Confirm**.
+3. Approve by clicking **Deactivate**.
 
 {end_tabs}
 
-Here is a sample notification email:
+!!! tip ""
+    Organization administrators cannot deactivate organization owners.
 
-<img src="/static/images/help/deactivate-user-email.png" alt="view-of-admin" width="800"/>
+## Reactivating a user
 
-## Reactivate a user
+{!admin-only.md!}
 
-Organization administrators can reactivate a deactivated user. The reactivated
-user will have the same role, stream subscriptions, user group memberships, and
-other settings and permissions as they did prior to deactivation. They will also
-have the same API key and bot API keys, but the bots will be deactivated until
-the user manually [reactivates](deactivate-or-reactivate-a-bot) them again.
+A reactivated user will have the same role, stream subscriptions, user group
+memberships, and other settings and permissions as they did prior to
+deactivation. They will also have the same API key and bot API keys, but their
+bots will be deactivated until the user manually
+[reactivates](deactivate-or-reactivate-a-bot) them again.
+
+### Reactivate a user
 
 {start_tabs}
 
 {settings_tab|deactivated-users-admin}
 
-4. Click the **Reactivate** button to the right of the user account that you
+1. Click the **Reactivate** button to the right of the user account that you
 want to reactivate.
 
 {end_tabs}
@@ -86,3 +84,9 @@ want to reactivate.
 !!! tip ""
     You may want to [review and adjust](/help/manage-user-stream-subscriptions)
     the reactivated user's stream subscriptions.
+
+## Related articles
+
+* [Change a user's role](/help/change-a-users-role)
+* [Change a user's name](/help/change-a-users-name)
+* [Deactivate your account](/help/deactivate-your-account)

--- a/templates/zerver/help/deactivate-your-account.md
+++ b/templates/zerver/help/deactivate-your-account.md
@@ -40,4 +40,5 @@
 * [Logging in](logging-in)
 * [Logging out](logging-out)
 * [Switching between organizations](switching-between-organizations)
+* [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)
 * [Deactivate your organization](/help/deactivate-your-organization)

--- a/templates/zerver/help/edit-a-bot.md
+++ b/templates/zerver/help/edit-a-bot.md
@@ -10,7 +10,7 @@ active bot in the organization.
 
 {settings_tab|your-bots}
 
-1. Click the pencil (<i class="fa fa-pencil"></i>) icon on the profile
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the profile
    card for the bot you want to edit.
 
 1. Edit bot information as desired, and click **Save changes**.
@@ -25,8 +25,8 @@ active bot in the organization.
 
 {settings_tab|bot-list-admin}
 
-1. In the **Actions** column, click the pencil (<i class="fa fa-pencil"></i>) icon for the
-   bot you want to edit.
+1. In the **Actions** column, click the **pencil** (<i class="fa
+   fa-pencil"></i>) icon for the bot you want to edit.
 
 1. Edit bot information as desired, and click **Save changes**.
 

--- a/templates/zerver/help/include/manage-this-user.md
+++ b/templates/zerver/help/include/manage-this-user.md
@@ -1,0 +1,6 @@
+1. Hover over a user's name in the right sidebar.
+
+1. Click on the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+   to the right of their name.
+
+1. Click **Manage this user**.

--- a/templates/zerver/help/rename-a-topic.md
+++ b/templates/zerver/help/rename-a-topic.md
@@ -21,7 +21,8 @@ for the details on when topic editing is allowed.
 
 {start_tabs}
 
-1. Click on the <i class="fa fa-pencil"></i> icon in the message recipient bar.
+1. Click on the **pencil** (<i class="fa fa-pencil"></i>) icon in the message
+   recipient bar.
 
 1. Edit the topic name.
 

--- a/templates/zerver/help/setting-up-zulip-for-a-class.md
+++ b/templates/zerver/help/setting-up-zulip-for-a-class.md
@@ -357,4 +357,4 @@ HTML archive](https://github.com/zulip/zulip-archive) to archive the information
 
 [make-private]: /help/change-the-privacy-of-a-stream
 [add-to-stream]: /help/add-or-remove-users-from-a-stream
-[deactivate-user]: /help/deactivate-or-reactivate-a-user#deactivate-ban-a-user
+[deactivate-user]: /help/deactivate-or-reactivate-a-user#deactivate-a-user

--- a/templates/zerver/help/zulip-cloud-billing.md
+++ b/templates/zerver/help/zulip-cloud-billing.md
@@ -28,9 +28,9 @@ you will need to sign up for an annual plan.
 
 ### What is the difference between automatic and manual billing?
 
-With automatic billing, you automatically purchase a Zulip license
-for each user in your organization at the start of each billing period
-(month or year). Deactivating a user frees up their license for reuse.
+With automatic billing, you automatically purchase a Zulip license for each user
+in your organization at the start of each billing period (month or year).
+[Deactivating a user][deactivate-user] frees up their license for reuse.
 Additional licenses are purchased automatically as needed.
 
 With manual billing, you choose and pay for a preset user limit. If
@@ -44,9 +44,8 @@ have a specific reason to do otherwise.
 
 ### How will I be charged for temporary users (e.g. limited-time clients)?
 
-Users [can be
-deactivated](/help/deactivate-or-reactivate-a-user#deactivate-ban-a-user) any
-time. Deactivating a user frees up their license for reuse.
+Users [can be deactivated][deactivate-user] any time. Deactivating a user frees
+up their license for reuse.
 
 ### How are guest accounts billed? Is there special pricing?
 
@@ -60,3 +59,5 @@ guest.
 * [Trying out Zulip](/help/trying-out-zulip)
 * [Zulip Cloud or self-hosting?](/help/zulip-cloud-or-self-hosting)
 * [Migrating from other chat tools](/help/migrating-from-other-chat-tools)
+
+[deactivate-user]: /help/deactivate-or-reactivate-a-user#deactivate-a-user


### PR DESCRIPTION
The first commit:
- Factor out instructions for navigating to the "Manage this user" tab, which we are currently using on 3 pages.
- Add links to related articles to Change a user's {role}/{name} pages.

The second commit fixes up some formatting inconsistencies.

The third commit updates the "Deactivate or reactivate a user" page, including:

- Expanding and clarifying the intro text.
- Merging the instructions for sending a notification to the user into the overall deactivation instructions.
- Removing the email screenshot, which I think is not necessary, as we've made the in-product UI sufficiently clear in the process of iterating on the PR for this feature.
- Updating links to anchor tags on this page **(with one caveat below)**.

**Remaining work**: Remove the link to `/help/deactivate-or-reactivate-a-user#notify-users-of-their-deactivation` from `static/templates/confirm_dialog/confirm_deactivate_user.hbs`. I think the link to the overall help page at the top of this modal is sufficient, but I wasn't sure how to correctly remove the question mark.


Current version: https://zulip.com/help/deactivate-or-reactivate-a-user

<details>
<summary>Deactivate or reactivate a user</summary>

![Screen Shot 2022-09-26 at 5 31 05 PM](https://user-images.githubusercontent.com/2090066/192404499-12ce715d-a598-4d1a-80ed-f8258e2d5a89.png)

Other tab:

![Screen Shot 2022-09-26 at 5 31 18 PM](https://user-images.githubusercontent.com/2090066/192404515-b0988757-06e7-4b46-a9fe-d2d66c6154f4.png)

</details>

Testing:
- Previewed the changed pages and manually tested all the new links.