### PR TITLE
Fixes part of #22892: For "Message retention", the "i" is removed

### DIFF
--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -70,8 +70,6 @@
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
                     <label for="id_realm_message_retention_setting" class="dropdown-title">{{t "Message retention period" }}
-                        <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip"
-                          aria-hidden="true" data-tippy-content="{{t 'Only owners can change message retention policy.' }}"></i>
                     </label>
                     <select name="realm_message_retention_setting"
                       id="id_realm_message_retention_setting" class="prop-element"


### PR DESCRIPTION
This pull request fixes the second checklist item: For "Message retention", the "i" should simply be removed.

Fixes: [22892](https://github.com/zulip/zulip/issues/22892)

Screenshot of the change:

![Skärmavbild 2022-09-26 kl  15 13 17](https://user-images.githubusercontent.com/58030654/192285776-161c5fb3-79b2-4357-aa42-2eadd336cf14.png)
