### PR TITLE
settings: Fix height of left sidebar for short screens.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1797,6 +1797,12 @@ $option_title_width: 180px;
         }
 
         .sidebar {
+            position: absolute;
+            width: 100%;
+            border: none;
+            /* 48px is the height of settings header and 45px is the height of tab-container */
+            height: calc(100% - 93px);
+
             li.active {
                 /* Don't highlight the active section in the settings list. */
                 background: inherit;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -1079,7 +1079,6 @@ h4.user_group_setting_subsection_title {
     #groups_overlay .right,
     #subscription_overlay .left,
     #subscription_overlay .right,
-    #settings_page .left,
     #settings_page .content-wrapper.right {
         position: absolute;
         display: block;


### PR DESCRIPTION
It was not possible to scroll to the bottom of the list on narrow-width when only single column was displayed on the settings overlay. This PR fixes the height of the sidebar and set to "100% - height of header - height of tab-container" which fixes the scroll behavior.

This is not a issue for two-column overlay where height is set to "100% - height of header" (the tab-container is already inside the header).

This duplicates some CSS to avoid using "!important". While doing this duplication, we remove "margin: 0" and "display: block" since these are already set as default values.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->#22876

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![settings-sidebar](https://user-images.githubusercontent.com/35494118/195910249-4f0c84b5-5385-426c-bfe5-a6c047b13087.gif)



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
