### PR TITLE
message_feed: Improve tooltip on edited/moved notice.

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -257,11 +257,16 @@ export class MessageListView {
         if (last_edit_timestamp !== undefined) {
             const last_edit_time = new Date(last_edit_timestamp * 1000);
             const today = new Date();
-            return (
-                timerender.render_date(last_edit_time, undefined, today)[0].textContent +
-                " at " +
-                timerender.stringify_time(last_edit_time)
-            );
+
+            let last_edit_date = timerender.render_date(last_edit_time, undefined, today)[0]
+                .textContent;
+
+            if (last_edit_date === "Today") {
+                last_edit_date = "today";
+            } else if (last_edit_date === "Yesterday") {
+                last_edit_date = "yesterday";
+            }
+            return `${last_edit_date} at ${timerender.stringify_time(last_edit_time)}`;
         }
         return undefined;
     }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import _ from "lodash";
 import tippy, {delegate} from "tippy.js";
 
+import render_message_edit_notice_tooltip from "../templates/message_edit_notice_tooltip.hbs";
 import render_message_inline_image_tooltip from "../templates/message_inline_image_tooltip.hbs";
 import render_narrow_to_compose_recipients_tooltip from "../templates/narrow_to_compose_recipients_tooltip.hbs";
 
@@ -10,6 +11,7 @@ import * as compose_state from "./compose_state";
 import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as narrow_state from "./narrow_state";
+import {page_params} from "./page_params";
 import * as popover_menus from "./popover_menus";
 import * as reactions from "./reactions";
 import * as recent_topics_util from "./recent_topics_util";
@@ -196,6 +198,24 @@ export function initialize() {
             const message = message_lists.current.get(rows.id($row));
             const time = new Date(message.timestamp * 1000);
             instance.setContent(timerender.get_full_datetime(time));
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
+        target: ".message_edit_notice",
+        appendTo: () => document.body,
+        onShow(instance) {
+            const $elem = $(instance.reference);
+
+            const edited_notice_str = $elem.attr("data-tippy-content");
+            const realm_allow_edit_history = page_params.realm_allow_edit_history;
+            const content = parse_html(
+                render_message_edit_notice_tooltip({edited_notice_str, realm_allow_edit_history}),
+            );
+            instance.setContent(content);
         },
         onHidden(instance) {
             instance.destroy();

--- a/static/templates/edited_notice.hbs
+++ b/static/templates/edited_notice.hbs
@@ -1,13 +1,13 @@
 {{#if msg/local_edit_timestamp}}
-<div class="message_edit_notice auto-select" title="{{#tr}}Edited ({last_edit_timestr}){{/tr}}">
+<div class="message_edit_notice auto-select" data-tippy-content="{{#tr}}Last edited {last_edit_timestr}{{/tr}}" aria-label="{{#tr}}Last edited {last_edit_timestr}{{/tr}}">
     {{t "SAVING" }}
 </div>
 {{else if moved}}
-<div class="message_edit_notice auto-select" title="{{#tr}}Moved ({last_edit_timestr}){{/tr}}">
+<div class="message_edit_notice auto-select" data-tippy-content="{{#tr}}Last moved {last_edit_timestr}{{/tr}}" aria-label="{{#tr}}Last moved {last_edit_timestr}{{/tr}}">
     {{t "MOVED" }}
 </div>
 {{else}}
-<div class="message_edit_notice auto-select" title="{{#tr}}Edited ({last_edit_timestr}){{/tr}}">
+<div class="message_edit_notice auto-select" data-tippy-content="{{#tr}}Last edited {last_edit_timestr}{{/tr}}" aria-label="{{#tr}}Last edited {last_edit_timestr}{{/tr}}">
     {{t "EDITED" }}
 </div>
 {{/if}}

--- a/static/templates/message_edit_notice_tooltip.hbs
+++ b/static/templates/message_edit_notice_tooltip.hbs
@@ -1,0 +1,7 @@
+<span>{{edited_notice_str}}</span>
+
+<br/>
+
+{{#if realm_allow_edit_history}}
+    <i> {{t 'Click to view edit history.' }} </i>
+{{/if}}


### PR DESCRIPTION
This PR modifies the default tooltip to a tippy one by removing the title attribute from the element and inserting the string text in aria-label attribute.
It uses the aria-label attribute to get the `last_edit_timestr` for the tooltip which is modified to follow the rules(english).
The tippy tooltip fetches the html content from a new `message_edit_notice_tooltip` template.
It also adds a second line to the tooltip: "Click to view edit history".
Currently on disabling the View edit history feature, the edited/moved notice gets hidden, so the idea of hiding the second line and showing only the first would not work in current scenario.

<!-- Describe your pull request here.-->
Fixes: #23075

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-10-29 11-43-15](https://user-images.githubusercontent.com/77766761/198816871-ee06f281-3392-403f-8c02-da04d9a253fb.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.

