### PR TITLE
right_sidebar: Fix full name overflowing its container. 

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -780,12 +780,22 @@ ul {
     .status_emoji {
         height: 18px;
         width: 18px;
-        top: 2px;
-
         /* Override the default 3px left margin for status emoji, which is
            intended for their presentation elsewhere to the left of a
            user's name. */
         margin-left: 0;
+        margin-right: 2px;
+    }
+
+    #status_message {
+        padding: 1px 0;
+        display: flex;
+        align-items: baseline;
+        hyphens: auto;
+    }
+
+    .status_text {
+        overflow-wrap: anywhere;
     }
 }
 

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -109,6 +109,11 @@
     flex-direction: row;
 }
 
+.user-name-and-status-wrapper {
+    display: block;
+    width: 100%;
+}
+
 .user-presence-link {
     width: calc(100% - 24px);
 

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -1,3 +1,6 @@
+/* Width of emoji used by user to display status. */
+$user_status_emoji_width: 24px;
+
 .right-sidebar {
     a:hover {
         text-decoration: none;
@@ -115,7 +118,7 @@
 }
 
 .user-presence-link {
-    width: calc(100% - 24px);
+    width: calc(100% - $user_status_emoji_width);
 
     .status_emoji {
         top: 9px;
@@ -128,6 +131,31 @@
 
 .selectable_sidebar_block {
     cursor: pointer;
+}
+
+.user_list_style_values {
+    .user-name-and-status-emoji {
+        display: block;
+        width: 100%;
+        height: 20px;
+
+        .user-name {
+            display: inline-block;
+            max-width: calc(100% - $user_status_emoji_width);
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .status_emoji {
+            line-height: 20px;
+            top: -2px;
+        }
+    }
+
+    .status-text {
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 .user_sidebar_entry {

--- a/static/templates/presence_row.hbs
+++ b/static/templates/presence_row.hbs
@@ -6,7 +6,7 @@
           data-user-id="{{user_id}}"
           data-name="{{name}}">
             {{#if user_list_style.WITH_STATUS}}
-                <div>
+                <div class="user-name-and-status-wrapper">
                     <div class="user-name-and-status-emoji">
                         <span class="user-name">{{name}}</span>
                         {{> status_emoji status_emoji_info}}

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -95,8 +95,12 @@
                         <div class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></div>
                     {{/if}}
                 {{/if}}
-                {{status_text}}
-                {{#if is_me}}(<a tabindex="0" class="clear_status">{{#tr}}clear{{/tr}}</a>){{/if}}
+                <span class="status_text">
+                    {{status_text}}
+                    {{#if is_me}}
+                    <span class="clear_status_button">(<a tabindex="0" class="clear_status">{{#tr}}clear{{/tr}}</a>)</span>
+                    {{/if}}
+                </span>
             </span>
         </li>
     {{/if}}


### PR DESCRIPTION
Solves part 2 of #22910

discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/display.20status.20and.20profile.20picture.20in.20right.20sidebar.20.2321035/near/1427246

<img width="205" alt="image" src="https://user-images.githubusercontent.com/25124304/193623338-0b973662-ae2b-4570-8a6f-96c26e448c12.png">
<img width="217" alt="image" src="https://user-images.githubusercontent.com/25124304/193623354-11b447e7-7d9a-4cad-8ce7-584e7cdf583e.png">
<img width="319" alt="image" src="https://user-images.githubusercontent.com/25124304/193623366-9e5bb3d2-38bd-42ec-8b88-938d8942092e.png">
