### PR TITLE
analytics: Fix cut off legends and range selector in existing charts.

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -107,6 +107,19 @@ $(() => {
     // Add configuration for any additional tooltips here.
 });
 
+// Helper used in vertical bar charts
+function make_rangeselector(button1, button2) {
+    return {
+        x: -0.045,
+        y: -0.62,
+        buttons: [
+            {stepmode: "backward", ...button1},
+            {stepmode: "backward", ...button2},
+            {step: "all", label: $t({defaultMessage: "All time"})},
+        ],
+    };
+}
+
 // SUMMARY STATISTICS
 function get_user_summary_statistics(data) {
     if (data.length === 0) {
@@ -198,7 +211,7 @@ function populate_messages_sent_over_time(data) {
         barmode: "group",
         width: 750,
         height: 400,
-        margin: {l: 40, r: 0, b: 40, t: 0},
+        margin: {l: 40, r: 10, b: 40, t: 0},
         xaxis: {
             fixedrange: true,
             rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
@@ -215,28 +228,12 @@ function populate_messages_sent_over_time(data) {
         font: font_12pt,
     };
 
-    function make_rangeselector(x, y, button1, button2) {
-        return {
-            x,
-            y,
-            buttons: [
-                {stepmode: "backward", ...button1},
-                {stepmode: "backward", ...button2},
-                {step: "all", label: $t({defaultMessage: "All time"})},
-            ],
-        };
-    }
-
     // This is also the cumulative rangeselector
     const daily_rangeselector = make_rangeselector(
-        0.68,
-        -0.62,
         {count: 10, label: $t({defaultMessage: "Last 10 days"}), step: "day"},
         {count: 30, label: $t({defaultMessage: "Last 30 days"}), step: "day"},
     );
     const weekly_rangeselector = make_rangeselector(
-        0.656,
-        -0.62,
         {count: 2, label: $t({defaultMessage: "Last 2 months"}), step: "month"},
         {count: 6, label: $t({defaultMessage: "Last 6 months"}), step: "month"},
     );
@@ -487,7 +484,7 @@ function populate_messages_sent_by_client(data) {
     const layout = {
         width: 750,
         height: null, // set in draw_plot()
-        margin: {l: 3, r: 40, b: 40, t: 0},
+        margin: {l: 10, r: 10, b: 40, t: 10},
         font: font_14pt,
         xaxis: {range: null}, // set in draw_plot()
         yaxis: {showticklabels: false},
@@ -626,7 +623,7 @@ function populate_messages_sent_by_client(data) {
 
 function populate_messages_sent_by_message_type(data) {
     const layout = {
-        margin: {l: 90, r: 0, b: 0, t: 0},
+        margin: {l: 90, r: 0, b: 10, t: 0},
         width: 750,
         height: 300,
         legend: {
@@ -743,32 +740,19 @@ function populate_messages_sent_by_message_type(data) {
 }
 
 function populate_number_of_users(data) {
+    const weekly_rangeselector = make_rangeselector(
+        {count: 2, label: $t({defaultMessage: "Last 2 months"}), step: "month"},
+        {count: 6, label: $t({defaultMessage: "Last 6 months"}), step: "month"},
+    );
+
     const layout = {
         width: 750,
         height: 370,
-        margin: {l: 40, r: 0, b: 65, t: 20},
+        margin: {l: 40, r: 10, b: 40, t: 0},
         xaxis: {
             fixedrange: true,
             rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
-            rangeselector: {
-                x: 0.64,
-                y: -0.79,
-                buttons: [
-                    {
-                        count: 2,
-                        label: $t({defaultMessage: "Last 2 months"}),
-                        step: "month",
-                        stepmode: "backward",
-                    },
-                    {
-                        count: 6,
-                        label: $t({defaultMessage: "Last 6 months"}),
-                        step: "month",
-                        stepmode: "backward",
-                    },
-                    {step: "all", label: $t({defaultMessage: "All time"})},
-                ],
-            },
+            rangeselector: weekly_rangeselector,
             tickangle: 0,
         },
         yaxis: {fixedrange: true, rangemode: "tozero"},
@@ -883,7 +867,7 @@ function populate_messages_read_over_time(data) {
         barmode: "group",
         width: 750,
         height: 400,
-        margin: {l: 40, r: 0, b: 40, t: 0},
+        margin: {l: 40, r: 10, b: 40, t: 0},
         xaxis: {
             fixedrange: true,
             rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
@@ -900,28 +884,12 @@ function populate_messages_read_over_time(data) {
         font: font_12pt,
     };
 
-    function make_rangeselector(x, y, button1, button2) {
-        return {
-            x,
-            y,
-            buttons: [
-                {stepmode: "backward", ...button1},
-                {stepmode: "backward", ...button2},
-                {step: "all", label: $t({defaultMessage: "All time"})},
-            ],
-        };
-    }
-
     // This is also the cumulative rangeselector
     const daily_rangeselector = make_rangeselector(
-        0.68,
-        -0.62,
         {count: 10, label: $t({defaultMessage: "Last 10 days"}), step: "day"},
         {count: 30, label: $t({defaultMessage: "Last 30 days"}), step: "day"},
     );
     const weekly_rangeselector = make_rangeselector(
-        0.656,
-        -0.62,
         {count: 2, label: $t({defaultMessage: "Last 2 months"}), step: "month"},
         {count: 6, label: $t({defaultMessage: "Last 6 months"}), step: "month"},
     );

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -10,8 +10,14 @@ import {page_params} from "../page_params";
 Plotly.register([PlotlyBar, PlotlyPie]);
 
 const font_14pt = {
-    family: "Source Sans 3",
+    family: "Open Sans, sans-serif",
     size: 14,
+    color: "#000000",
+};
+
+const font_12pt = {
+    family: "Open Sans, sans-serif",
+    size: 12,
     color: "#000000",
 };
 
@@ -197,6 +203,7 @@ function populate_messages_sent_over_time(data) {
             fixedrange: true,
             rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
             type: "date",
+            tickangle: 0,
         },
         yaxis: {fixedrange: true, rangemode: "tozero"},
         legend: {
@@ -205,7 +212,7 @@ function populate_messages_sent_over_time(data) {
             orientation: "h",
             font: font_14pt,
         },
-        font: font_14pt,
+        font: font_12pt,
     };
 
     function make_rangeselector(x, y, button1, button2) {
@@ -531,7 +538,6 @@ function populate_messages_sent_by_client(data) {
                 textinfo: "text",
                 hoverinfo: "none",
                 marker: {color: "#537c5e"},
-                font: {family: "Source Sans 3", size: 18, color: "#000000"},
             },
             trace_annotations: {
                 x: annotations.values,
@@ -623,7 +629,10 @@ function populate_messages_sent_by_message_type(data) {
         margin: {l: 90, r: 0, b: 0, t: 0},
         width: 750,
         height: 300,
-        font: font_14pt,
+        legend: {
+            font: font_14pt,
+        },
+        font: font_12pt,
     };
 
     function make_plot_data(time_series_data, num_steps) {
@@ -760,9 +769,10 @@ function populate_number_of_users(data) {
                     {step: "all", label: $t({defaultMessage: "All time"})},
                 ],
             },
+            tickangle: 0,
         },
         yaxis: {fixedrange: true, rangemode: "tozero"},
-        font: font_14pt,
+        font: font_12pt,
     };
 
     const end_dates = data.end_times.map((timestamp) => new Date(timestamp * 1000));
@@ -878,6 +888,7 @@ function populate_messages_read_over_time(data) {
             fixedrange: true,
             rangeslider: {bordercolor: "#D8D8D8", borderwidth: 1},
             type: "date",
+            tickangle: 0,
         },
         yaxis: {fixedrange: true, rangemode: "tozero"},
         legend: {
@@ -886,7 +897,7 @@ function populate_messages_read_over_time(data) {
             orientation: "h",
             font: font_14pt,
         },
-        font: font_14pt,
+        font: font_12pt,
     };
 
     function make_rangeselector(x, y, button1, button2) {

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -3,10 +3,6 @@ body {
     background-color: hsl(0, 0%, 98%);
 }
 
-hr {
-    border-width: 2px;
-}
-
 p {
     margin-bottom: 0;
 }
@@ -70,10 +66,6 @@ p {
     &:not(.pie-chart) .number-stat {
         position: relative;
         top: -30px;
-    }
-
-    &.pie-chart hr {
-        margin-bottom: 8px;
     }
 
     .button-container {

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -71,6 +71,7 @@ p {
     .button-container {
         position: relative;
         z-index: 1;
+        margin-bottom: 5px;
 
         > * {
             display: inline-block;
@@ -97,14 +98,6 @@ p {
         font-size: 0.8em;
         font-weight: 400;
     }
-
-    .buttons {
-        float: right;
-
-        button {
-            padding: 2px 6px;
-        }
-    }
 }
 
 .buttons button {
@@ -115,22 +108,15 @@ p {
     }
 }
 
-.button-active-users {
-    float: right;
-}
-
 .button {
     font-family: "Source Sans 3", sans-serif !important;
     border: none;
     border-radius: 4px;
     outline: none;
+    padding: 2px 6px;
 
     &:hover {
         background-color: hsl(0, 0%, 84%) !important;
-    }
-
-    &[data-user="everyone"] {
-        margin-right: 10px;
     }
 }
 
@@ -198,6 +184,10 @@ p {
     display: none;
 }
 
+#pie_messages_sent_by_type_total {
+    float: right;
+}
+
 #users_hover_info,
 #read_hover_info,
 #hoverinfo {
@@ -205,9 +195,9 @@ p {
     font-size: 0.8em;
     font-weight: 400;
     position: relative;
+    float: right;
     height: 0;
-    top: -35px;
-    left: 40px;
+    top: -25px;
 }
 
 .spinner::before {

--- a/static/styles/portico/stats.css
+++ b/static/styles/portico/stats.css
@@ -72,10 +72,6 @@ p {
         position: relative;
         z-index: 1;
 
-        label {
-            margin: 3px;
-        }
-
         > * {
             display: inline-block;
             vertical-align: top;

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -34,7 +34,7 @@
                 <div class="chart-container">
                     <h1>{{ _("Active users") }}</h1>
                     <div class="button-container">
-                        <div class="buttons button-active-users">
+                        <div class="buttons">
                             <button class="button" type="button" id="1day_actives_button">{{ _("Daily actives") }}</button>
                             <button class="button" type="button" id="15day_actives_button">{{ _("15 day actives") }}</button>
                             <button class="button" type="button" id="all_time_actives_button">{{ _("Total users") }}</button>
@@ -54,13 +54,17 @@
                 <div class="chart-container pie-chart">
                     <div id="pie_messages_sent_by_type">
                         <h1>{{ _("Messages sent by recipient type") }}</h1>
+                        <div class="button-container">
+                            <div class="buttons">
+                                <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
+                                <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
+                            </div>
+                        </div>
                         <div id="id_messages_sent_by_message_type">
                             <div class="spinner"></div>
                         </div>
                         <div id="pie_messages_sent_by_type_total" class="number-stat"></div>
                         <div class="buttons">
-                            <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
-                            <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
                             <button class="button" type="button" data-time="week">{{ _("Last week") }}</button>
                             <button class="button selected" type="button" data-time="month">{{ _("Last month") }}</button>
                             <button class="button" type="button" data-time="year">{{ _("Last year") }}</button>
@@ -113,12 +117,16 @@
                 <div class="chart-container pie-chart">
                     <div id="pie_messages_sent_by_client">
                         <h1>{{ _("Messages sent by client") }}</h1>
+                        <div class="button-container">
+                            <div class="buttons">
+                                <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
+                                <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
+                            </div>
+                        </div>
                         <div id="id_messages_sent_by_client">
                             <div class="spinner"></div>
                         </div>
                         <div class="buttons">
-                            <button class="button" type="button" data-user="user">{{ _("Me") }}</button>
-                            <button class="button selected" type="button" data-user="everyone">{{ _("Everyone") }}</button>
                             <button class="button" type="button" data-time="week">{{ _("Last week") }}</button>
                             <button class="button selected" type="button" data-time="month">{{ _("Last month") }}</button>
                             <button class="button" type="button" data-time="year">{{ _("Last year") }}</button>

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -71,7 +71,6 @@
                 <div class="chart-container">
                     <h1>{{ _("Messages sent over time") }}</h1>
                     <div class="button-container">
-                        <label>{{ _("Aggregation") }}</label>
                         <div class="buttons">
                             <button class="button" type="button" id='daily_button'>{{ _("Daily") }} </button>
                             <button class="button" type="button" id='weekly_button'>{{ _("Weekly") }} </button>
@@ -94,7 +93,6 @@
                 <div class="chart-container">
                     <h1>{{ _("Messages read over time") }}</h1>
                     <div class="button-container">
-                        <label>{{ _("Aggregation") }}</label>
                         <div class="buttons">
                             <button class="button" type="button" id='read_daily_button'>{{ _("Daily") }} </button>
                             <button class="button" type="button" id='read_weekly_button'>{{ _("Weekly") }} </button>

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -82,7 +82,7 @@
                     </div>
                     <div id="hoverinfo">
                         <span id="hover_date"></span>
-                        <span id="hover_me">{{ _("Me") }}:</span>
+                        <b id="hover_me">{{ _("Me") }}:</b>
                         <span id="hover_me_value"></span>
                         <b id="hover_human">{{ _("Humans") }}:</b>
                         <span id="hover_human_value"></span>
@@ -104,7 +104,7 @@
                     </div>
                     <div id="read_hover_info">
                         <span id="read_hover_date"></span>
-                        <span id="read_hover_me">{{ _("Me") }}:</span>
+                        <b id="read_hover_me">{{ _("Me") }}:</b>
                         <span id="read_hover_me_value"></span>
                         <b id="read_hover_everyone">{{ _("Everyone") }}:</b>
                         <span id="read_hover_everyone_value"></span>


### PR DESCRIPTION
It appears that when we have `font-family: "Source Sans 3"` for the Plotly.js `layout` parameter, the font-family that appears in the created chart is `"Open Sans", verdana, arial, sans-serif`, not what we intended (you can see this current behavior on the CZO stats page). And this then impacts a clips layer that's set on legends and range selectors, which I think is using "Source Sans 3" to calculate the width needed since it's a narrower font?

Setting the font-family as "Open Sans, sans-serif" fixes the text from being clipped, but the font size of 14 does not work for the horizontal axis on the vertical bar charts with the width we've selected, so this also changes the general font-size for those charts to 12, while still using font-size 14 for the legends.

But changing the font to size 12 on the **Active users** chart caused a bug in the chart rerendering when the range selector sliders were moved. Fixed this by changing the `y` value for the range selector from `-.79` to `-.69`, but I'm not sure why that works.

Marking this as a draft PR for now because I feel like there are other potential bugs from these changes that I haven't yet identified, nor do I feel clear on why the changes I've made work. But I would like some feedback on what I've done so far, and thoughts on how to proceed.

Fixes #18912.

---

**Screenshots and screen captures:**

<details>
<summary>Updated charts with labels not cut off</summary>

![Screenshot from 2022-09-28 18-18-56](https://user-images.githubusercontent.com/63245456/192833055-9ba8cd1f-3f0c-4f5c-ade9-6554ebec5326.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
