### PR TITLE
popovers: Align icons and content in middle.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -93,15 +93,20 @@
 }
 
 ul {
-    &.info_popover_actions i,
-    &.actions_popover i,
-    &.streams_popover i,
-    &.topics_popover i {
-        display: inline-block;
-        width: 14px;
-        text-align: center;
-        margin-right: 3px;
-        vertical-align: middle;
+    &.info_popover_actions a,
+    &.actions_popover a,
+    &.streams_popover a,
+    &.topics_popover a {
+        display: flex;
+        align-items: center;
+
+        i {
+            display: inline-block;
+            width: 14px;
+            text-align: center;
+            margin-right: 3px;
+            vertical-align: middle;
+        }
     }
 
     &.topics_popover {
@@ -114,10 +119,6 @@ ul {
                 font-size: 12px;
             }
         }
-    }
-
-    &.info_popover_actions i.fa-edit {
-        vertical-align: middle;
     }
 }
 


### PR DESCRIPTION
The icons like `x` for delete message were displayed below the text in alignment due to a regression.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/alignment.20in.20message.20popover

<img width="702" alt="Screenshot 2022-09-15 at 3 04 48 PM" src="https://user-images.githubusercontent.com/25124304/190370614-0daf3045-0f27-4f3b-b12b-0f5bcf19f45a.png">
