### PR TITLE
populate_db: Limit user_profiles for private messages to zulip realm.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -764,7 +764,9 @@ class Command(BaseCommand):
             ]
 
         # Extract a list of all users
-        user_profiles: List[UserProfile] = list(UserProfile.objects.filter(is_bot=False))
+        user_profiles: List[UserProfile] = list(
+            UserProfile.objects.filter(is_bot=False, realm=zulip_realm)
+        )
 
         # Create a test realm emoji.
         IMAGE_FILE_PATH = static_path("images/test-images/checkbox.png")


### PR DESCRIPTION
These are used for creating huddles and private messages (and some UserPresence objects). It'd be really weird, and potentially create some Messages that break our assumptions, for this to end up involving users in multiple realms.
I believe currently this hasn't been happening, because when this line runs, there are only users in "zulip" realm and system bots in "zulipinternal" - but the query has been excluding bots already.

Still, this query should be explicit about grabbing users from a single realm. This will also be helpful for the work adding the denormalized Message.realm field - so that the realm of Message objects that get manually created in generate_and_send_messages can be simply set to "zulip" with confidence that it's correct.
