### PR TITLE
help center: Clearly refer to mobile apps on /help/mobile-notifications.

### DIFF
--- a/templates/zerver/help/mobile-notifications.md
+++ b/templates/zerver/help/mobile-notifications.md
@@ -1,11 +1,11 @@
 # Mobile notifications
 
-In Zulip, you can customize whether [stream
-messages](/help/stream-notifications), [private
-messages](/help/pm-mention-alert-notifications) and
-[mentions][notifications-wildcard-mentions] trigger mobile
-notifications. You can also adjust whether notifications will be sent
-while you are online.
+You can customize whether [stream messages](/help/stream-notifications),
+[private messages](/help/pm-mention-alert-notifications) and
+[mentions][notifications-wildcard-mentions] trigger notifications in Zulip's
+[Android](https://zulip.com/apps/ios) and [iOS](https://zulip.com/apps/ios)
+apps. You can also adjust whether notifications will be sent while you are
+online.
 
 [notifications-wildcard-mentions]: /help/pm-mention-alert-notifications#wildcard-mentions
 


### PR DESCRIPTION
Addresses user confusion about whether "mobile notifications" might refer to text messages.

[CZO thread](https://chat.zulip.org/#narrow/stream/137-feedback/topic/text.20message.20notifications/near/1456215)

Current page: https://zulip.com/help/mobile-notifications
Proposed revision:

![Screen Shot 2022-10-28 at 10 42 45 AM](https://user-images.githubusercontent.com/2090066/198699392-d393639e-5b69-48be-a073-65c5a24a1229.png)
