### PR TITLE
css: Fix color of filter buttons being changed on hover for spectators.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -614,7 +614,7 @@ body.dark-theme {
         background-color: hsl(211, 18%, 25%) !important;
     }
 
-    .btn-recent-filters {
+    .recent_topics_container #recent_topics_table .btn-recent-filters {
         background-color: hsl(211, 29%, 14%);
         border-color: hsl(0, 0%, 0%);
         color: hsl(0, 0%, 100%);
@@ -622,6 +622,16 @@ body.dark-theme {
         &:focus {
             background-color: hsla(0, 0%, 0%, 0.5) !important;
             outline: 0;
+        }
+
+        &.fake_disabled_button {
+            cursor: not-allowed;
+            opacity: 0.5;
+
+            &:hover {
+                background-color: hsla(0, 0%, 0%, 0.5);
+                border-color: hsl(0, 0%, 0%);
+            }
         }
     }
 


### PR DESCRIPTION
We don't want the color to change at all on hover since these buttons are disabled. This only needed a fix for the dark theme.

before:
<img width="558" alt="Screenshot 2022-10-13 at 9 28 27 PM" src="https://user-images.githubusercontent.com/25124304/195649755-fee894f7-2c5f-4b83-b36c-94b5c8723bae.png">

after:
<img width="558" alt="Screenshot 2022-10-13 at 9 40 11 PM" src="https://user-images.githubusercontent.com/25124304/195649744-c93d3a85-5e64-4f47-9a8d-ab8a3b63ac18.png">