### PR TITLE
communities: Include organizations that do not require an invite.

### DIFF
--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -115,7 +115,8 @@ def communities_view(request: HttpRequest) -> HttpResponse:
         want_advertise_in_communities_directory=True
     ).order_by("name")
     for realm in want_to_be_advertised_realms:
-        if realm.allow_web_public_streams_access():
+        open_to_public = not realm.invite_required and not realm.emails_restricted_to_domains
+        if realm.allow_web_public_streams_access() or open_to_public:
             eligible_realms.append(
                 {
                     "id": realm.id,


### PR DESCRIPTION
Updates the organizations listed in the open communities directory to include organizations that do not require an invitation even if they have not enabled (or don't have) public access streams. See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/57-core-team/topic/open.20communities.20directory/near/1446480).

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
