### PR TITLE
css: fixed search message alert

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -194,10 +194,13 @@ p.n-margin {
 .all-messages-search-caution {
     border-radius: 4px;
     display: none;
-    height: 28px;
     font-size: 16px;
     margin: 0 auto 12px;
     padding: 5px;
+    /* Difference should be 16px to accommodate the icon. */
+    /* This emulates hanging indent. */
+    padding-left: 26px;
+    text-indent: -10px;
 
     i {
         margin: 0 3px 0 1px;


### PR DESCRIPTION
- Fixed the border to let it grow when the text is wrapped
- Used inline-flex property to align elements inside.

As a default, the jQuery function .show() gives the div display: block.

But we need it to be inline-flex if we're not to create another div just to align the elements inside.
There are several ways of doing this, so if it's not apropriate, let me know. I tried to avoid using .css() in the JS file to alter the styling. 

If the solution adopted (changing the display to inline-flex in the CSS file) is not ideal, let me know and I can just add a buffer div between the parent div and its elements just to align them as usual.

I apologized for the duplicate PR but the previous one had a long commit history that I couldn't squash due to merge conflicts with a file I didn't know. For safety, I decided to revert to a previous commit and push a clean history. (Now I learned I can create PR drafts =) ) 

Fixes: [<!-- Issue link, or clear description.-->](https://github.com/zulip/zulip/issues/23273)

**Screenshots and screen captures:**
Before:
![image](https://user-images.githubusercontent.com/15349795/197750852-a5a98895-9aaa-4d30-9e4e-d29e5a13cffc.png)

After:
![Opera Instantâneo_2022-10-25_072145_demo-elih1848 zulipdev com](https://user-images.githubusercontent.com/15349795/197750996-8634a7ee-7c19-40af-a5f3-ef5b94ca544d.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
