### PR TITLE
templates: Use help link widget in invite user modal.

### DIFF
--- a/static/templates/invite_user.hbs
+++ b/static/templates/invite_user.hbs
@@ -52,9 +52,7 @@
                 </div>
                 <div class="input-group">
                     <label for="invite_as">{{t "User(s) join as" }}
-                        <a href="/help/roles-and-permissions" target="_blank" rel="noopener noreferrer">
-                            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                        </a>
+                        {{> help_link_widget link="/help/roles-and-permissions" }}
                     </label>
                     <div>
                         <select id="invite_as">


### PR DESCRIPTION
Updates the help center link/icon in the invite user modal to use the `help_link_widget`.

When I was reviewing another PR, I noticed that this was the only frontend template with the help center link icon (`fa fa-question-circle-o`) not using the help link widget.

----

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
