### PR TITLE
test_decorators: Remove cachify test cases.

### DIFF
--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -3,7 +3,6 @@ import os
 import re
 import uuid
 from collections import defaultdict
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 from unittest import mock, skipUnless
 
@@ -2016,76 +2015,6 @@ class RestAPITest(ZulipTestCase):
         result = self.client_get("/json/users", HTTP_ACCEPT="text/html")
         self.assertEqual(result.status_code, 302)
         self.assertTrue(result["Location"].endswith("/login/?next=%2Fjson%2Fusers"))
-
-
-class CacheTestCase(ZulipTestCase):
-    def test_cachify_basics(self) -> None:
-        @lru_cache(maxsize=None)
-        def add(w: Any, x: Any, y: Any, z: Any) -> Any:
-            return w + x + y + z
-
-        for i in range(2):
-            self.assertEqual(add(1, 2, 4, 8), 15)
-            self.assertEqual(add("a", "b", "c", "d"), "abcd")
-
-    def test_cachify_is_per_call(self) -> None:
-        def test_greetings(greeting: str) -> Tuple[List[str], List[str]]:
-
-            result_log: List[str] = []
-            work_log: List[str] = []
-
-            @lru_cache(maxsize=None)
-            def greet(first_name: str, last_name: str) -> str:
-                msg = f"{greeting} {first_name} {last_name}"
-                work_log.append(msg)
-                return msg
-
-            result_log.append(greet("alice", "smith"))
-            result_log.append(greet("bob", "barker"))
-            result_log.append(greet("alice", "smith"))
-            result_log.append(greet("cal", "johnson"))
-
-            return (work_log, result_log)
-
-        work_log, result_log = test_greetings("hello")
-        self.assertEqual(
-            work_log,
-            [
-                "hello alice smith",
-                "hello bob barker",
-                "hello cal johnson",
-            ],
-        )
-
-        self.assertEqual(
-            result_log,
-            [
-                "hello alice smith",
-                "hello bob barker",
-                "hello alice smith",
-                "hello cal johnson",
-            ],
-        )
-
-        work_log, result_log = test_greetings("goodbye")
-        self.assertEqual(
-            work_log,
-            [
-                "goodbye alice smith",
-                "goodbye bob barker",
-                "goodbye cal johnson",
-            ],
-        )
-
-        self.assertEqual(
-            result_log,
-            [
-                "goodbye alice smith",
-                "goodbye bob barker",
-                "goodbye alice smith",
-                "goodbye cal johnson",
-            ],
-        )
 
 
 class TestUserAgentParsing(ZulipTestCase):


### PR DESCRIPTION
`cachify` has been removed in 9d448e73d2c3b7f2983f239a24e2d45ec9704904. We don't need to keep its tests.

TODO: `functools.lru_cache` can be replaced by `functools.cache` when we drop Python 3.8.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
