### PR TITLE
compose-box: Remove reset max-height calculation for preview click.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -758,11 +758,6 @@ test_ui("on_events", ({override, override_rewire}) => {
     })();
 
     (function test_markdown_preview_compose_clicked() {
-        let reset_compose_message_max_height_called = false;
-        override(resize, "reset_compose_message_max_height", () => {
-            reset_compose_message_max_height_called = true;
-        });
-
         // Tests setup
         function setup_visibilities() {
             $("#compose-textarea").show();
@@ -847,7 +842,6 @@ test_ui("on_events", ({override, override_rewire}) => {
 
         assert.equal($("#compose .preview_content").html(), "translated HTML: Nothing to preview");
         assert_visibilities();
-        assert.ok(reset_compose_message_max_height_called);
 
         let make_indicator_called = false;
         $("#compose-textarea").val("```foobarfoobar```");

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -696,7 +696,6 @@ export function initialize() {
             $("#compose .preview_content"),
             content,
         );
-        resize.reset_compose_message_max_height();
     });
 
     $("#compose").on("click", ".undo_markdown_preview", (e) => {

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -172,17 +172,24 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
         bottom_whitespace_height = h.bottom_whitespace_height;
     }
 
-    const $visible_textarea = $("#compose-textarea, #preview_message_area");
-    const compose_height = Number.parseInt($("#compose").outerHeight(), 10);
-    const compose_textarea_height = Number.parseInt($visible_textarea.outerHeight(), 10);
+    const compose_height = $("#compose").get(0).getBoundingClientRect().height;
+    const compose_textarea_height = Math.max(
+        $("#compose-textarea").get(0).getBoundingClientRect().height,
+        $("#preview_message_area").get(0).getBoundingClientRect().height,
+    );
     const compose_non_textarea_height = compose_height - compose_textarea_height;
 
-    // The `preview_message_area` can have a slightly different height
-    // than `compose-textarea` based on operating system. We just
-    // ensure that the last message is not overlapped by compose box.
-    $visible_textarea.css(
+    // We ensure that the last message is not overlapped by compose box.
+    $("#compose-textarea").css(
         "max-height",
-        // The 10 here leaves space for the selected message border.
+        // Because <textarea> max-height includes padding, we subtract
+        // 10 for the padding and 10 for the selected message border.
+        bottom_whitespace_height - compose_non_textarea_height - 20,
+    );
+    $("#preview_message_area").css(
+        "max-height",
+        // Because <div> max-height doesn't include padding, we only
+        // subtract 10 for the selected message border.
         bottom_whitespace_height - compose_non_textarea_height - 10,
     );
 }


### PR DESCRIPTION
Removes call to `reset_compose_message_max_height` when clicking on the markdown preview button, which due to the `#compose` div element momentarily shrinking to be empty of any text/preview content, caused the calculation of the max-height to grow larger on each subsequent click.

Also refactors `reset_compose_message_max_height` to use the height from `getBoundingClientRect`, which defaults to zero when empty.

And fixes a small discrepancy in how max-height is applied to a `<div>` element vs a `<textarea>` element, so that the visible height doesn't change between the preview and write modes in the compose box.

Fixes #23277.

---

**Notes**:
- There is still a moment when the compose box flickers to be empty when going from write to preview mode. But this no longer impacts the calculation/resetting of the max-height.
- To make the code more resistant to this error coming up again, we could check that `compose_height` is larger than `compose_textarea_height` before calculating the non-text area height available. I wasn't sure what we would want to default to if that we to happen...
```js
    let compose_non_textarea_height = 0;
    if (compose_height < compose_textarea_height) {
        // failed assertion
        compose_non_textarea_height = compose_height - ???;
    } else {
        compose_non_textarea_height = compose_height - compose_textarea_height;
    }
```

---

**Screenshots and screen captures:**

<details>
<summary>Message draft with image example - current bug</summary>

![Peek 2022-10-25 19-06](https://user-images.githubusercontent.com/63245456/197839569-9036117f-8435-4aed-907c-76d46a791b65.gif)
</details>

<details>
<summary>Message draft with image example - after update</summary>

![Peek 2022-10-25 19-04](https://user-images.githubusercontent.com/63245456/197839548-8d5d3c1c-073a-49fb-879b-d6972af41fbf.gif)
</details>



---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
