### PR TITLE
Cleanup references to "subject" in the frontend

### DIFF
--- a/docs/subsystems/unread_messages.md
+++ b/docs/subsystems/unread_messages.md
@@ -48,5 +48,5 @@ in the register call.
 Three event types are required to correctly maintain the `unread_msgs`. New
 messages can be created without the unread flag by the `message` event type.
 The unread flag can be added and removed by the `update_message_flags` event,
-and the subject of unread messages can be updated by the `update_message` event
+and the topic of unread messages can be updated by the `update_message` event
 type.

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -388,7 +388,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", () => {
         stream_post_policy: stream_data.stream_post_policy_values.admins.code,
     };
 
-    compose_state.topic("subject102");
+    compose_state.topic("topic102");
     compose_state.stream_name("stream102");
     stream_data.add_sub(sub);
     assert.ok(!compose_validate.validate());
@@ -403,7 +403,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", () => {
     page_params.is_admin = false;
     page_params.is_guest = true;
 
-    compose_state.topic("subject102");
+    compose_state.topic("topic102");
     compose_state.stream_name("stream102");
     assert.ok(!compose_validate.validate());
     assert.equal(
@@ -424,7 +424,7 @@ test_ui("test_validate_stream_message_post_policy_moderators_only", () => {
         stream_post_policy: stream_data.stream_post_policy_values.moderators.code,
     };
 
-    compose_state.topic("subject104");
+    compose_state.topic("topic104");
     compose_state.stream_name("stream104");
     stream_data.add_sub(sub);
     assert.ok(!compose_validate.validate());
@@ -457,7 +457,7 @@ test_ui("test_validate_stream_message_post_policy_full_members_only", () => {
         stream_post_policy: stream_data.stream_post_policy_values.non_new_members.code,
     };
 
-    compose_state.topic("subject103");
+    compose_state.topic("topic103");
     compose_state.stream_name("stream103");
     stream_data.add_sub(sub);
     assert.ok(!compose_validate.validate());

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -727,7 +727,7 @@ test("initialize", ({override, mock_template}) => {
         stream_typeahead_called = true;
     };
 
-    let subject_typeahead_called = false;
+    let topic_typeahead_called = false;
     $("#stream_message_recipient_topic").typeahead = (options) => {
         const topics = ["<&>", "even more ice", "furniture", "ice", "kronor", "more ice"];
         stream_topic_history.get_recent_topic_names = (stream_id) => {
@@ -789,7 +789,7 @@ test("initialize", ({override, mock_template}) => {
         expected_value = [];
         assert.deepEqual(actual_value, expected_value);
 
-        subject_typeahead_called = true;
+        topic_typeahead_called = true;
 
         // Unset the stream name.
         $("#stream_message_recipient_stream").val("");
@@ -1210,7 +1210,7 @@ test("initialize", ({override, mock_template}) => {
     // Now let's make sure that all the stub functions have been called
     // during the initialization.
     assert.ok(stream_typeahead_called);
-    assert.ok(subject_typeahead_called);
+    assert.ok(topic_typeahead_called);
     assert.ok(pm_recipient_typeahead_called);
     assert.ok(compose_textarea_typeahead_called);
 });

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1127,7 +1127,7 @@ test("initialize", ({override, mock_template}) => {
 
     event.key = "Tab";
     event.shiftKey = false;
-    event.target.id = "subject";
+    event.target.id = "stream_message_recipient_topic";
     $("form#send_message_form").trigger(event);
     event.target.id = "compose-textarea";
     $("form#send_message_form").trigger(event);

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -67,20 +67,6 @@ const {localstorage} = zrequire("localstorage");
 const drafts = zrequire("drafts");
 const timerender = zrequire("timerender");
 
-const legacy_draft = {
-    stream: "stream",
-    subject: "lunch",
-    type: "stream",
-    content: "whatever",
-};
-
-const compose_args_for_legacy_draft = {
-    stream: "stream",
-    topic: "lunch",
-    type: "stream",
-    content: "whatever",
-};
-
 const draft_1 = {
     stream: "stream",
     stream_id: 30,
@@ -96,7 +82,7 @@ const draft_2 = {
 };
 const short_msg = {
     stream: "stream",
-    subject: "topic",
+    topic: "topic",
     type: "stream",
     content: "a",
 };
@@ -108,10 +94,6 @@ function test(label, f) {
         f(helpers);
     });
 }
-
-test("legacy", () => {
-    assert.deepEqual(drafts.restore_message(legacy_draft), compose_args_for_legacy_draft);
-});
 
 test("draft_model add", ({override}) => {
     const draft_model = drafts.draft_model;
@@ -223,7 +205,7 @@ test("initialize", ({override_rewire}) => {
 test("remove_old_drafts", () => {
     const draft_3 = {
         stream: "stream",
-        subject: "topic",
+        topic: "topic",
         type: "stream",
         content: "Test stream message",
         updatedAt: Date.now(),
@@ -349,7 +331,7 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     };
     const draft_3 = {
         stream: "stream 2",
-        subject: "topic",
+        topic: "topic",
         type: "stream",
         content: "Test stream message 2",
         updatedAt: date(-10),
@@ -490,7 +472,7 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     };
     const stream_draft_2 = {
         stream: "stream 2",
-        subject: "topic",
+        topic: "topic",
         type: "stream",
         content: "Test stream message 2",
         updatedAt: date(-10),

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -421,7 +421,7 @@ test("merge_message_groups", () => {
             status_message: false,
             type: "stream",
             stream: "Test stream 1",
-            topic: "Test subject 1",
+            topic: "Test topic 1",
             sender_email: "test@example.com",
             timestamp: (next_timestamp += 1),
             ...message,
@@ -488,7 +488,7 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_messages_next_same_sender, []);
     })();
 
-    (function test_append_message_same_subject() {
+    (function test_append_message_same_topic() {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -508,11 +508,11 @@ test("merge_message_groups", () => {
         assert_message_list_equal(result.rerender_messages_next_same_sender, [message1]);
     })();
 
-    (function test_append_message_different_subject() {
+    (function test_append_message_different_topic() {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
-        const message2 = build_message_context({topic: "Test subject 2"});
+        const message2 = build_message_context({topic: "Test topic 2"});
         const message_group2 = build_message_group([message2]);
 
         const list = build_list([message_group1]);
@@ -527,11 +527,11 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_messages_next_same_sender, []);
     })();
 
-    (function test_append_message_different_subject_and_days() {
+    (function test_append_message_different_topic_and_days() {
         const message1 = build_message_context({timestamp: 1000});
         const message_group1 = build_message_group([message1]);
 
-        const message2 = build_message_context({topic: "Test subject 2", timestamp: 900000});
+        const message2 = build_message_context({topic: "Test topic 2", timestamp: 900000});
         const message_group2 = build_message_group([message2]);
 
         const list = build_list([message_group1]);
@@ -584,7 +584,7 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_messages_next_same_sender, []);
     })();
 
-    (function test_append_message_same_subject_me_message() {
+    (function test_append_message_same_topic_me_message() {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -605,7 +605,7 @@ test("merge_message_groups", () => {
         assert_message_list_equal(result.rerender_messages_next_same_sender, [message1]);
     })();
 
-    (function test_prepend_message_same_subject() {
+    (function test_prepend_message_same_topic() {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
@@ -627,11 +627,11 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_messages_next_same_sender, []);
     })();
 
-    (function test_prepend_message_different_subject() {
+    (function test_prepend_message_different_topic() {
         const message1 = build_message_context();
         const message_group1 = build_message_group([message1]);
 
-        const message2 = build_message_context({topic: "Test subject 2"});
+        const message2 = build_message_context({topic: "Test topic 2"});
         const message_group2 = build_message_group([message2]);
 
         const list = build_list([message_group1]);
@@ -645,11 +645,11 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_messages_next_same_sender, []);
     })();
 
-    (function test_prepend_message_different_subject_and_day() {
+    (function test_prepend_message_different_topic_and_day() {
         const message1 = build_message_context({timestamp: 900000});
         const message_group1 = build_message_group([message1]);
 
-        const message2 = build_message_context({topic: "Test subject 2", timestamp: 1000});
+        const message2 = build_message_context({topic: "Test topic 2", timestamp: 1000});
         const message_group2 = build_message_group([message2]);
 
         const list = build_list([message_group1]);

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -174,9 +174,9 @@ test("set_compose_defaults", () => {
         ["topic", "Bar"],
     ]);
 
-    const stream_and_subject = narrow_state.set_compose_defaults();
-    assert.equal(stream_and_subject.stream, "Foo");
-    assert.equal(stream_and_subject.topic, "Bar");
+    const stream_and_topic = narrow_state.set_compose_defaults();
+    assert.equal(stream_and_topic.stream, "Foo");
+    assert.equal(stream_and_topic.topic, "Bar");
 
     set_filter([["pm-with", "foo@bar.com"]]);
     let pm_test = narrow_state.set_compose_defaults();

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -27,11 +27,6 @@ run_test("CachedValue", () => {
     assert.equal(cv.get(), 12);
 });
 
-run_test("get_reload_topic", () => {
-    assert.equal(util.get_reload_topic({subject: "foo"}), "foo");
-    assert.equal(util.get_reload_topic({topic: "bar"}), "bar");
-});
-
 run_test("extract_pm_recipients", () => {
     assert.equal(util.extract_pm_recipients("bob@foo.com, alice@foo.com").length, 2);
     assert.equal(util.extract_pm_recipients("bob@foo.com, ").length, 1);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -170,7 +170,7 @@ export function restore_message(draft) {
         compose_args = {
             type: "stream",
             stream: draft.stream,
-            topic: util.get_draft_topic(draft),
+            topic: draft.topic,
             content: draft.content,
         };
     } else {
@@ -306,12 +306,8 @@ export function format_draft(draft) {
                 draft_model.editDraft(id, draft);
             }
         }
-        let draft_topic = util.get_draft_topic(draft);
+        const draft_topic = draft.topic || compose.empty_topic_placeholder();
         const draft_stream_color = stream_data.get_color(stream_name);
-
-        if (draft_topic === "") {
-            draft_topic = compose.empty_topic_placeholder();
-        }
 
         formatted = {
             draft_id: draft.id,

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -176,12 +176,9 @@ export function initialize() {
         const send_now = Number.parseInt(vars.send_after_reload, 10);
 
         try {
-            // TODO: preserve focus
-            const topic = util.get_reload_topic(vars);
-
             compose_actions.start(vars.msg_type, {
                 stream: vars.stream || "",
-                topic: topic || "",
+                topic: vars.topic || "",
                 private_message_recipient: vars.recipient || "",
                 content: vars.msg || "",
                 draft_id: vars.draft_id || "",

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -217,11 +217,6 @@ export function get_match_topic(obj) {
     return obj.match_subject;
 }
 
-export function get_draft_topic(obj) {
-    // We will need to support subject for old drafts.
-    return obj.topic || obj.subject || "";
-}
-
 export function get_reload_topic(obj) {
     // When we first upgrade to releases that have
     // topic=foo in the code, the user's reload URL

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -217,13 +217,6 @@ export function get_match_topic(obj) {
     return obj.match_subject;
 }
 
-export function get_reload_topic(obj) {
-    // When we first upgrade to releases that have
-    // topic=foo in the code, the user's reload URL
-    // may still have subject=foo from the prior version.
-    return obj.topic || obj.subject || "";
-}
-
 export function get_edit_event_topic(obj) {
     if (obj.topic === undefined) {
         return obj.subject;

--- a/templates/zerver/integrations/asana.md
+++ b/templates/zerver/integrations/asana.md
@@ -41,7 +41,7 @@ Get Zulip notifications for your Asana projects via Zapier!
 
 1.  Finally, configure **Data**. You have to add 2 fields:
 
-     * `subject` is the field corresponding to the subject of the message.
+     * `subject` is the field corresponding to the topic of the message.
      * `content` is the field corresponding to the content of the message.
 
 1.  You can format the content of the `content` and `subject` fields


### PR DESCRIPTION
This wraps up some of the preparation work done before removing "subject" in the frontend. More work needs to be done for some references to "subject" that still exist in the backend for messages.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
