### PR TITLE
recent-topics: Update user-facing strings to "recent conversations".

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -64,9 +64,10 @@ log][commit-log] for an up-to-date list of raw changes.
   clearer and link to the Zulip server troubleshooting guide.
 - Redesigned the interface for configuring message editing and
   deletion permissions to be easier to understand.
-- Improved Recent Topics. The timestamp links now go to the latest
-  message in the topic, arrow key navigation was improved, and many
-  other bug fixes or subtle improvements.
+- Improved "Recent topics" and renamed to "Recent conversations" with
+  the addition of including private messages in the view. The timestamp
+  links now go to the latest message in the topic, arrow key navigation
+  was improved, and many other bug fixes or subtle improvements.
 - Added support for emoji added in unicode versions since 2017, which
   had previously been unavailable in Zulip. Users using the deprecated
   "Google blobs" emoji set are automatically migrated to the modern
@@ -423,7 +424,7 @@ log][commit-log] for an up-to-date list of raw changes.
   sending email notifications after a mention or PM.
 - Improved integrations: BigBlueButton, GitHub, Grafana, PagerDuty,
   and many more.
-- Improved various interaction and performance details in Recent Topics.
+- Improved various interaction and performance details in "Recent topics".
 - Improved styling for poll and todo list widgets.
 - Zulip now supports configuring the database name and username when
   using a remote Postgres server. Previously, these were hardcoded to "zulip".
@@ -768,7 +769,7 @@ log][commit-log] for an up-to-date list of raw changes.
   allowing moderators and above to use the feature.
 - Added a native Giphy integration for sending animated GIFs.
 - Added support for muting another user.
-- Recent topics is no longer beta, no longer an overlay, supports
+- "Recent topics" is no longer beta, no longer an overlay, supports
   composing messages, and is now the default view. The previous
   default view, "All messages", is still available, and the default
   view can now be configured via "Display settings".
@@ -1049,7 +1050,7 @@ log][commit-log] for an up-to-date list of raw changes.
 - Redesigned the top navbar/search area to be much cleaner and show
   useful data like subscriber counts and stream descriptions in
   default views.
-- Added a new "recent topics" widget, which lets one browse recent
+- Added a new "Recent topics" widget, which lets one browse recent
   and ongoing conversations at a glance. We expect this widget to
   replace "All messages" as the default view in Zulip in the
   next major release.
@@ -2833,7 +2834,7 @@ running a version from before 1.7 should upgrade directly to 1.7.1.
 - Added easy configuration support for a remote PostgreSQL database.
 - Added extensive documentation on scalability, backups, and security.
 - Recent private message threads are now displayed expanded similar to
-  the pre-existing recent topics feature.
+  the pre-existing "Recent topics" feature.
 - Made it possible to set LDAP and EMAIL_HOST passwords in
   /etc/zulip/secrets.conf.
 - Improved the styling for the Administration page and added tabs.

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -65,7 +65,7 @@ Try narrowing from the message view:
   - narrow to a group PM
 - Click on the Zulip logo
   - narrow to a topic
-  - click on the Zulip logo (and verify you're in the Recent topics view)
+  - click on the Zulip logo (and verify you're in the Recent conversations view)
 
 ### Messagebox
 

--- a/frontend_tests/puppeteer_tests/message-basics.ts
+++ b/frontend_tests/puppeteer_tests/message-basics.ts
@@ -95,7 +95,7 @@ async function un_narrow_by_clicking_org_icon(page: Page): Promise<void> {
 
 async function expect_recent_topics(page: Page): Promise<void> {
     await page.waitForSelector("#recent_topics_table", {visible: true});
-    assert.strictEqual(await page.title(), "Recent topics - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "Recent conversations - Zulip Dev - Zulip");
 }
 
 async function test_navigations_from_home(page: Page): Promise<void> {

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -22,7 +22,7 @@ function make_message_view_header(filter) {
     const message_view_header = {};
     if (recent_topics_util.is_visible()) {
         return {
-            title: $t({defaultMessage: "Recent topics"}),
+            title: $t({defaultMessage: "Recent conversations"}),
             icon: "clock-o",
         };
     }

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -762,7 +762,7 @@ export function show() {
     compose_closed_ui.update_buttons_for_recent_topics();
 
     narrow_state.reset_current_filter();
-    const recent_topics_title = $t({defaultMessage: "Recent topics"});
+    const recent_topics_title = $t({defaultMessage: "Recent conversations"});
     narrow.set_narrow_title(recent_topics_title);
     message_view_header.render_title_area();
     narrow.handle_middle_pane_transition();

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -58,7 +58,7 @@ export const user_list_style_values = {
 export const default_view_values = {
     recent_topics: {
         code: "recent_topics",
-        description: $t({defaultMessage: "Recent topics"}),
+        description: $t({defaultMessage: "Recent conversations"}),
     },
     all_messages: {
         code: "all_messages",

--- a/static/templates/bookend.hbs
+++ b/static/templates/bookend.hbs
@@ -2,7 +2,7 @@
 <div class="{{#if is_trailing_bookend}}trailing_bookend {{/if}}bookend sub-unsub-message">
     {{#if is_spectator}}
         <span class="recent-topics-link">
-            <a href="#recent_topics">{{t "Browse recent topics" }}</a>
+            <a href="#recent_topics">{{t "Browse recent conversations" }}</a>
         </span>
     {{else}}
         <span class="stream-status">

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -256,11 +256,11 @@
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
                     <tr>
-                        <th colspan="2">{{t 'Recent topics' }}</th>
+                        <th colspan="2">{{t 'Recent conversations' }}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'View recent topics' }}</td>
+                    <td class="definition">{{t 'View recent conversations' }}</td>
                     <td><span class="hotkey"><kbd>T</kbd></span></td>
                 </tr>
                 <tr>

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -13,13 +13,13 @@
                 </a>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_recent_topics top_left_row" title="{{t 'Recent topics' }} (t)">
+            <li class="top_left_recent_topics top_left_row" title="{{t 'Recent conversations' }} (t)">
                 <a href="#recent_topics">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span>{{t 'Recent topics' }}</span>
+                    <span>{{t 'Recent conversations' }}</span>
                 </a>
             </li>
             <li class="top_left_private_messages hidden-for-spectators">

--- a/templates/corporate/case-studies/asciidoctor-case-study.md
+++ b/templates/corporate/case-studies/asciidoctor-case-study.md
@@ -67,10 +67,10 @@ discourse was gone,” Dan says.
 
 With Zulip, Dan has developed a comfortable workflow for catching up on
 conversations after being away. “When I start my day, I open up the [Recent
-topics](/help/recent-topics) page and work through the topics that have activity
-on-by-one,” Dan describes. More casual community participants can [skim the
-topic list](/help/reading-strategies) to find interesting discussions, and mark
-topics they don’t care about as read with a single click.
+topics](/help/recent-conversations) page and work through the topics that have
+activity on-by-one,” Dan describes. More casual community participants can [skim
+the topic list](/help/reading-strategies) to find interesting discussions, and
+mark topics they don’t care about as read with a single click.
 
 
 ## Powerful moderation tools help keep conversations on track

--- a/templates/corporate/case-studies/lean-case-study.md
+++ b/templates/corporate/case-studies/lean-case-study.md
@@ -103,7 +103,7 @@ It just worked.”
 Zulip’s unique combination of [topic-based
 organization](/why-zulip/) with a casual chat app feel helps
 the Lean community create a welcoming environment for newcomers. By [browsing
-recent topics](/help/recent-topics), newcomers can see what’s
+recent conversations](/help/recent-conversations), newcomers can see what’s
 being discussed without being overwhelmed. They can start a new topic to ask
 basic questions without worrying about interrupting other conversations. Zulip’s
 threading model makes managing conversations incredibly efficient, allowing more

--- a/templates/corporate/case-studies/recurse-center-case-study.md
+++ b/templates/corporate/case-studies/recurse-center-case-study.md
@@ -81,9 +81,9 @@ different levels of engagement. Current RC members can immerse themselves in the
 ongoing discussions, occasionally muting topics they don’t want to follow. RC
 leaders monitor the community asynchronously, reviewing the ongoing
 conversations a few times a day and jumping in as needed. Finally, alumni can
-drop by on occasion to skim [recent
-topics](https://zulip.com/help/recent-topics), catch up on their friends’ update
-threads, or search the discussion history for a topic of interest.
+drop by on occasion to skim [recent conversations](/help/recent-conversations),
+catch up on their friends’ update threads, or search the discussion history for
+a topic of interest.
 
 “Our community is 10 years old and spans continents,” RC’s Head of Retreat
 Rachel Petacat says. “Zulip provides the continuity that lets us maintain our
@@ -170,9 +170,9 @@ doesn’t see a message in some channel on that day, they’ll *never* see it.�
 
 Without dedicating a lot of time, John is able to stay involved in the community
 on Zulip, and share his expertise where relevant. “I scan [recent
-topics](https://zulip.com/help/recent-topics) for places where I could help, and
-rely on email notifications for private messages,” John explains. The experience
-of keeping up on Zulip is in sharp contrast with Slack, which John uses at work:
+topics](/help/recent-conversations) for places where I could help, and rely on
+email notifications for private messages,” John explains. The experience of
+keeping up on Zulip is in sharp contrast with Slack, which John uses at work:
 “It’s so hard to keep up with the Slack firehose.”
 
 > “Zulip allows people who are engaging with the community at different paces to connect.”

--- a/templates/corporate/development-community.md
+++ b/templates/corporate/development-community.md
@@ -213,7 +213,7 @@ difficult and rarely a useful goal. To make the best use of your time,
 we highly recommend that you unsubscribe from streams that you aren’t
 interested in, mute streams that are only of occasional interest, and
 make use of [Zulip’s skimming features](/help/reading-strategies),
-like Recent Topics, to spend your time on conversations that interest
+like Recent conversations, to spend your time on topics that interest
 you.
 
 ## Searching for past conversations

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -85,7 +85,7 @@
                     <li>
                         <div class="list-content">
                             Find active conversations, or see what happened while you were away,
-                            with the <a href="/help/recent-topics">Recent Topics</a>
+                            with the <a href="/help/recent-conversations">Recent conversations</a>
                             view. Read the topics you care about, and skip the rest.
                         </div>
                     </li>

--- a/templates/corporate/for/research.html
+++ b/templates/corporate/for/research.html
@@ -68,7 +68,7 @@
                     <li>
                         <div class="list-content">
                             Find active conversations, or see what happened while you were away,
-                            with the <a href="/help/recent-topics">Recent Topics</a> view.
+                            with the <a href="/help/recent-conversations">Recent conversations</a> view.
                         </div>
                     </li>
                     <li>

--- a/templates/zerver/help/configure-default-new-user-settings.md
+++ b/templates/zerver/help/configure-default-new-user-settings.md
@@ -16,7 +16,8 @@ preference settings, including the following:
     * [Displaying availability to other users](/help/status-and-availability)
     * [Allowing others to see when the user has read messages](/help/read-receipts)
 * Display settings, including:
-    * Default view ([Recent topics](/help/recent-topics) vs. [All messages](/help/reading-strategies#all-messages))
+    * Default view ([Recent conversations](/help/recent-conversations) vs.
+      [All messages](/help/reading-strategies#all-messages))
     * [Light theme vs. dark theme](/help/dark-theme)
     * [Emoji theme](/help/emoji-and-emoticons#change-your-emoji-set)
 * Notification settings, including:

--- a/templates/zerver/help/configure-default-view.md
+++ b/templates/zerver/help/configure-default-view.md
@@ -5,7 +5,7 @@ to the Zulip web app. You can also navigate to the default view via
 keyboard shortcuts.
 
 The default views available in Zulip are
-[Recent topics](/help/recent-topics) and
+[Recent conversations](/help/recent-conversations) and
 [All messages](/help/reading-strategies#all-messages). See
 [Reading strategies](/help/reading-strategies) for recommendations
 on how to use these views.
@@ -19,9 +19,9 @@ shortcut.
 
 Organization administrators can [set the default view for their
 organization](/help/configure-default-new-user-settings) to
-[**Recent topics**](/help/recent-topics) or
+[**Recent conversations**](/help/recent-conversations) or
 [**All messages**](/help/reading-strategies#all-messages).
-**Recent topics** is especially recommended for high-traffic
+**Recent conversations** is especially recommended for high-traffic
 organizations, and is configured by default.
 
 You can customize your personal default view regardless of
@@ -67,5 +67,5 @@ shortcut.
 ## Related articles
 
 * [Reading strategies](/help/reading-strategies)
-* [Recent topics](/help/recent-topics)
+* [Recent conversations](/help/recent-conversations)
 * [Keyboard shortcuts](/help/keyboard-shortcuts)

--- a/templates/zerver/help/finding-a-topic-to-read.md
+++ b/templates/zerver/help/finding-a-topic-to-read.md
@@ -2,9 +2,9 @@
 
 Like your email inbox, Zulip works best if you read it topic-by-topic.
 
-## From Recent topics
+## From Recent conversations
 
-{!recent-topics.md!}
+{!recent-conversations.md!}
 
 ## From the list of streams
 

--- a/templates/zerver/help/getting-started-with-zulip.md
+++ b/templates/zerver/help/getting-started-with-zulip.md
@@ -22,9 +22,9 @@ Like your email inbox, Zulip works best if you read it topic-by-topic.
 
 ### Finding a topic to read
 
-#### From Recent topics
+#### From Recent conversations
 
-{!recent-topics.md!}
+{!recent-conversations.md!}
 
 #### From the list of streams
 

--- a/templates/zerver/help/include/reading-topics.md
+++ b/templates/zerver/help/include/reading-topics.md
@@ -1,8 +1,8 @@
 {start_tabs}
 
-{tab|via-recent-topics}
+{tab|via-recent-conversations}
 
-1. Open **Recent topics** from the left sidebar or by pressing the
+1. Open **Recent conversations** from the left sidebar or by pressing the
    <kbd>Esc</kbd> key.
 
 1. Click on the name of a topic in the **Topic** column.
@@ -16,7 +16,7 @@
 
 1. You can then click on another topic in the left sidebar, use the
    <kbd>N</kbd> key to go to the next unread topic, or go back to the
-   **Recent topics** view.
+   **Recent conversations** view.
 
 {tab|via-left-sidebar}
 

--- a/templates/zerver/help/include/recent-conversations.md
+++ b/templates/zerver/help/include/recent-conversations.md
@@ -1,10 +1,10 @@
-Use the **Recent topics** view to get an overview of all the ongoing
+Use the **Recent conversations** view to get an overview of all the ongoing
 conversations. This view is particularly useful for catching up on
 messages sent while you were away.
 
 {start_tabs}
 
-1. Open **Recent topics** from the left sidebar or by pressing the
+1. Open **Recent conversations** from the left sidebar or by pressing the
    <kbd>Esc</kbd> key.
 
 1. The filters at the top help you quickly find relevant conversations.

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -77,7 +77,7 @@
 
 ## Reading messages
 * [Reading strategies](/help/reading-strategies)
-* [Recent topics](/help/recent-topics)
+* [Recent conversations](/help/recent-conversations)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)
 * [Emoji reactions](/help/emoji-reactions)

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -161,16 +161,16 @@ below, and add more to your repertoire as needed.
   don't show up in any views (including All messages), and don't contribute
   to unread counts. Read more about [muting topics](/help/mute-a-topic).
 
-## Recent topics
+## Recent conversations
 
-* **View recent topics**: <kbd>T</kbd>
+* **View recent conversations**: <kbd>T</kbd>
 
-* **Search recent topics**: <kbd>T</kbd>
+* **Search recent conversations**: <kbd>T</kbd>
 
-* **Escape from recent topics search**: <kbd>Esc</kbd> or arrow keys
+* **Escape from recent conversations search**: <kbd>Esc</kbd> or arrow keys
 
-* **Navigate recent topics**: Use arrow keys or vim keys (<kbd>J</kbd>,
-  <kbd>K</kbd>, <kbd>L</kbd>, <kbd>H</kbd>).
+* **Navigate recent conversations**: Use arrow keys or vim keys
+  (<kbd>J</kbd>, <kbd>K</kbd>, <kbd>L</kbd>, <kbd>H</kbd>).
 
 Use <kbd>Enter</kbd> to engage with elements.
 

--- a/templates/zerver/help/mute-a-topic.md
+++ b/templates/zerver/help/mute-a-topic.md
@@ -1,7 +1,7 @@
 # Mute a topic
 
 Messages from muted topics do not show up in either **All messages**
-or **Recent topics**, nor do they generate notifications (including
+or **Recent conversations**, nor do they generate notifications (including
 [alert word](/help/pm-mention-alert-notifications#alert-words)
 notifications), unless you are [mentioned](/help/mention-a-user-or-group).
 They also do not contribute to stream unread counts.

--- a/templates/zerver/help/mute-a-user.md
+++ b/templates/zerver/help/mute-a-user.md
@@ -34,8 +34,8 @@ have the following effects:
   for all messages. Zulip never shares whether or not you have read
   a message with a user you've muted.
 
-* Recent topics and other features that display avatars will show a
-  generic user symbol in place of a muted user's profile picture.
+* **Recent conversations** and other features that display avatars will
+  show a generic user symbol in place of a muted user's profile picture.
 
 * To avoid interfering with administration tasks, stream and
   organization settings display muted users' names and other details.

--- a/templates/zerver/help/reading-strategies.md
+++ b/templates/zerver/help/reading-strategies.md
@@ -15,9 +15,9 @@ topic-by-topic.
 
 ### Finding a topic to read
 
-#### From Recent topics
+#### From Recent conversations
 
-{!recent-topics.md!}
+{!recent-conversations.md!}
 
 #### From the list of streams
 
@@ -62,7 +62,7 @@ like to reply to later.
 ## Related articles
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)
-* [Recent topics](/help/recent-topics)
+* [Recent conversations](/help/recent-conversations)
 * [Searching for messages](/help/search-for-messages)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)

--- a/templates/zerver/help/recent-conversations.md
+++ b/templates/zerver/help/recent-conversations.md
@@ -1,6 +1,6 @@
-# Recent topics
+# Recent conversations
 
-{!recent-topics.md!}
+{!recent-conversations.md!}
 
 !!! keyboard_tip ""
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -69,7 +69,7 @@ TAB_SECTION_LABELS = {
     "custom-proxy-settings": "Custom proxy settings",
     "stream": "From a stream view",
     "not-stream": "From other views",
-    "via-recent-topics": "Via recent topics",
+    "via-recent-conversations": "Via recent conversations",
     "via-left-sidebar": "Via left sidebar",
     "instructions-for-all-platforms": "Instructions for all platforms",
     "public-streams": "Public streams",

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -154,7 +154,7 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
                 )
                 + "\n\n",
                 _(
-                    "Check out [Recent topics](#recent_topics) to see what's happening! "
+                    "Check out [Recent conversations](#recent_topics) to see what's happening! "
                     'You can return to this conversation by clicking "Private messages" in the upper left.'
                 ),
             ]

--- a/zerver/lib/url_redirects.py
+++ b/zerver/lib/url_redirects.py
@@ -21,6 +21,7 @@ POLICY_DOCUMENTATION_REDIRECTS: List[URLRedirect] = [
 
 HELP_DOCUMENTATION_REDIRECTS: List[URLRedirect] = [
     # Add URL redirects for help center documentation here:
+    URLRedirect("/help/recent-topics", "/help/recent-conversations"),
     URLRedirect(
         "/help/add-custom-profile-fields",
         "/help/custom-profile-fields",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8516,7 +8516,7 @@ paths:
           in: query
           description: |
             Whether to use the [maximum available screen width](/help/enable-full-width-display)
-            for the web app's center panel (message feed, recent topics) on wide screens.
+            for the web app's center panel (message feed, recent conversations) on wide screens.
           schema:
             type: boolean
           example: true
@@ -8586,7 +8586,7 @@ paths:
             The [default view](/help/configure-default-view) used when opening a new
             Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-            - "recent_topics" - Recent topics view
+            - "recent_topics" - Recent conversations view
             - "all_messages" - All messages view
           schema:
             type: string
@@ -10544,7 +10544,7 @@ paths:
                             type: boolean
                             description: |
                               Whether to use the [maximum available screen width](/help/enable-full-width-display)
-                              for the web app's center panel (message feed, recent topics) on wide screens.
+                              for the web app's center panel (message feed, recent conversations) on wide screens.
                           high_contrast_mode:
                             type: boolean
                             description: |
@@ -10594,7 +10594,7 @@ paths:
                               The [default view](/help/configure-default-view) used when opening a new
                               Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-                              - "recent_topics" - Recent topics view
+                              - "recent_topics" - Recent conversations view
                               - "all_messages" - All messages view
                           escape_navigates_to_default_view:
                             type: boolean
@@ -12468,7 +12468,7 @@ paths:
                             type: boolean
                             description: |
                               Whether to use the [maximum available screen width](/help/enable-full-width-display)
-                              for the web app's center panel (message feed, recent topics) on wide screens.
+                              for the web app's center panel (message feed, recent conversations) on wide screens.
                           high_contrast_mode:
                             type: boolean
                             description: |
@@ -12518,7 +12518,7 @@ paths:
                               The [default view](/help/configure-default-view) used when opening a new
                               Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-                              - "recent_topics" - Recent topics view
+                              - "recent_topics" - Recent conversations view
                               - "all_messages" - All messages view
                           escape_navigates_to_default_view:
                             type: boolean
@@ -13399,7 +13399,7 @@ paths:
           in: query
           description: |
             Whether to use the [maximum available screen width](/help/enable-full-width-display)
-            for the web app's center panel (message feed, recent topics) on wide screens.
+            for the web app's center panel (message feed, recent conversations) on wide screens.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
             the `PATCH /settings/display` endpoint.
@@ -13500,7 +13500,7 @@ paths:
             The [default view](/help/configure-default-view) used when opening a new
             Zulip web app window or hitting the `Esc` keyboard shortcut repeatedly.
 
-            - "recent_topics" - Recent topics view
+            - "recent_topics" - Recent conversations view
             - "all_messages" - All messages view
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -98,7 +98,7 @@ class TutorialTests(ZulipTestCase):
             expected_response = (
                 "In Zulip, topics [tell you what a message is about](/help/streams-and-topics). "
                 "They are light-weight subjects, very similar to the subject line of an email.\n\n"
-                "Check out [Recent topics](#recent_topics) to see what's happening! "
+                "Check out [Recent conversations](#recent_topics) to see what's happening! "
                 'You can return to this conversation by clicking "Private messages" in the upper left.'
             )
             self.assertEqual(most_recent_message(user).content, expected_response)


### PR DESCRIPTION
Replaces instances of "recent topics" in the web-app and documentation to be "recent conversations". Also, renames both `recent-topics.md` files in the help center to be `recent-conversations.md` and updates/redirects links to new URL.

Part of #23132. 

Did various checks/audits via `git-grep` for versions of "recent topics" (with space, dash, underscore) and lines that end with "recent". Obviously with these changes, there are still many instances of "recent topics" in the codebase, but I'm pretty confident that I've gotten the user facing strings and information that will be impacted by the rename of the "Recent topics" view to "Recent conversations".

**Notes**:
- Added a 2nd commit (that can be dropped or squashed) that updates `/docs/overview/changelog.md` for the rename change. Also, made past references in the changelog to consistently be `"Recent topics"`. 
- Does not update instances of "recent topics" in frontend code comments.
- Does not change case study text where "recent topics" was referenced in a quote (see Recurse center and Asciidoctor case studies), but does change generic text references to be "recent conversations".
  - In the Recurse Center case study, I made links to `https://zulip.com/help/recent-topics` into relative links for the updated page (`/help/recent-conversations`).
- Updates to the URL hash in the app (`#recent_topics`) will be done in a separate commit to close the issue above.

---

**Screenshots and screen captures:**

<details>
<summary>Web-app updates</summary>

![Screenshot from 2022-10-21 12-40-24](https://user-images.githubusercontent.com/63245456/197189336-2cfeaa96-98d4-401c-9255-2301b776825a.png)
![Screenshot from 2022-10-21 12-40-36](https://user-images.githubusercontent.com/63245456/197189341-84cea73d-1615-4589-a9f1-ffe9675e88fc.png)
![Screenshot from 2022-10-21 12-41-36](https://user-images.githubusercontent.com/63245456/197189342-94b9cf0c-998b-415b-8dd4-bb79771ce86c.png)
![Screenshot from 2022-10-21 12-42-23](https://user-images.githubusercontent.com/63245456/197189346-91b9bcb2-68c2-4886-bd52-570833fce940.png)
![Screenshot from 2022-10-21 12-52-34](https://user-images.githubusercontent.com/63245456/197189444-eb88dcc8-cd31-4248-9b86-fa77388f93e5.png)
![Screenshot from 2022-10-21 13-00-48](https://user-images.githubusercontent.com/63245456/197189633-482c239d-1d0d-4327-b81d-bb82d2b31fd7.png)
</details>

<details>
<summary>Landing page update example</summary>

![Screenshot from 2022-10-21 12-51-49](https://user-images.githubusercontent.com/63245456/197189396-f6b12185-7c2f-4a8c-806a-d95d255bbfd5.png)

</details>

<details>
<summary>Help center updates</summary>

![Screenshot from 2022-10-21 12-52-07](https://user-images.githubusercontent.com/63245456/197189659-9ac3b496-2b97-4226-a8ea-2f907278e00c.png)
![Screenshot from 2022-10-21 12-53-32](https://user-images.githubusercontent.com/63245456/197189878-49f8a454-dae7-4f05-839c-53f1e4d9416f.png)
![Screenshot from 2022-10-21 12-54-01](https://user-images.githubusercontent.com/63245456/197189880-f425d5ad-b149-4832-baf5-0d7a23483907.png)
![Screenshot from 2022-10-21 12-54-40](https://user-images.githubusercontent.com/63245456/197189882-337cb6d3-a85a-458f-9f23-f38ea5023370.png)
![Screenshot from 2022-10-21 12-54-50](https://user-images.githubusercontent.com/63245456/197189887-cc0a9e8c-1deb-4235-ac56-2e803542b146.png)
![Screenshot from 2022-10-21 12-56-38](https://user-images.githubusercontent.com/63245456/197189890-9aaed4fd-4981-4967-947c-6264044dcfe9.png)
![Screenshot from 2022-10-21 12-57-09](https://user-images.githubusercontent.com/63245456/197189895-d0f8020e-3f25-481f-b68e-1108b5252445.png)
![Screenshot from 2022-10-21 12-58-08](https://user-images.githubusercontent.com/63245456/197189899-7a8cb64a-5657-4d2e-85d9-198508aac652.png)
![Screenshot from 2022-10-21 12-58-40](https://user-images.githubusercontent.com/63245456/197189902-51f67023-afcc-40dd-9ece-4361a42196b0.png)
![Screenshot from 2022-10-21 12-58-57](https://user-images.githubusercontent.com/63245456/197189905-f76b8207-3dd5-4d11-9b30-0181e0ab7854.png)
</details>

<details>
<summary>API documentation examples</summary>

![Screenshot from 2022-10-21 14-01-53](https://user-images.githubusercontent.com/63245456/197191806-87c59a4f-1de4-4e15-afef-85841044f57a.png)
![Screenshot from 2022-10-21 14-02-15](https://user-images.githubusercontent.com/63245456/197191810-cab15fb0-77a2-47a1-ac0a-b751478a63b9.png)
![Screenshot from 2022-10-21 14-03-42](https://user-images.githubusercontent.com/63245456/197191811-a1fae0bf-01fd-4c88-a6fd-091d16d289b4.png)
![Screenshot from 2022-10-21 14-04-11](https://user-images.githubusercontent.com/63245456/197191815-db536711-f965-4462-9078-52511bc070a6.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
