### PR TITLE
Make topic and stream editing independent of `allow_message_editing` setting.

### DIFF
--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -742,7 +742,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
 test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
     mock_banners();
     $("#compose_banners .topic_resolved").length = 0;
-    override(settings_data, "user_can_edit_topic_of_any_message", () => true);
+    override(settings_data, "user_can_move_messages_to_another_topic", () => true);
 
     let error_shown = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -34,7 +34,6 @@ const dark_theme = mock_esm("../../static/js/dark_theme");
 const emoji_picker = mock_esm("../../static/js/emoji_picker");
 const hotspots = mock_esm("../../static/js/hotspots");
 const linkifiers = mock_esm("../../static/js/linkifiers");
-const message_edit = mock_esm("../../static/js/message_edit");
 const message_events = mock_esm("../../static/js/message_events");
 const message_lists = mock_esm("../../static/js/message_lists");
 const muted_topics_ui = mock_esm("../../static/js/muted_topics_ui");
@@ -469,7 +468,6 @@ run_test("realm settings", ({override}) => {
     page_params.realm_allow_message_editing = false;
     page_params.realm_message_content_edit_limit_seconds = 0;
     override(settings_org, "populate_auth_methods", noop);
-    override(message_edit, "update_message_topic_editing_pencil", noop);
     dispatch(event);
     assert_same(page_params.realm_allow_message_editing, true);
     assert_same(page_params.realm_message_content_edit_limit_seconds, 5);

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -57,6 +57,9 @@ run_test("get_editability", ({override}) => {
     page_params.realm_allow_message_editing = false;
     assert.equal(get_editability(message), editability_types.NO);
 
+    message.type = "stream";
+    assert.equal(get_editability(message), editability_types.TOPIC_ONLY);
+
     page_params.realm_allow_message_editing = true;
     // Limit of 0 means no time limit on editing messages
     page_params.realm_message_content_edit_limit_seconds = null;
@@ -143,7 +146,7 @@ run_test("is_topic_editable", ({override}) => {
     assert.equal(message_edit.is_topic_editable(message), true);
 
     page_params.realm_allow_message_editing = false;
-    assert.equal(message_edit.is_topic_editable(message), false);
+    assert.equal(message_edit.is_topic_editable(message), true);
 });
 
 run_test("get_deletability", ({override}) => {

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -116,9 +116,13 @@ run_test("is_topic_editable", ({override}) => {
 
     message.sent_by_me = false;
     page_params.is_admin = true;
-    assert.equal(message_edit.is_topic_editable(message), true);
+    override(settings_data, "user_can_edit_topic_of_any_message", () => false);
+    assert.equal(message_edit.is_topic_editable(message), false);
 
     page_params.is_admin = false;
+    message.sent_by_me = false;
+    assert.equal(message_edit.is_topic_editable(message), false);
+
     message.topic = "translated: (no topic)";
     assert.equal(message_edit.is_topic_editable(message), true);
 

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -17,7 +17,7 @@ const editability_types = message_edit.editability_types;
 const settings_data = mock_esm("../../static/js/settings_data");
 
 run_test("get_editability", ({override}) => {
-    override(settings_data, "user_can_edit_topic_of_any_message", () => true);
+    override(settings_data, "user_can_move_messages_to_another_topic", () => true);
     // You can't edit a null message
     assert.equal(get_editability(null), editability_types.NO);
     // You can't edit a message you didn't send
@@ -119,7 +119,7 @@ run_test("is_topic_editable", ({override}) => {
         type: "stream",
     };
     page_params.realm_allow_message_editing = true;
-    override(settings_data, "user_can_edit_topic_of_any_message", () => true);
+    override(settings_data, "user_can_move_messages_to_another_topic", () => true);
     page_params.is_admin = true;
 
     assert.equal(message_edit.is_topic_editable(message), false);
@@ -134,7 +134,7 @@ run_test("is_topic_editable", ({override}) => {
     page_params.sent_by_me = false;
     assert.equal(message_edit.is_topic_editable(message), true);
 
-    override(settings_data, "user_can_edit_topic_of_any_message", () => false);
+    override(settings_data, "user_can_move_messages_to_another_topic", () => false);
     assert.equal(message_edit.is_topic_editable(message), false);
 
     page_params.is_admin = false;
@@ -144,13 +144,13 @@ run_test("is_topic_editable", ({override}) => {
     assert.equal(message_edit.is_topic_editable(message), true);
 
     message.topic = "test topic";
-    override(settings_data, "user_can_edit_topic_of_any_message", () => false);
+    override(settings_data, "user_can_move_messages_to_another_topic", () => false);
     assert.equal(message_edit.is_topic_editable(message), false);
 
     page_params.realm_community_topic_editing_limit_seconds = 259200;
     message.timestamp = current_timestamp - 60;
 
-    override(settings_data, "user_can_edit_topic_of_any_message", () => true);
+    override(settings_data, "user_can_move_messages_to_another_topic", () => true);
     assert.equal(message_edit.is_topic_editable(message), true);
 
     message.timestamp = current_timestamp - 600000;

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -248,6 +248,14 @@ test_message_policy(
     settings_data.user_can_edit_topic_of_any_message,
 );
 
+run_test("user_can_edit_topic_of_any_message_nobody_case", () => {
+    page_params.is_admin = true;
+    page_params.is_guest = false;
+    page_params.realm_edit_topic_policy =
+        settings_config.edit_topic_policy_values.nobody.code;
+    assert.equal(settings_data.user_can_edit_topic_of_any_message(), false);
+});
+
 test_message_policy(
     "user_can_delete_own_message",
     "realm_delete_own_message_policy",

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -251,9 +251,16 @@ test_message_policy(
 run_test("user_can_edit_topic_of_any_message_nobody_case", () => {
     page_params.is_admin = true;
     page_params.is_guest = false;
-    page_params.realm_edit_topic_policy =
-        settings_config.edit_topic_policy_values.nobody.code;
+    page_params.realm_edit_topic_policy = settings_config.edit_topic_policy_values.nobody.code;
     assert.equal(settings_data.user_can_edit_topic_of_any_message(), false);
+});
+
+run_test("user_can_move_messages_between_streams_nobody_case", () => {
+    page_params.is_admin = true;
+    page_params.is_guest = false;
+    page_params.realm_move_messages_between_streams_policy =
+        settings_config.move_messages_between_streams_policy_values.nobody.code;
+    assert.equal(settings_data.user_can_move_messages_between_streams(), false);
 });
 
 test_message_policy(

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -243,16 +243,16 @@ function test_message_policy(label, policy, validation_func) {
 }
 
 test_message_policy(
-    "user_can_edit_topic_of_any_message",
+    "user_can_move_messages_to_another_topic",
     "realm_edit_topic_policy",
-    settings_data.user_can_edit_topic_of_any_message,
+    settings_data.user_can_move_messages_to_another_topic,
 );
 
-run_test("user_can_edit_topic_of_any_message_nobody_case", () => {
+run_test("user_can_move_messages_to_another_topic_nobody_case", () => {
     page_params.is_admin = true;
     page_params.is_guest = false;
     page_params.realm_edit_topic_policy = settings_config.edit_topic_policy_values.nobody.code;
-    assert.equal(settings_data.user_can_edit_topic_of_any_message(), false);
+    assert.equal(settings_data.user_can_move_messages_to_another_topic(), false);
 });
 
 run_test("user_can_move_messages_between_streams_nobody_case", () => {

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -201,7 +201,7 @@ export function warn_if_topic_resolved(topic_changed) {
             return;
         }
 
-        const button_text = settings_data.user_can_edit_topic_of_any_message()
+        const button_text = settings_data.user_can_move_messages_to_another_topic()
             ? $t({defaultMessage: "Unresolve topic"})
             : null;
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -61,11 +61,6 @@ export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
         return false;
     }
 
-    if (!page_params.realm_allow_message_editing) {
-        // If message editing is disabled, so is topic editing.
-        return false;
-    }
-
     // message senders can edit message topics indefinitely.
     if (message.sent_by_me) {
         return true;
@@ -140,6 +135,9 @@ export function get_editability(message, edit_limit_seconds_buffer = 0) {
     }
 
     if (!page_params.realm_allow_message_editing) {
+        if (message.type === "stream") {
+            return editability_types.TOPIC_ONLY;
+        }
         return editability_types.NO;
     }
 
@@ -200,10 +198,6 @@ export function get_deletability(message) {
 }
 
 export function can_move_message(message) {
-    if (!page_params.realm_allow_message_editing) {
-        return false;
-    }
-
     if (!message.is_stream) {
         return false;
     }
@@ -263,14 +257,6 @@ export function stream_and_topic_exist_in_edit_history(message, stream_id, topic
     }
 
     return false;
-}
-
-export function update_message_topic_editing_pencil() {
-    if (page_params.realm_allow_message_editing) {
-        $(".on_hover_topic_edit, .always_visible_topic_edit").show();
-    } else {
-        $(".on_hover_topic_edit, .always_visible_topic_edit").hide();
-    }
 }
 
 export function hide_message_edit_spinner($row) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -70,7 +70,7 @@ export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
         return true;
     }
 
-    if (!settings_data.user_can_edit_topic_of_any_message()) {
+    if (!settings_data.user_can_move_messages_to_another_topic()) {
         return false;
     }
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -65,10 +65,8 @@ export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
         // If message editing is disabled, so is topic editing.
         return false;
     }
-    // Organization admins and message senders can edit message topics indefinitely.
-    if (page_params.is_admin) {
-        return true;
-    }
+
+    // message senders can edit message topics indefinitely.
     if (message.sent_by_me) {
         return true;
     }
@@ -81,9 +79,10 @@ export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
         return false;
     }
 
-    // moderators can edit the topic if edit_topic_policy allows them to do so,
-    // irrespective of the topic editing deadline.
-    if (page_params.is_moderator) {
+    // Organization admins and moderators can edit message topics indefinitely,
+    // irrespective of the topic editing deadline, if edit_topic_policy allows
+    // them to do so.
+    if (page_params.is_admin || page_params.is_moderator) {
         return true;
     }
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -173,7 +173,6 @@ function set_timestr(message_container) {
 }
 
 function set_topic_edit_properties(group, message) {
-    group.realm_allow_message_editing = page_params.realm_allow_message_editing;
     group.always_visible_topic_edit = false;
     group.on_hover_topic_edit = false;
     // if a user who can edit a topic, can resolve it as well

--- a/static/js/popover_menus_data.js
+++ b/static/js/popover_menus_data.js
@@ -19,17 +19,14 @@ export function get_actions_popover_content_context(message_id) {
         muted_users.is_user_muted(message.sender_id) &&
         !message_container.is_hidden &&
         not_spectator;
-    const editability = message_edit.get_editability(message);
+    const is_content_editable = message_edit.is_content_editable(message);
     const can_move_message = message_edit.can_move_message(message);
 
     let editability_menu_item;
     let move_message_menu_item;
     let view_source_menu_item;
 
-    if (
-        editability === message_edit.editability_types.FULL ||
-        editability === message_edit.editability_types.CONTENT_ONLY
-    ) {
+    if (is_content_editable) {
         editability_menu_item = $t({defaultMessage: "Edit message"});
     } else {
         view_source_menu_item = $t({defaultMessage: "View message source"});

--- a/static/js/popover_menus_data.js
+++ b/static/js/popover_menus_data.js
@@ -26,16 +26,17 @@ export function get_actions_popover_content_context(message_id) {
     let move_message_menu_item;
     let view_source_menu_item;
 
-    if (editability === message_edit.editability_types.FULL) {
+    if (
+        editability === message_edit.editability_types.FULL ||
+        editability === message_edit.editability_types.CONTENT_ONLY
+    ) {
         editability_menu_item = $t({defaultMessage: "Edit message"});
-        if (message.is_stream) {
-            move_message_menu_item = $t({defaultMessage: "Move messages"});
-        }
-    } else if (can_move_message) {
-        move_message_menu_item = $t({defaultMessage: "Move messages"});
-        view_source_menu_item = $t({defaultMessage: "View message source"});
     } else {
         view_source_menu_item = $t({defaultMessage: "View message source"});
+    }
+
+    if (can_move_message) {
+        move_message_menu_item = $t({defaultMessage: "Move messages"});
     }
 
     // We do not offer "Mark as unread" on messages in streams

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -18,7 +18,6 @@ import * as emoji_picker from "./emoji_picker";
 import * as giphy from "./giphy";
 import * as hotspots from "./hotspots";
 import * as linkifiers from "./linkifiers";
-import * as message_edit from "./message_edit";
 import * as message_events from "./message_events";
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
@@ -260,9 +259,6 @@ export function dispatch_normal_event(event) {
                         case "default":
                             for (const [key, value] of Object.entries(event.data)) {
                                 page_params["realm_" + key] = value;
-                                if (key === "allow_message_editing") {
-                                    message_edit.update_message_topic_editing_pencil();
-                                }
                                 if (Object.hasOwn(realm_settings, key)) {
                                     settings_org.sync_realm_settings(key);
                                 }

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -290,6 +290,15 @@ export const common_message_policy_values = {
     },
 };
 
+export const edit_topic_policy_values = {
+    ...common_message_policy_values,
+    nobody: {
+        order: 6,
+        code: 6,
+        description: $t({defaultMessage: "Nobody"}),
+    },
+};
+
 export const time_limit_dropdown_values = [
     {
         text: $t({defaultMessage: "Any time"}),

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -299,6 +299,8 @@ export const edit_topic_policy_values = {
     },
 };
 
+export const move_messages_between_streams_policy_values = invite_to_realm_policy_values;
+
 export const time_limit_dropdown_values = [
     {
         text: $t({defaultMessage: "Any time"}),

--- a/static/js/settings_data.ts
+++ b/static/js/settings_data.ts
@@ -222,7 +222,7 @@ export function user_can_add_custom_emoji(): boolean {
     return user_has_permission(page_params.realm_add_custom_emoji_policy);
 }
 
-export function user_can_edit_topic_of_any_message(): boolean {
+export function user_can_move_messages_to_another_topic(): boolean {
     return user_has_permission(page_params.realm_edit_topic_policy);
 }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -117,6 +117,9 @@ export function get_organization_settings_options() {
     options.edit_topic_policy_values = get_sorted_options_list(
         settings_config.edit_topic_policy_values,
     );
+    options.move_messages_between_streams_policy_values = get_sorted_options_list(
+        settings_config.move_messages_between_streams_policy_values,
+    );
     return options;
 }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -273,7 +273,6 @@ function update_message_edit_sub_settings(is_checked) {
         "id_realm_message_content_edit_limit_minutes",
         true,
     );
-    settings_ui.disable_sub_setting_onchange(is_checked, "id_realm_edit_topic_policy", true);
 }
 
 function update_custom_value_input(property_name) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -114,6 +114,9 @@ export function get_organization_settings_options() {
     options.invite_to_realm_policy_values = get_sorted_options_list(
         settings_config.invite_to_realm_policy_values,
     );
+    options.edit_topic_policy_values = get_sorted_options_list(
+        settings_config.edit_topic_policy_values,
+    );
     return options;
 }
 

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -142,10 +142,7 @@ function message_hover($message_row) {
     }
 
     // But the message edit hover icon is determined by whether the message is still editable
-    const editability = message_edit.get_editability(message);
-    const is_content_editable =
-        editability === message_edit.editability_types.FULL ||
-        editability === message_edit.editability_types.CONTENT_ONLY;
+    const is_content_editable = message_edit.is_content_editable(message);
 
     const can_move_message = message_edit.can_move_message(message);
     const args = {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -143,7 +143,9 @@ function message_hover($message_row) {
 
     // But the message edit hover icon is determined by whether the message is still editable
     const editability = message_edit.get_editability(message);
-    const is_content_editable = editability === message_edit.editability_types.FULL;
+    const is_content_editable =
+        editability === message_edit.editability_types.FULL ||
+        editability === message_edit.editability_types.CONTENT_ONLY;
 
     const can_move_message = message_edit.can_move_message(message);
     const args = {

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -50,9 +50,9 @@
 
                 {{! edit topic pencil icon }}
                 {{#if always_visible_topic_edit}}
-                    <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon hidden-for-spectators" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
+                    <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon hidden-for-spectators" data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
                 {{else if on_hover_topic_edit}}
-                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon hidden-for-spectators" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
+                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon hidden-for-spectators" data-tippy-content="{{t 'Edit topic'}}" role="button" tabindex="0" aria-label="{{t 'Edit topic' }}"></i>
                 {{/if}}
 
                 {{#if user_can_resolve_topic}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -176,7 +176,7 @@
 
                 <div class="input-group">
                     <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can edit the topic of any message" }}</label>
-                    <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element" data-setting-widget-type="number" {{#unless realm_allow_message_editing}}disabled{{/unless}}>
+                    <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=edit_topic_policy_values}}
                     </select>
                 </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -191,7 +191,7 @@
                     <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages between streams" }}
                     </label>
                     <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=common_policy_values}}
+                        {{> dropdown_options_widget option_values=move_messages_between_streams_policy_values}}
                     </select>
                 </div>
             </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -175,7 +175,7 @@
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can edit the topic of any message" }}</label>
+                    <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can move messages to another topic" }}</label>
                     <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=edit_topic_policy_values}}
                     </select>
@@ -188,7 +188,7 @@
                   label=admin_settings_label.realm_allow_edit_history}}
 
                 <div class="input-group">
-                    <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages between streams" }}
+                    <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages to another stream" }}
                     </label>
                     <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=move_messages_between_streams_policy_values}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -142,7 +142,7 @@
 
         <div id="org-msg-editing" class="settings-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Message and topic editing" }}
+                <h3>{{t "Message editing" }}
                     {{> ../help_link_widget link="/help/configure-message-editing-and-deletion" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="msg-editing" }}
@@ -153,6 +153,12 @@
                   prefix="id_"
                   is_checked=realm_allow_message_editing
                   label=admin_settings_label.realm_allow_message_editing}}
+
+                {{> settings_checkbox
+                  setting_name="realm_allow_edit_history"
+                  prefix="id_"
+                  is_checked=realm_allow_edit_history
+                  label=admin_settings_label.realm_allow_edit_history}}
 
                 <div class="input-group time-limit-setting">
                     <label for="realm_message_content_edit_limit_seconds" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
@@ -173,27 +179,29 @@
                           {{#unless realm_allow_message_editing}}disabled{{/unless}}/>
                     </div>
                 </div>
+            </div>
+        </div>
 
-                <div class="input-group">
-                    <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can move messages to another topic" }}</label>
-                    <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=edit_topic_policy_values}}
-                    </select>
-                </div>
+        <div id="org-moving-msgs" class="settings-subsection-parent">
+            <div class="subsection-header">
+                <h3>{{t "Moving messages" }}
+                    {{> ../help_link_widget link="/help/configure-message-editing-and-deletion" }}
+                </h3>
+                {{> settings_save_discard_widget section_name="moving-msgs" }}
+            </div>
+            <div class="input-group">
+                <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can move messages to another topic" }}</label>
+                <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element" data-setting-widget-type="number">
+                    {{> dropdown_options_widget option_values=edit_topic_policy_values}}
+                </select>
+            </div>
 
-                {{> settings_checkbox
-                  setting_name="realm_allow_edit_history"
-                  prefix="id_"
-                  is_checked=realm_allow_edit_history
-                  label=admin_settings_label.realm_allow_edit_history}}
-
-                <div class="input-group">
-                    <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages to another stream" }}
-                    </label>
-                    <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
-                        {{> dropdown_options_widget option_values=move_messages_between_streams_policy_values}}
-                    </select>
-                </div>
+            <div class="input-group">
+                <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages to another stream" }}
+                </label>
+                <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
+                    {{> dropdown_options_widget option_values=move_messages_between_streams_policy_values}}
+                </select>
             </div>
         </div>
 

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -177,7 +177,7 @@
                 <div class="input-group">
                     <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can edit the topic of any message" }}</label>
                     <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element" data-setting-widget-type="number" {{#unless realm_allow_message_editing}}disabled{{/unless}}>
-                        {{> dropdown_options_widget option_values=common_message_policy_values}}
+                        {{> dropdown_options_widget option_values=edit_topic_policy_values}}
                     </select>
                 </div>
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 159**
+
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
+  `PATCH /realm`: Nobody added as an option for the realm setting
+  `edit_topic_policy`.
+
 Feature levels 157-158 are reserved for future use in 6.x maintenance
 releases.
 

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -30,6 +30,8 @@ format used by the Zulip server that they are interacting with.
   `move_messages_between_streams_policy`.
 * [`PATCH /messages/{message_id}`](/api/update-message): Permission to edit stream
   and topic of messages do not depend on `allow_message_editing` setting now.
+* [`PATCH /messages/{message_id}`](/api/update-message): Message senders are not
+  allowed to edit topics indefinitely now.
 
 Feature levels 157-158 are reserved for future use in 6.x maintenance
 releases.

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -25,6 +25,9 @@ format used by the Zulip server that they are interacting with.
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
   `PATCH /realm`: Nobody added as an option for the realm setting
   `edit_topic_policy`.
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
+  `PATCH /realm`: Nobody added as an option for the realm setting
+  `move_messages_between_streams_policy`.
 
 Feature levels 157-158 are reserved for future use in 6.x maintenance
 releases.

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -28,6 +28,8 @@ format used by the Zulip server that they are interacting with.
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),
   `PATCH /realm`: Nobody added as an option for the realm setting
   `move_messages_between_streams_policy`.
+* [`PATCH /messages/{message_id}`](/api/update-message): Permission to edit stream
+  and topic of messages do not depend on `allow_message_editing` setting now.
 
 Feature levels 157-158 are reserved for future use in 6.x maintenance
 releases.

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 156
+API_FEATURE_LEVEL = 159
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -105,14 +105,9 @@ def validate_message_edit_payload(
 
 
 def can_edit_topic(
-    message: Message,
     user_profile: UserProfile,
     is_no_topic_msg: bool,
 ) -> bool:
-    # You have permission to edit the message topic if you sent it.
-    if message.sender_id == user_profile.id:
-        return True
-
     # We allow anyone to edit (no topic) messages to help tend them.
     if is_no_topic_msg:
         return True
@@ -939,7 +934,7 @@ def check_update_message(
 
     is_no_topic_msg = message.topic_name() == "(no topic)"
 
-    if topic_name is not None and not can_edit_topic(message, user_profile, is_no_topic_msg):
+    if topic_name is not None and not can_edit_topic(user_profile, is_no_topic_msg):
         raise JsonableError(_("You don't have permission to edit this message"))
 
     # If there is a change to the content, check that it hasn't been too long
@@ -954,12 +949,10 @@ def check_update_message(
             raise JsonableError(_("The time limit for editing this message has passed"))
 
     # If there is a change to the topic, check that the user is allowed to
-    # edit it and that it has not been too long. If this is not the user who
-    # sent the message, they are not the admin, and the time limit for editing
-    # topics is passed, raise an error.
+    # edit it and that it has not been too long. If user is not admin or moderator,
+    # and the time limit for editing topics is passed, raise an error.
     if (
         topic_name is not None
-        and message.sender != user_profile
         and not user_profile.is_realm_admin
         and not user_profile.is_moderator
         and not is_no_topic_msg

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -112,9 +112,9 @@ def can_edit_topic(
     if is_no_topic_msg:
         return True
 
-    # The can_edit_topic_of_any_message helper returns whether the user can edit the topic
-    # or not based on edit_topic_policy setting and the user's role.
-    if user_profile.can_edit_topic_of_any_message():
+    # The can_move_messages_to_another_topic helper returns whether the user can edit
+    # the topic or not based on edit_topic_policy setting and the user's role.
+    if user_profile.can_move_messages_to_another_topic():
         return True
 
     return False

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -918,7 +918,7 @@ def check_update_message(
     """
     message, ignored_user_message = access_message(user_profile, message_id)
 
-    if not user_profile.realm.allow_message_editing:
+    if content is not None and not user_profile.realm.allow_message_editing:
         raise JsonableError(_("Your organization has turned off message editing"))
 
     # The zerver/views/message_edit.py call point already strips this

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -365,6 +365,15 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
         POLICY_NOBODY,
     ]
 
+    EDIT_TOPIC_POLICY_TYPES = [
+        POLICY_MEMBERS_ONLY,
+        POLICY_ADMINS_ONLY,
+        POLICY_FULL_MEMBERS_ONLY,
+        POLICY_MODERATORS_ONLY,
+        POLICY_EVERYONE,
+        POLICY_NOBODY,
+    ]
+
     DEFAULT_COMMUNITY_TOPIC_EDITING_LIMIT_SECONDS = 259200
 
     # Who in the organization is allowed to add custom emojis.

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2121,7 +2121,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):  # type
     def can_edit_user_groups(self) -> bool:
         return self.has_permission("user_group_edit_policy")
 
-    def can_edit_topic_of_any_message(self) -> bool:
+    def can_move_messages_to_another_topic(self) -> bool:
         return self.has_permission("edit_topic_policy")
 
     def can_add_custom_emoji(self) -> bool:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -374,6 +374,8 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
         POLICY_NOBODY,
     ]
 
+    MOVE_MESSAGES_BETWEEN_STREAMS_POLICY_TYPES = INVITE_TO_REALM_POLICY_TYPES
+
     DEFAULT_COMMUNITY_TOPIC_EDITING_LIMIT_SECONDS = 259200
 
     # Who in the organization is allowed to add custom emojis.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6460,6 +6460,11 @@ paths:
         **Note**: See [configuring message editing][config-message-editing]
         for detailed documentation on when users are allowed to edit topics.
 
+        **Changes**: Before Zulip 7.0 (feature level 159), editing
+        streams and topics of messages was forbidden if
+        `allow_message_editing` was `false`, regardless of the
+        `edit_topic_policy` or `move_messages_between_streams_policy`.
+
         [config-message-editing]: /help/configure-message-editing-and-deletion
       x-curl-examples-parameters:
         oneOf:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6464,6 +6464,8 @@ paths:
         streams and topics of messages was forbidden if
         `allow_message_editing` was `false`, regardless of the
         `edit_topic_policy` or `move_messages_between_streams_policy`.
+        Before Zulip 7.0 (feature level 159), message senders were allowed
+        to edit the topic indefinitely.
 
         [config-message-editing]: /help/configure-message-editing-and-deletion
       x-curl-examples-parameters:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4042,8 +4042,10 @@ paths:
                                         - 2 = Administrators only
                                         - 3 = [Full members][calc-full-member] only
                                         - 4 = Moderators only
+                                        - 6 = Nobody
 
-                                        **Changes**: New in Zulip 4.0 (feature level 56)
+                                        **Changes**: New in Zulip 4.0 (feature level 56). Nobody added
+                                        as an option in Zulip 7.0 (feature level 159).
 
                                         [permission-level]: /api/roles-and-permissions#permission-levels
                                         [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
@@ -11914,8 +11916,10 @@ paths:
                           - 2 = Administrators only
                           - 3 = [Full members][calc-full-member] only
                           - 4 = Moderators only
+                          - 6 = Nobody
 
-                          **Changes**: New in Zulip 4.0 (feature level 56)
+                          **Changes**: New in Zulip 4.0 (feature level 56). Nobody added
+                          as an option in Zulip 7.0 (feature level 159).
 
                           [permission-level]: /api/roles-and-permissions#permission-levels
                           [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3890,9 +3890,11 @@ paths:
                                         - 3 = [full members][calc-full-member] only
                                         - 4 = moderators only
                                         - 5 = everyone
+                                        - 6 = nobody
 
                                         **Changes**: New in Zulip 5.0 (feature level 75), replacing the
-                                        previous `allow_community_topic_editing` boolean.
+                                        previous `allow_community_topic_editing` boolean. Nobody added
+                                        as an option in Zulip 7.0 (feature level 159).
 
                                         [permission-level]: /api/roles-and-permissions#permission-levels
                                         [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member
@@ -12155,9 +12157,11 @@ paths:
                           - 3 = [full members][calc-full-member] only
                           - 4 = moderators only
                           - 5 = everyone
+                          - 6 = nobody
 
                           **Changes**: New in Zulip 5.0 (feature level 75), replacing the
-                          previous `allow_community_topic_editing` boolean.
+                          previous `allow_community_topic_editing` boolean. Nobody added as
+                          an option in Zulip 7.0 (feature level 159).
 
                           [permission-level]: /api/roles-and-permissions#permission-levels
                           [calc-full-member]: /api/roles-and-permissions#determining-if-a-user-is-a-full-member

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2572,7 +2572,7 @@ class RealmPropertyActionTest(BaseAction):
             default_code_block_language=["python", "javascript"],
             message_content_delete_limit_seconds=[1000, 1100, 1200],
             invite_to_realm_policy=Realm.INVITE_TO_REALM_POLICY_TYPES,
-            move_messages_between_streams_policy=Realm.COMMON_POLICY_TYPES,
+            move_messages_between_streams_policy=Realm.MOVE_MESSAGES_BETWEEN_STREAMS_POLICY_TYPES,
             add_custom_emoji_policy=Realm.COMMON_POLICY_TYPES,
             delete_own_message_policy=Realm.COMMON_MESSAGE_POLICY_TYPES,
             edit_topic_policy=Realm.COMMON_MESSAGE_POLICY_TYPES,

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1043,19 +1043,18 @@ class EditMessageTest(EditMessageTestCase):
         set_message_editing_params(True, "unlimited", Realm.POLICY_ADMINS_ONLY)
         do_edit_message_assert_success(id_, "D")
 
-        # without allow_message_editing, nothing is allowed
+        # without allow_message_editing, editing content is not allowed but
+        # editing topic is allowed if topic-edit time limit has not passed
+        # irrespective of content-edit time limit.
         set_message_editing_params(False, 240, Realm.POLICY_ADMINS_ONLY)
-        do_edit_message_assert_error(
-            id_, "E", "Your organization has turned off message editing", True
-        )
+        do_edit_message_assert_success(id_, "B", True)
+
+        set_message_editing_params(False, 240, Realm.POLICY_ADMINS_ONLY)
+        do_edit_message_assert_success(id_, "E", True)
         set_message_editing_params(False, 120, Realm.POLICY_ADMINS_ONLY)
-        do_edit_message_assert_error(
-            id_, "F", "Your organization has turned off message editing", True
-        )
+        do_edit_message_assert_success(id_, "F", True)
         set_message_editing_params(False, "unlimited", Realm.POLICY_ADMINS_ONLY)
-        do_edit_message_assert_error(
-            id_, "G", "Your organization has turned off message editing", True
-        )
+        do_edit_message_assert_success(id_, "G", True)
 
     def test_edit_topic_policy(self) -> None:
         def set_message_editing_params(
@@ -1162,11 +1161,9 @@ class EditMessageTest(EditMessageTestCase):
             id_, "H", "You don't have permission to edit this message", "iago"
         )
 
-        # users cannot edit topics if allow_message_editing is False
+        # users can edit topics even if allow_message_editing is False
         set_message_editing_params(False, "unlimited", Realm.POLICY_EVERYONE)
-        do_edit_message_assert_error(
-            id_, "D", "Your organization has turned off message editing", "cordelia"
-        )
+        do_edit_message_assert_success(id_, "D", "cordelia")
 
         # non-admin users cannot edit topics sent > 72 hrs ago
         message.date_sent = message.date_sent - datetime.timedelta(seconds=290000)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1153,6 +1153,15 @@ class EditMessageTest(EditMessageTestCase):
         )
         do_edit_message_assert_success(id_, "E", "iago")
 
+        # even owners and admins cannot edit the topics of messages
+        set_message_editing_params(True, "unlimited", Realm.POLICY_NOBODY)
+        do_edit_message_assert_error(
+            id_, "H", "You don't have permission to edit this message", "desdemona"
+        )
+        do_edit_message_assert_error(
+            id_, "H", "You don't have permission to edit this message", "iago"
+        )
+
         # users cannot edit topics if allow_message_editing is False
         set_message_editing_params(False, "unlimited", Realm.POLICY_EVERYONE)
         do_edit_message_assert_error(

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -2056,6 +2056,18 @@ class EditMessageTest(EditMessageTestCase):
                 messages = get_topic_messages(user_profile, new_stream, "test")
                 self.assert_length(messages, 4)
 
+        # Check sending messages when policy is Realm.POLICY_NOBODY.
+        do_set_realm_property(
+            user_profile.realm,
+            "move_messages_between_streams_policy",
+            Realm.POLICY_NOBODY,
+            acting_user=None,
+        )
+        check_move_message_according_to_policy(UserProfile.ROLE_REALM_OWNER, expect_fail=True)
+        check_move_message_according_to_policy(
+            UserProfile.ROLE_REALM_ADMINISTRATOR, expect_fail=True
+        )
+
         # Check sending messages when policy is Realm.POLICY_ADMINS_ONLY.
         do_set_realm_property(
             user_profile.realm,

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1176,7 +1176,7 @@ class RealmAPITest(ZulipTestCase):
             move_messages_between_streams_policy=Realm.COMMON_POLICY_TYPES,
             add_custom_emoji_policy=Realm.COMMON_POLICY_TYPES,
             delete_own_message_policy=Realm.COMMON_MESSAGE_POLICY_TYPES,
-            edit_topic_policy=Realm.COMMON_MESSAGE_POLICY_TYPES,
+            edit_topic_policy=Realm.EDIT_TOPIC_POLICY_TYPES,
             message_content_edit_limit_seconds=[1000, 1100, 1200],
         )
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1173,7 +1173,7 @@ class RealmAPITest(ZulipTestCase):
             ],
             message_content_delete_limit_seconds=[1000, 1100, 1200],
             invite_to_realm_policy=Realm.INVITE_TO_REALM_POLICY_TYPES,
-            move_messages_between_streams_policy=Realm.COMMON_POLICY_TYPES,
+            move_messages_between_streams_policy=Realm.MOVE_MESSAGES_BETWEEN_STREAMS_POLICY_TYPES,
             add_custom_emoji_policy=Realm.COMMON_POLICY_TYPES,
             delete_own_message_policy=Realm.COMMON_MESSAGE_POLICY_TYPES,
             edit_topic_policy=Realm.EDIT_TOPIC_POLICY_TYPES,

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -78,7 +78,7 @@ def update_realm(
     ),
     allow_message_editing: Optional[bool] = REQ(json_validator=check_bool, default=None),
     edit_topic_policy: Optional[int] = REQ(
-        json_validator=check_int_in(Realm.COMMON_MESSAGE_POLICY_TYPES), default=None
+        json_validator=check_int_in(Realm.EDIT_TOPIC_POLICY_TYPES), default=None
     ),
     mandatory_topics: Optional[bool] = REQ(json_validator=check_bool, default=None),
     message_content_edit_limit_seconds_raw: Optional[Union[int, str]] = REQ(

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -116,7 +116,7 @@ def update_realm(
         json_validator=check_int_in(Realm.COMMON_POLICY_TYPES), default=None
     ),
     move_messages_between_streams_policy: Optional[int] = REQ(
-        json_validator=check_int_in(Realm.COMMON_POLICY_TYPES), default=None
+        json_validator=check_int_in(Realm.MOVE_MESSAGES_BETWEEN_STREAMS_POLICY_TYPES), default=None
     ),
     user_group_edit_policy: Optional[int] = REQ(
         json_validator=check_int_in(Realm.COMMON_POLICY_TYPES), default=None


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- FIrst commit is just to remove an unnecessary comment.
- Second and third commits are to add `Nobody` option to `edit_topic_policy` and `move_message_between_streams_policy` setting.
- Fourth commit is for API changes to make stream and topic editing independent of `allow_message_editing`.
- Fifth commit is for webapp changes to make stream and topic editing independent of `allow_message_editing`.
- Sixth commit is to update API to make topic editing permission independent of message sender and not allow message sender to edit topic indefinitely.
- Seventh commit is a refactor commit (explained in detail in commit message).
- Eigth commit is to update webapp to make topic editing permission independent of message sender and not allow message sender to edit topic indefinitely.

Fixes: <!-- Issue link, or clear description.--> Part of #21739.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
