### PR TITLE
Update "Choosing between Zulip Cloud and self-hosting" and "Logging in" help pages

### DIFF
--- a/templates/zerver/help/change-your-password.md
+++ b/templates/zerver/help/change-your-password.md
@@ -6,19 +6,7 @@ account.
 
 ### If you've forgotten or never had a password
 
-{start_tabs}
-
-1. Log out.
-
-1. Go to your organization's login page.
-
-2. Below the **Password** field, click **Forgot password**.
-
-3. Enter your email address, and click **Send reset link**.
-
-4. You will receive a confirmation email within a few minutes. Open it and click **Reset password**.
-
-{end_tabs}
+{!change-password-via-email-confirmation.md!}
 
 ### If you know your current password
 

--- a/templates/zerver/help/include/advantages-of-self-hosting-zulip.md
+++ b/templates/zerver/help/include/advantages-of-self-hosting-zulip.md
@@ -17,6 +17,8 @@
 * Customize Zulip for all your needs. It's easy to develop and maintain [custom
   integrations](/api/incoming-webhooks-overview) and [features][modify-zulip].
 
+Learn more about [self-hosting Zulip](https://zulip.com/self-hosting/).
+
 [zulip-github]: https://github.com/zulip/zulip#readme
 [install-zulip]: https://zulip.readthedocs.io/en/latest/production/install.html
 [back-up-zulip]: https://zulip.readthedocs.io/en/stable/production/export-and-import.html#backups

--- a/templates/zerver/help/include/advantages-of-zulip-cloud.md
+++ b/templates/zerver/help/include/advantages-of-zulip-cloud.md
@@ -1,6 +1,6 @@
 * Simple managed solution, with no setup or maintenance
-  overhead. [Sign up](/new/) with just a few clicks.
+  overhead. [Sign up](https://zulip.com/new/) with just a few clicks.
 * Always updated to the latest version of Zulip.
-* Anyone can [start with Zulip Cloud Free](/new/). [Free or heavily
+* Anyone can [start with Zulip Cloud Free](https://zulip.com/new/). [Free or heavily
   discounted Zulip Cloud Standard](https://zulip.com/plans/) pricing is available for
   most non-business uses.

--- a/templates/zerver/help/include/change-password-via-email-confirmation.md
+++ b/templates/zerver/help/include/change-password-via-email-confirmation.md
@@ -1,0 +1,15 @@
+{start_tabs}
+
+1. If you are logged in, start by [logging out](/help/logging-out).
+
+2. Go to your organization's log in page at `https://<organization-url>/login/`.
+
+3. Click the **Forgot your password?** link below the **Log in** button or
+   buttons.
+
+4. Enter your email address, and click **Send reset link**.
+
+5. You will receive a confirmation email within a few minutes. Open it and click
+   **Reset password**.
+
+{end_tabs}

--- a/templates/zerver/help/include/switching-between-organizations.md
+++ b/templates/zerver/help/include/switching-between-organizations.md
@@ -1,0 +1,24 @@
+{start_tabs}
+
+{tab|web}
+
+You can log in to multiple Zulip organizations by opening multiple tabs, and
+logging into one Zulip organization in each tab. To switch Zulip organizations,
+just switch tabs.
+
+{tab|desktop}
+
+1. Click on a logo in the **organizations sidebar** on the left, or choose
+an organization from the **Window** menu in the top menu bar.
+
+{!desktop-toggle-sidebar-tip.md!}
+
+{tab|mobile}
+
+{!mobile-profile-menu.md!}
+
+1. Tap **Switch account**.
+
+1. Tap on the desired Zulip organization.
+
+{end_tabs}

--- a/templates/zerver/help/logging-in.md
+++ b/templates/zerver/help/logging-in.md
@@ -9,11 +9,59 @@ Organization administrators can
 including the SAML and LDAP integrations, or disable any of the methods above.
 
 You can log in with any method allowed by your organization, regardless of
-how you signed up. E.g. if you originally signed up using your Google
+how you signed up. For example, if you originally signed up using your Google
 account, you can later log in using GitHub, as long as your Google account
 and GitHub account use the same email address.
 
-## Log in to a Zulip organization for the first time
+## Find the Zulip log in URL
+
+Here are some ways to find the URL for your Zulip organization.
+
+{start_tabs}
+
+{tab|logged-out}
+
+* If your organization is hosted on [Zulip Cloud](https://zulip.com/plans/), go
+  to the [**Find your accounts**](https://zulip.com/accounts/find/) page and enter
+  the email address that you signed up with. You will receive an email with the
+  sign-in information for any Zulip organization(s) associated with your email
+  address.
+
+* Find an email in your inbox with a subject that contains the phrase: `Zulip:
+  Your new account details`. This email provides your organization's log in URL.
+
+* If you have visited your organization's log in page in the past, try reviewing
+  your browser's history. Searching for `zulipchat.com` should find the right
+  page if your Zulip organization is hosted on [Zulip
+  Cloud](https://zulip.com/plans/).
+
+* You can ask your organization administrators for your Zulip URL.
+
+{tab|logged-in}
+
+* If using Zulip in the browser, your organization's Zulip log in URL is the first part
+  of what you see in the URL bar (e.g., `<organization-name>.zulipchat.com` for
+  [Zulip Cloud](https://zulip.com/plans/) organizations).
+
+* In the Desktop app, select **Copy Zulip URL** from the **Zulip** menu to
+  copy the URL of the currently active organization. You can also access the
+  **Copy Zulip URL** option by right-clicking on an organization logo in the
+  **organizations sidebar** on the left.
+
+* In the Mobile app, tap your **profile picture** in the bottom right corner of
+  the app, then tap **switch account** to see the URLs for all the organizations
+  you are logged in to.
+
+* On [Zulip Cloud](https://zulip.com/plans/) and other Zulip servers updated to
+  [Zulip 6.0 or
+  higher](https://zulip.readthedocs.io/en/latest/overview/changelog.html#zulip-6-x-series),
+  click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper right
+  corner of the web or desktop app. Your organization's log in URL is shown in the top
+  section of the menu.
+
+{end_tabs}
+
+## Log in for the first time
 
 {start_tabs}
 
@@ -54,39 +102,22 @@ from the **Zulip** menu in the top menu bar.
 
 {end_tabs}
 
-For subsequent logins, see [switching between organizations](/help/switching-between-organizations).
+## Switch between organizations
 
-## Troubleshooting
+{!switching-between-organizations.md!}
 
-### I don't know my Zulip URL
+## Set or reset your password
 
-Some ideas:
+If you signed up using passwordless authentication and want to start logging in
+via email/password, you will need to create a password by following the instructions below. You can also reset a
+forgotten password.
 
-* If you know your organization is hosted on
-  [zulip.com](https://zulip.com), go to [find my
-  account](https://zulip.com/accounts/find/) and enter the email
-  address that you signed up with.
-
-* Try guessing the URL. Zulip URLs often look like `<name>.zulipchat.com`,
- `zulip.<name>.com`, or `chat.<name>.com` (replace `<name>` with the name of your
-  organization).
-
-* Ask your organization administrators for your Zulip URL.
-
-### I signed up with Google/GitHub auth and never set a password
-
-If you signed up using passwordless authentication and want to start logging
-in via email/password, you can
-[reset your password](/help/change-your-password).
-
-### I forgot my password
-
-You can [reset your password](/help/change-your-password). This requires
-access to the email address you currently have on file. We recommend
-[keeping your email address up to date](change-your-email-address).
+{!change-password-via-email-confirmation.md!}
 
 ## Related articles
 
 * [Logging out](logging-out)
 * [Switching between organizations](switching-between-organizations)
+* [Change your email address](change-your-email-address)
+* [Change your password](change-your-password)
 * [Deactivate your account](deactivate-your-account)

--- a/templates/zerver/help/switching-between-organizations.md
+++ b/templates/zerver/help/switching-between-organizations.md
@@ -2,30 +2,7 @@
 
 This article assumes you've [logged in](/help/logging-in) to each organization at least once.
 
-{start_tabs}
-
-{tab|web}
-
-You can log in to multiple Zulip organizations by opening multiple tabs, and
-logging into one Zulip organization in each tab. To switch Zulip organizations,
-just switch tabs.
-
-{tab|desktop}
-
-1. Click on a logo in the **organizations sidebar** on the left, or choose
-an organization from the **Window** menu in the top menu bar.
-
-{!desktop-toggle-sidebar-tip.md!}
-
-{tab|mobile}
-
-{!mobile-profile-menu.md!}
-
-1. Tap **Switch account**.
-
-1. Tap on the desired Zulip organization.
-
-{end_tabs}
+{!switching-between-organizations.md!}
 
 ## Related articles
 

--- a/templates/zerver/help/zulip-cloud-or-self-hosting.md
+++ b/templates/zerver/help/zulip-cloud-or-self-hosting.md
@@ -1,8 +1,8 @@
 # Choosing between Zulip Cloud and self-hosting
 
-Whether [signing up for Zulip Cloud](/new/) or [self-hosting
-Zulip][install-self-hosted] is the right choice for you depends on the
-needs of your organization.
+Whether [signing up for Zulip Cloud](https://zulip.com/new/) or [self-hosting
+Zulip](https://zulip.com/self-hosting) is the right choice for you depends on
+the needs of your organization.
 
 If you aren’t sure what you need, our high quality export and import
 tools ([cloud][export-cloud], [self-hosted][export-self-hosted])
@@ -18,13 +18,12 @@ ensure you can always move from our hosting to yours (and back).
 
 ## Related resources
 
-* [Sign up for Zulip Cloud](/new/)
-* [Self-hosting Zulip](/self-hosting/)
+* [Sign up for Zulip Cloud](https://zulip.com/new/)
+* [Self-hosting Zulip](https://zulip.com/self-hosting/)
 * [Trying out Zulip](/help/trying-out-zulip)
 * [Setting up your organization](/help/getting-your-organization-started-with-zulip)
 * [Migrating from other chat tools](/help/migrating-from-other-chat-tools)
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 
-[install-self-hosted]: https://zulip.readthedocs.io/en/stable/production/install.html
 [export-cloud]: /help/export-your-organization
 [export-self-hosted]: https://zulip.readthedocs.io/en/latest/production/export-and-import.html

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -86,6 +86,8 @@ TAB_SECTION_LABELS = {
     "onelogin": "OneLogin",
     "azuread": "AzureAD",
     "keycloak": "Keycloak",
+    "logged-in": "If you are logged in",
+    "logged-out": "If you are logged out",
 }
 
 


### PR DESCRIPTION
The first commit changes URLs on the "Choosing between Zulip Cloud and self-hosting" page to be non-relative when pointing to the Zulip landing page or `/new` for creating a new Zulip Cloud organization.

The second commit reorganizes and extend the "Logging in" help page.
    
I also moved some instructions from related pages into shared /include files, with minor tweaks, as part of updating this page. The non-trivial change made was that the instruction block for resetting your password while logged out was updated to include the URL for the log in page, because the current instructions don't quite work for organizations that have enabled web-public streams.

Links were manually tested.

Current "Logging in" page: https://zulip.com/help/logging-in

<details>
<summary>
Whole-page screenshot
</summary>

![Screen Shot 2022-10-25 at 8 55 35 AM](https://user-images.githubusercontent.com/2090066/197828661-e1bbe34c-4b6b-46ba-80d1-8a4839fcd974.png)

</details>

<details>
<summary>
URL instructions (logged out)
</summary>

![Screen Shot 2022-10-25 at 8 55 56 AM](https://user-images.githubusercontent.com/2090066/197828770-5dfa6294-dc9e-4a27-a58a-5a0a8f3188a1.png)

</details>

<details>
<summary>
URL instructions (logged in)
</summary>

![Screen Shot 2022-10-25 at 8 56 02 AM](https://user-images.githubusercontent.com/2090066/197828798-5840f0f1-8507-4c82-bf0e-d3df005cf2b4.png)

</details>

<details>
<summary>
Password instructions
</summary>

![Screen Shot 2022-10-25 at 8 56 14 AM](https://user-images.githubusercontent.com/2090066/197828884-13e6e088-cc73-48bc-a75c-3d42851f666b.png)


</details>