### PR TITLE
tippy: Don't show an error for a race condition in reaction tooltips.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -114,6 +114,11 @@ export function initialize() {
         target: ".message_reaction, .message_reactions .reaction_button",
         placement: "bottom",
         onShow(instance) {
+            if (!document.body.contains(instance.reference)) {
+                // It is possible for reaction to be removed before `onShow` is triggered,
+                // so, we check if the element exists before proceeding.
+                return false;
+            }
             const $elem = $(instance.reference);
             if (!instance.reference.classList.contains("reaction_button")) {
                 const local_id = $elem.attr("data-reaction-id");
@@ -130,6 +135,7 @@ export function initialize() {
                 $elem.get(0),
             ];
             hide_tooltip_if_reference_removed(target, config, instance, nodes_to_check_for_removal);
+            return true;
         },
         onHidden(instance) {
             instance.destroy();


### PR DESCRIPTION
We no longer throw an error if no message row exists for a reaction. This can happen when the reaction is removed when the code is in the process to get its message id. We simply hide the tooltip now and show no error.

discussion: https://chat.zulip.org/#narrow/stream/343-kandra-errors/topic/JS.20errors.3A.20Hovering.20over.20reaction
