### PR TITLE
help: Add "View messages sent by user" page.

### DIFF
--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -83,6 +83,7 @@
 * [Emoji reactions](/help/emoji-reactions)
 * [Star a message](/help/star-a-message)
 * [View and browse images](/help/view-and-browse-images)
+* [View messages sent by a user](/help/view-messages-sent-by-a-user)
 * [Link to a message or conversation](/help/link-to-a-message-or-conversation)
 * [Advanced search](/help/search-for-messages)
 * [View message Markdown source](/help/view-the-markdown-source-of-a-message)

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -30,7 +30,7 @@ Here is the **full list of search operators**.
 * `is:private`: Search all your private messages.
 * `pm-with:ada@zulip.com`: Search 1-on-1 private messages between you and Ada.
 * `sender:ada@zulip.com`: Search messages sent by Ada.
-* `sender:me`: Search sent messages.
+* `sender:me`: [Search messages you've sent](/help/view-messages-sent-by-a-user#view-messages-youve-sent).
 * `near:12345`: Show messages around the message with ID `12345`.
 * `id:12345`: Show only message `12345`.
 * `streams:public`: Search the history of all [public

--- a/templates/zerver/help/view-messages-sent-by-a-user.md
+++ b/templates/zerver/help/view-messages-sent-by-a-user.md
@@ -1,0 +1,45 @@
+# View messages sent by a user
+
+Zulip offers a convenient feature to search all messages sent by any user
+including yourself.
+
+## View messages sent by a user
+
+{start_tabs}
+
+{!right-sidebar-profile-menu.md!}
+
+1. Select **View messages sent** to view all messages sent by this user.
+
+{end_tabs}
+
+## View messages you've sent
+
+{start_tabs}
+
+{!self-user-actions-menu.md!}
+
+1. Select **View messages sent** to view all the messages you've sent.
+
+!!! tip ""
+
+    You can also search your messages by typing `sender:me` in the
+    search bar at the top of the app and pressing <kbd>Enter</kbd>.
+
+{end_tabs}
+
+
+## View private messages with yourself
+
+{start_tabs}
+
+{!self-user-actions-menu.md!}
+
+1. Select **View messages with yourself** to view messages you sent to
+   yourself.
+
+{end_tabs}
+
+## Related articles
+
+* [Searching for messages](/help/search-for-messages)


### PR DESCRIPTION
Some options in the profile menu are not documented in the help center.

Documents "View messages sent".
Documents "View messages with yourself".
Links `sender:me` search operator in [Searching for messages](https://zulip.com/help/search-for-messages) to the relevant section on this page.

Fixes: #23203.

**Screenshots and screen captures:**
<img width="857" alt="image" src="https://user-images.githubusercontent.com/2343554/197309029-c2fecfc6-ab29-4225-9f65-9235c493a412.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links
</details>