### PR TITLE
recent_topics: Presence status and emoji for PMs in recent topics.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -592,7 +592,12 @@ export function initialize() {
             $(".tooltip").remove();
         });
 
-    function do_render_buddy_list_tooltip($elem, title_data) {
+    function do_render_buddy_list_tooltip(
+        $elem,
+        title_data,
+        parent_element_to_append = null,
+        is_custom_observer_needed = true,
+    ) {
         let placement = "left";
         let observer;
         if (window.innerWidth < media_breakpoints_num.md) {
@@ -611,9 +616,14 @@ export function initialize() {
             showOnCreate: true,
             onHidden: (instance) => {
                 instance.destroy();
-                observer.disconnect();
+                if (is_custom_observer_needed) {
+                    observer.disconnect();
+                }
             },
             onShow: (instance) => {
+                if (!is_custom_observer_needed) {
+                    return;
+                }
                 // For both buddy list and top left corner pm list, `target_node`
                 // is their parent `ul` element. We cannot use MutationObserver
                 // directly on the reference element because it will be removed
@@ -638,7 +648,7 @@ export function initialize() {
                 observer = new MutationObserver(callback);
                 observer.observe(target_node, config);
             },
-            appendTo: () => document.body,
+            appendTo: () => parent_element_to_append || document.body,
         });
     }
 
@@ -661,6 +671,19 @@ export function initialize() {
 
         const title_data = buddy_data.get_title_data(user_ids_string, is_group);
         do_render_buddy_list_tooltip($elem, title_data);
+    });
+
+    // Recent conversations PMs
+    $("body").on("mouseenter", ".recent_topic_stream .pm_status_icon", (e) => {
+        e.stopPropagation();
+        const $elem = $(e.currentTarget);
+        const user_ids_string = $elem.attr("data-user-ids-string");
+        // Don't show tooltip for group PMs.
+        if (!user_ids_string || user_ids_string.split(",").length !== 1) {
+            return;
+        }
+        const title_data = recent_topics_ui.get_pm_tooltip_data(user_ids_string);
+        do_render_buddy_list_tooltip($elem, title_data, undefined, false);
     });
 
     // MISC

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -4,6 +4,7 @@ import _ from "lodash";
 import render_recent_topic_row from "../templates/recent_topic_row.hbs";
 import render_recent_topics_filters from "../templates/recent_topics_filters.hbs";
 import render_recent_topics_body from "../templates/recent_topics_table.hbs";
+import render_user_with_status_icon from "../templates/user_with_status_icon.hbs";
 
 import * as buddy_data from "./buddy_data";
 import * as compose_closed_ui from "./compose_closed_ui";
@@ -38,6 +39,7 @@ import * as top_left_corner from "./top_left_corner";
 import * as ui from "./ui";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
+import * as user_status from "./user_status";
 import * as user_topics from "./user_topics";
 
 let topics_widget;
@@ -406,7 +408,18 @@ function format_conversation(conversation_data) {
     } else if (type === "private") {
         // Private message info
         context.user_ids_string = last_msg.to_user_ids;
-        context.pm_with = last_msg.display_reply_to;
+        context.rendered_pm_with = last_msg.display_recipient
+            .filter(
+                (recipient) =>
+                    !people.is_my_user_id(recipient.id) || last_msg.display_recipient.length === 1,
+            )
+            .map((user) =>
+                render_user_with_status_icon({
+                    name: user.full_name,
+                    status_emoji_info: user_status.get_status_emoji(user.id),
+                }),
+            )
+            .join(", ");
         context.recipient_id = last_msg.recipient_id;
         context.pm_url = last_msg.pm_with_url;
         context.is_group = last_msg.display_recipient.length > 2;

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -70,13 +70,6 @@
             padding-right: 3px;
         }
 
-        .fa-group {
-            font-size: 0.8rem;
-            margin-left: 5px;
-            /* color: hsl(105, 2%, 50%); */
-            opacity: 0.6;
-        }
-
         .fa-envelope {
             font-size: 0.7rem;
             margin-right: 2px;
@@ -171,14 +164,6 @@
 
         .unread_hidden {
             visibility: hidden;
-        }
-
-        .user_circle {
-            /* Shrink the user activity circle for the recent topics context. */
-            min-width: 7px;
-            height: 7px;
-            margin-left: 8px;
-            top: 0;
         }
 
         .flex_container_pm {
@@ -394,6 +379,32 @@
             .recent_topic_actions {
                 margin-right: 5px;
                 font-size: 15px;
+            }
+        }
+
+        .pm_status_icon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            /* Increasing vertical padding any further will increase
+               the height of the row. */
+            padding: 5px 0 5px 8px;
+            /* To accommodate fa-group icon */
+            width: 14px;
+            height: 14px;
+
+            .fa-group {
+                font-size: 0.8rem;
+                /* color: hsl(105, 2%, 50%); */
+                opacity: 0.6;
+            }
+
+            .user_circle {
+                /* Shrink the user activity circle for the recent topics context. */
+                width: 7px;
+                height: 7px;
+                float: left;
+                position: unset;
             }
         }
     }

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -170,6 +170,10 @@
             /* Flex container to fit in user circle and group icon */
             display: flex;
             justify-content: space-between;
+
+            .tippy-content {
+                font-weight: 400;
+            }
         }
 
         .flex_container {
@@ -382,29 +386,39 @@
             }
         }
 
-        .pm_status_icon {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            /* Increasing vertical padding any further will increase
-               the height of the row. */
-            padding: 5px 0 5px 8px;
-            /* To accommodate fa-group icon */
-            width: 14px;
-            height: 14px;
-
-            .fa-group {
-                font-size: 0.8rem;
-                /* color: hsl(105, 2%, 50%); */
-                opacity: 0.6;
+        .private_conversation_row {
+            .recent_topic_stream {
+                /* Reduce padding of stream section so that user status
+                   icon can have more padding without impacting height of the row */
+                padding: 5px 0 5px 8px;
             }
 
-            .user_circle {
-                /* Shrink the user activity circle for the recent topics context. */
-                width: 7px;
-                height: 7px;
-                float: left;
-                position: unset;
+            .pm_status_icon {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                /* Increasing vertical padding any further will increase
+                the height of the row. */
+                padding: 8px;
+                position: relative;
+                right: -8px; /* To cancel padding-right */
+                /* To accommodate fa-group icon */
+                width: 14px;
+                height: 14px;
+
+                .fa-group {
+                    font-size: 0.8rem;
+                    /* color: hsl(105, 2%, 50%); */
+                    opacity: 0.6;
+                }
+
+                .user_circle {
+                    /* Shrink the user activity circle for the recent topics context. */
+                    width: 7px;
+                    height: 7px;
+                    float: left;
+                    position: unset;
+                }
             }
         }
     }

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -183,6 +183,12 @@
 
         .flex_container .left_part {
             flex-wrap: wrap;
+
+            .user_status_icon_wrapper {
+                display: inline-flex;
+                align-items: center;
+                flex-direction: row;
+            }
         }
 
         .flex_container .right_part {

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -1,4 +1,4 @@
-<tr id="recent_conversation:{{conversation_key}}" {{#if unread_count}}class="unread_topic"{{/if}} data-unread-count="{{unread_count}}" data-muted="{{muted}}" data-participated="{{participated}}" data-private="{{is_private}}">
+<tr id="recent_conversation:{{conversation_key}}" class="{{#if unread_count}}unread_topic{{/if}} {{#if is_private}}private_conversation_row{{/if}}" data-unread-count="{{unread_count}}" data-muted="{{muted}}" data-participated="{{participated}}" data-private="{{is_private}}">
     <td class="recent_topic_stream">
         <div class="flex_container flex_container_pm">
             <div class="left_part recent_topics_focusable">
@@ -15,7 +15,7 @@
             {{!-- For presence/group indicator --}}
             {{#if is_private}}
             <div class="right_part">
-                <span class="pm_status_icon">
+                <span class="pm_status_icon {{#unless is_group}}show-tooltip{{/unless}}" data-tippy-placement="top" data-user-ids-string="{{user_ids_string}}">
                     {{#if is_group}}
                     <span class="fa fa-group"></span>
                     {{else}}

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -15,7 +15,7 @@
             {{!-- For presence/group indicator --}}
             {{#if is_private}}
             <div class="right_part">
-                <span class="stream-privacy filter-icon">
+                <span class="pm_status_icon">
                     {{#if is_group}}
                     <span class="fa fa-group"></span>
                     {{else}}

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -30,7 +30,7 @@
         <div class="flex_container">
             <div class="left_part recent_topics_focusable line_clamp">
                 {{#if is_private}}
-                <a href="{{pm_url}}">{{pm_with}}</a>
+                <a href="{{pm_url}}">{{{rendered_pm_with}}}</a>
                 {{else}}
                 <a href="{{topic_url}}">{{topic}}</a>
                 {{/if}}

--- a/static/templates/user_with_status_icon.hbs
+++ b/static/templates/user_with_status_icon.hbs
@@ -1,0 +1,4 @@
+<div class="user_status_icon_wrapper">
+    <span class="user-name">{{name}}</span>
+    {{> status_emoji status_emoji_info}}
+</div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Fixes https://github.com/zulip/zulip/issues/23262



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="872" alt="Screenshot 2022-10-27 at 2 25 22 PM" src="https://user-images.githubusercontent.com/63820270/198246238-d6ca7ae3-cc05-4d7e-bf00-08577efcea7e.png">
<img width="872" alt="Screenshot 2022-10-27 at 2 25 27 PM" src="https://user-images.githubusercontent.com/63820270/198246243-21c42604-aa70-4521-b76d-cdafb7bd501b.png">
<img width="872" alt="Screenshot 2022-10-27 at 2 25 32 PM" src="https://user-images.githubusercontent.com/63820270/198246249-e6a0010d-51e6-44f6-8f85-d27700e369fd.png">
<img width="872" alt="Screenshot 2022-10-27 at 2 25 34 PM" src="https://user-images.githubusercontent.com/63820270/198246253-63f906ec-10ce-4bae-82ba-4fb4679b3339.png">



**Self-review checklist**


<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
