### PR TITLE
templates: Update text on 500 error page.

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -19,13 +19,35 @@
             <div class="errorbox">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _("Internal server error") }}</h1>
-                    {% trans %}
-                    <p>This Zulip server is currently experiencing some technical difficulties. Sorry about that!</p>
-                    <p>The page will reload automatically soon after service is restored.</p>
-                    <p>If you'd like, you can <a href="mailto:{{ support_email }}">drop us a line</a> to let us know what happened.</p>
-                    {% endtrans %}
+                    <p>
+                        {% trans %}
+                        Your Zulip chat cannot be loaded because the server is experiencing technical difficulties.
+                        {% endtrans %}
+                    </p>
+                    <p>
+                        {% trans %}
+                        This page will reload automatically when service is restored.
+                        {% endtrans %}
+                        {% if corporate_enabled %}
+                            {% trans %}
+                            In the meantime, you can <a href="mailto:{{support_email}}">contact Zulip support</a>.
+                            {% endtrans %}
+                        {% else %}
+                            {% trans %}
+                            In the meantime, you can <a href="mailto:{{support_email}}">contact
+                            this server's administrators</a> for support.
+                            {% endtrans %}
+                        {% endif %}
+                    </p>
+                    {% if not corporate_enabled %}
+                        <p>
+                            {% trans troubleshooting_url="https://zulip.readthedocs.io/en/latest/production/troubleshooting.html" %}
+                            If you administer this server, you may want to check out the
+                            <a href="{{troubleshooting_url}}">Zulip server troubleshooting guide</a>.
+                            {% endtrans %}
+                        </p>
+                    {% endif %}
                 </div>
-
             </div>
         </div>
     </div>


### PR DESCRIPTION
Makes the 500 error page text conditional on whether the server is self-hosted or Zulip Cloud.

In the case of Zulip Cloud, when `settings.CORPORATE_ENABLED` is true, the text provides an email address to contact Zulip support.

In the case of self-hosted, when `settings.CORPORATE_ENABLED` is false, the text provides an email address to contact server administrators and a link to Zulip's troubleshooting guide.

Fixes #23063.

<hr>

**Note:**

- This uses the value of `settings.CORPORATE_ENABLED` to distinguish between self-hosted servers and Zulip Cloud organizations.

<hr>

**Backend Test Failing**

- All the tests except one are passed.
- <details>
  <summary>Terminal Screenshot</summary>
   <img src="https://user-images.githubusercontent.com/56781761/193437521-3a0551ba-9ca5-45b6-ad00-949476d37c3d.png"> 
   </img>
  </details>
- `test_empty_backticks_in_missed_message (zerver.tests.test_email_notifications.TestMissedMessages)` [concerned code](https://github.com/zulip/zulip/blob/df8d84a009d3d86fae9a041b9a62cec8557febc7/zerver/tests/test_email_notifications.py#L484)

**Update:** 
- All the tests passed, thanks to @PIG208 for the[ help](https://github.com/zulip/zulip/pull/23120#issuecomment-1264687535).
<hr>

**Screenshots and screen captures:**

- <details>
  <summary>Zulip Cloud</summary>
   <img src="https://user-images.githubusercontent.com/56781761/194487026-bdf03db9-d0e0-419a-bd56-d73dcd4c3769.png"> 
   </img>
  </details>

- <details>
  <summary>Self Hosted</summary>
  <img src="https://user-images.githubusercontent.com/56781761/194487309-ed7e2873-8c8c-4241-9552-daa269dda40f.png"> 
  </img>
  </details>

<hr>

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
