### PR TITLE
help center: Fix indendation in saml-authentication.md azuread part.

### DIFF
--- a/templates/zerver/help/saml-authentication.md
+++ b/templates/zerver/help/saml-authentication.md
@@ -127,8 +127,8 @@ providers.
 
      1. Your organization's URL
      1. From the **SAML Signing Certificate** section:
-       * **App Federation Metadata Url**
-       * Certificate downloaded from **Certificate (Base64)**
+        * **App Federation Metadata Url**
+        * Certificate downloaded from **Certificate (Base64)**
      1. From the **Set up** section
         * **Login URL**
         * **Azure AD Identifier**


### PR DESCRIPTION
Quick PR to do the tweak @drrosa noticed in https://github.com/zulip/zulip/pull/22889#pullrequestreview-1102985190 

The second point in @drrosa comment was
> In `templates/zerver/help/include/saml-login-button.md`, I think "log in button" -> "log-in button" (nit):
> 
> ```
> 1. How you would like the Zulip log-in button to be labeled: “Log in with...”
> 1. *(optional)* An icon to use on the log-in button.
> ```


which I didn't include here, because I'm not sure which way we want to spell it? Text search doesn't show any instances of "log in button" outside of this doc, nor any instances of "log-in button" to have a clear precedent here.