### PR TITLE
help: Document "Mark messages as read on scroll" mobile app feature.

### DIFF
--- a/static/images/help/mobile-globe-icon.svg
+++ b/static/images/help/mobile-globe-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-globe">
+    <circle cx="12" cy="12" r="10"></circle>
+    <line x1="2" y1="12" x2="22" y2="12"></line>
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+</svg>

--- a/templates/zerver/help/marking-messages-as-read.md
+++ b/templates/zerver/help/marking-messages-as-read.md
@@ -1,24 +1,26 @@
 # Marking messages as read
 
-Zulip automatically keeps track of which messages you have and haven't
-read. Unread messages have a dark line along their left side, which fade as
-the message gets marked as read.
+## Move the blue box to mark messages as read
+In the Zulip desktop or web app, messages are marked as read when the
+**blue box** passes over them. You can move the blue box with the keyboard (see
+[keyboard shortcuts for navigation](/help/keyboard-shortcuts#navigation)),
+or by scrolling the message feed with your mouse.
 
-There are two situations in which messages automatically get marked as read.
+## Scroll to mark messages as read
 
-* **End of feed**: When you get to the bottom of a view, Zulip marks all
-  messages in that view as read.
+Zulip automatically keeps track of which messages you have and haven't read.
+Unread messages have a dark line along their left side, which fades as
+the message gets marked as read. When you get to the bottom of a view, Zulip
+marks all messages in that view as read.
 
-* **Blue box**: Messages are marked as read when the blue box passes over
-  them.
+## Mark all messages as read
 
-You can move the blue box either with the keyboard (arrow keys, <kbd>End</kbd>,
-etc.) or by scrolling the feed with your mouse.
-
-You can also manually **mark all messages as read**, or **mark all messages in a
+You can manually **mark all messages as read**, or **mark all messages in a
 stream or topic as read**.
 
 {start_tabs}
+
+{tab|desktop-web}
 
 1. Hover over a stream, topic, or **All messages** in the left sidebar.
 
@@ -28,3 +30,7 @@ stream or topic as read**.
 1. Click **Mark all messages as read**.
 
 {end_tabs}
+
+## Related articles
+
+* [Reading strategies](/help/reading-strategies)

--- a/templates/zerver/help/marking-messages-as-read.md
+++ b/templates/zerver/help/marking-messages-as-read.md
@@ -1,5 +1,21 @@
 # Marking messages as read
 
+## Configure whether messages are automatically marked as read
+
+{start_tabs}
+
+{tab|mobile}
+
+{!mobile-profile-menu.md!}
+
+1. Tap **Settings**.
+
+1. Tap **Mark messages as read on scroll**.
+
+1. Select **Always**, **Never** or **Only in conversation views**.
+
+{end_tabs}
+
 ## Move the blue box to mark messages as read
 In the Zulip desktop or web app, messages are marked as read when the
 **blue box** passes over them. You can move the blue box with the keyboard (see
@@ -28,6 +44,20 @@ stream or topic as read**.
    to the right.
 
 1. Click **Mark all messages as read**.
+
+{tab|mobile}
+
+1. Tap a stream, topic, or the all messages
+   (<img src="/static/images/help/mobile-globe-icon.svg" alt="globe" class="mobile-icon"/>)
+   tab.
+
+1. Tap **Mark stream as read**, **Mark topic as read**, or **Mark all as read**
+   near the top right corner of the app.
+
+!!! tip ""
+
+    You can also press and hold a topic until the long-press menu appears, and
+    select **Mark topic as read**.
 
 {end_tabs}
 

--- a/templates/zerver/help/reading-strategies.md
+++ b/templates/zerver/help/reading-strategies.md
@@ -63,4 +63,5 @@ like to reply to later.
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 * [Recent topics](/help/recent-topics)
-* [Search](/help/search-for-messages) for streams, topics, or messages.
+* [Searching for messages](/help/search-for-messages)
+* [Marking messages as read](/help/marking-messages-as-read)


### PR DESCRIPTION
The [Marking messages as read](https://zulip.com/help/marking-messages-as-read) help center article needs to be restructured before adding documentation for mobile app users.

- Splits the article into two sections so that we can document how to automatically and manually mark messages as read.
- Adds instructions for accessing the "Mark messages as read on scroll" setting in the mobile app.

Fixes: #22915.

**Screenshots and screen captures:**
<img width="695" alt="image" src="https://user-images.githubusercontent.com/2343554/190313175-b0b1d872-ee1f-4084-9ec4-7a83895ca126.png">

<img width="547" alt="image" src="https://user-images.githubusercontent.com/2343554/190313244-c543b98c-4155-4b26-8e57-597466997000.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>