### PR TITLE
Issue solved: Hide "Deactivated users" from collapsed settings sidebar.

### DIFF
--- a/static/templates/settings_overlay.hbs
+++ b/static/templates/settings_overlay.hbs
@@ -115,7 +115,7 @@
                     </li>
                     {{/unless}}
                     {{#unless is_guest}}
-                    <li tabindex="0" data-section="deactivated-users-admin">
+                    <li class="collapse-org-settings {{#unless is_admin}}hide-org-settings{{/unless}}" tabindex="0" data-section="deactivated-users-admin">
                         <i class="icon fa fa-user-times" aria-hidden="true"></i>
                         <div class="text">{{t "Deactivated users" }}</div>
                         {{#unless is_admin}}


### PR DESCRIPTION
"Deactivated users" button in organization settings is now by default collapsed under "Show more" for non-administrator users.

<!-- Describe your pull request here.-->

Fixes: [23235](https://github.com/zulip/zulip/issues/23235)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
View for non-administrator users (collapsed under show more):
![image](https://user-images.githubusercontent.com/57041231/198829865-ea1b59b6-2273-461a-9aff-a4b73e3bf211.png)

View for non-administrator users (expanded menu):
![image](https://user-images.githubusercontent.com/57041231/198829973-705b1cf4-f574-4a07-946c-0b4ce7a18712.png)

View for administrator users:
![image](https://user-images.githubusercontent.com/57041231/198829926-6bf33a8b-7d7a-491f-ac90-0e1ce5ee51bb.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
