### PR TITLE
settings_org: Add missing closing square bracket.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -551,7 +551,7 @@ function discard_property_element_changes(elem, for_realm_default_settings) {
             // needs custom reset code.
             $elem
                 .closest(".org-subsection-parent")
-                .find(`.setting_user_list_style_choice[value='${CSS.escape(property_value)}'`)
+                .find(`.setting_user_list_style_choice[value='${CSS.escape(property_value)}']`)
                 .prop("checked", true);
             break;
         case "email_notifications_batching_period_seconds":


### PR DESCRIPTION
Due to closing bracket not being present, discard
button of "Theme" subsection of default user settings resulted in error.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
