### PR TITLE
login page: Show form-independent errors even if email auth disabled.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -431,7 +431,7 @@ html {
     .alert {
         &:not(.alert-info) {
             padding: 0;
-            margin-bottom: 0;
+            margin-bottom: 5px;
             font-weight: 600;
             font-size: 0.7em;
             line-height: 1.2;

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -63,6 +63,19 @@ page can be easily identified in it's respective JavaScript file. -->
                         </p>
                     </div>
                 {% else %}
+
+                    {% if already_registered %}
+                    <div class="alert">
+                        {{ _("You've already registered with this email address. Please log in below.") }}
+                    </div>
+                    {% endif %}
+
+                    {% if deactivated_account_error %}
+                    <div class="alert">
+                        {{ deactivated_account_error }}
+                    </div>
+                    {% endif %}
+
                     {% if password_auth_enabled %}
                         <form name="login_form" id="login_form" method="post" class="login-form"
                           action="{{ url('login') }}">
@@ -107,18 +120,6 @@ page can be easily identified in it's respective JavaScript file. -->
                                 {% for error in form.errors.values() %}
                                 <div>{{ error | striptags }}</div>
                                 {% endfor %}
-                            </div>
-                            {% endif %}
-
-                            {% if already_registered %}
-                            <div class="alert">
-                                {{ _("You've already registered with this email address. Please log in below.") }}
-                            </div>
-                            {% endif %}
-
-                            {% if deactivated_account_error %}
-                            <div class="alert">
-                                {{ deactivated_account_error }}
                             </div>
                             {% endif %}
 


### PR DESCRIPTION
These used to only be shown conditional on the
{% if password_auth_enabled %} in the template. Meaning that if you had an org with email auth disabled and a deactivated user tried to log in, they wouldn't see the error shown and get confused.

This switches the position of where these error will be shown (above the login+password form instead of below it), but it looks fine.

Here's how it looks now, with, or without, the login form:
![Screenshot from 2022-10-11 22-06-51](https://user-images.githubusercontent.com/45007152/195190382-545516a4-15d2-497c-8bcd-6d6a5607096f.png)
![Screenshot from 2022-10-11 22-05-59](https://user-images.githubusercontent.com/45007152/195190387-1f875a11-1fb8-4152-b9ab-bf8b5420b37a.png)
