### PR TITLE
landing_nav: Add tabnabbing protection to external target="_blank" link

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -107,7 +107,7 @@
                             <a href="/help">Help center</a>
                         </li>
                         <li>
-                            <a href="https://zulip.com/development-community/" target="_blank">
+                            <a href="https://zulip.com/development-community/" target="_blank" rel="noopener noreferrer">
                                 Community chat
                             </a>
                         </li>
@@ -136,7 +136,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://github.com/zulip/zulip" target="_blank" rel="noopener noreferer">GitHub</a>
+                            <a href="https://github.com/zulip/zulip" target="_blank" rel="noopener noreferrer">GitHub</a>
                         </li>
                     </div>
                 </ul>


### PR DESCRIPTION
This has no impact because zulip.com is not attacker-controlled, but we should be consistent in protecting external `target="_blank"` links.