### PR TITLE
help: Document "Marking messages as unread" feature.

### DIFF
--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -79,6 +79,7 @@
 * [Reading strategies](/help/reading-strategies)
 * [Recent topics](/help/recent-topics)
 * [Marking messages as read](/help/marking-messages-as-read)
+* [Marking messages as unread](/help/marking-messages-as-unread)
 * [Emoji reactions](/help/emoji-reactions)
 * [Star a message](/help/star-a-message)
 * [View and browse images](/help/view-and-browse-images)

--- a/templates/zerver/help/marking-messages-as-read.md
+++ b/templates/zerver/help/marking-messages-as-read.md
@@ -75,5 +75,6 @@ stream or topic as read**.
 
 ## Related articles
 
+* [Marking messages as unread](/help/marking-messages-as-unread)
 * [Reading strategies](/help/reading-strategies)
 * [Read receipts](/help/read-receipts)

--- a/templates/zerver/help/marking-messages-as-unread.md
+++ b/templates/zerver/help/marking-messages-as-unread.md
@@ -1,0 +1,37 @@
+# Marking messages as unread
+
+Zulip offers tools to manually mark a series of messages as unread. If you want
+to remember to read a conversation later, you can mark the messages in that
+conversation as unread. When messages get marked as unread, a line will appear
+along the left side of those messages, and your name will be removed from the
+list of read receipts.
+
+## Mark as unread from selected message
+
+Selecting this option on a message tells Zulip that you want the messages in
+that conversation to be added to your queue of unread messages.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Select a stream, topic, or **All messages** in the left sidebar.
+
+1. Click the ellipsis (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+   to the right of the message where you want to begin marking as unread.
+
+1. Click **Mark as unread from here**.
+
+!!! keyboard_tip ""
+
+    You can also mark messages as unread by selecting a message, and using the
+    <kbd>Shift</kbd> + <kbd>U</kbd> shortcut.
+
+{end_tabs}
+
+## Related articles
+
+* [Reading strategies](/help/reading-strategies)
+* [Marking messages as read](/help/marking-messages-as-read)
+* [Star a message](/help/star-a-message)
+* [Read receipts](/help/read-receipts)

--- a/templates/zerver/help/read-receipts.md
+++ b/templates/zerver/help/read-receipts.md
@@ -79,6 +79,8 @@ You can configure:
 
 * [Status and availability](/help/status-and-availability)
 * [Typing notifications](/help/typing-notifications)
+* [Marking messages as read](/help/marking-messages-as-read)
+* [Marking messages as unread](/help/marking-messages-as-unread)
 
 [configure-personal-read-recipts]: /help/read-receipts#configure-whether-zulip-lets-others-see-when-youve-read-messages
 [configure-organization-read-recipts]:

--- a/templates/zerver/help/reading-strategies.md
+++ b/templates/zerver/help/reading-strategies.md
@@ -65,3 +65,4 @@ like to reply to later.
 * [Recent topics](/help/recent-topics)
 * [Searching for messages](/help/search-for-messages)
 * [Marking messages as read](/help/marking-messages-as-read)
+* [Marking messages as unread](/help/marking-messages-as-unread)

--- a/templates/zerver/help/star-a-message.md
+++ b/templates/zerver/help/star-a-message.md
@@ -42,3 +42,8 @@ can disable that feature.
 1. Under **Advanced**, toggle **Show counts for starred messages**.
 
 {end_tabs}
+
+## Related articles
+
+* [Marking messages as unread](/help/marking-messages-as-unread)
+* [Reading strategies](/help/reading-strategies)


### PR DESCRIPTION
- Documents the new "Mark as unread from here" option in the three-dot message menu.
- Adds new page "Marking messages as unread", just below "Marking messages as read" in the sidebar index.
- Cross-links with Reading strategies, Marking messages as read, Star a message, and Read receipts.

Fixes: https://github.com/zulip/zulip/issues/23052.

**Remarks:**
*This feature is already documented in the [keyboard shortcuts page](https://zulip.com/help/keyboard-shortcuts).

**Screenshots and screen captures:**

<img width="801" alt="image" src="https://user-images.githubusercontent.com/2343554/194675408-0626db11-8209-450b-9930-aee18a943982.png">

<img width="801" alt="image" src="https://user-images.githubusercontent.com/2343554/194675432-bf22120c-fc1b-4c98-a3c2-f85bc2381a09.png">



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links
</details>