### PR TITLE
realm_export: Improve estimate of data export size.

### DIFF
--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -205,9 +205,9 @@ class RealmExportTest(ZulipTestCase):
         realm_count = RealmCount.objects.create(
             realm_id=admin.realm.id,
             end_time=timezone_now(),
-            subgroup=1,
             value=0,
-            property="messages_sent:client:day",
+            property="messages_sent:message_type:day",
+            subgroup="public_stream",
         )
 
         # Space limit is set as 10 GiB


### PR DESCRIPTION
As suggested by the new comments, the cost for a Zulip data export scales with messages actually included in the export, so an organizations with 1M private messages but only 50K public stream messages should not be modeled the same as one with 1M public stream messages for the purpose of the limits here.

Also improve the comments and variable names more generally.


This fails tests; @mateuszmandera can I ask you investigate and fix that? 