### PR TITLE
popovers: Fix show three dots when menu is selected

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -49,6 +49,16 @@ let drafts_sidebar_elem;
 let stream_widget;
 let $stream_header_colorblock;
 
+// Keep the menu icon over which the popover is based off visible.
+function show_left_sidebar_menu_icon(element) {
+    $(element).closest("[class*='-sidebar-menu-icon']").addClass("left_sidebar_menu_icon_visible");
+}
+
+// Remove the class from element when popover is closed
+function hide_left_sidebar_menu_icon() {
+    $(".left_sidebar_menu_icon_visible").removeClass("left_sidebar_menu_icon_visible");
+}
+
 function get_popover_menu_items(sidebar_elem) {
     if (!sidebar_elem) {
         blueslip.error("Trying to get menu items when action popover is closed.");
@@ -120,6 +130,7 @@ export function drafts_popped() {
 export function hide_stream_popover() {
     if (stream_popped()) {
         $(current_stream_sidebar_elem).popover("destroy");
+        hide_left_sidebar_menu_icon();
         current_stream_sidebar_elem = undefined;
     }
 }
@@ -127,6 +138,7 @@ export function hide_stream_popover() {
 export function hide_topic_popover() {
     if (topic_popped()) {
         $(current_topic_sidebar_elem).popover("destroy");
+        hide_left_sidebar_menu_icon();
         current_topic_sidebar_elem = undefined;
     }
 }
@@ -134,6 +146,7 @@ export function hide_topic_popover() {
 export function hide_all_messages_popover() {
     if (all_messages_popped()) {
         $(all_messages_sidebar_elem).popover("destroy");
+        hide_left_sidebar_menu_icon();
         all_messages_sidebar_elem = undefined;
     }
 }
@@ -141,6 +154,7 @@ export function hide_all_messages_popover() {
 export function hide_starred_messages_popover() {
     if (starred_messages_popped()) {
         $(starred_messages_sidebar_elem).popover("destroy");
+        hide_left_sidebar_menu_icon();
         starred_messages_sidebar_elem = undefined;
     }
 }
@@ -148,6 +162,7 @@ export function hide_starred_messages_popover() {
 export function hide_drafts_popover() {
     if (drafts_popped()) {
         $(drafts_sidebar_elem).popover("destroy");
+        hide_left_sidebar_menu_icon();
         drafts_sidebar_elem = undefined;
     }
 }
@@ -257,6 +272,7 @@ function build_stream_popover(opts) {
     });
 
     current_stream_sidebar_elem = elt;
+    show_left_sidebar_menu_icon(elt);
 }
 
 function build_topic_popover(opts) {
@@ -307,6 +323,7 @@ function build_topic_popover(opts) {
     $(elt).popover("show");
 
     current_topic_sidebar_elem = elt;
+    show_left_sidebar_menu_icon(elt);
 }
 
 function build_all_messages_popover(e) {
@@ -332,6 +349,7 @@ function build_all_messages_popover(e) {
 
     $(elt).popover("show");
     all_messages_sidebar_elem = elt;
+    show_left_sidebar_menu_icon(elt);
     e.stopPropagation();
 }
 
@@ -362,6 +380,7 @@ function build_starred_messages_popover(e) {
 
     $(elt).popover("show");
     starred_messages_sidebar_elem = elt;
+    show_left_sidebar_menu_icon(elt);
     e.stopPropagation();
 }
 
@@ -386,6 +405,7 @@ function build_drafts_popover(e) {
 
     $(elt).popover("show");
     drafts_sidebar_elem = elt;
+    show_left_sidebar_menu_icon(elt);
     e.stopPropagation();
 }
 

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -387,6 +387,10 @@ li.top_left_recent_topics {
     line-height: 1.1;
 }
 
+.left_sidebar_menu_icon_visible {
+    display: block !important;
+}
+
 /*
     All of our left sidebar handlers use absolute
     positioning.  We should fix that.

--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -123,7 +123,6 @@
     visibility: visible !important;
     pointer-events: all !important;
     opacity: 1 !important;
-    color: hsl(0, 0%, 73%);
 }
 
 .emoji-info-popover {

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1498,6 +1498,14 @@ td.pointer {
     }
 }
 
+/* Make the action icon on the message row
+   always visible while the popover is open */
+.has_actions_popover .actions_hover {
+    visibility: visible !important;
+    pointer-events: all !important;
+    opacity: 1 !important;
+}
+
 .has_actions_popover .info {
     opacity: 1;
     visibility: visible;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1504,6 +1504,12 @@ td.pointer {
     visibility: visible !important;
     pointer-events: all !important;
     opacity: 1 !important;
+
+    i:focus {
+        /* Avoid displaying a focus outline outside the popover on the \vdots
+           icon when opened via the mouse. */
+        outline: 0 !important;
+    }
 }
 
 .has_actions_popover .info {


### PR DESCRIPTION
Fixes: #23157

After looking at the code for the in-message menus, the reaction button behaves precisely as required, but the three-dot menu is only visible if it has focus. Once you start going through the popover menu items using the keyboard, the 3-dots menu disappears. 

The emoji picker uses a class called `reaction_button_visible`  to achieve the desired behavior, so I used the same technique to fix the menu icons on the sidebar. 
https://github.com/zulip/zulip/blob/4df8c6610f19f08be1564d755aacb6c544eadbbc/static/js/emoji_picker.js#L687

Instead of creating a different function for all the different classes of menu icons (topic, stream, draft..), I used an 'attribute contains' selector to target all of them (they all end with '-sidebar-menu-icon')


For the in-message 3-dots menu, I found a less intrusive way of achieving the same thing. When the menu icon for that message row is triggered the class `has_actions_popover` is added to the element. So, I simply added a style that targets the 3-dots menu on that element.


**Screenshots and screen captures:**

![left-sidebar-preview](https://user-images.githubusercontent.com/30384633/195831123-2d0c8605-5d9c-4687-8e47-be8b01e9ed26.jpg)
![message-feed-preview](https://user-images.githubusercontent.com/30384633/195831129-12050c72-2c9a-4cc8-ac44-4f4e107e7520.jpg)

![sidebar-vid](https://user-images.githubusercontent.com/30384633/195878809-baee7e48-d87d-4538-bd95-8c91371df2c4.gif)

![message-feed-video](https://user-images.githubusercontent.com/30384633/195878040-0f5aa0b5-8614-494e-821b-665532780b9f.gif)




**Self-review checklist**


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
 
