### PR TITLE
python: Use ‘not in’ for negated membership tests

### DIFF
--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -129,7 +129,7 @@ def check_other_queues(queue_counts_dict: Dict[str, int]) -> List[Dict[str, Any]
 
 def check_rabbitmq_queues() -> None:
     pattern = re.compile(r"(\w+)\t(\d+)\t(\d+)")
-    if "USER" in os.environ and not os.environ["USER"] in ["root", "rabbitmq"]:
+    if "USER" in os.environ and os.environ["USER"] not in ["root", "rabbitmq"]:
         print("This script must be run as the root or rabbitmq user")
 
     list_queues_output = subprocess.check_output(

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1193,7 +1193,7 @@ def apply_event(
                 state["starred_messages"] = [
                     message
                     for message in state["starred_messages"]
-                    if not (message in event["messages"])
+                    if message not in event["messages"]
                 ]
     elif event["type"] == "realm_domains":
         if event["op"] == "add":


### PR DESCRIPTION
Fixes “E713 Test for membership should be `not in`” found by [ruff](https://github.com/charliermarsh/ruff).

(ruff looks like a promising future pyflakes/pycodestyle/flake8 replacement. It’s *really fast*!)