### PR TITLE
slack: Skip files where file_access: file_not_found.

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1034,7 +1034,7 @@ def process_message_files(
             # that are hidden because of 10k cap in free plan.
             continue
 
-        if fileinfo.get("file_access", "") == "access_denied":
+        if fileinfo.get("file_access", "") in ["access_denied", "file_not_found"]:
             # Slack sometimes includes file stubs for files it declares
             # inaccessible and does not further reference.
             continue


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: Slack exports can include a file reference stub that is inaccessible, with `file_access: file_not_found`. This change will skip them instead of faulting.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
