### PR TITLE
openapi fixes for `narrow` and `to` parameters

### DIFF
--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -15,7 +15,7 @@
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     --data-urlencode type=stream \
-    --data-urlencode to=Denmark \
+    --data-urlencode 'to="Denmark"' \
     --data-urlencode topic=Castle \
     --data-urlencode 'content=I come not, friends, to steal away your hearts.'
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5332,9 +5332,16 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: integer
+                oneOf:
+                  - type: string
+                  - type: integer
+                  - type: array
+                    items:
+                      type: string
+                  - type: array
+                    items:
+                      type: integer
+                    minLength: 1
               example: [9, 10]
           required: true
         - $ref: "#/components/parameters/RequiredContent"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5073,7 +5073,29 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
+                  oneOf:
+                    - type: object
+                      required:
+                        - operator
+                        - operand
+                      additionalProperties: false
+                      properties:
+                        operator:
+                          type: string
+                        operand:
+                          oneOf:
+                            - type: string
+                            - type: integer
+                            - type: array
+                              items:
+                                type: integer
+                        negated:
+                          type: boolean
+                    - type: array
+                      items:
+                        type: string
+                      minItems: 2
+                      maxItems: 2
                 default: []
               example: [{"operand": "Denmark", "operator": "stream"}]
         - $ref: "#/components/parameters/ClientGravatar"

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1401,7 +1401,7 @@ class TestIncomingWebhookBot(ZulipTestCase):
         payload = dict(
             type="private",
             content="Test message",
-            to=othello.email,
+            to=orjson.dumps([othello.email]).decode(),
         )
 
         result = self.api_post(webhook_bot, "/api/v1/messages", payload)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1028,7 +1028,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "to": "Denmark",
+                "to": orjson.dumps("Denmark").decode(),
             },
         )
         self.assert_json_success(result)
@@ -1067,7 +1067,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_email_response_for_auth_failures",
-                "to": "announce",
+                "to": orjson.dumps("announce").decode(),
             },
         )
         self.assert_json_success(result)
@@ -1111,7 +1111,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "to": "Denmark",
+                "to": orjson.dumps("Denmark").decode(),
             },
         )
         self.assert_json_success(result)
@@ -1156,7 +1156,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "to": "Denmark",
+                "to": orjson.dumps("Denmark").decode(),
             },
         )
         self.assert_json_success(result)
@@ -1192,7 +1192,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "to": "Denmark",
+                "to": orjson.dumps("Denmark").decode(),
             },
         )
         self.assert_json_success(result)
@@ -1229,7 +1229,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
                 "type": "stream",
                 "topic": "test topic",
                 "content": "test_receive_missed_stream_message_email_messages",
-                "to": "Denmark",
+                "to": orjson.dumps("Denmark").decode(),
             },
         )
         self.assert_json_success(result)

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -385,7 +385,7 @@ class TestMissedMessages(ZulipTestCase):
             {
                 "type": "private",
                 "content": "Test message",
-                "to": hamlet.email,
+                "to": orjson.dumps([hamlet.email]).decode(),
             },
         )
         self.assert_json_success(result)

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -117,7 +117,7 @@ class RateLimitTests(ZulipTestCase):
             "/api/v1/messages",
             {
                 "type": "stream",
-                "to": "Verona",
+                "to": orjson.dumps("Verona").decode(),
                 "content": content,
                 "topic": "whatever",
             },

--- a/zerver/tests/test_legacy_subject.py
+++ b/zerver/tests/test_legacy_subject.py
@@ -1,3 +1,5 @@
+import orjson
+
 from zerver.lib.test_classes import ZulipTestCase
 
 
@@ -7,7 +9,7 @@ class LegacySubjectTest(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to="Verona",
+            to=orjson.dumps("Verona").decode(),
             content="Test message",
         )
 

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -281,7 +281,11 @@ class ReactionMessageIDTest(ZulipTestCase):
         result = self.api_post(
             pm_sender,
             "/api/v1/messages",
-            {"type": "private", "content": "Test message", "to": pm_recipient.email},
+            {
+                "type": "private",
+                "content": "Test message",
+                "to": orjson.dumps([pm_recipient.email]).decode(),
+            },
         )
         pm_id = self.assert_json_success(result)["id"]
         reaction_info = {
@@ -306,7 +310,11 @@ class ReactionTest(ZulipTestCase):
         pm = self.api_post(
             pm_sender,
             "/api/v1/messages",
-            {"type": "private", "content": "Test message", "to": pm_recipient.email},
+            {
+                "type": "private",
+                "content": "Test message",
+                "to": orjson.dumps([pm_recipient.email]).decode(),
+            },
         )
         self.assert_json_success(pm)
         content = orjson.loads(pm.content)
@@ -336,7 +344,11 @@ class ReactionTest(ZulipTestCase):
         pm = self.api_post(
             pm_sender,
             "/api/v1/messages",
-            {"type": "private", "content": "Test message", "to": pm_recipient.email},
+            {
+                "type": "private",
+                "content": "Test message",
+                "to": orjson.dumps([pm_recipient.email]).decode(),
+            },
         )
         self.assert_json_success(pm)
 
@@ -417,7 +429,11 @@ class ReactionEventTest(ZulipTestCase):
         result = self.api_post(
             pm_sender,
             "/api/v1/messages",
-            {"type": "private", "content": "Test message", "to": pm_recipient.email},
+            {
+                "type": "private",
+                "content": "Test message",
+                "to": orjson.dumps([pm_recipient.email]).decode(),
+            },
         )
         pm_id = self.assert_json_success(result)["id"]
 
@@ -456,7 +472,11 @@ class ReactionEventTest(ZulipTestCase):
         result = self.api_post(
             pm_sender,
             "/api/v1/messages",
-            {"type": "private", "content": "Test message", "to": pm_recipient.email},
+            {
+                "type": "private",
+                "content": "Test message",
+                "to": orjson.dumps([pm_recipient.email]).decode(),
+            },
         )
         content = self.assert_json_success(result)
         pm_id = content["id"]

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -418,7 +418,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content_with_group_mention,
         )

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -66,7 +66,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content="whatever",
         )
@@ -122,7 +122,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content,
             widget_content=orjson.dumps(widget_content).decode(),
@@ -152,7 +152,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content,
         )
@@ -180,7 +180,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content,
         )
@@ -231,7 +231,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content,
         )
@@ -259,7 +259,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content,
         )
@@ -317,7 +317,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content,
         )
@@ -374,7 +374,7 @@ class WidgetContentTestCase(ZulipTestCase):
 
         payload = dict(
             type="stream",
-            to=stream_name,
+            to=orjson.dumps(stream_name).decode(),
             topic="whatever",
             content=content,
         )


### PR DESCRIPTION
- openapi: Fix `narrow` parameter schema.

  The previous schema incorrectly prohibited the two-element array form that we do in fact accept, and didn’t specify anything about the contents of the object form.

- openapi: Fix `to` parameter schema.

  The previous schema incorrectly prohibited the string, integer, and string-array forms that we do in fact accept.

- tests: Consistently JSON-encode `to` parameter

  Although our `POST /messages` handler accepts the `to` parameter with or without JSON encoding, there are two problems with passing it as an unencoded string.

  Firstly, you’d fail to send a message to a stream named ‘true’ or ‘false’ or ‘null’ or ‘2022’, as the JSON interpretation is prioritized over the plain string interpretation.

  Secondly, and more importantly for our tests, it violates our OpenAPI schema, which requires the parameter to be JSON-encoded.  This is because OpenAPI has no concept of a parameter that’s “optionally JSON-encoded”, nor should it: such a parameter cannot be unambiguously decoded for the reason above.

  Our version of openapi-core doesn’t currently detect this schema violation, but after the next upgrade it will.
