### PR TITLE
user_profile_modal: Move title and tab switcher to a fixed header.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -456,13 +456,6 @@ ul {
         width: fit-content;
     }
 
-    &.no-fields {
-        hr,
-        #content {
-            display: none;
-        }
-    }
-
     .tab-data {
         .active {
             display: block;

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -346,19 +346,18 @@ ul {
         padding-right: 16px;
     }
 
+    .modal__header {
+        justify-content: center;
+    }
+
     .modal__close {
-        float: right;
-        margin: 0;
+        position: absolute;
+        right: 20px;
     }
 
     #tab-toggle {
         font-weight: initial;
-        margin: 6px 4px 6px 0;
-        width: 100%;
-
-        .tab-switcher {
-            margin-left: 2px;
-        }
+        padding: 0 16px 6px;
     }
 
     .name {
@@ -406,18 +405,9 @@ ul {
         }
     }
 
-    #name {
-        font-size: 26px;
-        font-weight: 700;
-        margin-bottom: 5px;
-        max-width: 100%;
-        text-align: center;
-        line-height: 30px;
-
-        #edit-button {
-            font-size: 18px;
-            margin-left: 10px;
-        }
+    #edit-button {
+        font-size: 18px;
+        margin-left: 10px;
     }
 
     #default-section {
@@ -470,14 +460,6 @@ ul {
         hr,
         #content {
             display: none;
-        }
-    }
-
-    &:not(.no-fields) {
-        #body {
-            padding-bottom: 10px;
-            padding-top: 4px;
-            margin-top: 10px;
         }
     }
 

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -1,6 +1,6 @@
 <div class="micromodal" id="user-profile-modal" data-user-id="{{user_id}}" aria-hidden="true">
     <div class="modal__overlay" tabindex="-1" data-micromodal-close>
-        <div class="modal__container new-style{{#unless profile_data.length}} no-fields{{/unless}}" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
+        <div class="modal__container new-style" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <div class="modal__header">
                 <h1 class="modal__title" id="name">
                     {{full_name}}

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -1,9 +1,8 @@
 <div class="micromodal" id="user-profile-modal" data-user-id="{{user_id}}" aria-hidden="true">
     <div class="modal__overlay" tabindex="-1" data-micromodal-close>
         <div class="modal__container new-style{{#unless profile_data.length}} no-fields{{/unless}}" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
-            <main class="modal__body" id="body" data-simplebar data-simplebar-auto-hide="false">
-                <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
-                <div id="name">
+            <div class="modal__header">
+                <h1 class="modal__title" id="name">
                     {{full_name}}
                     {{#if is_bot}}
                     <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
@@ -13,8 +12,11 @@
                         <i class="fa fa-edit" id="edit-button" aria-hidden="true"></i>
                     </a>
                     {{/if}}
-                </div>
-                <div id="tab-toggle" class="center"></div>
+                </h1>
+                <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
+            </div>
+            <div id="tab-toggle" class="center"></div>
+            <main class="modal__body" id="body" data-simplebar data-simplebar-auto-hide="false">
                 <div class="tab-data">
                     <div class="tabcontent active" id="profile-tab">
                         <div class="top">


### PR DESCRIPTION
While going through the full profile of a user, we expect to find that specific user's in-depth details. Thus, we should have a fixed title displaying the name at the top of the modal to establish the connection of the profile data with the user.

We also fix the tab switcher between "Profile/Streams/User groups" to the top of the modal, for the added convinience of switching across the three options at any point of time.

<!-- Describe your pull request here.-->

[Discussion at CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/Full.20Profile.20design.20tweaks)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![full-profile-static-header](https://user-images.githubusercontent.com/82862779/195724927-5defc209-ae63-40a1-b453-bfa25b9bf389.gif)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
