### PR TITLE
help: Document option to display custom profile fields in profile summary.

### DIFF
--- a/templates/zerver/help/add-custom-profile-fields.md
+++ b/templates/zerver/help/add-custom-profile-fields.md
@@ -17,11 +17,12 @@ methods][authentication-production] documentation for details.
 
 {settings_tab|profile-field-settings}
 
-1. Under **Add a new profile field**, enter a **Label**, **Hint**, and **Type**.
+1. Click **Add a new profile field**.
 
-1. Click **Add profile field**.
+1. Fill out profile field information as desired, and click **Add**.
 
-1. Click and drag the vertical dots on the left to order the fields.
+1. In the **Labels** column, click and drag the vertical dots to reorder the
+   list of custom profile fields.
 
 {end_tabs}
 

--- a/templates/zerver/help/add-custom-profile-fields.md
+++ b/templates/zerver/help/add-custom-profile-fields.md
@@ -1,5 +1,7 @@
 # Add custom profile fields
 
+{!admin-only.md!}
+
 By default, user profiles show their name, email, date they joined, and when
 they were last active. You can also add custom profile fields like country
 of residence, birthday, manager, Twitter handle, and more.
@@ -39,6 +41,35 @@ There are several different types of fields available.
 * **List of options**: Creates a dropdown with a list of options.
 * **Person picker**: For selecting other users, like "Manager" or
     "Direct reports".
+
+## Display custom fields in user profile summaries
+
+Organizations may find it useful to display additional fields in a user's
+profile summary, such as pronouns, GitHub username, job title, team, etc.
+
+All field types other than "Long text" or "Person" have a checkbox option
+that controls whether to display a custom field in a user's profile summary.
+There's a limit to the number of custom profile fields that can be displayed
+at a time. If the maximum number of fields is already selected, all unselected
+checkboxes will be disabled.
+
+{start_tabs}
+
+{settings_tab|profile-field-settings}
+
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the profile field
+   you want to edit.
+
+1. Toggle **Display in profile summary**.
+
+4. Click **Save changes**.
+
+!!! tip ""
+
+    You can also choose which custom profile fields will be displayed by toggling
+    the checkboxes in the **Summary** column of the **Custom profile fields** table.
+
+{end_tabs}
 
 ## Related articles
 


### PR DESCRIPTION

- Updates instructions for adding a new custom profile field.
- Adds a section explaining what this option is and how to manage it via the settings table.
- Adds owner/admin only message at the top of the article.

Fixes: #23018.

**Screenshots and screen captures:**

- **Current docs: https://zulip.com/help/add-custom-profile-fields#add-a-custom-profile-field**

<img width="788" alt="image" src="https://user-images.githubusercontent.com/2343554/193955019-d4f6cd52-f242-4f7e-aa54-bb035da8cd69.png">

<img width="787" alt="image" src="https://user-images.githubusercontent.com/2343554/193955176-14603a05-444a-41cf-b280-4b1dbe3a3918.png">


**Remaining concerns:**
During testing, I noticed that if a non owner/admin user goes to http://localhost:9991/#organization/profile-field-settings, it will redirect to http://localhost:9991/#organization/undefined with the following message:
<img width="384" alt="image" src="https://user-images.githubusercontent.com/2343554/193955582-2eb82fa3-7bc2-49cc-abf7-f2746a6ae08f.png">

I am not sure if this is a known issue already, but maybe we should redirect to http://localhost:9991/#organization/ instead, and/or show an appropriate message if possible.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Manual testing of links
</details>