### PR TITLE
narrow: Fix browser title for search narrow views

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1536,7 +1536,7 @@ test("navbar_helpers", () => {
             operator: streams_public,
             is_common_narrow: true,
             icon: undefined,
-            title: "translated: Public stream messages in organization",
+            title: "translated: Messages in all public streams",
             redirect_url_with_search: "/#narrow/streams/public",
         },
         {

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1670,7 +1670,7 @@ test("navbar_helpers", () => {
 
     const stream_topic_search_operator_test_case = {
         operator: stream_topic_search_operator,
-        title: "Foo",
+        title: undefined,
     };
 
     test_get_title(stream_topic_search_operator_test_case);

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1550,14 +1550,14 @@ test("navbar_helpers", () => {
             operator: non_existent_stream,
             is_common_narrow: true,
             icon: "question-circle-o",
-            title: "translated: Unknown stream",
+            title: "translated: Unknown stream #Elephant",
             redirect_url_with_search: "#",
         },
         {
             operator: non_existent_stream_topic,
             is_common_narrow: true,
             icon: "question-circle-o",
-            title: "translated: Unknown stream",
+            title: "translated: Unknown stream #Elephant",
             redirect_url_with_search: "#",
         },
         {

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1478,6 +1478,9 @@ test("navbar_helpers", () => {
     const group_pm_including_missing_person = [
         {operator: "pm-with", operand: "joe@example.com,STEVE@foo.com,sally@doesnotexist.com"},
     ];
+    // not common narrows, but used for browser title updates
+    const is_alerted = [{operator: "is", operand: "alerted"}];
+    const is_unread = [{operator: "is", operand: "unread"}];
 
     const test_cases = [
         {
@@ -1597,6 +1600,20 @@ test("navbar_helpers", () => {
                 "sally@doesnotexist.com",
             ]),
             redirect_url_with_search: "/#narrow/pm-with/undefined",
+        },
+        {
+            operator: is_alerted,
+            is_common_narrow: false,
+            icon: undefined,
+            title: "translated: Alerted messages",
+            redirect_url_with_search: "#",
+        },
+        {
+            operator: is_unread,
+            is_common_narrow: false,
+            icon: undefined,
+            title: "translated: Unread messages",
+            redirect_url_with_search: "#",
         },
     ];
 

--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -36,7 +36,7 @@ async function create_stream_message_draft(page: Page): Promise<void> {
     await page.keyboard.press("KeyC");
     await page.waitForSelector("#stream-message", {visible: true});
     await common.fill_form(page, "form#send_message_form", {
-        stream_message_recipient_stream: "all",
+        stream_message_recipient_stream: "Denmark",
         stream_message_recipient_topic: "tests",
         content: "Test stream message.",
     });
@@ -78,7 +78,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
             page,
             ".draft-row .message_header_stream .stream_label",
         ),
-        "all",
+        "Denmark",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
@@ -117,20 +117,20 @@ async function test_restore_message_draft(page: Page): Promise<void> {
     await page.waitForSelector("#stream-message", {visible: true});
     await page.waitForSelector("#preview_message_area", {hidden: true});
     await common.check_form_contents(page, "form#send_message_form", {
-        stream_message_recipient_stream: "all",
+        stream_message_recipient_stream: "Denmark",
         stream_message_recipient_topic: "tests",
         content: "Test stream message.",
     });
     assert.strictEqual(
         await common.get_text_from_selector(page, "title"),
-        "#all > tests - Zulip Dev - Zulip",
+        "#Denmark > tests - Zulip Dev - Zulip",
         "Didn't narrow to the right topic.",
     );
 }
 
 async function edit_stream_message_draft(page: Page): Promise<void> {
     await common.fill_form(page, "form#send_message_form", {
-        stream_message_recipient_stream: "all",
+        stream_message_recipient_stream: "Denmark",
         stream_message_recipient_topic: "tests",
         content: "Updated stream message",
     });
@@ -147,7 +147,7 @@ async function test_edited_draft_message(page: Page): Promise<void> {
             page,
             ".draft-row .message_header_stream .stream_label",
         ),
-        "all",
+        "Denmark",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
@@ -159,7 +159,7 @@ async function test_edited_draft_message(page: Page): Promise<void> {
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row:nth-last-child(2) .rendered_markdown.restore-draft",
+            ".draft-row .message_row:not(.private-message) .rendered_markdown.restore-draft",
         ),
         "Updated stream message",
     );

--- a/frontend_tests/puppeteer_tests/message-basics.ts
+++ b/frontend_tests/puppeteer_tests/message-basics.ts
@@ -232,7 +232,7 @@ async function search_tests(page: Page): Promise<void> {
         "topic:test",
         "",
         expect_test_topic,
-        "All messages - Zulip Dev - Zulip",
+        "Search results - Zulip Dev - Zulip",
     );
 
     await search_silent_user(page, "sender:emailgateway@zulip.com", "");

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -667,7 +667,8 @@ export class Filter {
             (term_types.length === 2 && _.isEqual(term_types, ["stream", "topic"]))
         ) {
             if (!this._sub) {
-                return $t({defaultMessage: "Unknown stream"});
+                const search_text = this.operands("stream")[0];
+                return $t({defaultMessage: "Unknown stream #{search_text}"}, {search_text});
             }
             return this._sub.name;
         }
@@ -681,7 +682,8 @@ export class Filter {
                     return $t({defaultMessage: "Messages in all public streams"});
                 case "stream":
                     if (!this._sub) {
-                        return $t({defaultMessage: "Unknown stream"});
+                        const search_text = this.operands("stream")[0];
+                        return $t({defaultMessage: "Unknown stream #{search_text}"}, {search_text});
                     }
                     return this._sub.name;
                 case "is-starred":

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -678,7 +678,7 @@ export class Filter {
                 case "in-all":
                     return $t({defaultMessage: "All messages including muted streams"});
                 case "streams-public":
-                    return $t({defaultMessage: "Public stream messages in organization"});
+                    return $t({defaultMessage: "Messages in all public streams"});
                 case "stream":
                     if (!this._sub) {
                         return $t({defaultMessage: "Unknown stream"});

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -662,17 +662,14 @@ export class Filter {
     get_title() {
         // Nice explanatory titles for common views.
         const term_types = this.sorted_term_types();
-        if (
-            (term_types.length === 3 && _.isEqual(term_types, ["stream", "topic", "search"])) ||
-            (term_types.length === 2 && _.isEqual(term_types, ["stream", "topic"]))
-        ) {
+        if (term_types.length === 2 && _.isEqual(term_types, ["stream", "topic"])) {
             if (!this._sub) {
                 const search_text = this.operands("stream")[0];
                 return $t({defaultMessage: "Unknown stream #{search_text}"}, {search_text});
             }
             return this._sub.name;
         }
-        if (term_types.length === 1 || (term_types.length === 2 && term_types[1] === "search")) {
+        if (term_types.length === 1) {
             switch (term_types[0]) {
                 case "in-home":
                     return $t({defaultMessage: "All messages"});

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -706,6 +706,13 @@ export class Filter {
                 }
                 case "is-resolved":
                     return $t({defaultMessage: "Topics marked as resolved"});
+                // These cases return false for is_common_narrow, and therefore are not
+                // formatted in the message view header. They are used in narrow.js to
+                // update the browser title.
+                case "is-alerted":
+                    return $t({defaultMessage: "Alerted messages"});
+                case "is-unread":
+                    return $t({defaultMessage: "Unread messages"});
             }
         }
         /* istanbul ignore next */

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -140,16 +140,25 @@ function update_narrow_title(filter) {
     } else if (filter.has_operator("is")) {
         const title = filter.operands("is")[0];
         set_narrow_title(title.charAt(0).toUpperCase() + title.slice(1) + " messages");
-    } else if (filter.has_operator("pm-with") || filter.has_operator("group-pm-with")) {
-        const emails = filter.public_operators()[0].operand;
+    } else if (filter.has_operator("pm-with")) {
+        const emails = filter.operands("pm-with")[0];
         const user_ids = people.emails_strings_to_user_ids_string(emails);
         if (user_ids !== undefined) {
             const names = people.get_recipients(user_ids);
-            if (filter.has_operator("pm-with")) {
-                set_narrow_title(names);
+            set_narrow_title(names);
+        } else {
+            if (emails.includes(",")) {
+                set_narrow_title("Invalid users");
             } else {
-                set_narrow_title(names + " and others");
+                set_narrow_title("Invalid user");
             }
+        }
+    } else if (filter.has_operator("group-pm-with")) {
+        const emails = filter.operands("group-pm-with")[0];
+        const user_ids = people.emails_strings_to_user_ids_string(emails);
+        if (user_ids !== undefined) {
+            const names = people.get_recipients(user_ids);
+            set_narrow_title(names + " and others");
         } else {
             if (emails.includes(",")) {
                 set_narrow_title("Invalid users");

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -11,6 +11,7 @@ import * as condense from "./condense";
 import {Filter} from "./filter";
 import * as hash_util from "./hash_util";
 import * as hashchange from "./hashchange";
+import {$t} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_fetch from "./message_fetch";
 import * as message_helper from "./message_helper";
@@ -990,7 +991,7 @@ function handle_post_narrow_deactivate_processes() {
     widgetize.set_widgets_for_list();
     typing_events.render_notifications_for_narrow();
     message_view_header.initialize();
-    narrow_title = "All messages";
+    narrow_title = $t({defaultMessage: "All messages"});
     notifications.redraw_title();
     message_scroll.update_top_of_narrow_notices(message_lists.home);
 }

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -757,7 +757,8 @@ export function show() {
     compose_closed_ui.update_buttons_for_recent_topics();
 
     narrow_state.reset_current_filter();
-    narrow.set_narrow_title("Recent topics");
+    const recent_topics_title = $t({defaultMessage: "Recent topics"});
+    narrow.set_narrow_title(recent_topics_title);
     message_view_header.render_title_area();
     narrow.handle_middle_pane_transition();
 


### PR DESCRIPTION
Sets a default value of "Search" for complicated narrow search views and updates logic to use `filter.get_title` as a helper to generate better titles for some common search views.

Fixes #22952. Relevant [CZO design conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/browser.20title.20for.20narrow.20search.20views.20.2323216/near/1449802).

---

**Notes**:
- Does not update the existing logic for narrow searches that have "pm-with" or "group-pm-with" operators.
  - But does fix a subtle existing bug if a user uses those operators in a search, but not first. For example, "keyword group-pm-with:userA" now returns "Invalid user" as the browser title.  
  - We have different behavior for the message header and the browser title currently, so we would need to decide the preference here. Probably best done via a CZO conversation in design.
- As of this change, the default search title and titles generated from `filter.get_title` will be translated into the user's preferred language. As a prep for this change, I updated the browser titles for the default views, "All messages" and "Recent topics", to be translated.
- As prep for using `filter.get_title` for updating the browser title in narrows, I added cases for the two missing "is" operators, "alerted" and "unread". Only adds default text for now as they aren't "common" narrows, so the message view header still shows the search text/view and closing the search redirects to the default view (`/#`).
- Some narrows will now have more descriptive browser titles (like "in-home" or "is-resolved"). The @-mentions browser title is changed from "Mentioned messages" to "Mentions", which is more consistent with the web-app left sidebar. Per [this in CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/browser.20title.20for.20narrow.20search.20views.20.2323216/near/1450143), both the browser title and message header title for `streams:public` is updated to be "Messages in all public streams" in a prep commit.
- The "Unknown stream" title for both the browser and the message header is updated in a prep commit to include the stream name that was searched for: "Unknown stream #<seached_name>".

---

**Screenshots**:

<details>
<summary>Default views in spectator view with language set to Russian</summary>

![Screenshot from 2022-10-14 13-36-16](https://user-images.githubusercontent.com/63245456/195837999-556e6f2e-705d-4dca-8bd1-3c3cba3143ad.png)
![Screenshot from 2022-10-14 13-36-25](https://user-images.githubusercontent.com/63245456/195838007-aaff44f2-2af0-43cd-9111-182bea72f2c7.png)
</details>

<details>
<summary>"is" narrows in English</summary>

**Note**: The browser titles for @-mentions and resolved topics are changed from the current implementation. @-mentions is "Mentioned messages" and resolved topics is "Resolved messages".
![Screenshot from 2022-10-14 13-48-03](https://user-images.githubusercontent.com/63245456/195848232-a9381c5c-4197-41f6-88cb-277ff8fdce7b.png)
![Screenshot from 2022-10-14 13-48-17](https://user-images.githubusercontent.com/63245456/195848236-251b9e79-af25-4bba-b767-be8984d60819.png)
![Screenshot from 2022-10-14 13-48-39](https://user-images.githubusercontent.com/63245456/195848245-a3af4b3f-bfb9-4290-98ba-e14c82be48c1.png)
![Screenshot from 2022-10-14 13-48-51](https://user-images.githubusercontent.com/63245456/195848247-ec5e2f87-f8f5-456c-8dbc-e6c18e8f3f85.png)
![Screenshot from 2022-10-14 13-49-08](https://user-images.githubusercontent.com/63245456/195848252-930bcf2d-79db-4f53-8c00-fc6e89e04934.png)
![Screenshot from 2022-10-14 13-49-20](https://user-images.githubusercontent.com/63245456/195848257-c942e3bd-5a85-4586-94ac-ee1bba44e7d8.png)

</details>

<details>
<summary>"is" narrows in Russian</summary>

**Note**: The browser titles for alerted and unread messages are not already in the translated strings for Russian. So those two screenshots serve a bit to show what the current behavior is for non-English views.
![Screenshot from 2022-10-14 14-31-35](https://user-images.githubusercontent.com/63245456/195848117-d01c627f-304e-448e-ba59-0766422f7067.png)
![Screenshot from 2022-10-14 14-31-45](https://user-images.githubusercontent.com/63245456/195848133-879a6974-9be7-40b8-bc7e-cfd643695439.png)
![Screenshot from 2022-10-14 14-32-28](https://user-images.githubusercontent.com/63245456/195848137-b65d8f18-7f6b-4af8-aa2e-280c566227a2.png)
![Screenshot from 2022-10-14 14-32-38](https://user-images.githubusercontent.com/63245456/195848148-ae8b6411-84bf-4d65-937b-c1c049b622a6.png)
![Screenshot from 2022-10-14 14-32-55](https://user-images.githubusercontent.com/63245456/195848150-7af07060-b91f-4205-9616-255eeb464f28.png)
![Screenshot from 2022-10-14 14-33-07](https://user-images.githubusercontent.com/63245456/195848153-5f3f559c-3397-4336-8ee4-bfe1ab470658.png)
</details>

<details>
<summary>"in" narrows - both English and Russian</summary>

**Note**: Neither 'in:all' or 'in:home' search/narrows are not documented.
![Screenshot from 2022-10-14 16-03-16](https://user-images.githubusercontent.com/63245456/195866639-430825d7-3df8-4fea-8eb9-7d3f7e0152db.png)
![Screenshot from 2022-10-14 16-03-30](https://user-images.githubusercontent.com/63245456/195866646-828aa19f-399a-4288-a2e8-9b8947db0602.png)
![Screenshot from 2022-10-14 15-55-35](https://user-images.githubusercontent.com/63245456/195866716-0ead7ddb-a3c1-4467-a8b0-bd9b08b8fa79.png)
![Screenshot from 2022-10-14 15-55-46](https://user-images.githubusercontent.com/63245456/195866719-46b6a8d6-c774-4a05-b7ec-33f74b7f3112.png)
</details>

<details>
<summary>"streams:puiblic" narrow - without and with keyword search - English only because new string not translated yet</summary>

![Screenshot from 2022-10-17 18-38-37](https://user-images.githubusercontent.com/63245456/196249512-ffa0d20f-28e9-4839-ab33-bc31c829860d.png)
![Screenshot from 2022-10-17 18-39-20](https://user-images.githubusercontent.com/63245456/196249517-d622394e-d4eb-4ef5-8372-7d9beb451b68.png)
</details>

<details>
<summary>Unknown stream - English</summary>

![Screenshot from 2022-10-17 18-40-34](https://user-images.githubusercontent.com/63245456/196250277-2fe1c6b5-5f12-4c02-8a26-70c2a58680f3.png)
![Screenshot from 2022-10-17 18-40-48](https://user-images.githubusercontent.com/63245456/196250282-f52a2682-cf3a-4827-b50f-8a61f88c2349.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
