### PR TITLE
delete_topic: Use the same timeout pattern as /mark_all_as_read.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -976,13 +976,14 @@ export function delete_topic(stream_id, topic_name, failures = 0) {
         data: {
             topic_name,
         },
-        success() {},
-        error(xhr) {
-            if (failures >= 9) {
-                // Don't keep retrying indefinitely to avoid DoSing the server.
-                return;
-            }
-            if (xhr.status === 502) {
+        success(data) {
+            if (data.result === "partially_completed") {
+                if (failures >= 9) {
+                    // Don't keep retrying indefinitely to avoid DoSing the server.
+                    return;
+                }
+
+                failures += 1;
                 /* When trying to delete a very large topic, it's
                    possible for the request to the server to
                    time out after making some progress. Retry the
@@ -991,7 +992,6 @@ export function delete_topic(stream_id, topic_name, failures = 0) {
 
                    TODO: Show a nice loading indicator experience.
                 */
-                failures += 1;
                 delete_topic(stream_id, topic_name, failures);
             }
         },

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 6.0
 
+**Feature level 154**
+
+* [`POST /streams/{stream_id}/delete_topic`](/api/delete-topic):
+  When the process of deleting messages times out, a success response
+  with "partially_completed" result will now be returned by the server,
+  analogically to the `/mark_all_as_read` endpoint.
+
 **Feature level 153**
 
 * [`POST /mark_all_as_read`](/api/mark-all-as-read): Messages are now

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md, as well as
 # "**Changes**" entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 153
+API_FEATURE_LEVEL = 154
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -717,3 +717,15 @@ def mock_queue_publish(
 
     with mock.patch(method_to_patch, side_effect=verify_serialize):
         yield inner
+
+
+@contextmanager
+def timeout_mock(mock_path: str) -> Iterator[None]:
+    # timeout() doesn't work in test environment with database operations
+    # and they don't get committed - so we need to replace it with a mock
+    # that just calls the function.
+    def mock_timeout(seconds: int, func: Callable[[], object]) -> object:
+        return func()
+
+    with mock.patch(f"{mock_path}.timeout", new=mock_timeout):
+        yield

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14388,6 +14388,9 @@ paths:
         for very large topics. It now deletes messages in batches,
         starting with the newest messages, so that progress will be
         made even if the request times out.
+
+        As of feature level 154, in case of timeout, a success response
+        with "partially_completed" result will now be returned.
       parameters:
         - $ref: "#/components/parameters/StreamIdInPath"
         - name: topic_name
@@ -14400,7 +14403,26 @@ paths:
           required: true
       responses:
         "200":
-          $ref: "#/components/responses/SimpleSuccess"
+          description: Success or partial success.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/JsonSuccess"
+                      - $ref: "#/components/schemas/SuccessDescription"
+                  - allOf:
+                      - $ref: "#/components/schemas/PartiallyCompleted"
+                      - example:
+                          {
+                            "code": "REQUEST_TIMEOUT",
+                            "msg": "",
+                            "result": "partially_completed",
+                          }
+                        description: |
+                          If the request exceeds its processing time limit after having
+                          successfully marked some messages as read, response code 200
+                          with result "partially_completed" and code "REQUEST_TIMEOUT" will be returned like this:
         "400":
           description: Bad request.
           content:

--- a/zerver/tests/test_message_topics.py
+++ b/zerver/tests/test_message_topics.py
@@ -1,7 +1,12 @@
+from unittest import mock
+
+import orjson
 from django.utils.timezone import now as timezone_now
 
 from zerver.actions.streams import do_change_stream_permission
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import timeout_mock
+from zerver.lib.timeout import TimeoutExpired
 from zerver.models import Message, UserMessage, get_client, get_realm, get_stream
 
 
@@ -282,23 +287,51 @@ class TopicDeleteTest(ZulipTestCase):
             acting_user=user_profile,
         )
         # Delete the topic should now remove all messages
-        result = self.client_post(
-            endpoint,
-            {
-                "topic_name": topic_name,
-            },
-        )
+        with timeout_mock("zerver.views.streams"):
+            result = self.client_post(
+                endpoint,
+                {
+                    "topic_name": topic_name,
+                },
+            )
         self.assert_json_success(result)
         self.assertFalse(Message.objects.filter(id=last_msg_id).exists())
         self.assertTrue(Message.objects.filter(id=initial_last_msg_id).exists())
 
         # Delete again, to test the edge case of deleting an empty topic.
-        result = self.client_post(
-            endpoint,
-            {
-                "topic_name": topic_name,
-            },
-        )
+        with timeout_mock("zerver.views.streams"):
+            result = self.client_post(
+                endpoint,
+                {
+                    "topic_name": topic_name,
+                },
+            )
         self.assert_json_success(result)
         self.assertFalse(Message.objects.filter(id=last_msg_id).exists())
         self.assertTrue(Message.objects.filter(id=initial_last_msg_id).exists())
+
+    def test_topic_delete_timeout(self) -> None:
+        stream_name = "new_stream"
+        topic_name = "new topic 2"
+
+        user_profile = self.example_user("iago")
+        self.subscribe(user_profile, stream_name)
+
+        stream = get_stream(stream_name, user_profile.realm)
+        self.send_stream_message(user_profile, stream_name, topic_name=topic_name)
+
+        self.login_user(user_profile)
+        endpoint = "/json/streams/" + str(stream.id) + "/delete_topic"
+        with mock.patch("zerver.views.streams.timeout", side_effect=TimeoutExpired):
+            result = self.client_post(
+                endpoint,
+                {
+                    "topic_name": topic_name,
+                },
+            )
+            self.assertEqual(result.status_code, 200)
+
+            result_dict = orjson.loads(result.content)
+            self.assertEqual(
+                result_dict, {"result": "partially_completed", "msg": "", "code": "REQUEST_TIMEOUT"}
+            )


### PR DESCRIPTION
As @alexmv  pointed out in https://github.com/zulip/zulip/pull/22988#discussion_r986351526, we don't want to rely on 502.  Switch to the pattern we've worked out in #23128 