### PR TITLE
help-docs: Update search for messages article about "group-pm-with".

### DIFF
--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -3,40 +3,54 @@
 Zulip has a powerful search engine under its hood. Search for messages using
 the search bar at the top of the app.
 
-## Example
+## Basics
 
-* `stream:design has:link -is:starred new logo`
+Here's an example of a search query in the app:
+`stream:design has:link -is:starred new logo`
 
-Searches for messages in `#design` that have a link, that you haven't
-starred, and that contain the words `new` and `logo`.
+It searches for messages in the stream `#design` that have a link, that
+you haven't starred, and that contain the words `new` and `logo`.
 
 The permalink for that search (web only) will look something like
 this:
 
 `https://your-zulip-url/#narrow/stream/123-design/has/link/-is/starred/search/new.20logo`.
 
-## List of operators
-
 As you start typing, Zulip will suggest possible operator completions.
 Operators can be used with keywords, or on their own. For example,
 
-* `stream:design logo` will search for the word `logo` within `#design`
-* `stream:design` will navigate to `#design`
+* `stream:design logo` will search for the word `logo` within the stream
+  `#design`
+* `stream:design` will navigate to the stream `#design`
 
-Here is the **full list of search operators**.
+## List of search operators
+
+### Searching stream messages
 
 * `stream:design`: Search within the stream `#design`.
 * `stream:design topic:emoji+picker`: Search within the topic `emoji picker`.
+* `streams:public`: Search the history of all [public
+  streams](/help/change-the-privacy-of-a-stream) in the organization,
+  including streams you are not subscribed to.
+
+### Searching private messages
+
 * `is:private`: Search all your private messages.
 * `pm-with:ada@zulip.com`: Search 1-on-1 private messages between you and Ada.
 * `pm-with:ada@zulip.com,bob@zulip.com`: Search group private messages
   between you, Bob, and Ada.
 * `group-pm-with:ada@zulip.com`: Search all group private message
   conversations that include you and Ada, as well as any other users.
+
+### Searching by message sender or message ID
+
 * `sender:ada@zulip.com`: Search messages sent by Ada.
 * `sender:me`: [Search messages you've sent](/help/view-messages-sent-by-a-user#view-messages-youve-sent).
 * `near:12345`: Show messages around the message with ID `12345`.
 * `id:12345`: Show only message `12345`.
+
+### Searching by message characteristics and flags
+
 * `is:alerted`: See [alert words](/help/pm-mention-alert-notifications#alert-words).
 * `is:mentioned`: See [mentions](/help/mention-a-user-or-group).
 * `is:starred`: See [starred messages](/help/star-a-message).
@@ -46,11 +60,8 @@ Here is the **full list of search operators**.
 * `has:link`
 * `has:image`
 * `has:attachment`
-* `streams:public`: Search the history of all [public
-  streams](/help/change-the-privacy-of-a-stream) in the organization,
-  including streams you are not subscribed to.
 
-### Excluding messages
+## Excluding messages
 
 Zulip's search operators can be negated, to exclude messages matching
 the rule.  For example, `stream:design -is:resolved -has:image` will

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -29,13 +29,14 @@ Here is the **full list of search operators**.
 * `stream:design topic:emoji+picker`: Search within the topic `emoji picker`.
 * `is:private`: Search all your private messages.
 * `pm-with:ada@zulip.com`: Search 1-on-1 private messages between you and Ada.
+* `pm-with:ada@zulip.com,bob@zulip.com`: Search group private messages
+  between you, Bob, and Ada.
+* `group-pm-with:ada@zulip.com`: Search all group private message
+  conversations that include you and Ada, as well as any other users.
 * `sender:ada@zulip.com`: Search messages sent by Ada.
 * `sender:me`: [Search messages you've sent](/help/view-messages-sent-by-a-user#view-messages-youve-sent).
 * `near:12345`: Show messages around the message with ID `12345`.
 * `id:12345`: Show only message `12345`.
-* `streams:public`: Search the history of all [public
-  streams](/help/change-the-privacy-of-a-stream) in the organization.
-
 * `is:alerted`: See [alert words](/help/pm-mention-alert-notifications#alert-words).
 * `is:mentioned`: See [mentions](/help/mention-a-user-or-group).
 * `is:starred`: See [starred messages](/help/star-a-message).
@@ -45,10 +46,9 @@ Here is the **full list of search operators**.
 * `has:link`
 * `has:image`
 * `has:attachment`
-* `pm-with:ada@zulip.com,bob@zulip.com`: Search private message conversation
-  between you, Bob, and Ada.
-* `group-pm-with:ada@zulip.com,bob@zulip.com`: Search all group
-  private messages that include Ada and Bob.
+* `streams:public`: Search the history of all [public
+  streams](/help/change-the-privacy-of-a-stream) in the organization,
+  including streams you are not subscribed to.
 
 ### Excluding messages
 


### PR DESCRIPTION
Updates the help center article on searching for messages to have the correct format for the "group-pm-with" operator.
Also, reorders the list so that the private message searches are all together.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/.22group-pm-with.22.20search.20with.20multiple.20users/near/1456141).

---

**Notes**:
- Would it make sense to add a section after **Excluding messages** for combining operators to cover the use case of using the "group-pm-with" operator multiple times to search for group private messages with more than one person, but not exclusively with those specific users?

- I moved the `streams:public` operator to the end of the list because I felt like it stands out more there.

---

**Screenshots and screen captures:**

<details>
<summary>Updated full list of operators</summary>

[Current documentation](https://zulip.com/help/search-for-messages#list-of-operators)
![Screenshot from 2022-10-28 19-38-03](https://user-images.githubusercontent.com/63245456/198700067-3e6609ac-25f5-4877-ad83-bfe228993261.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
