### PR TITLE
analytics: Add summary statistics section to page.

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -122,6 +122,18 @@ function get_user_summary_statistics(data) {
     $("#id_active_fifteen_day_users").closest("summary-stats").show();
 }
 
+function get_total_messages_sent(data) {
+    if (data.length === 0) {
+        return;
+    }
+
+    const total_messages_sent = data.human.at(-1) + data.bot.at(-1);
+    const total_messages_string = total_messages_sent.toLocaleString();
+
+    $("#id_total_messages_sent").text(total_messages_string);
+    $("#id_total_messages_sent").closest("summary-stats").show();
+}
+
 // PLOTLY CHARTS
 function populate_messages_sent_over_time(data) {
     if (data.end_times.length === 0) {
@@ -312,6 +324,7 @@ function populate_messages_sent_over_time(data) {
     date_formatter = function (date) {
         return format_date(date, true);
     };
+    get_total_messages_sent(values);
     const cumulative_traces = make_traces(dates, values, "scatter", date_formatter);
 
     // Functions to draw and interact with the plot

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -101,6 +101,28 @@ $(() => {
     // Add configuration for any additional tooltips here.
 });
 
+// SUMMARY STATISTICS
+function get_user_summary_statistics(data) {
+    if (data.length === 0) {
+        return;
+    }
+
+    // Users that are not deactivated and are not bots.
+    const total_users = data.all_time.at(-1);
+    const total_users_string = total_users.toLocaleString();
+
+    $("#id_total_users").text(total_users_string);
+    $("#id_total_users").closest("summary-stats").show();
+
+    // Users that have been active in the last 15 days and are not bots.
+    const active_fifeteen_day_users = data._15day.at(-1);
+    const active_fifteen_day_users_string = active_fifeteen_day_users.toLocaleString();
+
+    $("#id_active_fifteen_day_users").text(active_fifteen_day_users_string);
+    $("#id_active_fifteen_day_users").closest("summary-stats").show();
+}
+
+// PLOTLY CHARTS
 function populate_messages_sent_over_time(data) {
     if (data.end_times.length === 0) {
         // TODO: do something nicer here
@@ -785,6 +807,7 @@ function populate_number_of_users(data) {
     // Initial drawing of plot
     draw_or_update_plot(all_time_trace, true);
     $("#all_time_actives_button").addClass("selected");
+    get_user_summary_statistics(data.everyone);
 }
 
 function populate_messages_read_over_time(data) {

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -134,6 +134,25 @@ function get_total_messages_sent(data) {
     $("#id_total_messages_sent").closest("summary-stats").show();
 }
 
+function get_thirty_days_messages_sent(data) {
+    if (data.length === 0) {
+        return;
+    }
+
+    const thirty_days_bot_messages = data.bot
+        .slice(-30)
+        .reduce((total_messages, day_messages) => total_messages + day_messages);
+    const thirty_days_human_messages = data.human
+        .slice(-30)
+        .reduce((total_messages, day_messages) => total_messages + day_messages);
+
+    const thirty_days_total_messages = thirty_days_bot_messages + thirty_days_human_messages;
+    const thirty_days_messages_string = thirty_days_total_messages.toLocaleString();
+
+    $("#id_thirty_days_messages_sent").text(thirty_days_messages_string);
+    $("#id_thirty_days_messages_sent").closest("summary-stats").show();
+}
+
 // PLOTLY CHARTS
 function populate_messages_sent_over_time(data) {
     if (data.end_times.length === 0) {
@@ -307,6 +326,7 @@ function populate_messages_sent_over_time(data) {
     };
     const last_day_is_partial = info.last_value_is_partial;
     const daily_traces = make_traces(info.dates, info.values, "bar", date_formatter);
+    get_thirty_days_messages_sent(info.values);
 
     info = aggregate_data("week");
     date_formatter = function (date) {

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -22,16 +22,21 @@ p {
 }
 
 .center-charts {
-    margin: 30px auto;
-    width: 790px; /* chart = 750px + 20px padding */
+    margin: 30px;
 }
 
-.stats-page .alert {
+.stats-page .alert,
+.analytics-page-header {
     text-align: center;
 }
 
+.flex-container {
+    display: flex;
+    flex-flow: wrap;
+    justify-content: space-around;
+}
+
 .chart-container {
-    display: inline-block;
     vertical-align: top;
     margin: 10px 0;
     padding: 20px;
@@ -222,21 +227,5 @@ p {
 @keyframes spinner {
     to {
         transform: rotate(360deg);
-    }
-}
-
-@media (width >= 1680px) {
-    .center-charts {
-        width: calc(
-            816px * 2
-        ); /* 790px + 4px for borders + 2px for il-block + 20px margins */
-
-        .left,
-        .right {
-            display: inline-block;
-            vertical-align: top;
-            margin: 0 10px;
-            width: 790px;
-        }
     }
 }

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -30,6 +30,20 @@ p {
     text-align: center;
 }
 
+.summary-stats {
+    vertical-align: top;
+    margin: 0 auto;
+    padding: 20px;
+    border: 2px solid hsl(0, 0%, 93%);
+    background-color: hsl(0, 0%, 100%);
+    width: 395px;
+
+    h1 {
+        margin-top: 0;
+        font-size: 1.5em;
+    }
+}
+
 .flex-container {
     display: flex;
     flex-flow: wrap;

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -21,8 +21,44 @@
         <div id="id_stats_errors" class="alert alert-error"></div>
         <div class="center-charts">
             <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ target_name }}{% endtrans %}</h1>
-
-            <div class="left">
+            <div class="flex-container">
+                <div class="chart-container">
+                    <h1>{{ _("Active users") }}</h1>
+                    <div class="button-container">
+                        <div class="buttons button-active-users">
+                            <button class="button" type="button" id="1day_actives_button">{{ _("Daily actives") }}</button>
+                            <button class="button" type="button" id="15day_actives_button">{{ _("15 day actives") }}</button>
+                            <button class="button" type="button" id="all_time_actives_button">{{ _("Total users") }}</button>
+                        </div>
+                    </div>
+                    <div id="id_number_of_users">
+                        <div class="spinner"></div>
+                    </div>
+                    <div id="users_hover_info" class="number-stat">
+                        <span id="users_hover_date"></span>
+                        <b id="users_hover_humans">{{ _("Users") }}: </b>
+                        <span id="users_hover_1day_value"></span>
+                        <span id="users_hover_15day_value"></span>
+                        <span id="users_hover_all_time_value"></span>
+                    </div>
+                </div>
+                <div class="chart-container pie-chart">
+                    <div id="pie_messages_sent_by_type">
+                        <h1>{{ _("Messages sent by recipient type") }}</h1>
+                        <div id="id_messages_sent_by_message_type">
+                            <div class="spinner"></div>
+                        </div>
+                        <div id="pie_messages_sent_by_type_total" class="number-stat"></div>
+                        <div class="buttons">
+                            <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
+                            <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
+                            <button class="button" type="button" data-time="week">{{ _("Last week") }}</button>
+                            <button class="button selected" type="button" data-time="month">{{ _("Last month") }}</button>
+                            <button class="button" type="button" data-time="year">{{ _("Last year") }}</button>
+                            <button class="button" type="button" data-time="cumulative">{{ _("All time") }}</button>
+                        </div>
+                    </div>
+                </div>
                 <div class="chart-container">
                     <h1>{{ _("Messages sent over time") }}</h1>
                     <div class="button-container">
@@ -46,64 +82,6 @@
                         <span id="hover_bot_value"></span>
                     </div>
                 </div>
-
-                <div class="chart-container pie-chart">
-                    <div id="pie_messages_sent_by_client">
-                        <h1>{{ _("Messages sent by client") }}</h1>
-                        <div id="id_messages_sent_by_client" class="number-stat">
-                            <div class="spinner"></div>
-                        </div>
-                        <div class="buttons">
-                            <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
-                            <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
-                            <button class="button" type="button" data-time="week">{{ _("Last week") }}</button>
-                            <button class="button selected" type="button" data-time="month">{{ _("Last month") }}</button>
-                            <button class="button" type="button" data-time="year">{{ _("Last year") }}</button>
-                            <button class="button" type="button" data-time="cumulative">{{ _("All time") }}</button>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="chart-container">
-                    <h1>{{ _("Active users") }}</h1>
-                    <div class="button-container">
-                        <div class="buttons button-active-users">
-                            <button class="button" type="button" id="1day_actives_button">{{ _("Daily actives") }}</button>
-                            <button class="button" type="button" id="15day_actives_button">{{ _("15 day actives") }}</button>
-                            <button class="button" type="button" id="all_time_actives_button">{{ _("Total users") }}</button>
-                        </div>
-                    </div>
-                    <div id="id_number_of_users">
-                        <div class="spinner"></div>
-                    </div>
-                    <div id="users_hover_info" class="number-stat">
-                        <span id="users_hover_date"></span>
-                        <b id="users_hover_humans">{{ _("Users") }}: </b>
-                        <span id="users_hover_1day_value"></span>
-                        <span id="users_hover_15day_value"></span>
-                        <span id="users_hover_all_time_value"></span>
-                    </div>
-                </div>
-            </div>
-
-            <div class="right">
-                <div class="chart-container pie-chart">
-                    <div id="pie_messages_sent_by_type">
-                        <h1>{{ _("Messages sent by recipient type") }}</h1>
-                        <div id="id_messages_sent_by_message_type">
-                            <div class="spinner"></div>
-                        </div>
-                        <div id="pie_messages_sent_by_type_total" class="number-stat"></div>
-                        <div class="buttons">
-                            <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
-                            <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
-                            <button class="button" type="button" data-time="week">{{ _("Last week") }}</button>
-                            <button class="button selected" type="button" data-time="month">{{ _("Last month") }}</button>
-                            <button class="button" type="button" data-time="year">{{ _("Last year") }}</button>
-                            <button class="button" type="button" data-time="cumulative">{{ _("All time") }}</button>
-                        </div>
-                    </div>
-                </div>
                 <div class="chart-container">
                     <h1>{{ _("Messages read over time") }}</h1>
                     <div class="button-container">
@@ -123,6 +101,22 @@
                         <span id="read_hover_me_value"></span>
                         <b id="read_hover_everyone">{{ _("Everyone") }}:</b>
                         <span id="read_hover_everyone_value"></span>
+                    </div>
+                </div>
+                <div class="chart-container pie-chart">
+                    <div id="pie_messages_sent_by_client">
+                        <h1>{{ _("Messages sent by client") }}</h1>
+                        <div id="id_messages_sent_by_client">
+                            <div class="spinner"></div>
+                        </div>
+                        <div class="buttons">
+                            <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
+                            <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
+                            <button class="button" type="button" data-time="week">{{ _("Last week") }}</button>
+                            <button class="button selected" type="button" data-time="month">{{ _("Last month") }}</button>
+                            <button class="button" type="button" data-time="year">{{ _("Last year") }}</button>
+                            <button class="button" type="button" data-time="cumulative">{{ _("All time") }}</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -21,6 +21,14 @@
         <div id="id_stats_errors" class="alert alert-error"></div>
         <div class="center-charts">
             <h1 class="analytics-page-header">{% trans %}Zulip analytics for {{ target_name }}{% endtrans %}</h1>
+            <div class="summary-stats">
+                <h1>{{ _("Organization summary") }}</h1>
+                <ul>
+                    <li>{{ _("Number of users") }}: <span id="id_total_users"></span></li>
+                    <li>{{ _("Users active during the last 15 days") }}: <span id="id_active_fifteen_day_users"></span></li>
+
+                </ul>
+            </div>
             <div class="flex-container">
                 <div class="chart-container">
                     <h1>{{ _("Active users") }}</h1>

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -26,7 +26,7 @@
                 <ul>
                     <li>{{ _("Number of users") }}: <span id="id_total_users"></span></li>
                     <li>{{ _("Users active during the last 15 days") }}: <span id="id_active_fifteen_day_users"></span></li>
-
+                    <li>{{ _("Total number of messages") }}: <span id="id_total_messages_sent"></span></li>
                 </ul>
             </div>
             <div class="flex-container">

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -27,6 +27,7 @@
                     <li>{{ _("Number of users") }}: <span id="id_total_users"></span></li>
                     <li>{{ _("Users active during the last 15 days") }}: <span id="id_active_fifteen_day_users"></span></li>
                     <li>{{ _("Total number of messages") }}: <span id="id_total_messages_sent"></span></li>
+                    <li>{{ _("Number of messages in the last 30 days") }}: <span id="id_thirty_days_messages_sent"></span></li>
                 </ul>
             </div>
             <div class="flex-container">


### PR DESCRIPTION
Adds a summary statistics section to the organization `/stats/` page. and adds the first three statistics using the data already there from the charts. Also, reorders the charts on the page and changes HTML/CSS to use Flexbox.

1. Number of users
2. Total number of messages
3. Number of messages in the last 30 days

Part of #20162. Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/summary.20stats.20.2320162/near/1441118).

---

**Notes**:
- The first commit is the reordering of the charts and switching to Flexbox.
- The second commit adds the summary statistics section to the HTML and the active users stat. This value matches the last updated count to the related chart.
- The 30 days statistic matches the **Messages sent over time** chart when set to daily and last 30 days, which means the current day is likely a partial sum since this count is updated every hour.

---

**Screenshots and screen captures:**

<details>
<summary>All charts</summary>

![Screenshot from 2022-09-28 17-31-36](https://user-images.githubusercontent.com/63245456/192824591-02457120-83cb-4085-bcc0-c1c5c43f39aa.png)
</details>

<details>
<summary>Summary section</summary>

![Screenshot from 2022-09-28 17-33-08](https://user-images.githubusercontent.com/63245456/192824201-44bf20f2-44ab-4c43-a556-439532e2d22f.png)
</details>

<details>
<summary>Screencast of resizing the window</summary>

[Screencast from 28-09-22 17:32:10.webm](https://user-images.githubusercontent.com/63245456/192824262-7eca51b4-b6fc-481a-b98c-f074739c0223.webm)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
