### PR TITLE
analytics: Add summary statistic for upload/storage space in use.

### DIFF
--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -59,6 +59,7 @@ def render_stats(
         data_url_suffix=data_url_suffix,
         for_installation=for_installation,
         remote=remote,
+        upload_space_used=request.user.realm.currently_used_upload_space_bytes(),
     )
 
     request_language = get_and_set_request_language(

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -17,6 +17,21 @@ const font_14pt = {
 
 let last_full_update = Number.POSITIVE_INFINITY;
 
+// Copied from attachments_ui.js
+function bytes_to_size(bytes, kb_with_1024_bytes = false) {
+    const kb_size = kb_with_1024_bytes ? 1024 : 1000;
+    const sizes = ["B", "KB", "MB", "GB", "TB"];
+    if (bytes === 0) {
+        return "0 B";
+    }
+    const i = Number.parseInt(Math.floor(Math.log(bytes) / Math.log(kb_size)), 10);
+    let size = Math.round(bytes / Math.pow(kb_size, i));
+    if (i > 0 && size < 10) {
+        size = Math.round((bytes / Math.pow(kb_size, i)) * 10) / 10;
+    }
+    return size + " " + sizes[i];
+}
+
 // TODO: should take a dict of arrays and do it for all keys
 function partial_sums(array) {
     let accumulator = 0;
@@ -151,6 +166,13 @@ function get_thirty_days_messages_sent(data) {
 
     $("#id_thirty_days_messages_sent").text(thirty_days_messages_string);
     $("#id_thirty_days_messages_sent").closest("summary-stats").show();
+}
+
+function set_storage_space_used_statistic(upload_space_used) {
+    const space_used = bytes_to_size(upload_space_used, true);
+
+    $("#id_storage_space_used").text(space_used);
+    $("#id_storage_space_used").closest("summary-stats").show();
 }
 
 // PLOTLY CHARTS
@@ -1113,3 +1135,5 @@ get_chart_data(
     {chart_name: "messages_read_over_time", min_length: "10"},
     populate_messages_read_over_time,
 );
+
+set_storage_space_used_statistic(page_params.upload_space_used);

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -28,6 +28,7 @@
                     <li>{{ _("Users active during the last 15 days") }}: <span id="id_active_fifteen_day_users"></span></li>
                     <li>{{ _("Total number of messages") }}: <span id="id_total_messages_sent"></span></li>
                     <li>{{ _("Number of messages in the last 30 days") }}: <span id="id_thirty_days_messages_sent"></span></li>
+                    <li>{{ _("File storage in use") }}: <span id="id_storage_space_used"></span></li>
                 </ul>
             </div>
             <div class="flex-container">


### PR DESCRIPTION
Adds the realm's used storage space for attachments to the stats view page parameters. This information is then added to the summary statistics section of the analytics page after being formatted by `stats.js`.

Part of #20162. Relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/3-backend/topic/used.20upload.20space.20.20CountStat/near/1442766).

**Notes**:
- Currently, not skipping the caching of `currently_used_upload_space_bytes`, which is part of the plan (see CZO link above).
- *Testing question*: So far, I have only manually tested these changes. Is there a place where adding some automated tests makes sense? The function `currently_used_upload_space_bytes` now being called in `stats.py` has automated test coverage in `test_uploads.py`. And `stats.js` has no automated tests.
- Currently, if either there is an error getting the CountStat data or the realm was created less than 24 hours ago (i.e., `analytics_ready = False`), then this statistic is still populated if there are attachments saved in the database. Is this the behavior we want? See screenshots below.
- I used/imported the `bytes_to_size` function from `attachments_ui.js`. We already import parts of `page_params.ts` and `i18n.ts`, but I wasn't sure if it would be better to just copy the function into `stats.js` with a comment that it is duplicated from `attachments_ui.js`?

---

**Screenshots and screen captures:**

<details>
<summary>Normal realm stats page</summary>

![Screenshot from 2022-09-30 15-41-33](https://user-images.githubusercontent.com/63245456/193282699-c1a8fa73-675d-4733-be4f-14b8f4af912b.png)
</details>

<details>
<summary>New realm stats page</summary>

*Note: I have a separate task marked for improving the empty graphs generated in this situation.*
![Screenshot from 2022-09-30 16-11-10](https://user-images.githubusercontent.com/63245456/193288745-53e4121f-05aa-4c2c-88d2-8a4247c356a7.png)
</details>

<details>
<summary>Error stats page</summary>

*Note: The spinners in the graphs never stop or go away.*
![Screenshot from 2022-09-30 16-10-27](https://user-images.githubusercontent.com/63245456/193288594-e0be8f75-73a4-4d57-b1f9-473d808235a4.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
