### PR TITLE
bots: Replace some redundant logic with is_cross_realm_bot_email.

### DIFF
--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -35,6 +35,7 @@ from zerver.models import (
     get_realm_user_dicts,
     get_user,
     get_user_profile_by_id_in_realm,
+    is_cross_realm_bot_email,
 )
 
 
@@ -487,7 +488,7 @@ def format_user_row(
 
     if is_bot:
         result["bot_type"] = row["bot_type"]
-        if row["email"] in settings.CROSS_REALM_BOT_EMAILS:
+        if is_cross_realm_bot_email(row["email"]):
             result["is_system_bot"] = True
 
         # Note that bot_owner_id can be None with legacy data.

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3868,8 +3868,8 @@ def get_user_by_id_in_realm_including_cross_realm(
         return user_profile
 
     # Note: This doesn't validate whether the `realm` passed in is
-    # None/invalid for the CROSS_REALM_BOT_EMAILS case.
-    if user_profile.delivery_email in settings.CROSS_REALM_BOT_EMAILS:
+    # None/invalid for the is_cross_realm_bot_email case.
+    if is_cross_realm_bot_email(user_profile.delivery_email):
         return user_profile
 
     raise UserProfile.DoesNotExist()


### PR DESCRIPTION
is_cross_realm_bot_email is just
`email.lower() in settings.CROSS_REALM_BOT_EMAILS` which is the same, aside of looking at .lower() - which is actually more correct.