### PR TITLE
emoji: Add star-struck.

### DIFF
--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -21,7 +21,7 @@ run_test("initialize", () => {
 
     const complete_emoji_catalog = _.sortBy(emoji_picker.complete_emoji_catalog, "name");
     assert.equal(complete_emoji_catalog.length, 11);
-    assert.equal(emoji.emojis_by_name.size, 1052);
+    assert.equal(emoji.emojis_by_name.size, 1053);
 
     let total_emoji_in_categories = 0;
 

--- a/tools/setup/emoji/emoji_names.py
+++ b/tools/setup/emoji/emoji_names.py
@@ -876,6 +876,7 @@ EMOJI_NAME_MAPS: Dict[str, Dict[str, Any]] = {
     "1f925": {"canonical_name": "lying", "aliases": []},
     "1f926": {"canonical_name": "face_palm", "aliases": []},
     "1f927": {"canonical_name": "sneezing", "aliases": []},
+    "1f929": {"canonical_name": "grinning_face_with_star_eyes", "aliases": ["star_struck"]},
     "1f930": {"canonical_name": "pregnant", "aliases": ["expecting"]},
     "1f933": {"canonical_name": "selfie", "aliases": []},
     "1f934": {"canonical_name": "prince", "aliases": []},

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -751,12 +751,13 @@ class RocketChatImporter(ZulipTestCase):
             zerver_realmemoji=zerver_realmemoji,
         )
 
-        # :grin: and :star_struck: are not present in Zulip's default
-        # emoji set, or in Reaction.UNICODE_EMOJI reaction type.
-        self.assert_length(total_reactions, 7)
+        # :grin: is not present in Zulip's default emoji set, or in
+        # Reaction.UNICODE_EMOJI reaction type.
+        self.assert_length(total_reactions, 8)
 
         grinning_emoji_code = name_to_codepoint["grinning"]
         innocent_emoji_code = name_to_codepoint["innocent"]
+        star_struck_emoji_code = name_to_codepoint["star_struck"]
         heart_emoji_code = name_to_codepoint["heart"]
         rocket_emoji_code = name_to_codepoint["rocket"]
 
@@ -770,13 +771,23 @@ class RocketChatImporter(ZulipTestCase):
         )
         self.assertEqual(
             self.get_set(total_reactions, "emoji_name"),
-            {"grinning", "innocent", "heart", "rocket", "check", "zulip", "harry-ron"},
+            {
+                "grinning",
+                "innocent",
+                "star_struck",
+                "heart",
+                "rocket",
+                "check",
+                "zulip",
+                "harry-ron",
+            },
         )
         self.assertEqual(
             self.get_set(total_reactions, "emoji_code"),
             {
                 grinning_emoji_code,
                 innocent_emoji_code,
+                star_struck_emoji_code,
                 heart_emoji_code,
                 rocket_emoji_code,
                 realmemoji_code["check"],
@@ -785,7 +796,7 @@ class RocketChatImporter(ZulipTestCase):
             },
         )
         self.assertEqual(self.get_set(total_reactions, "user_profile"), {2, 3, 4})
-        self.assert_length(self.get_set(total_reactions, "id"), 7)
+        self.assert_length(self.get_set(total_reactions, "id"), 8)
         self.assert_length(self.get_set(total_reactions, "message"), 1)
 
     def test_process_message_attachment(self) -> None:


### PR DESCRIPTION
People may often use this reaction in their Slack workspace, and currently, when the Slack archive is imported, the reaction is not translated.
Adding this by hand for now, until tools/setup/emoji/emoji_names.py is auto-generated instead of hand-curated.