### PR TITLE
help center: Add tip about how to add a link to a stream description.

### DIFF
--- a/templates/zerver/help/change-the-stream-description.md
+++ b/templates/zerver/help/change-the-stream-description.md
@@ -23,8 +23,16 @@ previews are disabled.
 
 {!save-changes.md!}
 
+!!! tip ""
+    Use [Markdown formatting][markdown-formatting] to include a link to a
+    website, Zulip [message][message-link], or [topic][topic-link] in the
+    stream description: `[link text](URL)`.
+
 {end_tabs}
 
 {!automated-notice-stream-event.md!}
 
 [markdown-formatting]: /help/format-your-message-using-markdown
+[message-link]: /help/link-to-a-message-or-conversation#get-a-link-to-a-specific-message
+[topic-link]:
+    /help/link-to-a-message-or-conversation#get-a-link-to-a-specific-topic


### PR DESCRIPTION
Fixes part of #16701.

Links were manually tested.

Current page: https://zulip.com/help/change-the-stream-description
Proposed (the only change is adding the tip):

<img width="810" alt="Screen Shot 2022-10-28 at 7 29 02 PM" src="https://user-images.githubusercontent.com/2090066/198814471-972b4430-1458-4861-ba66-1c6e6b4b13f7.png">
