### PR TITLE
recent-topics: Update hash for view to be "#recent".

### DIFF
--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -205,6 +205,19 @@ run_test("hash_interactions", ({override}) => {
         [floating_recipient_bar, "update"],
     ]);
 
+    // Test old "#recent_topics" hash redirects to "#recent".
+    recent_topics_ui_shown = false;
+    window.location.hash = "#recent_topics";
+
+    helper.clear_events();
+    $window_stub.trigger("hashchange");
+    assert.equal(recent_topics_ui_shown, true);
+    helper.assert_events([
+        [overlays, "close_for_hash_change"],
+        [message_viewport, "stop_auto_scrolling"],
+    ]);
+    assert.equal(window.location.hash, "#recent");
+
     window.location.hash = "#narrow/stream/Denmark";
 
     helper.clear_events();

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -272,8 +272,13 @@ export function is_spectator_compatible(hash) {
     // This implementation should agree with the similar function in zerver/lib/narrow.py.
     const web_public_allowed_hashes = [
         "",
-        "narrow", // full #narrow hash handled in narrow.is_spectator_compatible
+        // full #narrow hash handled in narrow.is_spectator_compatible
+        "narrow",
+        // TODO/compatibility: #recent_topics was renamed to #recent
+        // in 2022. We should support the old URL fragment at least
+        // until one cannot directly upgrade from Zulip 5.x.
         "recent_topics",
+        "recent",
         "keyboard-shortcuts",
         "message-formatting",
         "search-operators",

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -181,6 +181,17 @@ function do_hashchange_normal(from_reload) {
             show_default_view();
             break;
         case "#recent_topics":
+            // The URL for Recent Conversations was changed from
+            // #recent_topics to #recent in 2022. Because pre-change
+            // Welcome Bot messages included links to this URL, we
+            // need to support the "#recent_topics" hash as an alias
+            // for #recent permanently. We show the view and then
+            // replace the current URL hash in a way designed to hide
+            // this detail in the browser's forward/back session history.
+            recent_topics_ui.show();
+            window.location.replace("#recent");
+            break;
+        case "#recent":
             recent_topics_ui.show();
             break;
         case "#all_messages":

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -819,7 +819,7 @@ export function process_hotkey(e, hotkey) {
             narrow.narrow_to_next_pm_string();
             return true;
         case "open_recent_topics":
-            browser_history.go_to_location("#recent_topics");
+            browser_history.go_to_location("#recent");
             return true;
         case "all_messages":
             browser_history.go_to_location("#all_messages");

--- a/static/templates/bookend.hbs
+++ b/static/templates/bookend.hbs
@@ -2,7 +2,7 @@
 <div class="{{#if is_trailing_bookend}}trailing_bookend {{/if}}bookend sub-unsub-message">
     {{#if is_spectator}}
         <span class="recent-topics-link">
-            <a href="#recent_topics">{{t "Browse recent conversations" }}</a>
+            <a href="#recent">{{t "Browse recent conversations" }}</a>
         </span>
     {{else}}
         <span class="stream-status">

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -14,7 +14,7 @@
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_recent_topics top_left_row" title="{{t 'Recent conversations' }} (t)">
-                <a href="#recent_topics">
+                <a href="#recent">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -154,7 +154,7 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
                 )
                 + "\n\n",
                 _(
-                    "Check out [Recent conversations](#recent_topics) to see what's happening! "
+                    "Check out [Recent conversations](#recent) to see what's happening! "
                     'You can return to this conversation by clicking "Private messages" in the upper left.'
                 ),
             ]

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -98,7 +98,7 @@ class TutorialTests(ZulipTestCase):
             expected_response = (
                 "In Zulip, topics [tell you what a message is about](/help/streams-and-topics). "
                 "They are light-weight subjects, very similar to the subject line of an email.\n\n"
-                "Check out [Recent conversations](#recent_topics) to see what's happening! "
+                "Check out [Recent conversations](#recent) to see what's happening! "
                 'You can return to this conversation by clicking "Private messages" in the upper left.'
             )
             self.assertEqual(most_recent_message(user).content, expected_response)


### PR DESCRIPTION
Updates the hash used for the recent conversations view to be `"#recent"` instead of `"#recent_topics"`.

The old hash has a legacy implementation ~~with comments for it to be removed once servers cannot be directly updated from Zulip 5.x to the current version~~. This will need to be in place for old Welcome Bot messages in the future.

Fixes #23132. 

---

**Notes & Questions**:
- I added `window.location.replace("#recent")` in the `do_hashchange_normal` logic for `"#recent_topics"` to update the URL. This means the back/forward navigation is not broken by the redirect. Is there another way to update/rewrite the URL after the reload that would be better? And would it be worth it to add a node test for this, maybe in the "hash_interactions" test? 
- Because the hash changes a link in the potential messages from `Welcome Bot`is this really a temporary change? Or will we need some sort of redirect logic to always exist?
- I don't think we need to update the string saved on the server side for the default view because the default view hash is `"#"` or `""`. So I'm planning on doing that update/change in a separate PR.

---

**Screenshots and screen captures:**

<details>
<summary>Screenshot of new hash in URL</summary>

![Screenshot from 2022-10-24 14-31-06](https://user-images.githubusercontent.com/63245456/197536982-0b67260d-b916-4187-9d88-4471d91781c2.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
