### PR TITLE
i18n: Default external account fields name field tag for translation.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -10,7 +10,7 @@ import render_settings_profile_field_choice from "../templates/settings/profile_
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
-import {$t_html} from "./i18n";
+import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as people from "./people";
@@ -186,7 +186,9 @@ function set_up_create_field_form() {
             const profile_field_name =
                 page_params.realm_default_external_accounts[$profile_field_external_account_type]
                     .name;
-            $("#profile_field_name").val(profile_field_name).prop("disabled", true);
+            $("#profile_field_name")
+                .val($t({defaultMessage: "{profile_field_name}"}, {profile_field_name}))
+                .prop("disabled", true);
             $("#profile_field_hint").val("").prop("disabled", true);
         }
     } else {
@@ -383,7 +385,16 @@ function open_edit_form_modal(e) {
         }
 
         // Set initial value in edit form
-        $profile_field_form.find("input[name=name]").val(field.name);
+        if (
+            Number.parseInt(field.type, 10) === field_types.EXTERNAL_ACCOUNT.id &&
+            "select[name=external_acc_field_type]" !== "custom"
+        ) {
+            $profile_field_form
+                .find("input[name=name]")
+                .val($t({defaultMessage: "{field_name}"}, {field_name: field.name}));
+        } else {
+            $profile_field_form.find("input[name=name]").val(field.name);
+        }
         $profile_field_form.find("input[name=hint]").val(field.hint);
 
         $profile_field_form


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.--> [CZO](https://chat.zulip.org/#narrow/stream/378-api-design/topic/Name.20and.20Hint.20editable.20of.20default.20external.20account.20.2322371/near/1434321)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
