### PR TITLE
compose: Disable "New private message" button when user does not have permissions to send PM

### DIFF
--- a/static/js/compose_closed_ui.js
+++ b/static/js/compose_closed_ui.js
@@ -5,6 +5,7 @@ import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as narrow_state from "./narrow_state";
+import {page_params} from "./page_params";
 import * as people from "./people";
 import * as recent_topics_util from "./recent_topics_util";
 
@@ -62,7 +63,10 @@ function update_conversation_button(btn_text, title) {
 function update_buttons(text_stream) {
     const title_stream = text_stream + " (c)";
     const text_conversation = $t({defaultMessage: "New private message"});
-    const title_conversation = text_conversation + " (x)";
+    let title_conversation = text_conversation + " (x)";
+    if (page_params.realm_private_message_policy === 2) {
+        title_conversation = "Private messages are disabled in this organization.";
+    }
     update_stream_button(text_stream, title_stream);
     update_conversation_button(text_conversation, title_conversation);
 }
@@ -119,9 +123,13 @@ export function initialize() {
         compose_actions.start("stream", {trigger: "new topic button"});
     });
 
-    $("body").on("click", ".compose_private_button", () => {
-        compose_actions.start("private", {trigger: "new private message"});
-    });
+    if (page_params.realm_private_message_policy === 2) {
+        $(".compose_private_button").attr("disabled", true);
+    } else if (page_params.realm_private_message_policy === 1) {
+        $("body").on("click", ".compose_private_button", () => {
+            compose_actions.start("private", {trigger: "new private message"});
+        });
+    }
 
     $("body").on("click", ".compose_reply_button", () => {
         compose_actions.respond_to_message({trigger: "reply button"});

--- a/static/js/compose_closed_ui.js
+++ b/static/js/compose_closed_ui.js
@@ -8,6 +8,7 @@ import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as recent_topics_util from "./recent_topics_util";
+import * as settings_config from "./settings_config";
 
 export function get_recipient_label(message) {
     if (message === undefined) {
@@ -64,7 +65,10 @@ function update_buttons(text_stream) {
     const title_stream = text_stream + " (c)";
     const text_conversation = $t({defaultMessage: "New private message"});
     let title_conversation = text_conversation + " (x)";
-    if (page_params.realm_private_message_policy === 2) {
+    if (
+        page_params.realm_private_message_policy ===
+        settings_config.private_message_policy_values.disabled.code
+    ) {
         title_conversation = "Private messages are disabled in this organization.";
     }
     update_stream_button(text_stream, title_stream);
@@ -123,9 +127,15 @@ export function initialize() {
         compose_actions.start("stream", {trigger: "new topic button"});
     });
 
-    if (page_params.realm_private_message_policy === 2) {
+    if (
+        page_params.realm_private_message_policy ===
+        settings_config.private_message_policy_values.disabled.code
+    ) {
         $(".compose_private_button").attr("disabled", true);
-    } else if (page_params.realm_private_message_policy === 1) {
+    } else if (
+        page_params.realm_private_message_policy ===
+        settings_config.private_message_policy_values.by_anyone.code
+    ) {
         $("body").on("click", ".compose_private_button", () => {
             compose_actions.start("private", {trigger: "new private message"});
         });


### PR DESCRIPTION
When a user does not have the permissions to sent PM, the "new private
message" button must be disabled with the tooltip "You are not allowed
to send private messages in this organization." This commit contains
code changes implementing the above changes.

I have tested the changes with Chrome and Firefox(these are available with me). The changes should probably be tested with Safari as well.

The changes are made in the satic/js/compose_closed_ui.js file.

Fixes: #22660.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots:**
![image](https://user-images.githubusercontent.com/57625699/188190967-a5e8d2cc-d6e4-45e0-90f6-d30d2d0c6ffa.png "Chrome")

![image](https://user-images.githubusercontent.com/57625699/188192419-915d0b55-cee2-4876-a4e9-3e784bd24d7c.png "Firefox, dark mode")


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
