### PR TITLE
drop: Message_sent_when_you_were_not_subscribed from three dot menu.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -606,7 +606,6 @@ export function toggle_actions_popover(element, id) {
 
         const args = {
             message_id: message.id,
-            historical: message.historical,
             stream_id: message.stream_id,
             editability_menu_item,
             move_message_menu_item,

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -131,8 +131,4 @@
             <i class="fa fa-link" aria-hidden="true"></i> {{t "Copy link to message" }}
         </a>
     </li>
-
-    {{#if historical}}
-    <li class="small">({{t "Message sent when you were not subscribed" }})</li>
-    {{/if}}
 </ul>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Drop message "(Message sent when you were not subscribed)" in the three-dot message menu.
Fixes: #23198 

**Screenshots and screen captures:**
![2022-10-25 09 53 54 user-images githubusercontent com db49a8533e3b](https://user-images.githubusercontent.com/66828942/197682218-1862d424-40a6-41f0-a664-2dce61afcdd9.jpg)


**Changes made:**

- Removed `historical` from `static/templates/actions_popover_content.hbs`.
- Removed `historical` from args in `static/js/popovers.js`.