### PR TITLE
stream settings: Show stream header in narrow view.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1108,12 +1108,14 @@ h4.user_group_setting_subsection_title {
         }
     }
 
-    #subscription_overlay,
     #groups_overlay {
         .display-type {
             display: none;
         }
+    }
 
+    #subscription_overlay,
+    #groups_overlay {
         .user-groups-container,
         .subscriptions-container {
             height: 95%;


### PR DESCRIPTION
This changes the streams overlay so that the header with the stream name or with 'Create stream' is also visible in a narrow window.

Resolves #22963

![tmp](https://user-images.githubusercontent.com/74348920/190433782-9dd6edce-7e9e-4e40-8237-fc65278fe7c7.png)

![tmp2](https://user-images.githubusercontent.com/74348920/190433788-a7f355a1-ff4f-47e9-b0ee-b04f2ef1b594.png)
