### PR TITLE
custom_profile_fields: Display data of default external account type in edit form modal.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -307,8 +307,8 @@ function set_up_external_account_field_edit_form($profile_field_form, url_patter
     if ($profile_field_form.find("select[name=external_acc_field_type]").val() === "custom") {
         $profile_field_form.find("input[name=url_pattern]").val(url_pattern_val);
         $profile_field_form.find(".custom_external_account_detail").show();
-        $profile_field_form.find("input[name=name]").val("").closest(".input-group").show();
-        $profile_field_form.find("input[name=hint]").val("").closest(".input-group").show();
+        $profile_field_form.find("input[name=name]").closest(".input-group").show();
+        $profile_field_form.find("input[name=hint]").closest(".input-group").show();
     } else {
         $profile_field_form.find("input[name=name]").closest(".input-group").hide();
         $profile_field_form.find("input[name=hint]").closest(".input-group").hide();

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -307,11 +307,11 @@ function set_up_external_account_field_edit_form($profile_field_form, url_patter
     if ($profile_field_form.find("select[name=external_acc_field_type]").val() === "custom") {
         $profile_field_form.find("input[name=url_pattern]").val(url_pattern_val);
         $profile_field_form.find(".custom_external_account_detail").show();
-        $profile_field_form.find("input[name=name]").closest(".input-group").show();
-        $profile_field_form.find("input[name=hint]").closest(".input-group").show();
+        $profile_field_form.find("input[name=name]").prop("disabled", false);
+        $profile_field_form.find("input[name=hint]").prop("disabled", false);
     } else {
-        $profile_field_form.find("input[name=name]").closest(".input-group").hide();
-        $profile_field_form.find("input[name=hint]").closest(".input-group").hide();
+        $profile_field_form.find("input[name=name]").prop("disabled", true);
+        $profile_field_form.find("input[name=hint]").prop("disabled", true);
         $profile_field_form.find(".custom_external_account_detail").hide();
     }
 }


### PR DESCRIPTION
Remove redundant `Val(" ")` from an edit form modal of the custom
external account type field.

Display values of the "name" and "hint" field in a non-editable way while
editing default external account type profile fields.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->[CZO](https://chat.zulip.org/#narrow/stream/378-api-design/topic/Name.20and.20Hint.20editable.20of.20default.20external.20account.20.2322371/near/1434321)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![edit_form](https://user-images.githubusercontent.com/41695888/189922382-469905b6-fe61-4ef2-b111-f86b16e90f23.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
