### PR TITLE
unread: Stop accessing page_param.unread_msgs after init.

### DIFF
--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -699,32 +699,34 @@ test("message_unread", () => {
 test("server_counts", () => {
     // note that user_id 30 is "me"
 
-    page_params.unread_msgs = {
-        pms: [
-            {
-                other_user_id: 101,
-                // sender_id is deprecated.
-                sender_id: 101,
-                unread_message_ids: [31, 32, 60, 61, 62, 63],
-            },
-        ],
-        huddles: [
-            {
-                user_ids_string: "4,6,30,101",
-                unread_message_ids: [34, 50],
-            },
-        ],
-        streams: [
-            {
-                stream_id: 1,
-                topic: "test",
-                unread_message_ids: [33, 35, 36],
-            },
-        ],
-        mentions: [31, 34, 40, 41],
+    const unread_params = {
+        unread_msgs: {
+            pms: [
+                {
+                    other_user_id: 101,
+                    // sender_id is deprecated.
+                    sender_id: 101,
+                    unread_message_ids: [31, 32, 60, 61, 62, 63],
+                },
+            ],
+            huddles: [
+                {
+                    user_ids_string: "4,6,30,101",
+                    unread_message_ids: [34, 50],
+                },
+            ],
+            streams: [
+                {
+                    stream_id: 1,
+                    topic: "test",
+                    unread_message_ids: [33, 35, 36],
+                },
+            ],
+            mentions: [31, 34, 40, 41],
+        },
     };
 
-    unread.initialize();
+    unread.initialize(unread_params);
 
     assert.equal(unread.num_unread_for_user_ids_string("101"), 6);
     assert.equal(unread.num_unread_for_user_ids_string("4,6,101"), 2);

--- a/static/js/navbar_alerts.js
+++ b/static/js/navbar_alerts.js
@@ -14,6 +14,7 @@ import * as compose_ui from "./compose_ui";
 import {localstorage} from "./localstorage";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
+import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
@@ -172,7 +173,7 @@ export function initialize() {
             rendered_alert_content_html: render_desktop_notifications_alert_content(),
         });
     } else if (unread_ui.should_display_bankruptcy_banner()) {
-        const unread_msgs_count = page_params.unread_msgs.count;
+        const unread_msgs_count = unread.get_unread_message_count();
         open({
             data_process: "bankruptcy",
             custom_class: "bankruptcy",

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -558,6 +558,8 @@ export function initialize_everything() {
 
     const user_groups_params = pop_fields("realm_user_groups");
 
+    const unread_params = pop_fields("unread_msgs");
+
     const user_status_params = pop_fields("user_status");
     const i18n_params = pop_fields("language_list");
     const user_settings_params = pop_fields("user_settings");
@@ -648,7 +650,7 @@ export function initialize_everything() {
     search_pill_widget.initialize();
     reload.initialize();
     user_groups.initialize(user_groups_params);
-    unread.initialize();
+    unread.initialize(unread_params);
     bot_data.initialize(bot_params); // Must happen after people.initialize()
     message_fetch.initialize(server_events.home_view_loaded);
     message_scroll.initialize();

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -517,6 +517,10 @@ export function get_unread_messages(messages) {
     return messages.filter((message) => unread_messages.has(message.id));
 }
 
+export function get_unread_message_count() {
+    return unread_messages.size;
+}
+
 export function update_unread_topics(msg, event) {
     const new_topic = util.get_edit_event_topic(event);
     const {new_stream_id} = event;

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -793,8 +793,8 @@ export function get_msg_ids_for_starred() {
     return [];
 }
 
-export function initialize() {
-    const unread_msgs = page_params.unread_msgs;
+export function initialize(params) {
+    const unread_msgs = params.unread_msgs;
 
     unread_pm_counter.set_huddles(unread_msgs.huddles);
     unread_pm_counter.set_pms(unread_msgs.pms);

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -100,7 +100,7 @@ export function should_display_bankruptcy_banner() {
 
     const now = Date.now() / 1000;
     if (
-        page_params.unread_msgs.count > 500 &&
+        unread.get_unread_message_count() > 500 &&
         now - page_params.furthest_read_time > 60 * 60 * 24 * 2
     ) {
         // 2 days.


### PR DESCRIPTION
This adds a get_unread_message_count helper that returns the size of
unread_messages and replaces the usage of page_param.unread_msgs.count
elsewhere in the codebase.

Fixes: #23334.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
