### PR TITLE
message_feed_ui: Remove previous date from date separators.

### DIFF
--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -515,7 +515,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "bottom");
 
-        assert.ok(!message_group2.group_date_divider_html);
+        assert.ok(!message_group2.group_date_html);
         assert_message_groups_list_equal(list._message_groups, [message_group1, message_group2]);
         assert_message_groups_list_equal(result.append_groups, [message_group2]);
         assert.deepEqual(result.prepend_groups, []);
@@ -540,7 +540,7 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_groups, []);
         assert.deepEqual(result.append_messages, []);
         assert.deepEqual(result.rerender_messages_next_same_sender, []);
-        assert.equal(message_group2.group_date_divider_html, "900000000");
+        assert.equal(message_group2.group_date_html, "900000000");
     })();
 
     (function test_append_message_different_day() {
@@ -652,8 +652,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "top");
 
-        // We should have a group date divider between the recipient blocks.
-        assert.equal(message_group1.group_date_divider_html, "900000000");
+        assert.equal(message_group1.group_date_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2, message_group1]);
         assert.deepEqual(result.append_groups, []);
         assert_message_groups_list_equal(result.prepend_groups, [message_group2]);
@@ -672,7 +671,6 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "top");
 
-        // We should have a group date divider within the single recipient block.
         assert.equal(message_group2.message_containers[1].date_divider_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2]);
         assert.deepEqual(result.append_groups, []);

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -14,11 +14,8 @@ const noop = () => {};
 
 // timerender calls setInterval when imported
 mock_esm("../../static/js/timerender", {
-    render_date(time1, time2) {
-        if (time2 === undefined) {
-            return [{outerHTML: String(time1.getTime())}];
-        }
-        return [{outerHTML: String(time1.getTime()) + " - " + String(time2.getTime())}];
+    render_date(time) {
+        return [{outerHTML: String(time.getTime())}];
     },
     stringify_time(time) {
         return time.toString("h:mm TT");
@@ -543,7 +540,7 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.rerender_groups, []);
         assert.deepEqual(result.append_messages, []);
         assert.deepEqual(result.rerender_messages_next_same_sender, []);
-        assert.equal(message_group2.group_date_divider_html, "900000000 - 1000000");
+        assert.equal(message_group2.group_date_divider_html, "900000000");
     })();
 
     (function test_append_message_different_day() {
@@ -656,7 +653,7 @@ test("merge_message_groups", () => {
         const result = list.merge_message_groups([message_group2], "top");
 
         // We should have a group date divider between the recipient blocks.
-        assert.equal(message_group1.group_date_divider_html, "900000000 - 1000000");
+        assert.equal(message_group1.group_date_divider_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2, message_group1]);
         assert.deepEqual(result.append_groups, []);
         assert_message_groups_list_equal(result.prepend_groups, [message_group2]);
@@ -676,7 +673,7 @@ test("merge_message_groups", () => {
         const result = list.merge_message_groups([message_group2], "top");
 
         // We should have a group date divider within the single recipient block.
-        assert.equal(message_group2.message_containers[1].date_divider_html, "900000000 - 1000000");
+        assert.equal(message_group2.message_containers[1].date_divider_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2]);
         assert.deepEqual(result.append_groups, []);
         assert.deepEqual(result.prepend_groups, []);

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -222,36 +222,10 @@ run_test("render_date_renders_time_html", () => {
         return $span_stub;
     };
 
-    const $actual = timerender.render_date(message_time, undefined, today);
+    const $actual = timerender.render_date(message_time, today);
     assert.equal($actual.html(), expected_html);
     assert.equal(attrs["data-tippy-content"], "Friday, April 12, 2019");
     assert.equal(attrs.class, "timerender0");
-});
-
-run_test("render_date_renders_time_above_html", () => {
-    const today = date_2019;
-
-    const message_time = today;
-    const message_time_above = add(today, {days: -1});
-
-    const $span_stub = $("<span>");
-
-    let appended_val;
-    $span_stub.append = (...val) => {
-        appended_val = val;
-        return $span_stub;
-    };
-
-    const expected = [
-        $("<i>"),
-        $t({defaultMessage: "Yesterday"}),
-        $("<hr>"),
-        $("<i>"),
-        $t({defaultMessage: "Today"}),
-    ];
-
-    timerender.render_date(message_time, message_time_above, today);
-    assert.deepEqual(appended_val, expected);
 });
 
 run_test("get_full_time", () => {

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -109,7 +109,7 @@ export function get_date($elem) {
 
     const time = new Date(message.timestamp * 1000);
     const today = new Date();
-    const rendered_date = timerender.render_date(time, undefined, today)[0].outerHTML;
+    const rendered_date = timerender.render_date(time, today)[0].outerHTML;
 
     return rendered_date;
 }

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -107,7 +107,7 @@ function analyze_edit_history(message) {
 function render_group_display_date(group, message_container) {
     const time = new Date(message_container.msg.timestamp * 1000);
     const today = new Date();
-    const date_element = timerender.render_date(time, undefined, today)[0];
+    const date_element = timerender.render_date(time, today)[0];
 
     group.date = date_element.outerHTML;
 }
@@ -116,21 +116,18 @@ function update_group_date_divider(group, message_container, prev) {
     const time = new Date(message_container.msg.timestamp * 1000);
     const today = new Date();
 
+    // TODO: investigate
     if (prev !== undefined) {
         const prev_time = new Date(prev.msg.timestamp * 1000);
         if (!isSameDay(time, prev_time)) {
             // NB: group_date_divider_html is HTML, inserted into the document without escaping.
-            group.group_date_divider_html = timerender.render_date(
-                time,
-                prev_time,
-                today,
-            )[0].outerHTML;
+            group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
             group.show_group_date_divider = true;
         }
     } else {
         // Show the date in the recipient bar, but not a date separator bar.
         group.show_group_date_divider = false;
-        group.group_date_divider_html = timerender.render_date(time, undefined, today)[0].outerHTML;
+        group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
     }
 }
 
@@ -155,16 +152,11 @@ function update_message_date_divider(opts) {
         return;
     }
 
-    const prev_time = new Date(prev_msg_container.msg.timestamp * 1000);
     const curr_time = new Date(curr_msg_container.msg.timestamp * 1000);
     const today = new Date();
 
     curr_msg_container.want_date_divider = true;
-    curr_msg_container.date_divider_html = timerender.render_date(
-        curr_time,
-        prev_time,
-        today,
-    )[0].outerHTML;
+    curr_msg_container.date_divider_html = timerender.render_date(curr_time, today)[0].outerHTML;
 }
 
 function set_timestr(message_container) {
@@ -258,7 +250,7 @@ export class MessageListView {
             const last_edit_time = new Date(last_edit_timestamp * 1000);
             const today = new Date();
             return (
-                timerender.render_date(last_edit_time, undefined, today)[0].textContent +
+                timerender.render_date(last_edit_time, today)[0].textContent +
                 " at " +
                 timerender.stringify_time(last_edit_time)
             );

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -112,28 +112,18 @@ function render_group_display_date(group, message_container) {
     group.date = date_element.outerHTML;
 }
 
-function update_group_date_divider(group, message_container, prev) {
+function update_group_date(group, message_container, prev) {
     const time = new Date(message_container.msg.timestamp * 1000);
     const today = new Date();
 
-    // TODO: investigate
-    if (prev !== undefined) {
-        const prev_time = new Date(prev.msg.timestamp * 1000);
-        if (!isSameDay(time, prev_time)) {
-            // NB: group_date_divider_html is HTML, inserted into the document without escaping.
-            group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
-            group.show_group_date_divider = true;
-        }
-    } else {
-        // Show the date in the recipient bar, but not a date separator bar.
-        group.show_group_date_divider = false;
-        group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
-    }
+    // Show the date in the recipient bar if the previous message was from a different day.
+    group.show_recipient_bar_date = !same_day(message_container, prev);
+    group.group_date_html = timerender.render_date(time, today)[0].outerHTML;
 }
 
-function clear_group_date_divider(group) {
-    group.show_group_date_divider = false;
-    group.group_date_divider_html = undefined;
+function clear_group_date(group) {
+    group.show_recipient_bar_date = true;
+    group.group_date_html = undefined;
 }
 
 function clear_message_date_divider(msg) {
@@ -455,7 +445,7 @@ export class MessageListView {
                 current_group = start_group();
                 add_message_container_to_group(message_container);
 
-                update_group_date_divider(current_group, message_container, prev);
+                update_group_date(current_group, message_container, prev);
                 clear_message_date_divider(message_container);
 
                 message_container.include_recipient = true;
@@ -607,7 +597,7 @@ export class MessageListView {
                 !same_day(second_group.message_containers[0], first_group.message_containers[0])
             ) {
                 // The groups did not merge, so we need up update the date row for the old group
-                update_group_date_divider(second_group, curr_msg_container, prev_msg_container);
+                update_group_date(second_group, curr_msg_container, prev_msg_container);
                 // We could add an action to update the date row, but for now rerender the group.
                 message_actions.rerender_groups.push(second_group);
             }
@@ -621,11 +611,11 @@ export class MessageListView {
                 new_message_groups = new_message_groups.slice(1);
             } else if (first_group !== undefined && second_group !== undefined) {
                 if (same_day(prev_msg_container, curr_msg_container)) {
-                    clear_group_date_divider(second_group);
+                    clear_group_date(second_group);
                 } else {
                     // If we just sent the first message on a new day
-                    // in a narrow, make sure we render a date separator.
-                    update_group_date_divider(second_group, curr_msg_container, prev_msg_container);
+                    // in a narrow, make sure we render a date.
+                    update_group_date(second_group, curr_msg_container, prev_msg_container);
                 }
             }
             message_actions.append_groups = new_message_groups;

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1108,6 +1108,8 @@ body.dark-theme {
     .streams_subheader span::before,
     .streams_subheader span::after {
         opacity: 0.2;
+        border-top: 1px solid hsl(0, 0%, 88%);
+        border-bottom: 1px solid hsl(0, 0%, 100%);
     }
 
     .star:not(.empty-star),

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2471,12 +2471,12 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .sub-unsub-message,
 .date_row {
-    text-align: center;
     padding-bottom: 10px;
 }
 
 .date_row {
     padding-left: 2px;
+    text-align: right;
 }
 
 .sub-unsub-message span,
@@ -2494,6 +2494,10 @@ div.topic_edit_spinner .loading_indicator_spinner {
     font-weight: bold;
 }
 
+.sub-unsub-message {
+    text-align: center;
+}
+
 .sub-unsub-message span {
     font-size: 1em;
     text-transform: none;
@@ -2507,7 +2511,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     position: relative;
     content: " ";
     vertical-align: middle;
-    width: 50%;
     height: 0;
     opacity: 0.2;
     border-top: 1px solid hsl(0, 0%, 0%);
@@ -2515,14 +2518,27 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 .sub-unsub-message span::before,
+.sub-unsub-message span::after {
+    width: 50%;
+}
+
 .date_row span::before {
-    right: 0.5em;
+    width: 100%;
+}
+
+.date_row span::after {
+    width: 6px;
+    left: 0.25em;
+}
+
+.sub-unsub-message span::before,
+.date_row span::before {
+    right: 0.25em;
     margin-left: -50%;
 }
 
-.sub-unsub-message span::after,
-.date_row span::after {
-    left: 0.5em;
+.sub-unsub-message span::after {
+    left: 0.25em;
     margin-right: -50%;
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -870,7 +870,7 @@ td.pointer {
 .message_time {
     display: block;
     font-size: 12px;
-    opacity: 0.4;
+    opacity: 0.5;
     padding: 1px;
     font-weight: 400;
     position: absolute;
@@ -2490,7 +2490,8 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .sub-unsub-message .stream-status,
 .date_row span {
-    opacity: 0.5;
+    opacity: 0.6;
+    font-weight: bold;
 }
 
 .sub-unsub-message span {
@@ -2508,8 +2509,9 @@ div.topic_edit_spinner .loading_indicator_spinner {
     vertical-align: middle;
     width: 50%;
     height: 0;
-    border-top: 1px solid hsl(0, 0%, 88%);
-    border-bottom: 1px solid hsl(0, 0%, 100%);
+    opacity: 0.2;
+    border-top: 1px solid hsl(0, 0%, 0%);
+    border-bottom: 1px solid hsl(0, 0%, 0%);
 }
 
 .sub-unsub-message span::before,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2477,20 +2477,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .date_row {
     padding-left: 2px;
-
-    .date-direction {
-        display: inline-block;
-        padding-right: 5px;
-    }
-
-    .date-line {
-        display: inline-block;
-        vertical-align: middle;
-        width: 33%;
-        border-top: 1px solid hsl(0, 0%, 88%);
-        border-bottom: 1px solid hsl(0, 0%, 100%);
-        margin: 0 5px;
-    }
 }
 
 .sub-unsub-message span,

--- a/static/templates/message_group.hbs
+++ b/static/templates/message_group.hbs
@@ -2,10 +2,6 @@
 
 {{#each message_groups}}
     {{#with this}}
-        {{#if show_group_date_divider}}
-        <div class="date_row no-select">{{{group_date_divider_html}}}</div>
-        {{/if}}
-
         {{#if bookend_top}}
         {{> bookend}}
         {{/if}}

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -69,7 +69,7 @@
                     <i class="zulip-icon zulip-icon-mute on_hover_topic_mute recipient_bar_icon hidden-for-spectators" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>
                 {{/if}}
             </span>
-            <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date {{#if show_recipient_bar_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
         </div>
     </div>
 </div>
@@ -83,7 +83,7 @@
                 {{#tr}}You and {display_reply_to}{{/tr}}
             </a>
 
-            <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date {{#if show_recipient_bar_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This commit updates the date row between messages and message groups, removing the date of the previous message along with the down arrow for the next message.

The goal of this commit is to declutter the message feed UI as part of the redesign.

The change concerns the render functions in
timerender.js along with the files that reference these.

Fixes: #22967.

I was faced with the choice of whether to keep the downward arrows or not. I decided against in order to reduce the visual clutter even more. This is consistent with other chat apps such as Facebook Messenger and Discord.

**New design:**
![image](https://user-images.githubusercontent.com/8920712/193103879-f0d05441-0552-491b-83f2-d30f76b023e9.png)
