### PR TITLE
recent: Fix unread counts wrappings to next line in long topic names.

### DIFF
--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -331,17 +331,23 @@
         .recent_topic_stream {
             width: 25%;
             padding: 8px 0 8px 8px;
-            word-break: break-word;
-            hyphens: auto;
+
+            a {
+                word-break: break-word;
+                hyphens: auto;
+            }
         }
 
         .recent_topic_name {
             width: 40%;
-            word-break: break-word;
-            /* No hyphes for word break since it caused hyphens to appear before
-               the ellipsis `longText-...` which is not desirable. Ellipsis appears due
-               to the line clamp applied below.
-            */
+
+            a {
+                word-break: break-word;
+                /* No hyphes for word break since it caused hyphens to appear before
+                   the ellipsis `longText-...` which is not desirable. Ellipsis appears due
+                   to the line clamp applied below.
+                */
+            }
 
             .line_clamp {
                 /* This -webkit-box display property is webkit-specific, but


### PR DESCRIPTION
We limit the word break to only text present inside the `a` tags so that it doesn't apply to unread count.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20topics.20line-wrapping

This was caused by https://github.com/zulip/zulip/pull/23349

<img width="778" alt="Screenshot 2022-10-27 at 9 29 10 AM" src="https://user-images.githubusercontent.com/25124304/198188212-d60e6cf1-b857-4d8b-8a3f-0ef74200dab8.png">
