### PR TITLE
portico: Fix footer text overflow in different languages.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -397,9 +397,19 @@ input.text-error {
 
     .footer-section {
         margin: 0 20px;
-        max-width: max-content;
         vertical-align: top;
         text-align: left;
+        /* 20-22vw for fitting content in the 4 column grid layout. We
+           need to set max-width so to avoid content overflow in different
+           languagues on different widths. */
+        max-width: 21vw;
+
+        @media (width < 1200px) {
+            ul li {
+                text-indent: -5px;
+                padding-left: 5px;
+            }
+        }
 
         h3 {
             text-transform: uppercase;
@@ -1186,6 +1196,11 @@ input.new-organization-button {
         margin-left: auto;
         margin-right: auto;
         grid-template-columns: repeat(2, max-content);
+
+        .footer-section {
+            /* 40vw to fit content in 2 grid columns. */
+            max-width: 40vw;
+        }
     }
 }
 


### PR DESCRIPTION
We fix width of footer sections and let the text overflow within.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/landing.20page.20bottom.20menu.20issue.20.2322946

screenshots for <1200px - https://chat.zulip.org/#narrow/stream/9-issues/topic/landing.20page.20bottom.20menu.20issue.20.2322946/near/1439181