### PR TITLE
internal_prep_private_message: Remove redundant realm arg.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1593,7 +1593,6 @@ def internal_prep_stream_message_by_name(
 
 
 def internal_prep_private_message(
-    realm: Realm,
     sender: UserProfile,
     recipient_user: UserProfile,
     content: str,
@@ -1603,6 +1602,7 @@ def internal_prep_private_message(
     See _internal_prep_message for details of how this works.
     """
     addressee = Addressee.for_user_profile(recipient_user)
+    realm = recipient_user.realm
 
     return _internal_prep_message(
         realm=realm,
@@ -1616,8 +1616,7 @@ def internal_prep_private_message(
 def internal_send_private_message(
     sender: UserProfile, recipient_user: UserProfile, content: str
 ) -> Optional[int]:
-    realm = recipient_user.realm
-    message = internal_prep_private_message(realm, sender, recipient_user, content)
+    message = internal_prep_private_message(sender, recipient_user, content)
     if message is None:
         return None
     message_ids = do_send_messages([message])

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2257,13 +2257,12 @@ class InternalPrepTest(ZulipTestCase):
         )
 
     def test_error_handling(self) -> None:
-        realm = get_realm("zulip")
         sender = self.example_user("cordelia")
         recipient_user = self.example_user("hamlet")
         content = "x" * 15000
 
         result = internal_prep_private_message(
-            realm=realm, sender=sender, recipient_user=recipient_user, content=content
+            sender=sender, recipient_user=recipient_user, content=content
         )
         assert result is not None
         message = result.message
@@ -2274,7 +2273,7 @@ class InternalPrepTest(ZulipTestCase):
         recipient_user = self.mit_user("starnine")
         with self.assertLogs(level="ERROR") as m:
             result = internal_prep_private_message(
-                realm=realm, sender=sender, recipient_user=recipient_user, content=content
+                sender=sender, recipient_user=recipient_user, content=content
             )
 
         self.assertEqual(

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -694,7 +694,6 @@ def send_messages_for_new_subscribers(
 
             notifications.append(
                 internal_prep_private_message(
-                    realm=realm,
                     sender=sender,
                     recipient_user=recipient_user,
                     content=msg,


### PR DESCRIPTION
This is redundant and is taken based on recipient_user anyway.
