### PR TITLE
recent_topics: Fix long topic and stream words squeezing other rows.

### DIFF
--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -331,10 +331,17 @@
         .recent_topic_stream {
             width: 25%;
             padding: 8px 0 8px 8px;
+            word-break: break-word;
+            hyphens: auto;
         }
 
         .recent_topic_name {
             width: 40%;
+            word-break: break-word;
+            /* No hyphes for word break since it caused hyphens to appear before
+               the ellipsis `longText-...` which is not desirable. Ellipsis appears due
+               to the line clamp applied below.
+            */
 
             .line_clamp {
                 /* This -webkit-box display property is webkit-specific, but


### PR DESCRIPTION
Topics and streams containing long words can cause horizontal overflow and squeeze other columns too much.

<img width="778" alt="Screenshot 2022-10-26 at 9 58 59 PM" src="https://user-images.githubusercontent.com/25124304/198093506-90085060-2405-48c5-b18b-ec99a436614c.png">
