### PR TITLE
help-docs: Add a note about read receipts to 'Mute a user' article.

### DIFF
--- a/templates/zerver/help/marking-messages-as-read.md
+++ b/templates/zerver/help/marking-messages-as-read.md
@@ -76,3 +76,4 @@ stream or topic as read**.
 ## Related articles
 
 * [Reading strategies](/help/reading-strategies)
+* [Read receipts](/help/read-receipts)

--- a/templates/zerver/help/mute-a-user.md
+++ b/templates/zerver/help/mute-a-user.md
@@ -30,6 +30,10 @@ have the following effects:
 * Muted users are excluded from the autocomplete for composing a
   private message or [mentioning a user](/help/mention-a-user-or-group).
 
+* Muted users are excluded from [read receipts](/help/read-receipts)
+  for all messages. Zulip never shares whether or not you have read
+  a message with a user you've muted.
+
 * Recent topics and other features that display avatars will show a
   generic user symbol in place of a muted user's profile picture.
 


### PR DESCRIPTION
Adds a bullet point about muted users being excluded from read receipts for all messages.

Follow-up to #22941.

---

**Screenshots and screen captures:**

![Screenshot from 2022-09-28 13-10-23](https://user-images.githubusercontent.com/63245456/192804126-967a10c1-5fbf-42eb-8da5-951bcc006c88.png)

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
