### PR TITLE
docs: Update mypy documentation on django-stubs

### DIFF
--- a/docs/testing/mypy.md
+++ b/docs/testing/mypy.md
@@ -19,10 +19,7 @@ You can learn more about it at:
 - The
   [mypy cheat sheet for Python 3](https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html)
   is the best resource for quickly understanding how to write the PEP
-  484 type annotations used by mypy correctly. The
-  [Python 2 cheat sheet](https://mypy.readthedocs.io/en/latest/cheat_sheet.html)
-  is useful for understanding the type comment syntax needed for our
-  few modules that need to support both Python 2 and 3.
+  484 type annotations used by mypy correctly.
 
 - The
   [Python type annotation spec in PEP 484](https://www.python.org/dev/peps/pep-0484/).

--- a/docs/testing/mypy.md
+++ b/docs/testing/mypy.md
@@ -381,6 +381,21 @@ types might be appropriate. (But don’t use `Iterable` for a value
 that might be iterated multiple times, since a one-use iterator is
 `Iterable` too.)
 
+For example, if a function gets called with either a `list` or a `QuerySet`,
+and it only iterates the object once, the parameter can be typed as `Iterable`.
+
+```python
+def f(items: Iterable[Realm]) -> None:
+    for item in items:
+        ...
+
+realms_list: List[Realm] = [zulip, analytics]
+realms_queryset: QuerySet[Realm] = Realm.objects.all()
+
+f(realms_list)      # OK
+f(realms_queryset)  # Also OK
+```
+
 A function's return type can be mutable if the return value is always
 a freshly created collection, since the caller ends up with the only
 reference to the value and can freely mutate it without risk of


### PR DESCRIPTION
This is a follow-up to #18777.

Some additional documentation is added regarding features supported by django-stubs.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
