### PR TITLE
help: Migrate "Add custom profile fields" -> "Custom profile fields".

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -328,7 +328,7 @@ function open_custom_profile_field_form_modal() {
 
     dialog_widget.launch({
         form_id: "add-new-custom-profile-field-form",
-        help_link: "/help/add-custom-profile-fields",
+        help_link: "/help/custom-profile-fields#add-a-custom-profile-field",
         html_heading: $t_html({defaultMessage: "Add a new custom profile field"}),
         html_body,
         html_submit_button: $t_html({defaultMessage: "Add"}),

--- a/templates/corporate/features.html
+++ b/templates/corporate/features.html
@@ -284,7 +284,7 @@
                 Import an existing Slack, Mattermost, Gitter or Rocket.Chat workspace into Zulip.
             </p>
         </a>
-        <a class="feature-block" href="/help/add-custom-profile-fields" target="_blank" rel="noopener noreferrer">
+        <a class="feature-block" href="/help/custom-profile-fields" target="_blank" rel="noopener noreferrer">
             <h3>CUSTOM PROFILE FIELDS</h3>
             <p>
                 Use Zulip to store directory information, links to social

--- a/templates/corporate/for/business.html
+++ b/templates/corporate/for/business.html
@@ -414,7 +414,7 @@
                             Add partners, vendors and temporary contractors as <a href="/help/roles-and-permissions">guest users</a> in your organization.
                         </div>
                     </li>
-                    <li><div class="list-content">Use Zulip as your employee directory. Sync names, <a href="/help/roles-and-permissions">roles</a>, avatars, and <a href="/help/add-custom-profile-fields">custom profile fields</a> from LDAP or SAML.</div></li>
+                    <li><div class="list-content">Use Zulip as your employee directory. Sync names, <a href="/help/roles-and-permissions">roles</a>, avatars, and <a href="/help/custom-profile-fields">custom profile fields</a> from LDAP or SAML.</div></li>
                     <li><div class="list-content">Set a <a href="/help/message-retention-policy">message retention policy</a> that fits your needs.</div></li>
                 </ul>
             </div>

--- a/templates/zerver/help/custom-profile-fields.md
+++ b/templates/zerver/help/custom-profile-fields.md
@@ -1,4 +1,4 @@
-# Add custom profile fields
+# Custom profile fields
 
 {!admin-only.md!}
 

--- a/templates/zerver/help/custom-profile-fields.md
+++ b/templates/zerver/help/custom-profile-fields.md
@@ -28,6 +28,19 @@ methods][authentication-production] documentation for details.
 
 {end_tabs}
 
+## Edit a custom profile field
+
+{start_tabs}
+
+{settings_tab|profile-field-settings}
+
+1. In the **Actions** column, click the **pencil** (<i class="fa fa-pencil"></i>)
+   icon for the profile field you want to edit.
+
+1. Edit profile field information as desired, and click **Save changes**.
+
+{end_tabs}
+
 ## Profile field types
 
 There are several different types of fields available.
@@ -58,8 +71,8 @@ checkboxes will be disabled.
 
 {settings_tab|profile-field-settings}
 
-1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the profile field
-   you want to edit.
+1. In the **Actions** column, click the **pencil** (<i class="fa fa-pencil"></i>)
+   icon for the profile field you want to edit.
 
 1. Toggle **Display in profile summary**.
 

--- a/templates/zerver/help/edit-your-profile.md
+++ b/templates/zerver/help/edit-your-profile.md
@@ -4,7 +4,7 @@ By default, your profile includes your name, email, the date you joined, and
 when you were last active.
 
 Organization administrators can also
-[add custom profile fields](/help/add-custom-profile-fields). Custom profile
+[add custom profile fields](/help/custom-profile-fields#add-a-custom-profile-field). Custom profile
 fields are always optional, and will not appear in your profile unless you
 fill them out.
 

--- a/templates/zerver/help/include/customize-settings-for-new-users.md
+++ b/templates/zerver/help/include/customize-settings-for-new-users.md
@@ -1,6 +1,6 @@
 Customize settings for new users to get them off to a great start.
 
-* [Add custom profile fields](/help/add-custom-profile-fields), such as pronouns
+* [Add custom profile fields](/help/custom-profile-fields#add-a-custom-profile-field), such as pronouns
   or job title.
 * [Configure default new user settings][default-user-settings].
 * [Set default streams for new users](/help/set-default-streams-for-new-users).

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -153,7 +153,7 @@
 * [Invite new users](/help/invite-new-users)
 * [Restrict account creation](/help/restrict-account-creation)
 * [Deactivate or reactivate a user](/help/deactivate-or-reactivate-a-user)
-* [Add custom profile fields](/help/add-custom-profile-fields)
+* [Custom profile fields](/help/custom-profile-fields)
 * [Configure default new user settings](/help/configure-default-new-user-settings)
 * [Configure organization language](/help/configure-organization-language)
 * [User groups](/help/user-groups)

--- a/templates/zerver/help/public-access-option.md
+++ b/templates/zerver/help/public-access-option.md
@@ -130,7 +130,7 @@ but not to logged out visitors:
   [their status](/help/status-and-availability),
   and whether they have set themselves as unavailable.
 * Detailed profile information, such as [custom profile
-  fields](/help/add-custom-profile-fields).
+  fields](/help/custom-profile-fields).
 * Which users are subscribed to which web-public streams.
 
 ## Managing abuse

--- a/templates/zerver/help/view-someones-profile.md
+++ b/templates/zerver/help/view-someones-profile.md
@@ -2,7 +2,7 @@
 
 A user's profile includes their name, email, role, the date they joined,
 when they were last active, and any
-[custom profile fields](/help/add-custom-profile-fields) they've filled out.
+[custom profile fields](/help/custom-profile-fields) they've filled out.
 
 It also contains additional tabs showing a user's subscribed streams
 and user groups. Note that the information in those tabs is limited to
@@ -36,4 +36,4 @@ streams for which [you can see all subscribers](/help/stream-permissions).
 ## Related articles
 
 * [Edit your profile](/help/edit-your-profile)
-* [Add custom profile fields](/help/add-custom-profile-fields)
+* [Custom profile fields](/help/custom-profile-fields)

--- a/zerver/lib/url_redirects.py
+++ b/zerver/lib/url_redirects.py
@@ -22,6 +22,10 @@ POLICY_DOCUMENTATION_REDIRECTS: List[URLRedirect] = [
 HELP_DOCUMENTATION_REDIRECTS: List[URLRedirect] = [
     # Add URL redirects for help center documentation here:
     URLRedirect(
+        "/help/add-custom-profile-fields",
+        "/help/custom-profile-fields",
+    ),
+    URLRedirect(
         "/help/enable-enter-to-send",
         "/help/mastering-the-compose-box#toggle-between-ctrl-enter-and-enter-to-send-a-message",
     ),

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6488,7 +6488,7 @@ paths:
       tags: ["users"]
       description: |
         Retrieve details on all users in the organization. Optionally
-        includes values of [custom profile field](/help/add-custom-profile-fields).
+        includes values of [custom profile fields](/help/custom-profile-fields).
 
         You can also [fetch details on a single user](/api/get-user).
       x-curl-examples-parameters:
@@ -8227,7 +8227,7 @@ paths:
       summary: Get all custom profile fields
       tags: ["server_and_organizations"]
       description: |
-        Get all the [custom profile fields](/help/add-custom-profile-fields)
+        Get all the [custom profile fields](/help/custom-profile-fields)
         configured for the user's organization.
       responses:
         "200":
@@ -8341,7 +8341,7 @@ paths:
         endpoint allows administrative settings UI to change the field ordering.
 
         This endpoint is used to implement the dragging feature described in the
-        [custom profile fields documentation](/help/add-custom-profile-fields).
+        [custom profile fields documentation](/help/custom-profile-fields).
       x-requires-administrator: true
       parameters:
         - name: order
@@ -8365,7 +8365,7 @@ paths:
       summary: Create a custom profile field
       tags: ["server_and_organizations"]
       description: |
-        [Create a custom profile field](/help/add-custom-profile-fields) in the user's organization.
+        [Create a custom profile field](/help/custom-profile-fields#add-a-custom-profile-field) in the user's organization.
       x-requires-administrator: true
       parameters:
         - name: name
@@ -8389,8 +8389,8 @@ paths:
           in: query
           description: |
             The field type can be any of the supported custom profile field types. See the
-            [custom profile fields documentation](/help/add-custom-profile-fields)
-            more details on what each type means.
+            [custom profile fields documentation](/help/custom-profile-fields)
+            for more details on what each type means.
 
             - **1**: Short text
             - **2**: Long text
@@ -8440,7 +8440,7 @@ paths:
             The "Person picker" profile field is also not supported, but that is likely to
             be temporary.
 
-            [profile-field-types]: /help/add-custom-profile-fields#profile-field-types
+            [profile-field-types]: /help/custom-profile-fields#profile-field-types
 
             **Changes**: New in Zulip 6.0 (feature level 146).
           schema:
@@ -9191,7 +9191,7 @@ paths:
         Supports everything an administrator can do to edit details of another
         user's account, including editing full name,
         [role](/help/roles-and-permissions), and [custom profile
-        fields](/help/add-custom-profile-fields).
+        fields](/help/custom-profile-fields).
       parameters:
         - $ref: "#/components/parameters/UserId"
         - name: full_name
@@ -15505,15 +15505,15 @@ components:
         id:
           type: integer
           description: |
-            The ID of the custom profile field. This will be referenced in custom
-            the profile fields section of user objects.
+            The ID of the custom profile field. This will be referenced in the custom
+            profile fields section of user objects.
         type:
           type: integer
           description: |
             An integer indicating the type of the custom profile field, which determines
             how it is configured and displayed to users.
 
-            See the [Add custom profile fields](/help/add-custom-profile-fields)
+            See the [Custom profile fields](/help/custom-profile-fields#profile-field-types)
             article for details on what each type means.
 
             - **1**: Short text
@@ -15557,7 +15557,7 @@ components:
             Whether the custom profile field, display or not in the user profile summary.
 
             Currently it's value not allowed to be `true` of `Long text` and `Person picker`
-            [profile field types](/help/add-custom-profile-fields#profile-field-types).
+            [profile field types](/help/custom-profile-fields#profile-field-types).
 
             **Changes**: New in Zulip 6.0 (feature level 146).
     Hotspot:
@@ -17158,7 +17158,7 @@ components:
       name: include_custom_profile_fields
       in: query
       description: |
-        Whether the client wants [custom profile field](/help/add-custom-profile-fields)
+        Whether the client wants [custom profile field](/help/custom-profile-fields)
         data to be included in the response.
 
         **Changes**: New in Zulip 2.1.0. Previous versions do no offer these


### PR DESCRIPTION
- Renames the help article on custom profile fields to reflect that its content is not just about adding fields.
- Adds a redirect from the old URL to the new URL and updates internal links, linking to #add-a-custom-profile-field where appropriate.
- Adds a section on editing to the Custom profile fields help article.

Fixes: #23170.

**Screenshots and screen captures:**
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/2343554/196292417-8595e437-34ee-46e4-a643-07b55ba80f08.png">


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Link redirect from old to new URL.  
</details>