### PR TITLE
test_runner: Remove monkey-patched SubSuiteList.

### DIFF
--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -5,7 +5,7 @@ import shutil
 import unittest
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
-from unittest import TestLoader, TestSuite, runner
+from unittest import TestSuite, runner
 from unittest.result import TestResult
 
 import orjson
@@ -114,7 +114,7 @@ def run_subsuite(args: SubsuiteArgs) -> Tuple[int, Any]:
     # because we run our own version of the runner class.
     _, subsuite_index, subsuite, failfast, buffer = args
     runner = RemoteTestRunner(failfast=failfast, buffer=buffer)
-    result = runner.run(deserialize_suite(subsuite))
+    result = runner.run(subsuite)
     # Now we send instrumentation related events. This data will be
     # appended to the data structure in the main thread. For Mypy,
     # type of Partial is different from Callable. All the methods of
@@ -222,12 +222,6 @@ class ParallelTestSuite(django_runner.ParallelTestSuite):
         buffer: bool = False,
     ) -> None:
         super().__init__(subsuites=subsuites, processes=processes, failfast=failfast, buffer=buffer)
-        # We can't specify a consistent type for self.subsuites, since
-        # the whole idea here is to monkey-patch that so we can use
-        # most of django_runner.ParallelTestSuite with our own suite
-        # definitions.
-        assert not isinstance(self.subsuites, SubSuiteList)
-        self.subsuites: Union[SubSuiteList, List[TestSuite]] = SubSuiteList(self.subsuites)
 
 
 def check_import_error(test_name: str) -> None:
@@ -422,13 +416,7 @@ class Runner(DiscoverRunner):
 
 def get_test_names(suite: Union[TestSuite, ParallelTestSuite]) -> List[str]:
     if isinstance(suite, ParallelTestSuite):
-        # suite is ParallelTestSuite. It will have a subsuites parameter of
-        # type SubSuiteList. Each element of a SubsuiteList is a tuple whose
-        # first element is the type of TestSuite and the second element is a
-        # list of test names in that test suite. See serialize_suite() for the
-        # implementation details.
-        assert isinstance(suite.subsuites, SubSuiteList)
-        return [name for subsuite in suite.subsuites for name in subsuite[1]]
+        return [name for subsuite in suite.subsuites for name in get_test_names(subsuite)]
     else:
         return [t.id() for t in get_tests_from_suite(suite)]
 
@@ -441,33 +429,5 @@ def get_tests_from_suite(suite: TestSuite) -> Iterable[unittest.TestCase]:
             yield test
 
 
-def serialize_suite(suite: TestSuite) -> Tuple[Type[TestSuite], List[str]]:
-    return type(suite), get_test_names(suite)
-
-
-def deserialize_suite(args: Tuple[Type[TestSuite], List[str]]) -> TestSuite:
-    suite_class, test_names = args
-    suite = suite_class()
-    tests = TestLoader().loadTestsFromNames(test_names)
-    for test in get_tests_from_suite(tests):
-        suite.addTest(test)
-    return suite
-
-
 class RemoteTestRunner(django_runner.RemoteTestRunner):
     resultclass = RemoteTestResult
-
-
-class SubSuiteList(List[Tuple[Type[TestSuite], List[str]]]):
-    """
-    This class allows us to avoid changing the main logic of
-    ParallelTestSuite and still make it serializable.
-    """
-
-    def __init__(self, suites: List[TestSuite]) -> None:
-        serialized_suites = [serialize_suite(s) for s in suites]
-        super().__init__(serialized_suites)
-
-    def __getitem__(self, index: Any) -> Any:
-        suite = super().__getitem__(index)
-        return deserialize_suite(suite)


### PR DESCRIPTION
Unless I missed something, this monkey-patching approach is not meaningful when what we really need is just the names of the test, that can already be done in get_test_names. This addresses a typing issue of `ParallelTestSuite.subsuites` in #18777.

Signed-off-by: Zixuan James Li <p359101898@gmail.com>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
