### PR TITLE
markdown: Pass realm down into render_stream_description.

### DIFF
--- a/zerver/actions/custom_profile_fields.py
+++ b/zerver/actions/custom_profile_fields.py
@@ -172,7 +172,7 @@ def do_update_user_custom_profile_data_if_changed(
             field_value.value = custom_profile_field_value_string
             if field_value.field.is_renderable():
                 field_value.rendered_value = render_stream_description(
-                    custom_profile_field_value_string
+                    custom_profile_field_value_string, user_profile.realm
                 )
                 field_value.save(update_fields=["value", "rendered_value"])
             else:

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -1190,7 +1190,7 @@ def do_change_stream_description(
 
     with transaction.atomic():
         stream.description = new_description
-        stream.rendered_description = render_stream_description(new_description)
+        stream.rendered_description = render_stream_description(new_description, stream.realm)
         stream.save(update_fields=["description", "rendered_description"])
         RealmAuditLog.objects.create(
             realm=stream.realm,

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -190,7 +190,7 @@ def bulk_create_streams(realm: Realm, stream_dict: Dict[str, Dict[str, Any]]) ->
                     realm=realm,
                     name=name,
                     description=options["description"],
-                    rendered_description=render_stream_description(options["description"]),
+                    rendered_description=render_stream_description(options["description"], realm),
                     invite_only=options.get("invite_only", False),
                     stream_post_policy=options.get(
                         "stream_post_policy", Stream.STREAM_POST_POLICY_EVERYONE

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -993,7 +993,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int = 1) -> Rea
         )
     # Handle rendering of stream descriptions for import from non-Zulip
     for stream in data["zerver_stream"]:
-        stream["rendered_description"] = render_stream_description(stream["description"])
+        stream["rendered_description"] = render_stream_description(stream["description"], realm)
     bulk_import_model(data, Stream)
 
     realm.notifications_stream_id = notifications_stream_id

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -106,8 +106,8 @@ def get_default_value_for_history_public_to_subscribers(
     return history_public_to_subscribers
 
 
-def render_stream_description(text: str) -> str:
-    return markdown_convert(text, no_previews=True).rendered_content
+def render_stream_description(text: str, realm: Realm) -> str:
+    return markdown_convert(text, message_realm=realm, no_previews=True).rendered_content
 
 
 def send_stream_creation_event(stream: Stream, user_ids: List[int]) -> None:
@@ -155,7 +155,7 @@ def create_stream_if_needed(
             recipient = Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)
 
             stream.recipient = recipient
-            stream.rendered_description = render_stream_description(stream_description)
+            stream.rendered_description = render_stream_description(stream_description, realm)
             stream.save(update_fields=["recipient", "rendered_description"])
 
             event_time = timezone_now()

--- a/zerver/migrations/0206_stream_rendered_description.py
+++ b/zerver/migrations/0206_stream_rendered_description.py
@@ -12,7 +12,7 @@ def render_all_stream_descriptions(
     Stream = apps.get_model("zerver", "Stream")
     all_streams = Stream.objects.exclude(description="")
     for stream in all_streams:
-        stream.rendered_description = render_stream_description(stream.description)
+        stream.rendered_description = render_stream_description(stream.description, stream.realm)
         stream.save(update_fields=["rendered_description"])
 
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4223,7 +4223,7 @@ class SubscriptionAPITest(ZulipTestCase):
         events: List[Mapping[str, Any]] = []
         flush_per_request_caches()
         with self.tornado_redirected_to_list(events, expected_num_events=5):
-            with self.assert_database_query_count(37):
+            with self.assert_database_query_count(36):
                 self.common_subscribe_to_streams(
                     self.test_user,
                     streams_to_sub,
@@ -5095,7 +5095,7 @@ class SubscriptionAPITest(ZulipTestCase):
         ]
 
         # Test creating a public stream when realm does not have a notification stream.
-        with self.assert_database_query_count(37):
+        with self.assert_database_query_count(36):
             self.common_subscribe_to_streams(
                 self.test_user,
                 [new_streams[0]],
@@ -5103,7 +5103,7 @@ class SubscriptionAPITest(ZulipTestCase):
             )
 
         # Test creating private stream.
-        with self.assert_database_query_count(36):
+        with self.assert_database_query_count(35):
             self.common_subscribe_to_streams(
                 self.test_user,
                 [new_streams[1]],
@@ -5115,7 +5115,7 @@ class SubscriptionAPITest(ZulipTestCase):
         notifications_stream = get_stream(self.streams[0], self.test_realm)
         self.test_realm.notifications_stream_id = notifications_stream.id
         self.test_realm.save()
-        with self.assert_database_query_count(45):
+        with self.assert_database_query_count(44):
             self.common_subscribe_to_streams(
                 self.test_user,
                 [new_streams[2]],


### PR DESCRIPTION
This guarantees that the Realm is always non-None when we hit the
codepath is_static_or_current_realm_url via
do_change_stream_description, so that we can properly skip rewritting
some images.

Fixes #19405

Signed-off-by: Zixuan James Li <p359101898@gmail.com>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
