### PR TITLE
Fix vertical alignment in /me message.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -303,12 +303,14 @@ export class MessageList {
         }
         $row.find(".message_edit_form").append(edit_obj.$form);
         $row.find(".message_content, .status-message, .message_controls").hide();
+        $row.find(".sender-status").toggleClass("sender-status-edit");
         $row.find(".message_edit").css("display", "block");
         autosize($row.find(".message_edit_content"));
     }
 
     hide_edit_message($row) {
         $row.find(".message_content, .status-message, .message_controls").show();
+        $row.find(".sender-status").toggleClass("sender-status-edit");
         $row.find(".message_edit_form").empty();
         $row.find(".message_edit").hide();
         $row.trigger("mouseleave");

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -963,6 +963,18 @@ td.pointer {
     .message_edit_notice {
         vertical-align: middle;
     }
+
+    &.sender-status-edit {
+        /* Hackery to place the textarea for the message edit form nicely
+           for /me messages. */
+
+        vertical-align: top;
+        line-height: 0;
+
+        .message_edit_notice {
+            line-height: 0;
+        }
+    }
 }
 
 .message_edit_notice {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -961,7 +961,7 @@ td.pointer {
     max-width: calc(100% - 50px);
 
     .message_edit_notice {
-        line-height: 18px;
+        vertical-align: middle;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1078,7 +1078,7 @@ td.pointer {
     }
 
     &.sender-status-controls {
-        top: 10px;
+        top: 8px;
     }
 
     .message_failed {


### PR DESCRIPTION
Fixes: #23101 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="889" alt="Screenshot 2022-10-06 at 12 52 36 PM" src="https://user-images.githubusercontent.com/72064462/194243409-c5938969-53cf-4022-b872-9e073a9493d0.png">

<img width="885" alt="Screenshot 2022-10-06 at 12 52 14 PM" src="https://user-images.githubusercontent.com/72064462/194243444-8f627b66-77e2-4ae8-aec5-022d1af52a02.png">

<img width="885" alt="Screenshot 2022-10-06 at 12 51 43 PM" src="https://user-images.githubusercontent.com/72064462/194243490-ea888cfd-1d74-4cab-9013-7bf6d7f011db.png">
