### PR TITLE
custom_profile_fields: Fix empty field choices issue of select field.

### DIFF
--- a/web/src/settings_profile_fields.js
+++ b/web/src/settings_profile_fields.js
@@ -144,20 +144,6 @@ function read_external_account_field_data($profile_field_form) {
     return field_data;
 }
 
-export function update_choice_delete_btn($container, display_flag) {
-    const no_of_choice_row = $container.find(".choice-row").length;
-
-    // Disable delete button if there only one choice row
-    // Enable choice delete button more one than once choice
-    if (no_of_choice_row === 1) {
-        if (display_flag === true) {
-            $container.find(".choice-row .delete-choice").show();
-        } else {
-            $container.find(".choice-row .delete-choice").hide();
-        }
-    }
-}
-
 export function get_value_for_new_option(container) {
     let value = 0;
     for (const row of $(container).find(".choice-row")) {

--- a/web/src/settings_streams.js
+++ b/web/src/settings_streams.js
@@ -22,8 +22,6 @@ function add_choice_row($widget) {
     if ($widget.closest(".choice-row").next().hasClass("choice-row")) {
         return;
     }
-    const $choices_div = $("#default-stream-choices");
-    settings_profile_fields.update_choice_delete_btn($choices_div, true);
     create_choice_row();
 }
 
@@ -154,9 +152,7 @@ export function delete_default_stream(stream_id, $default_stream_row, $alert_ele
 
 function delete_choice_row(e) {
     const $row = $(e.currentTarget).parent();
-    const $container = $row.parent();
     $row.remove();
-    settings_profile_fields.update_choice_delete_btn($container, false);
 
     // Disable the submit button if no streams are selected.
     $("#add-default-stream-modal .dialog_submit_button").prop(
@@ -209,7 +205,6 @@ function show_add_default_streams_modal() {
         $("#add-default-stream-modal .dialog_submit_button").prop("disabled", true);
 
         create_choice_row();
-        settings_profile_fields.update_choice_delete_btn($("#default-stream-choices"), false);
         $("#default-stream-choices").on("click", "button.delete-choice", delete_choice_row);
     }
 

--- a/web/templates/settings/profile_field_choice.hbs
+++ b/web/templates/settings/profile_field_choice.hbs
@@ -3,7 +3,7 @@
     <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     <input type='text' class="modal_text_input" placeholder='{{t "New option" }}' value="{{ text }}" />
 
-    <button type='button' class="button rounded small delete-choice" title="{{t 'Delete' }}">
+    <button type='button' class="button rounded small delete-choice {{#if new_empty_choice_row}} hide {{/if}}" title="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>
     </button>
 </div>


### PR DESCRIPTION
While editing select type profile field, if we submit empty or zero
choices it fails silently, current implementation for this issue does
not work for some cases, and this commit will fix that.

This will disable dialog submit button in case of empty field choices.

Also removing code of all calls making to `update_choice_delete_btn`
as that function have no more use-case for empty field choices, still
keeping the function because it gets used in `settings_streams.js`..

<!-- Describe your pull request here.-->

Fixes: GH [comment](https://github.com/zulip/zulip/pull/22818#issuecomment-1239000262)<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshot/Gifs**:
![field_choices](https://github.com/zulip/zulip/assets/41695888/4a0db4c0-8f2e-4077-b920-ee729a272db1)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
