### PR TITLE
Fix arrow color of popover menu

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -482,19 +482,19 @@ body.dark-theme {
 
     .nav .dropdown-menu::after,
     .popover.bottom .arrow {
-        border-bottom-color: hsl(235, 18%, 7%);
+        border-bottom-color: hsl(212, 32%, 14%);
     }
 
     .popover.left .arrow {
-        border-left-color: hsl(235, 18%, 7%);
+        border-left-color: hsl(212, 32%, 14%);
     }
 
     .popover.top .arrow {
-        border-top-color: hsl(235, 18%, 7%);
+        border-top-color: hsl(212, 32%, 14%);
     }
 
     .popover.right .arrow {
-        border-right-color: hsl(235, 18%, 7%);
+        border-right-color: hsl(212, 32%, 14%);
     }
 
     .narrow_to_compose_recipients,

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -480,21 +480,15 @@ body.dark-theme {
         }
     }
 
-    .nav .dropdown-menu::after,
-    .popover.bottom .arrow {
+    .nav .dropdown-menu::after {
         border-bottom-color: hsl(212, 32%, 14%);
     }
 
-    .popover.left .arrow {
-        border-left-color: hsl(212, 32%, 14%);
-    }
-
-    .popover.top .arrow {
-        border-top-color: hsl(212, 32%, 14%);
-    }
-
-    .popover.right .arrow {
-        border-right-color: hsl(212, 32%, 14%);
+    .popover .arrow {
+        &::after {
+            background: hsl(212, 32%, 14%);
+            border: solid 1px hsla(0, 0%, 0%, 0.4);
+        }
     }
 
     .narrow_to_compose_recipients,

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -1,6 +1,8 @@
 .popover {
     width: auto;
     max-width: 100%;
+    border: solid 1px hsla(0, 0%, 0%, 0.4);
+    border-radius: 5px;
 
     hr {
         margin-top: 5px;
@@ -13,10 +15,78 @@
         font-size: small;
         text-align: justify;
     }
+
+    .arrow {
+        position: absolute;
+        left: 50% !important;
+        top: -7.3px !important;
+        width: 16px;
+        height: 16px;
+        transform: translate(-50%, 0) rotate(0deg);
+        clip-path: inset(0 0 53% 0);
+        border: none !important;
+
+        &::after {
+            position: absolute;
+            content: "";
+            top: 0 !important;
+            left: 0 !important;
+            width: 11px;
+            height: 11px;
+            margin: 0 !important;
+            transform: translateX(-2.7px) translateY(4.4px) rotate(45deg);
+            transform-origin: bottom right;
+            border-radius: 20% 0 0;
+            background: hsl(0, 0%, 100%);
+            border: solid 1px hsla(0, 0%, 0%, 0.4) !important;
+            box-sizing: border-box;
+        }
+    }
+
+    &.bottom .arrow {
+        top: -7.3px !important;
+        bottom: unset !important;
+        left: calc(50% + 22px) !important;
+        right: unset !important;
+        transform: translate(-50%, 0) rotate(0deg);
+    }
+
+    &.left .arrow {
+        top: calc(50% + 11px) !important;
+        bottom: unset !important;
+        left: unset !important;
+        right: -7.3px !important;
+        transform: translate(0, -50%) rotate(90deg);
+    }
+
+    &.top {
+        margin-top: -65px;
+    }
+
+    &.top .arrow {
+        top: unset !important;
+        bottom: -7.3px !important;
+        left: calc(50% + 22px) !important;
+        right: unset !important;
+        transform: translate(-50%, 0) rotate(180deg);
+    }
+
+    &.right .arrow {
+        top: calc(50% + 11px) !important;
+        bottom: unset !important;
+        left: -7.3px !important;
+        right: unset !important;
+        transform: translate(0, -50%) rotate(270deg);
+    }
+}
+
+.popover-inner {
+    border-radius: 5px;
 }
 
 .popover-content {
     padding: 5px 0;
+    border-radius: 5px;
 }
 
 .popover-title {


### PR DESCRIPTION
Arrow's color of popover menu was not same as main area of popover in dark-theme.
I fixed color to the correct one.

<img width="250" alt="before color" src="https://user-images.githubusercontent.com/86971544/192136897-b69f9ca5-c2b8-4ab4-a63a-1f22915e46ef.png">

<img width="250" alt="after color" src="https://user-images.githubusercontent.com/86971544/192136894-9013b976-f433-4978-9a4c-f33ff7fd9a72.png">


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
