### PR TITLE
popovers: Align icons and content in middle.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -101,7 +101,14 @@ ul {
         width: 14px;
         text-align: center;
         margin-right: 3px;
-        vertical-align: middle;
+
+        &.zulip-icon {
+            /* These icons are different from font awesome icons,
+                so they need to be aligned separately. */
+            line-height: 14px;
+            position: relative;
+            top: 2px;
+        }
     }
 
     &.topics_popover {

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -93,20 +93,15 @@
 }
 
 ul {
-    &.info_popover_actions a,
-    &.actions_popover a,
-    &.streams_popover a,
-    &.topics_popover a {
-        display: flex;
-        align-items: center;
-
-        i {
-            display: inline-block;
-            width: 14px;
-            text-align: center;
-            margin-right: 3px;
-            vertical-align: middle;
-        }
+    &.info_popover_actions i,
+    &.actions_popover i,
+    &.streams_popover i,
+    &.topics_popover i {
+        display: inline-block;
+        width: 14px;
+        text-align: center;
+        margin-right: 3px;
+        vertical-align: middle;
     }
 
     &.topics_popover {
@@ -119,6 +114,10 @@ ul {
                 font-size: 12px;
             }
         }
+    }
+
+    &.info_popover_actions i.fa-edit {
+        vertical-align: middle;
     }
 }
 


### PR DESCRIPTION
@timabbott the fix I had was buggy as mention in https://github.com/zulip/zulip/pull/22960#issuecomment-1249173623. While this is the ideal approach , I didn't want to go down to changing the html structure of these popovers.

So, I tracked that this was introduced in c8f346b5e55ccaae0374d960e514e8d528fddd5d and hence reverted the regression and introduced a new fix.

Should be aligned in middle:
<img width="211" alt="image" src="https://user-images.githubusercontent.com/25124304/190626771-8d85b74e-a9b7-4d6d-8def-3f67f07e6daa.png">
<img width="187" alt="image" src="https://user-images.githubusercontent.com/25124304/190626799-fe55ae74-d864-4ecb-bf51-2b1093033f75.png">
<img width="199" alt="image" src="https://user-images.githubusercontent.com/25124304/190626821-6d7c0d9c-5b7b-4114-bfc8-2f012a96c91d.png">
