### PR TITLE
settings: Uncheck display_in_profile_summary checkbox if hidden.

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -258,6 +258,7 @@ function set_up_create_field_form() {
         );
     } else {
         $("#profile_field_display_in_profile_summary").closest(".input-group").hide();
+        $("#profile_field_display_in_profile_summary").prop("checked", false);
     }
 }
 


### PR DESCRIPTION
We should uncheck the display_in_profile_summary checkbox in the custom profile creation form if the checkbox is hidden for type of fields like LONG_TEXT or USER which are not allowed to be displayed in profile summary.

This solves the bug where a user initially checks the display_in_profile_summary field and then changes the type to LONG_TEXT or USER where the checkbox is hidden but it is still checked and thus the request to server is made with display_in_profile_summary=true for which server returns error.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->#23171.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![custom-field-fix](https://user-images.githubusercontent.com/35494118/194712794-95110414-7cfc-4f67-8948-9b26a4b8664a.gif)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
