### PR TITLE
realm_redirect: Redirect always to the login page with the next parameter.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -420,7 +420,7 @@ class AuthBackendTest(ZulipTestCase):
 
         result = self.client_get("/login/")
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "http://zulip.testserver")
+        self.assertEqual(result["Location"], "http://zulip.testserver/")
 
     @override_settings(AUTHENTICATION_BACKENDS=("zproject.backends.ZulipDummyBackend",))
     def test_no_backend_enabled(self) -> None:
@@ -4988,7 +4988,7 @@ class TestTwoFactor(ZulipTestCase):
             # already logged in.
             result = self.client_get("/accounts/login/")
             self.assertEqual(result.status_code, 302)
-            self.assertEqual(result["Location"], "http://zulip.testserver")
+            self.assertEqual(result["Location"], "http://zulip.testserver/")
 
 
 class TestDevAuthBackend(ZulipTestCase):

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -796,9 +796,11 @@ def login_page(
     is_preview = "preview" in request.GET
     if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
         if request.user.is_authenticated and is_2fa_verified(request.user):
-            return HttpResponseRedirect(request.user.realm.uri)
+            redirect_to = get_safe_redirect_to(next, request.user.realm.uri)
+            return HttpResponseRedirect(redirect_to)
     elif request.user.is_authenticated and not is_preview:
-        return HttpResponseRedirect(request.user.realm.uri)
+        redirect_to = get_safe_redirect_to(next, request.user.realm.uri)
+        return HttpResponseRedirect(redirect_to)
     if is_subdomain_root_or_alias(request) and settings.ROOT_DOMAIN_LANDING_PAGE:
         redirect_url = reverse("realm_redirect")
         if request.GET:

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -2,10 +2,10 @@ import logging
 import urllib
 from contextlib import suppress
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 
 from django.conf import settings
-from django.contrib.auth import authenticate, get_backends
+from django.contrib.auth import REDIRECT_FIELD_NAME, authenticate, get_backends
 from django.contrib.sessions.backends.base import SessionBase
 from django.core import validators
 from django.core.exceptions import ValidationError
@@ -83,7 +83,6 @@ from zerver.views.auth import (
     create_preregistration_user,
     finish_desktop_flow,
     finish_mobile_flow,
-    get_safe_redirect_to,
     redirect_and_log_into_subdomain,
     redirect_to_deactivation_notice,
 )
@@ -988,7 +987,13 @@ def realm_redirect(request: HttpRequest, next: str = REQ(default="")) -> HttpRes
         if form.is_valid():
             subdomain = form.cleaned_data["subdomain"]
             realm = get_realm(subdomain)
-            redirect_to = get_safe_redirect_to(next, realm.uri)
+            redirect_to = urljoin(realm.uri, settings.HOME_NOT_LOGGED_IN)
+
+            if next:
+                redirect_to = append_url_query_string(
+                    redirect_to, urlencode({REDIRECT_FIELD_NAME: next})
+                )
+
             return HttpResponseRedirect(redirect_to)
     else:
         form = RealmRedirectForm()


### PR DESCRIPTION
Entering an organization via `accounts/go` with web-public stream enabled
takes the user to the web-public view even if the user is not logged in.

Now, a user is always redirected to `login_page` with the next parameter.

`login_page` view is updated to redirect an authenticated user based on
the `next` parameter, instead of always redirecting to `realm.uri`.

Minor updates in a few test cases to align with the changes.

Fixes: #23344


**Help and Questions**

1. On [this line](https://github.com/zulip/zulip/pull/23362/files#diff-940c870652d79870a457600e9cde59f74a5b9980268c9df6e62e0c0d846b7e66R6182), do we need to clean the url `http://zephyr.testserver/login/?next=` i.e omitting the next parameter if next is empty or is it fine?
2. For more thorough testing, I need a help which I have [asked in CZO](https://chat.zulip.org/#narrow/stream/49-development-help/topic/subdomains.20in.20dev.20environment). Any help is appreciated. [**Update: Issue Resolved, testing done.**]

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
