### PR TITLE
tests: Disable lazy loading of moto

### DIFF
--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -34,7 +34,7 @@ from django.http.request import QueryDict
 from django.http.response import HttpResponseBase
 from django.test import override_settings
 from django.urls import URLResolver
-from moto import mock_s3
+from moto.s3 import mock_s3
 from mypy_boto3_s3.service_resource import Bucket
 
 import zerver.lib.upload

--- a/zerver/tests/test_transfer.py
+++ b/zerver/tests/test_transfer.py
@@ -2,7 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 from django.conf import settings
-from moto import mock_s3
+from moto.s3 import mock_s3
 
 from zerver.actions.realm_emoji import check_add_realm_emoji
 from zerver.lib.avatar_hash import user_avatar_path


### PR DESCRIPTION
This works around some regression in moto 1.3.15 that I bisected to https://github.com/spulec/moto/commit/b8820009e811be23fdef99e7ce358ebc91493628 where `tools/test-backend test_transfer` fails when run by itself.

```pytb
$ tools/test-backend test_transfer
-- Running tests in serial mode.
Found 4 test(s).
Destroying test database for alias 'default'...
Using existing clone for alias 'default'...
Running zerver.tests.test_transfer.TransferUploadsToS3Test.test_transfer_avatars_to_s3
Running zerver.tests.test_transfer.TransferUploadsToS3Test.test_transfer_emoji_to_s3
Running zerver.tests.test_transfer.TransferUploadsToS3Test.test_transfer_message_files
Running zerver.tests.test_transfer.TransferUploadsToS3Test.test_transfer_uploads_to_s3

======================================================================
ERROR: test_transfer_avatars_to_s3 (zerver.tests.test_transfer.TransferUploadsToS3Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/moto/core/models.py", line 111, in wrapper
    result = func(*args, **kwargs)
  File "/srv/zulip/zerver/tests/test_transfer.py", line 48, in test_transfer_avatars_to_s3
    transfer_avatars_to_s3(1)
  File "/srv/zulip/zerver/lib/transfer.py", line 41, in transfer_avatars_to_s3
    _transfer_avatar_to_s3(user)
  File "/srv/zulip/zerver/lib/transfer.py", line 31, in _transfer_avatar_to_s3
    s3backend.upload_avatar_image(f, user, user)
  File "/srv/zulip/zerver/lib/upload.py", line 588, in upload_avatar_image
    self.write_avatar_images(s3_file_name, target_user_profile, image_data, content_type)
  File "/srv/zulip/zerver/lib/upload.py", line 547, in write_avatar_images
    upload_image_to_s3(
  File "/srv/zulip/zerver/lib/upload.py", line 359, in upload_image_to_s3
    key.put(
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/boto3/resources/factory.py", line 580, in do_action
    response = action(self, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/boto3/resources/action.py", line 88, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/botocore/client.py", line 512, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/botocore/client.py", line 919, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidAccessKeyId) when calling the PutObject operation: The AWS Access Key Id you provided does not exist in our records.

======================================================================
ERROR: test_transfer_emoji_to_s3 (zerver.tests.test_transfer.TransferUploadsToS3Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/moto/core/models.py", line 111, in wrapper
    result = func(*args, **kwargs)
  File "/srv/zulip/zerver/tests/test_transfer.py", line 98, in test_transfer_emoji_to_s3
    transfer_emoji_to_s3(1)
  File "/srv/zulip/zerver/lib/transfer.py", line 111, in transfer_emoji_to_s3
    _transfer_emoji_to_s3(realm_emoji)
  File "/srv/zulip/zerver/lib/transfer.py", line 101, in _transfer_emoji_to_s3
    s3backend.upload_emoji_image(f, realm_emoji.file_name, realm_emoji.author)
  File "/srv/zulip/zerver/lib/upload.py", line 720, in upload_emoji_image
    upload_image_to_s3(
  File "/srv/zulip/zerver/lib/upload.py", line 359, in upload_image_to_s3
    key.put(
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/boto3/resources/factory.py", line 580, in do_action
    response = action(self, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/boto3/resources/action.py", line 88, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/botocore/client.py", line 512, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/botocore/client.py", line 919, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidAccessKeyId) when calling the PutObject operation: The AWS Access Key Id you provided does not exist in our records.

======================================================================
ERROR: test_transfer_message_files (zerver.tests.test_transfer.TransferUploadsToS3Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/moto/core/models.py", line 111, in wrapper
    result = func(*args, **kwargs)
  File "/srv/zulip/zerver/tests/test_transfer.py", line 73, in test_transfer_message_files
    transfer_message_files_to_s3(1)
  File "/srv/zulip/zerver/lib/transfer.py", line 76, in transfer_message_files_to_s3
    _transfer_message_files_to_s3(attachment)
  File "/srv/zulip/zerver/lib/transfer.py", line 60, in _transfer_message_files_to_s3
    upload_image_to_s3(
  File "/srv/zulip/zerver/lib/upload.py", line 359, in upload_image_to_s3
    key.put(
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/boto3/resources/factory.py", line 580, in do_action
    response = action(self, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/boto3/resources/action.py", line 88, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/botocore/client.py", line 512, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/srv/zulip-py3-venv/lib/python3.8/site-packages/botocore/client.py", line 919, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidAccessKeyId) when calling the PutObject operation: The AWS Access Key Id you provided does not exist in our records.

----------------------------------------------------------------------
Ran 4 tests in 3.029s

FAILED (errors=3)
Destroying test database for alias 'default'...
```