### PR TITLE
 Stream privacy icon in typeaheads

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -206,6 +206,9 @@ js_rules = RuleList(
             "description": "Avoid using the `style=` attribute; we prefer styling in CSS files",
             "exclude": {
                 "web/tests/copy_and_paste.test.js",
+                "web/tests/filter.test.js",
+                "web/tests/search_suggestion_future.test.js",
+                "web/tests/search_suggestion_now.test.js",
             },
             "good_lines": ["#my-style {color: blue;}", "const style =", 'some_style = "test"'],
             "bad_lines": ['<p style="color: blue;">Foo</p>', 'style = "color: blue;"'],

--- a/web/e2e-tests/admin.test.ts
+++ b/web/e2e-tests/admin.test.ts
@@ -40,14 +40,17 @@ async function test_change_new_stream_notifications_setting(page: Page): Promise
         "rome",
     );
 
-    const rome_in_dropdown = await page.waitForSelector(
-        `xpath///*[@id="realm_notifications_stream_id_widget"]//*[${common.has_class_x(
-            "dropdown-list-body",
-        )} and count(li)=1]/li[normalize-space()="Rome"]`,
-        {visible: true},
-    );
-    assert.ok(rome_in_dropdown);
-    await rome_in_dropdown.click();
+    // Instead of using puppeteer click function, we are executing javascript inside browser because,
+    // puppeteer click was creating flake, and I was not able to find the better way to wait until
+    // the dropdown item is interactable.
+    await page.waitForFunction(() => {
+        // eslint-disable-next-line no-undef
+        if ($("#realm_notifications_stream_id_widget .stream_list_item").text().trim() === "Rome") {
+            $("#realm_notifications_stream_id_widget .stream_list_item").trigger("click"); // eslint-disable-line no-undef
+            return true;
+        }
+        return false;
+    });
 
     await submit_notifications_stream_settings(page);
 
@@ -72,7 +75,7 @@ async function test_change_signup_notifications_stream(page: Page): Promise<void
         "verona",
     );
     await page.waitForSelector(
-        "#realm_signup_notifications_stream_id_widget  .dropdown-list-body > li.list_item",
+        "#realm_signup_notifications_stream_id_widget  .dropdown-list-body > .stream_list_item_wrapper > li.list_item",
         {visible: true},
     );
     await page.keyboard.press("ArrowDown");

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -3,6 +3,8 @@ import _ from "lodash";
 
 import pygments_data from "../generated/pygments_data.json";
 import * as typeahead from "../shared/src/typeahead";
+import render_selected_stream_in_dropdown from "../templates/settings/selected_stream_in_dropdown.hbs";
+import render_stream_dropdown_list from "../templates/settings/stream_dropdown_list.hbs";
 
 import * as compose from "./compose";
 import * as compose_pm_pill from "./compose_pm_pill";
@@ -1022,6 +1024,8 @@ export function initialize_topic_edit_typeahead(form_field, stream_name, dropup)
         source() {
             return topics_seen_for(stream_name);
         },
+        modifier: (item) => render_stream_dropdown_list({item}),
+        selected_text_modifier: (item) => render_selected_stream_in_dropdown(item),
         items: 5,
     };
     form_field.typeahead(options);

--- a/web/src/dropdown_list_widget.js
+++ b/web/src/dropdown_list_widget.js
@@ -19,16 +19,20 @@ export class DropdownListWidget {
         include_current_item = true,
         value,
         on_update = () => {},
+        modifier = (item) => render_dropdown_list({item}),
+        selected_text_modifier = null,
     }) {
         // Initializing values
         this.widget_name = widget_name;
         this.data = data;
         this.default_text = default_text;
         this.render_text = render_text;
+        this.selected_text_modifier = selected_text_modifier;
         this.null_value = null_value;
         this.include_current_item = include_current_item;
         this.initial_value = value;
         this.on_update = on_update;
+        this.modifier = modifier;
 
         this.container_id = `${widget_name}_widget`;
         this.value_id = `id_${widget_name}`;
@@ -62,11 +66,17 @@ export class DropdownListWidget {
             this.render_default_text($elem);
             return;
         }
+        $elem.empty();
 
-        const text = this.render_text(item.name);
-        $elem.text(text);
-        $elem.removeClass("text-warning");
-        $elem.closest(".input-group").find(".dropdown_list_reset_button").show();
+        if (this.selected_text_modifier) {
+            // Render text with custom modifier.
+            $elem.append(this.selected_text_modifier(item));
+        } else {
+            const text = this.render_text(item.name);
+            $elem.text(text);
+            $elem.removeClass("text-warning");
+            $elem.closest(".input-group").find(".dropdown_list_reset_button").show();
+        }
     }
 
     update(value) {
@@ -115,9 +125,7 @@ export class DropdownListWidget {
 
         ListWidget.create($dropdown_list_body, get_data(data), {
             name: `${CSS.escape(this.widget_name)}_list`,
-            modifier(item) {
-                return render_dropdown_list({item});
-            },
+            modifier: this.modifier,
             filter: {
                 $element: $search_input,
                 predicate(item, value) {
@@ -396,9 +404,7 @@ export class MultiSelectDropdownListWidget extends DropdownListWidget {
 
         ListWidget.create($dropdown_list_body, data, {
             name: `${CSS.escape(this.widget_name)}_list`,
-            modifier(item) {
-                return render_dropdown_list({item});
-            },
+            modifier: this.modifier,
             multiselect: {
                 selected_items: this.data_selected,
             },

--- a/web/src/dropdown_list_widget.js
+++ b/web/src/dropdown_list_widget.js
@@ -68,14 +68,14 @@ export class DropdownListWidget {
         }
         $elem.empty();
 
+        $elem.removeClass("text-warning");
+        $elem.closest(".input-group").find(".dropdown_list_reset_button").show();
         if (this.selected_text_modifier) {
             // Render text with custom modifier.
             $elem.append(this.selected_text_modifier(item));
         } else {
             const text = this.render_text(item.name);
             $elem.text(text);
-            $elem.removeClass("text-warning");
-            $elem.closest(".input-group").find(".dropdown_list_reset_button").show();
         }
     }
 

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -419,6 +419,9 @@ export function get_available_streams_for_moving_messages(current_stream_id) {
         })
         .map((stream) => ({
             name: stream.name,
+            invite_only: stream.invite_only,
+            is_web_public: stream.is_web_public,
+            color: stream.color,
             value: stream.stream_id.toString(),
         }))
         .sort((a, b) => {

--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -1,5 +1,7 @@
 import Handlebars from "handlebars/runtime";
 
+import render_stream_icon_search from "../templates/stream_with_icon_in_search_result.hbs";
+
 import * as common from "./common";
 import {Filter} from "./filter";
 import * as huddle_data from "./huddle_data";
@@ -121,14 +123,27 @@ function get_stream_suggestions(last, operators) {
         const prefix = "stream";
         const highlighted_stream = highlight_query(regex, stream);
         const verb = last.negated ? "exclude " : "";
-        const description_html = verb + prefix + " " + highlighted_stream;
         const term = {
             operator: "stream",
             operand: stream,
             negated: last.negated,
         };
         const search_string = Filter.unparse([term]);
-        return {description_html, search_string};
+        const stream_sub = stream_data.get_sub(stream);
+
+        const rendered_stream_search_icon = render_stream_icon_search({
+            is_web_public: stream_sub.is_web_public,
+            color: stream_sub.color,
+            invite_only: stream_sub.invite_only,
+            rendered_stream_name: highlighted_stream,
+        });
+
+        const description_html = verb + prefix + rendered_stream_search_icon;
+
+        return {
+            description_html,
+            search_string,
+        };
     });
 
     return objs;

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -3,6 +3,8 @@ import $ from "jquery";
 import pygments_data from "../generated/pygments_data.json";
 import render_settings_deactivate_realm_modal from "../templates/confirm_dialog/confirm_deactivate_realm.hbs";
 import render_settings_admin_auth_methods_list from "../templates/settings/admin_auth_methods_list.hbs";
+import render_selected_stream_in_dropdown from "../templates/settings/selected_stream_in_dropdown.hbs";
+import render_stream_dropdown_list from "../templates/settings/stream_dropdown_list.hbs";
 
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
@@ -1011,13 +1013,17 @@ export function init_dropdown_widgets() {
         data: streams.map((x) => ({
             name: x.name,
             value: x.stream_id.toString(),
+            invite_only: x.invite_only,
+            is_web_public: x.is_web_public,
+            color: x.color,
         })),
         on_update() {
             save_discard_widget_status_handler($("#org-notifications"));
         },
         default_text: $t({defaultMessage: "Disabled"}),
-        render_text: (x) => `#${x}`,
         null_value: -1,
+        modifier: (item) => render_stream_dropdown_list({item}),
+        selected_text_modifier: (value) => render_selected_stream_in_dropdown(value),
     };
     notifications_stream_widget = new DropdownListWidget({
         widget_name: "realm_notifications_stream_id",

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -6,6 +6,8 @@ import render_all_messages_sidebar_actions from "../templates/all_messages_sideb
 import render_delete_topic_modal from "../templates/confirm_dialog/confirm_delete_topic.hbs";
 import render_drafts_sidebar_actions from "../templates/drafts_sidebar_action.hbs";
 import render_move_topic_to_stream from "../templates/move_topic_to_stream.hbs";
+import render_selected_stream_in_dropdown from "../templates/settings/selected_stream_in_dropdown.hbs";
+import render_stream_dropdown_list from "../templates/settings/stream_dropdown_list.hbs";
 import render_starred_messages_sidebar_actions from "../templates/starred_messages_sidebar_actions.hbs";
 import render_stream_sidebar_actions from "../templates/stream_sidebar_actions.hbs";
 import render_topic_sidebar_actions from "../templates/topic_sidebar_actions.hbs";
@@ -30,7 +32,6 @@ import * as resize from "./resize";
 import * as settings_data from "./settings_data";
 import * as starred_messages from "./starred_messages";
 import * as starred_messages_ui from "./starred_messages_ui";
-import * as stream_bar from "./stream_bar";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as stream_settings_ui from "./stream_settings_ui";
@@ -48,7 +49,6 @@ let all_messages_sidebar_elem;
 let starred_messages_sidebar_elem;
 let drafts_sidebar_elem;
 let stream_widget;
-let $stream_header_colorblock;
 
 // Keep the menu icon over which the popover is based off visible.
 function show_left_sidebar_menu_icon(element) {
@@ -548,10 +548,6 @@ export function build_move_topic_to_stream_popover(current_stream_id, topic_name
 
     function move_topic_post_render() {
         const $topic_input = $("#move_topic_form .inline_topic_edit");
-        $stream_header_colorblock = $("#dialog_widget_modal .topic_stream_edit_header").find(
-            ".stream_header_colorblock",
-        );
-        stream_bar.decorate(current_stream_name, $stream_header_colorblock, false);
         const streams_list =
             message_edit.get_available_streams_for_moving_messages(current_stream_id);
         const opts = {
@@ -561,6 +557,8 @@ export function build_move_topic_to_stream_popover(current_stream_id, topic_name
             include_current_item: false,
             value: current_stream_id,
             on_update: move_topic_on_update,
+            modifier: (item) => render_stream_dropdown_list({item}),
+            selected_text_modifier: (item) => render_selected_stream_in_dropdown(item),
         };
         stream_widget = new DropdownListWidget(opts);
 
@@ -640,11 +638,6 @@ export function register_click_handlers() {
         if (e.type === "keypress" && !keydown_util.is_enter_event(e)) {
             return;
         }
-        const stream_name = stream_data.maybe_get_stream_name(
-            Number.parseInt(stream_widget.value(), 10),
-        );
-
-        stream_bar.decorate(stream_name, $stream_header_colorblock, false);
     });
 
     register_stream_handlers();

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -126,6 +126,10 @@ export function render_stream(stream) {
         primary: stream.name,
         secondary: desc,
         is_unsubscribed: !stream.subscribed,
+        invite_only: stream.invite_only,
+        is_web_public: stream.is_web_public,
+        color: stream.color,
+        is_stream: true,
     });
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -488,12 +488,6 @@ div.overlay {
     border-bottom: 0;
 }
 
-.stream_header_colorblock {
-    @extend .stream-selection-header-colorblock;
-    margin-bottom: 5px;
-    z-index: 1;
-}
-
 .edit-controls .fa-angle-right,
 .topic_stream_edit_header .fa-angle-right {
     font-size: 0.9em;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1525,6 +1525,21 @@ $option_title_width: 180px;
         }
     }
 
+    a.active_stream {
+        display: inline-block;
+        clear: both;
+        font-weight: normal;
+        color: inherit;
+
+        .zulip-icon {
+            font-size: 13px;
+        }
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
+
     button.multiselect_btn {
         /* Matches the dropdown input margin so as to keep it aligned */
         margin-left: 9px;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -23,6 +23,10 @@ $left_sidebar_collapse_widget_gutter: 10px;
 $left_sidebar_width: 270px;
 $right_sidebar_width: 250px;
 
+/* The width of the empty space in the sidebar to separate
+   content from the edge of the window */
+$far_left_gutter_size: 10px;
+
 body,
 html {
     width: 100%;
@@ -2195,6 +2199,48 @@ div.focused_table {
 .nav .dropdown-menu a,
 .typeahead.dropdown-menu a {
     color: inherit;
+}
+
+.subscription_block,
+.stream-icon-name-wrapper {
+    padding: 0;
+    margin-right: 25px;
+    margin-left: $far_left_gutter_size;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+
+    &::after {
+        content: "";
+        display: block;
+        clear: both;
+    }
+
+    .stream-name {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        position: relative;
+        width: 100%;
+        padding-right: 2px;
+    }
+
+    &.stream-with-count {
+        margin-right: 15px;
+    }
+
+    &:not(.subscription_block) {
+        margin-left: 4px;
+        margin-right: 0;
+        display: inline-flex;
+
+        .stream-privacy {
+            min-width: 16px;
+        }
+    }
 }
 
 .typeahead.dropdown-menu {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -810,12 +810,22 @@ li.actual-dropdown-menu > a:focus {
     outline: 0;
 }
 
-li.actual-dropdown-menu i {
-    /* In gear menu, make icons the same width so labels line up. */
+li.actual-dropdown-menu i,
+.active_stream .stream-privacy span,
+.stream_list_item .stream-privacy span,
+.active_stream .stream-privacy i,
+.stream_list_item .stream-privacy i {
+    /* Make icons the same width so labels line up. */
     display: inline-block;
     width: 14px;
     text-align: center;
     margin-right: 3px;
+    min-width: unset;
+}
+
+.active_stream .stream-privacy span,
+.stream_list_item .stream-privacy span {
+    margin-right: 0;
 }
 
 #gear_menu_about_zulip {
@@ -2588,14 +2598,7 @@ select.invite-as {
         margin-top: 0;
     }
 
-    /* Override the default border-radius to properly align
-       the button corners with `stream_header_colorblock`. */
-    .dropdown-toggle {
-        border-radius: 1px 4px 4px 1px !important;
-    }
-
-    .dropdown-list-widget,
-    .stream_header_colorblock {
+    .dropdown-list-widget {
         margin-bottom: 10px;
     }
 

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -4,7 +4,6 @@
 <form class="new-style" id="move_topic_form">
     <p>{{t "Select a stream below or change topic name." }}</p>
     <div class="topic_stream_edit_header">
-        <div class="stream_header_colorblock"></div>
         <div class="move-topic-dropdown">
             {{> settings/dropdown_list_widget
               widget_name="select_stream"

--- a/web/templates/settings/selected_stream_in_dropdown.hbs
+++ b/web/templates/settings/selected_stream_in_dropdown.hbs
@@ -1,0 +1,9 @@
+<a class="active_stream" tabindex="0">
+    <span class="stream-privacy" style="color: {{color}};">
+        {{> ../stream_privacy
+          invite_only=invite_only
+          is_web_public=is_web_public
+          }}
+    </span>
+    <span>{{name}}</span>
+</a>

--- a/web/templates/settings/stream_dropdown_list.hbs
+++ b/web/templates/settings/stream_dropdown_list.hbs
@@ -1,0 +1,13 @@
+<div class="stream_list_item_wrapper">
+    {{#with item}}
+        <li class="list_item stream_list_item" role="presentation" data-value="{{value}}">
+            <a role="menuitem" tabindex="0">
+                <span class="stream-privacy" style="color: {{color}};">
+                    {{> ../stream_privacy
+                      invite_only=invite_only
+                      is_web_public=is_web_public
+                      }} </span> {{name}}
+            </a>
+        </li>
+    {{/with}}
+</div>

--- a/web/templates/stream_icon.hbs
+++ b/web/templates/stream_icon.hbs
@@ -1,0 +1,6 @@
+<span class="stream-privacy searchbar" style="color: {{color}};">
+    {{> stream_privacy
+      invite_only=invite_only
+      is_web_public=is_web_public
+      }}
+</span>

--- a/web/templates/stream_with_icon_in_search_result.hbs
+++ b/web/templates/stream_with_icon_in_search_result.hbs
@@ -1,0 +1,15 @@
+<div class="stream-icon-name-wrapper" tabindex="0">
+    <span class="stream-privacy" style="color: {{color}};">
+        {{> stream_privacy
+          invite_only=invite_only
+          is_web_public=is_web_public
+          }}
+    </span>
+    <span class="stream-name">
+        {{#if name}}
+        {{name}}
+        {{else}}
+        {{{rendered_stream_name}}}
+        {{/if}}
+    </span>
+</div>

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -17,6 +17,14 @@
 {{else if is_user_group}}
     <i class="typeahead-image icon fa fa-group no-presence-circle" aria-hidden="true"></i>
 {{/if}}
+{{#if is_stream}}
+    <span class="stream-privacy" style="color: {{color}};">
+        {{> stream_privacy
+          invite_only=invite_only
+          is_web_public=is_web_public
+          }}
+    </span>
+{{/if}}
 <strong>
     {{~ primary ~}}
 </strong>

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1101,7 +1101,7 @@ test("unparse", () => {
     assert.deepEqual(Filter.unparse(operators), string);
 });
 
-test("describe", () => {
+test("describe", ({mock_template}) => {
     let narrow;
     let string;
 
@@ -1113,11 +1113,38 @@ test("describe", () => {
     string = "exclude streams public";
     assert.equal(Filter.describe(narrow), string);
 
+    stream_data.add_sub({
+        stream_id: 88,
+        name: "devel",
+        subscribed: true,
+        is_web_public: false,
+        color: "red",
+        invite_only: true,
+    });
+
+    mock_template("stream_with_icon_in_search_result.hbs", true, (data, html) => {
+        assert.deepEqual(data, {
+            color: "red",
+            invite_only: true,
+            is_web_public: false,
+            name: "devel",
+        });
+        return html;
+    });
+    const stream_icon_html = `<div class="stream-icon-name-wrapper" tabindex="0">
+    <span class="stream-privacy" style="color: red;">
+        <i class="fa fa-lock" aria-hidden="true"></i>
+    </span>
+    <span class="stream-name">
+        devel
+    </span>
+</div>`;
+
     narrow = [
         {operator: "stream", operand: "devel"},
         {operator: "is", operand: "starred"},
     ];
-    string = "stream devel, starred messages";
+    string = `stream${stream_icon_html}, starred messages`;
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
@@ -1131,7 +1158,7 @@ test("describe", () => {
         {operator: "stream", operand: "devel"},
         {operator: "topic", operand: "JS"},
     ];
-    string = "stream devel &gt; JS";
+    string = `stream${stream_icon_html} &gt; JS`;
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
@@ -1170,7 +1197,7 @@ test("describe", () => {
         {operator: "stream", operand: "devel"},
         {operator: "topic", operand: "JS", negated: true},
     ];
-    string = "stream devel, exclude topic JS";
+    string = `stream${stream_icon_html}, exclude topic JS`;
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
@@ -1184,28 +1211,28 @@ test("describe", () => {
         {operator: "stream", operand: "devel"},
         {operator: "is", operand: "starred", negated: true},
     ];
-    string = "stream devel, exclude starred messages";
+    string = `stream${stream_icon_html}, exclude starred messages`;
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: "stream", operand: "devel"},
         {operator: "has", operand: "image", negated: true},
     ];
-    string = "stream devel, exclude messages with one or more image";
+    string = `stream${stream_icon_html}, exclude messages with one or more image`;
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: "has", operand: "abc", negated: true},
         {operator: "stream", operand: "devel"},
     ];
-    string = "invalid abc operand for has operator, stream devel";
+    string = `invalid abc operand for has operator, stream${stream_icon_html}`;
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: "has", operand: "image", negated: true},
         {operator: "stream", operand: "devel"},
     ];
-    string = "exclude messages with one or more image, stream devel";
+    string = `exclude messages with one or more image, stream${stream_icon_html}`;
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [];


### PR DESCRIPTION
<!-- Describe your pull request here.-->
It adds stream privacy icons in all the places except `Message compose addressee typeahead.` and `Adding streams in SETTINGS / DEFAULT STREAMS.` which are blocked by other PRs.

- [x] Move message typeahead.
-  [x] Move topic (via left sidebar menu) typeahead.
- [x] New stream notifications and New user notifications in SETTINGS / ORGANIZATION SETTINGS. Note that the decorator for the selected stream also needs to be modified to indicate the stream privacy setting, rather than always being shown as a #.
- [x] Stream reference compose box typeahead (i.e. #... typeahead).
- [x]  Top search bar auto-complete




Fixes: <!-- Issue link, or clear description.--> #22355
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
*Move message*
![Screenshot 2022-09-24 at 1 24 57 AM](https://user-images.githubusercontent.com/63820270/192047048-fbc0b226-1aa0-43ad-9527-042925113732.png)
![Screenshot 2022-10-08 at 3 54 35 PM](https://user-images.githubusercontent.com/63820270/194703120-a67abbed-264f-41cc-a138-b3320ce31c6a.png)


*Move Topic*
![Screenshot 2022-09-24 at 1 25 15 AM](https://user-images.githubusercontent.com/63820270/192047162-9d315323-f53d-4b6f-b540-8f704eed1128.png)
![Screenshot 2022-10-08 at 3 54 43 PM](https://user-images.githubusercontent.com/63820270/194703115-6fe8361d-8caa-406d-8d07-8cf3169aadb2.png)


*Settings ORG*
![settings_org_active_stream](https://user-images.githubusercontent.com/63820270/188557713-8865c1a3-7483-4f3d-92de-e254acdb1cfb.png)
![Screenshot 2022-09-24 at 1 28 53 AM](https://user-images.githubusercontent.com/63820270/192047591-79f70ad2-5d0d-4129-8894-c6b04ed0e70f.png)


*Search*
![Screenshot 2022-09-06 at 9 59 45 PM](https://user-images.githubusercontent.com/63820270/188689011-67412859-1b95-49dd-ab8f-35d3c0fb9993.png)



*Stream reference compose box typeahead*
![Screenshot 2022-09-06 at 9 59 34 PM](https://user-images.githubusercontent.com/63820270/188689092-8daddfc6-1fd5-4560-a8da-c92f71e57e88.png)



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
