### PR TITLE
ts: Convert util.js to TypeScript; add temporary types in types.ts.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -413,7 +413,7 @@ test("catch_buggy_draft_error", () => {
     // An error is logged but the draft isn't fixed in this codepath.
     blueslip.expect(
         "error",
-        "Cannot compare strings; at least one value is undefined: undefined, old_topic",
+        "Cannot compare strings; at least one value is undefined: (undefined), old_topic",
     );
     drafts.rename_stream_recipient(
         stream_B.stream_id,

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -421,6 +421,7 @@ test("merge_message_groups", () => {
             status_message: false,
             type: "stream",
             stream: "Test stream 1",
+            stream_id: 2,
             topic: "Test topic 1",
             sender_email: "test@example.com",
             timestamp: (next_timestamp += 1),

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -32,13 +32,6 @@ run_test("extract_pm_recipients", () => {
     assert.equal(util.extract_pm_recipients("bob@foo.com, ").length, 1);
 });
 
-run_test("is_pm_recipient", () => {
-    const message = {to_user_ids: "31,32,33"};
-    assert.ok(util.is_pm_recipient(31, message));
-    assert.ok(util.is_pm_recipient(32, message));
-    assert.ok(!util.is_pm_recipient(34, message));
-});
-
 run_test("lower_bound", () => {
     const arr = [{x: 10}, {x: 20}, {x: 30}, {x: 40}, {x: 50}];
 

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -81,8 +81,6 @@ run_test("same_recipient", () => {
 
     assert.ok(!util.same_recipient({type: "private", to_user_ids: undefined}, {type: "private"}));
 
-    assert.ok(!util.same_recipient({type: "unknown type"}, {type: "unknown type"}));
-
     assert.ok(!util.same_recipient(undefined, {type: "private"}));
 
     assert.ok(!util.same_recipient(undefined, undefined));
@@ -264,6 +262,7 @@ run_test("clean_user_content_links", () => {
                 '<a href="/#fragment" target="_blank">fragment</a>' +
                 '<div class="message_inline_image">' +
                 '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" title="inline image">upload</a> ' +
+                '<a role="button">button</a> ' +
                 "</div>",
         ),
         '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
@@ -273,6 +272,7 @@ run_test("clean_user_content_links", () => {
             '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>' +
             '<div class="message_inline_image">' +
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/inline.png" target="_blank" rel="noopener noreferrer" aria-label="inline image">upload</a> ' +
+            '<a role="button">button</a> ' +
             "</div>",
     );
 });

--- a/static/js/compose_fade_helper.js
+++ b/static/js/compose_fade_helper.js
@@ -16,6 +16,11 @@ export function set_focused_recipient(recipient) {
     focused_recipient = recipient;
 }
 
+function is_pm_recipient(user_id) {
+    const recipients = focused_recipient.to_user_ids.split(",");
+    return recipients.includes(user_id.toString());
+}
+
 export function would_receive_message(user_id) {
     if (focused_recipient.type === "stream") {
         const sub = sub_store.get(focused_recipient.stream_id);
@@ -30,7 +35,7 @@ export function would_receive_message(user_id) {
     }
 
     // PM, so check if the given email is in the recipients list.
-    return util.is_pm_recipient(user_id, focused_recipient);
+    return is_pm_recipient(user_id);
 }
 
 export function want_normal_display() {

--- a/static/js/types.ts
+++ b/static/js/types.ts
@@ -1,3 +1,26 @@
+// TODO/typescript: Move this to message_store
+export type MatchedMessage = {
+    match_content?: string;
+    match_subject?: string;
+};
+
+// TODO/typescript: Move this to message_store
+export type MessageType = "private" | "stream";
+
+// TODO/typescript: Move this to message_store
+export type RawMessage = {
+    sender_email: string;
+    stream_id: number;
+    subject: string;
+    type: MessageType;
+} & MatchedMessage;
+
+// TODO/typescript: Move this to message_store
+export type Message = RawMessage & {
+    to_user_ids: string;
+    topic: string;
+};
+
 // TODO/typescript: Move this to server_events_dispatch
 export type UserGroupUpdateEvent = {
     id: number;
@@ -7,6 +30,40 @@ export type UserGroupUpdateEvent = {
         name?: string;
         description?: string;
     };
+};
+
+// TODO/typescript: Move this to server_events
+export type TopicLink = {
+    text: string;
+    url: string;
+};
+
+// TODO/typescript: Move this to server_events
+export type UpdateMessageEvent = {
+    id: number;
+    type: string;
+    user_id: number | null;
+    rendering_only: boolean;
+    message_id: number;
+    message_ids: number[];
+    flags: string[];
+    edit_timestamp: number;
+    stream_name?: string;
+    stream_id?: number;
+    new_stream_id?: number;
+    propagate_mode?: string;
+    orig_subject?: string;
+    subject?: string;
+    topic_links?: TopicLink[];
+    orig_content?: string;
+    orig_rendered_content?: string;
+    prev_rendered_content_version?: number;
+    content?: string;
+    rendered_content?: string;
+    is_me_message?: boolean;
+    // The server is still using subject.
+    // This will not be set until it gets fixed.
+    topic?: string;
 };
 
 // TODO/typescript: Move the User and Stream placeholder

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -55,10 +55,6 @@ export const same_stream_and_topic = function util_same_stream_and_topic(a, b) {
     return a.stream_id === b.stream_id && lower_same(a.topic, b.topic);
 };
 
-export function is_pm_recipient(user_id, message) {
-    const recipients = message.to_user_ids.split(",");
-    return recipients.includes(user_id.toString());
-}
 
 export function extract_pm_recipients(recipients) {
     return recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -41,7 +41,10 @@ export function lower_bound(array, value, less) {
 
 export const lower_same = function lower_same(a, b) {
     if (a === undefined || b === undefined) {
-        blueslip.error(`Cannot compare strings; at least one value is undefined: ${a}, ${b}`);
+        blueslip.error(
+            `Cannot compare strings; at least one value is undefined: \
+${a ?? "(undefined)"}, ${b ?? "(undefined)"}`,
+        );
         return false;
     }
     return a.toLowerCase() === b.toLowerCase();

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -116,7 +116,7 @@ js_rules = RuleList(
     rules=[
         {
             "pattern": "subject|SUBJECT",
-            "exclude": {"static/js/util.js", "frontend_tests/"},
+            "exclude": {"static/js/types.ts", "static/js/util.ts", "frontend_tests/"},
             "exclude_pattern": "emails",
             "description": "avoid subject in JS code",
             "good_lines": ["topic_name"],


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Continues @ysulyma's work from #22793:
> This commit converts `util.js` to TypeScript. In order to do this, it adds a `Message` type in `types.ts`. It also updates the linting logic which forbids `subject`: trivially to ignore `util.ts` instead of `util.js`, but also to ignore `types.ts` due to the `match_subject` property of `Message`.
> 
> This was mostly straightforward, but in a few places I had to add non-null assertions or explicit casts due to the existing code not being type-safe.

This prepares us for converting people.js into people.ts.

Note that all the types added in `types.ts` are temporary and we will need to move them to the right place once the typescript migration project proceeds.

There are some non-blocking issues with `util` itself as I worked on it. For example, utilities like `set_match_data` and `get_match_topic` are supposed to be temporary during the unfinished project of changing `subject` to `topic`. The latest work that I could track is #11115. With that, we should be able to remove these helpers. Ideally, `util.ts` should not contain any application specific types.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
