### PR TITLE
popovers: Fix width of message actions popover.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -258,6 +258,7 @@ test_ui("actions_popover", ({override, mock_template}) => {
         };
     };
 
+    mock_template("actions_popover_template.hbs", false, () => "actions-template");
     mock_template("actions_popover_content.hbs", false, (opts) => {
         // TODO: Test all the properties of the popover
         assert.equal(

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -5,6 +5,7 @@ import $ from "jquery";
 import tippy, {hideAll} from "tippy.js";
 
 import render_actions_popover_content from "../templates/actions_popover_content.hbs";
+import render_actions_popover_template from "../templates/actions_popover_template.hbs";
 import render_no_arrow_popover from "../templates/no_arrow_popover.hbs";
 import render_playground_links_popover_content from "../templates/playground_links_popover_content.hbs";
 import render_remind_me_popover_content from "../templates/remind_me_popover_content.hbs";
@@ -20,6 +21,7 @@ import * as compose_actions from "./compose_actions";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as condense from "./condense";
+import {media_breakpoints_num} from "./css_variables";
 import * as dialog_widget from "./dialog_widget";
 import * as emoji_picker from "./emoji_picker";
 import * as feature_flags from "./feature_flags";
@@ -558,11 +560,18 @@ export function toggle_actions_popover(element, id) {
             placement: message_viewport.height() - ypos < 220 ? "top" : "bottom",
             title: "",
             content: render_actions_popover_content(args),
+            template: render_actions_popover_template(),
             html: true,
             trigger: "manual",
         });
         $elt.popover("show");
         $current_actions_popover_elem = $elt;
+    }
+
+    if (window.innerWidth < media_breakpoints_num.xl) {
+        // This ensures that the popover doesn't overflow to the right of the window.
+        const actions_popover_left = window.innerWidth - $(".actions_popover_wrapper").outerWidth();
+        $(".actions_popover_wrapper").css("left", actions_popover_left);
     }
 }
 

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -48,6 +48,16 @@ kbd {
     }
 }
 
+@media (width < $xl_min) {
+    .hide-xl {
+        display: none !important;
+    }
+
+    .show-xl {
+        display: block !important;
+    }
+}
+
 .light {
     font-weight: 300;
 }

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -145,6 +145,20 @@ ul {
     }
 }
 
+.actions_popover_wrapper {
+    .arrow {
+        position: absolute;
+    }
+
+    @media (width < $xl_min) {
+        width: max-content;
+    }
+
+    @media (width <= $mm_min) {
+        width: auto;
+    }
+}
+
 .actions_popover {
     .mark_as_unread {
         .unread_count {

--- a/static/templates/actions_popover_template.hbs
+++ b/static/templates/actions_popover_template.hbs
@@ -1,0 +1,6 @@
+<div class="popover actions_popover_wrapper">
+    <div class="arrow hide-xl"></div>
+    <div class="popover-content">
+        <div></div>
+    </div>
+</div>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -71,7 +71,6 @@ EXEMPT_FILES = make_set(
         "static/js/confirm_dialog.js",
         "static/js/copy_and_paste.js",
         "static/js/csrf.ts",
-        "static/js/css_variables.js",
         "static/js/dark_theme.js",
         "static/js/debug.js",
         "static/js/deprecated_feature_notice.js",


### PR DESCRIPTION
Fixes #23017
This change allows us to have non-wrapped text in English on small widths without affecting other popovers.

<img width="428" alt="image" src="https://user-images.githubusercontent.com/25124304/193787447-b6bc858f-d057-4536-803c-220100518fca.png">


Since the arrow is aligned correctly, I don't think we need to remove it, right?
