### PR TITLE
zproject: Break cyclic imports of Django from settings modules

### DIFF
--- a/zerver/apps.py
+++ b/zerver/apps.py
@@ -16,6 +16,12 @@ class ZerverConfig(AppConfig):
     name: str = "zerver"
 
     def ready(self) -> None:
+        if settings.SENTRY_DSN:  # nocoverage
+            from zproject.config import get_config
+            from zproject.sentry import setup_sentry
+
+            setup_sentry(settings.SENTRY_DSN, get_config("machine", "deploy_type", "development"))
+
         # We import zerver.signals here for the side effect of
         # registering the user_logged_in signal receiver.  This import
         # needs to be here (rather than e.g. at top-of-file) to avoid

--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -120,25 +120,6 @@ class RequireReallyDeployed(logging.Filter):
         return settings.PRODUCTION
 
 
-def skip_200_and_304(record: logging.LogRecord) -> bool:
-    # Apparently, `status_code` is added by Django and is not an actual
-    # attribute of LogRecord; as a result, mypy throws an error if we
-    # access the `status_code` attribute directly.
-    if getattr(record, "status_code", None) in [200, 304]:
-        return False
-
-    return True
-
-
-def skip_site_packages_logs(record: logging.LogRecord) -> bool:
-    # This skips the log records that are generated from libraries
-    # installed in site packages.
-    # Workaround for https://code.djangoproject.com/ticket/26886
-    if "site-packages" in record.pathname:
-        return False
-    return True
-
-
 def find_log_caller_module(record: logging.LogRecord) -> Optional[str]:
     """Find the module name corresponding to where this record was logged.
 

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -76,34 +76,6 @@ class LinkifierDict(TypedDict):
     id: int
 
 
-class SAMLIdPConfigDict(TypedDict, total=False):
-    entity_id: str
-    url: str
-    slo_url: str
-    attr_user_permanent_id: str
-    attr_first_name: str
-    attr_last_name: str
-    attr_username: str
-    attr_email: str
-    attr_org_membership: str
-    auto_signup: bool
-    display_name: str
-    display_icon: str
-    limit_to_subdomains: List[str]
-    extra_attrs: List[str]
-    x509cert: str
-    x509cert_path: str
-
-
-class OIDCIdPConfigDict(TypedDict, total=False):
-    oidc_url: str
-    display_name: str
-    display_icon: Optional[str]
-    client_id: str
-    secret: Optional[str]
-    auto_signup: bool
-
-
 class UnspecifiedValue:
     """In most API endpoints, we use a default value of `None"` to encode
     parameters that the client did not pass, which is nicely Pythonic.
@@ -317,9 +289,3 @@ class RealmPlaygroundDict(TypedDict):
     name: str
     pygments_language: str
     url_prefix: str
-
-
-class SCIMConfigDict(TypedDict):
-    bearer_token: str
-    scim_client_name: str
-    name_formatted_included: bool

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -86,7 +86,7 @@ from zerver.lib.redis_utils import get_dict_from_redis, get_redis_client, put_di
 from zerver.lib.request import RequestNotes
 from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.subdomains import get_subdomain
-from zerver.lib.types import OIDCIdPConfigDict, ProfileDataElementUpdateDict
+from zerver.lib.types import ProfileDataElementUpdateDict
 from zerver.lib.url_encoding import append_url_query_string
 from zerver.lib.users import check_full_name, validate_user_custom_profile_field
 from zerver.models import (
@@ -105,6 +105,7 @@ from zerver.models import (
     remote_user_to_email,
     supported_auth_backends,
 )
+from zproject.settings_types import OIDCIdPConfigDict
 
 redis_client = get_redis_client()
 

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1224,10 +1224,6 @@ TWO_FACTOR_PATCH_ADMIN = False
 
 # Allow the environment to override the default DSN
 SENTRY_DSN = os.environ.get("SENTRY_DSN", SENTRY_DSN)
-if SENTRY_DSN:
-    from .sentry import setup_sentry
-
-    setup_sentry(SENTRY_DSN, get_config("machine", "deploy_type", "development"))
 
 SCIM_SERVICE_PROVIDER = {
     "USER_ADAPTER": "zerver.lib.scim.ZulipSCIMUser",

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -2,11 +2,8 @@ import os
 import sys
 import time
 from copy import deepcopy
-from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import urljoin
-
-from django.template.loaders import app_directories
 
 import zerver.lib.logging_util
 from scripts.lib.zulip_tools import get_tornado_ports
@@ -160,20 +157,6 @@ ALLOWED_HOSTS += ["127.0.0.1", "localhost"]
 ALLOWED_HOSTS += [EXTERNAL_HOST_WITHOUT_PORT, "." + EXTERNAL_HOST_WITHOUT_PORT]
 # ... and with the hosts in REALM_HOSTS.
 ALLOWED_HOSTS += REALM_HOSTS.values()
-
-
-class TwoFactorLoader(app_directories.Loader):
-    def get_dirs(self) -> List[Union[str, Path]]:
-        dirs = super().get_dirs()
-        # app_directories.Loader returns only a list of
-        # Path objects by calling get_app_template_dirs
-        two_factor_dirs: List[Union[str, Path]] = []
-        for d in dirs:
-            assert isinstance(d, Path)
-            if d.match("two_factor/*"):
-                two_factor_dirs.append(d)
-        return two_factor_dirs
-
 
 MIDDLEWARE = (
     "zerver.middleware.TagRequests",
@@ -675,7 +658,7 @@ non_html_template_engine_settings["OPTIONS"].update(
 two_factor_template_options = deepcopy(default_template_engine_settings["OPTIONS"])
 del two_factor_template_options["environment"]
 del two_factor_template_options["extensions"]
-two_factor_template_options["loaders"] = ["zproject.settings.TwoFactorLoader"]
+two_factor_template_options["loaders"] = ["zproject.template_loaders.TwoFactorLoader"]
 
 two_factor_template_engine_settings = {
     "NAME": "Two_Factor",

--- a/zproject/config.py
+++ b/zproject/config.py
@@ -2,10 +2,8 @@ import configparser
 import os
 from typing import Optional, overload
 
-from django.core.exceptions import ImproperlyConfigured
 
-
-class ZulipSettingsError(ImproperlyConfigured):
+class ZulipSettingsError(Exception):
     pass
 
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -1,15 +1,14 @@
 import os
 from email.headerregistry import Address
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from scripts.lib.zulip_tools import deport
+from zproject.settings_types import JwtAuthKey, OIDCIdPConfigDict, SAMLIdPConfigDict
 
 from .config import DEVELOPMENT, PRODUCTION, get_secret
 
 if TYPE_CHECKING:
     from django_auth_ldap.config import LDAPSearch
-
-    from zerver.lib.types import OIDCIdPConfigDict, SAMLIdPConfigDict
 
 if PRODUCTION:
     from .prod_settings import EXTERNAL_HOST, ZULIP_ADMINISTRATOR
@@ -85,7 +84,7 @@ SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = ""
 SOCIAL_AUTH_SAML_ORG_INFO: Optional[Dict[str, Dict[str, str]]] = None
 SOCIAL_AUTH_SAML_TECHNICAL_CONTACT: Optional[Dict[str, str]] = None
 SOCIAL_AUTH_SAML_SUPPORT_CONTACT: Optional[Dict[str, str]] = None
-SOCIAL_AUTH_SAML_ENABLED_IDPS: Dict[str, "SAMLIdPConfigDict"] = {}
+SOCIAL_AUTH_SAML_ENABLED_IDPS: Dict[str, SAMLIdPConfigDict] = {}
 SOCIAL_AUTH_SAML_SECURITY_CONFIG: Dict[str, Any] = {}
 # Set this to True to enforce that any configured IdP needs to specify
 # the limit_to_subdomains setting to be considered valid:
@@ -102,7 +101,7 @@ SOCIAL_AUTH_APPLE_SCOPE = ["name", "email"]
 SOCIAL_AUTH_APPLE_EMAIL_AS_USERNAME = True
 
 # Generic OpenID Connect:
-SOCIAL_AUTH_OIDC_ENABLED_IDPS: Dict[str, "OIDCIdPConfigDict"] = {}
+SOCIAL_AUTH_OIDC_ENABLED_IDPS: Dict[str, OIDCIdPConfigDict] = {}
 SOCIAL_AUTH_OIDC_FULL_NAME_VALIDATED = False
 
 SOCIAL_AUTH_SYNC_CUSTOM_ATTRS_DICT: Dict[str, Dict[str, Dict[str, str]]] = {}
@@ -374,16 +373,7 @@ TERMS_OF_SERVICE_MESSAGE: Optional[str] = None
 STATSD_HOST = ""
 
 # Configuration for JWT auth.
-if TYPE_CHECKING:
-
-    class JwtAuthKey(TypedDict):
-        key: str
-        # See https://pyjwt.readthedocs.io/en/latest/algorithms.html for a list
-        # of supported algorithms.
-        algorithms: List[str]
-
-
-JWT_AUTH_KEYS: Dict[str, "JwtAuthKey"] = {}
+JWT_AUTH_KEYS: Dict[str, JwtAuthKey] = {}
 
 # https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-SERVER_EMAIL
 # Django setting for what from address to use in error emails.

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -3,7 +3,7 @@ import pwd
 from typing import Dict, Optional, Set, Tuple
 
 from scripts.lib.zulip_tools import deport
-from zerver.lib.types import SCIMConfigDict
+from zproject.settings_types import SCIMConfigDict
 
 ZULIP_ADMINISTRATOR = "desdemona+admin@zulip.com"
 

--- a/zproject/settings_types.py
+++ b/zproject/settings_types.py
@@ -1,0 +1,42 @@
+from typing import List, Optional, TypedDict
+
+
+class JwtAuthKey(TypedDict):
+    key: str
+    # See https://pyjwt.readthedocs.io/en/latest/algorithms.html for a list
+    # of supported algorithms.
+    algorithms: List[str]
+
+
+class SAMLIdPConfigDict(TypedDict, total=False):
+    entity_id: str
+    url: str
+    slo_url: str
+    attr_user_permanent_id: str
+    attr_first_name: str
+    attr_last_name: str
+    attr_username: str
+    attr_email: str
+    attr_org_membership: str
+    auto_signup: bool
+    display_name: str
+    display_icon: str
+    limit_to_subdomains: List[str]
+    extra_attrs: List[str]
+    x509cert: str
+    x509cert_path: str
+
+
+class OIDCIdPConfigDict(TypedDict, total=False):
+    oidc_url: str
+    display_name: str
+    display_icon: Optional[str]
+    client_id: str
+    secret: Optional[str]
+    auto_signup: bool
+
+
+class SCIMConfigDict(TypedDict):
+    bearer_token: str
+    scim_client_name: str
+    name_formatted_included: bool

--- a/zproject/template_loaders.py
+++ b/zproject/template_loaders.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from typing import List, Union
+
+from django.template.loaders import app_directories
+
+
+class TwoFactorLoader(app_directories.Loader):
+    def get_dirs(self) -> List[Union[str, Path]]:
+        dirs = super().get_dirs()
+        # app_directories.Loader returns only a list of
+        # Path objects by calling get_app_template_dirs
+        two_factor_dirs: List[Union[str, Path]] = []
+        for d in dirs:
+            assert isinstance(d, Path)
+            if d.match("two_factor/*"):
+                two_factor_dirs.append(d)
+        return two_factor_dirs

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -5,7 +5,7 @@ import ldap
 from django_auth_ldap.config import LDAPSearch
 
 from zerver.lib.db import TimeTrackingConnection, TimeTrackingCursor
-from zerver.lib.types import OIDCIdPConfigDict, SAMLIdPConfigDict, SCIMConfigDict
+from zproject.settings_types import OIDCIdPConfigDict, SAMLIdPConfigDict, SCIMConfigDict
 
 from .config import DEPLOY_ROOT, get_from_file_if_exists
 from .settings import (


### PR DESCRIPTION
Import cycles from `zproject.settings` to `django.conf.settings` or various other Django modules can prevent the django-stubs mypy plugin from inferring types of `django.conf.settings` members, depending on the order in which mypy traverses the files. See

- typeddjango/django-stubs#1162

Cc @PIG208