### PR TITLE
help: Fix "Reply mentioning user" documentation.

### DIFF
--- a/templates/zerver/help/mention-a-user-or-group.md
+++ b/templates/zerver/help/mention-a-user-or-group.md
@@ -5,6 +5,8 @@ message. Mentions follow the same
 [notification settings](/help/pm-mention-alert-notifications) as private
 messages and alert words.
 
+## Mention a user or group
+
 ### From the compose box
 
 {start_tabs}
@@ -23,11 +25,22 @@ messages and alert words.
 
 {!right-sidebar-profile-menu.md!}
 
-1. Select **Reply mentioning user**.
+1. Select **Copy mention syntax** to add it to your clipboard.
+
+1. Paste the user's mention syntax in the compose box.
 
 {end_tabs}
 
-Alternatively, click on the profile picture of any user in the main message feed.
+### Via a message
+
+{start_tabs}
+
+1. Click on a user's profile picture or name on a message they sent.
+
+1. Select **Reply mentioning user** to start a reply to the conversation
+   with a mention inserted into the compose box.
+
+{end_tabs}
 
 ## Silently mention a user
 
@@ -58,3 +71,4 @@ streams](/help/stream-notifications).
 ## Related articles
 
 * [Restrict wildcard mentions](/help/restrict-wildcard-mentions)
+* [Quote and reply](/help/quote-and-reply)


### PR DESCRIPTION
- Corrects "Reply mentioning user" option which is available in the user menu if accessed from a message.
- Documents "Copy mention syntax" option which is available from the right sidebar.

Fixes: #23202.

*Note: Uses [Markdown macro](https://github.com/zulip/zulip/pull/23251/files#diff-ca6b188c6d015324299e737f1902702c193c265e895850be9216df8611d8eb2c) created in the previous PR #23251, and updates `/help/include/right-sidebar-view-full-profile.md` while we are here.

**Screenshots and screen captures:**
- https://zulip.com/help/mention-a-user-or-group
<img width="560" alt="image" src="https://user-images.githubusercontent.com/2343554/195965119-594dff5a-cccb-4355-9ac2-deb41055fb38.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>