### PR TITLE
Improve design of Recent topics when there are no topics to show 

### DIFF
--- a/web/src/list_widget.js
+++ b/web/src/list_widget.js
@@ -98,6 +98,24 @@ export function numeric_sort(prop) {
     };
 }
 
+export function empty_feed_notice(table, table_widget) {
+    const $table_search = table.closest(".settings-section").find(".search").val();
+
+    if (table_widget.get_current_list().length === 0 && $table_search !== "") {
+        $(`.${table.attr("id")}`).addClass("empty-table");
+        $(`#${table.attr("id")}`).removeClass("required-empty-text");
+        $(`#${table.attr("id")}`).addClass("required-search-results-empty-text");
+    } else if (table_widget.get_current_list().length === 0) {
+        $(`.${table.attr("id")}`).addClass("empty-table");
+        $(`#${table.attr("id")}`).addClass("required-empty-text");
+        $(`#${table.attr("id")}`).removeClass("required-search-results-empty-text");
+    } else {
+        $(`.${table.attr("id")}`).removeClass("empty-table");
+        $(`#${table.attr("id")}`).removeClass("required-empty-text");
+        $(`#${table.attr("id")}`).addClass("required-search-results-empty-text");
+    }
+}
+
 export function valid_filter_opts(opts) {
     if (!opts.filter) {
         return true;
@@ -213,6 +231,9 @@ export function create($container, list, opts) {
     // into the specified container.
     widget.render = function (how_many) {
         let load_count = how_many || DEFAULTS.LOAD_COUNT;
+
+        empty_feed_notice($container, widget);
+
         if (opts.get_min_load_count) {
             load_count = opts.get_min_load_count(meta.offset, load_count);
         }

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -288,7 +288,7 @@ export function hide_loading_indicator() {
         abs_positioned: false,
     });
     // Show empty table text if there are no messages fetched.
-    $("#recent_topics_table tbody").addClass("required-text");
+    $("#recent_topics_table tbody").addClass("required-empty-text");
 }
 
 export function process_messages(messages) {
@@ -844,6 +844,15 @@ export function complete_rerender() {
             // filtering for us, which is called using click_handlers.
             predicate(topic_data) {
                 return !filters_should_hide_topic(topic_data);
+            },
+            onupdate() {
+                const $recent_topics_search = $("#recent_topics_search").val();
+
+                if (topics_widget.get_current_list().length === 0 && $recent_topics_search !== "") {
+                    $container.attr("data-empty", "No topics match your current filters.");
+                } else {
+                    $container.attr("data-empty", "No topics found.");
+                }
             },
         },
         sort_fields: {

--- a/web/src/settings_emoji.js
+++ b/web/src/settings_emoji.js
@@ -109,7 +109,7 @@ export function populate_emoji() {
     }
 
     const $emoji_table = $("#admin_emoji_table").expectOne();
-    ListWidget.create($emoji_table, Object.values(emoji_data), {
+    const emoji_table_widget = ListWidget.create($emoji_table, Object.values(emoji_data), {
         name: "emoji_list",
         modifier(item) {
             if (item.deactivated !== true) {
@@ -131,6 +131,28 @@ export function populate_emoji() {
                 return item.name.toLowerCase().includes(value);
             },
             onupdate() {
+                const $emoji_table_search = $emoji_table
+                    .closest(".settings-section")
+                    .find(".search")
+                    .val();
+
+                const $active_emoji_list = emoji_table_widget.get_current_list().filter((emoji) => {
+                    if (!emoji.deactivated) {
+                        return emoji;
+                    }
+                    return null;
+                });
+
+                if ($active_emoji_list.length === 0 && $emoji_table_search !== "") {
+                    $(".admin_emoji_table").addClass("empty-table");
+                    $emoji_table.attr("data-empty", "No custom emoji match your current filter.");
+                } else if ($active_emoji_list.length === 0) {
+                    $(".admin_emoji_table").addClass("empty-table");
+                    $emoji_table.attr("data-empty", "No custom emoji found.");
+                } else {
+                    $(".admin_emoji_table").removeClass("empty-table");
+                    $emoji_table.attr("data-empty", "No custom emoji found.");
+                }
                 ui.reset_scrollbar($emoji_table);
             },
         },
@@ -142,6 +164,16 @@ export function populate_emoji() {
         $simplebar_container: $("#emoji-settings .progressive-table-wrapper"),
     });
 
+    const $active_emoji = emoji_table_widget.get_current_list().filter((emoji) => {
+        if (!emoji.deactivated) {
+            return emoji;
+        }
+        return null;
+    });
+
+    if ($active_emoji.length === 0) {
+        $(".admin_emoji_table").addClass("empty-table");
+    }
     loading.destroy_indicator($("#admin_page_emoji_loading_indicator"));
 }
 

--- a/web/src/settings_muted_topics.js
+++ b/web/src/settings_muted_topics.js
@@ -26,12 +26,28 @@ export function populate_list() {
                 return item.topic.toLocaleLowerCase().includes(value);
             },
             onupdate() {
+                const $muted_topics_table_search = $search_input.val();
+
+                if (all_muted_topics.length === 0 && $muted_topics_table_search !== "") {
+                    $(".muted_topics_table").addClass("empty-table");
+                    $muted_topics_table.attr("data-empty", "No topics match your current filter.");
+                } else if (all_muted_topics.length === 0) {
+                    $(".muted_topics_table").addClass("empty-table");
+                    $muted_topics_table.attr("data-empty", "You have not muted any topics yet.");
+                } else {
+                    $(".muted_topics_table").removeClass("empty-table");
+                    $muted_topics_table.attr("data-empty", "You have not muted any topics yet.");
+                }
                 ui.reset_scrollbar($muted_topics_table.closest(".progressive-table-wrapper"));
             },
         },
         $parent_container: $("#muted-topic-settings"),
         $simplebar_container: $("#muted-topic-settings .progressive-table-wrapper"),
     });
+
+    if (all_muted_topics.length === 0) {
+        $(".muted_topics_table").addClass("empty-table");
+    }
 }
 
 export function set_up() {

--- a/web/src/settings_muted_users.js
+++ b/web/src/settings_muted_users.js
@@ -30,12 +30,28 @@ export function populate_list() {
                 return item.user_name.toLocaleLowerCase().includes(value);
             },
             onupdate() {
+                const $muted_users_table_search = $search_input.val();
+
+                if (all_muted_users.length === 0 && $muted_users_table_search !== "") {
+                    $(".muted_users_table").addClass("empty-table");
+                    $muted_users_table.attr("data-empty", "No users match your current filter.");
+                } else if (all_muted_users.length === 0) {
+                    $(".muted_users_table").addClass("empty-table");
+                    $muted_users_table.attr("data-empty", "You have not muted any users yet.");
+                } else {
+                    $(".muted_users_table").removeClass("empty-table");
+                    $muted_users_table.attr("data-empty", "You have not muted any users yet.");
+                }
                 ui.reset_scrollbar($muted_users_table.closest(".progressive-table-wrapper"));
             },
         },
         $parent_container: $("#muted-user-settings"),
         $simplebar_container: $("#muted-user-settings .progressive-table-wrapper"),
     });
+
+    if (all_muted_users.length === 0) {
+        $(".muted_users_table").addClass("empty-table");
+    }
 }
 
 export function set_up() {

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -299,7 +299,9 @@ section.bots.create_table = () => {
                     item.display_email.toLowerCase().includes(value)
                 );
             },
-            onupdate: reset_scrollbar($bots_table),
+            onupdate() {
+                reset_scrollbar($bots_table);
+            },
         },
         $parent_container: $("#admin-bot-list").expectOne(),
         init_sort: ["alphabetic", "full_name"],
@@ -327,7 +329,9 @@ section.active.create_table = (active_users) => {
         filter: {
             $element: $users_table.closest(".settings-section").find(".search"),
             filterer: people.filter_for_user_settings_search,
-            onupdate: reset_scrollbar($users_table),
+            onupdate() {
+                reset_scrollbar($users_table);
+            },
         },
         $parent_container: $("#admin-user-list").expectOne(),
         init_sort: ["alphabetic", "full_name"],
@@ -356,7 +360,9 @@ section.deactivated.create_table = (deactivated_users) => {
         filter: {
             $element: $deactivated_users_table.closest(".settings-section").find(".search"),
             filterer: people.filter_for_user_settings_search,
-            onupdate: reset_scrollbar($deactivated_users_table),
+            onupdate() {
+                reset_scrollbar($deactivated_users_table);
+            },
         },
         $parent_container: $("#admin-deactivated-users-list").expectOne(),
         init_sort: ["alphabetic", "full_name"],

--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -52,14 +52,6 @@
             }
         }
 
-        .required-text:empty::after {
-            content: attr(data-empty);
-            display: block;
-            font-style: italic;
-            color: hsl(0deg 0% 67%);
-            position: absolute;
-        }
-
         .fa-check-square-o,
         .fa-square-o {
             padding: 0 2px;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -76,6 +76,16 @@ $user_status_emoji_width: 24px;
         }
     }
 
+    &:empty::after {
+        content: attr(data-empty);
+        display: block;
+        margin: 10px 0;
+        font-family: inherit;
+        font-size: 1rem;
+        text-align: center;
+        color: hsl(0, 0%, 67%);
+    }
+
     .user_circle {
         min-width: 8px;
         height: 8px;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1612,7 +1612,7 @@ $option_title_width: 180px;
     width: 100px;
 }
 
-.required-text {
+.required-empty-text {
     &:empty::after {
         content: attr(data-empty);
         margin: 10px 0;
@@ -1630,6 +1630,30 @@ $option_title_width: 180px;
     &.thick:empty::after {
         width: 100%;
     }
+}
+
+.required-search-results-empty-text {
+    &:empty::after {
+        content: attr(data-search-results-empty);
+        margin: 10px 0;
+        font-family: inherit;
+        font-size: 1.25rem;
+        text-align: center;
+
+        color: hsl(0, 0%, 67%);
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translateX(-50%);
+    }
+
+    &.thick:empty::after {
+        width: 100%;
+    }
+}
+
+.empty-table {
+    margin-bottom: 100px;
 }
 
 #payload_url_inputbox,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1615,10 +1615,16 @@ $option_title_width: 180px;
 .required-text {
     &:empty::after {
         content: attr(data-empty);
-        display: block;
+        margin: 10px 0;
+        font-family: inherit;
+        font-size: 1.25rem;
+        text-align: center;
 
-        font-style: italic;
         color: hsl(0deg 0% 67%);
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translateX(-50%);
     }
 
     &.thick:empty::after {
@@ -1717,10 +1723,6 @@ $option_title_width: 180px;
 #toggle_collapse {
     margin-left: 2px;
     display: inline-block;
-}
-
-.admin_exports_table {
-    margin-bottom: 20px;
 }
 
 .settings_textarea {

--- a/web/templates/recent_topics_table.hbs
+++ b/web/templates/recent_topics_table.hbs
@@ -19,6 +19,5 @@
                 <th data-sort="numeric" data-sort-prop="last_msg_id" class="last_msg_time_header active descend">{{t 'Time' }}</th>
             </tr>
         </thead>
-        <tbody data-empty="{{t 'No topics match your current filter.' }}"></tbody>
     </table>
 </div>

--- a/web/templates/recent_topics_table.hbs
+++ b/web/templates/recent_topics_table.hbs
@@ -19,5 +19,6 @@
                 <th data-sort="numeric" data-sort-prop="last_msg_id" class="last_msg_time_header active descend">{{t 'Time' }}</th>
             </tr>
         </thead>
+        <tbody data-empty="{{t 'No topics found.' }}"></tbody>
     </table>
 </div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -22,7 +22,7 @@
                 </button>
             </div>
             <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar>
-                <ul id="user_presences" class="filters required-text" data-empty="{{t 'No matching users.' }}"></ul>
+                <ul id="user_presences" class="filters" data-empty="{{t 'No matching users.' }}"></ul>
                 <div id="buddy_list_wrapper_padding"></div>
             </div>
         </div>

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -18,13 +18,13 @@
         <span class="alert_word_status_text"></span>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table alert-words-table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="word">{{t "Word" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="alert-words-table" class="alert-words-table required-text thick"
-              data-empty="{{t 'There are no current alert words.' }}"></tbody>
+            <tbody id="alert-words-table" class="alert-words-table required-empty-text"
+              data-empty="{{t 'No alert words found.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -7,7 +7,7 @@
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table uploaded_files_table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="name" class="upload-file-name">{{t "File" }}</th>
                 <th class="active upload-date" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
@@ -15,8 +15,10 @@
                 <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
                 <th class="upload-actions actions">{{t "Actions" }}</th>
             </thead>
-            <tbody class="required-text" data-empty="{{t 'You have not uploaded any files.' }}"
-              id="uploaded_files_table"></tbody>
+            <tbody class="required-empty-text required-search-results-empty-text" data-empty="{{t 'You have not uploaded any files.' }}"
+              data-search-results-empty="{{t 'No files match your current filter.' }}"
+              id="uploaded_files_table">
+            </tbody>
         </table>
     </div>
     <div id="attachments_loading_indicator"></div>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -12,7 +12,7 @@
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table admin_bots_table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
@@ -23,8 +23,10 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody id="admin_bots_table" class="admin_bot_table required-text thick"
-              data-empty="{{t 'No bots match your current filter.' }}"></tbody>
+            <tbody id="admin_bots_table" class="admin_bot_table required-empty-text required-search-results-empty-text thick"
+              data-empty="{{t 'No bots found.' }}"
+              data-search-results-empty="{{t 'No bots match your current filter.' }}">
+            </tbody>
         </table>
     </div>
     <div id="admin_page_bots_loading_indicator"></div>

--- a/web/templates/settings/bot_settings.hbs
+++ b/web/templates/settings/bot_settings.hbs
@@ -26,10 +26,10 @@
             <li class="inactive-bots-tab"><a>{{t "Inactive bots" }}</a></li>
         </ul>
 
-        <ol class="bots_list required-text" id="active_bots_list" data-empty="{{t 'You have no active bots.' }}">
+        <ol class="bots_list required-empty-text" id="active_bots_list" data-empty="{{t 'You have no active bots.' }}">
         </ol>
 
-        <ol class="bots_list required-text" id="inactive_bots_list" data-empty="{{t 'You have no inactive bots.' }}">
+        <ol class="bots_list required-empty-text" id="inactive_bots_list" data-empty="{{t 'You have no inactive bots.' }}">
         </ol>
 
     </div>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -44,7 +44,7 @@
                 <th>{{t "Status" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_exports_table" class="required-text" data-empty="{{t 'No exports.' }}"></tbody>
+            <tbody id="admin_exports_table" class="required-empty-text" data-empty="{{t 'No exports found.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -10,7 +10,7 @@
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table admin_deactivated_users_table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}}>{{t "Email" }}</th>
@@ -20,8 +20,10 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody id="admin_deactivated_users_table" class="required-text thick admin_user_table"
-              data-empty="{{t 'No users match your current filter.' }}"></tbody>
+            <tbody id="admin_deactivated_users_table" class="required-empty-text required-search-results-empty-text thick admin_user_table"
+              data-empty="{{t 'No users found.' }}"
+              data-search-results-empty="{{t 'No users match your current filter.' }}">
+            </tbody>
         </table>
     </div>
     <div id="admin_page_deactivated_users_loading_indicator"></div>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -27,15 +27,17 @@
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table admin_default_streams_table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
                 {{#if is_admin}}
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody class="required-text" data-empty="{{t 'No default streams match you current filter.' }}"
-              id="admin_default_streams_table" class="admin_default_stream_table"></tbody>
+            <tbody class="required-empty-text required-search-results-empty-text" data-empty="{{t 'No default streams found.' }}"
+              data-search-results-empty="{{t 'No default streams match your current filter.' }}"
+              id="admin_default_streams_table" class="admin_default_stream_table">
+            </tbody>
         </table>
     </div>
 

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -14,7 +14,7 @@
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped">
+        <table class="table table-condensed table-striped admin_invites_table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="invitee">{{t "Invitee" }}</th>
                 {{#if is_admin }}
@@ -25,7 +25,8 @@
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_invites_table" class="required-text thick admin_invites_table" data-empty="{{t 'No invites match your current filter.' }}"></tbody>
+            <tbody id="admin_invites_table" class="required-empty-text required-search-results-empty-text thick admin_invites_table" data-empty="{{t 'No invites to show.' }}"
+              data-search-results-empty="{{t 'No invites match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_invites_loading_indicator"></div>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -71,7 +71,8 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_linkifiers_table" class="required-text" data-empty="{{t 'No linkifiers set.' }}"></tbody>
+                <tbody id="admin_linkifiers_table" class="required-empty-text required-search-results-empty-text" data-empty="{{t 'No linkifiers set.' }}"
+                  data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
             </table>
         </div>
     </div>

--- a/web/templates/settings/muted_topics_settings.hbs
+++ b/web/templates/settings/muted_topics_settings.hbs
@@ -4,14 +4,15 @@
         <input id="muted_topics_search" class="search" type="text" placeholder="{{t 'Filter muted topics' }}" aria-label="{{t 'Filter muted topics' }}"/>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table muted_topics_table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="stream">{{t "Stream" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="topic">{{t "Topic" }}</th>
                 <th data-sort="numeric" data-sort-prop="date_muted" class="topic_date_updated">{{t "Date muted" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="muted_topics_table" class="required-text" data-empty="{{t 'You have not muted any topics yet.'}}"></tbody>
+            <tbody id="muted_topics_table" class="required-empty-text required-search-results-empty-text" data-empty="{{t 'You have not muted any topics yet.'}}"
+              data-search-results-empty="{{t 'No topics match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -4,13 +4,14 @@
         <input id="muted_users_search" class="search" type="text" placeholder="{{t 'Filter muted users' }}" aria-label="{{t 'Filter muted users' }}"/>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table muted_users_table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="user_name">{{t "User" }}</th>
                 <th data-sort="numeric" data-sort-prop="date_muted">{{t "Date muted" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="muted_users_table" class="required-text" data-empty="{{t 'You have not muted any users yet.'}}"></tbody>
+            <tbody id="muted_users_table" class="required-empty-text required-search-results-empty-text" data-empty="{{t 'You have not muted any users yet.'}}"
+              data-search-results-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -78,7 +78,9 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_playgrounds_table" class="required-text" data-empty="{{t 'No playgrounds configured.' }}"></tbody>
+                <tbody id="admin_playgrounds_table" class="required-empty-text required-search-results-empty-text" data-empty="{{t 'No playgrounds configured.' }}"
+                  data-search-results-empty="{{t 'No playgrounds match your current filter.' }}">
+                </tbody>
             </table>
         </div>
     </div>

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -9,7 +9,7 @@
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>
-        <table class="table table-condensed table-striped wrapped-table">
+        <table class="table table-condensed table-striped wrapped-table admin_users_table">
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
@@ -20,8 +20,10 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody id="admin_users_table" class="admin_user_table required-text thick"
-              data-empty="{{t 'No users match your current filter.' }}"></tbody>
+            <tbody id="admin_users_table" class="admin_user_table required-empty-text required-search-results-empty-text thick"
+              data-empty="{{t 'No users match your current filter.' }}"
+              data-search-results-empty="{{t 'No users match your current filter.' }}">
+            </tbody>
         </table>
     </div>
     <div id="admin_page_users_loading_indicator"></div>


### PR DESCRIPTION
Improve the layout to display the message more nicely when no search results are found.

Fixes: #23072 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Recent Topics

https://user-images.githubusercontent.com/72064462/194719630-448f3b98-0ead-44e3-855c-a0779dd5380f.mp4

**_Recent topics doesn't update in realtime [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20topics.20don't.20update.20in.20realtime)_** 

### Users(right side bar)

![Screenshot 2022-10-08 at 10 52 32 PM](https://user-images.githubusercontent.com/72064462/194719854-0fec584a-04f0-4449-8ddb-dc020f5da424.png)

### Settings

**Personal**

- Uploaded Files:

https://user-images.githubusercontent.com/72064462/194717983-8347cee1-8f1b-477e-9970-a6441ae85eb7.mp4

- Muted topics:

https://user-images.githubusercontent.com/72064462/194718019-414980df-b107-4fc7-8ba9-2d35bac78c5d.mp4

- Muted users:

https://user-images.githubusercontent.com/72064462/194718041-542b5a63-2ce2-4f1d-93ac-bc4e12b3534f.mp4

**Organization**

- Custom emoji

https://user-images.githubusercontent.com/72064462/194718164-a46d7152-1295-4985-8d9d-aeace8d5cb59.mp4

- Users 

https://user-images.githubusercontent.com/72064462/194718175-c294309f-24ed-42fc-a425-39f66d865548.mp4

- Deactivated users

https://user-images.githubusercontent.com/72064462/194718184-f44b42b0-4394-4680-83df-637036bdabce.mp4

- Bots

<img width="1069" alt="bots" src="https://user-images.githubusercontent.com/72064462/194718200-a1b858cf-c104-4863-ac5e-8244e9edb37b.png">

- Default streams

Uploading default_streams.mp4…

- Linkifiers 

https://user-images.githubusercontent.com/72064462/194718223-b788ced6-fb9c-47a1-a976-39618feff6f5.mp4

- Code playgrounds

https://user-images.githubusercontent.com/72064462/194718282-7d52e3db-49b8-4a6a-9610-aa54d97f712e.mp4

- Invites 

https://user-images.githubusercontent.com/72064462/194718235-d1b44177-8386-4819-b7cd-63e728e82c50.mp4

- Data exports

<img width="1043" alt="data_exports" src="https://user-images.githubusercontent.com/72064462/194718246-bc92b189-52ba-45f2-a85e-c357bd50c084.png">

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
