### PR TITLE
settings: Add a tooltip to the "Deactive organization" button.

### DIFF
--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -84,13 +84,14 @@
         </div>
         <h3 class="light">
             {{t "Deactivate organization" }}
-            <i class="fa fa-info-circle settings-info-icon realm_deactivation_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can deactivate the organization.' }}"></i>
+            {{> ../help_link_widget link="/help/deactivate-your-organization" }}
         </h3>
         <div class="deactivate-realm-section">
             <div class="input-group">
-                <button class="button rounded btn-danger" id="deactivate_realm_button">
-                    {{t 'Deactivate organization' }}
-                </button>
+                <div class="inline-block tippy-zulip-tooltip" data-tippy-content="{{t 'Only organization owners may deactivate an organization.' }}">
+                    <button class="button rounded btn-danger" id="deactivate_realm_button"> {{t 'Deactivate organization' }}
+                    </button>
+                </div>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Remove "i" and change to a "?" with a link to `/help/deactivate-your-organization` for the section "Deactivate organization". When holding the mouse over the button, there is a tooltip showed to the users that says "Only organization owners may deactivate an organization."

This PR fixes the first task in the issue.
Fixes part of #22892.

![Skärmavbild 2022-10-10 kl  14 43 13](https://user-images.githubusercontent.com/58030654/194891933-411c2fdf-c4d5-43bc-8d52-5c323c7a7eb5.png)
