### PR TITLE
css: Increase opacity of sidebar titles in dark theme.

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -246,10 +246,14 @@ body.dark-theme {
     :disabled,
     input:not([type="radio"]):read-only,
     textarea:read-only,
-    .sidebar-title,
     .recipient_row_date {
         color: inherit;
         opacity: 0.5;
+    }
+
+    .sidebar-title {
+        color: inherit;
+        opacity: 0.75;
     }
 
     .rendered_markdown button,


### PR DESCRIPTION
0.5 opacity felt too light to make users miss their presence. This opacity reduction is only applied in dark theme to sidebar titles.

discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/private.20messages.20section.20.2320870

before: 
<img width="1245" alt="Screenshot 2022-10-31 at 11 25 31 PM" src="https://user-images.githubusercontent.com/25124304/199076378-3ddb5d1e-224b-4386-a685-3d5df34328aa.png">

after:
<img width="1245" alt="Screenshot 2022-10-31 at 11 25 08 PM" src="https://user-images.githubusercontent.com/25124304/199076397-ced9585e-6681-410d-a61d-34682f1b9de0.png">
