### PR TITLE
drafts: Update draft count when drafts change in another tab.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -186,8 +186,15 @@ test("snapshot_message", ({override_rewire}) => {
 });
 
 test("initialize", ({override_rewire}) => {
+    let beforeunload_listener_called = false;
+    let storage_listener_called = false;
     window.addEventListener = (event_name, f) => {
+        if (event_name === "storage") {
+            storage_listener_called = true;
+            return;
+        }
         assert.equal(event_name, "beforeunload");
+        beforeunload_listener_called = true;
         let called = false;
         override_rewire(drafts, "update_draft", () => {
             called = true;
@@ -200,6 +207,8 @@ test("initialize", ({override_rewire}) => {
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     drafts.initialize();
+    assert.ok(beforeunload_listener_called);
+    assert.ok(storage_listener_called);
 });
 
 test("remove_old_drafts", () => {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -35,11 +35,12 @@ function set_count(count) {
     ui_util.update_unread_count_in_dom($drafts_li, count);
 }
 
+// the key that the drafts are stored under.
+const KEY = "drafts";
+
 export const draft_model = (function () {
     const exports = {};
 
-    // the key that the drafts are stored under.
-    const KEY = "drafts";
     const ls = localstorage();
     ls.version = 1;
 
@@ -760,6 +761,13 @@ export function initialize() {
 
     window.addEventListener("beforeunload", () => {
         update_draft();
+    });
+    window.addEventListener("storage", (event) => {
+        const ls = localstorage();
+        const drafts = ls.getValueFromStorageEvent(event, KEY);
+        if (drafts !== undefined) {
+            set_count(Object.keys(drafts).length);
+        }
     });
 
     set_count(Object.keys(draft_model.get()).length);

--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -123,6 +123,17 @@ export const localstorage = function () {
             return undefined;
         },
 
+        getValueFromStorageEvent(event, key) {
+            if (event.key !== ls.formGetter(_data.VERSION, key)) {
+                return undefined;
+            }
+            const data = ls.parseJSON(event.newValue);
+            if (data) {
+                return data.data;
+            }
+            return undefined;
+        },
+
         set(name, data) {
             if (_data.VERSION !== undefined) {
                 ls.setData(_data.VERSION, name, data, _data.expires);


### PR DESCRIPTION
This commit adds a listener for when drafts change in localstorage, allowing us to update the draft count when changes are made in other tabs.

CZO conversation here: https://chat.zulip.org/#narrow/stream/9-issues/topic/draft.20count.20not.20updating.20in.20multiple.20tabs

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
