### PR TITLE
settings(admin/org): Customize reactivation confirmation modal for bots

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_settings_deactivation_user_modal from "../templates/confirm_dialog/confirm_deactivate_user.hbs";
+import render_settings_reactivation_bot_modal from "../templates/confirm_dialog/confirm_reactivate_bot.hbs";
 import render_settings_reactivation_user_modal from "../templates/confirm_dialog/confirm_reactivate_user.hbs";
 import render_admin_human_form from "../templates/settings/admin_human_form.hbs";
 import render_admin_user_list from "../templates/settings/admin_user_list.hbs";
@@ -524,7 +525,14 @@ export function confirm_reactivation(user_id, handle_confirm, loading_spinner) {
     const opts = {
         username: user.full_name,
     };
-    const html_body = render_settings_reactivation_user_modal(opts);
+
+    let html_body;
+    // check if bot or human
+    if (user.is_bot) {
+        html_body = render_settings_reactivation_bot_modal(opts);
+    } else {
+        html_body = render_settings_reactivation_user_modal(opts);
+    }
 
     confirm_dialog.launch({
         html_heading: $t_html({defaultMessage: "Reactivate {name}"}, {name: user.full_name}),

--- a/static/templates/confirm_dialog/confirm_reactivate_bot.hbs
+++ b/static/templates/confirm_dialog/confirm_reactivate_bot.hbs
@@ -1,0 +1,7 @@
+<p>
+    {{#tr}}
+    <z-user></z-user> will have the same properties as it did prior to deactivation,
+    including role, owner and stream subscriptions.
+    {{#*inline "z-user"}}<strong>{{username}}</strong>{{/inline}}
+    {{/tr}}
+</p>

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -52,6 +52,7 @@ IGNORED_PHRASES = [
     # BeautifulSoup will remove <z-user> which is horribly confusing,
     # so we need more of the sentence.
     r"<z-user></z-user> will have the same role",
+    r"<z-user></z-user> will have the same properties",
     # Things using "I"
     r"I understand",
     r"I'm",


### PR DESCRIPTION
**bots: customize reactivation confirmation modal for bots.**
- created a new confirmation dialog hbs file - confirm_reactivate_bots.hbs
- added a condition in the settings_users.js file to check if the modal call is a bot or human

Fixes: [#23270 ](https://github.com/zulip/zulip/issues/23270)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Bot reactivation modal
![image](https://user-images.githubusercontent.com/74467681/197834312-cde43654-6621-4ff1-b6b3-5c5fbf07ecb7.png)

User reactivation modal
![User reactivation modal](https://user-images.githubusercontent.com/74467681/196646111-32413df5-0c6c-4883-99e1-eff16d29ddcb.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
