### PR TITLE
narrow: Return default search title for "group-pm-with" operator.

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -386,6 +386,14 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
+    set_filter([["group-pm-with", ["Yo"]]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: This user does not exist!"),
+    );
+
     set_filter([["sender", "ray@example.com"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -158,19 +158,6 @@ function update_narrow_title(filter) {
         } else {
             set_narrow_title(filter_title);
         }
-    } else if (filter.has_operator("group-pm-with")) {
-        const emails = filter.operands("group-pm-with")[0];
-        const user_ids = people.emails_strings_to_user_ids_string(emails);
-        if (user_ids !== undefined) {
-            const names = people.get_recipients(user_ids);
-            set_narrow_title(names + " and others");
-        } else {
-            if (emails.includes(",")) {
-                set_narrow_title("Invalid users");
-            } else {
-                set_narrow_title("Invalid user");
-            }
-        }
     } else {
         set_narrow_title(search_default);
     }

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -330,19 +330,24 @@ function pick_empty_narrow_banner() {
                 title: $t({defaultMessage: "This user does not exist!"}),
             };
         case "group-pm-with":
+            if (people.get_by_email(first_operand)) {
+                return {
+                    title: $t({
+                        defaultMessage: "You have no group private messages with this person yet!",
+                    }),
+                    html: $t_html(
+                        {
+                            defaultMessage: "Why not <z-link>start the conversation</z-link>?",
+                        },
+                        {
+                            "z-link": (content_html) =>
+                                `<a href="#" class="empty_feed_compose_private">${content_html}</a>`,
+                        },
+                    ),
+                };
+            }
             return {
-                title: $t({
-                    defaultMessage: "You have no group private messages with this person yet!",
-                }),
-                html: $t_html(
-                    {
-                        defaultMessage: "Why not <z-link>start the conversation</z-link>?",
-                    },
-                    {
-                        "z-link": (content_html) =>
-                            `<a href="#" class="empty_feed_compose_private">${content_html}</a>`,
-                    },
-                ),
+                title: $t({defaultMessage: "This user does not exist!"}),
             };
     }
     return default_banner;


### PR DESCRIPTION
Because "group-pm-with" is not a common search operator, instead of setting a specialized title in the browser and tab, just use the default title, "Search results". See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/.22group-pm-with.22.20search.20with.20multiple.20users/near/1456484).

Also, when "group-pm-with" is the first and only operator and we need to set an empty narrow banner title:
- I added a check for whether the operand matches a user, so that the title is set based on whether the user exists or not.
- Since we're removing the "Invalid user" browser/tab title for this search operator, it seemed important to update that empty banner for this case.
- Note that if there are multiple search operators, then a default banner will be used. 

Follow-up work from #23216.

---

**Screenshots and screen captures:**

<details>
<summary>No group private messages with user</summary>

**New browser/tab title**, empty banner is the same as current behavior
![Screenshot from 2022-11-01 11-22-07](https://user-images.githubusercontent.com/63245456/199250788-6a64e5ba-13ea-4a56-afd3-569808d25c86.png)
</details>

<details>
<summary>Group private messages with user</summary>

**New browser/tab title**, no empty banner because there are messages
![Screenshot from 2022-11-01 11-22-22](https://user-images.githubusercontent.com/63245456/199250814-afda776c-9b1e-43f0-8171-85e6738e042a.png)
</details>

<details>
<summary>User does not exist</summary>

**New browser/tab title and new empty banner message** 
![Screenshot from 2022-11-01 11-23-00](https://user-images.githubusercontent.com/63245456/199250860-cf5c8c6f-e0cd-430a-a8c3-5ea0c6a93e52.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
