### PR TITLE
navigate: Fetch messages if not avaialble in navigate_to_end.

### DIFF
--- a/static/js/navigate.js
+++ b/static/js/navigate.js
@@ -1,5 +1,7 @@
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
+import * as narrow from "./narrow";
+import * as narrow_state from "./narrow_state";
 import * as rows from "./rows";
 import * as unread_ops from "./unread_ops";
 
@@ -48,8 +50,20 @@ export function to_home() {
 }
 
 export function to_end() {
-    const next_id = message_lists.current.last().id;
     message_viewport.set_last_movement_direction(1);
+    if (
+        narrow_state.narrowed_to_topic() &&
+        !message_lists.current.data.fetch_status.has_found_newest()
+    ) {
+        const narrowed_topic = narrow_state.topic();
+        const narrowed_stream = narrow_state.stream();
+        narrow.activate([
+            {operator: "stream", operand: narrowed_stream},
+            {operator: "topic", operand: narrowed_topic},
+        ]);
+    }
+
+    const next_id = message_lists.current.last().id;
     message_lists.current.select_id(next_id, {then_scroll: true, from_scroll: true});
     unread_ops.process_scrolled_to_bottom();
 }


### PR DESCRIPTION
When we go to a topic narrow message using search or using a link and message is somewhat at a beginning of a topic with large number of messages, using "End" keyboard shortcut or the "Scroll to bottom" arrow in UI results in scrolling till the last message that is available and then remaining messages of the topic are load and shown below. Instead it should go to the actual end of that particular topic.

So, we check that if the newest message of that topic is not available, we fetch the messages from server and scroll down till the end of the topic using "narrow.activate".

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->#22986.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![navigate-to-end](https://user-images.githubusercontent.com/35494118/193092336-e68116e0-a482-46e8-9663-6692615229dd.gif)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
