### PR TITLE
view_code_in_playground: Fix tooltip being partially hidden.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -219,6 +219,7 @@ export function initialize() {
             ".sidebar-title",
             "#user_filter_icon",
             "#scroll-to-bottom-button-clickable-area",
+            ".code_external_link",
         ],
         appendTo: () => document.body,
     });

--- a/static/templates/view_code_in_playground.hbs
+++ b/static/templates/view_code_in_playground.hbs
@@ -1,2 +1,2 @@
 {{! Display the "view code in playground" option for code blocks}}
-<a target="_blank" rel="noopener noreferrer" class="tippy-zulip-tooltip code_external_link"><i class="fa fa-external-link"></i></a>
+<a target="_blank" rel="noopener noreferrer" class="code_external_link"><i class="fa fa-external-link"></i></a>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/code.20playground.20tooltip
before:
![image](https://user-images.githubusercontent.com/25124304/190956055-42b7c6e8-db0d-4dbe-b3fb-01c6892dd970.png)
after:
<img width="539" alt="Screenshot 2022-09-19 at 11 15 58 AM" src="https://user-images.githubusercontent.com/25124304/190956136-096a4676-cd2a-43c9-8b94-8985737ed1f2.png">
