### PR TITLE
email_validation: Restore case-insensitive domain validation.

### DIFF
--- a/zerver/lib/email_validation.py
+++ b/zerver/lib/email_validation.py
@@ -62,7 +62,7 @@ def get_realm_email_validator(realm: Realm) -> Callable[[str], None]:
         if "+" in address.username:
             raise EmailContainsPlusError
 
-        domain = address.domain
+        domain = address.domain.lower()
 
         if domain in allowed_domains:
             return

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -97,7 +97,7 @@ def same_realm_zephyr_user(user_profile: UserProfile, email: str) -> bool:
     except ValidationError:
         return False
 
-    domain = Address(addr_spec=email).domain
+    domain = Address(addr_spec=email).domain.lower()
 
     # Assumes allow_subdomains=False for all RealmDomain's corresponding to
     # these realms.
@@ -116,7 +116,7 @@ def same_realm_irc_user(user_profile: UserProfile, email: str) -> bool:
     except ValidationError:
         return False
 
-    domain = Address(addr_spec=email).domain
+    domain = Address(addr_spec=email).domain.lower()
     if domain.startswith("irc."):
         domain = domain[len("irc.") :]
 
@@ -133,7 +133,7 @@ def same_realm_jabber_user(user_profile: UserProfile, email: str) -> bool:
 
     # If your Jabber users have a different email domain than the
     # Zulip users, this is where you would do any translation.
-    domain = Address(addr_spec=email).domain
+    domain = Address(addr_spec=email).domain.lower()
 
     # Assumes allow_subdomains=False for all RealmDomain's corresponding to
     # these realms.


### PR DESCRIPTION
This was broken by commit b945aa3443110cac98736ba33c32ff5899e0b237 (#22604), because `email_to_domain` implicitly lowercased the result.

No adjustment is needed for `is_disposable_domain`, which already lowercases its argument.