### PR TITLE
Improve organization in display settings

### DIFF
--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -69,15 +69,15 @@ export const default_view_values = {
 export const color_scheme_values = {
     automatic: {
         code: 1,
-        description: $t({defaultMessage: "Sync with computer"}),
-    },
-    night: {
-        code: 2,
-        description: $t({defaultMessage: "Dark theme"}),
+        description: $t({defaultMessage: "Automatic (follows system settings)"}),
     },
     day: {
         code: 3,
-        description: $t({defaultMessage: "Light theme"}),
+        description: $t({defaultMessage: "Light"}),
+    },
+    night: {
+        code: 2,
+        description: $t({defaultMessage: "Dark"}),
     },
 };
 

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -3,11 +3,7 @@
         <!-- this is inline block so that the alert notification can sit beside
         it. If there's not an alert, don't make it inline-block.-->
         <div class="subsection-header inline-block">
-            {{#if for_realm_settings}}
-            <h3>{{t "Time" }}</h3>
-            {{else}}
-            <h3>{{t "Language and time" }}</h3>
-            {{/if}}
+            <h3>{{t "General" }}</h3>
             {{> settings_save_discard_widget section_name="lang-time-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
         {{#unless for_realm_settings}}
@@ -26,20 +22,19 @@
             </select>
         </div>
 
+        <div class="input-group">
+            <label for="color_scheme" class="dropdown-title">{{t "Theme" }}</label>
+            <select name="color_scheme" class="setting_color_scheme prop-element" data-setting-widget-type="number">
+                {{> dropdown_options_widget option_values=color_scheme_values}}
+            </select>
+        </div>
     </div>
 
 
     <div class="theme-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
-            <h3 class="light">{{t "Theme" }}</h3>
+            <h3 class="light">{{t "Emoji" }}</h3>
             {{> settings_save_discard_widget section_name="theme-settings" show_only_indicator=(not for_realm_settings) }}
-        </div>
-
-        <div class="input-group">
-            <label for="color_scheme" class="dropdown-title">{{t "Color scheme" }}</label>
-            <select name="color_scheme" class="setting_color_scheme prop-element" data-setting-widget-type="number">
-                {{> dropdown_options_widget option_values=color_scheme_values}}
-            </select>
         </div>
 
         <div class="input-group">
@@ -82,6 +77,14 @@
           prefix=prefix}}
         {{/if}}
 
+    </div>
+
+    <div class="advanced-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+        <div class="subsection-header">
+            <h3 class="light">{{t "Advanced" }}</h3>
+            {{> settings_save_discard_widget section_name="advanced-settings" show_only_indicator=(not for_realm_settings) }}
+        </div>
+
         <div class="input-group">
             <label class="title">{{t "User list style" }}</label>
             <div class="user_list_style_values grey-box">
@@ -107,13 +110,6 @@
                     </label>
                 {{/each}}
             </div>
-        </div>
-    </div>
-
-    <div class="advanced-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
-        <div class="subsection-header">
-            <h3 class="light">{{t "Advanced" }}</h3>
-            {{> settings_save_discard_widget section_name="advanced-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
         <div class="input-group thinner setting-next-is-related">

--- a/templates/zerver/help/change-the-time-format.md
+++ b/templates/zerver/help/change-the-time-format.md
@@ -9,7 +9,7 @@ format (e.g. 5:00 PM) or a 24-hour format (e.g. 17:00).
 
 {settings_tab|display-settings}
 
-1. Under **Language and time**, select your preferred option from the
+1. Under **General**, select your preferred option from the
 **Time format** dropdown.
 
 {end_tabs}

--- a/templates/zerver/help/change-your-language.md
+++ b/templates/zerver/help/change-your-language.md
@@ -13,7 +13,7 @@ messages you receive.
 
 {settings_tab|display-settings}
 
-1. Under **Language and time**, click the button under **Language**.
+1. Under **General**, click the button under **Language**.
 
 1. Select a language.
 

--- a/templates/zerver/help/dark-theme.md
+++ b/templates/zerver/help/dark-theme.md
@@ -9,13 +9,13 @@ for working in a dark space.
 
 {settings_tab|display-settings}
 
-2. Under **Theme**, configure **Color scheme**.
+2. Under **General**, configure **Theme**.
 
 {end_tabs}
 
-The default is **Sync with computer**, which detects which theme to use based
-on the color scheme used by your operating system.
+The default is **Automatic (follows system settings)**, which detects which theme to use based
+on the theme used by your operating system.
 
 You can also specify **Dark theme** or **Light theme** if you'd like
-Zulip to use the same color scheme regardless of your operating system
+Zulip to use the same theme regardless of your operating system
 configuration.

--- a/templates/zerver/help/emoji-and-emoticons.md
+++ b/templates/zerver/help/emoji-and-emoticons.md
@@ -64,7 +64,7 @@ you send. Zulip emoji are compatible with screen readers and other accessibility
 
 {settings_tab|display-settings}
 
-1. Under **Theme**, select **Google**,
+1. Under **Emoji**, select **Google**,
    **Twitter**, **Plain text**, or **Google blobs** for the emoji theme.
 
 {end_tabs}

--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -21,7 +21,7 @@ automatically by Zulip.
 
 {settings_tab|display-settings}
 
-1. Under **Theme**, select **Convert emoticons before sending**.
+1. Under **Emoji**, select **Convert emoticons before sending**.
 
 {end_tabs}
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Items in the personal/display settings are reordered and sections are renamed. The same applies for organization/user settings.

Fixes: <!-- Issue link, or clear description.--> #23288 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/53159963/200454064-83a915d7-8629-4659-a810-7aa6caad8afb.mov

<img width="789" alt="Screen Shot 2022-11-07 at 8 47 16 PM" src="https://user-images.githubusercontent.com/53159963/200454075-cf8b5515-0254-4808-88a9-071f86ae68ca.png">
<img width="789" alt="Screen Shot 2022-11-07 at 8 47 27 PM" src="https://user-images.githubusercontent.com/53159963/200454081-2ed3bdf9-dfa2-442b-9472-d6a6985a6f2a.png">
<img width="789" alt="Screen Shot 2022-11-07 at 8 47 44 PM" src="https://user-images.githubusercontent.com/53159963/200454085-cde31ecc-0e1d-432e-9a19-52a9eb397802.png">
<img width="789" alt="Screen Shot 2022-11-07 at 8 47 57 PM" src="https://user-images.githubusercontent.com/53159963/200454093-2909423c-de12-4c9c-9ba4-a8e68da7bfa8.png">
<img width="789" alt="Screen Shot 2022-11-07 at 8 48 10 PM" src="https://user-images.githubusercontent.com/53159963/200454100-fe74c352-df22-49d8-8d29-208ced5ea93a.png">


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
