### PR TITLE
unread: Extract old_unreads_missing.

### DIFF
--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -1,7 +1,6 @@
 import * as blueslip from "./blueslip";
 import {FoldDict} from "./fold_dict";
 import * as message_store from "./message_store";
-import {page_params} from "./page_params";
 import * as people from "./people";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
@@ -25,6 +24,7 @@ import * as util from "./util";
 // for more details on how this system is designed.
 
 export let messages_read_in_narrow = false;
+export let old_unreads_missing = false;
 
 export function set_messages_read_in_narrow(value) {
     messages_read_in_narrow = value;
@@ -560,7 +560,7 @@ export function process_loaded_messages(messages, expect_no_new_unreads = false)
                 continue;
             }
 
-            if (expect_no_new_unreads && !page_params.unread_msgs.old_unreads_missing) {
+            if (expect_no_new_unreads && !old_unreads_missing) {
                 // This may happen due to races, where someone narrows
                 // to a view and the message_fetch request returns
                 // before server_events system delivers the message to
@@ -796,6 +796,7 @@ export function get_msg_ids_for_starred() {
 export function initialize(params) {
     const unread_msgs = params.unread_msgs;
 
+    old_unreads_missing = unread_msgs.old_unreads_missing;
     unread_pm_counter.set_huddles(unread_msgs.huddles);
     unread_pm_counter.set_pms(unread_msgs.pms);
     unread_topic_counter.set_streams(unread_msgs.streams);


### PR DESCRIPTION
This avoids post-initialization access to page_params inside unread.js.

A follow-up to #23352

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
