### PR TITLE
restart-server: Default to running config and database checks.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -363,7 +363,8 @@ else:
 
 # Perform system checks -- including database checks, so we don't need
 # to do them when we do migrations, below.
-subprocess.check_call(["./manage.py", "check", "--database", "default"], preexec_fn=su_to_zulip)
+if not args.skip_checks:
+    subprocess.check_call(["./manage.py", "check", "--database", "default"], preexec_fn=su_to_zulip)
 
 # Our next optimization is to check whether any migrations are needed
 # before we start the critical section of the restart.  This saves
@@ -465,7 +466,7 @@ else:
         )
 
     logging.info("Restarting Zulip...")
-    start_args = []
+    start_args = ["--skip-checks"]
     if migrations_needed:
         start_args.append("--fill-cache")
     if IS_SERVER_UP:

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -645,6 +645,9 @@ def deport(netloc: str) -> str:
 def start_arg_parser(action: str, add_help: bool = False) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=add_help)
     parser.add_argument("--fill-cache", action="store_true", help="Fill the memcached caches")
+    parser.add_argument(
+        "--skip-checks", action="store_true", help="Skip syntax and database checks"
+    )
     if action == "restart":
         parser.add_argument(
             "--less-graceful",

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -41,6 +41,11 @@ if pwd.getpwuid(os.getuid()).pw_name != "zulip":
     logging.error("Must be run as user 'zulip'.")
     sys.exit(1)
 
+
+if not args.skip_checks:
+    logging.info("Running syntax and database checks")
+    subprocess.check_call(["./manage.py", "check", "--database", "default"])
+
 if args.fill_cache:
     logging.info("Filling memcached caches")
     subprocess.check_call(["./manage.py", "fill_memcached_caches", "--skip-checks"])


### PR DESCRIPTION
If there is a syntax error in `settings.py`, `restart-server` should provide a reasonable message about this.  It did so prior to af08bcdb3fb3, becausde any invocation `./manage.py` without `--skip-checks` will verify `settings.py`, among several other checks. After af08bcdb3fb3, there are no `./manage.py` calls in most restarts, which fa77be6e6c2b took further.

Add an explicit `./manage.py check` in the default case. upgrade-zulip-stage-2 overrides this by passing `--skip-checks`, for performance.  This also means that `upgrade-zulip-from-git` itself picks up the same `--skip-checks` flag, since it inherits the same flag parsing, though that is perhaps of dubious utility.


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
