### PR TITLE
Improvements to compose_state getter/setters

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -296,7 +296,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
 
     // Test sending a message with content.
     compose_state.set_message_type("stream");
-    compose_state.stream_name("social");
+    compose_state.set_stream_name("social");
 
     $("#compose-textarea").val("message me");
     $("#compose-textarea").hide();
@@ -390,7 +390,7 @@ test_ui("finish", ({override, override_rewire}) => {
         $("#compose .markdown_preview").hide();
         $("#compose-textarea").val("foobarfoobar");
         compose_state.set_message_type("stream");
-        compose_state.stream_name("social");
+        compose_state.set_stream_name("social");
         override_rewire(people, "get_by_user_id", () => []);
         compose_finished_event_checked = false;
         let schedule_message = false;

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -125,8 +125,8 @@ test("start", ({override, override_rewire}) => {
     assert_visible("#stream-message");
     assert_hidden("#private-message");
 
-    assert.equal($("#stream_message_recipient_stream").val(), "stream1");
-    assert.equal($("#stream_message_recipient_topic").val(), "topic1");
+    assert.equal(compose_state.stream_name(), "stream1");
+    assert.equal(compose_state.topic(), "topic1");
     assert.equal(compose_state.get_message_type(), "stream");
     assert.ok(compose_state.composing());
 
@@ -145,8 +145,8 @@ test("start", ({override, override_rewire}) => {
 
     opts = {};
     start("stream", opts);
-    assert.equal($("#stream_message_recipient_stream").val(), "Denmark");
-    assert.equal($("#stream_message_recipient_topic").val(), "");
+    assert.equal(compose_state.stream_name(), "Denmark");
+    assert.equal(compose_state.topic(), "");
 
     compose_defaults = {
         trigger: "compose_hotkey",
@@ -154,8 +154,8 @@ test("start", ({override, override_rewire}) => {
 
     opts = {};
     start("stream", opts);
-    assert.equal($("#stream_message_recipient_stream").val(), "Denmark");
-    assert.equal($("#stream_message_recipient_topic").val(), "");
+    assert.equal(compose_state.stream_name(), "Denmark");
+    assert.equal(compose_state.topic(), "");
 
     const social = {
         subscribed: true,
@@ -168,8 +168,8 @@ test("start", ({override, override_rewire}) => {
     // More than 1 subscription, do not autofill
     opts = {};
     start("stream", opts);
-    assert.equal($("#stream_message_recipient_stream").val(), "");
-    assert.equal($("#stream_message_recipient_topic").val(), "");
+    assert.equal(compose_state.stream_name(), "");
+    assert.equal(compose_state.topic(), "");
     stream_data.clear_subscriptions();
 
     // Start PM
@@ -261,7 +261,7 @@ test("respond_to_message", ({override, override_rewire}) => {
     opts = {};
 
     respond_to_message(opts);
-    assert.equal($("#stream_message_recipient_stream").val(), "devel");
+    assert.equal(compose_state.stream_name(), "devel");
 });
 
 test("reply_with_mention", ({override, override_rewire}) => {
@@ -288,7 +288,7 @@ test("reply_with_mention", ({override, override_rewire}) => {
     const opts = {};
 
     reply_with_mention(opts);
-    assert.equal($("#stream_message_recipient_stream").val(), "devel");
+    assert.equal(compose_state.stream_name(), "devel");
     assert.equal(syntax_to_insert, "@**Bob Roberts**");
 
     // Test for extended mention syntax
@@ -306,7 +306,7 @@ test("reply_with_mention", ({override, override_rewire}) => {
     people.add_active_user(bob_2);
 
     reply_with_mention(opts);
-    assert.equal($("#stream_message_recipient_stream").val(), "devel");
+    assert.equal(compose_state.stream_name(), "devel");
     assert.equal(syntax_to_insert, "@**Bob Roberts|40**");
 });
 

--- a/frontend_tests/node_tests/compose_state.js
+++ b/frontend_tests/node_tests/compose_state.js
@@ -30,14 +30,14 @@ run_test("has_full_recipient", ({override}) => {
     override(compose_pm_pill, "get_emails", () => emails);
 
     compose_state.set_message_type("stream");
-    compose_state.stream_name("");
+    compose_state.set_stream_name("");
     compose_state.topic("");
     assert.equal(compose_state.has_full_recipient(), false);
 
     compose_state.topic("foo");
     assert.equal(compose_state.has_full_recipient(), false);
 
-    compose_state.stream_name("bar");
+    compose_state.set_stream_name("bar");
     assert.equal(compose_state.has_full_recipient(), true);
 
     compose_state.set_message_type("private");

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -230,14 +230,14 @@ test_ui("validate", ({override, mock_template}) => {
     assert.ok(compose_validate.validate());
 
     compose_state.set_message_type("stream");
-    compose_state.stream_name("");
+    compose_state.set_stream_name("");
     assert.ok(!compose_validate.validate());
     assert.equal(
         $("#compose-error-msg").html(),
         $t_html({defaultMessage: "Please specify a stream"}),
     );
 
-    compose_state.stream_name("Denmark");
+    compose_state.set_stream_name("Denmark");
     page_params.realm_mandatory_topics = true;
     compose_state.topic("");
     assert.ok(!compose_validate.validate());
@@ -339,7 +339,7 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
         subscribed: true,
     };
     stream_data.add_sub(sub);
-    compose_state.stream_name("social");
+    compose_state.set_stream_name("social");
     assert.ok(compose_validate.validate());
     assert.ok(!$("#compose-all-everyone").visible());
     assert.ok(!$("#compose-send-status").visible());
@@ -389,7 +389,7 @@ test_ui("test_validate_stream_message_post_policy_admin_only", () => {
     };
 
     compose_state.topic("topic102");
-    compose_state.stream_name("stream102");
+    compose_state.set_stream_name("stream102");
     stream_data.add_sub(sub);
     assert.ok(!compose_validate.validate());
     assert.equal(
@@ -398,13 +398,13 @@ test_ui("test_validate_stream_message_post_policy_admin_only", () => {
     );
 
     // Reset error message.
-    compose_state.stream_name("social");
+    compose_state.set_stream_name("social");
 
     page_params.is_admin = false;
     page_params.is_guest = true;
 
     compose_state.topic("topic102");
-    compose_state.stream_name("stream102");
+    compose_state.set_stream_name("stream102");
     assert.ok(!compose_validate.validate());
     assert.equal(
         $("#compose-error-msg").html(),
@@ -425,7 +425,7 @@ test_ui("test_validate_stream_message_post_policy_moderators_only", () => {
     };
 
     compose_state.topic("topic104");
-    compose_state.stream_name("stream104");
+    compose_state.set_stream_name("stream104");
     stream_data.add_sub(sub);
     assert.ok(!compose_validate.validate());
     assert.equal(
@@ -436,7 +436,7 @@ test_ui("test_validate_stream_message_post_policy_moderators_only", () => {
     );
 
     // Reset error message.
-    compose_state.stream_name("social");
+    compose_state.set_stream_name("social");
 
     page_params.is_guest = true;
     assert.equal(
@@ -458,7 +458,7 @@ test_ui("test_validate_stream_message_post_policy_full_members_only", () => {
     };
 
     compose_state.topic("topic103");
-    compose_state.stream_name("stream103");
+    compose_state.set_stream_name("stream103");
     stream_data.add_sub(sub);
     assert.ok(!compose_validate.validate());
     assert.equal(
@@ -517,7 +517,7 @@ test_ui("test_message_overflow", () => {
     page_params.user_id = 30;
     const message = "a".repeat(10000 + 1);
 
-    compose_state.stream_name("social");
+    compose_state.set_stream_name("social");
     compose_state.topic("priyam");
     $("#compose-textarea").val(message);
 
@@ -665,7 +665,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, override_rewire, moc
     compose_validate.warn_if_mentioning_unsubscribed_user(mentioned);
     assert.equal($("#compose_invite_users").visible(), false);
 
-    compose_state.stream_name("random");
+    compose_state.set_stream_name("random");
     const sub = {
         stream_id: 111,
         name: "random",
@@ -795,7 +795,7 @@ test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
     assert.ok(!$error_area.visible());
 
     compose_state.set_message_type("stream");
-    compose_state.stream_name("Do not exist");
+    compose_state.set_stream_name("Do not exist");
     compose_state.topic(resolved_topic.resolve_name("hello"));
     compose_state.message_content("content");
 
@@ -803,7 +803,7 @@ test_ui("test warn_if_topic_resolved", ({override, mock_template}) => {
     compose_validate.warn_if_topic_resolved(true);
     assert.ok(!$error_area.visible());
 
-    compose_state.stream_name("random");
+    compose_state.set_stream_name("random");
 
     // Show the warning now as stream also exists
     compose_validate.warn_if_topic_resolved(true);

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -161,7 +161,7 @@ test("snapshot_message", ({override_rewire}) => {
     function set_compose_state() {
         compose_state.set_message_type(curr_draft.type);
         compose_state.message_content(curr_draft.content);
-        compose_state.stream_name(curr_draft.stream);
+        compose_state.set_stream_name(curr_draft.stream);
         compose_state.topic(curr_draft.topic);
         compose_state.private_message_recipient(curr_draft.private_message_recipient);
     }

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -602,7 +602,7 @@ run_test("narrow_to_compose_target errors", ({disallow_rewire}) => {
 
     // No-op when empty stream.
     compose_state.set_message_type("stream");
-    compose_state.stream_name("");
+    compose_state.set_stream_name("");
     narrow.to_compose_target();
 });
 
@@ -616,7 +616,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
 
     compose_state.set_message_type("stream");
     stream_data.add_sub({name: "ROME", stream_id: 99});
-    compose_state.stream_name("ROME");
+    compose_state.set_stream_name("ROME");
 
     // Test with existing topic
     compose_state.topic("one");

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -458,8 +458,8 @@ export function initialize() {
     $("#compose-send-status").on("click", ".sub_unsub_button", (event) => {
         event.preventDefault();
 
-        const stream_name = $("#stream_message_recipient_stream").val();
-        if (stream_name === undefined) {
+        const stream_name = compose_state.stream_name();
+        if (stream_name === "") {
             return;
         }
         const sub = stream_data.get_sub(stream_name);

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -262,8 +262,8 @@ export function update_placeholder_text() {
 
     const opts = {
         message_type: compose_state.get_message_type(),
-        stream: $("#stream_message_recipient_stream").val(),
-        topic: $("#stream_message_recipient_topic").val(),
+        stream: compose_state.stream_name(),
+        topic: compose_state.topic(),
         private_message_recipient: compose_pm_pill.get_emails(),
     };
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -323,7 +323,7 @@ export function start(msg_type, opts) {
     //
     // TODO: Move these into a conditional on message_type, using an
     // explicit "clear" function for compose_state.
-    compose_state.stream_name(opts.stream);
+    compose_state.set_stream_name(opts.stream);
     compose_state.topic(opts.topic);
 
     // Set the recipients with a space after each comma, so it looks nice.

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -27,8 +27,8 @@ export function set_focused_recipient(msg_type) {
     };
 
     if (focused_recipient.type === "stream") {
-        const stream_name = $("#stream_message_recipient_stream").val();
-        focused_recipient.topic = $("#stream_message_recipient_topic").val();
+        const stream_name = compose_state.stream_name();
+        focused_recipient.topic = compose_state.topic();
         focused_recipient.stream = stream_name;
         const sub = stream_data.get_sub(stream_name);
         if (sub) {

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -36,9 +36,18 @@ function get_or_set(fieldname, keep_leading_whitespace) {
     };
 }
 
-// TODO: Break out setters and getter into their own functions.
-export const stream_name = get_or_set("stream_message_recipient_stream");
+export function stream_name() {
+    return $("#stream_message_recipient_stream").val().trim();
+}
 
+export function set_stream_name(newval) {
+    if (newval !== undefined) {
+        const $elem = $("#stream_message_recipient_stream");
+        $elem.val(newval);
+    }
+}
+
+// TODO: Break out setter and getter into their own functions.
 export const topic = get_or_set("stream_message_recipient_topic");
 
 // We can't trim leading whitespace in `compose_textarea` because

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -183,7 +183,7 @@ export function update_stream_name(sub, new_name) {
 
     // Update compose_state if needed
     if (compose_state.stream_name() === old_name) {
-        compose_state.stream_name(new_name);
+        compose_state.set_stream_name(new_name);
     }
 
     // Update navbar if needed


### PR DESCRIPTION
This PR does two things:

(1) Breaks out `compose_state.stream_name()` into separate getter and setter function, which had been marked as a TODO.

(2) Replaces any getting of stream name or topic that is a direct call to an HTML element's value. Now we always use  `compose_state.stream_name()` and `compose_state.topic()`. It's easier to understand what this does when reading code, and also makes it easier to change how getting these values works. In an upcoming change, I'll be changing where the stream_name lives in the DOM and this will make that change easier to read.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
