### PR TITLE
Button text not visible in modal

### DIFF
--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -84,7 +84,6 @@
     border-radius: 0.25rem;
     border-width: 0;
     cursor: pointer;
-    appearance: button;
     text-transform: none;
     overflow: visible;
     line-height: 1.15;
@@ -93,6 +92,10 @@
     backface-visibility: hidden;
     transform: translateZ(0);
     transition: transform 0.25s ease-out;
+
+    &:hover {
+        text-decoration: none;
+    }
 
     &:disabled {
         cursor: not-allowed;


### PR DESCRIPTION
Try to send message and have not login yet, this modal window shows up.
But login button and sign-up button is not styled design in browser（safari）.

-1 -------------
This is the issue depends on "appearance" of css.
We cannot superscription some styles of "appearance" by just writing other code.
So **I deleted "appearance" from this stylesheet**.

-2 -------------
Moreover I found that text is underlined when I hover the button, which may be not planned.
So I added code "text-decoration:none".

【before / 1】
<img width="250" alt="appearance_before" src="https://user-images.githubusercontent.com/86971544/192131157-b63ebc0d-a702-481e-845b-01454c8f7ffb.png">

 【before / 2】
<img width="250" alt="hover_before" src="https://user-images.githubusercontent.com/86971544/192131163-46fba9e2-462c-4089-a7d8-6ebb2d904d11.png">

【after】
<img width="250" alt="appearance_after" src="https://user-images.githubusercontent.com/86971544/192131167-f6bea92a-75b7-409f-94c9-ee20d98cc6d9.png">


- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.