### PR TITLE
Fix global icon margin in message view header

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1712,12 +1712,10 @@ div.focused_table {
         }
 
         i {
-            margin-right: 3px;
+            margin: 0 3px 0 5px;
         }
 
         .fa {
-            margin: 0 3px 0 5px;
-
             &.fa-lock {
                 position: relative;
                 top: 0.5px;


### PR DESCRIPTION
The global icon in the header of the message view did not have the same margins as the hashtag icon.

I added margins to the CSS of the global icons. The margin values are the same as the hashtag icons have.

■hashtag icon
<img width="150" alt="hashtag" src="https://user-images.githubusercontent.com/86971544/192140029-60eaa360-93d0-4d30-b78f-7b6a3ba4cf38.png">
■old global icon
<img width="150" alt="global_before" src="https://user-images.githubusercontent.com/86971544/192140070-d832972e-4d93-45b5-9176-84bb0ba91321.png">
■global icon (margins added)
<img width="150" alt="margin_added" src="https://user-images.githubusercontent.com/86971544/192140071-96c65e17-0c5a-4634-8b96-4293b41e69e7.png">


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
