### PR TITLE
templates: Update HTML title and metadata elements for base/portico pages.

### DIFF
--- a/static/html/5xx.html
+++ b/static/html/5xx.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8" />
-        <title>Zulip - 500 internal server error</title>
+        <title>500 internal server error | Zulip</title>
         <base href="/static/webpack-bundles/" />
 
         <meta http-equiv="refresh" content="60;URL='/'" />

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Error") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_class_name %}error{% endblock %}
 
 {% block portico_content %}
@@ -10,13 +14,15 @@
             <div class="errorbox">
                 <div class="errorcontent">
                     {% if status_code == 405 %}
-                    <h1 class="lead">Method not allowed (405)</h1>
+                    <h1 class="lead">{{ _("Method not allowed (405)") }}</h1>
                     {% else %}
-                    <h1 class="lead">Page not found (404)</h1>
+                    <h1 class="lead">{{ _("Page not found (404)") }}</h1>
                     {% endif %}
                     <p>
+                        {% trans %}
                         If this error is unexpected, you can
                         <a href="mailto:{{ support_email }}">contact support</a>.
+                        {% endtrans %}
                     </p>
                 </div>
             </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Internal server error") }} | Zulip</title>
+{% endblock %}
+
 {% block customhead %}
 {{ super() }}
 <meta http-equiv="refresh" content="60;URL='/'" />
@@ -14,10 +18,12 @@
             <img src="/static/images/errors/500art.svg" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
-                    <h1 class="lead">Internal server error</h1>
+                    <h1 class="lead">{{ _("Internal server error") }}</h1>
+                    {% trans %}
                     <p>This Zulip server is currently experiencing some technical difficulties. Sorry about that!</p>
                     <p>The page will reload automatically soon after service is restored.</p>
                     <p>If you'd like, you can <a href="mailto:{{ support_email }}">drop us a line</a> to let us know what happened.</p>
+                    {% endtrans %}
                 </div>
 
             </div>

--- a/templates/analytics/activity.html
+++ b/templates/analytics/activity.html
@@ -4,7 +4,7 @@
 {# User activity. #}
 
 {% block title %}
-<title>{{ title }}</title>
+<title>{{ title }} | Zulip analytics</title>
 {% endblock %}
 
 

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -1,6 +1,14 @@
 {% extends "zerver/base.html" %}
 {% set entrypoint = "stats" %}
 
+{% block title %}
+<title>
+    {% trans %}
+    Analytics for {{ target_name }} | Zulip
+    {% endtrans %}
+</title>
+{% endblock %}
+
 {% block content %}
 <div class="app portico-page stats-page">
 

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -4,7 +4,7 @@
 {# User activity. #}
 
 {% block title %}
-<title>Info</title>
+<title>Support panel | Zulip</title>
 {% endblock %}
 
 {% block content %}

--- a/templates/confirmation/confirm_email_change.html
+++ b/templates/confirmation/confirm_email_change.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Email changed") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="app confirm-email-change-page flex full-page">

--- a/templates/confirmation/confirm_preregistrationuser.html
+++ b/templates/confirmation/confirm_preregistrationuser.html
@@ -1,6 +1,10 @@
 {% extends "zerver/base.html" %}
 {% set entrypoint = "confirm-preregistrationuser" %}
 
+{% block title %}
+<title>{{ _("Confirming your email address") }} | Zulip</title>
+{% endblock %}
+
 {% block content %}
 
 {#

--- a/templates/confirmation/link_does_not_exist.html
+++ b/templates/confirmation/link_does_not_exist.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Confirmation link does not exist") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="error_page">
     <div class="container">

--- a/templates/confirmation/link_expired.html
+++ b/templates/confirmation/link_expired.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Confirmation link expired or deactivated") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="error_page">
     <div class="container">

--- a/templates/confirmation/link_malformed.html
+++ b/templates/confirmation/link_malformed.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Confirmation link malformed") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="error_page">
     <div class="container">

--- a/templates/corporate/apps.html
+++ b/templates/corporate/apps.html
@@ -1,6 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
+{% set PAGE_TITLE = "Download the Zulip app for your device" %}
+
+{% set PAGE_DESCRIPTION = "Zulip has apps for every platform. Download the Zulip
+  app for macOS, Windows, Linux, Android, iOS or Terminal." %}
+
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <style media="screen">

--- a/templates/corporate/attribution.html
+++ b/templates/corporate/attribution.html
@@ -1,12 +1,8 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Zulip attributions</title>
-{% endblock %}
-
-{% set PAGE_TITLE = 'Zulip website attributions' %}
-{% set PAGE_DESCRIPTION = '' %}
+{% set PAGE_TITLE = "Website attributions | Zulip" %}
+{% set PAGE_DESCRIPTION = "Attributions for the Zulip website." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "billing" %}
 
+{% block title %}
+<title>{{ _("Billing") }} | Zulip</title>
+{% endblock %}
+
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 {% endblock %}

--- a/templates/corporate/case-studies/asciidoctor-case-study.html
+++ b/templates/corporate/case-studies/asciidoctor-case-study.html
@@ -1,9 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Case study: Asciidoctor open-source community</title>
-{% endblock %}
+{% set PAGE_TITLE = "Case study: Asciidoctor open-source community | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Learn how Zulip became the heart of the Asciidoctor
+  community by enabling organized, inclusive and thoughtful discussion." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/case-studies/idrift-case-study.html
+++ b/templates/corporate/case-studies/idrift-case-study.html
@@ -1,9 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Case study: iDrift AS, distributed tech company</title>
-{% endblock %}
+{% set PAGE_TITLE = "Case study: iDrift AS, distributed tech company | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Learn why using Zulip significantly increases the
+  size of the team for which a manager can meaningfully know what’s going on." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/case-studies/lean-case-study.html
+++ b/templates/corporate/case-studies/lean-case-study.html
@@ -1,9 +1,8 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Case study: Lean theorem prover community</title>
-{% endblock %}
+{% set PAGE_TITLE = "Case study: Lean theorem prover community | Zulip" %}
+{% set PAGE_DESCRIPTION = "Zulip enables collaboration at scale: “We could never do what we’re doing on Slack or Discord.”" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/case-studies/recurse-center-case-study.html
+++ b/templates/corporate/case-studies/recurse-center-case-study.html
@@ -1,9 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Case study: Recurse Center</title>
-{% endblock %}
+{% set PAGE_TITLE = "Case study: Recurse Center | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "“Switching to Zulip has turned out to be one of the
+  best decisions we’ve made,” says Recurse Center co-founder and CEO Nick
+  Bergson-Shilcock." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/case-studies/rust-case-study.html
+++ b/templates/corporate/case-studies/rust-case-study.html
@@ -1,9 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Case study: Rust programming language community</title>
-{% endblock %}
+{% set PAGE_TITLE = "Case study: Rust programming language community | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Learn why Rust development would not be moving at the
+  pace that it has been without Zulip, and the organized, searchable conversations it enables." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/case-studies/tum-case-study.html
+++ b/templates/corporate/case-studies/tum-case-study.html
@@ -1,9 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Case study: Zulip at Technical University of Munich Department of Informatics</title>
-{% endblock %}
+{% set PAGE_TITLE = "Case study: Technical University of Munich Department of Informatics | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "How do you teach computer science to 1400 freshmen?
+  “Zulip is the only app that makes hundreds of conversations manageable.”" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/case-studies/ucsd-case-study.html
+++ b/templates/corporate/case-studies/ucsd-case-study.html
@@ -1,9 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Case study: Zulip at University of California San Diego</title>
-{% endblock %}
+{% set PAGE_TITLE = "Case study: University of California San Diego | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "How do you teach graduate-level mathematics to
+  students across six continents? “I chose Zulip especially for the threaded model
+  and the TeX integration.”" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/communities.html
+++ b/templates/corporate/communities.html
@@ -1,6 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "communities" %}
 
+{% set PAGE_TITLE = "Open communities directory | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Zulip communities that are open to the public, and
+  have opted in to be listed." %}
+
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 {% endblock %}

--- a/templates/corporate/development-community.html
+++ b/templates/corporate/development-community.html
@@ -1,12 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'The Zulip development community' %}
-{% set PAGE_DESCRIPTION = 'Join the Zulip community to contribute, ask questions, or provide feedback to the creators of Zulip.' %}
+{% set PAGE_TITLE = "Development community | Zulip" %}
 
-{% block title %}
-<title>The Zulip development community</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Join the Zulip development community to contribute,
+  ask questions, or provide feedback to the creators of Zulip. Everyone is
+  welcome!" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/event_status.html
+++ b/templates/corporate/event_status.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "billing-event-status" %}
 
+{% block title %}
+<title>{{ _("Billing status") }} | Zulip</title>
+{% endblock %}
+
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 {% endblock %}

--- a/templates/corporate/features.html
+++ b/templates/corporate/features.html
@@ -1,8 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'Zulip features' %}
-{% set PAGE_DESCRIPTION = 'First class threading on top of everything you could want from real-time chat.' %}
+{% set PAGE_TITLE = "Features | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "From highly configurable notifications, to powerful
+  formatting and flexible administration, Zulip has you covered." %}
 
 {% block portico_content %}
 

--- a/templates/corporate/for/business.html
+++ b/templates/corporate/for/business.html
@@ -1,9 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Zulip: Efficient communication for your business.</title>
-{% endblock %}
+{% set PAGE_TITLE = "Zulip for business" %}
+
+{% set PAGE_DESCRIPTION = "Zulip offers efficient communication for your
+  business, with organized and inclusive threaded team chat. Free for
+  light use!" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/for/communities.html
+++ b/templates/corporate/for/communities.html
@@ -1,9 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Zulip for communities</title>
-{% endblock %}
+{% set PAGE_TITLE = "Zulip for communities" %}
+
+{% set PAGE_DESCRIPTION = "Zulip is designed with communities in mind, including
+  open-source projects, research collaborations, and volunteer organizations.
+  Reach out for a sponsorship!" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/for/education.html
+++ b/templates/corporate/for/education.html
@@ -1,12 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'Teach a course with Zulip.' %}
-{% set PAGE_DESCRIPTION = 'Online, in-person, and anything in between' %}
+{% set PAGE_TITLE = "Zulip for education" %}
 
-{% block title %}
-<title>Teach a course with Zulip for Education: Online, in-person, and anything in between</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Make Zulip the communication hub for your class.
+  Online, in-person, and anything in between. Free for most classes!" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/for/events.html
+++ b/templates/corporate/for/events.html
@@ -1,12 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'Zulip for conferences and events' %}
-{% set PAGE_DESCRIPTION = 'Conferences, workshops, hackathons. In-person, online, and anything in between.' %}
+{% set PAGE_TITLE = "Zulip for events and conferences" %}
 
-{% block title %}
-<title>Zulip for conferences and events: Conferences, workshops, hackathons. In-person, online, and anything in between.</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Make Zulip the communication hub for your
+  conference, workshop, hackathon, or other event. In-person, online, and anything
+  in between." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -1,12 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-(% set PAGE_TITLE = 'Modern chat for open source' %}
-{% set PAGE_DESCRIPTION = 'Zulip is the only modern team chat app that is ideal for both live and asynchronous conversations. Discuss issues, pull requests and feature ideas, engage with users, answer questions, and onboard new contributors.' %}
+{% set PAGE_TITLE = "Zulip for open-source projects" %}
 
-{% block title %}
-<title>Zulip: the best group chat for open-source projects</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Grow your community with thoughtful and inclusive
+  discussion, using the only modern team chat app that is ideal for both live
+  and asynchronous conversations." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/for/research.html
+++ b/templates/corporate/for/research.html
@@ -1,12 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'Zulip for research' %}
-{% set PAGE_DESCRIPTION = 'Chat for your project, research group, department or scientific field' %}
+{% set PAGE_TITLE = "Zulip for researchers and academics" %}
 
-{% block title %}
-<title>Zulip for research: Chat for your project, research group, department or scientific field</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Make Zulip the communication hub for your research
+  group, department or scientific field. The only modern team chat ideal for both
+  live and asynchronous conversations." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/for/use-cases.html
+++ b/templates/corporate/for/use-cases.html
@@ -1,9 +1,9 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Use cases and customer stories</title>
-{% endblock %}
+{% set PAGE_TITLE = "Use cases and customer stories | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Learn how our customers are using Zulip." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/hello.html
+++ b/templates/corporate/hello.html
@@ -1,6 +1,12 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
+{% set PAGE_TITLE = "Zulip: Open-source team chat with topic-based threading" %}
+
+{% set PAGE_DESCRIPTION = "Zulip is the only modern team chat app that is
+  designed for both live and asynchronous conversations. Organized to help you
+  collaborate productively and efficiently." %}
+
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/templates/corporate/history.html
+++ b/templates/corporate/history.html
@@ -1,9 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Zulip history</title>
-{% endblock %}
+{% set PAGE_TITLE = "History of the Zulip project" %}
+
+{% set PAGE_DESCRIPTION = "Learn how Zulip grew from a small startup to become
+  the project with the most active open-source development community of any team
+  chat software." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -17,7 +19,7 @@
     <div class="hero bg-pycon">
         <div class="bg-dimmer"></div>
         <div class="content">
-            <h1 class="center">Zulip History</h1>
+            <h1 class="center">History of the Zulip project</h1>
         </div>
     </div>
     <div class="main">

--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -1,9 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Zulip jobs</title>
-{% endblock %}
+{% set PAGE_TITLE = "Jobs | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "We're hiring! Learn about our openings and how to
+  apply." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/plans.html
+++ b/templates/corporate/plans.html
@@ -1,12 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'Zulip plans and pricing' %}
-{% set PAGE_DESCRIPTION = 'Get started today.' %}
+{% set PAGE_TITLE = "Plans and pricing | Zulip" %}
 
-{% block title %}
-<title>Zulip plans and pricing</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Choose between Zulip Cloud Free and Zulip Cloud
+  Standard, or self-host our open-source software for free. Support contracts
+  available." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/security.html
+++ b/templates/corporate/security.html
@@ -1,9 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Zulip security</title>
-{% endblock %}
+{% set PAGE_TITLE = "Security | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Making sure your information stays protected is our
+  highest priority. Learn how Zulip’s security strategy covers all aspects of our
+  product and business." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/self-hosting.html
+++ b/templates/corporate/self-hosting.html
@@ -1,12 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'Self-host Zulip today.' %}
-{% set PAGE_DESCRIPTION = 'Open-source software that provides enterprise-grade reliability and security.' %}
+{% set PAGE_TITLE = "Self-host Zulip" %}
 
-{% block title %}
-<title>Self-host Zulip today. Open-source software that provides enterprise-grade reliability and security.</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Open-source team chat with enterprise-grade
+  reliability and security. Take charge of your mission-critical communication
+  platform." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/support_request_thanks.html
+++ b/templates/corporate/support_request_thanks.html
@@ -1,13 +1,19 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Thanks for contacting us") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="flex full-page thanks-page">
     <div class="center-block new-style">
-        <h1>Thanks for contacting us!</h1>
-        <p>We will be in touch with you soon.</p>
+        <h1>{{ _("Thanks for contacting us!") }}</h1>
+        <p>{{ _("We will be in touch with you soon.") }}</p>
         <p>
+            {% trans %}
             You can find answers to frequently asked questions in the
             <a href="/help/">Zulip help center</a>.
+            {% endtrans %}
         </p>
     </div>
 </div>

--- a/templates/corporate/team.html
+++ b/templates/corporate/team.html
@@ -1,9 +1,11 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% block title %}
-<title>Zulip: the best group chat for open source projects</title>
-{% endblock %}
+{% set PAGE_TITLE = "The Zulip team" %}
+
+{% set PAGE_DESCRIPTION = "Zulip has the most active open-source
+development community of any team chat software, with over 1100 code
+contributors, and more than 75 with 100+ commits." %}
 
 {% block portico_content %}
 

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "upgrade" %}
 
+{% block title %}
+<title>{{ _("Upgrade") }} | Zulip</title>
+{% endblock %}
+
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 {% endblock %}

--- a/templates/corporate/why-zulip.html
+++ b/templates/corporate/why-zulip.html
@@ -1,12 +1,12 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
-{% set PAGE_TITLE = 'Team chat with first-class threading' %}
-{% set PAGE_DESCRIPTION = 'Most team chats are overwhelming to keep up with. Zulip takes a different approach.' %}
+{% set PAGE_TITLE = "How Zulip's topic-based threading improves team
+  communication" %}
 
-{% block title %}
-<title>The best group chat</title>
-{% endblock %}
+{% set PAGE_DESCRIPTION = "Make better decisions, faster with chat that’s
+  organized right. Follow the discussions that matter to you, easily and
+  efficiently, in real time or asynchronously." %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/corporate/zephyr-mirror.html
+++ b/templates/corporate/zephyr-mirror.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>Zephyr mirroring information | Zulip</title>
+{% endblock %}
+
 {# Zephyr mirroring information page #}
 
 {% block portico_content %}

--- a/templates/corporate/zephyr.html
+++ b/templates/corporate/zephyr.html
@@ -2,7 +2,7 @@
 {% set entrypoint = "landing-page" %}
 
 {% block title %}
-<title>Zulip zephyr</title>
+<title>Zephyr for MIT | Zulip</title>
 {% endblock %}
 
 {% block customhead %}

--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -1,4 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
+
+{% block title %}
+<title>{{ _("Accept the Terms of Service") }} | Zulip</title>
+{% endblock %}
+
 {#
 Allow the user to accept a TOS, creating an email record of that fact.
 Users only hit this page if they are coming from a migration or other update of the TOS;

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico_signup.html" %}
 {# Home page for not logged-in users. #}
 
+{% block title %}
+<title>{{ _("Sign up") }} | Zulip</title>
+{% endblock %}
+
 {# This is where we pitch the app and solicit signups. #}
 
 {% block portico_content %}

--- a/templates/zerver/accounts_send_confirm.html
+++ b/templates/zerver/accounts_send_confirm.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico_signup.html" %}
 {# Displayed after a user attempts to sign up. #}
 
+{% block title %}
+<title>{{ _("Confirm your email address") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <!-- The following empty tag has unique data-page-id so that this
 page can be easily identified in it's respective JavaScript file -->

--- a/templates/zerver/auth_subdomain.html
+++ b/templates/zerver/auth_subdomain.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Authentication subdomain error") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="error_page">
@@ -8,13 +12,15 @@
             <img src="/static/images/errors/500art.svg" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
-                    <h1 class="lead">Authentication subdomain</h1>
+                    <h1 class="lead">{{ _("Authentication subdomain") }}</h1>
                     <p>
+                        {% trans %}
                         It appears you ended up here by accident. This site
                         is meant to be an intermediate step in the authentication process
                         and shouldn't be accessed manually. If you came here directly,
                         you probably got the address wrong. If you got stuck here while trying
                         to log in, this is most likely a server bug or misconfiguration.
+                        {% endtrans %}
                     </p>
                 </div>
             </div>

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -11,8 +11,6 @@
             {% else %}
                 {% if PAGE_TITLE %}
                 <title>{{ PAGE_TITLE }}</title>
-                {% else %}
-                <title>Zulip</title>
                 {% endif %}
             {% endif %}
         {% endblock %}

--- a/templates/zerver/close_window.html
+++ b/templates/zerver/close_window.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8" />
-        <title>Callback complete</title>
+        <title>{{ _("Video call ended") }} | Zulip</title>
         <script>
             window.close();
             // Why doesn’t this work in Firefox?  See
@@ -10,6 +10,6 @@
         </script>
     </head>
     <body>
-        <p>You may now close this window.</p>
+        <p>{{ _("You may now close this window.") }}</p>
     </body>
 </html>

--- a/templates/zerver/config_error.html
+++ b/templates/zerver/config_error.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Configuration error") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="error_page" style="padding-bottom: 60px;">
@@ -8,7 +12,7 @@
             <img src="/static/images/errors/500art.svg" alt=""/>
             <div class="errorbox config-error">
                 <div class="errorcontent">
-                    <h1 class="lead">Configuration error</h1>
+                    <h1 class="lead">{{ _("Configuration error") }}</h1>
                     <br />
                     {% if error_name == "ldap_error_realm_is_none" %}
                         {% trans %}

--- a/templates/zerver/confirm_continue_registration.html
+++ b/templates/zerver/confirm_continue_registration.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Account not found") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="app register-page">
     <div class="app-main confirm-continue-page-container">

--- a/templates/zerver/create_realm.html
+++ b/templates/zerver/create_realm.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico_signup.html" %}
 {# Home page for not logged-in users. #}
 
+{% block title %}
+<title>{{ _("Create a new organization") }} | Zulip</title>
+{% endblock %}
+
 {# This is where we pitch the app and solicit signups. #}
 
 {% block portico_content %}

--- a/templates/zerver/deactivated.html
+++ b/templates/zerver/deactivated.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Deactivated organization") }} | Zulip</title>
+{% endblock %}
+
 {% block customhead %}
 {{ super() }}
 <meta http-equiv="refresh" content="60;URL='/'" />

--- a/templates/zerver/desktop_login.html
+++ b/templates/zerver/desktop_login.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "desktop-login" %}
 
+{% block title %}
+<title>{{ _("Finish desktop app login") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="flex new-style">
     <div class="desktop-redirect-box">

--- a/templates/zerver/desktop_redirect.html
+++ b/templates/zerver/desktop_redirect.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "desktop-redirect" %}
 
+{% block title %}
+<title>{{ _("Log in to desktop app") }} | Zulip</title>
+{% endblock %}
+
 {% block content %}
 <div class="flex new-style">
     <div class="desktop-redirect-box white-box">

--- a/templates/zerver/development/dev_login.html
+++ b/templates/zerver/development/dev_login.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "dev-login" %}
 
+{% block title %}
+<title>Log in | Zulip Dev</title>
+{% endblock %}
+
 {# Login page. #}
 {% block portico_content %}
 <!-- The following empty tag has unique data-page-id so that this

--- a/templates/zerver/development/dev_tools.html
+++ b/templates/zerver/development/dev_tools.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>Tools and data sets | Zulip Dev</title>
+{% endblock %}
+
 {# Login page. #}
 {% block portico_content %}
 

--- a/templates/zerver/development/email_log.html
+++ b/templates/zerver/development/email_log.html
@@ -1,5 +1,10 @@
 {% extends "zerver/base.html" %}
 {% set entrypoint = "dev-email-log" %}
+
+{% block title %}
+<title>Email log | Zulip Dev</title>
+{% endblock %}
+
 {% block content %}
 <div class="container">
     <div style="position: fixed">

--- a/templates/zerver/development/integrations_dev_panel.html
+++ b/templates/zerver/development/integrations_dev_panel.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "dev-integrations-panel" %}
 
+{% block title %}
+<title>Integrations developer panel | Zulip Dev</title>
+{% endblock %}
+
 {% block customhead %}
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -1,6 +1,10 @@
 {% extends "zerver/base.html" %}
 {% set entrypoint = "digest" %}
 
+{% block title %}
+<title>{{ _("Digest") }} | Zulip</title>
+{% endblock %}
+
 {% block content %}
 <body>
     <div class="portico-wrap">

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Find your accounts") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="app find-account-page flex full-page">

--- a/templates/zerver/insecure_desktop_app.html
+++ b/templates/zerver/insecure_desktop_app.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Update required") }} | Zulip</title>
+{% endblock %}
+
 {% block content %}
 
 <div class="error_page">

--- a/templates/zerver/invalid_email.html
+++ b/templates/zerver/invalid_email.html
@@ -1,4 +1,9 @@
 {% extends "zerver/portico.html" %}
+
+{% block title %}
+<title>{{ _("Invalid email") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
     <h3>{{ _('Invalid email') }}</h3>

--- a/templates/zerver/invalid_realm.html
+++ b/templates/zerver/invalid_realm.html
@@ -1,4 +1,9 @@
 {% extends "zerver/portico.html" %}
+
+{% block title %}
+<title>{{ _("Organization does not exist") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="app find-account-page flex full-page">

--- a/templates/zerver/log_into_subdomain_token_invalid.html
+++ b/templates/zerver/log_into_subdomain_token_invalid.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Invalid or expired login session") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="app portico-page">
     <div class="app-main portico-page-container center-block flex full-page account-creation new-style">

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -1,5 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "signup" %}
+
+{% block title %}
+<title>{{ _("Log in") }} | Zulip</title>
+{% endblock %}
+
 {# Login page. #}
 
 {% block portico_content %}

--- a/templates/zerver/meta_tags.html
+++ b/templates/zerver/meta_tags.html
@@ -2,8 +2,6 @@
 {% if allow_search_engine_indexing %}
     {% if PAGE_DESCRIPTION %}
     <meta name="description" content="{{ PAGE_DESCRIPTION }}" />
-    {% else %}
-    <meta name="description" content="Zulip combines the immediacy of real-time chat with an email threading model. With Zulip, you can catch up on important conversations while ignoring irrelevant ones." />
     {% endif %}
 {% else %}
     <meta name="robots" content="noindex,nofollow" />
@@ -15,10 +13,9 @@
 <meta property="og:site_name" content="Zulip" />
 {% if PAGE_TITLE %}
 <meta property="og:title" content="{{ PAGE_TITLE }}" />
+{% endif %}
+{% if PAGE_DESCRIPTION %}
 <meta property="og:description" content="{{ PAGE_DESCRIPTION }}" />
-{% else %}
-<meta property="og:title" content="Chat for distributed teams" />
-<meta property="og:description" content="Zulip combines the immediacy of real-time chat with an email threading model. With Zulip, you can catch up on important conversations while ignoring irrelevant ones." />
 {% endif %}
 {% if PAGE_METADATA_IMAGE %}
 <meta property="og:image" content="{{ PAGE_METADATA_IMAGE }}" />

--- a/templates/zerver/no_spare_licenses.html
+++ b/templates/zerver/no_spare_licenses.html
@@ -1,4 +1,9 @@
 {% extends "zerver/portico.html" %}
+
+{% block title %}
+<title>{{ _("No licenses available") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <br/>
 <br/>

--- a/templates/zerver/rate_limit_exceeded.html
+++ b/templates/zerver/rate_limit_exceeded.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Rate limit exceeded") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="error_page">

--- a/templates/zerver/realm_creation_failed.html
+++ b/templates/zerver/realm_creation_failed.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico.html" %}
 {% set entrypoint = "landing-page" %}
 
+{% block title %}
+<title>{{ _("Error creating new organization") }} | Zulip</title>
+{% endblock %}
+
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 {% endblock %}

--- a/templates/zerver/realm_reactivation.html
+++ b/templates/zerver/realm_reactivation.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Organization successfully reactivated") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="app portico-page">
     <div class="app-main portico-page-container center-block flex full-page account-creation new-style">

--- a/templates/zerver/realm_reactivation_link_error.html
+++ b/templates/zerver/realm_reactivation_link_error.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Organization reactivation link expired or invalid") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="app portico-page">
     <div class="app-main portico-page-container center-block flex full-page account-creation new-style">

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Log in to your organization") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="app goto-account-page flex full-page">

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -1,5 +1,10 @@
 {% extends "zerver/portico_signup.html" %}
 {% set entrypoint = "register" %}
+
+{% block title %}
+<title>{{ _("Registration") }} | Zulip</title>
+{% endblock %}
+
 {#
 Gather other user information, after having confirmed
 their email address.

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -1,4 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
+
+{% block title %}
+<title>{{ _("Reset your password") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="flex new-style app portico-page">

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -1,6 +1,10 @@
 {% extends "zerver/portico_signup.html" %}
 {% set entrypoint = "register" %}
 
+{% block title %}
+<title>{{ _("Set a new password") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="password-container flex full-page new-style">

--- a/templates/zerver/reset_done.html
+++ b/templates/zerver/reset_done.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Password successfully reset") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="app portico-page">
     <div class="app-main portico-page-container center-block flex full-page account-creation new-style">

--- a/templates/zerver/reset_emailed.html
+++ b/templates/zerver/reset_emailed.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Password reset email sent") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="app portico-page">
     <div class="app-main portico-page-container center-block flex full-page account-creation new-style">

--- a/templates/zerver/social_auth_select_email.html
+++ b/templates/zerver/social_auth_select_email.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico_signup.html" %}
 
+{% block title %}
+<title>{{ _("Select account for authentication") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 <div class="register-account flex full-page new-style" id="choose_email">
     <div class="lead">

--- a/templates/zerver/unsubscribe_link_error.html
+++ b/templates/zerver/unsubscribe_link_error.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Error unsubscribing email") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <h1>{% trans %}Unknown email unsubscribe request{% endtrans %}</h1>

--- a/templates/zerver/unsubscribe_success.html
+++ b/templates/zerver/unsubscribe_success.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Email settings updated") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="app portico-page">

--- a/templates/zerver/unsupported_browser.html
+++ b/templates/zerver/unsupported_browser.html
@@ -1,5 +1,9 @@
 {% extends "zerver/portico.html" %}
 
+{% block title %}
+<title>{{ _("Unsupported browser") }} | Zulip</title>
+{% endblock %}
+
 {% block portico_content %}
 
 <div class="error_page unsupported_browser_page">

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -181,6 +181,7 @@ class DocPageTest(ZulipTestCase):
         self._test("/communities/", "Open communities directory")
         self._test("/development-community/", "Zulip development community")
         self._test("/features/", "Beautiful messaging")
+        self._test("/jobs/", "Work with us")
         self._test("/self-hosting/", "Self-host Zulip")
         self._test("/security/", "TLS encryption")
         self._test("/use-cases/", "Use cases and customer stories")


### PR DESCRIPTION
Updates templates that extend `base.html`, `portico.html` and `portico_signup.html` so that the HTML title element is either set via the `PAGE_TILE` variable (for portico landing pages as well as documentation pages generated from markdown files) or via a specific `<title>` element on the template. This removes the default "Zulip" title from the base template.

Also, removes default metadata elements for SEO and open graph data, and instead updates those based on the `PAGE_TITLE` and `PAGE_DESCRIPTION` variables, which again are limited to portico landing pages.

---

**Notes**:
- The first 5 commits are a refactor of `test_doc_endpoints` in `zerver/tests/test_docs.py`, which had become a bit of a "catch all" test. Made small commits for each update so that it would be easy to review.
- The 6th commit is the renaming of the existing `OPEN_GRAPH` variables to the more accurate `PAGE` or `PAGE_METADATA` variables.
- The 7th commit is a pass to set `<title>` elements on pages that have been using the default "Zulip" value and that are not portico landing pages covered in the `test_docs.py` tests.
  - If we don't want to remove the default at this point, I can update the PR to remove this commit and leave the "Zulip" default for the `<title>` element in the final commit.
  - I also made some small translation updates while making this pass.
  - I'll add comments where I had doubts or questions.
- The 8th commit is a pass to set the `PAGE_TITLE` and `PAGE_DESCRIPTION` variables explicitly on the portico landing pages and remove the default settings for these HTML elements:
  - `<title>`
  - `<meta name="description" content="..."  />`
  - `<meta property="og:title" content="..."  />`
  - `<meta property="og:description" content="..."  />`

---

**Next steps**:

- @alya: There are two lists below.
  - The first lists pages with the title and description variables for SEO and open graph data that need to be reviewed and updated. Note that neither variable can be a blank string to pass the `test_doc.py` test, but otherwise you don't need to do anything to update the tests when you update these templates.
  - The second lists pages that now no longer have the default "Zulip" title. These need to also be reviewed, but note that there were templates that had a title set that are not in the list. A more extensive review can be done via the `git-grep` search noted at the top of the list.

<details>
<summary>Templates with `PAGE_TITLE` and `PAGE_DESCRIPTION`</summary>

**You can also get this list via `git grep '{% set PAGE_TITLE ='`**

```console
templates/corporate/apps.html
templates/corporate/attribution.html
templates/corporate/case-studies/asciidoctor-case-study.html
templates/corporate/case-studies/idrift-case-study.html
templates/corporate/case-studies/lean-case-study.html
templates/corporate/case-studies/recurse-center-case-study.html
templates/corporate/case-studies/rust-case-study.html
templates/corporate/case-studies/tum-case-study.html
templates/corporate/case-studies/ucsd-case-study.html
templates/corporate/communities.html
templates/corporate/development-community.html
templates/corporate/features.html
templates/corporate/for/business.html
templates/corporate/for/communities.html
templates/corporate/for/education.html
templates/corporate/for/events.html
templates/corporate/for/open-source.html
templates/corporate/for/research.html
templates/corporate/for/use-cases.html
templates/corporate/hello.html
templates/corporate/history.html
templates/corporate/jobs.html
templates/corporate/plans.html
templates/corporate/security.html
templates/corporate/self-hosting.html
templates/corporate/team.html
templates/corporate/why-zulip.html
```
</details>

<details>
<summary>Templates with updated `<title>` elements</summary>

**You can also get a similar list via git grep -c '<title>' templates/`**

```console
templates/404.html
templates/500.html
templates/analytics/stats.html
templates/confirmation/confirm_email_change.html
templates/confirmation/confirm_preregistrationuser.html
templates/confirmation/link_does_not_exist.html
templates/confirmation/link_expired.html
templates/confirmation/link_malformed.html
templates/corporate/billing.html
templates/corporate/event_status.html
templates/corporate/support_request_thanks.html
templates/corporate/upgrade.html
templates/corporate/zephyr.html
templates/corporate/zephyr-mirror.html
templates/zerver/accounts_accept_terms.html
templates/zerver/accounts_home.html
templates/zerver/accounts_send_confirm.html
templates/zerver/auth_subdomain.html
templates/zerver/config_error.html
templates/zerver/confirm_continue_registration.html
templates/zerver/create_realm.html
templates/zerver/deactivated.html
templates/zerver/desktop_login.html
templates/zerver/desktop_redirect.html
templates/zerver/development/dev_login.html
templates/zerver/development/dev_tools.html
templates/zerver/development/email_log.html
templates/zerver/development/integrations_dev_panel.html
templates/zerver/digest_base.html
templates/zerver/find_account.html
templates/zerver/insecure_desktop_app.html
templates/zerver/invalid_email.html
templates/zerver/invalid_realm.html
templates/zerver/log_into_subdomain_token_invalid.html
templates/zerver/login.html
templates/zerver/no_spare_licenses.html
templates/zerver/rate_limit_exceeded.html
templates/zerver/realm_creation_failed.html
templates/zerver/realm_reactivation.html
templates/zerver/realm_reactivation_link_error.html
templates/zerver/realm_redirect.html
templates/zerver/register.html
templates/zerver/reset.html
templates/zerver/reset_confirm.html
templates/zerver/reset_done.html
templates/zerver/reset_emailed.html
templates/zerver/social_auth_select_email.html
templates/zerver/unsubscribe_link_error.html
templates/zerver/unsubscribe_success.html
templates/zerver/unsupported_browser.html
```
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
