### PR TITLE
lint: Enable caching for Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "nyc": "^15.0.0",
     "openapi-examples-validator": "^4.0.0",
     "openapi-types": "^12.0.0",
-    "prettier": "^2.0.5",
+    "prettier": "^3.0.0-alpha.4",
     "puppeteer": "^17.1.0",
     "source-map": "https://codeload.github.com/benthemonkey/source-map/tar.gz/d95423f77edef6cbb9e21d2d6014c7de85ae220a",
     "stylelint": "^14.0.1",

--- a/tools/check-openapi
+++ b/tools/check-openapi
@@ -40,6 +40,7 @@ async function checkFile(file) {
 
     let ok = true;
     const reformats = new Map();
+    const promises = [];
 
     visit(doc, {
         Map(key, node) {
@@ -70,43 +71,54 @@ async function checkFile(file) {
                 node.value instanceof Scalar &&
                 typeof node.value.value === "string"
             ) {
-                let formatted = Prettier.format(node.value.value, {parser: "markdown"});
-                if (![Scalar.BLOCK_FOLDED, Scalar.BLOCK_LITERAL].includes(node.value.type)) {
-                    formatted = formatted.replace(/\n$/, "");
-                }
-                if (formatted !== node.value.value) {
-                    if (argv.fix) {
-                        reformats.set(node.value.range[0], {
-                            value: formatted,
-                            context: {afterKey: true},
+                promises.push(
+                    (async () => {
+                        let formatted = await Prettier.format(node.value.value, {
+                            parser: "markdown",
                         });
-                    } else {
-                        ok = false;
-                        const {line, col} = lineCounter.linePos(node.value.range[0]);
-                        console.error(
-                            "%s:%d:%d: Format description with Prettier:",
-                            file,
-                            line,
-                            col,
-                        );
-                        let diff = "";
-                        for (const part of Diff.diffLines(node.value.value, formatted)) {
-                            const prefix = part.added
-                                ? "\u001B[32m+"
-                                : part.removed
-                                ? "\u001B[31m-"
-                                : "\u001B[34m ";
-                            diff += prefix;
-                            diff += part.value.replace(/\n$/, "").replace(/\n/g, "\n" + prefix);
-                            diff += "\n";
+                        if (
+                            ![Scalar.BLOCK_FOLDED, Scalar.BLOCK_LITERAL].includes(node.value.type)
+                        ) {
+                            formatted = formatted.replace(/\n$/, "");
                         }
-                        diff += "\u001B[0m";
-                        console.error(diff);
-                    }
-                }
+                        if (formatted !== node.value.value) {
+                            if (argv.fix) {
+                                reformats.set(node.value.range[0], {
+                                    value: formatted,
+                                    context: {afterKey: true},
+                                });
+                            } else {
+                                ok = false;
+                                const {line, col} = lineCounter.linePos(node.value.range[0]);
+                                console.error(
+                                    "%s:%d:%d: Format description with Prettier:",
+                                    file,
+                                    line,
+                                    col,
+                                );
+                                let diff = "";
+                                for (const part of Diff.diffLines(node.value.value, formatted)) {
+                                    const prefix = part.added
+                                        ? "\u001B[32m+"
+                                        : part.removed
+                                        ? "\u001B[31m-"
+                                        : "\u001B[34m ";
+                                    diff += prefix;
+                                    diff += part.value
+                                        .replace(/\n$/, "")
+                                        .replace(/\n/g, "\n" + prefix);
+                                    diff += "\n";
+                                }
+                                diff += "\u001B[0m";
+                                console.error(diff);
+                            }
+                        }
+                    })(),
+                );
             }
         },
     });
+    await Promise.all(promises);
 
     if (!ok) {
         process.exitCode = 1;

--- a/tools/lint
+++ b/tools/lint
@@ -174,7 +174,7 @@ def run() -> None:
     )
     linter_config.external_linter(
         "prettier",
-        ["node_modules/.bin/prettier", "--check", "--loglevel=warn"],
+        ["node_modules/.bin/prettier", "--check", "--log-level=warn"],
         ["css", "flow", "js", "json", "md", "ts", "yaml", "yml"],
         fix_arg=["--write"],
         description="Formats CSS, JavaScript, YAML",

--- a/tools/lint
+++ b/tools/lint
@@ -174,7 +174,7 @@ def run() -> None:
     )
     linter_config.external_linter(
         "prettier",
-        ["node_modules/.bin/prettier", "--check", "--log-level=warn"],
+        ["node_modules/.bin/prettier", "--cache", "--check", "--log-level=warn"],
         ["css", "flow", "js", "json", "md", "ts", "yaml", "yml"],
         fix_arg=["--write"],
         description="Formats CSS, JavaScript, YAML",

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 153
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (207, 0)
+PROVISION_VERSION = (208, 0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8335,10 +8335,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-prettier@^2.0.5:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@^3.0.0-alpha.4:
+  version "3.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0-alpha.4.tgz#eee71d6b520b970f44e4045f2dc772bf6f80815f"
+  integrity sha512-+KeqJv4E5kaRsDRgSx9IeVygLKGHRmcoPvRJvPFp3bC1mw8opsva555gGb8TaJzUiHXoLZcus1EX+nlHPda7Pw==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Caching is new in Prettier 2.7.0, but broken before 3.0.0-alpha.4.