### PR TITLE
Remove text highlighting in compose box

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -521,7 +521,7 @@ export function on_topic_narrow() {
     compose_validate.warn_if_topic_resolved(true);
     compose_fade.set_focused_recipient("stream");
     compose_fade.update_message_list();
-    $("#compose-textarea").trigger("focus").trigger("select");
+    $("#compose-textarea").trigger("focus");
 }
 
 export function quote_and_reply(opts) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [#23146](https://github.com/zulip/zulip/issues/23146)

Previously, the compose box will highlight text when one of the two cases happen:

1. When the user has a stream selected, no topic selected and contains content
2. When the user has both stream and topic selected but doesn't contain any content

There is also a bug where a empty compose box that only contains spaces would be highlighted when the user switches topics.

The new changes will drop the text-highlighting resolve the bug altogether.

<!-- Issue link, or clear description.-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
