### PR TITLE
fix(email-notifications): preserve threading in supporting clients after topic marked resolved

### DIFF
--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -1,7 +1,17 @@
 {% if show_message_content %}
     {% if group_pm %} {% trans %}Group PMs with {{ huddle_display_name }}{% endtrans %}
     {% elif private_message %} {% trans %}PMs with {{ sender_str }}{% endtrans %}
-    {% elif stream_email_notify or mention %} #{{ stream_name }} > {{ topic_name }}
+    {% elif stream_email_notify or mention %}
+        {#
+        Some email clients, like Gmail Web (as of 2022), will auto-thread
+        emails that share a subject and recipients, but will disregard
+        [Bracketed Prefixes] in the style of old-school mailing lists. We take
+        advantage of this to retain thread continuity in email notifications
+        even after a topic is resolved.
+        #}
+        {% if topic_resolved %}{% trans %}[resolved] #{{ stream_name }} > {{ topic_name }}{% endtrans %}
+        {% else %}#{{ stream_name }} > {{ topic_name }}
+        {% endif %}
     {% endif %}
 {% else %}
     {% trans %}New messages{% endtrans %}

--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -1,7 +1,7 @@
 {% if show_message_content %}
     {% if group_pm %} {% trans %}Group PMs with {{ huddle_display_name }}{% endtrans %}
     {% elif private_message %} {% trans %}PMs with {{ sender_str }}{% endtrans %}
-    {% elif stream_email_notify or mention %} #{{ stream_header }}
+    {% elif stream_email_notify or mention %} #{{ stream_name }} > {{ topic_name }}
     {% endif %}
 {% else %}
     {% trans %}New messages{% endtrans %}

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -481,10 +481,10 @@ def do_send_missedmessage_events_reply_in_zulip(
             )
         message = missed_messages[0]["message"]
         stream = Stream.objects.only("id", "name").get(id=message.recipient.type_id)
-        stream_header = f"{stream.name} > {message.topic_name()}"
+        topic_name = message.topic_name()
         context.update(
             stream_name=stream.name,
-            stream_header=stream_header,
+            topic_name=topic_name,
         )
     else:
         raise AssertionError("Invalid messages!")

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -27,6 +27,7 @@ from zerver.lib.notification_data import get_mentioned_user_group_name
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import FromAddress, send_future_email
 from zerver.lib.soft_deactivation import soft_reactivate_if_personal_notification
+from zerver.lib.topic import get_topic_resolution_and_bare_name
 from zerver.lib.types import DisplayRecipientT
 from zerver.lib.url_encoding import (
     huddle_narrow_url,
@@ -481,10 +482,11 @@ def do_send_missedmessage_events_reply_in_zulip(
             )
         message = missed_messages[0]["message"]
         stream = Stream.objects.only("id", "name").get(id=message.recipient.type_id)
-        topic_name = message.topic_name()
+        topic_resolved, topic_name = get_topic_resolution_and_bare_name(message.topic_name())
         context.update(
             stream_name=stream.name,
             topic_name=topic_name,
+            topic_resolved=topic_resolved,
         )
     else:
         raise AssertionError("Invalid messages!")

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -270,3 +270,17 @@ def get_topic_history_for_stream(
     cursor.close()
 
     return generate_topic_history_from_db_rows(rows)
+
+
+def get_topic_resolution_and_bare_name(stored_name: str) -> Tuple[bool, str]:
+    """
+    Resolved topics are denoted only by a title change, not by a boolean toggle in a database column. This
+    method inspects the topic name and returns a tuple of:
+
+    - Whether the topic has been resolved
+    - The topic name with the resolution prefix, if present in stored_name, removed
+    """
+    if stored_name.startswith(RESOLVED_TOPIC_PREFIX):
+        return (True, stored_name[len(RESOLVED_TOPIC_PREFIX) :])
+
+    return (False, stored_name)

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -1051,6 +1051,13 @@ class TestMissedMessages(ZulipTestCase):
     def test_extra_context_in_missed_stream_messages_email_notify(self) -> None:
         self._extra_context_in_missed_stream_messages_email_notify(False)
 
+    @override_settings(SEND_MISSED_MESSAGE_EMAILS_AS_USER=True)
+    def test_resolved_topic_missed_stream_messages_thread_friendly_as_user(self) -> None:
+        self._resolved_topic_missed_stream_messages_thread_friendly(True)
+
+    def test_resolved_topic_missed_stream_messages_thread_friendly(self) -> None:
+        self._resolved_topic_missed_stream_messages_thread_friendly(False)
+
     @override_settings(EMAIL_GATEWAY_PATTERN="")
     def test_reply_warning_in_missed_personal_messages(self) -> None:
         self._reply_warning_in_missed_personal_messages(False)

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -626,6 +626,29 @@ class TestMissedMessages(ZulipTestCase):
             msg_id, verify_body_include, email_subject, send_as_user, trigger="mentioned"
         )
 
+    def _resolved_topic_missed_stream_messages_thread_friendly(self, send_as_user: bool) -> None:
+        topic_name = "threading and so forth"
+        othello_user = self.example_user("othello")
+        msg_id = -1
+        for i in range(0, 3):
+            msg_id = self.send_stream_message(
+                othello_user,
+                "Denmark",
+                content=str(i),
+                topic_name=topic_name,
+            )
+
+        self.assert_json_success(self.resolve_topic_containing_message(othello_user, msg_id))
+
+        verify_body_include = [
+            "Othello, the Moor of Venice: > 0 > 1 > 2 -- ",
+            "You are receiving this because you have email notifications enabled for #Denmark.",
+        ]
+        email_subject = "[resolved] #Denmark > threading and so forth"
+        self._test_cases(
+            msg_id, verify_body_include, email_subject, send_as_user, trigger="stream_email_notify"
+        )
+
     def _extra_context_in_missed_personal_messages(
         self,
         send_as_user: bool,

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -3006,12 +3006,9 @@ class EditMessageTest(EditMessageTestCase):
         self.assert_json_error(result, "Nothing to change")
 
         resolved_topic = RESOLVED_TOPIC_PREFIX + original_topic
-        result = self.client_patch(
-            "/json/messages/" + str(id1),
-            {
-                "topic": resolved_topic,
-                "propagate_mode": "change_all",
-            },
+        result = self.resolve_topic_containing_message(
+            admin_user,
+            id1,
             HTTP_ACCEPT_LANGUAGE="de",
         )
 


### PR DESCRIPTION
Resolves #22538, where some email clients will break threading if the subject changes other than in prefix blurbs, by stripping a resolved topic's checkmark prefix before adding it to the email subject, and instead prefixing the entire email subject with "[Resolved]", a bracketed format some clients understand from the era of mailing lists.

**Screenshots and screen captures:** The threading behavior is screenshotted in the CZO thread; I haven't actually configured email notifications in a local Zulip instance to manually test the output yet. Open to carving out that time if we think it's useful here (otherwise, I'll defer to the passing tests).

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
    * Tested in a sense of "the unit test verifies the subject that would have been sent out, and it matches the format Tim sketched out on CZO". See header blurb...
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
