### PR TITLE
zilencer: Fix missing decorators on remote_server_dispatch.

### DIFF
--- a/zilencer/auth.py
+++ b/zilencer/auth.py
@@ -7,6 +7,7 @@ from django.urls import path
 from django.urls.resolvers import URLPattern
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import gettext as _
+from django.views.decorators.csrf import csrf_exempt
 from typing_extensions import Concatenate, ParamSpec
 
 from zerver.decorator import get_basic_credentials, process_client
@@ -19,7 +20,7 @@ from zerver.lib.exceptions import (
 )
 from zerver.lib.rate_limiter import should_rate_limit
 from zerver.lib.request import RequestNotes
-from zerver.lib.rest import get_target_view_function_or_response
+from zerver.lib.rest import default_never_cache_responses, get_target_view_function_or_response
 from zerver.lib.subdomains import get_subdomain
 from zerver.models import Realm
 from zilencer.models import (
@@ -107,6 +108,8 @@ def authenticated_remote_server_view(
     return _wrapped_view_func
 
 
+@default_never_cache_responses
+@csrf_exempt
 def remote_server_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
     result = get_target_view_function_or_response(request, kwargs)
     if isinstance(result, HttpResponse):


### PR DESCRIPTION
In 5c49e4ba06f3a515f2c141c2f6344b3e6af8e613, we neglected to include the CSRF and caching decorators required for all API views in the new remote_server_dispatch function.

I'm not sure why our automated tests didn't catch this, but this made the remote server API endpoints nonfunctional in a production environment.

@PIG208 if you have an opportunity to add a test that would have failed without these changes, that'd be appreciated.