### PR TITLE
recent_topics_ui: Allow unread count click in PM row to mark row as read.

### DIFF
--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -256,6 +256,17 @@ run_test("read", ({override}) => {
         },
         success: channel_post_opts.success,
     });
+
+    msgs_to_flag_read = [1, 2, 3, 4, 5];
+    message_flags.mark_as_read(msgs_to_flag_read);
+    assert.deepEqual(channel_post_opts, {
+        url: "/json/messages/flags",
+        data: {
+            messages: "[1,2,3,4,5]",
+            op: "add",
+            flag: "read",
+        },
+    });
 });
 
 run_test("read_empty_data", ({override}) => {

--- a/frontend_tests/node_tests/pm_list_data.js
+++ b/frontend_tests/node_tests/pm_list_data.js
@@ -109,8 +109,8 @@ function get_list_info(zoomed) {
 test("get_conversations", ({override}) => {
     pm_conversations.recent.insert([alice.user_id, bob.user_id], 1);
     pm_conversations.recent.insert([me.user_id], 2);
-    let num_unread_for_person = 1;
-    override(unread, "num_unread_for_person", () => num_unread_for_person);
+    let num_unread_for_user_ids_string = 1;
+    override(unread, "num_unread_for_user_ids_string", () => num_unread_for_user_ids_string);
 
     assert.equal(narrow_state.filter(), undefined);
 
@@ -144,7 +144,7 @@ test("get_conversations", ({override}) => {
     let pm_data = pm_list_data.get_conversations();
     assert.deepEqual(pm_data, expected_data);
 
-    num_unread_for_person = 0;
+    num_unread_for_user_ids_string = 0;
 
     pm_data = pm_list_data.get_conversations();
     expected_data[0].unread = 0;
@@ -161,7 +161,7 @@ test("get_conversations bot", ({override}) => {
     pm_conversations.recent.insert([alice.user_id, bob.user_id], 1);
     pm_conversations.recent.insert([bot_test.user_id], 2);
 
-    override(unread, "num_unread_for_person", () => 1);
+    override(unread, "num_unread_for_user_ids_string", () => 1);
 
     assert.equal(narrow_state.filter(), undefined);
 
@@ -258,8 +258,8 @@ test("get_list_info", ({override}) => {
     assert.equal(pm_list_data.get_active_user_ids_string(), undefined);
 
     // Mock to arrange that each user has exactly 1 unread.
-    const num_unread_for_person = 1;
-    override(unread, "num_unread_for_person", () => num_unread_for_person);
+    const num_unread_for_user_ids_string = 1;
+    override(unread, "num_unread_for_user_ids_string", () => num_unread_for_user_ids_string);
 
     // Initially, we append 2 conversations and check for the
     // `conversations_to_be_shown` returned in list_info.
@@ -401,7 +401,7 @@ test("get_list_info", ({override}) => {
     );
 
     // We now test some no unreads cases.
-    override(unread, "num_unread_for_person", () => 0);
+    override(unread, "num_unread_for_user_ids_string", () => 0);
     pm_conversations.clear_for_testing();
     pm_conversations.recent.insert([alice.user_id], 1);
     pm_conversations.recent.insert([bob.user_id], 2);

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -123,7 +123,7 @@ run_test("topics", ({override}) => {
 run_test("get_next_unread_pm_string", ({override}) => {
     pm_conversations.recent.get_strings = () => ["1", "read", "2,3", "4", "unk"];
 
-    override(unread, "num_unread_for_person", (user_ids_string) => {
+    override(unread, "num_unread_for_user_ids_string", (user_ids_string) => {
         if (user_ids_string === "unk") {
             return undefined;
         }
@@ -143,7 +143,7 @@ run_test("get_next_unread_pm_string", ({override}) => {
     assert.equal(tg.get_next_unread_pm_string("read"), "2,3");
     assert.equal(tg.get_next_unread_pm_string("2,3"), "4");
 
-    override(unread, "num_unread_for_person", () => 0);
+    override(unread, "num_unread_for_user_ids_string", () => 0);
 
     assert.equal(tg.get_next_unread_pm_string("2,3"), undefined);
 });

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -420,8 +420,8 @@ test("private_messages", () => {
     };
     people.add_active_user(bob);
 
-    assert.equal(unread.num_unread_for_person(alice.user_id.toString()), 0);
-    assert.equal(unread.num_unread_for_person(bob.user_id.toString()), 0);
+    assert.equal(unread.num_unread_for_user_ids_string(alice.user_id.toString()), 0);
+    assert.equal(unread.num_unread_for_user_ids_string(bob.user_id.toString()), 0);
     assert.deepEqual(unread.get_msg_ids_for_user_ids_string(alice.user_id.toString()), []);
     assert.deepEqual(unread.get_msg_ids_for_user_ids_string(bob.user_id.toString()), []);
     assert.deepEqual(unread.get_msg_ids_for_user_ids_string(), []);
@@ -439,9 +439,9 @@ test("private_messages", () => {
         flags: ["read"],
     };
     unread.process_loaded_messages([message, read_message]);
-    assert.equal(unread.num_unread_for_person(alice.user_id.toString()), 1);
+    assert.equal(unread.num_unread_for_user_ids_string(alice.user_id.toString()), 1);
 
-    assert.equal(unread.num_unread_for_person(""), 0);
+    assert.equal(unread.num_unread_for_user_ids_string(""), 0);
 
     assert.deepEqual(unread.get_msg_ids_for_user_ids_string(alice.user_id.toString()), [
         message.id,
@@ -451,8 +451,8 @@ test("private_messages", () => {
     assert.deepEqual(unread.get_all_msg_ids(), [message.id]);
 
     unread.mark_as_read(message.id);
-    assert.equal(unread.num_unread_for_person(alice.user_id.toString()), 0);
-    assert.equal(unread.num_unread_for_person(""), 0);
+    assert.equal(unread.num_unread_for_user_ids_string(alice.user_id.toString()), 0);
+    assert.equal(unread.num_unread_for_user_ids_string(""), 0);
     assert.deepEqual(unread.get_msg_ids_for_user_ids_string(alice.user_id.toString()), []);
     assert.deepEqual(unread.get_msg_ids_for_user_ids_string(bob.user_id.toString()), []);
     assert.deepEqual(unread.get_msg_ids_for_private(), []);
@@ -725,9 +725,9 @@ test("server_counts", () => {
 
     unread.initialize();
 
-    assert.equal(unread.num_unread_for_person("101"), 6);
-    assert.equal(unread.num_unread_for_person("4,6,101"), 2);
-    assert.equal(unread.num_unread_for_person("30"), 0);
+    assert.equal(unread.num_unread_for_user_ids_string("101"), 6);
+    assert.equal(unread.num_unread_for_user_ids_string("4,6,101"), 2);
+    assert.equal(unread.num_unread_for_user_ids_string("30"), 0);
 
     assert.equal(unread.num_unread_for_topic(0, "bogus"), 0);
     assert.equal(unread.num_unread_for_topic(1, "bogus"), 0);
@@ -742,7 +742,7 @@ test("server_counts", () => {
     assert.equal(unread.num_unread_for_topic(1, "test"), 2);
 
     unread.mark_as_read(34);
-    assert.equal(unread.num_unread_for_person("4,6,101"), 1);
+    assert.equal(unread.num_unread_for_user_ids_string("4,6,101"), 1);
 });
 
 test("empty_cases", () => {

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -422,9 +422,9 @@ test("private_messages", () => {
 
     assert.equal(unread.num_unread_for_person(alice.user_id.toString()), 0);
     assert.equal(unread.num_unread_for_person(bob.user_id.toString()), 0);
-    assert.deepEqual(unread.get_msg_ids_for_person(alice.user_id.toString()), []);
-    assert.deepEqual(unread.get_msg_ids_for_person(bob.user_id.toString()), []);
-    assert.deepEqual(unread.get_msg_ids_for_person(), []);
+    assert.deepEqual(unread.get_msg_ids_for_user_ids_string(alice.user_id.toString()), []);
+    assert.deepEqual(unread.get_msg_ids_for_user_ids_string(bob.user_id.toString()), []);
+    assert.deepEqual(unread.get_msg_ids_for_user_ids_string(), []);
     assert.deepEqual(unread.get_msg_ids_for_private(), []);
 
     const message = {
@@ -443,16 +443,18 @@ test("private_messages", () => {
 
     assert.equal(unread.num_unread_for_person(""), 0);
 
-    assert.deepEqual(unread.get_msg_ids_for_person(alice.user_id.toString()), [message.id]);
-    assert.deepEqual(unread.get_msg_ids_for_person(bob.user_id.toString()), []);
+    assert.deepEqual(unread.get_msg_ids_for_user_ids_string(alice.user_id.toString()), [
+        message.id,
+    ]);
+    assert.deepEqual(unread.get_msg_ids_for_user_ids_string(bob.user_id.toString()), []);
     assert.deepEqual(unread.get_msg_ids_for_private(), [message.id]);
     assert.deepEqual(unread.get_all_msg_ids(), [message.id]);
 
     unread.mark_as_read(message.id);
     assert.equal(unread.num_unread_for_person(alice.user_id.toString()), 0);
     assert.equal(unread.num_unread_for_person(""), 0);
-    assert.deepEqual(unread.get_msg_ids_for_person(alice.user_id.toString()), []);
-    assert.deepEqual(unread.get_msg_ids_for_person(bob.user_id.toString()), []);
+    assert.deepEqual(unread.get_msg_ids_for_user_ids_string(alice.user_id.toString()), []);
+    assert.deepEqual(unread.get_msg_ids_for_user_ids_string(bob.user_id.toString()), []);
     assert.deepEqual(unread.get_msg_ids_for_private(), []);
     assert.deepEqual(unread.get_all_msg_ids(), []);
     const counts = unread.get_counts();

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -91,7 +91,7 @@ export function sort_users(user_ids) {
 }
 
 function get_num_unread(user_id) {
-    return unread.num_unread_for_person(user_id.toString());
+    return unread.num_unread_for_user_ids_string(user_id.toString());
 }
 
 export function user_last_seen_time_status(user_id) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -447,11 +447,20 @@ export function initialize() {
 
     $("body").on("click", "#recent_topics_table .on_hover_topic_read", (e) => {
         e.stopPropagation();
-        const topic_row_index = $(e.target).closest("tr").index();
+        const $elt = $(e.currentTarget);
+        const topic_row_index = $elt.closest("tr").index();
         recent_topics_ui.focus_clicked_element(topic_row_index, recent_topics_ui.COLUMNS.read);
-        const stream_id = Number.parseInt($(e.currentTarget).attr("data-stream-id"), 10);
-        const topic = $(e.currentTarget).attr("data-topic-name");
-        unread_ops.mark_topic_as_read(stream_id, topic);
+        const user_ids_string = $elt.attr("data-user-ids-string");
+        if (user_ids_string) {
+            // PM row
+            unread_ops.mark_pm_as_read(user_ids_string);
+        } else {
+            // Stream row
+            const stream_id = Number.parseInt($elt.attr("data-stream-id"), 10);
+            const topic = $elt.attr("data-topic-name");
+            unread_ops.mark_topic_as_read(stream_id, topic);
+        }
+        recent_topics_ui.change_focused_element($elt, "down_arrow");
     });
 
     $("body").on("keydown", ".on_hover_topic_read", ui_util.convert_enter_to_click);

--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -66,6 +66,10 @@ export const send_read = (function () {
     return add;
 })();
 
+export function mark_as_read(message_ids) {
+    send_flag_update_for_messages(message_ids, "read", "add");
+}
+
 export function mark_as_unread(message_ids) {
     send_flag_update_for_messages(message_ids, "read", "remove");
 }

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -247,7 +247,7 @@ export function _possible_unread_message_ids() {
         if (current_filter_pm_string === undefined) {
             return [];
         }
-        return unread.get_msg_ids_for_person(current_filter_pm_string);
+        return unread.get_msg_ids_for_user_ids_string(current_filter_pm_string);
     }
 
     if (current_filter.can_bucket_by("is-private")) {

--- a/static/js/pm_list_data.js
+++ b/static/js/pm_list_data.js
@@ -40,7 +40,7 @@ export function get_conversations() {
         const reply_to = people.user_ids_string_to_emails_string(user_ids_string);
         const recipients_string = people.get_recipients(user_ids_string);
 
-        const num_unread = unread.num_unread_for_person(user_ids_string);
+        const num_unread = unread.num_unread_for_user_ids_string(user_ids_string);
         const is_group = user_ids_string.includes(",");
         const is_active = user_ids_string === active_user_ids_string;
 

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -812,7 +812,10 @@ function is_focus_at_last_table_row() {
 function has_unread(row) {
     const last_msg_id = topics_widget.get_current_list()[row].last_msg_id;
     const last_msg = message_store.get(last_msg_id);
-    return unread.num_unread_for_topic(last_msg.stream_id, last_msg.topic) > 0;
+    if (last_msg.type === "stream") {
+        return unread.num_unread_for_topic(last_msg.stream_id, last_msg.topic) > 0;
+    }
+    return unread.num_unread_for_user_ids_string(last_msg.to_user_ids) > 0;
 }
 
 export function focus_clicked_element(topic_row_index, col, topic_key) {

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -69,8 +69,8 @@ let col_focus = 1;
 export const COLUMNS = {
     stream: 0,
     topic: 1,
-    mute: 2,
-    read: 3,
+    read: 2,
+    mute: 3,
 };
 
 // The number of selectable actions in a recent_topics.  Used to

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -302,7 +302,7 @@ export function process_messages(messages) {
 
 function message_to_conversation_unread_count(msg) {
     if (msg.type === "private") {
-        return unread.num_unread_for_person(msg.to_user_ids);
+        return unread.num_unread_for_user_ids_string(msg.to_user_ids);
     }
     return unread.num_unread_for_topic(msg.stream_id, msg.topic);
 }

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -78,7 +78,7 @@ export const COLUMNS = {
 // increased when we add new actions, or rethought if we add optional
 // actions that only appear in some rows.
 const MAX_SELECTABLE_TOPIC_COLS = 4;
-const MAX_SELECTABLE_PM_COLS = 2;
+const MAX_SELECTABLE_PM_COLS = 3;
 
 // we use localstorage to persist the recent topic filters
 const ls_key = "recent_topic_filters";
@@ -357,6 +357,7 @@ function format_conversation(conversation_data) {
         displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);
     } else if (type === "private") {
         // Private message info
+        context.user_ids_string = last_msg.to_user_ids;
         context.pm_with = last_msg.display_reply_to;
         context.recipient_id = last_msg.recipient_id;
         context.pm_url = last_msg.pm_with_url;
@@ -873,8 +874,7 @@ function down_arrow_navigation(row, col) {
     if (is_focus_at_last_table_row()) {
         return;
     }
-    const type = get_row_type(row);
-    if (type === "stream" && col === 2 && !has_unread(row + 1)) {
+    if (col === 2 && !has_unread(row + 1)) {
         col_focus = 1;
     }
     row_focus += 1;

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -84,13 +84,13 @@ export function get_next_unread_pm_string(curr_pm) {
     const curr_pm_index = my_pm_strings.indexOf(curr_pm); // -1 if not found
 
     for (let i = curr_pm_index + 1; i < my_pm_strings.length; i += 1) {
-        if (unread.num_unread_for_person(my_pm_strings[i]) > 0) {
+        if (unread.num_unread_for_user_ids_string(my_pm_strings[i]) > 0) {
             return my_pm_strings[i];
         }
     }
 
     for (let i = 0; i < curr_pm_index; i += 1) {
-        if (unread.num_unread_for_person(my_pm_strings[i]) > 0) {
+        if (unread.num_unread_for_user_ids_string(my_pm_strings[i]) > 0) {
             return my_pm_strings[i];
         }
     }

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -207,7 +207,7 @@ class UnreadPMCounter {
         return util.sorted_ids(ids);
     }
 
-    get_msg_ids_for_person(user_ids_string) {
+    get_msg_ids_for_user_ids_string(user_ids_string) {
         if (!user_ids_string) {
             return [];
         }
@@ -728,8 +728,8 @@ export function get_msg_ids_for_topic(stream_id, topic_name) {
     return unread_topic_counter.get_msg_ids_for_topic(stream_id, topic_name);
 }
 
-export function get_msg_ids_for_person(user_ids_string) {
-    return unread_pm_counter.get_msg_ids_for_person(user_ids_string);
+export function get_msg_ids_for_user_ids_string(user_ids_string) {
+    return unread_pm_counter.get_msg_ids_for_user_ids_string(user_ids_string);
 }
 
 export function get_msg_ids_for_private() {

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -716,7 +716,7 @@ export function get_topics_with_unread_mentions(stream_id) {
     return unread_topic_counter.get_topics_with_unread_mentions(stream_id);
 }
 
-export function num_unread_for_person(user_ids_string) {
+export function num_unread_for_user_ids_string(user_ids_string) {
     return unread_pm_counter.num_unread(user_ids_string);
 }
 

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -227,3 +227,11 @@ export function mark_topic_as_read(stream_id, topic, cont) {
         success: cont,
     });
 }
+
+export function mark_pm_as_read(user_ids_string) {
+    // user_ids_string is a stringified list of user ids which are
+    // participants in the conversation other than the current
+    // user. Eg: "123,124" or "123"
+    const unread_msg_ids = unread.get_msg_ids_for_user_ids_string(user_ids_string);
+    message_flags.mark_as_read(unread_msg_ids);
+}

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -163,13 +163,6 @@
             background-color: hsl(105, 2%, 50%);
         }
 
-        .unread_count_pm {
-            /* 10px of unread count + 23px for bell icon */
-            margin-right: 33px;
-            /* match the opacity with topic unread count without hover */
-            opacity: 0.7;
-        }
-
         .unread_mention_info:not(:empty) {
             margin-right: -5px;
         }
@@ -220,6 +213,12 @@
         .recent_topic_actions .recent_topics_focusable {
             display: flex;
             align-items: center;
+            padding-bottom: 3px;
+
+            &.single_action_button {
+                /* 10px of unread count + 23px for bell icon */
+                margin-right: 33px;
+            }
         }
 
         .recent_topics_participants {

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -37,7 +37,11 @@
             </div>
             <div class="right_part">
                 {{#if is_private}}
-                <span class="unread_count unread_count_pm {{#unless unread_count}}unread_hidden{{/unless}}">{{unread_count}}</span>
+                <div class="recent_topic_actions">
+                    <div class="recent_topics_focusable single_action_button">
+                        <span class="unread_count unread_count_pm {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                    </div>
+                </div>
                 {{else}}
                 <span class="unread_mention_info {{#unless mention_in_unread}}unread_hidden{{/unless}}">@</span>
                 <div class="recent_topic_actions">


### PR DESCRIPTION
Fixes #23261

We now send the user to next column after marking a row read. Added a bit of bottom padding below unread count indicator.
<img width="1543" alt="Screenshot 2022-10-21 at 4 45 07 PM" src="https://user-images.githubusercontent.com/25124304/197183667-12eab3ac-4dc5-4045-8661-b3ec9bd5ab4f.png">
