### PR TITLE
recent_topics: Improve behaviour of inplace rerender.

### DIFF
--- a/static/js/list_widget.js
+++ b/static/js/list_widget.js
@@ -172,7 +172,9 @@ export function create($container, list, opts) {
         return undefined;
     }
 
-    const widget = {};
+    const widget = {
+        meta,
+    };
 
     widget.get_current_list = function () {
         return meta.filtered_list;

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -164,6 +164,10 @@ function set_table_focus(row, col, using_keyboard) {
         return true;
     }
 
+    if (col === 2 && !has_unread(row)) {
+        col = 1;
+        col_focus = 1;
+    }
     const $topic_row = $topic_rows.eq(row);
     // We need to allow table to render first before setting focus.
     setTimeout(
@@ -911,13 +915,7 @@ function up_arrow_navigation(row, col) {
     }
 }
 
-function down_arrow_navigation(row, col) {
-    if (is_focus_at_last_table_row()) {
-        return;
-    }
-    if (col === 2 && !has_unread(row + 1)) {
-        col_focus = 1;
-    }
+function down_arrow_navigation() {
     row_focus += 1;
 }
 
@@ -1103,6 +1101,7 @@ export function change_focused_element($elt, input_key) {
             case "right_arrow":
                 right_arrow_navigation(row_focus, col_focus);
                 break;
+            case "down_arrow":
             case "vim_down":
                 // We stop user at last table row
                 // so that user doesn't end up in
@@ -1114,10 +1113,7 @@ export function change_focused_element($elt, input_key) {
                 if (is_focus_at_last_table_row()) {
                     return true;
                 }
-                down_arrow_navigation(row_focus, col_focus);
-                break;
-            case "down_arrow":
-                down_arrow_navigation(row_focus, col_focus);
+                down_arrow_navigation();
                 break;
             case "vim_up":
                 // See comment on vim_down.

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -164,10 +164,17 @@ function set_table_focus(row, col, using_keyboard) {
         return true;
     }
 
-    if (col === 2 && !has_unread(row)) {
+    const unread = has_unread(row);
+    if (col === 2 && !unread) {
         col = 1;
         col_focus = 1;
     }
+    const type = get_row_type(row);
+    if (col === 3 && type === "private") {
+        col = unread ? 2 : 1;
+        col_focus = col;
+    }
+
     const $topic_row = $topic_rows.eq(row);
     // We need to allow table to render first before setting focus.
     setTimeout(
@@ -193,7 +200,6 @@ function set_table_focus(row, col, using_keyboard) {
     // TODO: This fake "message" object is designed to allow using the
     // get_recipient_label helper inside compose_closed_ui. Surely
     // there's a more readable way to write this code.
-    const type = get_row_type(row);
     let message;
     if (type === "private") {
         message = {
@@ -770,7 +776,7 @@ export function complete_rerender() {
         },
         html_selector: get_topic_row,
         $simplebar_container: $("#recent_topics_table .table_fix_head"),
-        callback_after_render: revive_current_focus,
+        callback_after_render: () => setTimeout(revive_current_focus, 0),
         is_scroll_position_for_render,
         post_scroll__pre_render_callback: set_focus_to_element_in_center,
         get_min_load_count,


### PR DESCRIPTION
This PR aims to fix both https://github.com/zulip/zulip/issues/23331 and https://github.com/zulip/zulip/issues/23332, along with behaviour described in https://chat.zulip.org/#narrow/stream/9-issues/topic/Recent.20topics.20Enter.

We used to hide and show topic rows in the DOM when topics are updated. This resulted in incorrect calculations in the length of visible topics. As a consequence, focus is sometimes set to hidden topics. Removing hidden topics from DOM helps us keep the calculations correct.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Recent.20topics.20Enter

@m-e-l-u-h-a-n FYI