### PR TITLE
Fix disabled recent filter button's hover color

### DIFF
--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -130,8 +130,13 @@
                 opacity: 0.5;
 
                 &:hover {
-                    background-color: hsl(0, 0%, 100%);
+                    background-color: hsl(0, 0%, 80%);
                     border-color: hsl(0, 0%, 80%);
+                }
+
+                &:focus {
+                    background-color: hsl(0, 0%, 80%) !important;
+                    outline: 0;
                 }
             }
         }


### PR DESCRIPTION
About filter buttons in recent topics view.

I found that disabled buttons in dark theme, I cannot read the text when I hover them because of its color style.

Also buttons changed their appearance when I click(=focus) them.
I think this is not good reaction as disabled button.

So I changed the css for hover & focus.

【before / hover】
<img width="200" alt="before_hover" src="https://user-images.githubusercontent.com/86971544/192136133-e5b3f2f1-5a6c-4aaa-88f7-c85684eb1825.png">
【before / focus】
<img width="200" alt="before_focus" src="https://user-images.githubusercontent.com/86971544/192136138-135c3a80-422a-4b9d-afdb-0578e96d5be4.png">
【After / hover&focus】
<img width="200" alt="after" src="https://user-images.githubusercontent.com/86971544/192136140-75a2ab34-5dfe-4f60-99f1-72dfe8504f31.png">


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
