### PR TITLE
Fix message.realm bug in internal_prep_private_message and simplify retention query to use Message.realm

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -85,6 +85,7 @@ from zerver.models import (
     get_stream_by_id_in_realm,
     get_system_bot,
     get_user_by_delivery_email,
+    is_cross_realm_bot_email,
     query_for_ids,
 )
 from zerver.tornado.django_api import send_event
@@ -1602,7 +1603,10 @@ def internal_prep_private_message(
     See _internal_prep_message for details of how this works.
     """
     addressee = Addressee.for_user_profile(recipient_user)
-    realm = recipient_user.realm
+    if not is_cross_realm_bot_email(recipient_user.delivery_email):
+        realm = recipient_user.realm
+    else:
+        realm = sender.realm
 
     return _internal_prep_message(
         realm=realm,

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -189,7 +189,6 @@ def move_expired_messages_to_archive_by_recipient(
 ) -> int:
     assert message_retention_days != -1
 
-    # This function will archive appropriate messages and their related objects.
     query = SQL(
         """
     INSERT INTO zerver_archivedmessage ({dst_fields}, archive_transaction_id)
@@ -222,7 +221,6 @@ def move_expired_personal_and_huddle_messages_to_archive(
     assert message_retention_days != -1
     check_date = timezone_now() - timedelta(days=message_retention_days)
 
-    # This function will archive appropriate messages and their related objects.
     recipient_types = (Recipient.PERSONAL, Recipient.HUDDLE)
 
     # Archive expired personal and huddle Messages in the realm, including cross-realm messages.


### PR DESCRIPTION
We can simplify the private message archiving query in `retention.py` now that we have message.realm.