### PR TITLE
url_encoding: Use user name instead of email in personal_narrow_url.

### DIFF
--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,6 +1,7 @@
-from email.headerregistry import Address
 from typing import Any, Dict, List
 from urllib.parse import quote, urlsplit
+
+import re2
 
 from zerver.lib.topic import get_topic_from_message_info
 from zerver.models import Realm, Stream, UserProfile
@@ -21,8 +22,8 @@ def encode_stream(stream_id: int, stream_name: str) -> str:
 
 def personal_narrow_url(realm: Realm, sender: UserProfile) -> str:
     base_url = f"{realm.uri}/#narrow/pm-with/"
-    email_user = Address(addr_spec=sender.email).username.lower()
-    pm_slug = str(sender.id) + "-" + hash_util_encode(email_user)
+    encoded_user_name = re2.sub(r'[ "%\/<>`\p{C}]+', "-", sender.full_name)
+    pm_slug = str(sender.id) + "-" + encoded_user_name
     return base_url + pm_slug
 
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -1183,6 +1183,21 @@ class TestMissedMessages(ZulipTestCase):
             msg_id, verify_body_include, email_subject, send_as_user=False, verify_html_body=True
         )
 
+    def test_pm_link_in_missed_message_header(self) -> None:
+        cordelia = self.example_user("cordelia")
+        msg_id = self.send_personal_message(
+            cordelia,
+            self.example_user("hamlet"),
+            "Let's test PM link in email notifications",
+        )
+
+        encoded_name = "Cordelia,-Lear's-daughter"
+        verify_body_include = [
+            f"view it in Zulip Dev Zulip: http://zulip.testserver/#narrow/pm-with/{cordelia.id}-{encoded_name}"
+        ]
+        email_subject = "PMs with Cordelia, Lear's daughter"
+        self._test_cases(msg_id, verify_body_include, email_subject, send_as_user=False)
+
     def test_sender_name_in_missed_message(self) -> None:
         hamlet = self.example_user("hamlet")
         msg_id_1 = self.send_stream_message(


### PR DESCRIPTION
This PR updates the urls for personal narrow sent in email notifications to be of form "{user_id}-{encoded_full_name}" to make it consistent with the urls that we use for such narrows in webapp which were recently updated in b4eddad for improving performance. We encode the full name in the same way that we do in webapp by replacing the url characters encoded by browser with "-".

Discussion - https://chat.zulip.org/#narrow/stream/6-frontend/topic/parseOneAddress.20perf/near/1455057
<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
