### PR TITLE
help: Update documentation on bots.

### DIFF
--- a/templates/zerver/help/add-a-bot-or-integration.md
+++ b/templates/zerver/help/add-a-bot-or-integration.md
@@ -12,11 +12,23 @@ is visible and available for anyone to use.
 
 {start_tabs}
 
+{tab|via-personal-settings}
+
 {settings_tab|your-bots}
 
-2. Click **Add a new bot**.
+1. Click **Add a new bot**.
 
-3. Fill out the fields, and click **Create bot**.
+1. Fill out the fields, and click **Add**.
+
+{tab|via-organization-settings}
+
+{settings_tab|bot-list-admin}
+
+1. Click **Add a new bot**.
+
+1. Fill out the fields, and click **Add**.
+
+{end_tabs}
 
 !!! warn ""
 
@@ -24,8 +36,6 @@ is visible and available for anyone to use.
     the various fields.
     Nearly all third-party integrations should use **Incoming webhook**
     as the **bot type**.
-
-{end_tabs}
 
 Depending on the type of bot you're creating, you may need to download its
 `.zuliprc` configuration file. For that, click the **download**

--- a/templates/zerver/help/bots-and-integrations.md
+++ b/templates/zerver/help/bots-and-integrations.md
@@ -9,7 +9,7 @@ Bots allow you to
 A bot that sends content to or from another product is often called an
 **integration**.
 
-### Pre-made bots
+## Pre-made bots
 
 Zulip natively supports integrations with over one hundred products, and with
 almost a thousand more through Zapier and IFTTT. If you're looking to add an

--- a/templates/zerver/help/deactivate-or-reactivate-a-bot.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-bot.md
@@ -9,16 +9,63 @@ add. Organization admins can prevent users from reactivating bots by
 Organization administrators can also deactivate or reactivate any existing
 bot, regardless of who owns them.
 
-### Deactivate or reactivate a bot
+## Deactivate a bot
 
 {start_tabs}
 
+{tab|via-personal-settings}
+
+{settings_tab|your-bots}
+
+1. Click the **deactivate bot** (<i class="fa fa-user-times"></i>) icon on the profile
+   card for the bot you want to deactivate.
+
+1. Approve by clicking **Deactivate**.
+
+!!! tip ""
+
+    You can also click the **pencil** (<i class="fa fa-pencil"></i>) icon,
+    scroll down to the bottom, and click **Deactivate bot**.
+
+{tab|via-organization-settings}
+
 {settings_tab|bot-list-admin}
 
-4. Find the bot that you would like to manage and click
-**Deactivate** or **Reactivate** to its right.
+1. In the **Actions** column, click the **deactivate bot** (<i class="fa fa-user-times"></i>)
+   icon for the bot you want to deactivate.
+
+1. Approve by clicking **Deactivate**.
+
+!!! tip ""
+
+    You can also click the **pencil** (<i class="fa fa-pencil"></i>) icon,
+    scroll down to the bottom, and click **Deactivate bot**.
 
 {end_tabs}
+
+## Reactivate a bot
+
+{start_tabs}
+
+{tab|via-personal-settings}
+
+{settings_tab|your-bots}
+
+1. Click the **Inactive bots** tab.
+
+1. Click **Reactivate bot** on the profile card for the bot you want to reactivate.
+
+{tab|via-organization-settings}
+
+{settings_tab|bot-list-admin}
+
+1. In the **Actions** column, click the **reactivate bot** (<i class="fa fa-user-plus"></i>)
+   icon for the bot you want to reactivate.
+
+1. Approve by clicking **Confirm**.
+
+{end_tabs}
+
 
 ## Related articles
 

--- a/templates/zerver/help/edit-a-bot.md
+++ b/templates/zerver/help/edit-a-bot.md
@@ -10,7 +10,7 @@ active bot in the organization.
 
 {settings_tab|your-bots}
 
-1. Click the pencil (<i class="fa fa-pencil"></i>) icon on the profile
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the profile
    card for the bot you want to edit.
 
 1. Edit bot information as desired, and click **Save changes**.
@@ -25,8 +25,8 @@ active bot in the organization.
 
 {settings_tab|bot-list-admin}
 
-1. In the **Actions** column, click the pencil (<i class="fa fa-pencil"></i>) icon for the
-   bot you want to edit.
+1. In the **Actions** column, click the **pencil** (<i class="fa fa-pencil"></i>)
+   icon for the bot you want to edit.
 
 1. Edit bot information as desired, and click **Save changes**.
 

--- a/templates/zerver/help/restrict-bot-creation.md
+++ b/templates/zerver/help/restrict-bot-creation.md
@@ -6,7 +6,7 @@ By default, anyone other than guests can [add a bot](/help/add-a-bot-or-integrat
 integration to the Zulip organization. Organization administrators can
 change who is allowed to add bots.
 
-### Configure who can add bots
+## Configure who can add bots
 
 {start_tabs}
 

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -26,7 +26,7 @@ link_mapping = {
     ],
     "display-settings": ["Personal settings", "Display settings", "/#settings/display-settings"],
     "notifications": ["Personal settings", "Notifications", "/#settings/notifications"],
-    "your-bots": ["Personal settings", "Bots", "/#settings/your-bots"],
+    "your-bots": ["Personal settings", "your Bots", "/#settings/your-bots"],
     "alert-words": ["Personal settings", "Alert words", "/#settings/alert-words"],
     "uploaded-files": ["Personal settings", "Uploaded files", "/#settings/uploaded-files"],
     "muted-topics": ["Personal settings", "Muted topics", "/#settings/muted-topics"],
@@ -64,7 +64,11 @@ link_mapping = {
         "Deactivated users",
         "/#organization/deactivated-users-admin",
     ],
-    "bot-list-admin": ["Manage organization", "Bots", "/#organization/bot-list-admin"],
+    "bot-list-admin": [
+        "Manage organization",
+        "your organization's Bots",
+        "/#organization/bot-list-admin",
+    ],
     "default-streams-list": [
         "Manage organization",
         "Default streams",

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -77,6 +77,7 @@ TAB_SECTION_LABELS = {
     "web-public-streams": "Web-public streams",
     "via-user-profile": "Via the user's profile",
     "via-organization-settings": "Via organization settings",
+    "via-personal-settings": "Via personal settings",
     "default-subdomain": "Default subdomain",
     "custom-subdomain": "Custom subdomain",
     "zulip-cloud": "Zulip Cloud",


### PR DESCRIPTION
- Adds new tab to `zerver/lib/markdown/tabbed_sections.py` to document managing bots from both personal settings and organization settings.
- Documents adding bots from the organization settings Bots panel.
- Separates instructions for deactivating and reactivating a bot from both personal settings and organization settings.
- Fixes a few formatting issues such as missing bold formatting and heading level.

Fixes: #23066.

**Screenshots and screen captures:**

- https://zulip.com/help/add-a-bot-or-integration
<img width="781" alt="image" src="https://user-images.githubusercontent.com/2343554/196055789-b7c50ed4-ca50-4c54-8bed-ac69da729ce3.png">

<img width="545" alt="image" src="https://user-images.githubusercontent.com/2343554/196055795-8bd106d5-f5f0-4dee-adcf-ccff0a219a47.png">

- https://zulip.com/help/deactivate-or-reactivate-a-bot
<img width="541" alt="image" src="https://user-images.githubusercontent.com/2343554/196055902-7b69e65b-a200-4691-b96e-0b3e4e0279ba.png">

<img width="531" alt="image" src="https://user-images.githubusercontent.com/2343554/196055939-1e047b12-d15e-42a2-87f8-261fbc96db45.png">


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>