### PR TITLE
Group settings UI

### DIFF
--- a/static/js/user_group_create.js
+++ b/static/js/user_group_create.js
@@ -12,7 +12,7 @@ import * as user_group_settings_ui from "./user_groups_settings_ui";
 class UserGroupMembershipError {
     report_no_members_to_user_group() {
         $("#user_group_membership_error").text(
-            $t({defaultMessage: "You cannot create a user_group with no members!"}),
+            $t({defaultMessage: "You cannot create a user group with no members!"}),
         );
         $("#user_group_membership_error").show();
     }

--- a/static/js/user_group_create_members.js
+++ b/static/js/user_group_create_members.js
@@ -101,7 +101,6 @@ export function build_widgets() {
                 user_id,
                 full_name: user.full_name,
                 is_current_user: user_id === current_user_id,
-                disabled: user_id === current_user_id,
             };
             return render_new_user_group_user(item);
         },

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -327,6 +327,7 @@ body.dark-theme {
         background-color: transparent;
     }
 
+    .create_user_group_plus_button,
     .create_stream_plus_button {
         color: hsl(0, 0%, 100%);
         background-color: hsla(0, 0%, 0%, 0.2);

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -721,6 +721,10 @@ h4.user_group_setting_subsection_title {
         #stream_creation_form {
             margin: 0;
 
+            .user_group_create_info.show {
+                margin: 5px;
+            }
+
             #user_group_creating_indicator,
             #stream_creating_indicator {
                 &:not(:empty) {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -76,6 +76,7 @@
     margin-right: 10px;
 }
 
+.create_user_group_plus_button,
 .create_stream_plus_button {
     font-size: 24px;
     font-weight: 500;
@@ -96,6 +97,12 @@
         position: relative;
         top: -5px;
     }
+}
+
+.create_user_group_button {
+    position: relative;
+    top: 7px;
+    margin: 0 7px 0 0;
 }
 
 #create_user_group_description,

--- a/static/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/static/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -15,6 +15,12 @@
                     <button type="button" class="btn clear_search_button" id="clear_search_group_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
+                    <div id="add_new_user_group"  class="tippy-zulip-tooltip" data-tippy-content="{{t 'Create new user group' }}" data-tippy-placement="bottom">
+                        <button class="create_user_group_button create_user_group_plus_button">
+                            <span>+</span>
+                        </button>
+                        <div class="float-clear"></div>
+                    </div>
                 </div>
                 <div class="user-groups-list" data-simplebar>
                 </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: Some changes as mentioned on [#frontend > User groups UI](https://chat.zulip.org/#narrow/stream/6-frontend/topic/User.20groups.20UI/near/1425441)

Support for live update events was supposed to be part of it, but accidentally I had got my local git repository broken, so I could recover only these three commits. So creating a PR for them as backup, as I am still in a broken repo state I think I'll have to clone again and start over for live update on `#groups` overlay.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
