### PR TITLE
bots: Change logic for Notification bot after moved message

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -813,7 +813,7 @@ def do_update_message(
 
     send_event(user_profile.realm, event, users_to_be_notified)
 
-    sent_resolve_topic_notification = None
+    resolved_topic_message_id = None
     if topic_name is not None and content is None and len(changed_messages) > 0:
         # When stream is changed and topic is marked as resolved or unresolved
         # in the same API request, resolved or unresolved notification should
@@ -824,7 +824,7 @@ def do_update_message(
             stream_to_send_resolve_topic_notification = new_stream
 
         assert stream_to_send_resolve_topic_notification is not None
-        sent_resolve_topic_notification = maybe_send_resolve_topic_notifications(
+        resolved_topic_message_id = maybe_send_resolve_topic_notifications(
             user_profile=user_profile,
             stream=stream_to_send_resolve_topic_notification,
             old_topic=orig_topic_name,
@@ -867,25 +867,57 @@ def do_update_message(
         new_thread_notification_string = None
         if send_notification_to_new_thread and (
             new_stream is not None
-            or not sent_resolve_topic_notification
+            or not resolved_topic_message_id
             or (
                 pre_truncation_topic_name is not None
                 and orig_topic_name.lstrip(RESOLVED_TOPIC_PREFIX)
                 != pre_truncation_topic_name.lstrip(RESOLVED_TOPIC_PREFIX)
             )
         ):
-            if moved_all_visible_messages:
+            stream_for_new_topic = new_stream if new_stream is not None else stream_being_edited
+            assert stream_for_new_topic.recipient_id is not None
+
+            new_topic = topic_name if topic_name is not None else orig_topic_name
+
+            changed_message_ids = [changed_message.id for changed_message in changed_messages]
+
+            # We calculate whether the user moved the entire topic
+            # using that user's own permissions, which is important to
+            # avoid leaking information about whether there are
+            # messages in the destination topic's deeper history that
+            # the acting user does not have permission to access.
+            #
+            # TODO: These queries are quite inefficient, in that we're
+            # fetching full copies of all the messages in the
+            # destination topic to answer the question of whether the
+            # current user has access to at least one such message.
+            #
+            # The main strength of the current implementation is that
+            # it reuses existing logic, which is good for keeping it
+            # correct as we maintain the codebase.
+            preexisting_topic_messages = messages_for_topic(
+                stream_for_new_topic.recipient_id, new_topic
+            ).exclude(id__in=[*changed_message_ids, resolved_topic_message_id])
+
+            visible_preexisting_messages = bulk_access_messages(
+                user_profile, preexisting_topic_messages, stream=stream_for_new_topic
+            )
+
+            no_visible_preexisting_messages = len(visible_preexisting_messages) == 0
+
+            if no_visible_preexisting_messages and moved_all_visible_messages:
                 new_thread_notification_string = gettext_lazy(
                     "This topic was moved here from {old_location} by {user}."
                 )
-            elif changed_messages_count == 1:
-                new_thread_notification_string = gettext_lazy(
-                    "A message was moved here from {old_location} by {user}."
-                )
             else:
-                new_thread_notification_string = gettext_lazy(
-                    "{changed_messages_count} messages were moved here from {old_location} by {user}."
-                )
+                if changed_messages_count == 1:
+                    new_thread_notification_string = gettext_lazy(
+                        "A message was moved here from {old_location} by {user}."
+                    )
+                else:
+                    new_thread_notification_string = gettext_lazy(
+                        "{changed_messages_count} messages were moved here from {old_location} by {user}."
+                    )
 
         send_message_moved_breadcrumbs(
             user_profile,


### PR DESCRIPTION
Previously, when a user moves a message to another topic, the Notification bot will post a message saying "This topic was moved here from..." This is confusing when the topic already contains messages. The changes aims to make the messages more clear by changing the logic for the Notification bot. When there is already messages in the topic, the bot will post "A message was moved here from..." or "N messages were moved here from...". The bot will post "This topic was moved here from (somewhere) by (someone)." when the topic is empty.

Fixes #23267

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/62449508/210453950-ce9331bb-b84d-49be-9f97-04e0a7635736.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
