### PR TITLE
help center: Rewrite "Contact support" page

### DIFF
--- a/templates/zerver/help/contact-support.md
+++ b/templates/zerver/help/contact-support.md
@@ -1,34 +1,38 @@
 # Contact support
 
-General and technical support for Zulip is available through three
-channels:
+We're here to help! This page will guide you to the best way to reach us.
 
-* [The Zulip development community][development-community].
-  Depending on the time of day/week of your query and the complexity
-  of your question, you may get complete responses immediately or up
-  to a couple days later, but Zulip's threading makes it easy for us
-  to reply to every thread. Please read the community conventions
-  (linked above) and choose a topic when starting a conversation.
-* We aim to reply to [email support](mailto:support@zulip.com)
-  questions within a business day. Simple queries or requests for
-  data imports generally receive faster replies.
-* GitHub [server](https://github.com/zulip/zulip/issues/new), web
-  [frontend](https://github.com/zulip/zulip/issues/new), [mobile
-  app](https://github.com/zulip/zulip-mobile/issues/new), [desktop
-  app](https://github.com/zulip/zulip-desktop/issues/new). If you
-  aren't able to provide a clear bug report or are otherwise
-  uncertain, it can be helpful to discuss in
-  [the Zulip development community][development-community]
-  first to help create a better GitHub issue.
-* We don't offer phone support except as part of enterprise contracts.
+* For **support requests** regarding your Zulip Cloud organization or
+  self-hosted server, [email Zulip support](mailto:support@zulip.com).
+    * Response time: Usually 1-3 business days, or within one business day for
+  paid customers.
 
-We love hearing feedback! Please reach out if you have feedback,
-questions, or just want to brainstorm how to make Zulip work for your
-organization.
+* For **sales**, **billing**, **partnerships**, and **other commercial
+  questions**, contact [sales@zulip.com](mailto:sales@zulip.com).
+    * Response time: Usually within one business day.
+
+* To **suggest new features**, **report an issue**, or **share any other
+  feedback**, join the [Zulip development community][development-community].
+  It's the best place to interactively discuss your problem or proposal. Please
+  [follow the community norms](/development-community/#community-norms) when
+  posting.
+    * Response time: Usually within one business day.
+
+* If you have a **concrete bug report**, you can create an issue in the
+  appropriate [Zulip GitHub repository](https://github.com/zulip). Use the
+  [server/web app](https://github.com/zulip/zulip/issues/new) repository if you
+  aren't sure where to start.
+    * Response time: Usually within one week.
+
+* Phone support is available only for **Enterprise support customers**.
+
+Your feedback helps us make Zulip better for everyone! Please reach out if you
+have questions, suggestions, or just want to brainstorm how to make Zulip work
+for your organization.
 
 [development-community]: https://zulip.com/development-community/
 
-## Billing and commercial questions
+## Related articles
 
-We provide exclusively [email support](mailto:support@zulip.com)
-for sales, billing, partnerships, and other commercial questions.
+* [Zulip Cloud billing](/help/zulip-cloud-billing)
+* [View Zulip version](/help/view-zulip-version)

--- a/templates/zerver/help/zulip-cloud-billing.md
+++ b/templates/zerver/help/zulip-cloud-billing.md
@@ -60,3 +60,4 @@ guest.
 * [Trying out Zulip](/help/trying-out-zulip)
 * [Zulip Cloud or self-hosting?](/help/zulip-cloud-or-self-hosting)
 * [Migrating from other chat tools](/help/migrating-from-other-chat-tools)
+* [Contact support](/help/contact-support)


### PR DESCRIPTION
Approach:

- Structure page as use case -> recommended channel.
- Include expected SLAs for all channels.

Current page: https://zulip.com/help/contact-support

Testing: Manually tested links.

Updated page:

![Screen Shot 2022-09-26 at 4 35 03 PM](https://user-images.githubusercontent.com/2090066/192399161-c68081ac-167c-407f-ad5e-13112e3b074e.png)
