### PR TITLE
Fix the bug creating duplicate Confirmations for a PreregistrationUser

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -6660,7 +6660,10 @@ class TestMaybeSendToRegistration(ZulipTestCase):
 
         email = self.example_email("hamlet")
         user = PreregistrationUser(email=email, realm=realm)
+        streams = Stream.objects.filter(realm=realm)
         user.save()
+        user.streams.set(streams)
+
         create_confirmation_link(user, Confirmation.USER_REGISTRATION)
 
         with mock.patch("zerver.views.auth.HomepageForm", return_value=Form()):
@@ -6671,7 +6674,12 @@ class TestMaybeSendToRegistration(ZulipTestCase):
             assert confirmation is not None
             confirmation_key = confirmation.confirmation_key
             self.assertIn("do_confirm/" + confirmation_key, result["Location"])
-            self.assertEqual(PreregistrationUser.objects.all().count(), 1)
+            prereg_users = list(PreregistrationUser.objects.all())
+            self.assert_length(prereg_users, 2)
+            self.assertEqual(
+                list(prereg_users[0].streams.all().order_by("id")),
+                list(prereg_users[1].streams.all().order_by("id")),
+            )
 
 
 class TestAdminSetBackends(ZulipTestCase):

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -250,7 +250,6 @@ def maybe_send_to_registration(
             )
 
         if multiuse_obj is not None:
-            request.session.modified = True
             streams_to_subscribe = list(multiuse_obj.streams.all())
             prereg_user.streams.set(streams_to_subscribe)
             prereg_user.invited_as = invited_as


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/343-kandra-errors/topic/Confirmation.2EMultipleObjectsReturned.3A.20get.28.29.20returned.20more.2E.2E.2E

Copying the explanation from the commit message:
There was the following bug here:
1. Send an email invite to a user.
2. Have the user sign up via social auth without going through that
   invite, meaning either going via a multiuse invite link or just
   straight-up Sign up if the org permissions allow.

That resulted in the PreregistrationUser that got generated in step (1)
having 2 Confirmations tied to it - because maybe_send_to_registration
grabbed the object and created a new confirmation link for it. That is a
corrupted state, Confirmation is supposed to be unique.

One could try to do fancy things with checking whether a
PreregistrationUser already have a Confirmation link, but to avoid races
between ConfirmationEmailWorker and maybe_send_to_registration, this
would require taking locks and so on - which gets needlessly
complicated. It's simpler to not have them compete for the same object.

The point of the PreregistrationUser re-use in
maybe_send_to_registration is that if an admin invites a user, setting
their initial streams and role, it'd be an annoying experience if the
user ends up signing up not via the invite and those initial streams
streams etc. don't get set up. (ref https://github.com/zulip/zulip/pull/22557#discussion_r928047717)
But to handle this, we can just copy the
relevant values from the pre-existing prereg_user, rather than re-using
the object itself.