### PR TITLE
shared: Bump version to 0.0.15

### DIFF
--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zulip/shared",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "license": "Apache-2.0",
   "scripts": {
     "version": "tools/npm-version",


### PR DESCRIPTION
Looks like I can't push this directly; I have to go through a PR:

```
$ git push upstream main shared-0.0.15
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 6 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 459 bytes | 459.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: error: 4 of 4 required status checks are expected. Changes must be made through a pull request.
To github.com:zulip/zulip.git
 * [new tag]             shared-0.0.15 -> shared-0.0.15
 ! [remote rejected]     main -> main (protected branch hook declined)
error: failed to push some refs to 'github.com:zulip/zulip.git'
```

Note that a new tag was successfully pushed; it points to 72303bc0b0dd62d03f6700ec48a68e7f6926aedc. We should update the tag if we end up with a different commit in `main`.