### PR TITLE
messagebox: Undo regression that removed higlights for mentions. 

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -698,7 +698,8 @@ body.dark-theme {
         text-shadow: none;
     }
 
-    .mention .messagebox {
+    .group_mention .messagebox,
+    .direct_mention .messagebox {
         background-color: hsla(8, 78%, 43%, 0.15);
     }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1255,7 +1255,8 @@ td.pointer {
     background-color: hsl(0, 0%, 88%);
 }
 
-.mention .messagebox {
+.group_mention .messagebox,
+.direct_mention .messagebox {
     background-color: hsl(8, 94%, 94%);
 }
 


### PR DESCRIPTION
Regression introduced in 3f66a9ef2bd5ab38ced2d11640a0ba899f82e347

CZO discussion https://chat.zulip.org/#narrow/stream/9-issues/topic/mention.20highlighting.20broken/near/1441212
