### PR TITLE
modals: Add `data-simplebar` to `login` and `api key` modal.

### DIFF
--- a/static/templates/login_to_access.hbs
+++ b/static/templates/login_to_access.hbs
@@ -9,7 +9,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
-            <main class="modal__content">
+            <main class="modal__content" data-simplebar>
                 {{#if empty_narrow}}
                 <p>
                     {{#tr}}

--- a/static/templates/settings/api_key_modal.hbs
+++ b/static/templates/settings/api_key_modal.hbs
@@ -7,7 +7,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
-            <main class="modal__content">
+            <main class="modal__content" data-simplebar>
                 <div id="password_confirmation">
                     <span class="alert-notification" id="api_key_status"></span>
                     <div id="api_key_form">


### PR DESCRIPTION
c439b9d3af9d22f3b7b144422bffa0e3384167b7 added `data-simplebar` to the `dialog_widget` module, but these modals don't use it. So, add it separately.

![image](https://user-images.githubusercontent.com/58626718/190854777-5f8b4cb6-1636-4bd3-b924-f3a06839dc36.png)

![image](https://user-images.githubusercontent.com/58626718/190854794-d1613158-9f9d-4163-bf79-0a0b05626a1c.png)
