### PR TITLE
help center: Clean up documentation on sending messages.

### DIFF
--- a/templates/zerver/help/include/compose-and-send-message.md
+++ b/templates/zerver/help/include/compose-and-send-message.md
@@ -1,6 +1,7 @@
-1. Press <kbd>Tab</kbd> or click on the compose box to compose your
-   message.
+1. Click on the compose box, or press <kbd>Tab</kbd> to compose your message. You
+   can [preview your message](/help/preview-your-message-before-sending) before
+   sending.
 
-1. Click **Send**, or use <kbd>Enter</kbd> or <kbd>Ctrl</kbd> +
-   <kbd>Enter</kbd> (depending on your settings. See
-  [enable enter to send](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)).
+1. Click **Send**, or use a [keyboard
+   shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
+   to send your message.

--- a/templates/zerver/help/include/how-to-start-a-new-topic.md
+++ b/templates/zerver/help/include/how-to-start-a-new-topic.md
@@ -2,8 +2,8 @@
 
 {tab|stream}
 
-1. Click the **New topic** button at the bottom of the Zulip window,
-   or type <kbd>C</kbd>.
+1. Click the **New topic** button at the bottom of the app, or
+   use the <kbd>C</kbd> keyboard shortcut.
 
 1. Enter a topic name. Auto-complete will provide suggestions for previously
    used topics.
@@ -12,8 +12,8 @@
 
 {tab|not-stream}
 
-1. Click the **New topic** button at the bottom of the Zulip window, or
-   type <kbd>C</kbd>.
+1. Click the **New topic** button at the bottom of the app, or
+   use the <kbd>C</kbd> keyboard shortcut.
 
 1. Enter a stream name. Auto-complete will provide suggestions for streams you
    can send to.

--- a/templates/zerver/help/include/replying-to-messages.md
+++ b/templates/zerver/help/include/replying-to-messages.md
@@ -2,11 +2,19 @@ To reply to an existing thread:
 
 {start_tabs}
 
-1. Click the **Message...** button at the bottom of the Zulip window.
+1. Click the **Message...** button at the bottom of the app.
 
-{!compose-and-send-message.md!}
+1. Compose your message. You
+   can [preview your message](/help/preview-your-message-before-sending) before
+   sending.
+
+1. Click **Send**, or use a [keyboard
+   shortcut](/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message)
+   to send your message.
+
+
+!!! tip ""
+    You can also reply by clicking on a message, or using the <kbd>R</kbd> or
+    <kbd>Enter</kbd> keyboard shortcuts to reply to the message in the blue box.
 
 {end_tabs}
-
-You can also reply by clicking on a message, or using <kbd>R</kbd> or
-<kbd>Enter</kbd> to reply to the message in the blue box.

--- a/templates/zerver/help/include/send-group-pm.md
+++ b/templates/zerver/help/include/send-group-pm.md
@@ -1,0 +1,34 @@
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click the **New private message** button at the bottom of the app, or
+   use the <kbd>X</kbd> keyboard shortcut.
+
+1. Start typing the name of the person you want to message, and
+   select their name from the list of suggestions. You can continue
+   adding as many message recipients as you like.
+
+{!compose-and-send-message.md!}
+
+{tab|mobile}
+
+1. Tap the private messages
+   ( <img src="/static/images/help/mobile-pm-tab-icon.svg" alt="private messages" class="mobile-icon"/> )
+   tab at the bottom of the app.
+
+2. Tap the **New group PM** button at the top of the app.
+
+3. Start typing the name of the person you want to message, and
+   select their name from the list of suggestions. You can continue
+   adding as many message recipients as you like.
+
+4. Approve by tapping the checkmark
+   (<img src="/static/images/help/mobile-check-circle-icon.svg" alt="checkmark" class="mobile-icon"/>)
+   button in the bottom right corner of the app.
+
+5. Compose your message, and tap the send
+   (<img src="/static/images/help/mobile-send-circle-icon.svg" alt="send" class="mobile-icon"/>)
+   button in the bottom right corner of the app.
+
+{end_tabs}

--- a/templates/zerver/help/include/starting-a-new-private-thread.md
+++ b/templates/zerver/help/include/starting-a-new-private-thread.md
@@ -1,14 +1,4 @@
-{start_tabs}
-
-1. Click the **New private message** button at the bottom of the Zulip
-   window, or type <kbd>X</kbd>.
-
-1. Type the names of one or more recipients. Auto-complete will provide
-   suggestions for users you can message.
-
-{!compose-and-send-message.md!}
-
-{end_tabs}
+{!send-group-pm.md!}
 
 !!! tip ""
 

--- a/templates/zerver/help/private-messages.md
+++ b/templates/zerver/help/private-messages.md
@@ -25,7 +25,7 @@ and do not appear in your list of streams.
 1. Start typing the name of the person you want to message, and
    select their name from the list of suggestions.
 
-1. Compose your message, and click **Send**.
+{!compose-and-send-message.md!}
 
 !!! tip ""
 
@@ -56,40 +56,7 @@ and do not appear in your list of streams.
 
 ## Send a group PM
 
-{start_tabs}
-
-{tab|desktop-web}
-
-1. Click the **New private message** button at the bottom of the app, or
-   use the <kbd>X</kbd> keyboard shortcut.
-
-1. Start typing the name of the person you want to message, and
-   select their name from the list of suggestions. You can continue
-   adding as many message recipients as you like.
-
-1. Compose your message, and click **Send**.
-
-{tab|mobile}
-
-1. Tap the private messages
-   ( <img src="/static/images/help/mobile-pm-tab-icon.svg" alt="private messages" class="mobile-icon"/> )
-   tab at the bottom of the app.
-
-1. Tap the **New group PM** button at the top of the app.
-
-1. Start typing the name of the person you want to message, and
-   select their name from the list of suggestions. You can continue
-   adding as many message recipients as you like.
-
-1. Approve by tapping the checkmark
-   (<img src="/static/images/help/mobile-check-circle-icon.svg" alt="checkmark" class="mobile-icon"/>)
-   button in the bottom right corner of the app.
-
-1. Compose your message, and tap the send
-   (<img src="/static/images/help/mobile-send-circle-icon.svg" alt="send" class="mobile-icon"/>)
-   button in the bottom right corner of the app.
-
-{end_tabs}
+{!send-group-pm.md!}
 
 ## Access a PM or group PM
 


### PR DESCRIPTION
- Consolidate /help/starting-a-new-private-thread and /help/private-messages.
- Tweak the wording on compose-and-send-message.md.
- Use compose-and-send-message.md where appropriate (and not otherwise).

Note: Mobile instructions are unchanged.

<details>
<summary>
Private messages
</summary>

Current: https://zulip.com/help/private-messages#send-a-group-pm
![Screen Shot 2022-10-17 at 12 05 54 PM](https://user-images.githubusercontent.com/2090066/196264177-4f0d2523-1f28-45f9-b1e5-955f34cf8bad.png)
</details>

<details>
<summary>
Starting a new private thread
</summary>
Current:

- https://zulip.com/help/starting-a-new-private-thread
- https://zulip.com/help/getting-started-with-zulip#starting-a-new-private-thread

![Screen Shot 2022-10-17 at 12 05 11 PM](https://user-images.githubusercontent.com/2090066/196264549-a1b86f6b-5eb0-49f4-bce0-7f2509a30c12.png)
</details>

<details>
<summary>
Starting a new topic
</summary>

Current:

- https://zulip.com/help/starting-a-new-topic
- https://zulip.com/help/getting-started-with-zulip#how-to-start-a-new-topic

![Screen Shot 2022-10-18 at 9 50 05 PM](https://user-images.githubusercontent.com/2090066/196600687-674b0a30-cc99-459b-8b00-c5e828ef562e.png)

![Screen Shot 2022-10-18 at 9 50 10 PM](https://user-images.githubusercontent.com/2090066/196600700-81711ada-46bc-42b2-bdc2-168c516531c9.png)

</details>
<details>
<summary>
Replying to messages
</summary>

Current:

- https://zulip.com/help/replying-to-messages
- https://zulip.com/help/getting-started-with-zulip#responding-to-an-existing-thread

Note that I removed the instruction for getting to the compose box, as you should already be in the message part of the compose box.

![Screen Shot 2022-10-18 at 9 51 25 PM](https://user-images.githubusercontent.com/2090066/196600640-034c11e0-43b3-4215-a064-ee18e27af95d.png)

</details>

