### PR TITLE
test_auth_backends: Fix SOCIAL_AUTH_GITHUB_TEAM_ID mock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,7 @@ Your pull request will likely go through several stages of review.
    progress on the PR by getting more frequent feedback. A project maintainer
    may leave a comment asking someone with expertise in the area you're working
    on to review your work.
-5. Final code review and integration for server and webapp PRs is generally done
+5. Final code review and integration for server and web app PRs is generally done
    by `@timabbott`.
 
 #### How to help move the review process forward

--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -200,7 +200,7 @@ If the PR makes any frontend changes, you should make sure to play with the part
 of the app being changed to validate that things look and work as expected.
 While not all of the situations below will apply, here are some ideas for things
 that should be tested if they are applicable. Use the [development
-environment][development-environment] to test any webapp changes.
+environment][development-environment] to test any web app changes.
 
 This might seem like a long process, but you can go through it quite quickly
 once you get the hang of it. Trust us, it will save time and review round-trips
@@ -265,7 +265,7 @@ Some scenarios to consider:
 - Try clicking on any interactive elements, multiple times, in a variety of orders.
 - If the feature affects the **message view**, try it out in different types of
   narrows: topic, stream, All messages, PMs.
-- If the feature affects the **compose box** in the webapp, try both ways of
+- If the feature affects the **compose box** in the web app, try both ways of
   [resizing the compose box](https://zulip.com/help/resize-the-compose-box).
   Test both stream messages and PMs.
 - If the feature might require **elevated permissions**, check it out as a user who has

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -574,24 +574,24 @@ export function parse({raw_content, helper_config}) {
     return parse_with_options({raw_content, helper_config, options});
 }
 
-// NOTE: Everything below this line is likely to be webapp-specific
+// NOTE: Everything below this line is likely to be web-specific
 //       and won't be used by future platforms such as mobile.
 //       We may eventually move this code to a new file, but we want
 //       to wait till the dust settles a bit on some other changes first.
 
-let webapp_helpers;
+let web_app_helpers;
 
 export function initialize(helper_config) {
-    // This is generally only intended to be called by the webapp. Most
+    // This is generally only intended to be called by the web app. Most
     // other platforms should call setup().
-    webapp_helpers = helper_config;
+    web_app_helpers = helper_config;
 }
 
 export function apply_markdown(message) {
-    // This is generally only intended to be called by the webapp. Most
+    // This is generally only intended to be called by the web app. Most
     // other platforms should call parse().
     const raw_content = message.raw_content;
-    const {content, flags} = parse({raw_content, helper_config: webapp_helpers});
+    const {content, flags} = parse({raw_content, helper_config: web_app_helpers});
     message.content = content;
     message.flags = flags;
     message.is_me_message = is_status_message(raw_content);
@@ -604,14 +604,14 @@ export function add_topic_links(message) {
     }
     message.topic_links = get_topic_links({
         topic: message.topic,
-        get_linkifier_map: webapp_helpers.get_linkifier_map,
+        get_linkifier_map: web_app_helpers.get_linkifier_map,
     });
 }
 
 export function contains_backend_only_syntax(content) {
     return content_contains_backend_only_syntax({
         content,
-        get_linkifier_map: webapp_helpers.get_linkifier_map,
+        get_linkifier_map: web_app_helpers.get_linkifier_map,
     });
 }
 
@@ -620,5 +620,5 @@ export function parse_non_message(raw_content) {
     // a message, but we want to convert it to HTML. Note that we parse
     // raw_content exactly as if it were a Zulip message, so we will
     // handle things like mentions, stream links, and linkifiers.
-    return parse({raw_content, helper_config: webapp_helpers}).content;
+    return parse({raw_content, helper_config: web_app_helpers}).content;
 }

--- a/templates/zerver/help/view-zulip-version.md
+++ b/templates/zerver/help/view-zulip-version.md
@@ -31,7 +31,7 @@ Zulip Cloud organizations are always updated to the latest version of Zulip.
 ## Zulip desktop app version
 
 The [Zulip desktop app](/apps/) has an independent version from the server and
-webapp.
+web app.
 
 ### View Zulip desktop app version
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -76,6 +76,10 @@ whitespace_rules: List["Rule"] = [
         "pattern": "\t",
         "description": "Fix tab-based whitespace",
     },
+    {
+        "pattern": r"(?i:webapp)",
+        "description": "Web app should be two words",
+    },
 ]
 comma_whitespace_rule: List["Rule"] = [
     {

--- a/zerver/tests/fixtures/config.generate_data.json
+++ b/zerver/tests/fixtures/config.generate_data.json
@@ -3,7 +3,7 @@
   {
     "nouns":["server", "FAILED EXPORT", "RECENT TOPICS",  "laptop", "BOTS", "router", "bridge",
       "cat5", "nas", "MOBILE", "file server", "API", "wifi", "printer",
-      "plotter", "WEBAPP", "desktop", "PLOTS", "database", "URLS", "keurig"],
+      "plotter", "WEB APP", "desktop", "PLOTS", "database", "URLS", "keurig"],
 
     "adjectives": ["new", "LAST",  "old", "first", "NEW", "last", "big", "little",
       "leased", "FIRST", "owned", "red", "blue", "OLD", "green"],

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3610,13 +3610,6 @@ class GitHubAuthBackendTest(SocialAuthBase):
             body=json.dumps(email_data),
         )
 
-        requests_mock.add(
-            requests_mock.GET,
-            "https://api.github.com/teams/zulip-webapp/members/None",
-            status=200,
-            body=json.dumps(email_data),
-        )
-
         self.email_data = email_data
 
     def get_account_data_dict(
@@ -3647,7 +3640,7 @@ class GitHubAuthBackendTest(SocialAuthBase):
             ],
         )
 
-    @override_settings(SOCIAL_AUTH_GITHUB_TEAM_ID="zulip-webapp")
+    @override_settings(SOCIAL_AUTH_GITHUB_TEAM_ID="51246")
     def test_social_auth_github_team_not_member_failed(self) -> None:
         account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
         subdomain = "zulip"
@@ -3669,7 +3662,7 @@ class GitHubAuthBackendTest(SocialAuthBase):
             ],
         )
 
-    @override_settings(SOCIAL_AUTH_GITHUB_TEAM_ID="zulip-webapp")
+    @override_settings(SOCIAL_AUTH_GITHUB_TEAM_ID="51247")
     def test_social_auth_github_team_member_success(self) -> None:
         account_data_dict = self.get_account_data_dict(email=self.email, name=self.name)
         with mock.patch(

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -324,7 +324,7 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/login/")
 
-        # Load webapp directly if spectator access is enabled.
+        # Load web app directly if spectator access is enabled.
         do_set_realm_property(realm, "enable_spectator_access", True, acting_user=None)
         result = self.client_get("/")
         self.assertEqual(result.status_code, 200)


### PR DESCRIPTION
`SOCIAL_AUTH_GITHUB_TEAM_ID` is expected to be the string of an integer.

The `requests` mock for the bogus `/None` URL is unused because the function that would request it is itself mocked.