### PR TITLE
Make sure full name gets checked even when empty in admin user editin…

### DIFF
--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -241,7 +241,7 @@ def update_user_backend(
             )
         do_change_user_role(target, role, acting_user=user_profile)
 
-    if full_name is not None and target.full_name != full_name and full_name.strip() != "":
+    if full_name is not None and target.full_name != full_name:
         # We don't respect `name_changes_disabled` here because the request
         # is on behalf of the administrator.
         check_change_full_name(target, full_name, user_profile)


### PR DESCRIPTION
In the Admin tool for editing users, the input for their full name should run the name check logic even if empty.

This change makes sure the name checking logic is run when the input box is empty and the "Save changes" button is pressed, triggering the same error modal as when the name is too short to show and does not close the admin tool modal.

<!-- Describe your pull request here.-->

Fixes: #22904 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![msedge_l2IPaQIuqf](https://user-images.githubusercontent.com/14200637/199296236-49fd4373-8cb0-434e-a197-4e0918d1cf01.png)

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
