### PR TITLE
drafts: Don't update draft count when successfully sending messages.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -147,6 +147,10 @@ test_ui("send_message", ({override, override_rewire}) => {
         return stub_state;
     }
 
+    const $container = $(".top_left_drafts");
+    const $child = $(".unread_count");
+    $container.set_find_results(".unread_count", $child);
+
     override(server_events, "assert_get_events_running", () => {
         stub_state.get_events_running_called += 1;
     });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -11,6 +11,7 @@ import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as compose_validate from "./compose_validate";
+import * as drafts from "./drafts";
 import * as echo from "./echo";
 import * as flatpickr from "./flatpickr";
 import {$t, $t_html} from "./i18n";
@@ -256,6 +257,10 @@ export function send_message(request = create_message_object()) {
         }
 
         echo.message_send_error(message.id, response);
+
+        // We might not have updated the draft count because we assumed the
+        // message would send. Ensure that the displayed count is correct.
+        drafts.sync_count();
     }
 
     transmit.send_message(request, success, error);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -56,12 +56,14 @@ export const draft_model = (function () {
         return get()[id] || false;
     };
 
-    function save(drafts) {
+    function save(drafts, update_count = true) {
         ls.set(KEY, drafts);
-        set_count(Object.keys(drafts).length);
+        if (update_count) {
+            set_count(Object.keys(drafts).length);
+        }
     }
 
-    exports.addDraft = function (draft) {
+    exports.addDraft = function (draft, update_count = true) {
         const drafts = get();
 
         // use the base16 of the current time + a random string to reduce
@@ -70,7 +72,7 @@ export const draft_model = (function () {
 
         draft.updatedAt = getTimestamp();
         drafts[id] = draft;
-        save(drafts);
+        save(drafts, update_count);
 
         return id;
     };
@@ -103,6 +105,11 @@ export const draft_model = (function () {
 
     return exports;
 })();
+
+export function sync_count() {
+    const drafts = draft_model.get();
+    set_count(Object.keys(drafts).length);
+}
 
 export function delete_all_drafts() {
     const drafts = draft_model.get();
@@ -229,9 +236,9 @@ export function update_draft(opts = {}) {
         return draft_id;
     }
 
-    // We have never saved a draft for this message, so add
-    // one.
-    const new_draft_id = draft_model.addDraft(draft);
+    // We have never saved a draft for this message, so add one.
+    const update_count = opts.update_count === undefined ? true : opts.update_count;
+    const new_draft_id = draft_model.addDraft(draft, update_count);
     $("#compose-textarea").data("draft-id", new_draft_id);
     maybe_notify(no_notify);
 

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -235,10 +235,10 @@ export function try_deliver_locally(message_request) {
 
     // Save a locally echoed message in drafts, so it cannot be
     // lost. It will be cleared if the message is sent successfully.
-    // We ask the drafts system to not notify the user, since they'd
-    // be quite distracting in the very common case that the message
-    // sends normally.
-    const draft_id = drafts.update_draft({no_notify: true});
+    // We ask the drafts system to not notify the user or update the
+    // draft count, since that would be quite distracting in the very
+    // common case that the message sends normally.
+    const draft_id = drafts.update_draft({no_notify: true, update_count: false});
     message_request.draft_id = draft_id;
 
     // Now that we've committed to delivering the message locally, we


### PR DESCRIPTION
Fixes #21757.

Previously the draft count would briefly increase between the action of sending a message and the success of sending that message. Now the draft count will only increase if the message fails to send.

Tested locally:
* Count didn't update when sending a message
* If I raised an exception from the message-sending backend code, the count did update after the message failed to send.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
