### PR TITLE
unread_ui: Reduce unnecessary calls to `update_unread_counts`.

### DIFF
--- a/frontend_tests/node_tests/example5.js
+++ b/frontend_tests/node_tests/example5.js
@@ -26,7 +26,6 @@ const message_util = mock_esm("../../static/js/message_util");
 const notifications = mock_esm("../../static/js/notifications");
 const pm_list = mock_esm("../../static/js/pm_list");
 const recent_topics_data = mock_esm("../../static/js/recent_topics_data");
-const resize = mock_esm("../../static/js/resize");
 const stream_list = mock_esm("../../static/js/stream_list");
 const unread_ops = mock_esm("../../static/js/unread_ops");
 const unread_ui = mock_esm("../../static/js/unread_ui");
@@ -94,7 +93,6 @@ run_test("insert_message", ({override}) => {
     helper.redirect(message_util, "add_new_messages");
     helper.redirect(notifications, "received_messages");
     helper.redirect(recent_topics_data, "process_message");
-    helper.redirect(resize, "resize_page_components");
     helper.redirect(stream_list, "update_streams_sidebar");
     helper.redirect(unread_ops, "process_visible");
     helper.redirect(unread_ui, "update_unread_counts");
@@ -112,7 +110,6 @@ run_test("insert_message", ({override}) => {
         [message_util, "add_new_messages_data"],
         [message_util, "add_new_messages"],
         [unread_ui, "update_unread_counts"],
-        [resize, "resize_page_components"],
         [unread_ops, "process_visible"],
         [notifications, "received_messages"],
         [stream_list, "update_streams_sidebar"],

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -7,6 +7,7 @@ const _ = require("lodash");
 const {mock_esm, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
+const {page_params} = require("../zjsunit/zpage_params");
 
 set_global("document", "document-stub");
 
@@ -267,6 +268,9 @@ run_test("initialize", () => {
     reset_lists();
 
     let home_loaded = false;
+    page_params.unread_msgs = {
+        old_unreads_missing: false,
+    };
 
     function home_view_loaded() {
         home_loaded = true;
@@ -351,6 +355,9 @@ run_test("loading_newer", () => {
 
     (function test_narrow() {
         const msg_list = simulate_narrow();
+        page_params.unread_msgs = {
+            old_unreads_missing: true,
+        };
 
         const data = {
             req: {

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -11,21 +11,14 @@ const $ = require("../zjsunit/zjquery");
 const noop = () => {};
 
 const color_data = mock_esm("../../static/js/color_data");
-const message_util = mock_esm("../../static/js/message_util");
 const stream_color = mock_esm("../../static/js/stream_color");
 const stream_list = mock_esm("../../static/js/stream_list");
 const stream_muting = mock_esm("../../static/js/stream_muting");
 const stream_settings_ui = mock_esm("../../static/js/stream_settings_ui", {
     update_settings_for_subscribed: noop,
 });
+const unread_ui = mock_esm("../../static/js/unread_ui");
 
-mock_esm("../../static/js/all_messages_data", {
-    all_messages_data: {
-        all_messages() {
-            return ["msg"];
-        },
-    },
-});
 const message_lists = mock_esm("../../static/js/message_lists", {
     current: {},
 });
@@ -278,16 +271,14 @@ test("marked_subscribed (normal)", ({override}) => {
 
     narrow_to_frontend();
 
-    let args;
     let list_updated = false;
 
     const stream_list_stub = make_stub();
     const message_view_header_stub = make_stub();
-    const message_util_stub = make_stub();
 
     override(stream_list, "add_sidebar_row", stream_list_stub.f);
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
-    override(message_util, "do_unread_count_updates", message_util_stub.f);
+    override(unread_ui, "update_unread_counts", noop);
     override(
         message_view_header,
         "maybe_rerender_title_area_for_stream",
@@ -299,10 +290,7 @@ test("marked_subscribed (normal)", ({override}) => {
 
     stream_events.mark_subscribed(sub, [], "blue");
 
-    args = message_util_stub.get_args("messages");
-    assert.deepEqual(args.messages, ["msg"]);
-
-    args = stream_list_stub.get_args("sub");
+    const args = stream_list_stub.get_args("sub");
     assert.equal(args.sub.stream_id, sub.stream_id);
     assert.equal(message_view_header_stub.num_calls, 1);
 
@@ -313,9 +301,9 @@ test("marked_subscribed (normal)", ({override}) => {
 });
 
 test("marked_subscribed (color)", ({override}) => {
-    override(message_util, "do_unread_count_updates", noop);
     override(stream_list, "add_sidebar_row", noop);
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
+    override(unread_ui, "update_unread_counts", noop);
 
     const sub = {
         subscribed: false,
@@ -349,9 +337,9 @@ test("marked_subscribed (emails)", ({override}) => {
 
     // Test assigning subscriber emails
     // narrow state is undefined
-    override(message_util, "do_unread_count_updates", noop);
     override(stream_list, "add_sidebar_row", noop);
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
+    override(unread_ui, "update_unread_counts", noop);
 
     const subs_stub = make_stub();
     override(stream_settings_ui, "update_settings_for_subscribed", subs_stub.f);
@@ -378,6 +366,7 @@ test("mark_unsubscribed (update_settings_for_unsubscribed)", ({override}) => {
     override(stream_settings_ui, "update_settings_for_unsubscribed", stub.f);
     override(stream_list, "remove_sidebar_row", noop);
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
+    override(unread_ui, "update_unread_counts", noop);
 
     stream_events.mark_unsubscribed(sub);
     const args = stub.get_args("sub");
@@ -400,6 +389,7 @@ test("mark_unsubscribed (render_title_area)", ({override}) => {
     override(message_lists.current, "update_trailing_bookend", noop);
     override(stream_list, "remove_sidebar_row", noop);
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
+    override(unread_ui, "update_unread_counts", noop);
 
     stream_events.mark_unsubscribed(sub);
 

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -514,7 +514,7 @@ test("mentions", () => {
     };
 
     const muted_direct_mention_message = {
-        id: 17,
+        id: 18,
         type: "stream",
         stream_id: muted_stream_id,
         topic: "lunch",
@@ -542,6 +542,7 @@ test("mentions", () => {
         mention_me_message.id,
         mention_all_message.id,
         muted_mention_all_message.id,
+        muted_direct_mention_message.id,
     ]);
     test_notifiable_count(counts.home_unread_messages, 3);
 

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -24,7 +24,6 @@ import {page_params} from "./page_params";
 import * as pm_list from "./pm_list";
 import * as recent_senders from "./recent_senders";
 import * as recent_topics_ui from "./recent_topics_ui";
-import * as resize from "./resize";
 import * as stream_list from "./stream_list";
 import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
@@ -156,7 +155,6 @@ export function insert_new_messages(messages, sent_by_this_client) {
     if (any_untracked_unread_messages) {
         unread_ui.update_unread_counts();
     }
-    resize.resize_page_components();
 
     unread_ops.process_visible();
     notifications.received_messages(messages);

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -116,7 +116,7 @@ function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) 
 export function insert_new_messages(messages, sent_by_this_client) {
     messages = messages.map((message) => message_helper.process_new_message(message));
 
-    unread.process_loaded_messages(messages);
+    const any_untracked_unread_messages = unread.process_loaded_messages(messages, false);
     huddle_data.process_loaded_messages(messages);
 
     // all_messages_data is the data that we use to populate
@@ -153,7 +153,9 @@ export function insert_new_messages(messages, sent_by_this_client) {
         notifications.notify_local_mixes(messages, need_user_to_scroll);
     }
 
-    unread_ui.update_unread_counts();
+    if (any_untracked_unread_messages) {
+        unread_ui.update_unread_counts();
+    }
     resize.resize_page_components();
 
     unread_ops.process_visible();

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -49,16 +49,9 @@ function process_result(data, opts) {
 
     messages = messages.map((message) => message_helper.process_new_message(message));
 
-    // In case any of the newly fetched messages are new, add them to
-    // our unread data structures.  It's important that this run even
-    // when fetching in a narrow, since we might return unread
-    // messages that aren't in the home view data set (e.g. on a muted
-    // stream).
-    //
-    // BUG: This code path calls pm_list.update_private_messages, even
-    // if there were no private messages (or even no new messages at
-    // all) in data.messages, which is a waste of resources.
-    message_util.do_unread_count_updates(messages);
+    // In some rare situations, we expect to discover new unread
+    // messages not tracked in unread.js during this fetching process.
+    message_util.do_unread_count_updates(messages, true);
 
     // If we're loading more messages into the home view, save them to
     // the all_messages_data as well, as the message_lists.home is

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -7,10 +7,15 @@ import * as resize from "./resize";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
 
-export function do_unread_count_updates(messages) {
-    unread.process_loaded_messages(messages);
-    unread_ui.update_unread_counts();
-    resize.resize_page_components();
+export function do_unread_count_updates(messages, expect_no_new_unreads = false) {
+    const any_new_unreads = unread.process_loaded_messages(messages, expect_no_new_unreads);
+
+    if (any_new_unreads) {
+        // The following operations are expensive, and thus should
+        // only happen if we found any unread messages justifying it.
+        unread_ui.update_unread_counts();
+        resize.resize_page_components();
+    }
 }
 
 export function add_messages(messages, msg_list, opts) {

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -3,7 +3,6 @@ import $ from "jquery";
 import {all_messages_data} from "./all_messages_data";
 import * as loading from "./loading";
 import * as message_store from "./message_store";
-import * as resize from "./resize";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
 
@@ -14,7 +13,6 @@ export function do_unread_count_updates(messages, expect_no_new_unreads = false)
         // The following operations are expensive, and thus should
         // only happen if we found any unread messages justifying it.
         unread_ui.update_unread_counts();
-        resize.resize_page_components();
     }
 }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -814,11 +814,6 @@ export function show_userlist_sidebar() {
     resize.resize_page_components();
 }
 
-export function show_pm_list_sidebar() {
-    $(".app-main .column-left").addClass("expanded");
-    resize.resize_page_components();
-}
-
 let current_user_sidebar_user_id;
 let current_user_sidebar_popover;
 

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -1,10 +1,8 @@
 import $ from "jquery";
 
-import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import * as color_data from "./color_data";
 import * as message_lists from "./message_lists";
-import * as message_util from "./message_util";
 import * as message_view_header from "./message_view_header";
 import * as narrow_state from "./narrow_state";
 import * as overlays from "./overlays";
@@ -17,6 +15,7 @@ import * as stream_list from "./stream_list";
 import * as stream_muting from "./stream_muting";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
+import * as unread_ui from "./unread_ui";
 
 // In theory, this function should apply the account-level defaults,
 // however, they are only called after a manual override, so
@@ -140,9 +139,9 @@ export function mark_subscribed(sub, subscribers, color) {
         message_lists.current.update_trailing_bookend();
     }
 
-    // Update unread counts as the new stream in sidebar might
-    // need its unread counts re-calculated
-    message_util.do_unread_count_updates(all_messages_data.all_messages());
+    // The new stream in sidebar might need its unread counts
+    // re-calculated.
+    unread_ui.update_unread_counts();
 
     stream_list.add_sidebar_row(sub);
     stream_list.update_subscribe_to_more_streams_link();
@@ -167,6 +166,10 @@ export function mark_unsubscribed(sub) {
     if (narrow_state.is_for_stream_id(sub.stream_id)) {
         message_lists.current.update_trailing_bookend();
     }
+
+    // Unread messages in the now-unsubscribe stream need to be
+    // removed from global count totals.
+    unread_ui.update_unread_counts();
 
     stream_list.remove_sidebar_row(sub.stream_id);
     stream_list.update_subscribe_to_more_streams_link();

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -8,6 +8,7 @@ import * as overlays from "./overlays";
 import * as settings_notifications from "./settings_notifications";
 import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
+import * as unread_ui from "./unread_ui";
 
 export function update_is_muted(sub, value) {
     sub.is_muted = value;
@@ -54,9 +55,9 @@ export function update_is_muted(sub, value) {
         navigate.plan_scroll_to_selected();
         message_scroll.suppress_selection_update_on_next_scroll();
 
-        if (!message_lists.home.empty()) {
-            message_util.do_unread_count_updates(message_lists.home.all_messages());
-        }
+        // Since muted streams aren't counted in visible unread
+        // counts, we need to update the rendering of them.
+        unread_ui.update_unread_counts();
     }, 0);
 
     settings_notifications.update_muted_stream_state(sub);

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -25,7 +25,6 @@ import * as message_edit from "./message_edit";
 import * as muted_topics_ui from "./muted_topics_ui";
 import {page_params} from "./page_params";
 import * as popovers from "./popovers";
-import * as resize from "./resize";
 import * as settings_data from "./settings_data";
 import * as starred_messages from "./starred_messages";
 import * as starred_messages_ui from "./starred_messages_ui";
@@ -167,12 +166,8 @@ export function hide_drafts_popover() {
     }
 }
 
-// These are the only two functions that is really shared by the
-// two popovers, so we could split out topic stuff to
-// another module pretty easily.
 export function show_streamlist_sidebar() {
     $(".app-main .column-left").addClass("expanded");
-    resize.resize_page_components();
 }
 
 export function hide_streamlist_sidebar() {


### PR DESCRIPTION
Possibly fixes #23142

Calling `unread_ui.update_unread_counts` is expensive, and so we should limit the calls to it when necessary.

We limit calling `do_unread_count_updates` from `message_fetch` since we already have full unread messages data of the user via the `/register` call, and we don't need to update the UI for messages that we are just forward filling. If we receive any new unread messages, they are handled by `message_events.insert_new_messages` which call
`unread_ui.update_unread_counts` directly. This change does not impact stream or topic being muted, for them to be updated for unread count.