### PR TITLE
recent: Fix alignment of unread mention icon.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -725,6 +725,7 @@ li.topic-list-item {
         background-color: hsl(0, 0%, 100%);
     }
 
+    #subscribe-to-more-streams,
     .show-more-topics {
         display: none;
     }

--- a/static/styles/recent_topics.css
+++ b/static/styles/recent_topics.css
@@ -165,6 +165,8 @@
 
         .unread_mention_info:not(:empty) {
             margin-right: -5px;
+            /* Match with its font-size. */
+            line-height: 14px;
         }
 
         .unread_hidden {


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20topics.20mentions

<img width="1246" alt="Screenshot 2022-11-01 at 8 09 00 AM" src="https://user-images.githubusercontent.com/25124304/199146751-57ab104b-2fd6-422c-8be2-dd1c0117b1f2.png">
