### PR TITLE
narrow: Check private message policy for empty narrow title.

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -15,6 +15,7 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const {Filter} = zrequire("../js/filter");
 const narrow = zrequire("narrow");
+const settings_config = zrequire("settings_config");
 
 const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
 mock_esm("../../static/js/spectators", {
@@ -296,6 +297,22 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
+    // organization has disabled sending private messages
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.disabled.code;
+    set_filter([["is", "private"]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: You are not allowed to send private messages in this organization.",
+        ),
+    );
+
+    // sending private messages enabled
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.by_anyone.code;
     set_filter([["is", "private"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
@@ -323,6 +340,11 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         empty_narrow_html("translated: No topics are marked as resolved."),
     );
 
+    // organization has disabled sending private messages
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.disabled.code;
+
+    // prioritize information about invalid user(s) in narrow/search
     set_filter([["pm-with", ["Yo"]]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
@@ -340,6 +362,19 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         empty_narrow_html("translated: One or more of these users do not exist!"),
     );
 
+    set_filter([["pm-with", "alice@example.com"]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: You are not allowed to send private messages in this organization.",
+        ),
+    );
+
+    // sending private messages enabled
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.by_anyone.code;
     set_filter([["pm-with", "alice@example.com"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
@@ -375,6 +410,32 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
+    // organization has disabled sending private messages
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.disabled.code;
+
+    // prioritize information about invalid user in narrow/search
+    set_filter([["group-pm-with", ["Yo"]]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html("translated: This user does not exist!"),
+    );
+
+    set_filter([["group-pm-with", "alice@example.com"]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: You are not allowed to send group private messages in this organization.",
+        ),
+    );
+
+    // sending private messages enabled
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.by_anyone.code;
     set_filter([["group-pm-with", "alice@example.com"]]);
     hide_all_empty_narrow_messages();
     narrow_banner.show_empty_narrow_message();
@@ -384,14 +445,6 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
             "translated: You have no group private messages with this person yet!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
-    );
-
-    set_filter([["group-pm-with", ["Yo"]]]);
-    hide_all_empty_narrow_messages();
-    narrow_banner.show_empty_narrow_message();
-    assert.equal(
-        $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: This user does not exist!"),
     );
 
     set_filter([["sender", "ray@example.com"]]);

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -57,6 +57,13 @@ const ray = {
     full_name: "Raymond",
 };
 
+const bot = {
+    email: "bot@example.com",
+    user_id: 25,
+    full_name: "Example Bot",
+    is_bot: true,
+};
+
 function hide_all_empty_narrow_messages() {
     const all_empty_narrow_messages = [
         ".empty_feed_notice",
@@ -372,6 +379,32 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
+    // private messages with a bot are possible even though
+    // the organization has disabled sending private messages
+    people.add_active_user(bot);
+    set_filter([["pm-with", "bot@example.com"]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated HTML: You have no private messages with Example Bot yet.",
+            'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
+        ),
+    );
+
+    // group private messages with bots are not possible when
+    // sending private messages is disabled
+    set_filter([["pm-with", bot.email + "," + alice.email]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: You are not allowed to send private messages in this organization.",
+        ),
+    );
+
     // sending private messages enabled
     page_params.realm_private_message_policy =
         settings_config.private_message_policy_values.by_anyone.code;
@@ -381,7 +414,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no private messages with this person yet!",
+            "translated HTML: You have no private messages with Alice Smith yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -405,7 +438,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no private messages with these people yet!",
+            "translated: You have no private messages with these people yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -433,6 +466,18 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
         ),
     );
 
+    // group private messages with bots are not possible when
+    // sending private messages is disabled
+    set_filter([["group-pm-with", "bot@example.com"]]);
+    hide_all_empty_narrow_messages();
+    narrow_banner.show_empty_narrow_message();
+    assert.equal(
+        $(".empty_feed_notice_main").html(),
+        empty_narrow_html(
+            "translated: You are not allowed to send group private messages in this organization.",
+        ),
+    );
+
     // sending private messages enabled
     page_params.realm_private_message_policy =
         settings_config.private_message_policy_values.by_anyone.code;
@@ -442,7 +487,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no group private messages with this person yet!",
+            "translated HTML: You have no group private messages with Alice Smith yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -452,7 +497,9 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: You haven't received any messages sent by this user yet!"),
+        empty_narrow_html(
+            "translated HTML: You haven't received any messages sent by Raymond yet.",
+        ),
     );
 
     set_filter([["sender", "sinwar@example.com"]]);

--- a/frontend_tests/puppeteer_tests/message-basics.ts
+++ b/frontend_tests/puppeteer_tests/message-basics.ts
@@ -152,7 +152,7 @@ async function search_silent_user(page: Page, str: string, item: string): Promis
     await page.waitForSelector("#search_query", {visible: true});
     await common.select_item_via_typeahead(page, "#search_query", str, item);
     await page.waitForSelector(".empty_feed_notice", {visible: true});
-    const expect_message = "You haven't received any messages sent by this user yet!";
+    const expect_message = "You haven't received any messages sent by Email Gateway yet.";
     assert.strictEqual(
         await common.get_text_from_selector(page, ".empty_feed_notice"),
         expect_message,

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -483,7 +483,8 @@ function validate_private_message() {
     const user_ids = compose_pm_pill.get_user_ids();
 
     if (
-        page_params.realm_private_message_policy === 2 && // Frontend check for for PRIVATE_MESSAGE_POLICY_DISABLED
+        page_params.realm_private_message_policy ===
+            settings_config.private_message_policy_values.disabled.code &&
         (user_ids.length !== 1 || !people.get_by_user_id(user_ids[0]).is_bot)
     ) {
         // Unless we're composing to a bot

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -281,7 +281,7 @@ function pick_empty_narrow_banner() {
                 search_data: retrieve_search_query_data(),
             };
         }
-        case "pm-with":
+        case "pm-with": {
             if (!people.is_valid_bulk_emails_for_compose(first_operand.split(","))) {
                 if (!first_operand.includes(",")) {
                     return {
@@ -292,9 +292,11 @@ function pick_empty_narrow_banner() {
                     title: $t({defaultMessage: "One or more of these users do not exist!"}),
                 };
             }
+            const user_ids = people.emails_strings_to_user_ids_array(first_operand);
             if (
                 page_params.realm_private_message_policy ===
-                settings_config.private_message_policy_values.disabled.code
+                    settings_config.private_message_policy_values.disabled.code &&
+                (user_ids.length !== 1 || !people.get_by_user_id(user_ids[0]).is_bot)
             ) {
                 return {
                     title: $t({
@@ -326,9 +328,12 @@ function pick_empty_narrow_banner() {
                     };
                 }
                 return {
-                    title: $t({
-                        defaultMessage: "You have no private messages with this person yet!",
-                    }),
+                    title: $t_html(
+                        {
+                            defaultMessage: "You have no private messages with {person} yet.",
+                        },
+                        {person: people.get_by_user_id(user_ids[0]).full_name},
+                    ),
                     html: $t_html(
                         {
                             defaultMessage: "Why not <z-link>start the conversation</z-link>?",
@@ -343,7 +348,7 @@ function pick_empty_narrow_banner() {
                 };
             }
             return {
-                title: $t({defaultMessage: "You have no private messages with these people yet!"}),
+                title: $t({defaultMessage: "You have no private messages with these people yet."}),
                 html: $t_html(
                     {
                         defaultMessage: "Why not <z-link>start the conversation</z-link>?",
@@ -356,19 +361,27 @@ function pick_empty_narrow_banner() {
                     },
                 ),
             };
-        case "sender":
-            if (people.get_by_email(first_operand)) {
+        }
+        case "sender": {
+            const sender = people.get_by_email(first_operand);
+            if (sender) {
                 return {
-                    title: $t({
-                        defaultMessage: "You haven't received any messages sent by this user yet!",
-                    }),
+                    title: $t_html(
+                        {
+                            defaultMessage:
+                                "You haven't received any messages sent by {person} yet.",
+                        },
+                        {person: sender.full_name},
+                    ),
                 };
             }
             return {
                 title: $t({defaultMessage: "This user does not exist!"}),
             };
-        case "group-pm-with":
-            if (!people.get_by_email(first_operand)) {
+        }
+        case "group-pm-with": {
+            const person_in_group_pm = people.get_by_email(first_operand);
+            if (!person_in_group_pm) {
                 return {
                     title: $t({defaultMessage: "This user does not exist!"}),
                 };
@@ -385,9 +398,12 @@ function pick_empty_narrow_banner() {
                 };
             }
             return {
-                title: $t({
-                    defaultMessage: "You have no group private messages with this person yet!",
-                }),
+                title: $t_html(
+                    {
+                        defaultMessage: "You have no group private messages with {person} yet.",
+                    },
+                    {person: person_in_group_pm.full_name},
+                ),
                 html: $t_html(
                     {
                         defaultMessage: "Why not <z-link>start the conversation</z-link>?",
@@ -398,6 +414,7 @@ function pick_empty_narrow_banner() {
                     },
                 ),
             };
+        }
     }
     return default_banner;
 }

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -5,6 +5,7 @@ import {narrow_error} from "./narrow_error";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as settings_config from "./settings_config";
 import * as spectators from "./spectators";
 import * as stream_data from "./stream_data";
 
@@ -186,6 +187,17 @@ function pick_empty_narrow_banner() {
                     };
                 case "private":
                     // You have no private messages.
+                    if (
+                        page_params.realm_private_message_policy ===
+                        settings_config.private_message_policy_values.disabled.code
+                    ) {
+                        return {
+                            title: $t({
+                                defaultMessage:
+                                    "You are not allowed to send private messages in this organization.",
+                            }),
+                        };
+                    }
                     return {
                         title: $t({defaultMessage: "You have no private messages yet!"}),
                         html: $t_html(
@@ -280,6 +292,17 @@ function pick_empty_narrow_banner() {
                     title: $t({defaultMessage: "One or more of these users do not exist!"}),
                 };
             }
+            if (
+                page_params.realm_private_message_policy ===
+                settings_config.private_message_policy_values.disabled.code
+            ) {
+                return {
+                    title: $t({
+                        defaultMessage:
+                            "You are not allowed to send private messages in this organization.",
+                    }),
+                };
+            }
             if (!first_operand.includes(",")) {
                 // You have no private messages with this person
                 if (people.is_current_user(first_operand)) {
@@ -345,26 +368,35 @@ function pick_empty_narrow_banner() {
                 title: $t({defaultMessage: "This user does not exist!"}),
             };
         case "group-pm-with":
-            if (people.get_by_email(first_operand)) {
+            if (!people.get_by_email(first_operand)) {
+                return {
+                    title: $t({defaultMessage: "This user does not exist!"}),
+                };
+            }
+            if (
+                page_params.realm_private_message_policy ===
+                settings_config.private_message_policy_values.disabled.code
+            ) {
                 return {
                     title: $t({
-                        defaultMessage: "You have no group private messages with this person yet!",
+                        defaultMessage:
+                            "You are not allowed to send group private messages in this organization.",
                     }),
-                    html: $t_html(
-                        {
-                            defaultMessage: "Why not <z-link>start the conversation</z-link>?",
-                        },
-                        {
-                            "z-link": (content_html) =>
-                                `<a href="#" class="empty_feed_compose_private">${content_html.join(
-                                    "",
-                                )}</a>`,
-                        },
-                    ),
                 };
             }
             return {
-                title: $t({defaultMessage: "This user does not exist!"}),
+                title: $t({
+                    defaultMessage: "You have no group private messages with this person yet!",
+                }),
+                html: $t_html(
+                    {
+                        defaultMessage: "Why not <z-link>start the conversation</z-link>?",
+                    },
+                    {
+                        "z-link": (content_html) =>
+                            `<a href="#" class="empty_feed_compose_private">${content_html}</a>`,
+                    },
+                ),
             };
     }
     return default_banner;


### PR DESCRIPTION
For narrows that focus on private messages ("is:private", "pm-with", "group-pm-with"), we want to check the organization private message policy and set an empty narrow title that matches that policy.

Fixes #21889.

---

**Notes**:
- These are the empty narrow titles when only the one search operator is used.
- The "pm-with" operator still pops up a compose box for the private message recipients. We may also want to update that behavior based on this organization policy setting? See "Private messages - no messages" screenshot below. If so, does this feel like a follow-up or something to add to this PR?
- The invalid user searches for "pm-with" will pull up the banner saying the user does or doesn't exist. The invalid user searches for "group-pm-with" will return the privacy policy message. See "Invalid users" screenshots below. We should probably make these consistent. One thought I had is that we could show both messages in this case? For example,

<details>
<summary>Invalid user and privacy policy message</summary>

![Screenshot from 2022-11-01 15-43-01](https://user-images.githubusercontent.com/63245456/199260974-f011d13c-c9a4-4889-b443-bdf11ae9fa42.png)
</details>

*Note that the browser/tab titles and the invalid user empty narrow title for "group-pm-with" are being updated in a separate pull request (see #23399).*

---

**Screenshots and screen captures:**

<details>
<summary>No private messages</summary>

**Note** that this is probably rather uncommon due to Welcome Bot messages for new users, but it felt like a case that should be covered.
![Screenshot from 2022-11-01 12-05-00](https://user-images.githubusercontent.com/63245456/199254934-c48d977f-c386-4ae5-a67d-0bdd2c590dd2.png)
</details>

<details>
<summary>Invalid user or users</summary>

**Note** for "pm-with" if the user (or one of the users) searched for does not exist, the banner with that information is shown. But if "group-pm-with" is used and the user doesn't exist, then the privacy policy is shown.
![Screenshot from 2022-11-01 12-02-14](https://user-images.githubusercontent.com/63245456/199255135-4483e14b-2dc4-4f7b-92f7-cc08739ba4fa.png)
![Screenshot from 2022-11-01 15-22-18](https://user-images.githubusercontent.com/63245456/199256001-ecf34ae0-e0de-4801-9320-e3d0c99bf5d0.png)
![Screenshot from 2022-11-01 15-30-27](https://user-images.githubusercontent.com/63245456/199257822-ecfba4d0-c982-4202-a3d6-28479bc46f1d.png)
</details>

<details>
<summary>Group private messages - no messages</summary>

![Screenshot from 2022-11-01 11-59-53](https://user-images.githubusercontent.com/63245456/199255172-e39b83c8-dfb4-4add-ac1a-608323e39e01.png)
</details>

<details>
<summary>Group private messages - there are messages</summary>

![Screenshot from 2022-11-01 11-59-38](https://user-images.githubusercontent.com/63245456/199255208-dd0b1098-626b-4512-beca-5d4f4b9ed923.png)
</details>

<details>
<summary>Private messages - no mesages</summary>

![Screenshot from 2022-11-01 11-58-31](https://user-images.githubusercontent.com/63245456/199255239-2fe2da14-2d9b-48ec-882f-52b84d513a5f.png)
</details>

<details>
<summary>Private messages - there are messages</summary>

![Screenshot from 2022-11-01 15-24-03](https://user-images.githubusercontent.com/63245456/199256436-028d11e0-68e7-4e13-8988-47cd26827fdc.png)

</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
