### PR TITLE
filter: Show stream and topic title for near link narrows.

### DIFF
--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -662,7 +662,10 @@ export class Filter {
     get_title() {
         // Nice explanatory titles for common views.
         const term_types = this.sorted_term_types();
-        if (term_types.length === 2 && _.isEqual(term_types, ["stream", "topic"])) {
+        if (
+            (term_types.length === 3 && _.isEqual(term_types, ["stream", "topic", "near"])) ||
+            (term_types.length === 2 && _.isEqual(term_types, ["stream", "topic"]))
+        ) {
             if (!this._sub) {
                 const search_text = this.operands("stream")[0];
                 return $t({defaultMessage: "Unknown stream #{search_text}"}, {search_text});


### PR DESCRIPTION
Updates the `filter.get_title` logic to return the stream name for narrows that include the stream, topic and near operators. That way the browser/tab title remains the same for these views, which have a particular scroll offset.

Note that the addition of any additional narrow/search operators will then return the default "Search results" title.

Follow-up to #23216. See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/browser.20title.20for.20narrow.20search.20views.20.2323216/near/1455524).

---

**Notes**:
- Do we also want this behavior if the operators are stream and near, without the topic? I don't think that there is anyway to get to such a view without inputting that information manually.
- Do we want the message header to be the formatted stream version for this near view? This could be a follow-up to this PR or a conversation in design.

---

**Screenshots and screen captures:**

<details>
<summary>Current behavior - title is "Search results" for near link/view</summary>

![Screenshot from 2022-10-26 18-17-04](https://user-images.githubusercontent.com/63245456/198080333-189659ae-45eb-46af-ac0c-ddf48f0ba5fc.png)
</details>

<details>
<summary>After updates - title is the stream and topic for the near link/view</summary>

![Screenshot from 2022-10-26 18-15-29](https://user-images.githubusercontent.com/63245456/198080353-c6dd44ab-5952-484e-8382-c8b949f0c349.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
