### PR TITLE
recent: Fix alignment of unread count in PM rows.

### DIFF
--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -210,15 +210,14 @@
             opacity: 0.7;
         }
 
+        .recent_topic_actions.dummy_action_button {
+            visibility: hidden;
+        }
+
         .recent_topic_actions .recent_topics_focusable {
             display: flex;
             align-items: center;
             padding-bottom: 3px;
-
-            &.single_action_button {
-                /* 10px of unread count + 23px for bell icon */
-                margin-right: 33px;
-            }
         }
 
         .recent_topics_participants {
@@ -393,11 +392,6 @@
             .recent_topic_actions {
                 margin-right: 5px;
                 font-size: 15px;
-            }
-
-            .unread_count_pm {
-                /* Margin equal to size of recent topic actions */
-                margin-right: 44px;
             }
         }
     }

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -38,8 +38,14 @@
             <div class="right_part">
                 {{#if is_private}}
                 <div class="recent_topic_actions">
-                    <div class="recent_topics_focusable single_action_button">
+                    <div class="recent_topics_focusable">
                         <span class="unread_count unread_count_pm {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-user-ids-string="{{user_ids_string}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
+                    </div>
+                </div>
+                <div class="recent_topic_actions dummy_action_button">
+                    <div class="recent_topics_focusable">
+                        {{!-- Invisible icon, used only for alignment of unread count. --}}
+                        <i class="zulip-icon zulip-icon-mute on_hover_topic_unmute recipient_bar_icon"></i>
                     </div>
                 </div>
                 {{else}}


### PR DESCRIPTION
The alignment was off in both narrow and wide screens. Added an invisible mute icon to PM rows to keep the unread counts aligned with topic rows.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Recent.20coversations.20unread.20alignment

narrow (see aaron):
<img width="655" alt="Screenshot 2022-10-30 at 12 08 26 PM" src="https://user-images.githubusercontent.com/25124304/198866202-ab741fd4-3970-4df8-8faf-6d40cc712ba0.png">

wide:
<img width="655" alt="Screenshot 2022-10-30 at 12 09 25 PM" src="https://user-images.githubusercontent.com/25124304/198866195-0735ce6a-ceaa-4031-a348-ce6f76add3cc.png">

