### PR TITLE
python: Use ‘not in’ for more negated membership tests

### DIFF
--- a/scripts/nagios/check-rabbitmq-consumers
+++ b/scripts/nagios/check-rabbitmq-consumers
@@ -19,7 +19,7 @@ states = {
     3: "UNKNOWN",
 }
 
-if "USER" in os.environ and not os.environ["USER"] in ["root", "rabbitmq"]:
+if "USER" in os.environ and os.environ["USER"] not in ["root", "rabbitmq"]:
     print("This script must be run as the root or rabbitmq user")
 
 

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -399,7 +399,7 @@ def enforce_proper_coverage(coverage_json: Any) -> bool:
     coverage_lost = False
     for relative_path in enforce_fully_covered:
         path = ROOT_DIR + "/" + relative_path
-        if not (path in coverage_json):
+        if path not in coverage_json:
             coverage_lost = True
             print_error(f"{relative_path} has no node test coverage")
             continue


### PR DESCRIPTION
Fixes “E713 Test for membership should be `not in`” found by ruff (now that I’ve [fixed](https://github.com/charliermarsh/ruff/pull/238) it not to ignore scripts lacking a .py extension).

Followup to #22982.