### PR TITLE
Revert "zulip-puppet-apply: Work around broken Puppet on Ubuntu 22.04."

### DIFF
--- a/scripts/lib/ruby3hack.rb
+++ b/scripts/lib/ruby3hack.rb
@@ -1,7 +1,0 @@
-# Work around https://bugs.launchpad.net/ubuntu/+source/puppet/+bug/1969939.
-
-require 'fileutils'
-
-def FileUtils.symlink(src, dest, options = {}, **kwargs)
-  FileUtils.ln_s(src, dest, **options, **kwargs)
-end

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -66,8 +66,6 @@ puppet_env["FACTER_zulip_scripts_path"] = scripts_path
 # This is to suppress Puppet warnings with ruby 2.7.
 if (distro_info["ID"], distro_info["VERSION_ID"]) in [("ubuntu", "20.04")]:
     puppet_env["RUBYOPT"] = "-W0"
-if (distro_info["ID"], distro_info["VERSION_ID"]) in [("ubuntu", "22.04")]:
-    puppet_env["RUBYOPT"] = "-r " + os.path.join(scripts_path, "lib", "ruby3hack.rb")
 
 
 def noop_would_change(puppet_cmd: List[str]) -> bool:


### PR DESCRIPTION
This reverts commit 25c87cc7da800f6d314f34708cf6cf4720fcdd68 (#21328).

This upstream Ubuntu bug was fixed.

Tested on Ubuntu 22.04.

```console
# rm /usr/share/postgresql/14/tsearch_data/en_us.dict
# /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
Notice: Compiled catalog for zulip-jammy.lxd in environment production in 3.12 seconds
Notice: /Stage[main]/Zulip::Postgresql_base/File[/usr/share/postgresql/14/tsearch_data/en_us.dict]/ensure: created
Notice: Applied catalog in 0.71 seconds
```