### PR TITLE
Publish Open communities directory

### DIFF
--- a/docs/tutorials/screenshot-and-gif-software.md
+++ b/docs/tutorials/screenshot-and-gif-software.md
@@ -47,7 +47,6 @@ to check out your branch.
 - [QuickTime](https://support.apple.com/en-in/HT201066)
 - [GIPHY](https://giphy.com/apps/giphycapture)
 - [CloudApp](https://www.getcloudapp.com)
-- [GIF Brewery](http://gifbrewery.com)
 - [Kap](https://getkap.co)
 - [Gifski](https://sindresorhus.com/gifski)]
 - [Gyazo GIF](https://gyazo.com/en)

--- a/templates/corporate/for/communities.md
+++ b/templates/corporate/for/communities.md
@@ -116,14 +116,14 @@ Zulip’s topic-based threading model solves the problems described above:
 
 ## Try Zulip today!
 
-You can see Zulip in action in our own
-[Zulip development community](https://zulip.com/development-community/), which sends
-thousands of messages a week. We often get feedback from contributors
-around the world that they love how responsive Zulip’s project leaders
-are in public Zulip conversations. We are able to achieve this despite
-the project leaders collectively spending only a few hours a day
-managing the community and spending most of their time integrating
-improvements into Zulip.
+You can see Zulip in action in our own [Zulip development
+community](/development-community/), or in other open
+communities that have [opted in](/help/communities-directory) to be listed in our
+[directory](/communities/). We often get feedback from contributors around the
+world that they love how responsive Zulip’s project leaders are in public Zulip
+conversations. We are able to achieve this despite the project leaders
+collectively spending only a few hours a day managing the community and spending
+most of their time integrating improvements into Zulip.
 
 Many communities that migrated from
 [Slack](/help/import-from-slack),

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -666,6 +666,15 @@
                     </li>
                     <li>
                         <div class="list-content">
+                            See how <a href="/communities/">other open
+                            communities</a> are using Zulip, and learn about <a
+                            href="/help/moderating-open-organizations">best
+                            practices</a> for moderating an open Zulip
+                            organization.
+                        </div>
+                    </li>
+                    <li>
+                        <div class="list-content">
                             If you have any questions,
                             please contact us at <a href="mailto:sales@zulip.com">
                             sales@zulip.com</a>. You can also drop by our

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -60,6 +60,9 @@
             <li>
                 <a href="/case-studies/recurse-center/">Recurse Center</a>
             </li>
+            <li>
+                <a href="/communities/">{{ _("Open communities directory") }}</a>
+            </li>
         </ul>
     </div>
     <div class="footer-section">

--- a/templates/zerver/help/include/communities-directory-intro.md
+++ b/templates/zerver/help/include/communities-directory-intro.md
@@ -1,12 +1,10 @@
-!!! tip ""
-
-    Coming to the [Zulip website](https://zulip.com) summer 2022 —
-    [sign up][communities-directory-instructions] to be listed when it launches!
-
-The Zulip communities directory offers publicly accessible [Zulip Cloud][zulip-cloud]
-organizations an opportunity to be listed on the [Zulip website](https://zulip.com). It's a way
-for open-source projects, research communities, and others to advertise their
-Zulip community and support the Zulip project.
+The [Zulip communities directory](https://zulip.com/communities/) offers
+publicly accessible [Zulip Cloud][zulip-cloud] organizations an opportunity to
+be listed on the [Zulip website](https://zulip.com). It's a way for [open-source
+projects](https://zulip.com/for/open-source/), [research
+communities](https://zulip.com/for/research/), and
+[others](https://zulip.com/for/communities) to advertise their Zulip community
+and support the Zulip project.
 
 The directory will display your community's name, logo, and a link to you Zulip
 chat. Other information from your [organization
@@ -14,4 +12,3 @@ profile](/help/create-your-organization-profile) and the size of your
 organization may be included as well.
 
 [zulip-cloud]: https://zulip.com/plans/
-[communities-directory-instructions]: /help/communities-directory#change-whether-your-organization-may-be-listed-in-the-zulip-communities-directory

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -89,6 +89,9 @@
                         <li>
                             <a href="https://zulip.com/case-studies/recurse-center/">Recurse Center</a>
                         </li>
+                        <li>
+                            <a href="https://zulip.com/communities/">Open communities directory</a>
+                        </li>
                     </div>
                 </ul>
             </div>

--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -146,6 +146,11 @@ class BaseDocumentationSpider(scrapy.Spider):
         ):
             return
 
+        # This page has some invisible to the user anchor links like #all
+        # that are currently invisible, and thus would otherwise fail this test.
+        if url.startswith("http://localhost:9981/communities"):
+            return
+
         callback: Callable[[Response], Optional[Iterator[Request]]] = self.parse
         dont_filter = False
         method = "GET"


### PR DESCRIPTION
Links to the Open communities directory from the help center, landing page nav, /for/communities, and /for/open-source.

Links have been manually tested to the extent that's possible.

## Help center updates

- Current: https://zulip.com/help/communities-directory
- Updated:
![Screen Shot 2022-10-03 at 3 37 21 PM](https://user-images.githubusercontent.com/2090066/193698703-ad4b6fc8-f8db-4162-9105-2f819ac76a94.png)

Note that this intro text also appears in 2 other places:

```
alya@wyndle zulip % git grep directory-intro
templates/zerver/help/communities-directory.md:{!communities-directory-intro.md!}
templates/zerver/help/create-your-organization-profile.md:{!communities-directory-intro.md!}
templates/zerver/help/moderating-open-organizations.md:{!communities-directory-intro.md!}
```

Links have been manually tested.

## Navigation updates

![Screen Shot 2022-10-04 at 11 55 50 AM](https://user-images.githubusercontent.com/2090066/193902954-6e1a240e-f28e-4c36-81de-24a56e54bfe4.png)

![Screen Shot 2022-10-04 at 11 55 16 AM](https://user-images.githubusercontent.com/2090066/193902968-6630d91e-bc9d-42e9-a14f-a1e0d01e0480.png)


## /for/X page text updates


![Screen Shot 2022-10-04 at 11 54 46 AM](https://user-images.githubusercontent.com/2090066/193902992-12612c04-7e23-4ae9-a96c-6cbaa5014a80.png)


![Screen Shot 2022-10-04 at 11 54 57 AM](https://user-images.githubusercontent.com/2090066/193903012-ff802a5a-eae0-4df9-98e8-1200201af8c1.png)
