### PR TITLE
css: Fix background color of date_row in unread PMs.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -408,9 +408,21 @@ body.dark-theme {
             }
         }
 
+        .private-message.unread {
+            .date_row {
+                background-color: hsl(208, 17%, 29%);
+            }
+        }
+
         .message_row.unread ~ .message_row.unread {
             .date_row {
                 background-color: transparent;
+            }
+        }
+
+        .private-message.unread ~ .private-message.unread {
+            .date_row {
+                background-color: hsl(208, 17%, 29%);
             }
         }
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3079,6 +3079,12 @@ div.topic_edit_spinner .loading_indicator_spinner {
         }
     }
 
+    .private-message.unread {
+        .date_row {
+            background-color: hsl(192, 20%, 95%);
+        }
+    }
+
     /* Select all but the first .message_row.unread,
        and remove the properties set from the previous rule. */
     .message_row.unread ~ .message_row.unread {
@@ -3086,6 +3092,12 @@ div.topic_edit_spinner .loading_indicator_spinner {
             position: unset;
             z-index: 0;
             background-color: transparent;
+        }
+    }
+
+    .private-message.unread ~ .private-message.unread {
+        .date_row {
+            background-color: hsl(192, 20%, 95%);
         }
     }
 }


### PR DESCRIPTION
This was a regression introduced in the commit
a80500cf5d6a1d82d97a9b2e56586a74fa433ef9
where we forgot to change the color of for unread PM date rows while change the color for the date row of unread stream messages.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/date.20dividers.20in.20PMs
<img width="707" alt="image" src="https://user-images.githubusercontent.com/25124304/194465007-d411db13-3eb1-4bb2-9735-f90efff2ad1c.png">
<img width="965" alt="image" src="https://user-images.githubusercontent.com/25124304/194465015-91bfcf36-b52f-4869-b59a-d9dd570aa0b7.png">

Sorry, this should fix it now!
