### PR TITLE
misc: Improve app title bar for stream and topic views.

### DIFF
--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -123,7 +123,7 @@ async function test_restore_message_draft(page: Page): Promise<void> {
     });
     assert.strictEqual(
         await common.get_text_from_selector(page, "title"),
-        "tests - Zulip Dev - Zulip",
+        "#all > tests - Zulip Dev - Zulip",
         "Didn't narrow to the right topic.",
     );
 }

--- a/frontend_tests/puppeteer_tests/message-basics.ts
+++ b/frontend_tests/puppeteer_tests/message-basics.ts
@@ -29,7 +29,7 @@ async function expect_verona_stream(page: Page): Promise<void> {
         ["Verona > other topic", ["verona other topic c"]],
         ["Verona > test", ["verona test d"]],
     ]);
-    assert.strictEqual(await page.title(), "Verona - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "#Verona - Zulip Dev - Zulip");
 }
 
 async function expect_verona_stream_test_topic(page: Page): Promise<void> {
@@ -103,7 +103,7 @@ async function test_navigations_from_home(page: Page): Promise<void> {
     await page.click(`#zhome [title='Narrow to stream "Verona"']`);
     await expect_verona_stream(page);
 
-    assert.strictEqual(await page.title(), "Verona - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "#Verona - Zulip Dev - Zulip");
     await un_narrow(page);
     await expect_home(page);
 
@@ -192,7 +192,7 @@ async function search_tests(page: Page): Promise<void> {
         "Verona",
         "Stream",
         expect_verona_stream,
-        "Verona - Zulip Dev - Zulip",
+        "#Verona - Zulip Dev - Zulip",
     );
 
     await search_and_check(
@@ -208,7 +208,7 @@ async function search_tests(page: Page): Promise<void> {
         "stream:Verona",
         "",
         expect_verona_stream,
-        "Verona - Zulip Dev - Zulip",
+        "#Verona - Zulip Dev - Zulip",
     );
 
     await search_and_check(
@@ -216,7 +216,7 @@ async function search_tests(page: Page): Promise<void> {
         "stream:Verona topic:test",
         "",
         expect_verona_stream_test_topic,
-        "test - Zulip Dev - Zulip",
+        "#Verona > test - Zulip Dev - Zulip",
     );
 
     await search_and_check(
@@ -224,7 +224,7 @@ async function search_tests(page: Page): Promise<void> {
         "stream:Verona topic:other+topic",
         "",
         expect_verona_other_topic,
-        "other topic - Zulip Dev - Zulip",
+        "#Verona > other topic - Zulip Dev - Zulip",
     );
 
     await search_and_check(

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -129,10 +129,12 @@ function update_narrow_title(filter) {
     // If the operator is something other than "stream", "topic", or
     // "is", we shouldn't update the narrow title
     if (filter.has_operator("stream")) {
+        const stream_name = filter.operands("stream")[0];
         if (filter.has_operator("topic")) {
-            set_narrow_title(filter.operands("topic")[0]);
+            const topic_name = filter.operands("topic")[0];
+            set_narrow_title("#" + stream_name + " > " + topic_name);
         } else {
-            set_narrow_title(filter.operands("stream")[0]);
+            set_narrow_title("#" + stream_name);
         }
     } else if (filter.has_operator("is")) {
         const title = filter.operands("is")[0];


### PR DESCRIPTION
We want to be able to differentiate between the stream and the topic in the title bar, but the current implementation displays both the steam name and the topic name in the same way which becomes difficult to comprehend at a glance.

In this commit, we make the following changes,

- <stream_name> to #<stream_name> (when viewing the entire stream)

- <topic_name> to #<stream_name> > <topic_name> (when viewing a topic)

These changes help us differentiate between a stream and a topic with with a quick glance.

Fixes #22969.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![support-strean](https://user-images.githubusercontent.com/82862779/194603075-29256081-13bd-4818-b3ad-1efd7a99cb00.png)


![printer-topic-test-stream](https://user-images.githubusercontent.com/82862779/194603046-8fce78da-66ba-4e08-b2d1-46646f4a13ee.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
