### PR TITLE
integrations: Increase font size of logo disclaimer.

### DIFF
--- a/static/styles/portico/integrations.css
+++ b/static/styles/portico/integrations.css
@@ -569,6 +569,11 @@ $category-text: hsl(219, 23%, 33%);
                 margin: 20px 0;
             }
 
+            .logos_disclaimer {
+                font-size: 13px;
+                font-style: italic;
+            }
+
             @media (width >= 768px) {
                 width: calc(100% - 200px);
             }

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -150,7 +150,7 @@
                         {% if integration.is_enabled() %}
                         <div id="{{ integration.name }}" class="integration-instructions markdown">
                             <div class="help-content"></div>
-                            <p style="font-size:11px; font-style:italic;">
+                            <p class="logos_disclaimer">
                                 Logos are trademarks of their respective owners.
                                 None of the integrations on this page are created by,
                                 affiliated with, or supported by the companies


### PR DESCRIPTION
Increased font size from 11px to 13px. This text was unreadable on mobile as per Google report at 11px font size.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/small.20text.20on.20integrations.20pages/near/1445866

before:
<img width="1121" alt="Screenshot 2022-10-19 at 12 37 20 PM" src="https://user-images.githubusercontent.com/25124304/196621272-17157c19-aa7a-4346-991f-2248a24c571b.png">

after:
<img width="1121" alt="Screenshot 2022-10-19 at 12 37 12 PM" src="https://user-images.githubusercontent.com/25124304/196621292-9830593e-bb35-4b08-b442-cfcc9e81e163.png">
