### PR TITLE
popovers: Hide mark as unread button for spectators.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -499,7 +499,9 @@ export function toggle_actions_popover(element, id) {
         // fetch_status data structure means we'll be able to mark
         // everything below the current message as read correctly.
         const should_display_mark_as_unread =
-            message_lists.current.data.fetch_status.has_found_newest() && !message.unread;
+            message_lists.current.data.fetch_status.has_found_newest() &&
+            !message.unread &&
+            not_spectator;
 
         const should_display_edit_history_option =
             message.edit_history &&


### PR DESCRIPTION
Since spectators cannot mark messages as unread, hide this button in message actions popover.

discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/mark.20as.20unread