### PR TITLE
help-menu: Update tip at the bottom of search operators tab.

### DIFF
--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -158,25 +158,7 @@
                     </tr>
                 </tbody>
             </table>
-            {{#tr}}
-                <p>You can use any combination of these search operators in a single query. For example:</p>
-                <z-operator>
-                    <z-stream-prefix></z-stream-prefix><z-stream>streamname</z-stream>
-                    <z-sender-prefix></z-sender-prefix><z-email>user@example.com</z-email>
-                    <z-keyword>keyword</z-keyword>
-                </z-operator>
-                <p>
-                    That query would search for messages sent by <z-email>user@example.com</z-email> to
-                    stream <z-stream>streamname</z-stream> containing
-                    the keyword <z-keyword>keyword</z-keyword>.
-                </p>
-                {{#*inline "z-operator"}}<p><span class="operator">{{> @partial-block}}</span></p>{{/inline}}
-                {{#*inline "z-stream-prefix"}}stream:{{/inline}}
-                {{#*inline "z-stream"}}<span class="operator_value">{{> @partial-block}}</span>{{/inline}}
-                {{#*inline "z-sender-prefix"}}email:{{/inline}}
-                {{#*inline "z-email"}}<span class="operator_value">{{> @partial-block}}</span>{{/inline}}
-                {{#*inline "z-keyword"}}<span class="operator_value">keyword</span>{{/inline}}
-            {{/tr}}
+            <p>{{t "You can combine search operators as needed." }}</p>
             <hr />
             <a href="help/search-for-messages#search-operators" target="_blank" rel="noopener noreferrer">{{t "Detailed search operators documentation" }}</a>
         </div>


### PR DESCRIPTION
Updates the tip at the bottom of the search operators tab in the `?` menu to only state that operators can be combined as needed.

Fixes #22866.

**Screenshots and screen captures:**

![Screenshot from 2022-10-31 19-44-08](https://user-images.githubusercontent.com/63245456/199240408-9154e45c-ca2b-41d1-9010-dfc56ba6c728.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
