### PR TITLE
Do not allow moving messages for locally echoed messages or messages that are not sent successfully.

### DIFF
--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -93,16 +93,17 @@ run_test("get_editability", ({override}) => {
     page_params.is_admin = false;
     message.timestamp = current_timestamp - 60;
     assert.equal(get_editability(message), editability_types.TOPIC_ONLY);
+});
 
-    // Test `message_edit.is_topic_editable()`
+run_test("is_topic_editable", ({override}) => {
+    const now = new Date();
+    const current_timestamp = now / 1000;
+
+    const message = {
+        sent_by_me: true,
+    };
+    page_params.realm_allow_message_editing = true;
     assert.equal(message_edit.is_topic_editable(message), true);
-
-    message.sent_by_me = true;
-    override(settings_data, "user_can_edit_topic_of_any_message", () => false);
-    assert.equal(message_edit.is_topic_editable(message), true);
-
-    message.sent_by_me = false;
-    assert.equal(message_edit.is_topic_editable(message), false);
 
     message.sent_by_me = false;
     page_params.is_admin = true;
@@ -113,6 +114,12 @@ run_test("get_editability", ({override}) => {
     assert.equal(message_edit.is_topic_editable(message), true);
 
     message.topic = "test topic";
+    override(settings_data, "user_can_edit_topic_of_any_message", () => false);
+    assert.equal(message_edit.is_topic_editable(message), false);
+
+    page_params.realm_community_topic_editing_limit_seconds = 259200;
+    message.timestamp = current_timestamp - 60;
+
     override(settings_data, "user_can_edit_topic_of_any_message", () => true);
     assert.equal(message_edit.is_topic_editable(message), true);
 

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -101,8 +101,17 @@ run_test("is_topic_editable", ({override}) => {
 
     const message = {
         sent_by_me: true,
+        locally_echoed: true,
     };
     page_params.realm_allow_message_editing = true;
+
+    assert.equal(message_edit.is_topic_editable(message), false);
+
+    message.locally_echoed = false;
+    message.failed_request = true;
+    assert.equal(message_edit.is_topic_editable(message), false);
+
+    message.failed_request = false;
     assert.equal(message_edit.is_topic_editable(message), true);
 
     message.sent_by_me = false;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -56,6 +56,10 @@ export const editability_types = {
 };
 
 export function is_topic_editable(message, edit_limit_seconds_buffer = 0) {
+    if (!is_message_editable_ignoring_permissions(message)) {
+        return false;
+    }
+
     if (!page_params.realm_allow_message_editing) {
         // If message editing is disabled, so is topic editing.
         return false;
@@ -199,6 +203,10 @@ export function can_move_message(message) {
     }
 
     if (!message.is_stream) {
+        return false;
+    }
+
+    if (!is_message_editable_ignoring_permissions(message)) {
         return false;
     }
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -440,7 +440,6 @@ function edit_message($row, raw_content) {
     }
 
     const is_editable = editability === editability_types.FULL;
-    // current message's stream has been already been added and selected in Handlebars
 
     const $form = $(
         render_message_edit_form({

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -122,6 +122,8 @@ export function is_message_editable_ignoring_permissions(message) {
         return false;
     }
 
+    // Messages where we're currently locally echoing an edit not yet acknowledged
+    // by the server.
     if (currently_echoing_messages.has(message.id)) {
         return false;
     }

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -134,9 +134,7 @@ function message_hover($message_row) {
     message_unhover();
     $current_message_hover = $message_row;
 
-    // Locally echoed messages have !is_topic_editable and thus go
-    // through this code path.
-    if (!message_edit.is_topic_editable(message)) {
+    if (!message.sent_by_me) {
         // The actions and reactions icon hover logic is handled entirely by CSS
         return;
     }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is just to remove a comment.
- Second commit is to extract a checks for locally echoed or failed message in a function.
- Third commit is to show "View source" icon when both editing and moving message is not allowed. ([CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/message.20action.20shortcuts/near/1449037))
- Fourth commit is refactor in tests to test `is_topic_editable` separately.
- Fifth commit is to not show UI for moving locally echoed or failed messages
<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
