### PR TITLE
Add assert_query_count helper.

### DIFF
--- a/analytics/tests/test_activity_views.py
+++ b/analytics/tests/test_activity_views.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.utils.timezone import now as timezone_now
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import queries_captured
 from zerver.models import Client, UserActivity, UserProfile, flush_per_request_caches
 
 
@@ -33,23 +32,17 @@ class ActivityTest(ZulipTestCase):
         user_profile.save(update_fields=["is_staff"])
 
         flush_per_request_caches()
-        with queries_captured() as queries:
+        with self.assert_database_query_count(19):
             result = self.client_get("/activity")
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 19)
-
         flush_per_request_caches()
-        with queries_captured() as queries:
+        with self.assert_database_query_count(8):
             result = self.client_get("/realm_activity/zulip/")
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 8)
-
         iago = self.example_user("iago")
         flush_per_request_caches()
-        with queries_captured() as queries:
+        with self.assert_database_query_count(5):
             result = self.client_get(f"/user_activity/{iago.id}/")
             self.assertEqual(result.status_code, 200)
-
-        self.assert_length(queries, 5)

--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -435,8 +435,8 @@ requires a more subtle restructuring of the code.)
 We try to prevent these bugs in our tests by using a context manager
 called `queries_captured()` that captures the SQL queries used by
 the backend during a particular operation. We make assertions about
-those queries, often simply asserting that the number of queries is
-below some threshold.
+those queries, often simply by using the `assert_database_query_count`
+that checks the number of queries.
 
 ### Event-based tests
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -10,13 +10,13 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generator,
     Iterable,
     Iterator,
     List,
     Mapping,
     Optional,
     Tuple,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -131,16 +131,21 @@ def simulated_empty_cache() -> Iterator[List[Tuple[str, Union[str, List[str]], O
         yield cache_queries
 
 
+class CapturedQueryDict(TypedDict):
+    sql: bytes
+    time: str
+
+
 @contextmanager
 def queries_captured(
     include_savepoints: bool = False, keep_cache_warm: bool = False
-) -> Generator[List[Dict[str, Union[str, bytes]]], None, None]:
+) -> Iterator[List[CapturedQueryDict]]:
     """
     Allow a user to capture just the queries executed during
     the with statement.
     """
 
-    queries: List[Dict[str, Union[str, bytes]]] = []
+    queries: List[CapturedQueryDict] = []
 
     def wrapper_execute(
         self: TimeTrackingCursor,

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -16,7 +16,7 @@ from zerver.lib.bot_config import ConfigError, get_bot_config
 from zerver.lib.bot_lib import get_bot_handler
 from zerver.lib.integrations import EMBEDDED_BOTS, WebhookIntegration
 from zerver.lib.test_classes import UploadSerializeMixin, ZulipTestCase
-from zerver.lib.test_helpers import avatar_disk_path, get_test_image_file, queries_captured
+from zerver.lib.test_helpers import avatar_disk_path, get_test_image_file
 from zerver.models import (
     Realm,
     Service,
@@ -153,12 +153,10 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.assert_num_bots_equal(num_bots)
 
-        with queries_captured() as queries:
+        with self.assert_database_query_count(3):
             users_result = self.client_get("/json/users")
 
         self.assert_json_success(users_result)
-
-        self.assert_length(queries, 3)
 
     def test_add_bot(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -12,7 +12,6 @@ from zerver.actions.custom_profile_fields import (
 from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
 from zerver.lib.markdown import markdown_convert
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import queries_captured
 from zerver.lib.types import ProfileDataElementUpdateDict, ProfileDataElementValue
 from zerver.models import (
     CustomProfileField,
@@ -908,12 +907,10 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
         test_bot = self.create_test_bot("foo-bot", iago)
         self.login_user(iago)
 
-        with queries_captured() as queries:
+        with self.assert_database_query_count(4):
             response = self.client_get(
                 "/json/users", {"client_gravatar": "false", "include_custom_profile_fields": "true"}
             )
-
-        self.assert_length(queries, 4)
 
         raw_users_data = self.assert_json_success(response)["members"]
 

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -18,12 +18,7 @@ from zerver.lib.events import fetch_initial_state_data
 from zerver.lib.exceptions import AccessDeniedError
 from zerver.lib.request import RequestVariableMissingError
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import (
-    HostRequestMock,
-    dummy_handler,
-    queries_captured,
-    stub_event_queue_user_events,
-)
+from zerver.lib.test_helpers import HostRequestMock, dummy_handler, stub_event_queue_user_events
 from zerver.lib.users import get_api_key, get_raw_user_data
 from zerver.models import (
     Realm,
@@ -1114,11 +1109,9 @@ class FetchQueriesTest(ZulipTestCase):
         self.login_user(user)
 
         flush_per_request_caches()
-        with queries_captured() as queries:
+        with self.assert_database_query_count(37):
             with mock.patch("zerver.lib.events.always_want") as want_mock:
                 fetch_initial_state_data(user)
-
-        self.assert_length(queries, 37)
 
         expected_counts = dict(
             alert_words=1,
@@ -1165,14 +1158,13 @@ class FetchQueriesTest(ZulipTestCase):
         for event_type in sorted(wanted_event_types):
             count = expected_counts[event_type]
             flush_per_request_caches()
-            with queries_captured() as queries:
+            with self.assert_database_query_count(count):
                 if event_type == "update_message_flags":
                     event_types = ["update_message_flags", "message"]
                 else:
                     event_types = [event_type]
 
                 fetch_initial_state_data(user, event_types=event_types)
-            self.assert_length(queries, count)
 
 
 class TestEventsRegisterAllPublicStreamsDefaults(ZulipTestCase):

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -9,7 +9,7 @@ from zerver.actions.users import do_change_can_create_users, do_change_user_role
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.streams import access_stream_for_send_message
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import most_recent_message, queries_captured
+from zerver.lib.test_helpers import most_recent_message
 from zerver.lib.users import is_administrator_role
 from zerver.models import (
     UserProfile,
@@ -357,8 +357,8 @@ class TestQueryCounts(ZulipTestCase):
     def test_capturing_queries(self) -> None:
         # It's a common pitfall in Django to accidentally perform
         # database queries in a loop, due to lazy evaluation of
-        # foreign keys. We use the queries_captured context manager to
-        # ensure our query count is predictable.
+        # foreign keys. We use the assert_database_query_count
+        # context manager to ensure our query count is predictable.
         #
         # When a test containing one of these query count assertions
         # fails, we'll want to understand the new queries and whether
@@ -368,15 +368,12 @@ class TestQueryCounts(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         cordelia = self.example_user("cordelia")
 
-        with queries_captured() as queries:
+        with self.assert_database_query_count(15):
             self.send_personal_message(
                 from_user=hamlet,
                 to_user=cordelia,
                 content="hello there!",
             )
-
-        # The assert_length helper is another useful extra from ZulipTestCase.
-        self.assert_length(queries, 15)
 
 
 class TestDevelopmentEmailsLog(ZulipTestCase):

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -245,7 +245,7 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         flush_per_request_caches()
-        with queries_captured() as queries:
+        with self.assert_database_query_count(47):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page(stream="Denmark")
                 self.check_rendered_logged_in_app(result)
@@ -253,7 +253,6 @@ class HomeTest(ZulipTestCase):
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
 
-        self.assert_length(queries, 47)
         self.assert_length(cache_mock.call_args_list, 5)
 
         html = result.content.decode()
@@ -392,12 +391,11 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         flush_per_request_caches()
-        with queries_captured() as queries:
+        with self.assert_database_query_count(44):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page()
                 self.check_rendered_logged_in_app(result)
                 self.assert_length(cache_mock.call_args_list, 6)
-            self.assert_length(queries, 44)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")
@@ -425,10 +423,8 @@ class HomeTest(ZulipTestCase):
 
         # Then for the second page load, measure the number of queries.
         flush_per_request_caches()
-        with queries_captured() as queries2:
+        with self.assert_database_query_count(42):
             result = self._get_home_page()
-
-        self.assert_length(queries2, 42)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode()

--- a/zerver/tests/test_message_dict.py
+++ b/zerver/tests/test_message_dict.py
@@ -7,7 +7,7 @@ from zerver.lib.cache import cache_delete, to_dict_cache_key_id
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.message import MessageDict, messages_for_ids, sew_messages_and_reactions
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import make_client, queries_captured
+from zerver.lib.test_helpers import make_client
 from zerver.lib.topic import TOPIC_LINKS
 from zerver.lib.types import DisplayRecipientT, UserDisplayRecipient
 from zerver.models import (
@@ -177,13 +177,12 @@ class MessageDictTest(ZulipTestCase):
         self.assertTrue(num_ids >= 600)
 
         flush_per_request_caches()
-        with queries_captured() as queries:
+        with self.assert_database_query_count(7):
             rows = list(MessageDict.get_raw_db_rows(ids))
 
             objs = [MessageDict.build_dict_from_raw_db_row(row) for row in rows]
             MessageDict.post_process_dicts(objs, apply_markdown=False, client_gravatar=False)
 
-        self.assert_length(queries, 7)
         self.assert_length(rows, num_ids)
 
     def test_applying_markdown(self) -> None:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -3061,8 +3061,9 @@ class GetOldMessagesTest(ZulipTestCase):
             get_messages_backend(request, user_profile)
 
         for query in queries:
-            if "/* get_messages */" in query["sql"]:
-                sql = str(query["sql"]).replace(" /* get_messages */", "")
+            sql = str(query["sql"])
+            if "/* get_messages */" in sql:
+                sql = sql.replace(" /* get_messages */", "")
                 self.assertEqual(sql, expected)
                 return
         raise AssertionError("get_messages query not found")
@@ -3241,7 +3242,7 @@ class GetOldMessagesTest(ZulipTestCase):
             get_messages_backend(request, user_profile)
 
         # Verify the query for old messages looks correct.
-        queries = [q for q in all_queries if "/* get_messages */" in q["sql"]]
+        queries = [q for q in all_queries if "/* get_messages */" in str(q["sql"])]
         self.assert_length(queries, 1)
         sql = queries[0]["sql"]
         self.assertNotIn(f"AND message_id = {LARGER_THAN_MAX_MESSAGE_ID}", sql)
@@ -3287,7 +3288,7 @@ class GetOldMessagesTest(ZulipTestCase):
             with queries_captured() as all_queries:
                 get_messages_backend(request, user_profile)
 
-        queries = [q for q in all_queries if "/* get_messages */" in q["sql"]]
+        queries = [q for q in all_queries if "/* get_messages */" in str(q["sql"])]
         self.assert_length(queries, 1)
         sql = queries[0]["sql"]
         self.assertNotIn(f"AND message_id = {LARGER_THAN_MAX_MESSAGE_ID}", sql)
@@ -3311,7 +3312,7 @@ class GetOldMessagesTest(ZulipTestCase):
         with queries_captured() as all_queries:
             get_messages_backend(request, user_profile)
 
-        queries = [q for q in all_queries if "/* get_messages */" in q["sql"]]
+        queries = [q for q in all_queries if "/* get_messages */" in str(q["sql"])]
         self.assert_length(queries, 1)
 
         sql = queries[0]["sql"]
@@ -3324,7 +3325,7 @@ class GetOldMessagesTest(ZulipTestCase):
         with first_visible_id_as(first_visible_message_id):
             with queries_captured() as all_queries:
                 get_messages_backend(request, user_profile)
-            queries = [q for q in all_queries if "/* get_messages */" in q["sql"]]
+            queries = [q for q in all_queries if "/* get_messages */" in str(q["sql"])]
             sql = queries[0]["sql"]
             self.assertNotIn("AND message_id <=", sql)
             self.assertNotIn("AND message_id >=", sql)
@@ -3377,7 +3378,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
         # Next, verify the use_first_unread_anchor setting invokes
         # the `message_id = LARGER_THAN_MAX_MESSAGE_ID` hack.
-        queries = [q for q in all_queries if "/* get_messages */" in q["sql"]]
+        queries = [q for q in all_queries if "/* get_messages */" in str(q["sql"])]
         self.assert_length(queries, 1)
         self.assertIn(f"AND zerver_message.id = {LARGER_THAN_MAX_MESSAGE_ID}", queries[0]["sql"])
 

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -42,7 +42,6 @@ from zerver.lib.test_helpers import (
     message_stream_count,
     most_recent_message,
     most_recent_usermessage,
-    queries_captured,
     reset_emails_in_zulip_realm,
 )
 from zerver.lib.timestamp import convert_to_UTC, datetime_to_timestamp
@@ -1622,7 +1621,7 @@ class StreamMessagesTest(ZulipTestCase):
         # during the course of the unit test.
         flush_per_request_caches()
         cache_delete(get_stream_cache_key(stream_name, realm.id))
-        with queries_captured() as queries:
+        with self.assert_database_query_count(13):
             check_send_stream_message(
                 sender=sender,
                 client=sending_client,
@@ -1630,8 +1629,6 @@ class StreamMessagesTest(ZulipTestCase):
                 topic=topic_name,
                 body=content,
             )
-
-        self.assert_length(queries, 13)
 
     def test_stream_message_dict(self) -> None:
         user_profile = self.example_user("iago")

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -19,7 +19,7 @@ from zerver.lib.retention import (
     restore_retention_policy_deletions_for_stream,
 )
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import queries_captured, zulip_reaction_info
+from zerver.lib.test_helpers import zulip_reaction_info
 from zerver.lib.upload import create_attachment
 from zerver.models import (
     ArchivedAttachment,
@@ -1053,10 +1053,9 @@ class TestDoDeleteMessages(ZulipTestCase):
         message_ids = [self.send_stream_message(cordelia, "Verona", str(i)) for i in range(0, 10)]
         messages = Message.objects.filter(id__in=message_ids)
 
-        with queries_captured() as queries:
+        with self.assert_database_query_count(19):
             do_delete_messages(realm, messages)
         self.assertFalse(Message.objects.filter(id__in=message_ids).exists())
-        self.assert_length(queries, 19)
 
         archived_messages = ArchivedMessage.objects.filter(id__in=message_ids)
         self.assertEqual(archived_messages.count(), len(message_ids))

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -956,11 +956,10 @@ class LoginTest(ZulipTestCase):
         flush_per_request_caches()
         ContentType.objects.clear_cache()
 
-        with queries_captured() as queries, cache_tries_captured() as cache_tries:
+        # Ensure the number of queries we make is not O(streams)
+        with self.assert_database_query_count(96), cache_tries_captured() as cache_tries:
             with self.captureOnCommitCallbacks(execute=True):
                 self.register(self.nonreg_email("test"), "test")
-        # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 96)
 
         # We can probably avoid a couple cache hits here, but there doesn't
         # seem to be any O(N) behavior.  Some of the cache hits are related

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -17,12 +17,7 @@ from zerver.lib.soft_deactivation import (
 )
 from zerver.lib.stream_subscription import get_subscriptions_for_send_message
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import (
-    get_subscription,
-    get_user_messages,
-    make_client,
-    queries_captured,
-)
+from zerver.lib.test_helpers import get_subscription, get_user_messages, make_client
 from zerver.models import (
     AlertWord,
     Client,
@@ -340,9 +335,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)
         self.assertNotEqual(idle_user_msg_list[-1].content, message)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(8):
             reactivate_user_if_soft_deactivated(long_term_idle_user)
-        self.assert_length(queries, 8)
         self.assertFalse(long_term_idle_user.long_term_idle)
         self.assertEqual(
             last_realm_audit_log_entry(RealmAuditLog.USER_SOFT_ACTIVATED).modified_user,
@@ -402,9 +396,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)
         self.assertNotEqual(idle_user_msg_list[-1], sent_message)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(6):
             add_missing_messages(long_term_idle_user)
-        self.assert_length(queries, 6)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assert_length(idle_user_msg_list, idle_user_msg_count + 1)
         self.assertEqual(idle_user_msg_list[-1], sent_message)
@@ -419,9 +412,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)
         self.assertNotEqual(idle_user_msg_list[-1], sent_message)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(7):
             add_missing_messages(long_term_idle_user)
-        self.assert_length(queries, 7)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assert_length(idle_user_msg_list, idle_user_msg_count + 1)
         self.assertEqual(idle_user_msg_list[-1], sent_message)
@@ -444,9 +436,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_count = len(idle_user_msg_list)
         for sent_message in sent_message_list:
             self.assertNotEqual(idle_user_msg_list.pop(), sent_message)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(6):
             add_missing_messages(long_term_idle_user)
-        self.assert_length(queries, 6)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assert_length(idle_user_msg_list, idle_user_msg_count + 2)
         for sent_message in sent_message_list:
@@ -476,9 +467,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_count = len(idle_user_msg_list)
         for sent_message in sent_message_list:
             self.assertNotEqual(idle_user_msg_list.pop(), sent_message)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(6):
             add_missing_messages(long_term_idle_user)
-        self.assert_length(queries, 6)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assert_length(idle_user_msg_list, idle_user_msg_count + 2)
         for sent_message in sent_message_list:
@@ -509,11 +499,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)
         self.assertEqual(idle_user_msg_list[-1].id, sent_message_id)
-        with queries_captured() as queries:
-            add_missing_messages(long_term_idle_user)
         # There are no streams to fetch missing messages from, so
         # the Message.objects query will be avoided.
-        self.assert_length(queries, 4)
+        with self.assert_database_query_count(4):
+            add_missing_messages(long_term_idle_user)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         # No new UserMessage rows should have been created.
         self.assert_length(idle_user_msg_list, idle_user_msg_count)
@@ -538,9 +527,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         idle_user_msg_count = len(idle_user_msg_list)
         for sent_message in sent_message_list:
             self.assertNotEqual(idle_user_msg_list.pop(), sent_message)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(6):
             add_missing_messages(long_term_idle_user)
-        self.assert_length(queries, 6)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assert_length(idle_user_msg_list, idle_user_msg_count + 2)
         for sent_message in sent_message_list:
@@ -576,9 +564,8 @@ class SoftDeactivationMessageTest(ZulipTestCase):
 
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         idle_user_msg_count = len(idle_user_msg_list)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(10):
             add_missing_messages(long_term_idle_user)
-        self.assert_length(queries, 10)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assert_length(idle_user_msg_list, idle_user_msg_count + num_new_messages)
         long_term_idle_user.refresh_from_db()

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -3,7 +3,6 @@ from typing import Any, List, Mapping
 import orjson
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.test_helpers import queries_captured
 from zerver.models import Huddle, get_huddle_hash
 
 
@@ -148,13 +147,12 @@ class TypingHappyPathTestPMs(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with queries_captured() as queries:
+        with self.assert_database_query_count(4):
             with self.tornado_redirected_to_list(events, expected_num_events=1):
                 result = self.api_post(sender, "/api/v1/typing", params)
 
         self.assert_json_success(result)
         self.assert_length(events, 1)
-        self.assert_length(queries, 4)
 
         event = events[0]["event"]
         event_recipient_emails = {user["email"] for user in event["recipients"]}
@@ -185,12 +183,11 @@ class TypingHappyPathTestPMs(ZulipTestCase):
             op="start",
         )
 
-        with queries_captured() as queries:
+        with self.assert_database_query_count(5):
             with self.tornado_redirected_to_list(events, expected_num_events=1):
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
-        self.assert_length(queries, 5)
 
         # We should not be adding new Huddles just because
         # a user started typing in the compose box.  Let's
@@ -366,12 +363,11 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with queries_captured() as queries:
+        with self.assert_database_query_count(5):
             with self.tornado_redirected_to_list(events, expected_num_events=1):
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
-        self.assert_length(queries, 5)
 
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])
@@ -402,12 +398,11 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with queries_captured() as queries:
+        with self.assert_database_query_count(5):
             with self.tornado_redirected_to_list(events, expected_num_events=1):
                 result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
-        self.assert_length(queries, 5)
 
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -41,7 +41,6 @@ from zerver.lib.test_helpers import (
     cache_tries_captured,
     get_subscription,
     get_test_image_file,
-    queries_captured,
     reset_emails_in_zulip_realm,
     simulated_empty_cache,
 )
@@ -805,7 +804,7 @@ class QueryCountTest(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
 
-        with queries_captured() as queries:
+        with self.assert_database_query_count(91):
             with cache_tries_captured() as cache_tries:
                 with self.tornado_redirected_to_list(events, expected_num_events=11):
                     fred = do_create_user(
@@ -816,8 +815,6 @@ class QueryCountTest(ZulipTestCase):
                         prereg_user=prereg_user,
                         acting_user=None,
                     )
-
-        self.assert_length(queries, 91)
 
         self.assert_length(cache_tries, 28)
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]
@@ -1320,12 +1317,11 @@ class UserProfileTest(ZulipTestCase):
 
         # Subscribe to the stream.
         self.subscribe(iago, stream.name)
-        with queries_captured() as queries:
+        with self.assert_database_query_count(6):
             result = orjson.loads(
                 self.client_get(f"/json/users/{iago.id}/subscriptions/{stream.id}").content
             )
 
-        self.assert_length(queries, 6)
         self.assertTrue(result["is_subscribed"])
 
         # Logging in with a Guest user.
@@ -2031,11 +2027,10 @@ class GetProfileTest(ZulipTestCase):
         """
         realm = get_realm("zulip")
         email = self.example_user("hamlet").email
-        with queries_captured() as queries:
+        with self.assert_database_query_count(1):
             with simulated_empty_cache() as cache_queries:
                 user_profile = get_user(email, realm)
 
-        self.assert_length(queries, 1)
         self.assert_length(cache_queries, 1)
         self.assertEqual(user_profile.email, email)
 


### PR DESCRIPTION
This adds a helper based on testing patterns of using the `queries_captured`
context manager with `assert_length` to check the number of queries
executed for preventing performance regression.

It explains the rationale of checking the query count through an
`AssertionError` and prints the queries captured as `assert_length` does,
but with a format optimized for displaying the queries in a more
readable manner.

There are some instances where we left out switching from `queries_captured`+`assert_length`
to `assert_query_count`, in which we actually do more checks with the queries captured.
Note that this also includes checks that look for queries to fall within a certain range,
For example:
https://github.com/zulip/zulip/blob/7db221c8dccbce9d8340e5dca0e25ecf8f4cc963/zerver/tests/test_message_fetch.py#L3055-L3068
In this case, the original way of checking queries is preferred.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
