### PR TITLE
external_accounts: Make ExternalAccount dataclass to fix typing

### DIFF
--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -31,9 +31,9 @@ def try_add_realm_default_custom_profile_field(
     field_data = DEFAULT_EXTERNAL_ACCOUNTS[field_subtype]
     custom_profile_field = CustomProfileField(
         realm=realm,
-        name=field_data["name"],
+        name=str(field_data.name),
         field_type=CustomProfileField.EXTERNAL_ACCOUNT,
-        hint=field_data["hint"],
+        hint=field_data.hint,
         field_data=orjson.dumps(dict(subtype=field_subtype)).decode(),
     )
     custom_profile_field.save()

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -190,8 +190,8 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
             field = CustomProfileField.objects.get(name=invalid_field_name, realm=realm)
         # The field is created with 'Twitter username' name as per values in default fields dict
         field = CustomProfileField.objects.get(name="Twitter username")
-        self.assertEqual(field.name, DEFAULT_EXTERNAL_ACCOUNTS["twitter"]["name"])
-        self.assertEqual(field.hint, DEFAULT_EXTERNAL_ACCOUNTS["twitter"]["hint"])
+        self.assertEqual(field.name, DEFAULT_EXTERNAL_ACCOUNTS["twitter"].name)
+        self.assertEqual(field.hint, DEFAULT_EXTERNAL_ACCOUNTS["twitter"].hint)
 
         result = self.client_delete(f"/json/realm/profile_fields/{field.id}")
         self.assert_json_success(result)


### PR DESCRIPTION
Commit 1a426fa6be0f77bd9debf3e6620ac646f6cc586b (#22977) changed `name` to be a `StrPromise` rather than a `str`.