### PR TITLE
modal: Make the modal content scrollable instead of the whole modal.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -37,6 +37,10 @@
         background-color: hsla(0, 0%, 83%, 0.5);
     }
 
+    .modal__content.simplebar-scrollable-y + .modal__footer {
+        border-top: 1px solid hsla(0, 0%, 100%, 0.2);
+    }
+
     .modal-bg,
     .modal__container {
         background-color: hsl(212, 28%, 18%);

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -83,10 +83,15 @@
 }
 
 .modal__content {
+    display: flex;
     font-size: 1rem;
     overflow-y: auto;
     padding: 0 24px;
     line-height: 1.5;
+
+    &.simplebar-scrollable-y + .modal__footer {
+        border-top: 1px solid hsl(0, 0%, 87%);
+    }
 }
 
 .modal__btn {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -792,11 +792,6 @@ ul {
         margin: 0;
     }
 
-    /* Ensure that the dropdown can overflow the modal. */
-    .modal__content {
-        overflow: visible;
-    }
-
     /* Override the default border-radius to properly align
        the button corners with `stream_header_colorblock`. */
     .dropdown-toggle {

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -1,6 +1,6 @@
 <div class="micromodal" id="dialog_widget_modal" aria-hidden="true">
     <div class="modal__overlay" tabindex="-1">
-        <div {{#if id}}id="{{id}}" {{/if}}class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title" data-simplebar>
+        <div {{#if id}}id="{{id}}" {{/if}}class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <header class="modal__header">
                 <h1 class="modal__title dialog_heading">
                     {{{ heading_text }}}
@@ -10,7 +10,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
-            <main class="modal__content">
+            <main class="modal__content" data-simplebar>
                 <div class="alert" id="dialog_error"></div>
                 {{{ html_body }}}
             </main>


### PR DESCRIPTION
See https://chat.zulip.org/#narrow/stream/6-frontend/topic/Modal.20bug/near/1437163.

### Before

### Light mode

![image](https://user-images.githubusercontent.com/58626718/192215424-f8306fa2-2016-4e5c-8bcd-51fbf30cb2c9.png)

![image](https://user-images.githubusercontent.com/58626718/192214800-f7679767-8c48-4ba0-93c6-01c2e972e07b.png)

### Dark mode

![image](https://user-images.githubusercontent.com/58626718/191990750-ec92fc13-be9f-433c-b9e7-6236567cf2f7.png)

![image](https://user-images.githubusercontent.com/58626718/191990550-ee9bf465-7922-449a-9892-7c43607d2571.png)

### After

### Light mode
![image](https://user-images.githubusercontent.com/58626718/192215075-dba824dd-98fb-4828-9c36-3fc66c796752.png)

![image](https://user-images.githubusercontent.com/58626718/192214800-f7679767-8c48-4ba0-93c6-01c2e972e07b.png)

### Dark mode

![image](https://user-images.githubusercontent.com/58626718/191990451-aa6a4922-3608-414f-918f-2d8d4f64db40.png)

![image](https://user-images.githubusercontent.com/58626718/191990550-ee9bf465-7922-449a-9892-7c43607d2571.png)
