### PR TITLE
Fix invalid openapi definition

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14932,7 +14932,7 @@ components:
   # Security definitions
   #######################
   securitySchemes:
-    BasicAuth:
+    basicAuth:
       type: http
       scheme: basic
       description: |


### PR DESCRIPTION
The current openapi definition results when using the official editor.swagger.io:

```
Semantic error at security.0
Security requirements must match a security definition
Jump to line 37
Semantic error at paths./real-time.post.security.0
Security requirements must match a security definition
Jump to line 14738
```

The security requirements are case-sensitive

Fixes: [https://github.com/zulip/zulip/issues/22937](https://github.com/zulip/zulip/issues/22937)

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.