### PR TITLE
auth: Add JWT-based user API key fetch.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -72,7 +72,7 @@ from zerver.lib.test_helpers import (
 )
 from zerver.lib.types import Validator
 from zerver.lib.upload import DEFAULT_AVATAR_SIZE, MEDIUM_AVATAR_SIZE, resize_avatar
-from zerver.lib.users import get_all_api_keys
+from zerver.lib.users import get_all_api_keys, get_api_key, get_raw_user_data
 from zerver.lib.validator import (
     check_bool,
     check_dict_only,
@@ -5413,9 +5413,10 @@ class TestJWTLogin(ZulipTestCase):
             )
 
     def test_login_failure_when_key_does_not_exist(self) -> None:
-        data = {"json_web_token": "not relevant"}
-        result = self.client_post("/accounts/login/jwt/", data)
-        self.assert_json_error_contains(result, "Auth key for this subdomain not found.", 400)
+        with self.settings(JWT_AUTH_KEYS={"acme": {"key": "key", "algorithms": ["HS256"]}}):
+            data = {"json_web_token": "not relevant"}
+            result = self.client_post("/accounts/login/jwt/", data)
+            self.assert_json_error_contains(result, "Auth key for this subdomain not found.", 400)
 
     def test_login_failure_when_key_is_missing(self) -> None:
         with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key", "algorithms": ["HS256"]}}):
@@ -6757,6 +6758,167 @@ class LDAPBackendTest(ZulipTestCase):
             warn_log.output,
             ["WARNING:django_auth_ldap:('Realm is None', 1) while authenticating hamlet"],
         )
+
+
+class JWTFetchAPIKeyTest(ZulipTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.email = self.example_email("hamlet")
+        self.realm = get_realm("zulip")
+        self.user_profile = get_user_by_delivery_email(self.email, self.realm)
+        self.api_key = get_api_key(self.user_profile)
+        self.raw_user_data = get_raw_user_data(
+            self.user_profile.realm,
+            self.user_profile,
+            target_user=self.user_profile,
+            client_gravatar=False,
+            user_avatar_url_field_optional=False,
+            include_custom_profile_fields=False,
+        )[self.user_profile.id]
+
+    def test_success(self) -> None:
+        payload = {"email": self.email}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_success(result)
+            data = result.json()
+            self.assertEqual(data["api_key"], self.api_key)
+            self.assertEqual(data["email"], self.email)
+            self.assertNotIn("user", data)
+
+    def test_success_with_profile_false(self) -> None:
+        payload = {"email": self.email}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token, "include_profile": "false"}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_success(result)
+            data = result.json()
+            self.assertEqual(data["api_key"], self.api_key)
+            self.assertEqual(data["email"], self.email)
+            self.assertNotIn("user", data)
+
+    def test_success_with_profile_true(self) -> None:
+        payload = {"email": self.email}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token, "include_profile": "true"}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_success(result)
+            data = result.json()
+            self.assertEqual(data["api_key"], self.api_key)
+            self.assertEqual(data["email"], self.email)
+            self.assertIn("user", data)
+            self.assertEqual(data["user"], self.raw_user_data)
+
+    def test_invalid_subdomain_from_request_failure(self) -> None:
+        with mock.patch("zerver.views.auth.get_realm_from_request", return_value=None):
+            result = self.client_post("/jwt/fetch_api_key")
+            self.assert_json_error_contains(result, "Invalid subdomain", 404)
+
+    def test_jwt_key_not_found_failure(self) -> None:
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            with mock.patch(
+                "zerver.views.auth.get_realm_from_request", return_value=get_realm("zephyr")
+            ):
+                result = self.client_post("/jwt/fetch_api_key")
+                self.assert_json_error_contains(
+                    result, "Auth key for this subdomain not found", 400
+                )
+
+    def test_missing_jwt_payload_failure(self) -> None:
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            result = self.client_post("/jwt/fetch_api_key")
+            self.assert_json_error_contains(result, "No JSON web token passed in request", 400)
+
+    def test_invalid_jwt_signature_failure(self) -> None:
+        payload = {"email": self.email}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, "wrong_key", algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(result, "Bad JSON web token", 400)
+
+    def test_invalid_jwt_format_failure(self) -> None:
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            req_data = {"json_web_token": "bad_jwt_token"}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(result, "Bad JSON web token", 400)
+
+    def test_missing_email_in_jwt_failure(self) -> None:
+        payload = {"bar": "baz"}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(
+                result, "No email specified in JSON web token claims", 400
+            )
+
+    def test_empty_email_in_jwt_failure(self) -> None:
+        payload = {"email": ""}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(
+                result, "No email specified in JSON web token claims", 400
+            )
+
+    def test_user_not_found_failure(self) -> None:
+        payload = {"email": self.nonreg_email("alice")}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(result, "Your username or password is incorrect", 401)
+
+    def test_inactive_user_failure(self) -> None:
+        payload = {"email": self.email}
+        do_deactivate_user(self.user_profile, acting_user=None)
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(result, "Account is deactivated", 401)
+
+    def test_inactive_realm_failure(self) -> None:
+        payload = {"email": self.email}
+        do_deactivate_realm(self.user_profile.realm, acting_user=None)
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(result, "This organization has been deactivated", 401)
+
+    def test_invalid_realm_for_user_failure(self) -> None:
+        payload = {"email": self.mit_email("starnine")}
+        with self.settings(JWT_AUTH_KEYS={"zulip": {"key": "key1", "algorithms": ["HS256"]}}):
+            key = settings.JWT_AUTH_KEYS["zulip"]["key"]
+            [algorithm] = settings.JWT_AUTH_KEYS["zulip"]["algorithms"]
+            web_token = jwt.encode(payload, key, algorithm)
+            req_data = {"json_web_token": web_token}
+            result = self.client_post("/jwt/fetch_api_key", req_data)
+            self.assert_json_error_contains(result, "Invalid subdomain", 404)
 
 
 # Don't load the base class as a test: https://bugs.python.org/issue17519.

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -67,9 +67,9 @@ from zerver.lib.subdomains import get_subdomain, is_subdomain_root_or_alias
 from zerver.lib.types import ViewFuncT
 from zerver.lib.url_encoding import append_url_query_string
 from zerver.lib.user_agent import parse_user_agent
-from zerver.lib.users import get_api_key
+from zerver.lib.users import get_api_key, get_raw_user_data
 from zerver.lib.utils import has_api_key_format
-from zerver.lib.validator import validate_login_email
+from zerver.lib.validator import check_bool, validate_login_email
 from zerver.models import (
     MultiuseInvite,
     PreregistrationUser,
@@ -855,6 +855,99 @@ def start_two_factor_auth(
     return two_fa_view(request, **kwargs)
 
 
+def process_api_key_fetch_authenticate_result(
+    request: HttpRequest, user_profile: Optional[UserProfile], return_data: Dict[str, bool]
+) -> str:
+    if return_data.get("inactive_user"):
+        raise UserDeactivatedError()
+    if return_data.get("inactive_realm"):
+        raise RealmDeactivatedError()
+    if return_data.get("password_auth_disabled"):
+        raise PasswordAuthDisabledError()
+    if return_data.get("password_reset_needed"):
+        raise PasswordResetRequiredError()
+    if return_data.get("invalid_subdomain"):
+        raise InvalidSubdomainError()
+    if user_profile is None:
+        raise AuthenticationFailedError()
+
+    assert user_profile.is_authenticated
+
+    # Maybe sending 'user_logged_in' signal is the better approach:
+    #   user_logged_in.send(sender=user_profile.__class__, request=request, user=user_profile)
+    # Not doing this only because over here we don't add the user information
+    # in the session. If the signal receiver assumes that we do then that
+    # would cause problems.
+    email_on_new_login(sender=user_profile.__class__, request=request, user=user_profile)
+
+    # Mark this request as having a logged-in user for our server logs.
+    process_client(request, user_profile)
+    RequestNotes.get_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
+
+    api_key = get_api_key(user_profile)
+    return api_key
+
+
+@csrf_exempt
+@has_request_variables
+def jwt_fetch_api_key(
+    request: HttpRequest,
+    json_web_token: str = REQ(default=""),
+    include_profile: bool = REQ(default=False, json_validator=check_bool),
+) -> HttpResponse:
+    return_data: Dict[str, bool] = {}
+
+    realm = get_realm_from_request(request)
+    if realm is None:
+        raise InvalidSubdomainError()
+
+    try:
+        key = settings.JWT_AUTH_KEYS[realm.subdomain]["key"]
+        algorithms = settings.JWT_AUTH_KEYS[realm.subdomain]["algorithms"]
+    except KeyError:
+        raise JsonableError(_("Auth key for this subdomain not found"))
+
+    try:
+        json_web_token = request.POST["json_web_token"]
+        options = {"verify_signature": True}
+        payload = jwt.decode(json_web_token, key, algorithms=algorithms, options=options)
+    except KeyError:
+        raise JsonableError(_("No JSON web token passed in request"))
+    except jwt.InvalidTokenError:
+        raise JsonableError(_("Bad JSON web token"))
+
+    remote_email = payload.get("email", None)
+    if remote_email is None or not remote_email:
+        raise JsonableError(_("No email specified in JSON web token claims"))
+
+    user_profile = authenticate(
+        username=remote_email, realm=realm, return_data=return_data, use_dummy_backend=True
+    )
+    if user_profile is not None:
+        assert isinstance(user_profile, UserProfile)
+
+    api_key = process_api_key_fetch_authenticate_result(request, user_profile, return_data)
+    assert user_profile is not None
+
+    result: Dict[str, Any] = {
+        "api_key": api_key,
+        "email": user_profile.delivery_email,
+    }
+
+    if include_profile:
+        members = get_raw_user_data(
+            realm,
+            user_profile,
+            target_user=user_profile,
+            client_gravatar=False,
+            user_avatar_url_field_optional=False,
+            include_custom_profile_fields=False,
+        )
+        result["user"] = members[user_profile.id]
+
+    return json_success(request, data=result)
+
+
 @csrf_exempt
 @require_post
 @has_request_variables
@@ -874,31 +967,14 @@ def api_fetch_api_key(
     user_profile = authenticate(
         request=request, username=username, password=password, realm=realm, return_data=return_data
     )
-    if return_data.get("inactive_user"):
-        raise UserDeactivatedError()
-    if return_data.get("inactive_realm"):
-        raise RealmDeactivatedError()
-    if return_data.get("password_auth_disabled"):
-        raise PasswordAuthDisabledError()
-    if return_data.get("password_reset_needed"):
-        raise PasswordResetRequiredError()
-    if user_profile is None:
-        raise AuthenticationFailedError()
+    if user_profile is not None:
+        assert isinstance(user_profile, UserProfile)
 
-    assert user_profile.is_authenticated
+    api_key = api_key = process_api_key_fetch_authenticate_result(
+        request, user_profile, return_data
+    )
+    assert user_profile is not None
 
-    # Maybe sending 'user_logged_in' signal is the better approach:
-    #   user_logged_in.send(sender=user_profile.__class__, request=request, user=user_profile)
-    # Not doing this only because over here we don't add the user information
-    # in the session. If the signal receiver assumes that we do then that
-    # would cause problems.
-    email_on_new_login(sender=user_profile.__class__, request=request, user=user_profile)
-
-    # Mark this request as having a logged-in user for our server logs.
-    process_client(request, user_profile)
-    RequestNotes.get_notes(request).requestor_for_logs = user_profile.format_requestor_for_logs()
-
-    api_key = get_api_key(user_profile)
     return json_success(request, data={"api_key": api_key, "email": user_profile.delivery_email})
 
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -372,7 +372,7 @@ TERMS_OF_SERVICE_MESSAGE: Optional[str] = None
 # Hostname used for Zulip's statsd logging integration.
 STATSD_HOST = ""
 
-# Configuration for JWT auth.
+# Configuration for JWT auth and user API keys fetch.
 if TYPE_CHECKING:
 
     class JwtAuthKey(TypedDict):
@@ -382,6 +382,8 @@ if TYPE_CHECKING:
         algorithms: List[str]
 
 
+# Set a JwtAuthKey for a specific subdomain id to be used for logging
+# users in or fetching user API keys through Json Web Token.
 JWT_AUTH_KEYS: Dict[str, "JwtAuthKey"] = {}
 
 # https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-SERVER_EMAIL

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -152,6 +152,22 @@ AUTHENTICATION_BACKENDS: Tuple[str, ...] = (
     # "zproject.backends.GenericOpenIdConnectBackend",  # Generic OIDC integration, setup below
 )
 
+## JWT-based users login and API keys fetching.
+##
+## If you want to login users or fetch API keys via JWT in Zulip,
+## you need to set the secret key and algorithm to use to validate
+## JWT tokens received.
+JWT_AUTH_KEYS: Dict[str, Any] = {
+    # Subdomain for which you want to enable the service.
+    "zulip": {
+        # Shared secret key used to validate jwt tokens.
+        "key": "key1",
+        # Algorithm with which the jwt token are signed.
+        "algorithms": ["HS256"],
+    }
+}
+
+
 ## LDAP integration.
 ##
 ## Zulip supports retrieving information about users via LDAP, and

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -25,6 +25,7 @@ from zerver.views.auth import (
     api_fetch_api_key,
     api_get_server_settings,
     json_fetch_api_key,
+    jwt_fetch_api_key,
     log_into_subdomain,
     login_page,
     logout_then_login,
@@ -747,6 +748,12 @@ v1_api_mobile_patterns = [
 # View for uploading messages from email mirror
 urls += [
     path("email_mirror_message", email_mirror_message),
+]
+
+#  This view accepts a JWT containing an email and returns an API key
+#  and the details for a single user.
+urls += [
+    path("jwt/fetch_api_key", jwt_fetch_api_key),
 ]
 
 # Include URL configuration files for site-specified extra installed


### PR DESCRIPTION
This PR adds a new endpoint `/jwt/fetch_api_key` that accepts a Json Web Token (JWT) and can be used to fetch API keys for a certain user. 

The target realm is inferred from the request Headers through `get_realm_from_request`.
The user email is part of the JWT payload.

```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImhhbWxldEB6dWxpcC5jb20ifQ.EsHxSVt54zPR-ywgPH54TB1FYmrGKsfq7hsQEhp_9w0
```
```json
{
  "email": "hamlet@zulip.com"
}
```
If the payload is verified and a valid user is found in the realm, a JSON containing an user API key and raw user data is returned in response.

```json
{
  "result": "success",
  "msg": "",
  "api_key": "gIPGp8r2DNNPRv2MQdHOiOK5guWLJGvp",
  "user": {
    "email": "user10@zulipdev.com",
    "user_id": 10,
    "avatar_version": 1,
    "is_admin": false,
    "is_owner": false,
    "is_guest": false,
    "is_billing_admin": false,
    "role": 400,
    "is_bot": false,
    "full_name": "King Hamlet",
    "timezone": "",
    "is_active": true,
    "date_joined": "2022-09-07T14:20:48.079950+00:00",
    "avatar_url": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1"
  }
}
```

It has been added a dictionary in the settings named `JWT_FETCH_API_KEYS` that must be configured in order to set the JWT verification keys for a given realm host.

```python
JWT_FETCH_API_KEYS: Dict[str, Any] = {
    # Subdomain Host(s) for which you want to enable JWT-based API keys fetching.
    "localhost:9991": {
        # Shared secret key used to validate jwt tokens.
        "key": "key1",
        # Algorithm with which the jwt token are signed.
        "algorithms": ["HS256"],
    }
}
```