### PR TITLE
help: Update message menu documentation.

### DIFF
--- a/templates/zerver/help/configure-notification-bot.md
+++ b/templates/zerver/help/configure-notification-bot.md
@@ -16,7 +16,7 @@ The notification bot also generates automated private messages to
 individual users for some user specific events, such as [being
 subscribed to a stream][add-users-to-stream] by another user.
 
-Additionally, when [moving messages to a another stream][move-messages],
+Additionally, when [moving messages to another stream][move-messages],
 users can have the notification bot send automated notices to help
 others find the moved content.
 

--- a/templates/zerver/help/edit-or-delete-a-message.md
+++ b/templates/zerver/help/edit-or-delete-a-message.md
@@ -19,25 +19,22 @@ content.
 
 {!message-actions.md!}
 
-1. Click the pencil (<i class="fa fa-pencil"></i>) icon.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon.
 
 1. Edit the message, and click **Save**.
 
+!!! warn ""
+    **Note:** If you don't see the **pencil** (<i class="fa fa-pencil"></i>) icon,
+    you are not permitted to edit this message.
+
 {end_tabs}
 
-!!! warn ""
+!!! tip ""
 
-    **Note:** After you have edited a message, the message is publicly
+    After you have edited a message, the message is publicly
     marked as **EDITED**. You can
-    [view a message's edit history](/help/view-a-messages-edit-history),
-    assuming that feature has not been
-    [disabled by an organization administrator](/help/disable-message-edit-history).
-
-If you don't see the pencil (<i class="fa fa-pencil"></i>) icon, the message content
-can no longer be edited. You should see a file (<i class="fa fa-file-code-o"></i>)
-icon instead. Clicking the file icon will allow you to view the
-[Markdown source](/help/view-the-markdown-source-of-a-message) of the message, or
-[edit the topic](/help/rename-a-topic).
+    [view a message's edit history](/help/view-a-messages-edit-history)
+    if it is [enabled](/help/disable-message-edit-history) in your organization.
 
 ## Delete a message
 
@@ -96,6 +93,7 @@ permissions to delete that message.
 
 ## Related articles
 
+* [View the Markdown source of a message](/help/view-the-markdown-source-of-a-message)
 * [Delete a topic](/help/delete-a-topic)
 * [Archive a stream](/help/archive-a-stream)
 * [Message retention policy](/help/message-retention-policy)

--- a/templates/zerver/help/emoji-reactions.md
+++ b/templates/zerver/help/emoji-reactions.md
@@ -11,7 +11,7 @@ underneath the message.
 
 {!message-actions.md!}
 
-1. Click the smiley face (<i class="fa fa-smile-o"></i>) icon.
+1. Click the **smiley face** (<i class="fa fa-smile-o"></i>) icon.
 
     !!! warn ""
 

--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -26,11 +26,11 @@ destination streams.
 
 1. Select the destination stream for the topic from the streams dropdown list.
 
-1. (optional) Change the topic.
+1. _(optional)_ Change the topic name.
 
 1. Toggle whether automated notices should be sent.
 
-1. Click **Confirm**.
+1. Click **Confirm** to move the topic to another stream.
 
 
 !!! warn ""
@@ -52,13 +52,13 @@ destination streams.
 
 1. Select the destination stream for the message from the streams dropdown list.
 
-1. (optional) Change the topic.
-
-1. Toggle whether automated notices should be sent.
+1. _(optional)_ Change the topic name.
 
 1. From the dropdown menu, select which messages to move.
 
-1. Click **Save**.
+1. Toggle whether automated notices should be sent.
+
+1. Click **Confirm** to move the selected content to another stream.
 
 
 !!! warn ""

--- a/templates/zerver/help/move-content-to-another-topic.md
+++ b/templates/zerver/help/move-content-to-another-topic.md
@@ -29,7 +29,9 @@ for the details on when topic editing is allowed.
 
 1. From the dropdown menu, select which messages to move.
 
-1. Click **Save**.
+1. Toggle whether automated notices should be sent.
+
+1. Click **Confirm** to move the selected content to another topic.
 
 {end_tabs}
 

--- a/templates/zerver/help/quote-and-reply.md
+++ b/templates/zerver/help/quote-and-reply.md
@@ -19,7 +19,7 @@ to avoid unnecessarily mentioning someone twice.
 
 {!message-actions-menu.md!}
 
-1. Click **Quote and reply**.
+1. Click **Quote and reply or forward**.
 
 1. *(optional)* Delete any parts of the quoted message that are not
    relevant to your reply.
@@ -30,7 +30,7 @@ to avoid unnecessarily mentioning someone twice.
 
 !!! keyboard_tip ""
 
-    You can also use <kbd>></kbd> to **quote and reply** to the
+    You can also use <kbd>></kbd> to **quote and reply or forward** the
     selected message.
 
 ## Related articles

--- a/templates/zerver/help/rename-a-topic.md
+++ b/templates/zerver/help/rename-a-topic.md
@@ -21,29 +21,30 @@ for the details on when topic editing is allowed.
 
 {start_tabs}
 
-1. Click on the <i class="fa fa-pencil"></i> icon in the message recipient bar.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon in the message recipient bar.
 
 1. Edit the topic name.
 
-1. Click the **✔** to save your changes.
+1. Click the **checkmark** (<i class="fa fa-check"></i>) icon to save your changes.
 
 {end_tabs}
 
 
-### Via a message (alternate method)
+### Via the left sidebar (alternate method)
 
 {start_tabs}
 
-{!message-actions-menu.md!}
+{!topic-actions.md!}
 
-1. Select **Move message**. If you do not see this option, you do not have permission
-   to edit the topic of this message.
+1. Select **Move topic**.
 
-1. Edit the topic.
+1. Edit the topic name.
 
-1. From the dropdown menu, select **Change previous and following messages to this topic**.
+1. _(optional)_  Select the destination stream for the topic from the streams dropdown list.
 
-1. Click **Save**.
+1. Toggle whether automated notices should be sent.
+
+1. Click **Confirm** to rename the topic.
 
 {end_tabs}
 

--- a/templates/zerver/help/star-a-message.md
+++ b/templates/zerver/help/star-a-message.md
@@ -10,7 +10,7 @@ tasks you need to go back to or documents you reference often.
 {tab|desktop}
 {!message-actions.md!}
 
-1. Click the star (<i class="fa fa-star-o"></i>) icon.
+1. Click the **star** (<i class="fa fa-star-o"></i>) icon.
 
 {tab|mobile}
 

--- a/templates/zerver/help/view-the-markdown-source-of-a-message.md
+++ b/templates/zerver/help/view-the-markdown-source-of-a-message.md
@@ -9,10 +9,11 @@ formatted, or to copy the Markdown source for a reply.
 
 {!message-actions-menu.md!}
 
-3. Click **View source**.
+3. Click **View message source**.
 
 {end_tabs}
 
 ## Related articles
 
 * [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Edit or delete a message](/help/edit-or-delete-a-message)


### PR DESCRIPTION
Updates all help center documentation according to the latest changes to the three-dot message menu and the UI for moving and editing messages.

Fixes #23217.

**Screenshots and screen captures:**

- https://zulip.com/help/edit-or-delete-a-message
<img width="780" alt="image" src="https://user-images.githubusercontent.com/2343554/195741721-698888f2-125d-4dd6-9579-a9d6a0c810dc.png">

- https://zulip.com/help/move-content-to-another-topic
<img width="549" alt="image" src="https://user-images.githubusercontent.com/2343554/195741589-4be63da5-d89d-4e2b-854a-abf3cd4cbb9b.png">

- https://zulip.com/help/move-content-to-another-stream
<img width="566" alt="image" src="https://user-images.githubusercontent.com/2343554/195741560-3a624ade-8c55-4b54-ae54-75b6f71d8d26.png">

- https://zulip.com/help/quote-and-reply
<img width="692" alt="image" src="https://user-images.githubusercontent.com/2343554/195741167-631df812-ee9e-48f2-981e-9d961d10f74f.png">

- https://zulip.com/help/rename-a-topic
<img width="552" alt="image" src="https://user-images.githubusercontent.com/2343554/195741093-069ccd0c-0894-4525-9e41-4b4d7defec77.png">

- https://zulip.com/help/view-the-markdown-source-of-a-message
<img width="543" alt="image" src="https://user-images.githubusercontent.com/2343554/195740974-e57dc8f1-7a61-43fb-bc80-4e5f3561ff8a.png">


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>
