### PR TITLE
templates: Remove prefilled support email content from error pages.

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -17,7 +17,7 @@
                     <h1 class="lead">Internal server error</h1>
                     <p>This Zulip server is currently experiencing some technical difficulties. Sorry about that!</p>
                     <p>The page will reload automatically soon after service is restored.</p>
-                    <p>If you'd like, you can <a href="mailto:{{ support_email }}?Subject=500%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20500%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+                    <p>If you'd like, you can <a href="mailto:{{ support_email }}">drop us a line</a> to let us know what happened.</p>
                 </div>
 
             </div>

--- a/templates/zerver/unsubscribe_link_error.html
+++ b/templates/zerver/unsubscribe_link_error.html
@@ -9,6 +9,6 @@
     but we don't recognize the URL.{% endtrans %}
 </p>
 
-<p>{% trans %}Please double-check that you have the full URL and try again, or <a href="mailto:{{ support_email }}?Subject=Unsubscribe%20me%2C%20please!&Body=Hi%20there!%0A%0AI%20clicked%20this%20unsubscribe%20link%20in%20a%20Zulip%20e-mail%2C%20but%20it%20took%20me%20to%20an%20error%20page%3A%0A%0A_____________%0A%0APlease%20unsubscribe%20me.%0A%0AThanks%2C%0A_____________%0A">email us</a> and we'll get this squared away!{% endtrans %}</p>
+<p>{% trans %}Please double-check that you have the full URL and try again, or <a href="mailto:{{ support_email }}">email us</a> and we'll get this squared away!{% endtrans %}</p>
 
 {% endblock %}


### PR DESCRIPTION
Removes the prefilled content for support emails in `500.html` and `unsubscribe_link_error.html` templates since both cases are rather rare and the prefilled content is not useful for organizations that do not use English as their main communication language.

[Relevant CZO conversation](https://chat.zulip.org/#narrow/stream/2-general/topic/prefilled.20email.20content/near/1433076)

Came up in relation to work on #22868, [link to specific comment/discussion](https://github.com/zulip/zulip/pull/22868#discussion_r963601932).

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
