### PR TITLE
do_mark_all_as_read: Split up the work into batches.

### DIFF
--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -22,6 +22,13 @@ export function mark_all_as_read() {
         success: () => {
             // After marking all messages as read, we reload the browser.
             // This is useful to avoid leaving ourselves deep in the past.
+            // This is also the currently intended behavior in case of partial success,
+            // (response code 200 with result "partially_completed")
+            // where the request times out after marking some messages as read,
+            // so we don't need to distinguish that scenario here.
+            // TODO: The frontend handling of partial success can be improved
+            // by re-running the request in a loop, while showing some status indicator
+            // to the user.
             reload.initiate({
                 immediate: true,
                 save_pointer: false,

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 153**
+
+* [`POST /mark_all_as_read`](/api/mark-all-as-read): Messages are now
+  marked as read in batches, so that progress will be made even if the
+  request times out because of an extremely large number of unread
+  messages to process. Upon timeout, a success response with a
+  "partially_completed" result will be returned by the server.
+
 **Feature level 152**
 
 * [`PATCH /messages/{message_id}`](/api/update-message): The

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 152
+API_FEATURE_LEVEL = 153
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -37,6 +37,7 @@ class ErrorCode(Enum):
     PASSWORD_RESET_REQUIRED = auto()
     AUTHENTICATION_FAILED = auto()
     UNAUTHORIZED = auto()
+    REQUEST_TIMEOUT = auto()
 
 
 class JsonableError(Exception):

--- a/zerver/lib/response.py
+++ b/zerver/lib/response.py
@@ -45,6 +45,10 @@ def json_success(request: HttpRequest, data: Mapping[str, Any] = {}) -> HttpResp
     return json_response(data=data)
 
 
+def json_partial_success(request: HttpRequest, data: Mapping[str, Any] = {}) -> HttpResponse:
+    return json_response(res_type="partially_completed", data=data, status=200)
+
+
 def json_response_from_error(exception: JsonableError) -> HttpResponse:
     """
     This should only be needed in middleware; in app code, just raise.

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -412,7 +412,9 @@ def validate_against_openapi_schema(
     if (endpoint, method) in EXCLUDE_DOCUMENTED_ENDPOINTS:
         return True
     # Check if the response matches its code
-    if status_code.startswith("2") and (content.get("result", "success").lower() != "success"):
+    if status_code.startswith("2") and (
+        content.get("result", "success").lower() not in ["success", "partially_completed"]
+    ):
         raise SchemaError("Response is not 200 but is validating against 200 schema")
     # Code is not declared but appears in various 400 responses. If
     # common, it can be added to 400 response schema

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4533,9 +4533,41 @@ paths:
       tags: ["messages"]
       description: |
         Marks all of the current user's unread messages as read.
+
+        **Changes**: Before Zulip 6.0 (feature level 153), this
+        request did a single atomic operation, which could time out
+        with 10,000s of unread messages to mark as read.
+
+        It now marks messages as read in batches, starting with the
+        newest messages, so that progress will be made even if the
+        request times out.
+
+        If the server's processing is interrupted by a timeout, it
+        will return an HTTP 200 success response with result
+        "partially_completed". A correct client should repeat the
+        request when handling such a response.
       responses:
         "200":
-          $ref: "#/components/responses/SimpleSuccess"
+          description: Success or partial success.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/JsonSuccess"
+                      - $ref: "#/components/schemas/SuccessDescription"
+                  - allOf:
+                      - $ref: "#/components/schemas/PartiallyCompleted"
+                      - example:
+                          {
+                            "code": "REQUEST_TIMEOUT",
+                            "msg": "",
+                            "result": "partially_completed",
+                          }
+                        description: |
+                          If the request exceeds its processing time limit after having
+                          successfully marked some messages as read, response code 200
+                          with result "partially_completed" and code "REQUEST_TIMEOUT" will be returned like this:
   /mark_stream_as_read:
     post:
       operationId: mark-stream-as-read
@@ -16693,6 +16725,23 @@ components:
             result:
               enum:
                 - error
+            msg:
+              type: string
+    PartiallyCompleted:
+      allOf:
+        - $ref: "#/components/schemas/JsonResponseBase"
+        - required:
+            - result
+            - code
+          additionalProperties: false
+          properties:
+            result:
+              enum:
+                - partially_completed
+            code:
+              type: string
+              description: |
+                A string that identifies the cause of the partial completion of the request.
             msg:
               type: string
     ApiKeyResponse:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -934,13 +934,13 @@ class OpenAPIAttributesTest(ZulipTestCase):
                 for status_code, response in operation["responses"].items():
                     schema = response["content"]["application/json"]["schema"]
                     if "oneOf" in schema:
-                        for subschema_index, subschema in enumerate(schema["oneOf"]):
+                        for _, subschema in enumerate(schema["oneOf"]):
                             validate_schema(subschema)
                             assert validate_against_openapi_schema(
                                 subschema["example"],
                                 path,
                                 method,
-                                status_code + "_" + str(subschema_index),
+                                status_code,
                             )
                         continue
                     validate_schema(schema)


### PR DESCRIPTION
Going with an approach kind of like in https://github.com/zulip/zulip/pull/22988. At first I tried moving the work into `deferred_work` queue, but it gave a janky experience in the webapp, since it meant the client got success response immediately and upon it, reloads (but the messages are still being handled in the worker). Removing the reload upon response is not a sufficient solution either, because the reload is important to properly refresh the state. So the way webapp behaves upon clicking "mark all as read" would have to be reworked somehow i think. 

So I went with just batching what happens in `do_mark_all_messages_as_read` + upon timeout of the request (`502`), reload the client just like in case of success. Looping to repeat requests like in #22988  doesn't make sense to me, because the reload is important for a non-janky experience. So this solution here is far from ideal, but at least an improvement i think. 

Fixes #15403.
