### PR TITLE
filter: Fix browser title for private message narrows with near operators.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1481,6 +1481,15 @@ test("navbar_helpers", () => {
     // not common narrows, but used for browser title updates
     const is_alerted = [{operator: "is", operand: "alerted"}];
     const is_unread = [{operator: "is", operand: "unread"}];
+    const stream_topic_near = [
+        {operator: "stream", operand: "foo"},
+        {operator: "topic", operand: "bar"},
+        {operator: "near", operand: "12"},
+    ];
+    const pm_with_near = [
+        {operator: "pm-with", operand: "joe@example.com"},
+        {operator: "near", operand: "12"},
+    ];
 
     const test_cases = [
         {
@@ -1613,6 +1622,20 @@ test("navbar_helpers", () => {
             is_common_narrow: false,
             icon: undefined,
             title: "translated: Unread messages",
+            redirect_url_with_search: "#",
+        },
+        {
+            operator: stream_topic_near,
+            is_common_narrow: false,
+            icon: "hashtag",
+            title: "Foo",
+            redirect_url_with_search: "#",
+        },
+        {
+            operator: pm_with_near,
+            is_common_narrow: false,
+            icon: "envelope",
+            title: properly_separated_names([joe.full_name]),
             redirect_url_with_search: "#",
         },
     ];

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -664,7 +664,8 @@ export class Filter {
         const term_types = this.sorted_term_types();
         if (
             (term_types.length === 3 && _.isEqual(term_types, ["stream", "topic", "near"])) ||
-            (term_types.length === 2 && _.isEqual(term_types, ["stream", "topic"]))
+            (term_types.length === 2 && _.isEqual(term_types, ["stream", "topic"])) ||
+            (term_types.length === 1 && _.isEqual(term_types, ["stream"]))
         ) {
             if (!this._sub) {
                 const search_text = this.operands("stream")[0];
@@ -697,12 +698,6 @@ export class Filter {
                     return $t({defaultMessage: "All messages including muted streams"});
                 case "streams-public":
                     return $t({defaultMessage: "Messages in all public streams"});
-                case "stream":
-                    if (!this._sub) {
-                        const search_text = this.operands("stream")[0];
-                        return $t({defaultMessage: "Unknown stream #{search_text}"}, {search_text});
-                    }
-                    return this._sub.name;
                 case "is-starred":
                     return $t({defaultMessage: "Starred messages"});
                 case "is-mentioned":

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -672,6 +672,23 @@ export class Filter {
             }
             return this._sub.name;
         }
+        if (
+            (term_types.length === 2 && _.isEqual(term_types, ["pm-with", "near"])) ||
+            (term_types.length === 1 && _.isEqual(term_types, ["pm-with"]))
+        ) {
+            const emails = this.operands("pm-with")[0].split(",");
+            const names = emails.map((email) => {
+                if (!people.get_by_email(email)) {
+                    return email;
+                }
+                return people.get_by_email(email).full_name;
+            });
+
+            // We use join to handle the addition of a comma and space after every name
+            // and also to ensure that we return a string and not an array so that we
+            // can have the same return type as other cases.
+            return names.join(", ");
+        }
         if (term_types.length === 1) {
             switch (term_types[0]) {
                 case "in-home":
@@ -692,20 +709,6 @@ export class Filter {
                     return $t({defaultMessage: "Mentions"});
                 case "is-private":
                     return $t({defaultMessage: "Private messages"});
-                case "pm-with": {
-                    const emails = this.operands("pm-with")[0].split(",");
-                    const names = emails.map((email) => {
-                        if (!people.get_by_email(email)) {
-                            return email;
-                        }
-                        return people.get_by_email(email).full_name;
-                    });
-
-                    // We use join to handle the addition of a comma and space after every name
-                    // and also to ensure that we return a string and not an array so that we
-                    // can have the same return type as other cases.
-                    return names.join(", ");
-                }
                 case "is-resolved":
                     return $t({defaultMessage: "Topics marked as resolved"});
                 // These cases return false for is_common_narrow, and therefore are not


### PR DESCRIPTION
Updates `filter.get_title` logic to return a list of users for narrows with `pm_with` and `near` operators.

Additional commits are related improvements:
- Combines the three stream narrows that return a title into one case.
- Adds test cases for both stream and private messages with near operators.

Follow-up to #23348.

**Notes**:
- Starting a conversation on CZO [here](https://chat.zulip.org/#narrow/stream/101-design/topic/private.20message.20header.20and.20browser.20titles/near/1455982) about the differences between the private message narrows browser/tab titles and message header titles, which is a further improvement that could be made to `filter.get_title` and `narrow.update_narrow_title`.

---

**Screenshots and screen captures:**

<details>
<summary>Example of updated browser/tab title with near operator</summary>

![Screenshot from 2022-10-27 13-08-29](https://user-images.githubusercontent.com/63245456/198269094-165f67cb-537b-49f2-b13f-c51277a45a64.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
