### PR TITLE
Fix spectator view custom profile fields

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -255,13 +255,13 @@ function render_user_info_popover(
     const is_system_bot = user.is_system_bot;
     const status_text = user_status.get_status_text(user.user_id);
     const status_emoji_info = user_status.get_status_emoji(user.user_id);
+    const spectator_view = page_params.is_spectator;
 
     // TODO: The show_manage_menu calculation can get a lot simpler
     // if/when we allow muting bot users.
     const can_manage_user = page_params.is_admin && !is_me && !is_system_bot;
-    const show_manage_menu = muting_allowed || can_manage_user;
+    const show_manage_menu = !spectator_view && (muting_allowed || can_manage_user);
 
-    const spectator_view = page_params.is_spectator;
     let date_joined;
     if (spectator_view) {
         const dateFormat = new Intl.DateTimeFormat("default", {dateStyle: "long"});

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -146,11 +146,14 @@ def fetch_initial_state_data(
     if want("alert_words"):
         state["alert_words"] = [] if user_profile is None else user_alert_words(user_profile)
 
-    # Spectators can't access full user profiles or personal settings,
-    # so there's no need to send custom profile field data.
-    if want("custom_profile_fields") and user_profile is not None:
-        fields = custom_profile_fields_for_realm(realm.id)
-        state["custom_profile_fields"] = [f.as_dict() for f in fields]
+    if want("custom_profile_fields"):
+        if user_profile is None:
+            # Spectators can't access full user profiles or
+            # personal settings, so we send an empty list.
+            state["custom_profile_fields"] = []
+        else:
+            fields = custom_profile_fields_for_realm(realm.id)
+            state["custom_profile_fields"] = [f.as_dict() for f in fields]
         state["custom_profile_field_types"] = {
             item[4]: {"id": item[0], "name": str(item[1])}
             for item in CustomProfileField.ALL_FIELD_TYPES


### PR DESCRIPTION
Updates the server to send an empty list of `custom_profile_fields` in `page_params` for spectators, rather than not sending the field at all. Fixes an error on the frontend where `custom_profile_fields` was undefined when users tried to access a message's sender info.

Also, updates `render_user_info_popover` to load the `login_to_access modal` in spectator views, and updates the hotkey implementation for viewing a message's sender info, `show_sender_info`, to also load the `login_to_access modal`.

---

**Notes**:
- I added the second commit because I noticed with the server change, we now loaded a basic version of the user info popover for spectators. That basic version included the user's role and join date, as well as the three dot menu which opens up the modal for muting a user, see screenshots below. Note that if the spectator tries to mute the user, then the `login_to_access` modal appears. The help center article for the [public access option](https://zulip.com/help/public-access-option#information-that-can-be-accessed-via-api-when-web-public-streams-are-enabled) does say that information is available [via the API](https://zulip.com/help/public-access-option#information-about-users), but doesn't imply that it will be visible in the web-app. Currently, due to the bug, nothing is shown to the spectator when they click on a user's name/avatar or use the hotkey shortcut.
- I put the check for loading the `login_to_access` modal in `render_user_info_popover`. Alternatively, we could put that check in the three places (`show_user_info_popover_for_message`, `show_user_info_popover`, `.on("click", ".user-list-sidebar-menu-icon"`) that the render function is called. Since the user list isn't displayed in the spectator view, we could probably only put the check in the first two function calls. I went with the current implementation because seemed clearer that we didn't want that popover rendered in spectator views.
- I noted a bit of a delay and image blurriness when the user info popover is loaded in the dev environment for a logged-in user. This seems to be present when I manually test the current `main` without these changes, so I think this is an existing issue and not introduced by these changes.
- If we want the frontend changes, then these two commits can be squashed, but I didn't want to assume that's the behavior we want, so I kept them separate for ease of reviewing and making updates/changes.

---

**Screenshots and screen captures:**

<details>
<summary>Current behavior in dev environment</summary>

![Screenshot from 2022-10-13 15-15-11](https://user-images.githubusercontent.com/63245456/195606609-ba767735-4fc1-4f45-b968-c017bd46d984.png)
</details>


<details>
<summary>After the server sends the empty list for custom profile fields</summary>

![Screenshot from 2022-10-13 13-42-42](https://user-images.githubusercontent.com/63245456/195606749-a29b1d44-1c9d-41bb-8ddd-d1313c5f877b.png)
![Screenshot from 2022-10-13 15-21-39](https://user-images.githubusercontent.com/63245456/195608166-b36ea411-12ef-4da8-9ac5-4659fc18f14e.png)
![Screenshot from 2022-10-13 15-21-17](https://user-images.githubusercontent.com/63245456/195608160-520a8a7d-dc6e-4af4-a4a6-5a106528ba2a.png)
</details>


<details>
<summary>After updating the frontend for popovers and hotkeys</summary>

![Screenshot from 2022-10-13 14-01-12](https://user-images.githubusercontent.com/63245456/195606925-00f98c96-f262-4e23-8c31-93c02710aae3.png)
![Screenshot from 2022-10-13 14-01-37](https://user-images.githubusercontent.com/63245456/195606930-b704cfa9-b403-4c85-80fc-2676dd54115d.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
