### PR TITLE
streams: Fix can_remove_subscribers_from_stream type

### DIFF
--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -606,7 +606,7 @@ def can_access_stream_history_by_id(user_profile: UserProfile, stream_id: int) -
 
 
 def can_remove_subscribers_from_stream(
-    stream: Stream, user_profile: UserProfile, sub: Subscription
+    stream: Stream, user_profile: UserProfile, sub: Optional[Subscription]
 ) -> bool:
     if not check_basic_stream_access(user_profile, stream, sub, allow_realm_admin=True):
         return False


### PR DESCRIPTION
Added by commit c3fe8420fdf5994908ee0bab1e8d17e7cec3272b (#22589).

Cc @sahil839 @PIG208.