### PR TITLE
left_sidebar: Hide stream section separator when there is only one.

### DIFF
--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -606,12 +606,8 @@ test_ui("separators_only_pinned_and_dormant", ({override_rewire, mock_template})
     assert.ok(inactive_subheader_flag);
 });
 
-test_ui("separators_only_pinned", ({mock_template}) => {
+test_ui("separators_only_pinned", () => {
     // Test only pinned streams
-
-    create_stream_subheader({mock_template});
-    pinned_subheader_flag = false;
-
     // Get coverage on early-exit.
     stream_list.build_stream_list();
 
@@ -640,16 +636,14 @@ test_ui("separators_only_pinned", ({mock_template}) => {
     };
 
     stream_list.build_stream_list();
-    const $pinned_subheader = $("<pinned-subheader-stub>");
     const expected_elems = [
-        $pinned_subheader.html(), // pinned
+        // no section sub-header since there is only one section
         $("<devel-sidebar-row-stub>"),
         $("<Rome-sidebar-row-stub>"),
         // no separator at the end as no stream follows
     ];
 
     assert.deepEqual(appended_elems, expected_elems);
-    assert.ok(pinned_subheader_flag);
 });
 
 test_ui("rename_stream", ({mock_template}) => {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -145,8 +145,13 @@ export function build_stream_list(force_rerender) {
     const any_pinned_streams = stream_groups.pinned_streams.length > 0;
     const any_normal_streams = stream_groups.normal_streams.length > 0;
     const any_dormant_streams = stream_groups.dormant_streams.length > 0;
+    const need_section_subheaders =
+        (any_pinned_streams ? 1 : 0) +
+            (any_normal_streams ? 1 : 0) +
+            (any_dormant_streams ? 1 : 0) >=
+        2;
 
-    if (any_pinned_streams) {
+    if (any_pinned_streams && need_section_subheaders) {
         elems.push(
             render_stream_subheader({
                 subheader_name: $t({
@@ -164,7 +169,7 @@ export function build_stream_list(force_rerender) {
         add_sidebar_li(stream_id);
     }
 
-    if (any_normal_streams) {
+    if (any_normal_streams && need_section_subheaders) {
         elems.push(
             render_stream_subheader({
                 subheader_name: $t({
@@ -182,7 +187,7 @@ export function build_stream_list(force_rerender) {
         add_sidebar_li(stream_id);
     }
 
-    if (any_dormant_streams) {
+    if (any_dormant_streams && need_section_subheaders) {
         elems.push(
             render_stream_subheader({
                 subheader_name: $t({


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Showing section separators in the left sidebar ("Pinned streams", "Active streams", etc.) is unnecessary when there is only one section, and can feel confusing. We should show the separators only when there is more than one section present.

Fixes: <!-- Issue link, or clear description.--> #22843

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/53159963/188324052-2fcbf564-1405-402f-9773-4a7788e75cb3.mov


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
