### PR TITLE
left_sidebar: Make topics list header sticky.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -615,6 +615,21 @@ body.dark-theme {
         }
     }
 
+    #stream_filters .narrow-filter.active-filter {
+        .topic-list .filter-topics,
+        > .bottom_left_row {
+            background-color: hsl(208, 31%, 24%);
+        }
+    }
+
+    .zoom-in {
+        #topics_header,
+        .narrow-filter > .bottom_left_row,
+        #stream_filters .topic-list .filter-topics {
+            background-color: hsl(212, 28%, 18%);
+        }
+    }
+
     #user_presences li:hover,
     #user_presences li.highlighted_user {
         background-color: hsla(136, 25%, 73%, 0.2);

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -118,6 +118,10 @@ li.show-more-topics {
 
                 &.filter-topics {
                     padding-bottom: 0;
+                    position: sticky;
+                    top: 43px;
+                    z-index: 2;
+                    background-color: hsl(0, 0%, 100%);
                 }
 
                 .input-append.topic_search_section {
@@ -373,6 +377,13 @@ li.active-sub-filter {
     border-radius: 4px;
 }
 
+#stream_filters .narrow-filter.active-filter {
+    .topic-list .filter-topics,
+    > .bottom_left_row {
+        background-color: hsl(202, 56%, 91%);
+    }
+}
+
 #global_filters {
     margin-bottom: $sections_vertical_gutter;
 
@@ -611,6 +622,10 @@ li.topic-list-item {
 }
 
 #topics_header {
+    position: sticky;
+    top: 0;
+    background-color: hsl(0, 0%, 100%);
+    z-index: 2;
     margin-right: 10px;
     color: hsl(0, 0%, 43%);
 
@@ -702,6 +717,14 @@ li.topic-list-item {
 }
 
 .zoom-in {
+    .narrow-filter > .bottom_left_row {
+        position: sticky;
+        top: 20px;
+        z-index: 2;
+        padding-bottom: 1px;
+        background-color: hsl(0, 0%, 100%);
+    }
+
     .show-more-topics {
         display: none;
     }


### PR DESCRIPTION
Fixes #22911

`Back to streams`, stream name and filter topics are all sticky now and their color changes based on which filter is active and the currently applied theme.


<img width="361" alt="Screenshot 2022-10-27 at 5 33 50 PM" src="https://user-images.githubusercontent.com/25124304/198281511-890a6017-680f-43eb-a720-97d7db2211a8.png">
<img width="361" alt="Screenshot 2022-10-27 at 5 33 39 PM" src="https://user-images.githubusercontent.com/25124304/198281520-5c68055c-b36c-4a5a-af76-d88e2ec6edcb.png">
<img width="361" alt="Screenshot 2022-10-27 at 5 44 20 PM" src="https://user-images.githubusercontent.com/25124304/198281492-399b46aa-5760-460e-9f08-186904bd035a.png">
<img width="361" alt="Screenshot 2022-10-27 at 5 44 04 PM" src="https://user-images.githubusercontent.com/25124304/198281505-e5864908-b907-4ec5-a09b-4e37f7313451.png">