### PR TITLE
development environment sentence case updates

### DIFF
--- a/templates/zerver/development/dev_login.html
+++ b/templates/zerver/development/dev_login.html
@@ -90,7 +90,7 @@ page can be easily identified in it's respective JavaScript file -->
             {{ csrf_input }}
             <h2>Realm</h2>
             <select name="new_realm" onchange="this.form.submit()">
-                <option value="all_realms" {% if not current_realm %}selected="selected"{% endif %}>All Realms</option>
+                <option value="all_realms" {% if not current_realm %}selected="selected"{% endif %}>All realms</option>
                 {% for realm in all_realms %}
                 <option value="{{realm.string_id}}" {% if current_realm == realm %}selected="selected"{% endif %}>{{realm.name}}</option>
                 {% endfor %}
@@ -99,10 +99,10 @@ page can be easily identified in it's respective JavaScript file -->
         <div id="devtools-wrapper">
             <div id="devtools-registration">
                 <form name="register_dev_user" action="{{ url('register_dev_user') }}" method="POST">
-                    <input type="submit" class="btn btn-admin" value="Create New User" />
+                    <input type="submit" class="btn btn-admin" value="Create new user" />
                 </form>
                 <form name="register_dev_realm" action="{{ url('register_dev_realm') }}" method="POST">
-                    <input type="submit" class="btn btn-admin" value="Create New Realm" />
+                    <input type="submit" class="btn btn-admin" value="Create new realm" />
                 </form>
                 <form name="register_demo_dev_realm" action="{{ url('register_demo_dev_realm') }}" method="POST">
                     <input type="submit" class="btn btn-admin" value="Create demo organization" />


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This Pull Request changes the sentence style on the Zulip development environment login screen.
Fixes: #23009 
Changes Titles of Create New User, Create New Realm, and All Realms so that they are consistent with Zulip's sentence case pattern.

**Screenshots and screen captures:**
<img width="519" alt="Screen Shot 2022-09-20 at 8 53 35 PM" src="https://user-images.githubusercontent.com/86123149/191390503-44c0ba56-8026-4919-bdc0-f958a751ee7f.png">

**Self-review checklist**


- [x] Create New User -> Create new users
- [x] Create New Realm -> Create new realm
- [x] [in the Realm dropdown] All Realms -> All realms

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
