### PR TITLE
Updated tip at the bottom of the? menu "Search operators" tab

### DIFF
--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -166,7 +166,7 @@
                     <z-keyword>keyword</z-keyword>
                 </z-operator>
                 <p>
-                    That query would search for messages sent by <z-email>email</z-email> to
+                    That query would search for messages sent by <z-email>user@example.com</z-email> to
                     stream <z-stream>streamname</z-stream> containing
                     the keyword <z-keyword>keyword</z-keyword>.
                 </p>


### PR DESCRIPTION


Update the example email tip at the bottom of the? menu "Search operators" tab.

Fixes: https://github.com/zulip/zulip/issues/22866

Before:
![image](https://user-images.githubusercontent.com/79783828/189105058-a5ace694-ba06-4a01-aeac-74d061527dcd.png)

After:
![image](https://user-images.githubusercontent.com/79783828/189105179-252555ab-3c40-4e54-97e9-18b2f11ab10c.png)
