### PR TITLE
models: Tighten type annotation for query_for_ids

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -155,7 +155,15 @@ class AndNonZero(models.Lookup):
         return f"{lhs} & {rhs} != 0", lhs_params + rhs_params
 
 
-def query_for_ids(query: QuerySet, user_ids: List[int], field: str) -> QuerySet:
+ModelT = TypeVar("ModelT", bound=models.Model)
+RowT = TypeVar("RowT")
+
+
+def query_for_ids(
+    query: "ValuesQuerySet[ModelT, RowT]",
+    user_ids: List[int],
+    field: str,
+) -> "ValuesQuerySet[ModelT, RowT]":
     """
     This function optimizes searches of the form
     `user_profile_id in (1, 2, 3, 4)` by quickly


### PR DESCRIPTION
This makes use of the type parameters of `ValuesQuerySet` (a.k.a `_QuerySet`) to provide a more accurate type annotation for `query_for_ids`.

Note that `QuerySet[ModelT]` is equivalent to `_QuerySet[ModelT, ModelT]`.

Extracted from #18777 (cc @PIG208).