### PR TITLE
Refactor some organization settings related code.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -531,11 +531,39 @@ test("set_up", ({override, override_rewire}) => {
         update: noop,
     }));
     $("#id_realm_message_content_edit_limit_minutes").set_parent(
-        $.create("<stub edit limit parent>"),
+        $.create("<stub edit limit custom input parent>"),
     );
     $("#id_realm_message_content_delete_limit_minutes").set_parent(
-        $.create("<stub delete limit parent>"),
+        $.create("<stub delete limit custom input parent>"),
     );
+    const $stub_message_content_edit_limit_parent = $.create(
+        "<stub message_content_edit_limit parent",
+    );
+    $("#id_realm_message_content_edit_limit_seconds").set_parent(
+        $stub_message_content_edit_limit_parent,
+    );
+
+    const $stub_message_content_delete_limit_parent = $.create(
+        "<stub message_content_delete_limit parent",
+    );
+    $("#id_realm_message_content_delete_limit_seconds").set_parent(
+        $stub_message_content_delete_limit_parent,
+    );
+
+    const $custom_edit_limit_input = $("#id_realm_message_content_edit_limit_minutes");
+    $stub_message_content_edit_limit_parent.set_find_results(
+        ".admin-realm-time-limit-input",
+        $custom_edit_limit_input,
+    );
+    $custom_edit_limit_input.attr("id", "id_realm_message_content_edit_limit_minutes");
+
+    const $custom_delete_limit_input = $("#id_realm_message_content_delete_limit_minutes");
+    $stub_message_content_delete_limit_parent.set_find_results(
+        ".admin-realm-time-limit-input",
+        $custom_delete_limit_input,
+    );
+    $custom_delete_limit_input.attr("id", "id_realm_message_content_delete_limit_minutes");
+
     $("#id_realm_message_retention_days").set_parent($.create("<stub retention period parent>"));
     $("#message_content_in_email_notifications_label").set_parent(
         $.create("<stub in-content setting checkbox>"),

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -370,17 +370,17 @@ function test_sync_realm_settings() {
 
     {
         /* Test message content edit limit dropdown value sync */
-        const $property_elem = $("#id_realm_msg_edit_limit_setting");
+        const $property_elem = $("#id_realm_message_content_edit_limit_seconds");
         $property_elem.length = 1;
-        $property_elem.attr("id", "id_realm_msg_edit_limit_setting");
+        $property_elem.attr("id", "id_realm_message_content_edit_limit_seconds");
 
         page_params.realm_message_content_edit_limit_seconds = 120;
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
-        assert.equal($("#id_realm_msg_edit_limit_setting").val(), "upto_two_min");
+        assert.equal($("#id_realm_message_content_edit_limit_seconds").val(), "upto_two_min");
 
         page_params.realm_message_content_edit_limit_seconds = 130;
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
-        assert.equal($("#id_realm_msg_edit_limit_setting").val(), "custom_period");
+        assert.equal($("#id_realm_message_content_edit_limit_seconds").val(), "custom_period");
     }
 
     {
@@ -457,7 +457,9 @@ function test_discard_changes_button(discard_changes) {
     const $edit_topic_policy = $("#id_realm_edit_topic_policy").val(
         settings_config.common_message_policy_values.by_admins_only.code,
     );
-    const $msg_edit_limit_setting = $("#id_realm_msg_edit_limit_setting").val("custom_period");
+    const $msg_edit_limit_setting = $("#id_realm_message_content_edit_limit_seconds").val(
+        "custom_period",
+    );
     const $message_content_edit_limit_minutes = $(
         "#id_realm_message_content_edit_limit_minutes",
     ).val(130);
@@ -467,7 +469,7 @@ function test_discard_changes_button(discard_changes) {
     ).val(130);
 
     $allow_edit_history.attr("id", "id_realm_allow_edit_history");
-    $msg_edit_limit_setting.attr("id", "id_realm_msg_edit_limit_setting");
+    $msg_edit_limit_setting.attr("id", "id_realm_message_content_edit_limit_seconds");
     $msg_delete_limit_setting.attr("id", "id_realm_msg_delete_limit_setting");
     $edit_topic_policy.attr("id", "id_realm_edit_topic_policy");
     $message_content_edit_limit_minutes.attr("id", "id_realm_message_content_edit_limit_minutes");

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -358,8 +358,11 @@ function test_sync_realm_settings() {
     {
         /* Test message content edit limit minutes sync */
         const $property_elem = $("#id_realm_message_content_edit_limit_minutes");
+        const $property_dropdown_elem = $("#id_realm_message_content_edit_limit_seconds");
         $property_elem.length = 1;
+        $property_dropdown_elem.length = 1;
         $property_elem.attr("id", "id_realm_message_content_edit_limit_minutes");
+        $property_dropdown_elem.attr("id", "id_realm_message_content_edit_limit_seconds");
 
         page_params.realm_create_public_stream_policy = 1;
         page_params.realm_message_content_edit_limit_seconds = 120;
@@ -370,10 +373,6 @@ function test_sync_realm_settings() {
 
     {
         /* Test message content edit limit dropdown value sync */
-        const $property_elem = $("#id_realm_message_content_edit_limit_seconds");
-        $property_elem.length = 1;
-        $property_elem.attr("id", "id_realm_message_content_edit_limit_seconds");
-
         page_params.realm_message_content_edit_limit_seconds = 120;
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
         assert.equal($("#id_realm_message_content_edit_limit_seconds").val(), "120");
@@ -486,8 +485,6 @@ function test_discard_changes_button(discard_changes) {
         $msg_edit_limit_setting,
         $msg_delete_limit_setting,
         $edit_topic_policy,
-        $message_content_edit_limit_minutes,
-        $message_content_delete_limit_minutes,
     ];
 
     const {$discard_button, props} = createSaveButtons("msg-editing");

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -376,7 +376,7 @@ function test_sync_realm_settings() {
 
         page_params.realm_message_content_edit_limit_seconds = 120;
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
-        assert.equal($("#id_realm_message_content_edit_limit_seconds").val(), "upto_two_min");
+        assert.equal($("#id_realm_message_content_edit_limit_seconds").val(), "120");
 
         page_params.realm_message_content_edit_limit_seconds = 130;
         settings_org.sync_realm_settings("message_content_edit_limit_seconds");
@@ -500,9 +500,9 @@ function test_discard_changes_button(discard_changes) {
         $edit_topic_policy.val(),
         settings_config.common_message_policy_values.by_everyone.code,
     );
-    assert.equal($msg_edit_limit_setting.val(), "upto_one_hour");
+    assert.equal($msg_edit_limit_setting.val(), "3600");
     assert.equal($message_content_edit_limit_minutes.val(), "60");
-    assert.equal($msg_delete_limit_setting.val(), "upto_two_min");
+    assert.equal($msg_delete_limit_setting.val(), "120");
     assert.equal($message_content_delete_limit_minutes.val(), "2");
     assert.ok(props.hidden);
 }

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -463,14 +463,16 @@ function test_discard_changes_button(discard_changes) {
     const $message_content_edit_limit_minutes = $(
         "#id_realm_message_content_edit_limit_minutes",
     ).val(130);
-    const $msg_delete_limit_setting = $("#id_realm_msg_delete_limit_setting").val("custom_period");
+    const $msg_delete_limit_setting = $("#id_realm_message_content_delete_limit_seconds").val(
+        "custom_period",
+    );
     const $message_content_delete_limit_minutes = $(
         "#id_realm_message_content_delete_limit_minutes",
     ).val(130);
 
     $allow_edit_history.attr("id", "id_realm_allow_edit_history");
     $msg_edit_limit_setting.attr("id", "id_realm_message_content_edit_limit_seconds");
-    $msg_delete_limit_setting.attr("id", "id_realm_msg_delete_limit_setting");
+    $msg_delete_limit_setting.attr("id", "id_realm_message_content_delete_limit_seconds");
     $edit_topic_policy.attr("id", "id_realm_edit_topic_policy");
     $message_content_edit_limit_minutes.attr("id", "id_realm_message_content_edit_limit_minutes");
     $message_content_delete_limit_minutes.attr(

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -291,7 +291,7 @@ export const common_message_policy_values = {
     },
 };
 
-const time_limit_dropdown_values = [
+export const time_limit_dropdown_values = [
     {
         text: $t({defaultMessage: "Any time"}),
         value: "any_time",

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -291,71 +291,51 @@ export const common_message_policy_values = {
     },
 };
 
-const time_limit_dropdown_values = new Map([
-    [
-        "any_time",
-        {
-            text: $t({defaultMessage: "Any time"}),
-            seconds: null,
-        },
-    ],
-    [
-        "upto_two_min",
-        {
-            text: $t(
-                {defaultMessage: "Up to {time_limit} after posting"},
-                {time_limit: $t({defaultMessage: "2 minutes"})},
-            ),
-            seconds: 2 * 60,
-        },
-    ],
-    [
-        "upto_ten_min",
-        {
-            text: $t(
-                {defaultMessage: "Up to {time_limit} after posting"},
-                {time_limit: $t({defaultMessage: "10 minutes"})},
-            ),
-            seconds: 10 * 60,
-        },
-    ],
-    [
-        "upto_one_hour",
-        {
-            text: $t(
-                {defaultMessage: "Up to {time_limit} after posting"},
-                {time_limit: $t({defaultMessage: "1 hour"})},
-            ),
-            seconds: 60 * 60,
-        },
-    ],
-    [
-        "upto_one_day",
-        {
-            text: $t(
-                {defaultMessage: "Up to {time_limit} after posting"},
-                {time_limit: $t({defaultMessage: "1 day"})},
-            ),
-            seconds: 24 * 60 * 60,
-        },
-    ],
-    [
-        "upto_one_week",
-        {
-            text: $t(
-                {defaultMessage: "Up to {time_limit} after posting"},
-                {time_limit: $t({defaultMessage: "1 week"})},
-            ),
-            seconds: 7 * 24 * 60 * 60,
-        },
-    ],
-    [
-        "custom_period",
-        {
-            text: $t({defaultMessage: "Custom"}),
-        },
-    ],
-]);
+const time_limit_dropdown_values = [
+    {
+        text: $t({defaultMessage: "Any time"}),
+        value: "any_time",
+    },
+    {
+        text: $t(
+            {defaultMessage: "Up to {time_limit} after posting"},
+            {time_limit: $t({defaultMessage: "2 minutes"})},
+        ),
+        value: 2 * 60,
+    },
+    {
+        text: $t(
+            {defaultMessage: "Up to {time_limit} after posting"},
+            {time_limit: $t({defaultMessage: "10 minutes"})},
+        ),
+        value: 10 * 60,
+    },
+    {
+        text: $t(
+            {defaultMessage: "Up to {time_limit} after posting"},
+            {time_limit: $t({defaultMessage: "1 hour"})},
+        ),
+        value: 60 * 60,
+    },
+    {
+        text: $t(
+            {defaultMessage: "Up to {time_limit} after posting"},
+            {time_limit: $t({defaultMessage: "1 day"})},
+        ),
+        value: 24 * 60 * 60,
+    },
+    {
+        text: $t(
+            {defaultMessage: "Up to {time_limit} after posting"},
+            {time_limit: $t({defaultMessage: "1 week"})},
+        ),
+        value: 7 * 24 * 60 * 60,
+    },
+    {
+        text: $t({defaultMessage: "Custom"}),
+        value: "custom_period",
+    },
+];
 export const msg_edit_limit_dropdown_values = time_limit_dropdown_values;
 export const msg_delete_limit_dropdown_values = time_limit_dropdown_values;
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -314,18 +314,23 @@ function get_time_limit_dropdown_setting_value(property_name) {
     return "custom_period";
 }
 
-function set_msg_edit_limit_dropdown() {
-    const dropdown_elem_val = get_time_limit_dropdown_setting_value(
-        "realm_message_content_edit_limit_seconds",
-    );
-    $("#id_realm_message_content_edit_limit_seconds").val(dropdown_elem_val);
-    $("#id_realm_message_content_edit_limit_minutes").val(
-        get_realm_time_limits_in_minutes("realm_message_content_edit_limit_seconds"),
-    );
+function set_time_limit_setting(property_name) {
+    const dropdown_elem_val = get_time_limit_dropdown_setting_value(property_name);
+    $(`#id_${CSS.escape(property_name)}`).val(dropdown_elem_val);
+
+    const $custom_input = $(`#id_${CSS.escape(property_name)}`)
+        .parent()
+        .find(".admin-realm-time-limit-input");
+    $custom_input.val(get_realm_time_limits_in_minutes(property_name));
+
     change_element_block_display_property(
-        "id_realm_message_content_edit_limit_minutes",
+        $custom_input.attr("id"),
         dropdown_elem_val === "custom_period",
     );
+}
+
+function set_msg_edit_limit_dropdown() {
+    set_time_limit_setting("realm_message_content_edit_limit_seconds");
 }
 
 function message_delete_limit_setting_enabled(setting_value) {
@@ -359,17 +364,7 @@ function set_delete_own_message_policy_dropdown(setting_value) {
 }
 
 function set_msg_delete_limit_dropdown() {
-    const dropdown_elem_val = get_time_limit_dropdown_setting_value(
-        "realm_message_content_delete_limit_seconds",
-    );
-    $("#id_realm_message_content_delete_limit_seconds").val(dropdown_elem_val);
-    $("#id_realm_message_content_delete_limit_minutes").val(
-        get_realm_time_limits_in_minutes("realm_message_content_delete_limit_seconds"),
-    );
-    change_element_block_display_property(
-        "id_realm_message_content_delete_limit_minutes",
-        dropdown_elem_val === "custom_period",
-    );
+    set_time_limit_setting("realm_message_content_delete_limit_seconds");
 }
 
 function set_message_retention_setting_dropdown() {
@@ -576,10 +571,8 @@ function discard_property_element_changes(elem, for_realm_default_settings) {
             }
             break;
         case "realm_message_content_edit_limit_seconds":
-            set_msg_edit_limit_dropdown();
-            break;
         case "realm_message_content_delete_limit_seconds":
-            set_msg_delete_limit_dropdown();
+            set_time_limit_setting(property_name);
             break;
         default:
             if (property_value !== undefined) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -170,7 +170,7 @@ function get_property_value(property_name, for_realm_default_settings) {
         return "custom_days";
     }
 
-    if (property_name === "realm_msg_edit_limit_setting") {
+    if (property_name === "realm_message_content_edit_limit_seconds") {
         if (page_params.realm_message_content_edit_limit_seconds === null) {
             return "any_time";
         }
@@ -305,7 +305,11 @@ function set_giphy_rating_dropdown() {
 }
 
 function update_message_edit_sub_settings(is_checked) {
-    settings_ui.disable_sub_setting_onchange(is_checked, "id_realm_msg_edit_limit_setting", true);
+    settings_ui.disable_sub_setting_onchange(
+        is_checked,
+        "id_realm_message_content_edit_limit_seconds",
+        true,
+    );
     settings_ui.disable_sub_setting_onchange(
         is_checked,
         "id_realm_message_content_edit_limit_minutes",
@@ -315,8 +319,8 @@ function update_message_edit_sub_settings(is_checked) {
 }
 
 function set_msg_edit_limit_dropdown() {
-    const value = get_property_value("realm_msg_edit_limit_setting");
-    $("#id_realm_msg_edit_limit_setting").val(value);
+    const value = get_property_value("realm_message_content_edit_limit_seconds");
+    $("#id_realm_message_content_edit_limit_seconds").val(value);
     change_element_block_display_property(
         "id_realm_message_content_edit_limit_minutes",
         value === "custom_period",
@@ -473,7 +477,7 @@ function update_dependent_subsettings(property_name) {
         case "realm_allow_message_editing":
             update_message_edit_sub_settings(page_params.realm_allow_message_editing);
             break;
-        case "realm_msg_edit_limit_setting":
+        case "realm_message_content_edit_limit_seconds":
         case "realm_message_content_edit_limit_minutes":
             set_msg_edit_limit_dropdown();
             break;
@@ -965,7 +969,9 @@ export function register_save_discard_widget_handlers(
 
         switch (subsection) {
             case "msg_editing": {
-                const edit_limit_setting_value = $("#id_realm_msg_edit_limit_setting").val();
+                const edit_limit_setting_value = $(
+                    "#id_realm_message_content_edit_limit_seconds",
+                ).val();
                 data.allow_message_editing = $("#id_realm_allow_message_editing").prop("checked");
                 switch (edit_limit_setting_value) {
                     case "custom_period": {
@@ -1196,7 +1202,7 @@ export function build_page() {
         }
     });
 
-    $("#id_realm_msg_edit_limit_setting").on("change", (e) => {
+    $("#id_realm_message_content_edit_limit_seconds").on("change", (e) => {
         const msg_edit_limit_dropdown_value = e.target.value;
         const show_custom_limit_input = msg_edit_limit_dropdown_value === "custom_period";
         change_element_block_display_property(

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -325,6 +325,22 @@ function update_message_edit_sub_settings(is_checked) {
     settings_ui.disable_sub_setting_onchange(is_checked, "id_realm_edit_topic_policy", true);
 }
 
+function update_custom_value_input(property_name) {
+    const $dropdown_elem = $(`#id_${CSS.escape(property_name)}`);
+    const custom_input_elem_id = $dropdown_elem
+        .parent()
+        .find(".admin-realm-time-limit-input")
+        .attr("id");
+
+    const show_custom_limit_input = $dropdown_elem.val() === "custom_period";
+    change_element_block_display_property(custom_input_elem_id, show_custom_limit_input);
+    if (show_custom_limit_input) {
+        $(`#${CSS.escape(custom_input_elem_id)}`).val(
+            get_realm_time_limits_in_minutes(property_name),
+        );
+    }
+}
+
 function set_msg_edit_limit_dropdown() {
     const value = get_property_value("realm_message_content_edit_limit_seconds");
     $("#id_realm_message_content_edit_limit_seconds").val(value.toString());
@@ -1211,38 +1227,12 @@ export function build_page() {
         }
     });
 
-    $("#id_realm_message_content_edit_limit_seconds").on("change", (e) => {
-        const msg_edit_limit_dropdown_value = e.target.value;
-        const show_custom_limit_input = msg_edit_limit_dropdown_value === "custom_period";
-        change_element_block_display_property(
-            "id_realm_message_content_edit_limit_minutes",
-            show_custom_limit_input,
-        );
-
-        if (!show_custom_limit_input) {
-            // Set the input value to the original setting value if hiding the input box
-            // so that the save-discard widget is hidden again if we change the setting
-            // again to original input.
-            const setting_value = get_property_value("realm_message_content_edit_limit_minutes");
-            $("#id_realm_message_content_edit_limit_minutes").val(setting_value);
-        }
+    $("#id_realm_message_content_edit_limit_seconds").on("change", () => {
+        update_custom_value_input("realm_message_content_edit_limit_seconds");
     });
 
-    $("#id_realm_message_content_delete_limit_seconds").on("change", (e) => {
-        const msg_delete_limit_dropdown_value = e.target.value;
-        const show_custom_limit_input = msg_delete_limit_dropdown_value === "custom_period";
-        change_element_block_display_property(
-            "id_realm_message_content_delete_limit_minutes",
-            show_custom_limit_input,
-        );
-
-        if (!show_custom_limit_input) {
-            // Set the input value to the original setting value if hiding the input box
-            // so that the save-discard widget is hidden again if we change the setting
-            // again to original input.
-            const setting_value = get_property_value("realm_message_content_delete_limit_minutes");
-            $("#id_realm_message_content_delete_limit_minutes").val(setting_value);
-        }
+    $("#id_realm_message_content_delete_limit_seconds").on("change", () => {
+        update_custom_value_input("realm_message_content_delete_limit_seconds");
     });
 
     $("#id_realm_message_retention_setting").on("change", (e) => {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -190,7 +190,7 @@ function get_property_value(property_name, for_realm_default_settings) {
         return "retain_for_period";
     }
 
-    if (property_name === "realm_msg_delete_limit_setting") {
+    if (property_name === "realm_message_content_delete_limit_seconds") {
         if (page_params.realm_message_content_delete_limit_seconds === null) {
             return "any_time";
         }
@@ -342,10 +342,10 @@ function set_delete_own_message_policy_dropdown(setting_value) {
     $("#id_realm_delete_own_message_policy").val(setting_value);
     settings_ui.disable_sub_setting_onchange(
         message_delete_limit_setting_enabled(setting_value),
-        "id_realm_msg_delete_limit_setting",
+        "id_realm_message_content_delete_limit_seconds",
         true,
     );
-    const limit_value = get_property_value("realm_msg_delete_limit_setting");
+    const limit_value = get_property_value("realm_message_content_delete_limit_seconds");
     if (limit_value === "custom_period") {
         settings_ui.disable_sub_setting_onchange(
             message_delete_limit_setting_enabled(setting_value),
@@ -356,8 +356,8 @@ function set_delete_own_message_policy_dropdown(setting_value) {
 }
 
 function set_msg_delete_limit_dropdown() {
-    const value = get_property_value("realm_msg_delete_limit_setting");
-    $("#id_realm_msg_delete_limit_setting").val(value);
+    const value = get_property_value("realm_message_content_delete_limit_seconds");
+    $("#id_realm_message_content_delete_limit_seconds").val(value);
     change_element_block_display_property(
         "id_realm_message_content_delete_limit_minutes",
         value === "custom_period",
@@ -484,7 +484,7 @@ function update_dependent_subsettings(property_name) {
         case "realm_message_retention_days":
             set_message_retention_setting_dropdown();
             break;
-        case "realm_msg_delete_limit_setting":
+        case "realm_message_content_delete_limit_seconds":
         case "realm_message_content_delete_limit_minutes":
             set_msg_delete_limit_dropdown();
             break;
@@ -993,7 +993,9 @@ export function register_save_discard_widget_handlers(
                             ).seconds;
                     }
                 }
-                const delete_limit_setting_value = $("#id_realm_msg_delete_limit_setting").val();
+                const delete_limit_setting_value = $(
+                    "#id_realm_message_content_delete_limit_seconds",
+                ).val();
                 switch (delete_limit_setting_value) {
                     case "any_time": {
                         data.message_content_delete_limit_seconds = JSON.stringify("unlimited");
@@ -1219,7 +1221,7 @@ export function build_page() {
         }
     });
 
-    $("#id_realm_msg_delete_limit_setting").on("change", (e) => {
+    $("#id_realm_message_content_delete_limit_seconds").on("change", (e) => {
         const msg_delete_limit_dropdown_value = e.target.value;
         const show_custom_limit_input = msg_delete_limit_dropdown_value === "custom_period";
         change_element_block_display_property(

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -171,15 +171,18 @@ function get_property_value(property_name, for_realm_default_settings) {
     }
 
     if (property_name === "realm_message_content_edit_limit_seconds") {
-        if (page_params.realm_message_content_edit_limit_seconds === null) {
+        const setting_value = page_params.realm_message_content_edit_limit_seconds;
+        if (setting_value === null) {
             return "any_time";
         }
 
-        for (const [value, elem] of settings_config.msg_edit_limit_dropdown_values) {
-            if (elem.seconds === page_params.realm_message_content_edit_limit_seconds) {
-                return value;
-            }
+        const valid_limit_values = settings_config.msg_edit_limit_dropdown_values.map(
+            (x) => x.value,
+        );
+        if (valid_limit_values.includes(setting_value)) {
+            return setting_value;
         }
+
         return "custom_period";
     }
 
@@ -191,14 +194,18 @@ function get_property_value(property_name, for_realm_default_settings) {
     }
 
     if (property_name === "realm_message_content_delete_limit_seconds") {
-        if (page_params.realm_message_content_delete_limit_seconds === null) {
+        const setting_value = page_params.realm_message_content_delete_limit_seconds;
+        if (setting_value === null) {
             return "any_time";
         }
-        for (const [value, elem] of settings_config.msg_delete_limit_dropdown_values) {
-            if (elem.seconds === page_params.realm_message_content_delete_limit_seconds) {
-                return value;
-            }
+
+        const valid_limit_values = settings_config.msg_delete_limit_dropdown_values.map(
+            (x) => x.value,
+        );
+        if (valid_limit_values.includes(setting_value)) {
+            return setting_value;
         }
+
         return "custom_period";
     }
 
@@ -320,7 +327,7 @@ function update_message_edit_sub_settings(is_checked) {
 
 function set_msg_edit_limit_dropdown() {
     const value = get_property_value("realm_message_content_edit_limit_seconds");
-    $("#id_realm_message_content_edit_limit_seconds").val(value);
+    $("#id_realm_message_content_edit_limit_seconds").val(value.toString());
     change_element_block_display_property(
         "id_realm_message_content_edit_limit_minutes",
         value === "custom_period",
@@ -357,7 +364,7 @@ function set_delete_own_message_policy_dropdown(setting_value) {
 
 function set_msg_delete_limit_dropdown() {
     const value = get_property_value("realm_message_content_delete_limit_seconds");
-    $("#id_realm_message_content_delete_limit_seconds").val(value);
+    $("#id_realm_message_content_delete_limit_seconds").val(value.toString());
     change_element_block_display_property(
         "id_realm_message_content_delete_limit_minutes",
         value === "custom_period",
@@ -987,10 +994,10 @@ export function register_save_discard_widget_handlers(
                         break;
                     }
                     default: {
-                        data.message_content_edit_limit_seconds =
-                            settings_config.msg_edit_limit_dropdown_values.get(
-                                edit_limit_setting_value,
-                            ).seconds;
+                        data.message_content_edit_limit_seconds = Number.parseInt(
+                            edit_limit_setting_value,
+                            10,
+                        );
                     }
                 }
                 const delete_limit_setting_value = $(
@@ -1010,10 +1017,10 @@ export function register_save_discard_widget_handlers(
                         break;
                     }
                     default: {
-                        data.message_content_delete_limit_seconds =
-                            settings_config.msg_delete_limit_dropdown_values.get(
-                                delete_limit_setting_value,
-                            ).seconds;
+                        data.message_content_delete_limit_seconds = Number.parseInt(
+                            delete_limit_setting_value,
+                            10,
+                        );
                     }
                 }
                 data.delete_own_message_policy = $("#id_realm_delete_own_message_policy").val();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -957,7 +957,7 @@ export function register_save_discard_widget_handlers(
     });
 
     parse_time_limit = function parse_time_limit($elem) {
-        return Math.floor(Number.parseFloat($elem.val(), 10).toFixed(1) * 60);
+        return Math.floor(Number.parseFloat(Number($elem.val()), 10).toFixed(1) * 60);
     };
 
     function get_complete_data_for_subsection(subsection) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -788,52 +788,52 @@ function check_property_changed(elem, for_realm_default_settings) {
     const $elem = $(elem);
     const property_name = extract_property_name($elem, for_realm_default_settings);
     let current_val = get_property_value(property_name, for_realm_default_settings);
-    let changed_val;
+    let proposed_val;
 
     switch (property_name) {
         case "realm_authentication_methods":
             current_val = sort_object_by_key(current_val);
             current_val = JSON.stringify(current_val);
-            changed_val = get_auth_method_list_data();
-            changed_val = JSON.stringify(changed_val);
+            proposed_val = get_auth_method_list_data();
+            proposed_val = JSON.stringify(proposed_val);
             break;
         case "realm_notifications_stream_id":
-            changed_val = Number.parseInt(notifications_stream_widget.value(), 10);
+            proposed_val = Number.parseInt(notifications_stream_widget.value(), 10);
             break;
         case "realm_signup_notifications_stream_id":
-            changed_val = Number.parseInt(signup_notifications_stream_widget.value(), 10);
+            proposed_val = Number.parseInt(signup_notifications_stream_widget.value(), 10);
             break;
         case "realm_default_code_block_language":
-            changed_val = default_code_language_widget.value();
+            proposed_val = default_code_language_widget.value();
             break;
         case "email_notifications_batching_period_seconds":
         case "email_notification_batching_period_edit_minutes": {
-            changed_val = get_email_notification_batching_setting_element_value();
+            proposed_val = get_email_notification_batching_setting_element_value();
             break;
         }
         case "realm_message_content_edit_limit_minutes":
         case "realm_message_content_delete_limit_minutes": {
             const input_val = Number.parseInt($(`#id_${CSS.escape(property_name)}`).val(), 10);
             if (Number.isNaN(input_val)) {
-                changed_val = null;
+                proposed_val = null;
                 break;
             }
-            changed_val = input_val.toString();
+            proposed_val = input_val.toString();
             break;
         }
         case "realm_default_language":
-            changed_val = $(
+            proposed_val = $(
                 "#org-notifications .language_selection_widget .language_selection_button span",
             ).attr("data-language-code");
             break;
         default:
             if (current_val !== undefined) {
-                changed_val = get_input_element_value($elem, typeof current_val);
+                proposed_val = get_input_element_value($elem, typeof current_val);
             } else {
                 blueslip.error("Element refers to unknown property " + property_name);
             }
     }
-    return current_val !== changed_val;
+    return current_val !== proposed_val;
 }
 
 export function save_discard_widget_status_handler($subsection, for_realm_default_settings) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -727,7 +727,7 @@ export function get_input_element_value(input_elem, input_type) {
             }
             return undefined;
         case "time-limit":
-            return get_message_edit_or_delete_limit_setting_value($input_elem);
+            return get_time_limit_setting_value($input_elem);
         default:
             return undefined;
     }
@@ -776,7 +776,7 @@ function get_email_notification_batching_setting_element_value() {
     return setting_value_in_minutes * 60;
 }
 
-function get_message_edit_or_delete_limit_setting_value($input_elem, for_api_data = true) {
+function get_time_limit_setting_value($input_elem, for_api_data = true) {
     const select_elem_val = $input_elem.val();
 
     if (select_elem_val === "any_time") {
@@ -833,7 +833,7 @@ function check_property_changed(elem, for_realm_default_settings) {
         }
         case "realm_message_content_edit_limit_seconds":
         case "realm_message_content_delete_limit_seconds":
-            proposed_val = get_message_edit_or_delete_limit_setting_value($elem, false);
+            proposed_val = get_time_limit_setting_value($elem, false);
             break;
         case "realm_default_language":
             proposed_val = $(

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -896,7 +896,7 @@ function enable_or_disable_save_button($subsection_elem) {
     for (const setting_elem of time_limit_settings) {
         const dropdown_elem_val = $(setting_elem).find("select").val();
         const custom_input_elem_val = Number.parseInt(
-            $(setting_elem).find(".admin-realm-time-limit-input").val(),
+            Number($(setting_elem).find(".admin-realm-time-limit-input").val()),
             10,
         );
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -764,18 +764,6 @@ function get_auth_method_list_data() {
     return new_auth_methods;
 }
 
-function get_email_notification_batching_setting_element_value() {
-    const select_elem_val = $("#realm-user-default-settings")
-        .find(".setting_email_notifications_batching_period_seconds")
-        .val();
-    if (select_elem_val !== "custom_period") {
-        return Number.parseInt(select_elem_val, 10);
-    }
-    const edit_elem_val = $("#realm_email_notification_batching_period_edit_minutes").val();
-    const setting_value_in_minutes = Number.parseInt(edit_elem_val, 10);
-    return setting_value_in_minutes * 60;
-}
-
 function get_time_limit_setting_value($input_elem, for_api_data = true) {
     const select_elem_val = $input_elem.val();
 
@@ -827,10 +815,8 @@ function check_property_changed(elem, for_realm_default_settings) {
             proposed_val = default_code_language_widget.value();
             break;
         case "email_notifications_batching_period_seconds":
-        case "email_notification_batching_period_edit_minutes": {
-            proposed_val = get_email_notification_batching_setting_element_value();
+            proposed_val = get_time_limit_setting_value($elem, false);
             break;
-        }
         case "realm_message_content_edit_limit_seconds":
         case "realm_message_content_delete_limit_seconds":
             proposed_val = get_time_limit_setting_value($elem, false);
@@ -1058,14 +1044,6 @@ export function register_save_discard_widget_handlers(
         for (const input_elem of properties_elements) {
             const $input_elem = $(input_elem);
             if (check_property_changed($input_elem, for_realm_default_settings)) {
-                if (
-                    $input_elem.hasClass("email_notification_batching_period_edit_minutes") ||
-                    $input_elem.hasClass("setting_email_notifications_batching_period_seconds")
-                ) {
-                    const setting_value = get_email_notification_batching_setting_element_value();
-                    data.email_notifications_batching_period_seconds = setting_value;
-                    continue;
-                }
                 const input_value = get_input_element_value($input_elem);
                 if (input_value !== undefined) {
                     let property_name;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1485,7 +1485,7 @@ $option_title_width: 180px;
 #id_realm_edit_topic_policy,
 #id_realm_message_content_edit_limit_seconds,
 #id_realm_delete_own_message_policy,
-#id_realm_msg_delete_limit_setting {
+#id_realm_message_content_delete_limit_seconds {
     width: 325px;
 }
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1483,7 +1483,7 @@ $option_title_width: 180px;
 #id_realm_move_messages_between_streams_policy,
 #id_realm_invite_to_realm_policy,
 #id_realm_edit_topic_policy,
-#id_realm_msg_edit_limit_setting,
+#id_realm_message_content_edit_limit_seconds,
 #id_realm_delete_own_message_policy,
 #id_realm_msg_delete_limit_setting {
     width: 325px;

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -124,7 +124,7 @@
             <label for="email_notifications_batching_period">
                 {{t "Delay before sending message notification emails" }}
             </label>
-            <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element" data-setting-widget-type="number">
+            <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element" data-setting-widget-type="time-limit">
                 {{#each email_notifications_batching_period_values}}
                     <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}
@@ -135,8 +135,8 @@
                 </label>
                 <input type="text"
                   name="email_notification_batching_period_edit_minutes"
-                  class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input prop-element"
-                  data-setting-widget-type="number"
+                  class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input"
+                  data-setting-widget-type="time-limit"
                   autocomplete="off"
                   id="{{prefix}}email_notification_batching_period_edit_minutes"/>
             </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -198,12 +198,12 @@
                 </div>
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_msg_delete_limit_setting" class="dropdown-title">
+                    <label for="realm_message_content_delete_limit_seconds" class="dropdown-title">
                         {{t "Time limit for deleting messages" }}
                         <i class="fa fa-info-circle settings-info-icon tippy-zulip-tooltip"
                           aria-hidden="true" data-tippy-content="{{t 'Administrators can delete any message.' }}"></i>
                     </label>
-                    <select name="realm_msg_delete_limit_setting" id="id_realm_msg_delete_limit_setting" class="prop-element">
+                    <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element">
                         {{#each msg_delete_limit_dropdown_values}}
                             <option value="{{0}}">{{1.text}}</option>
                         {{/each}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -156,7 +156,7 @@
 
                 <div class="input-group time-limit-setting">
                     <label for="realm_message_content_edit_limit_seconds" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
-                    <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element" {{#unless realm_allow_message_editing}}disabled{{/unless}}>
+                    <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
                         {{#each msg_edit_limit_dropdown_values}}
                             <option value="{{value}}">{{text}}</option>
                         {{/each}}
@@ -203,7 +203,7 @@
                         <i class="fa fa-info-circle settings-info-icon tippy-zulip-tooltip"
                           aria-hidden="true" data-tippy-content="{{t 'Administrators can delete any message.' }}"></i>
                     </label>
-                    <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element">
+                    <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element" data-setting-widget-type="time-limit">
                         {{#each msg_delete_limit_dropdown_values}}
                             <option value="{{value}}">{{text}}</option>
                         {{/each}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -167,7 +167,7 @@
                         </label>
                         <input type="text" id="id_realm_message_content_edit_limit_minutes"
                           name="realm_message_content_edit_limit_minutes"
-                          class="admin-realm-time-limit-input prop-element"
+                          class="admin-realm-time-limit-input"
                           autocomplete="off"
                           value="{{ realm_message_content_edit_limit_minutes }}"
                           {{#unless realm_allow_message_editing}}disabled{{/unless}}/>
@@ -214,7 +214,7 @@
                         </label>
                         <input type="text" id="id_realm_message_content_delete_limit_minutes"
                           name="realm_message_content_delete_limit_minutes"
-                          class="admin-realm-time-limit-input prop-element"
+                          class="admin-realm-time-limit-input"
                           autocomplete="off"
                           value="{{ realm_message_content_delete_limit_minutes }}"/>
                     </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -155,8 +155,8 @@
                   label=admin_settings_label.realm_allow_message_editing}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_msg_edit_limit_setting" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
-                    <select name="realm_msg_edit_limit_setting" id="id_realm_msg_edit_limit_setting" class="prop-element" {{#unless realm_allow_message_editing}}disabled{{/unless}}>
+                    <label for="realm_message_content_edit_limit_seconds" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
+                    <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element" {{#unless realm_allow_message_editing}}disabled{{/unless}}>
                         {{#each msg_edit_limit_dropdown_values}}
                             <option value="{{0}}">{{1.text}}</option>
                         {{/each}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -158,7 +158,7 @@
                     <label for="realm_message_content_edit_limit_seconds" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
                     <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element" {{#unless realm_allow_message_editing}}disabled{{/unless}}>
                         {{#each msg_edit_limit_dropdown_values}}
-                            <option value="{{0}}">{{1.text}}</option>
+                            <option value="{{value}}">{{text}}</option>
                         {{/each}}
                     </select>
                     <div class="dependent-block">
@@ -205,7 +205,7 @@
                     </label>
                     <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element">
                         {{#each msg_delete_limit_dropdown_values}}
-                            <option value="{{0}}">{{1.text}}</option>
+                            <option value="{{value}}">{{text}}</option>
                         {{/each}}
                     </select>
                     <div class="dependent-block">


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR does some preparatory refactors for #21739.

- First commit just changes the variable name as discussed [here](https://github.com/zulip/zulip/pull/22770#discussion_r953181848).
- Second and third commits updates the id and name attributes of setting elements, so that we can remove extra code in further commits.
- Fourth commit changes `time_limit_dropdown_values` to a list to make it similar to the options list for notification batching period setting.
- Fifth commit is for extracting the code for showing and hiding custom input in a separate function.
- Sixth commit is for sending only updated settings in the API request data for message edit subsection.
- Seventh commit is to show save-discard widget only after custom input value is changed.
- Eigth commit is to extract code to set the msg edit and limit setting elements into a separate function.
- Last two commits are to refactor the code for realm-level default of email notification batching period setting such that we do not handle this setting as a special case.
<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Only user-facing changes are that the save-discard button is shown only after custom input is changed and also the flashing of save changes button mentioned in [this comment](https://github.com/zulip/zulip/pull/22863#issuecomment-1248348263) is fixed.
![msg-edit-refactor](https://user-images.githubusercontent.com/35494118/191534181-fe04248e-b605-46fb-b325-40ae2391dedd.gif)



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
