### PR TITLE
rendered_markdown: Fix alignment of icons in code blocks.

### DIFF
--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -534,15 +534,15 @@
         doesn't scroll along with the code div in narrow windows */
         position: absolute;
         right: 2px;
-        margin-top: -6px;
+        margin-top: -4px;
     }
 
     .code_external_link {
         visibility: hidden;
         position: absolute;
         right: 23px;
-        margin-top: -4px;
-        font-size: 1.4em;
+        margin-top: -3px;
+        font-size: 17px;
         /* The default icon and on-hover colors are inherited from <a> tag.
         so we set our own to match the copy-to-clipbord icon */
         color: hsl(0, 0%, 47%);


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/code.20buttons.20not.20aligned
<img width="156" alt="image" src="https://user-images.githubusercontent.com/25124304/191679107-a30693ce-7e60-4229-bea5-06e5540dbb3e.png">
<img width="615" alt="image" src="https://user-images.githubusercontent.com/25124304/191679119-31e76abc-b9b3-460d-999a-50c96dcb5dce.png">