### PR TITLE
do_deactivate_user: Revoke sessions in transaction.on_commit().

### DIFF
--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -165,20 +165,28 @@ def do_deactivate_user(
 
         transaction.on_commit(lambda: delete_user_sessions(user_profile))
 
-    event = dict(
-        type="realm_user",
-        op="remove",
-        person=dict(user_id=user_profile.id, full_name=user_profile.full_name),
-    )
-    send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
-
-    if user_profile.is_bot:
-        event = dict(
-            type="realm_bot",
+        event_remove_user = dict(
+            type="realm_user",
             op="remove",
-            bot=dict(user_id=user_profile.id, full_name=user_profile.full_name),
+            person=dict(user_id=user_profile.id, full_name=user_profile.full_name),
         )
-        send_event(user_profile.realm, event, bot_owner_user_ids(user_profile))
+        transaction.on_commit(
+            lambda: send_event(
+                user_profile.realm, event_remove_user, active_user_ids(user_profile.realm_id)
+            )
+        )
+
+        if user_profile.is_bot:
+            event_remove_bot = dict(
+                type="realm_bot",
+                op="remove",
+                bot=dict(user_id=user_profile.id, full_name=user_profile.full_name),
+            )
+            transaction.on_commit(
+                lambda: send_event(
+                    user_profile.realm, event_remove_bot, bot_owner_user_ids(user_profile)
+                )
+            )
 
 
 @transaction.atomic(durable=True)

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -163,7 +163,8 @@ def do_deactivate_user(
         if settings.BILLING_ENABLED:
             update_license_ledger_if_needed(user_profile.realm, event_time)
 
-    delete_user_sessions(user_profile)
+        transaction.on_commit(lambda: delete_user_sessions(user_profile))
+
     event = dict(
         type="realm_user",
         op="remove",

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1266,7 +1266,8 @@ class InactiveUserTest(ZulipTestCase):
         """
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
-        do_deactivate_user(user_profile, acting_user=None)
+        with self.captureOnCommitCallbacks(execute=True):
+            do_deactivate_user(user_profile, acting_user=None)
 
         result = self.client_post(
             "/json/messages",

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1625,7 +1625,8 @@ class ActivateTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(Session.objects.filter(pk=session_key).count(), 1)
 
-        do_deactivate_user(user, acting_user=None)
+        with self.captureOnCommitCallbacks(execute=True):
+            do_deactivate_user(user, acting_user=None)
         self.assertEqual(Session.objects.filter(pk=session_key).count(), 0)
 
         result = self.client_get("/json/users")


### PR DESCRIPTION
Fixes #21709.

https://chat.zulip.org/#narrow/stream/31-production-help/topic/sync_ldap_user_data.20error.20.2321709/near/1362304
This makes it necessary to add `with self.captureOnCommitCallbacks(execute=True):` in tests of `do_deactivate_user` that rely on the sessions getting revoked.

Tested manually by verifying in dev environment with `fakeldap` that  `./manage.py sync_ldap_user_data`  that without this fix triggers the exception from #21709, now succeeds (and the session gets revoked)

I think this shouldn't create any security issues like CVE-2022-24751 (62ba8e455d8f460001d9fb486a6dabfd1ed67717), but double-checking my thinking here would be helpful.