### PR TITLE
msg_actions_popover: Allow keyboard navigation to mark as unread button.

### DIFF
--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -46,7 +46,7 @@
 
     {{#if should_display_mark_as_unread}}
         <li>
-            <a class="mark_as_unread" data-message-id="{{message_id}}">
+            <a class="mark_as_unread" data-message-id="{{message_id}}" tabindex="0">
                 <span class="unread_count">1</span>
                 {{t "Mark as unread from here" }}
                 <span class="hotkey-hint">(U)</span>


### PR DESCRIPTION
We missed defining `tabindex` in the HTML element of the button.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/message.20menu.20keyboard.20nav