### PR TITLE
Add new hotkey "m" for moving messages and some minor changes in message popover.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -80,7 +80,7 @@ mock_esm("../../static/js/recent_topics_util", {
     is_in_focus: () => false,
 });
 
-mock_esm("../../static/js/stream_popover", {
+const stream_popover = mock_esm("../../static/js/stream_popover", {
     stream_popped: () => false,
     topic_popped: () => false,
     all_messages_popped: () => false,
@@ -262,7 +262,7 @@ function test_normal_typing() {
 run_test("allow normal typing when processing text", ({override, override_rewire}) => {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
-    assert_unmapped("bfmoyz");
+    assert_unmapped("bfoyz");
     assert_unmapped("BEFHILNOQTWXYZ");
 
     // All letters should return false if we are composing text.
@@ -336,7 +336,7 @@ run_test("modal open", ({override}) => {
     test_normal_typing();
 });
 
-run_test("misc", () => {
+run_test("misc", ({override}) => {
     // Next, test keys that only work on a selected message.
     const message_view_only_keys = "@+>RjJkKsSuvi:GM";
 
@@ -370,6 +370,12 @@ run_test("misc", () => {
     assert_mapping(":", reactions, "open_reactions_popover", true);
     assert_mapping(">", compose_actions, "quote_and_reply");
     assert_mapping("e", message_edit, "start");
+
+    override(message_edit, "can_move_message", () => true);
+    assert_mapping("m", stream_popover, "build_move_topic_to_stream_popover");
+
+    override(message_edit, "can_move_message", () => false);
+    assert_unmapped("m");
 });
 
 run_test("lightbox overlay open", ({override}) => {

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -77,9 +77,9 @@ run_test("get_editability", ({override}) => {
     assert.equal(get_editability(message, 45), editability_types.TOPIC_ONLY);
     delete message.submessages;
     message.type = "private";
-    assert.equal(get_editability(message, 45), editability_types.NO_LONGER);
+    assert.equal(get_editability(message, 45), editability_types.NO);
     // If we don't pass a second argument, treat it as 0
-    assert.equal(get_editability(message), editability_types.NO_LONGER);
+    assert.equal(get_editability(message), editability_types.NO);
 
     message = {
         sent_by_me: false,

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -109,6 +109,10 @@ run_test("get_editability", ({override}) => {
     assert.equal(message_edit.is_topic_editable(message), true);
 
     page_params.is_admin = false;
+    message.topic = "translated: (no topic)";
+    assert.equal(message_edit.is_topic_editable(message), true);
+
+    message.topic = "test topic";
     override(settings_data, "user_can_edit_topic_of_any_message", () => true);
     assert.equal(message_edit.is_topic_editable(message), true);
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -148,6 +148,7 @@ const keypress_mappings = {
     106: {name: "vim_down", message_view_only: true}, // 'j'
     107: {name: "vim_up", message_view_only: true}, // 'k'
     108: {name: "vim_right", message_view_only: true}, // 'l'
+    109: {name: "move_message", message_view_only: true}, // 'm'
     110: {name: "n_key", message_view_only: false}, // 'n'
     112: {name: "p_key", message_view_only: false}, // 'p'
     113: {name: "query_streams", message_view_only: true}, // 'q'
@@ -963,6 +964,14 @@ export function process_hotkey(e, hotkey) {
         case "edit_message": {
             const $row = message_lists.current.get_row(msg.id);
             message_edit.start($row);
+            return true;
+        }
+        case "move_message": {
+            if (!message_edit.can_move_message(msg)) {
+                return false;
+            }
+
+            stream_popover.build_move_topic_to_stream_popover(msg.stream_id, msg.topic, msg);
             return true;
         }
     }

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -181,6 +181,21 @@ export function get_deletability(message) {
     return false;
 }
 
+export function can_move_message(message) {
+    if (!page_params.realm_allow_message_editing) {
+        return false;
+    }
+
+    if (!message.is_stream) {
+        return false;
+    }
+
+    return (
+        get_editability(message) !== editability_types.NO ||
+        settings_data.user_can_move_messages_between_streams()
+    );
+}
+
 export function stream_and_topic_exist_in_edit_history(message, stream_id, topic) {
     /*  Checks to see if a stream_id and a topic match any historical
         stream_id and topic state in the message's edit history.

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -45,7 +45,6 @@ export let notify_new_thread_default = true;
 
 export const editability_types = {
     NO: 1,
-    NO_LONGER: 2,
     // Note: TOPIC_ONLY does not include stream messages with no topic sent
     // by someone else. You can edit the topic of such a message by editing
     // the topic of the whole recipient_row it appears in, but you can't
@@ -149,7 +148,7 @@ export function get_editability(message, edit_limit_seconds_buffer = 0) {
     if (message.type === "stream") {
         return editability_types.TOPIC_ONLY;
     }
-    return editability_types.NO_LONGER;
+    return editability_types.NO;
 }
 
 export function get_deletability(message) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -68,6 +68,10 @@ export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
         return true;
     }
 
+    if (message.topic === compose.empty_topic_placeholder()) {
+        return true;
+    }
+
     if (!settings_data.user_can_edit_topic_of_any_message()) {
         return false;
     }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -543,10 +543,10 @@ export function toggle_actions_popover(element, id) {
         if (editability === message_edit.editability_types.FULL) {
             editability_menu_item = $t({defaultMessage: "Edit message"});
             if (message.is_stream) {
-                move_message_menu_item = $t({defaultMessage: "Move message"});
+                move_message_menu_item = $t({defaultMessage: "Move messages"});
             }
         } else if (can_move_message) {
-            move_message_menu_item = $t({defaultMessage: "Move message"});
+            move_message_menu_item = $t({defaultMessage: "Move messages"});
             view_source_menu_item = $t({defaultMessage: "View message source"});
         } else {
             view_source_menu_item = $t({defaultMessage: "View message source"});

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -534,8 +534,8 @@ export function toggle_actions_popover(element, id) {
             !message_container.is_hidden &&
             not_spectator;
         const editability = message_edit.get_editability(message);
-        const is_stream_editable =
-            message.is_stream && settings_data.user_can_move_messages_between_streams();
+        const can_move_message = message_edit.can_move_message(message);
+
         let editability_menu_item;
         let move_message_menu_item;
         let view_source_menu_item;
@@ -545,10 +545,7 @@ export function toggle_actions_popover(element, id) {
             if (message.is_stream) {
                 move_message_menu_item = $t({defaultMessage: "Move message"});
             }
-        } else if (
-            editability === message_edit.editability_types.TOPIC_ONLY ||
-            is_stream_editable
-        ) {
+        } else if (can_move_message) {
             move_message_menu_item = $t({defaultMessage: "Move message"});
             view_source_menu_item = $t({defaultMessage: "View message source"});
         } else {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -144,10 +144,8 @@ function message_hover($message_row) {
     // But the message edit hover icon is determined by whether the message is still editable
     const editability = message_edit.get_editability(message);
     const is_content_editable = editability === message_edit.editability_types.FULL;
-    const is_stream_editable =
-        message.is_stream && settings_data.user_can_move_messages_between_streams();
-    const can_move_message =
-        editability === message_edit.editability_types.TOPIC_ONLY || is_stream_editable;
+
+    const can_move_message = message_edit.can_move_message(message);
     const args = {
         is_content_editable: is_content_editable && !message.status_message,
         can_move_message,

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -23,6 +23,7 @@
     <li>
         <a class="popover_move_message" data-message-id="{{message_id}}" tabindex="0">
             <i class="fa fa-arrows" aria-hidden="true"></i> {{move_message_menu_item}}
+            <span class="hotkey-hint">(m)</span>
         </a>
     </li>
     {{/if}}

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -104,6 +104,7 @@
     <li>
         <a class="popover_view_source" data-message-id="{{message_id}}" tabindex="0">
             <i class="fa fa-file-code-o" aria-hidden="true"></i> {{view_source_menu_item}}
+            <span class="hotkey-hint">(e)</span>
         </a>
     </li>
     {{/if}}

--- a/static/templates/edit_content_button.hbs
+++ b/static/templates/edit_content_button.hbs
@@ -1,7 +1,7 @@
 {{#if is_content_editable}}
 <i class="fa fa-pencil edit_content_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Edit message' }} (e)" data-tippy-content="{{#tr}}Edit message{{/tr}} (e)"></i>
 {{else if can_move_message}}
-<i class="fa fa-arrows move_message_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Move message' }} (e)" data-tippy-content="{{#tr}}Move message{{/tr}}"></i>
+<i class="fa fa-arrows move_message_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'Move message' }} (m)" data-tippy-content="{{#tr}}Move message{{/tr}} (m)"></i>
 {{else}}
 <i class="fa fa-file-code-o view_source_button edit_message_button" role="button" tabindex="0" aria-label="{{t 'View message source' }} (e)" data-tippy-content="{{#tr}}View message source{{/tr}} (e)" data-message-id="{{msg_id}}"></i>
 {{/if}}

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -217,7 +217,7 @@
                     <td><span class="hotkey"><kbd>V</kbd></span></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
-                    <td class="definition">{{t 'Edit selected message or view message source' }}</td>
+                    <td class="definition">{{t 'Edit selected message or view source' }}</td>
                     <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
                 <tr id="move-message-hotkey-help">

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -220,6 +220,10 @@
                     <td class="definition">{{t 'Edit selected message or view message source' }}</td>
                     <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
+                <tr id="move-message-hotkey-help">
+                    <td class="definition">{{t 'Move messages or topic' }}</td>
+                    <td><span class="hotkey"><kbd>M</kbd></span></td>
+                </tr>
                 <tr>
                     <td class="definition">{{t 'Star selected message' }}</td>
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -145,6 +145,8 @@ below, and add more to your repertoire as needed.
 
 * **Edit message or view message source**: <kbd>E</kbd>
 
+* **Move message and (optionally) other messages in the same topic**: <kbd>M</kbd>
+
 * **Star message**: <kbd>Ctrl</kbd> + <kbd>S</kbd>
 
 * **React with <img alt=":thumbs_up:" class="emoji"


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is just a refactor to remove `NO_LONGER` from `message_edit.editability_types`.
- Second commit adds `m` hotkey for moving message.
- Third commit is to add `e` option to `View message source` option.
- Fourth commit is to update the description for `e` keyboard shortcut.
- Fifth commit is to deduplicate some code.

Fixes: <!-- Issue link, or clear description.--> #23112, #23113

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
