### PR TITLE
tornado: Fix Tornado CSRF check with X-Forwarded-Proto

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-common/proxy
+++ b/puppet/zulip/files/nginx/zulip-include-common/proxy
@@ -3,6 +3,7 @@ proxy_http_version 1.1;
 # http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
 proxy_set_header Connection "";
 proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Real-Ip $remote_addr;
 proxy_next_upstream off;

--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -13,6 +13,8 @@ from tornado import autoreload
 from tornado.platform.asyncio import AsyncIOMainLoop
 
 settings.RUNNING_INSIDE_TORNADO = True
+if settings.PRODUCTION:
+    settings.SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 from zerver.lib.async_utils import NoAutoCreateEventLoopPolicy
 from zerver.lib.debug import interactive_debug_listen


### PR DESCRIPTION
Since Django factors `request.is_secure()` into its CSRF check, we need this to tell it to consider requests forwarded from nginx to Tornado as secure.