### PR TITLE
Organize message three-dot menu and change topic editing to be done from modal only.

### DIFF
--- a/frontend_tests/puppeteer_tests/edit.ts
+++ b/frontend_tests/puppeteer_tests/edit.ts
@@ -20,10 +20,9 @@ async function trigger_edit_last_message(page: Page): Promise<void> {
     await page.waitForSelector(".message_edit_content", {visible: true});
 }
 
-async function edit_stream_message(page: Page, topic: string, content: string): Promise<void> {
+async function edit_stream_message(page: Page, content: string): Promise<void> {
     await trigger_edit_last_message(page);
 
-    await common.clear_and_type(page, ".message_edit_topic", topic);
     await common.clear_and_type(page, ".message_edit_content", content);
     await page.click(".message_edit_save");
 
@@ -37,7 +36,7 @@ async function test_stream_message_edit(page: Page): Promise<void> {
         content: "test editing",
     });
 
-    await edit_stream_message(page, "edits", "test edited");
+    await edit_stream_message(page, "test edited");
 
     await common.check_messages_sent(page, "zhome", [["Verona > edits", ["test edited"]]]);
 }
@@ -61,7 +60,7 @@ async function test_edit_message_with_slash_me(page: Page): Promise<void> {
         )} and normalize-space()="Desdemona"]`,
     );
 
-    await edit_stream_message(page, "edits", "/me test edited a message with me");
+    await edit_stream_message(page, "/me test edited a message with me");
 
     await page.waitForSelector(
         `xpath/${last_message_xpath}//*[${common.has_class_x(

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -128,7 +128,7 @@ export function initialize() {
         }
 
         // UI elements for triggering message editing or viewing edit history.
-        if ($target.is("i.edit_content_button") || $target.is(".message_edit_notice")) {
+        if ($target.is("i.edit_message_button") || $target.is(".message_edit_notice")) {
             return true;
         }
 
@@ -273,10 +273,23 @@ export function initialize() {
 
     // MESSAGE EDITING
 
-    $("body").on("click", ".edit_content_button", function (e) {
+    $("body").on("click", ".edit_content_button, .view_source_button", function (e) {
         const $row = message_lists.current.get_row(rows.id($(this).closest(".message_row")));
         message_lists.current.select_id(rows.id($row));
         message_edit.start($row);
+        e.stopPropagation();
+        popovers.hide_all();
+    });
+    $("body").on("click", ".move_message_button", function (e) {
+        const $row = message_lists.current.get_row(rows.id($(this).closest(".message_row")));
+        const message_id = rows.id($row);
+        message_lists.current.select_id(message_id);
+        const message = message_lists.current.get(message_id);
+        stream_popover.build_move_topic_to_stream_popover(
+            message.stream_id,
+            message.topic,
+            message,
+        );
         e.stopPropagation();
         popovers.hide_all();
     });

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -978,6 +978,7 @@ export function move_topic_containing_message_to_stream(
     new_topic_name,
     send_notification_to_new_thread,
     send_notification_to_old_thread,
+    propagate_mode,
 ) {
     function reset_modal_ui() {
         currently_topic_editing_messages = currently_topic_editing_messages.filter(
@@ -997,7 +998,7 @@ export function move_topic_containing_message_to_stream(
 
     const request = {
         stream_id: new_stream_id,
-        propagate_mode: "change_all",
+        propagate_mode,
         topic: new_topic_name,
         send_notification_to_old_thread,
         send_notification_to_new_thread,

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -985,7 +985,6 @@ export function move_topic_containing_message_to_stream(
             (id) => id !== message_id,
         );
         dialog_widget.hide_dialog_spinner();
-        dialog_widget.close_modal();
     }
     if (currently_topic_editing_messages.includes(message_id)) {
         ui_report.client_error(
@@ -1012,15 +1011,11 @@ export function move_topic_containing_message_to_stream(
             // The main UI will update via receiving the event
             // from server_events.js.
             reset_modal_ui();
+            dialog_widget.close_modal();
         },
         error(xhr) {
             reset_modal_ui();
-            ui_report.error(
-                $t_html({defaultMessage: "Error moving the topic"}),
-                xhr,
-                $("#home-error"),
-                4000,
-            );
+            ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
         },
     });
 }

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -15,9 +15,7 @@ import * as composebox_typeahead from "./composebox_typeahead";
 import * as condense from "./condense";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
-import {DropdownListWidget} from "./dropdown_list_widget";
 import * as echo from "./echo";
-import * as giphy from "./giphy";
 import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as markdown from "./markdown";
@@ -28,9 +26,7 @@ import {page_params} from "./page_params";
 import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
-import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
-import * as sub_store from "./sub_store";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as util from "./util";
@@ -401,7 +397,6 @@ export function get_available_streams_for_moving_messages(current_stream_id) {
 }
 
 function edit_message($row, raw_content) {
-    let stream_widget;
     $row.find(".message_reactions").hide();
     condense.hide_message_expander($row);
     condense.hide_message_condenser($row);
@@ -426,43 +421,16 @@ function edit_message($row, raw_content) {
         file_upload_enabled = true;
     }
 
-    const is_stream_editable =
-        message.is_stream && settings_data.user_can_move_messages_between_streams();
-    const is_editable =
-        editability === editability_types.TOPIC_ONLY ||
-        editability === editability_types.FULL ||
-        is_stream_editable;
-    const is_content_editable = editability === editability_types.FULL;
+    const is_editable = editability === editability_types.FULL;
     // current message's stream has been already been added and selected in Handlebars
-    const available_streams = is_stream_editable
-        ? get_available_streams_for_moving_messages(message.stream_id)
-        : null;
-
-    const select_move_stream_widget_name = `select_move_stream_${message.id}`;
-    const opts = {
-        widget_name: select_move_stream_widget_name,
-        data: available_streams,
-        default_text: $t({defaultMessage: "No streams"}),
-        include_current_item: true,
-        value: message.stream_id,
-        on_update: set_propagate_selector_display,
-    };
 
     const $form = $(
         render_message_edit_form({
-            is_stream: message.type === "stream",
             message_id: message.id,
             is_editable,
-            is_content_editable,
-            topic: message.topic,
             content: raw_content,
             file_upload_enabled,
             minutes_to_edit: Math.floor(page_params.realm_message_content_edit_limit_seconds / 60),
-            is_stream_editable,
-            select_move_stream_widget_name,
-            notify_new_thread: notify_new_thread_default,
-            notify_old_thread: notify_old_thread_default,
-            giphy_enabled: giphy.is_giphy_enabled(),
             max_message_length: page_params.max_message_length,
         }),
     );
@@ -478,82 +446,37 @@ function edit_message($row, raw_content) {
         .toggle(compose.compute_show_video_chat_button());
     upload.feature_check($(`#edit_form_${CSS.escape(rows.id($row))} .compose_upload_file`));
 
-    const $stream_header_colorblock = $row.find(".stream_header_colorblock");
     const $message_edit_content = $row.find("textarea.message_edit_content");
-    const $message_edit_topic = $row.find("input.message_edit_topic");
-    const $message_edit_topic_propagate = $row.find("select.message_edit_topic_propagate");
-    const $message_edit_breadcrumb_messages = $row.find("div.message_edit_breadcrumb_messages");
     const $message_edit_countdown_timer = $row.find(".message_edit_countdown_timer");
     const $copy_message = $row.find(".copy_message");
 
-    // One might expect us to initially show the message move
-    // propagation select UI if and only if the user has permission to
-    // edit the topic. However, in the common case that a user sent
-    // the message themselves and thus has permission to edit the
-    // content, this dropdown can feel like clutter, so we don't show
-    // it until the stream/topic has been changed in that case.
-    //
-    // So we show this widget initially if and only if the stream or
-    // topic is editable, but the content is not.
-    $message_edit_topic_propagate.toggle(is_editable && !is_content_editable);
-
-    if (is_stream_editable) {
-        stream_widget = new DropdownListWidget(opts);
-        stream_widget.setup();
-    }
-    stream_bar.decorate(message.stream, $stream_header_colorblock, false);
-
-    switch (editability) {
-        case editability_types.NO:
-            $message_edit_content.attr("readonly", "readonly");
-            $message_edit_topic.attr("readonly", "readonly");
-            create_copy_to_clipboard_handler($row, $copy_message[0], message.id);
-            break;
-        case editability_types.NO_LONGER:
-            // You can currently only reach this state in non-streams. If that
-            // changes (e.g. if we stop allowing topics to be modified forever
-            // in streams), then we'll need to disable
-            // row.find('input.message_edit_topic') as well.
-            $message_edit_content.attr("readonly", "readonly");
-            create_copy_to_clipboard_handler($row, $copy_message[0], message.id);
-            break;
-        case editability_types.TOPIC_ONLY:
-            $message_edit_content.attr("readonly", "readonly");
-            // Hint why you can edit the topic but not the message content
-            create_copy_to_clipboard_handler($row, $copy_message[0], message.id);
-            break;
-        case editability_types.FULL: {
-            $copy_message.remove();
-            const edit_id = `#edit_form_${CSS.escape(rows.id($row))} .message_edit_content`;
-            const listeners = resize.watch_manual_resize(edit_id);
-            if (listeners) {
-                currently_editing_messages.get(rows.id($row)).listeners = listeners;
-            }
-            composebox_typeahead.initialize_compose_typeahead(edit_id);
-            compose_ui.handle_keyup(null, $(edit_id).expectOne());
-            $(edit_id).on("keydown", function (event) {
-                compose_ui.handle_keydown(event, $(this).expectOne());
-            });
-            $(edit_id).on("keyup", function (event) {
-                compose_ui.handle_keyup(event, $(this).expectOne());
-            });
-            break;
+    if (editability !== editability_types.FULL) {
+        $message_edit_content.attr("readonly", "readonly");
+        create_copy_to_clipboard_handler($row, $copy_message[0], message.id);
+    } else {
+        $copy_message.remove();
+        const edit_id = `#edit_form_${CSS.escape(rows.id($row))} .message_edit_content`;
+        const listeners = resize.watch_manual_resize(edit_id);
+        if (listeners) {
+            currently_editing_messages.get(rows.id($row)).listeners = listeners;
         }
+        composebox_typeahead.initialize_compose_typeahead(edit_id);
+        compose_ui.handle_keyup(null, $(edit_id).expectOne());
+        $(edit_id).on("keydown", function (event) {
+            compose_ui.handle_keydown(event, $(this).expectOne());
+        });
+        $(edit_id).on("keyup", function (event) {
+            compose_ui.handle_keyup(event, $(this).expectOne());
+        });
     }
 
-    // Add tooltip
+    // Add tooltip and timer
     if (
         editability === editability_types.FULL &&
         page_params.realm_message_content_edit_limit_seconds > 0
     ) {
         $row.find(".message-edit-timer").show();
-    }
 
-    // add timer
-    if (
-        editability === editability_types.FULL &&
-        page_params.realm_message_content_edit_limit_seconds > 0
-    ) {
         // Give them at least 10 seconds.
         // If you change this number also change edit_limit_buffer in
         // zerver.actions.message_edit.check_update_message
@@ -575,11 +498,6 @@ function edit_message($row, raw_content) {
             if (seconds_left <= 0) {
                 clearInterval(countdown_timer);
                 $message_edit_content.prop("readonly", "readonly");
-                if (message.type === "stream") {
-                    $message_edit_topic.prop("readonly", "readonly");
-                    $message_edit_topic_propagate.hide();
-                    $message_edit_breadcrumb_messages.hide();
-                }
                 // We don't go directly to a "TOPIC_ONLY" type state (with an active Save button),
                 // since it isn't clear what to do with the half-finished edit. It's nice to keep
                 // the half-finished edit around so that they can copy-paste it, but we don't want
@@ -594,13 +512,6 @@ function edit_message($row, raw_content) {
 
     if (!is_editable) {
         $row.find(".message_edit_close").trigger("focus");
-    } else if (message.type === "stream" && message.topic === compose.empty_topic_placeholder()) {
-        $message_edit_topic.val("");
-        $message_edit_topic.trigger("focus");
-    } else if (editability === editability_types.TOPIC_ONLY) {
-        $row.find(".message_edit_topic").trigger("focus");
-    } else if (editability !== editability_types.FULL && is_stream_editable) {
-        $row.find(".select_stream_setting .dropdown-toggle").trigger("focus");
     } else {
         $message_edit_content.trigger("focus");
         // Put cursor at end of input.
@@ -616,55 +527,6 @@ function edit_message($row, raw_content) {
 
     edit_obj.scrolled_by = scroll_by;
     message_viewport.scrollTop(message_viewport.scrollTop() + scroll_by);
-
-    const original_stream_id = message.stream_id;
-    const original_topic = message.topic;
-
-    // Change the `stream_header_colorblock` when clicked on any dropdown item.
-    function update_stream_header_colorblock() {
-        // Stop the execution if stream_widget is undefined.
-        if (!stream_widget) {
-            return;
-        }
-        const stream_name = stream_data.maybe_get_stream_name(
-            Number.parseInt(stream_widget.value(), 10),
-        );
-
-        stream_bar.decorate(stream_name, $stream_header_colorblock, false);
-    }
-
-    function set_propagate_selector_display() {
-        update_stream_header_colorblock();
-        const new_topic = $message_edit_topic.val();
-        const new_stream_id = is_stream_editable
-            ? Number.parseInt(stream_widget.value(), 10)
-            : null;
-        const is_topic_edited = new_topic !== original_topic && new_topic !== "";
-        const is_stream_edited = is_stream_editable ? new_stream_id !== original_stream_id : false;
-
-        $message_edit_topic_propagate.toggle(
-            is_topic_edited || is_stream_edited || $message_edit_topic_propagate.is(":visible"),
-        );
-        $message_edit_breadcrumb_messages.toggle(is_stream_edited);
-
-        if (is_stream_edited) {
-            /* Reinitialize the typeahead component with content for the new stream. */
-            const new_stream_name = sub_store.get(new_stream_id).name;
-            $message_edit_topic.data("typeahead").unlisten();
-            composebox_typeahead.initialize_topic_edit_typeahead(
-                $message_edit_topic,
-                new_stream_name,
-                true,
-            );
-        }
-    }
-
-    if (!message.locally_echoed) {
-        $message_edit_topic.on("keyup", () => {
-            set_propagate_selector_display();
-        });
-    }
-    composebox_typeahead.initialize_topic_edit_typeahead($message_edit_topic, message.stream, true);
 }
 
 function start_edit_maintaining_scroll($row, content) {
@@ -877,17 +739,8 @@ export function save_message_row_edit($row) {
     let changed = false;
     let edit_locally_echoed = false;
 
-    let content_changed = false;
     let new_content;
     const old_content = message.raw_content;
-
-    let topic_changed = false;
-    let new_topic;
-    const old_topic = message.topic;
-
-    let stream_changed = false;
-    let new_stream_id;
-    const old_stream_id = message.stream_id;
 
     show_message_edit_spinner($row);
 
@@ -895,68 +748,21 @@ export function save_message_row_edit($row) {
     const can_edit_content = $edit_content_input.attr("readonly") !== "readonly";
     if (can_edit_content) {
         new_content = $edit_content_input.val();
-        content_changed = old_content !== new_content;
-        changed = content_changed;
-    }
-
-    const $edit_topic_input = $row.find(".message_edit_topic");
-    const can_edit_topic = message.is_stream && $edit_topic_input.attr("readonly") !== "readonly";
-    if (can_edit_topic) {
-        new_topic = $edit_topic_input.val();
-        topic_changed = new_topic !== old_topic && new_topic.trim() !== "";
-    }
-
-    const can_edit_stream =
-        message.is_stream && settings_data.user_can_move_messages_between_streams();
-    if (can_edit_stream) {
-        const $edit_stream_input = $(`#id_select_move_stream_${message_id}`);
-        new_stream_id = Number.parseInt($edit_stream_input.data("value"), 10);
-        stream_changed = new_stream_id !== old_stream_id;
+        changed = old_content !== new_content;
     }
 
     // Editing a not-yet-acked message (because the original send attempt failed)
     // just results in the in-memory message being changed
     if (message.locally_echoed) {
-        if (new_content !== message.raw_content || topic_changed || stream_changed) {
+        if (new_content !== message.raw_content) {
             // `edit_locally` handles the case where `new_topic/new_stream_id` is undefined
             echo.edit_locally(message, {
                 raw_content: new_content,
-                new_topic,
-                new_stream_id,
             });
             $row = message_lists.current.get_row(message_id);
         }
         end_message_row_edit($row);
         return;
-    }
-
-    const request = {message_id: message.id};
-
-    if (topic_changed || stream_changed) {
-        const selected_topic_propagation =
-            $row.find("select.message_edit_topic_propagate").val() || "change_later";
-        const send_notification_to_old_thread = $row
-            .find(".send_notification_to_old_thread")
-            .is(":checked");
-        const send_notification_to_new_thread = $row
-            .find(".send_notification_to_new_thread")
-            .is(":checked");
-        request.propagate_mode = selected_topic_propagation;
-        request.send_notification_to_old_thread = send_notification_to_old_thread;
-        request.send_notification_to_new_thread = send_notification_to_new_thread;
-        notify_old_thread_default = send_notification_to_old_thread;
-        notify_new_thread_default = send_notification_to_new_thread;
-        changed = true;
-    }
-
-    if (topic_changed) {
-        request.topic = new_topic;
-    }
-    if (stream_changed) {
-        request.stream_id = new_stream_id;
-    }
-    if (content_changed) {
-        request.content = new_content;
     }
 
     if (!changed) {
@@ -965,15 +771,11 @@ export function save_message_row_edit($row) {
         return;
     }
 
-    if (
-        changed &&
-        !topic_changed &&
-        !stream_changed &&
-        !markdown.contains_backend_only_syntax(new_content)
-    ) {
-        // If the topic isn't changed, and the new message content
-        // could have been locally echoed, than we can locally echo
-        // the edit.
+    const request = {message_id: message.id, content: new_content};
+
+    if (!markdown.contains_backend_only_syntax(new_content)) {
+        // If the new message content could have been locally echoed,
+        // than we can locally echo the edit.
         currently_echoing_messages.set(message_id, {
             raw_content: new_content,
             orig_content: message.content,

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -317,7 +317,7 @@ export class MessageList {
     show_edit_topic_on_recipient_row($recipient_row, $form) {
         $recipient_row.find(".topic_edit_form").append($form);
         $recipient_row.find(".on_hover_topic_edit").hide();
-        $recipient_row.find(".edit_content_button").hide();
+        $recipient_row.find(".edit_message_button").hide();
         $recipient_row.find(".stream_topic").hide();
         $recipient_row.find(".topic_edit").show();
         $recipient_row.find(".always_visible_topic_edit").hide();
@@ -326,7 +326,7 @@ export class MessageList {
     hide_edit_topic_on_recipient_row($recipient_row) {
         $recipient_row.find(".stream_topic").show();
         $recipient_row.find(".on_hover_topic_edit").show();
-        $recipient_row.find(".edit_content_button").show();
+        $recipient_row.find(".edit_message_button").show();
         $recipient_row.find(".topic_edit_form").empty();
         $recipient_row.find(".topic_edit").hide();
         $recipient_row.find(".always_visible_topic_edit").show();

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1333,18 +1333,26 @@ export function register_click_handlers() {
         e.stopPropagation();
         e.preventDefault();
     });
-    $("body").on(
-        "click",
-        ".popover_edit_message, .popover_move_message, .popover_view_source",
-        (e) => {
-            const message_id = $(e.currentTarget).data("message-id");
-            const $row = message_lists.current.get_row(message_id);
-            hide_actions_popover();
-            message_edit.start($row);
-            e.stopPropagation();
-            e.preventDefault();
-        },
-    );
+    $("body").on("click", ".popover_edit_message, .popover_view_source", (e) => {
+        const message_id = $(e.currentTarget).data("message-id");
+        const $row = message_lists.current.get_row(message_id);
+        hide_actions_popover();
+        message_edit.start($row);
+        e.stopPropagation();
+        e.preventDefault();
+    });
+    $("body").on("click", ".popover_move_message", (e) => {
+        const message_id = $(e.currentTarget).data("message-id");
+        const message = message_lists.current.get(message_id);
+        hide_actions_popover();
+        stream_popover.build_move_topic_to_stream_popover(
+            message.stream_id,
+            message.topic,
+            message,
+        );
+        e.stopPropagation();
+        e.preventDefault();
+    });
     $("body").on("click", ".rehide_muted_user_message", (e) => {
         const message_id = $(e.currentTarget).data("message-id");
         const $row = message_lists.current.get_row(message_id);

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -389,7 +389,7 @@ function build_drafts_popover(e) {
     e.stopPropagation();
 }
 
-function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
+function build_move_topic_to_stream_popover(current_stream_id, topic_name) {
     const current_stream_name = stream_data.maybe_get_stream_name(current_stream_id);
     const args = {
         topic_name,
@@ -801,7 +801,7 @@ export function register_topic_handlers() {
         const $topic_row = $(e.currentTarget);
         const stream_id = Number.parseInt($topic_row.attr("data-stream-id"), 10);
         const topic_name = $topic_row.attr("data-topic-name");
-        build_move_topic_to_stream_popover(e, stream_id, topic_name);
+        build_move_topic_to_stream_popover(stream_id, topic_name);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -171,7 +171,7 @@ export function initialize() {
                 // content from it.
                 //
                 // TODO: Change the template structure so logic is unnecessary.
-                const $edit_button = $elem.find("i.edit_content_button");
+                const $edit_button = $elem.find("i.edit_message_button");
                 content = $edit_button.attr("data-tippy-content");
             }
 

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -142,10 +142,15 @@ function message_hover($message_row) {
     }
 
     // But the message edit hover icon is determined by whether the message is still editable
-    const is_message_editable =
-        message_edit.get_editability(message) === message_edit.editability_types.FULL;
+    const editability = message_edit.get_editability(message);
+    const is_content_editable = editability === message_edit.editability_types.FULL;
+    const is_stream_editable =
+        message.is_stream && settings_data.user_can_move_messages_between_streams();
+    const can_move_message =
+        editability === message_edit.editability_types.TOPIC_ONLY || is_stream_editable;
     const args = {
-        is_editable: is_message_editable && !message.status_message,
+        is_content_editable: is_content_editable && !message.status_message,
+        can_move_message,
         msg_id: id,
     };
     $message_row.find(".edit_content").html(render_edit_content_button(args));

--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -225,6 +225,12 @@
     }
 }
 
+#select_stream_widget {
+    .dropdown-toggle:disabled {
+        pointer-events: none;
+    }
+}
+
 @keyframes mmfadeIn {
     from {
         opacity: 0;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1555,7 +1555,7 @@ div.focused_table {
 
 .message_edit_topic_propagate {
     display: inline-block;
-    width: 320px;
+    width: auto;
     margin-bottom: 10px;
     max-width: 100%;
 }

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -1,12 +1,13 @@
 {{! Contents of the "message actions" popup }}
 <ul class="nav nav-list actions_popover">
-    {{#if should_display_hide_option}}
+    {{#if should_display_quote_and_reply}}
     <li>
-        <a class="rehide_muted_user_message" data-message-id="{{message_id}}" tabindex="0">
-            <i class="fa fa-eye-slash" aria-hidden="true"></i>
-            {{t "Hide muted message again" }}
+        <a class="respond_button" data-message-id="{{message_id}}" tabindex="0">
+            <i class="fa fa-reply" aria-hidden="true"></i> {{t "Quote and reply or forward" }}
+            <span class="hotkey-hint">(>)</span>
         </a>
     </li>
+    <hr />
     {{/if}}
 
     {{#if editability_menu_item}}
@@ -27,21 +28,27 @@
     </li>
     {{/if}}
 
-    {{#if should_display_quote_and_reply}}
+    {{#if should_display_delete_option}}
     <li>
-        <a class="respond_button" data-message-id="{{message_id}}" tabindex="0">
-            <i class="fa fa-reply" aria-hidden="true"></i> {{t "Quote and reply or forward" }}
-            <span class="hotkey-hint">(>)</span>
+        <a class="delete_message" data-message-id="{{message_id}}" tabindex="0">
+            <i class="fa fa-times" aria-hidden="true"></i>
+            {{t "Delete message" }}
         </a>
     </li>
     {{/if}}
 
-    {{#if view_source_menu_item}}
+    {{#if (or editability_menu_item move_message_menu_item should_display_delete_option)}}
+    <hr />
+    {{/if}}
+
+    {{#if should_display_add_reaction_option}}
     <li>
-        <a class="popover_view_source" data-message-id="{{message_id}}" tabindex="0">
-            <i class="fa fa-file-code-o" aria-hidden="true"></i> {{view_source_menu_item}}
+        <a class="reaction_button" data-message-id="{{message_id}}" tabindex="0">
+            <i class="fa fa-smile-o" aria-hidden="true"></i>
+            {{#tr}}Add emoji reaction{{/tr}}
         </a>
     </li>
+    <hr />
     {{/if}}
 
     {{#if should_display_mark_as_unread}}
@@ -58,6 +65,15 @@
     <li>
         <a class='reminder_button' data-message-id="{{message_id}}" tabindex="0">
             <i class="fa fa-bell" aria-hidden="true"></i> {{t "Remind me about this" }}
+        </a>
+    </li>
+    {{/if}}
+
+    {{#if should_display_hide_option}}
+    <li>
+        <a class="rehide_muted_user_message" data-message-id="{{message_id}}" tabindex="0">
+            <i class="fa fa-eye-slash" aria-hidden="true"></i>
+            {{t "Hide muted message again" }}
         </a>
     </li>
     {{/if}}
@@ -80,28 +96,23 @@
     </li>
     {{/if}}
 
+    {{#if (or should_display_mark_as_unread should_display_reminder_option should_display_hide_option should_display_collapse should_display_uncollapse)}}
+    <hr />
+    {{/if}}
+
+    {{#if view_source_menu_item}}
+    <li>
+        <a class="popover_view_source" data-message-id="{{message_id}}" tabindex="0">
+            <i class="fa fa-file-code-o" aria-hidden="true"></i> {{view_source_menu_item}}
+        </a>
+    </li>
+    {{/if}}
+
     {{#if should_display_edit_history_option}}
     <li>
         <a class="view_edit_history" data-message-id="{{message_id}}" tabindex="0">
             <i class="fa fa-clock-o" aria-hidden="true"></i>
             {{t "View edit history" }}
-        </a>
-    </li>
-    {{/if}}
-    {{#if should_display_delete_option}}
-    <li>
-        <a class="delete_message" data-message-id="{{message_id}}" tabindex="0">
-            <i class="fa fa-times" aria-hidden="true"></i>
-            {{t "Delete message" }}
-        </a>
-    </li>
-    {{/if}}
-
-    {{#if should_display_add_reaction_option}}
-    <li>
-        <a class="reaction_button" data-message-id="{{message_id}}" tabindex="0">
-            <i class="fa fa-smile-o" aria-hidden="true"></i>
-            {{#tr}}Add emoji reaction{{/tr}}
         </a>
     </li>
     {{/if}}

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -23,7 +23,6 @@
     <li>
         <a class="popover_move_message" data-message-id="{{message_id}}" tabindex="0">
             <i class="fa fa-arrows" aria-hidden="true"></i> {{move_message_menu_item}}
-            <span class="hotkey-hint">(e)</span>
         </a>
     </li>
     {{/if}}

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -90,7 +90,7 @@
     <li>
         <a class="popover_toggle_collapse" data-message-id="{{message_id}}" tabindex="0">
             <i class="fa fa-plus" aria-hidden="true"></i>
-            {{t "Un-collapse" }} <span class="hotkey-hint">(–)</span>
+            {{t "Expand message" }} <span class="hotkey-hint">(–)</span>
         </a>
     </li>
     {{/if}}

--- a/static/templates/edit_content_button.hbs
+++ b/static/templates/edit_content_button.hbs
@@ -1,5 +1,7 @@
-{{#if is_editable}}
-<i class="fa fa-pencil edit_content_button" role="button" tabindex="0" aria-label="{{t 'Edit message' }} (e)" data-tippy-content="{{#tr}}Edit message{{/tr}} (e)"></i>
+{{#if is_content_editable}}
+<i class="fa fa-pencil edit_content_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Edit message' }} (e)" data-tippy-content="{{#tr}}Edit message{{/tr}} (e)"></i>
+{{else if can_move_message}}
+<i class="fa fa-arrows move_message_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Move message' }} (e)" data-tippy-content="{{#tr}}Move message{{/tr}}"></i>
 {{else}}
-<i class="fa fa-file-code-o edit_content_button" role="button" tabindex="0" aria-label="{{t 'View message source' }} (e)" data-tippy-content="{{#tr}}View message source{{/tr}} (e)" data-message-id="{{msg_id}}"></i>
+<i class="fa fa-file-code-o view_source_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'View message source' }} (e)" data-tippy-content="{{#tr}}View message source{{/tr}} (e)" data-message-id="{{msg_id}}"></i>
 {{/if}}

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -217,7 +217,7 @@
                     <td><span class="hotkey"><kbd>V</kbd></span></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
-                    <td class="definition">{{t 'Edit selected message' }}</td>
+                    <td class="definition">{{t 'Edit selected message or view message source' }}</td>
                     <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
                 <tr>

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -5,37 +5,6 @@
         <span class="send-status-close">&times;</span>
         <span class="error-msg"></span>
     </div>
-    {{#if is_stream}}
-    <div class="edit-controls">
-        <div class="message_edit_header">
-            <div class="stream_header_colorblock" {{#unless is_stream_editable}}style="display:none"{{/unless}}></div>
-            <div class="select_stream_setting" {{#unless is_stream_editable}}style="display:none"{{/unless}}>
-                {{> settings/dropdown_list_widget
-                  widget_name=select_move_stream_widget_name
-                  list_placeholder=(t 'Filter streams')}}
-            </div>
-            <i class="fa fa-angle-right" aria-hidden="true" {{#unless is_stream_editable}}style="display:none"{{/unless}}></i>
-            <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" autocomplete="off" />
-        </div>
-        <select class='message_edit_topic_propagate' style='display:none;'>
-            <option value="change_one"> {{t "Move only this message" }}</option>
-            <option selected="selected" value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
-            <option value="change_all"> {{t "Move all messages in this topic" }}</option>
-        </select>
-        <div class="message_edit_breadcrumb_messages"  style='display:none;'>
-            <label class="checkbox">
-                <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />
-                <span></span>
-                {{t "Send automated notice to new topic" }}
-            </label>
-            <label class="checkbox">
-                <input class="send_notification_to_old_thread" name="send_notification_to_old_thread" type="checkbox" {{#if notify_old_thread}}checked="checked"{{/if}} />
-                <span></span>
-                {{t "Send automated notice to old topic" }}
-            </label>
-        </div>
-    </div>
-    {{/if}}
     <div class="edit-controls">
         {{> copy_message_button message_id=this.message_id}}
         <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
@@ -57,7 +26,7 @@
                 <div class="btn-wrapper inline-block">
                     <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
                 </div>
-                {{#if is_content_editable}}
+                {{#if is_editable}}
                 <div class="message-edit-feature-group">
                     {{> compose_control_buttons }}
                 </div>
@@ -65,7 +34,7 @@
             {{else}}
                 <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
             {{/if}}
-            {{#if is_content_editable}}
+            {{#if is_editable}}
             <div class="message-edit-timer">
                 <span class="message_edit_countdown_timer"></span>
                 <span>

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -11,7 +11,7 @@
               list_placeholder=(t 'Filter streams')}}
         </div>
         <i class="fa fa-angle-right" aria-hidden="true"></i>
-        <input name="new_topic_name" type="text" class="inline_topic_edit" autocomplete="off" value="{{topic_name}}" />
+        <input name="new_topic_name" type="text" class="inline_topic_edit" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         <input name="old_topic_name" type="hidden" class="inline_topic_edit" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         {{#if from_message_actions_popover}}

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -1,4 +1,6 @@
+{{#unless from_message_actions_popover}}
 <p>{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
+{{/unless}}
 <form class="new-style" id="move_topic_form">
     <p>{{t "Select a stream below or change topic name." }}</p>
     <div class="topic_stream_edit_header">
@@ -12,6 +14,13 @@
         <input name="new_topic_name" type="text" class="inline_topic_edit" autocomplete="off" value="{{topic_name}}" />
         <input name="old_topic_name" type="hidden" class="inline_topic_edit" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
+        {{#if from_message_actions_popover}}
+        <select class="message_edit_topic_propagate">
+            <option value="change_one"> {{t "Move only this message" }}</option>
+            <option selected="selected" value="change_later"> {{t "Move this and all following messages in this topic" }}</option>
+            <option value="change_all"> {{t "Move all messages in this topic" }}</option>
+        </select>
+        {{/if}}
         <div class="topic_move_breadcrumb_messages">
             <label class="checkbox">
                 <input class="send_notification_to_new_thread" name="send_notification_to_new_thread" type="checkbox" {{#if notify_new_thread}}checked="checked"{{/if}} />

--- a/templates/zerver/help/collapse-a-message.md
+++ b/templates/zerver/help/collapse-a-message.md
@@ -14,5 +14,6 @@ remove the message content from view.
 
 {end_tabs}
 
-To un-collapse a message, click **[More...]** at the bottom of the collapsed
-message.
+!!! tip ""
+     To expand a message, click **[More...]** at the bottom of the collapsed
+     message.

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -143,7 +143,7 @@ below, and add more to your repertoire as needed.
 
 * **View image**: <kbd>V</kbd>
 
-* **Edit message**: <kbd>E</kbd>
+* **Edit message or view message source**: <kbd>E</kbd>
 
 * **Star message**: <kbd>Ctrl</kbd> + <kbd>S</kbd>
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to reorganize the three-dot menu as per #23076.
- Second commit is a simple refactor to not pass unused variable.
- Third commit is to allow only content editing from message edit UI and not topic or stream editing.
- Fourth commit is to change topic editing UI to be a modal.
- Fifth commit is to show "Move message" icon instead of "View source" icon if only moving message is allowed.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures**
![message-popover](https://user-images.githubusercontent.com/35494118/193838972-2047ada9-cf5d-4626-a7d9-ac99fc139302.gif)



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
