### PR TITLE
forms: Update create organization part of registration form.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -960,7 +960,7 @@ button#register_auth_button_gitlab {
         margin-bottom: 0;
         font-size: 21px;
         line-height: 40px;
-        color: hsla(0, 0%, 0%, 0.2);
+        color: hsla(0, 0%, 0%, 0.5);
         border: 0;
         border-bottom: 1px solid hsla(0, 0%, 90%, 1);
 

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -28,6 +28,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
 
             <fieldset class="org-registration">
                 {% if creating_new_team %}
+                <legend>{{ _('Your organization') }}</legend>
                 <div class="input-box">
                     <div class="inline-block relative">
                         <input id="id_team_name" class="required" type="text"
@@ -92,9 +93,6 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                             <p class="error help-inline text-error team_subdomain_error_server">{{ error }}</p>
                             {% endfor %}
                         {% endif %}
-                    </div>
-                    <div class="help-text">
-                        {{ _("The URL users will use to access the new organization.") }}
                     </div>
                 </div>
                 {% endif %}


### PR DESCRIPTION
Adds a legend to the "org-registration" fieldset where the user inputs info about the new organization. Previously, there was only a legend for the "user-registration" fieldset. Also, increases the opacity of CSS rule for the legend color so that they are more visible.

Removes the hint text about what the organization URL value is used for since it is pretty clear from the field's name.

[Relevant CZO conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/new.20org.20URL.20hint/near/1423597)

---

**Screenshots and screen captures:**

<details>
<summary>Current versions of form in dev environment</summary>

![Screenshot from 2022-09-09 21-17-56](https://user-images.githubusercontent.com/63245456/189703227-86224740-5068-4ab5-bd4a-1b1fe67204a1.png)
![Screenshot from 2022-09-09 21-18-07](https://user-images.githubusercontent.com/63245456/189703231-9f7a4ede-41e4-444b-8360-7eb43c5a8688.png)
</details>

<details>
<summary>Updated versions of form in dev environment</summary>

![Screenshot from 2022-09-09 18-52-27](https://user-images.githubusercontent.com/63245456/189703262-52446895-a336-4dbc-9865-edab3a4fa228.png)
![Screenshot from 2022-09-09 18-53-03](https://user-images.githubusercontent.com/63245456/189703271-cf623cca-d727-4599-a502-17bcd51dc869.png)
</details>

--

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
