### PR TITLE
shared: Prescribe atomic push when bumping version.

### DIFF
--- a/static/shared/tools/npm-postversion
+++ b/static/shared/tools/npm-postversion
@@ -23,7 +23,7 @@ Next steps:
 
   \$ ${bold}git log --stat -p upstream..${reset}  # check your work!
 
-  \$ ${bold}git push upstream main shared-${npm_package_version}${reset}
+  \$ ${bold}git push --atomic upstream main shared-${npm_package_version}${reset}
 
   \$ ${bold}npm publish${reset}  # should prompt for an OTP, from your 2FA setup
 "


### PR DESCRIPTION
This way, if the maintainer isn't able to update `main`, the push doesn't add the shared-VERSION tag either. That avoids ending up with a tag that potentially doesn't get included in the history of the main branch.

The Git docs warn that servers might or might not support this feature, but GitHub does -- indeed they boasted about it when it first came out, in Git 2.4 back in 2015:
  https://github.blog/2015-04-30-git-2-4-atomic-pushes-push-to-deploy-and-more/

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
