### PR TITLE
drafts: Update topic when it's renamed and for a going forward change.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -128,12 +128,27 @@ export function confirm_delete_all_drafts() {
     });
 }
 
-export function rename_topic(stream_id, old_topic, new_topic) {
+export function rename_stream_recipient(old_stream_id, old_topic, new_stream_id, new_topic) {
     const current_drafts = draft_model.get();
     for (const draft_id of Object.keys(current_drafts)) {
         const draft = current_drafts[draft_id];
-        if (util.same_stream_and_topic(draft, {stream_id, topic: old_topic})) {
-            draft.topic = new_topic;
+        if (util.same_stream_and_topic(draft, {stream_id: old_stream_id, topic: old_topic})) {
+            // If new_stream_id is undefined, that means the stream wasn't updated.
+            if (new_stream_id !== undefined) {
+                draft.stream_id = new_stream_id;
+                // TODO: For now we need both a stream_id and stream (stream name)
+                // because there can be partial input in the stream field.
+                // Once we complete our UI plan to change the stream input field
+                // to a dropdown_list_widget, there will no longer be the possibility
+                // of invalid partial input in the stream field, and we can have the
+                // drafts system ignore the legacy `stream` field, using only `stream_id`.
+                // After enough drafts are autodeleted, we'd no longer have a `stream` field.
+                draft.stream = sub_store.get(new_stream_id).name;
+            }
+            // If new_topic is undefined, that means the topic wasn't updated.
+            if (new_topic !== undefined) {
+                draft.topic = new_topic;
+            }
             draft_model.editDraft(draft_id, draft, false);
         }
     }

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -288,7 +288,9 @@ export function update_messages(events) {
                 compose_fade.set_focused_recipient("stream");
             }
 
-            drafts.rename_topic(old_stream_id, orig_topic, new_topic);
+            if (going_forward_change) {
+                drafts.rename_stream_recipient(old_stream_id, orig_topic, new_stream_id, new_topic);
+            }
 
             for (const msg of event_messages) {
                 if (page_params.realm_allow_edit_history) {


### PR DESCRIPTION
This is a different implementation of #22094 which didn't consider the case of message moving outside of updating a topic name and caused this error: https://chat.zulip.org/#narrow/stream/343-kandra-errors/topic/JS.20error.3A.20drafts.20error.20with.20new.20topic

Tested manually. Open to adding unit tests if there's a good place for them!

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
