### PR TITLE
Fixes #22866: Update tip at the bottom of the ? menu 'Search Operators' tab

### DIFF
--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -159,17 +159,7 @@
                 </tbody>
             </table>
             {{#tr}}
-                <p>You can use any combination of these search operators in a single query. For example:</p>
-                <z-operator>
-                    <z-stream-prefix></z-stream-prefix><z-stream>streamname</z-stream>
-                    <z-sender-prefix></z-sender-prefix><z-email>user@example.com</z-email>
-                    <z-keyword>keyword</z-keyword>
-                </z-operator>
-                <p>
-                    That query would search for messages sent by <z-email>user@example.com</z-email> to
-                    stream <z-stream>streamname</z-stream> containing
-                    the keyword <z-keyword>keyword</z-keyword>.
-                </p>
+                <p>{{t 'You can combine search operators as needed.'}}</p>
                 {{#*inline "z-operator"}}<p><span class="operator">{{> @partial-block}}</span></p>{{/inline}}
                 {{#*inline "z-stream-prefix"}}stream:{{/inline}}
                 {{#*inline "z-stream"}}<span class="operator_value">{{> @partial-block}}</span>{{/inline}}


### PR DESCRIPTION
**Description:**
Made appropriate changes to the help area of the "Search Operators" tab and marked text for internationalization.

Fixes #22866: Update tip at the bottom of the ? menu 'Search Operators' tab

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/41968151/192180320-52eca8ba-9f11-4e23-9a23-51730d4248aa.png)

