### PR TITLE
modal: Make the modal content scrollable instead of the whole modal.

### DIFF
--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -43,6 +43,7 @@
     justify-content: flex-end;
     align-items: center;
     padding: 20px 24px;
+    border-top: 1px solid hsla(0, 0%, 100%, 0.2);
 }
 
 .modal__title {
@@ -71,6 +72,7 @@
 }
 
 .modal__content {
+    display: flex;
     font-size: 1rem;
     overflow-y: auto;
     padding: 0 24px;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -809,13 +809,6 @@ input[type="checkbox"] {
     margin-top: 5px;
 }
 
-#edit_bot_modal {
-    /* Ensure that the dropdown can overflow the modal. */
-    .modal__content {
-        overflow: visible;
-    }
-}
-
 .edit_bot_form {
     font-size: 100%;
     margin: 0;

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -1,6 +1,6 @@
 <div class="micromodal" id="dialog_widget_modal" aria-hidden="true">
     <div class="modal__overlay" tabindex="-1" data-micromodal-close>
-        <div {{#if id}}id="{{id}}" {{/if}}class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title" data-simplebar>
+        <div {{#if id}}id="{{id}}" {{/if}}class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <header class="modal__header">
                 <h1 class="modal__title dialog_heading">
                     {{{ heading_text }}}
@@ -10,7 +10,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
-            <main class="modal__content">
+            <main class="modal__content" data-simplebar>
                 <div class="alert" id="dialog_error"></div>
                 {{{ html_body }}}
             </main>


### PR DESCRIPTION
The first commit is required for the second commit to work in the `Manage bot` modal, since scrolling requires the `overflow: auto` CSS.

### Before
![lb](https://user-images.githubusercontent.com/58626718/190191974-ed3ce1f8-3500-454c-ae35-f709df03bd3e.gif)
![db](https://user-images.githubusercontent.com/58626718/190192077-9b3e646f-aa3b-47b8-9c53-0eaf5ccc7f2e.gif)

### After
![la](https://user-images.githubusercontent.com/58626718/190192307-2767dac0-ed37-4028-92b5-13c6baf070cc.gif)
![da](https://user-images.githubusercontent.com/58626718/190192478-f1e76cbc-5bc1-4a91-96e6-bdcdc1548091.gif)


