### PR TITLE
email_notifications: Fix missed message email notifications of the welcome bot.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1492,6 +1492,7 @@ def _internal_prep_message(
     sender: UserProfile,
     addressee: Addressee,
     content: str,
+    *,
     email_gateway: bool = False,
     mention_backend: Optional[MentionBackend] = None,
     limit_unread_user_ids: Optional[Set[int]] = None,
@@ -1543,6 +1544,7 @@ def internal_prep_stream_message(
     stream: Stream,
     topic: str,
     content: str,
+    *,
     email_gateway: bool = False,
     limit_unread_user_ids: Optional[Set[int]] = None,
 ) -> Optional[SendMessageRequest]:
@@ -1586,6 +1588,7 @@ def internal_prep_private_message(
     sender: UserProfile,
     recipient_user: UserProfile,
     content: str,
+    *,
     mention_backend: Optional[MentionBackend] = None,
 ) -> Optional[SendMessageRequest]:
     """
@@ -1621,12 +1624,18 @@ def internal_send_stream_message(
     stream: Stream,
     topic: str,
     content: str,
+    *,
     email_gateway: bool = False,
     limit_unread_user_ids: Optional[Set[int]] = None,
 ) -> Optional[int]:
 
     message = internal_prep_stream_message(
-        sender, stream, topic, content, email_gateway, limit_unread_user_ids=limit_unread_user_ids
+        sender,
+        stream,
+        topic,
+        content,
+        email_gateway=email_gateway,
+        limit_unread_user_ids=limit_unread_user_ids,
     )
 
     if message is None:

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -504,6 +504,7 @@ def build_message_send_dict(
     email_gateway: bool = False,
     mention_backend: Optional[MentionBackend] = None,
     limit_unread_user_ids: Optional[Set[int]] = None,
+    disable_external_notifications: bool = False,
 ) -> SendMessageRequest:
     """Returns a dictionary that can be passed into do_send_messages.  In
     production, this is always called by check_message, but some
@@ -610,6 +611,7 @@ def build_message_send_dict(
         links_for_embed=links_for_embed,
         widget_content=widget_content_dict,
         limit_unread_user_ids=limit_unread_user_ids,
+        disable_external_notifications=disable_external_notifications,
     )
 
     return message_send_dict
@@ -893,6 +895,7 @@ def do_send_messages(
                 user_id=user_id,
                 flags=user_flags.get(user_id, []),
                 private_message=(message_type == "private"),
+                disable_external_notifications=send_request.disable_external_notifications,
                 online_push_user_ids=send_request.online_push_user_ids,
                 pm_mention_push_disabled_user_ids=send_request.pm_mention_push_disabled_user_ids,
                 pm_mention_email_disabled_user_ids=send_request.pm_mention_email_disabled_user_ids,
@@ -926,6 +929,7 @@ def do_send_messages(
             wildcard_mention_user_ids=list(send_request.wildcard_mention_user_ids),
             muted_sender_user_ids=list(send_request.muted_sender_user_ids),
             all_bot_user_ids=list(send_request.all_bot_user_ids),
+            disable_external_notifications=send_request.disable_external_notifications,
         )
 
         if send_request.message.is_stream_message():
@@ -1346,6 +1350,7 @@ def check_message(
     skip_stream_access_check: bool = False,
     mention_backend: Optional[MentionBackend] = None,
     limit_unread_user_ids: Optional[Set[int]] = None,
+    disable_external_notifications: bool = False,
 ) -> SendMessageRequest:
     """See
     https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html
@@ -1477,6 +1482,7 @@ def check_message(
         email_gateway=email_gateway,
         mention_backend=mention_backend,
         limit_unread_user_ids=limit_unread_user_ids,
+        disable_external_notifications=disable_external_notifications,
     )
 
     if stream is not None and message_send_dict.rendering_result.mentions_wildcard:
@@ -1496,6 +1502,7 @@ def _internal_prep_message(
     email_gateway: bool = False,
     mention_backend: Optional[MentionBackend] = None,
     limit_unread_user_ids: Optional[Set[int]] = None,
+    disable_external_notifications: bool = False,
 ) -> Optional[SendMessageRequest]:
     """
     Create a message object and checks it, but doesn't send it or save it to the database.
@@ -1527,6 +1534,7 @@ def _internal_prep_message(
             email_gateway=email_gateway,
             mention_backend=mention_backend,
             limit_unread_user_ids=limit_unread_user_ids,
+            disable_external_notifications=disable_external_notifications,
         )
     except JsonableError as e:
         logging.exception(
@@ -1590,6 +1598,7 @@ def internal_prep_private_message(
     content: str,
     *,
     mention_backend: Optional[MentionBackend] = None,
+    disable_external_notifications: bool = False,
 ) -> Optional[SendMessageRequest]:
     """
     See _internal_prep_message for details of how this works.
@@ -1606,13 +1615,23 @@ def internal_prep_private_message(
         addressee=addressee,
         content=content,
         mention_backend=mention_backend,
+        disable_external_notifications=disable_external_notifications,
     )
 
 
 def internal_send_private_message(
-    sender: UserProfile, recipient_user: UserProfile, content: str
+    sender: UserProfile,
+    recipient_user: UserProfile,
+    content: str,
+    *,
+    disable_external_notifications: bool = False,
 ) -> Optional[int]:
-    message = internal_prep_private_message(sender, recipient_user, content)
+    message = internal_prep_private_message(
+        sender,
+        recipient_user,
+        content,
+        disable_external_notifications=disable_external_notifications,
+    )
     if message is None:
         return None
     message_ids = do_send_messages([message])

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -169,6 +169,7 @@ class SendMessageRequest:
     delivery_type: Optional[str] = None
     limit_unread_user_ids: Optional[Set[int]] = None
     service_queue_events: Optional[Dict[str, List[Dict[str, Any]]]] = None
+    disable_external_notifications: bool = False
 
 
 # We won't try to fetch more unread message IDs from the database than

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -20,6 +20,7 @@ class UserMessageNotificationsData:
     stream_push_notify: bool
     stream_email_notify: bool
     sender_is_muted: bool
+    disable_external_notifications: bool
 
     def __post_init__(self) -> None:
         # Check that there's no dubious data.
@@ -36,6 +37,7 @@ class UserMessageNotificationsData:
         user_id: int,
         flags: Collection[str],
         private_message: bool,
+        disable_external_notifications: bool,
         online_push_user_ids: Set[int],
         pm_mention_push_disabled_user_ids: Set[int],
         pm_mention_email_disabled_user_ids: Set[int],
@@ -60,6 +62,7 @@ class UserMessageNotificationsData:
                 stream_push_notify=False,
                 stream_email_notify=False,
                 sender_is_muted=False,
+                disable_external_notifications=False,
             )
 
         # `wildcard_mention_user_ids` are those user IDs for whom wildcard mentions should
@@ -96,6 +99,7 @@ class UserMessageNotificationsData:
             stream_push_notify=(user_id in stream_push_user_ids),
             stream_email_notify=(user_id in stream_email_user_ids),
             sender_is_muted=(user_id in muted_sender_user_ids),
+            disable_external_notifications=disable_external_notifications,
         )
 
     # For these functions, acting_user_id is the user sent a message
@@ -110,6 +114,9 @@ class UserMessageNotificationsData:
             return True
 
         if self.sender_is_muted:
+            return True
+
+        if self.disable_external_notifications:
             return True
 
         return False

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -101,6 +101,19 @@ class UserMessageNotificationsData:
     # For these functions, acting_user_id is the user sent a message
     # (or edited a message) triggering the event for which we need to
     # determine notifiability.
+    def trivially_should_not_notify(self, acting_user_id: int) -> bool:
+        """This function involves the checks which are users' notification
+        settings independent and and thus don't depend on what type of notification
+        (email/push) it is.
+        """
+        if self.user_id == acting_user_id:
+            return True
+
+        if self.sender_is_muted:
+            return True
+
+        return False
+
     def is_notifiable(self, acting_user_id: int, idle: bool) -> bool:
         return self.is_email_notifiable(acting_user_id, idle) or self.is_push_notifiable(
             acting_user_id, idle
@@ -113,10 +126,7 @@ class UserMessageNotificationsData:
         if not idle and not self.online_push_enabled:
             return None
 
-        if self.user_id == acting_user_id:
-            return None
-
-        if self.sender_is_muted:
+        if self.trivially_should_not_notify(acting_user_id):
             return None
 
         # The order here is important. If, for example, both
@@ -140,10 +150,7 @@ class UserMessageNotificationsData:
         if not idle:
             return None
 
-        if self.user_id == acting_user_id:
-            return None
-
-        if self.sender_is_muted:
+        if self.trivially_should_not_notify(acting_user_id):
             return None
 
         # The order here is important. If, for example, both

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -93,7 +93,12 @@ def send_initial_pms(user: UserProfile) -> None:
     )
 
     internal_send_private_message(
-        get_system_bot(settings.WELCOME_BOT, user.realm_id), user, content
+        get_system_bot(settings.WELCOME_BOT, user.realm_id),
+        user,
+        content,
+        # Note: Welcome bot doesn't trigger email/push notifications,
+        # as this is intended to be seen contextually in the application.
+        disable_external_notifications=True,
     )
 
 
@@ -214,7 +219,15 @@ def send_welcome_bot_response(send_request: SendMessageRequest) -> None:
     welcome_bot = get_system_bot(settings.WELCOME_BOT, send_request.message.sender.realm_id)
     human_response_lower = send_request.message.content.lower()
     content = select_welcome_bot_response(human_response_lower)
-    internal_send_private_message(welcome_bot, send_request.message.sender, content)
+
+    internal_send_private_message(
+        welcome_bot,
+        send_request.message.sender,
+        content,
+        # Note: Welcome bot doesn't trigger email/push notifications,
+        # as this is intended to be seen contextually in the application.
+        disable_external_notifications=True,
+    )
 
 
 @transaction.atomic

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1683,6 +1683,7 @@ Output:
             stream_email_notify=kwargs.get("stream_email_notify", False),
             stream_push_notify=kwargs.get("stream_push_notify", False),
             sender_is_muted=kwargs.get("sender_is_muted", False),
+            disable_external_notifications=kwargs.get("disable_external_notifications", False),
         )
 
     def get_maybe_enqueue_notifications_parameters(

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -113,6 +113,23 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertFalse(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
+        # 'disable_external_notifications' takes precedence over other flags.
+        user_data = self.create_user_notifications_data_object(
+            user_id=user_id,
+            pm_push_notify=True,
+            pm_email_notify=True,
+            mention_push_notify=True,
+            mention_email_notify=True,
+            wildcard_mention_push_notify=True,
+            wildcard_mention_email_notify=True,
+            disable_external_notifications=True,
+        )
+        self.assertEqual(
+            user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
+            None,
+        )
+        self.assertFalse(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
+
     def test_is_email_notifiable(self) -> None:
         user_id = self.example_user("hamlet").id
         acting_user_id = self.example_user("cordelia").id
@@ -209,6 +226,23 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertFalse(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
+        # Message sender is the welcome bot.
+        user_data = self.create_user_notifications_data_object(
+            user_id=user_id,
+            pm_push_notify=True,
+            pm_email_notify=True,
+            mention_push_notify=True,
+            mention_email_notify=True,
+            wildcard_mention_push_notify=True,
+            wildcard_mention_email_notify=True,
+            disable_external_notifications=True,
+        )
+        self.assertEqual(
+            user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
+            None,
+        )
+        self.assertFalse(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
+
     def test_is_notifiable(self) -> None:
         # This is just for coverage purposes. We've already tested all scenarios above,
         # and `is_notifiable` is a simple OR of the email and push functions.
@@ -224,6 +258,7 @@ class TestNotificationData(ZulipTestCase):
                 user_id=user_id,
                 flags=["mentioned"],
                 private_message=True,
+                disable_external_notifications=False,
                 online_push_user_ids=set(),
                 pm_mention_email_disabled_user_ids=set(),
                 pm_mention_push_disabled_user_ids=set(),

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -958,7 +958,7 @@ class LoginTest(ZulipTestCase):
         ContentType.objects.clear_cache()
 
         # Ensure the number of queries we make is not O(streams)
-        with self.assert_database_query_count(96), cache_tries_captured() as cache_tries:
+        with self.assert_database_query_count(95), cache_tries_captured() as cache_tries:
             with self.captureOnCommitCallbacks(execute=True):
                 self.register(self.nonreg_email("test"), "test")
 

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -15,7 +15,15 @@ class TutorialTests(ZulipTestCase):
         user = self.example_user("hamlet")
         welcome_bot = get_system_bot(settings.WELCOME_BOT, user.realm_id)
         content = "Shortened welcome message."
-        internal_send_private_message(welcome_bot, user, content)
+        internal_send_private_message(
+            welcome_bot,
+            user,
+            content,
+            # disable_external_notifications set to False will still lead
+            # the tests to pass. Setting this to True, because we contextually
+            # set this to true for welcome_bot in the codebase.
+            disable_external_notifications=True,
+        )
 
     def test_tutorial_status(self) -> None:
         user = self.example_user("hamlet")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -804,7 +804,7 @@ class QueryCountTest(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
 
-        with self.assert_database_query_count(91):
+        with self.assert_database_query_count(90):
             with cache_tries_captured() as cache_tries:
                 with self.tornado_redirected_to_list(events, expected_num_events=11):
                     fred = do_create_user(

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -783,6 +783,9 @@ def missedmessage_hook(
             stream_email_notify=internal_data.get("stream_email_notify", False),
             # Since one is by definition idle, we don't need to check online_push_enabled
             online_push_enabled=False,
+            disable_external_notifications=internal_data.get(
+                "disable_external_notifications", False
+            ),
         )
 
         mentioned_user_group_id = internal_data.get("mentioned_user_group_id")
@@ -933,6 +936,7 @@ def process_message_event(
     wildcard_mention_user_ids = set(event_template.get("wildcard_mention_user_ids", []))
     muted_sender_user_ids = set(event_template.get("muted_sender_user_ids", []))
     all_bot_user_ids = set(event_template.get("all_bot_user_ids", []))
+    disable_external_notifications = event_template.get("disable_external_notifications", False)
 
     wide_dict: Dict[str, Any] = event_template["message_dict"]
 
@@ -973,6 +977,7 @@ def process_message_event(
             user_id=user_profile_id,
             flags=flags,
             private_message=private_message,
+            disable_external_notifications=disable_external_notifications,
             online_push_user_ids=online_push_user_ids,
             pm_mention_push_disabled_user_ids=pm_mention_push_disabled_user_ids,
             pm_mention_email_disabled_user_ids=pm_mention_email_disabled_user_ids,
@@ -1128,6 +1133,7 @@ def process_message_update_event(
     wildcard_mention_user_ids = set(event_template.pop("wildcard_mention_user_ids", []))
     muted_sender_user_ids = set(event_template.pop("muted_sender_user_ids", []))
     all_bot_user_ids = set(event_template.pop("all_bot_user_ids", []))
+    disable_external_notifications = event_template.pop("disable_external_notifications", False)
 
     # TODO/compatibility: Translation code for the rename of
     # `push_notify_user_ids` to `online_push_user_ids`.  Remove this
@@ -1179,6 +1185,7 @@ def process_message_update_event(
                 user_id=user_profile_id,
                 flags=flags,
                 private_message=(stream_name is None),
+                disable_external_notifications=disable_external_notifications,
                 online_push_user_ids=online_push_user_ids,
                 pm_mention_push_disabled_user_ids=pm_mention_push_disabled_user_ids,
                 pm_mention_email_disabled_user_ids=pm_mention_email_disabled_user_ids,


### PR DESCRIPTION
A missed message email notification, where the message is the welcome message sent by the welcome bot on account creation, get sent when the user somehow not focuses the browser tab during account creation.

No missed message email notification should be sent for the messages generated by the welcome bot.

A separate function named `trivially_should_not_notify` is added which extracts the common checks from `get_push_notification_trigger` and `get_email_notification_trigger` which are users' notification settings
independent and thus don't depend on what type of notification (email/push) it is.

A check is introduced in `trivially_should_not_notify`, not to notify if `sender_is_welcome_bot` is true.

TestCases are updated to include the `sender_is_welcome_bot` check in the early (False) return patterns of `is_push_notifiable` and `is_email_noitifiable`.

**One query reduced** for both `test_create_user_with_multiple_streams` and `test_register`.

**Reason:** When welcome bot sends message after user creation `do_send_messages` calls [`get_active_presence_idle_user_ids`](https://github.com/zulip/zulip/blob/aebdf6af8c6675fbd2792888d701d582c4a1110a/zerver/actions/message_send.py#L732), [`user_ids`](https://github.com/zulip/zulip/blob/aebdf6af8c6675fbd2792888d701d582c4a1110a/zerver/actions/message_send.py#L758) in `get_active_presence_idle_user_ids` remains empty if
`sender_is_welcome_bot` is true because `is_notifiable` returns false. `get_active_presence_idle_user_ids` calls `filter_presence_idle_user_ids` and since the `user_ids` is empty, the query inside the function doesn't
get executed. 

**Manual Testing:** The issue is hard to reproduce in a UI. To reproduce the issue, raise an exception in zerver/views/home.py by adding raise Exception("Throw exception after account creation") before return web_public_view(home_real)(request) [reference](https://github.com/zulip/zulip/blob/2ff4143aa4cd68a1eb338455ef005f9c6bec17a8/zerver/views/home.py#L131)

Create a new account, then visit \emails to see the missed message email notification. No more missed message email notification get received after including the changes.

Fixes: #22884

<hr>

**Screenshots and screen captures:**

**Before**
- <details>
  <summary>Terminal: missed_message email sent.</summary>
   <img src="https://user-images.githubusercontent.com/56781761/197336688-84cd6876-f04b-4ba1-a076-272d48d457be.png"> 
   </img>
  </details>

- <details>
  <summary>Email</summary>
   <img src="https://user-images.githubusercontent.com/56781761/197336710-a3ed1fbf-1e74-4da6-a5af-9872c74b9b3c.png"> 
   </img>
  </details>

**After**
- <details>
  <summary>Terminal: No email sent.</summary>
   <img src="https://user-images.githubusercontent.com/56781761/197336727-4b292aee-4801-4c74-b6e5-a0fc80904723.png"> 
   </img>
  </details>

<hr>

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
