### PR TITLE
error_pages: Fix content overlapping with header.

### DIFF
--- a/templates/confirmation/link_does_not_exist.html
+++ b/templates/confirmation/link_does_not_exist.html
@@ -6,7 +6,7 @@
 
 {% block portico_content %}
 <div class="error_page">
-    <div class="container">
+    <div class="container row-fluid">
         <img src="/static/images/errors/400art.svg" alt=""/>
         <div class="errorbox">
             <div class="errorcontent">

--- a/templates/confirmation/link_malformed.html
+++ b/templates/confirmation/link_malformed.html
@@ -6,7 +6,7 @@
 
 {% block portico_content %}
 <div class="error_page">
-    <div class="container">
+    <div class="container row-fluid">
         <img src="/static/images/errors/500art.svg" alt=""/>
         <div class="errorbox">
             <div class="errorcontent">


### PR DESCRIPTION
We add top margin to the error pages whose content was overlapping with the page header.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/error.20page.20CSS
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/25124304/194829714-7a3e94a4-ebe3-4870-9109-42b4b1033eca.png">
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/25124304/194829853-00e37ca7-a146-4e2b-b1b1-aa7664ceccf1.png">
