### PR TITLE
Catch and fix drafts with undefined topics.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -7,12 +7,14 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 const {user_settings} = require("../zjsunit/zpage_params");
 
+const blueslip = zrequire("blueslip");
 const compose_pm_pill = zrequire("compose_pm_pill");
 const user_pill = zrequire("user_pill");
 const people = zrequire("people");
 const compose_state = zrequire("compose_state");
 const sub_store = zrequire("sub_store");
 const stream_data = zrequire("stream_data");
+
 const aaron = {
     email: "aaron@zulip.com",
     user_id: 6,
@@ -375,6 +377,55 @@ test("rename_stream_recipient", ({override_rewire}) => {
     assert_draft("id2", "A", "b");
     assert_draft("id3", "B", "e");
     assert_draft("id4", "B", "e");
+});
+
+// There were some buggy drafts that had their topics
+// renamed to `undefined` in #23238.
+// TODO/compatibility: The next two tests can be deleted
+// in 2023 since all relevant drafts will have either
+// been run through this code or else been deleted after
+// 30 days.
+test("catch_buggy_draft_error", () => {
+    const stream_A = {
+        subscribed: false,
+        name: "A",
+        stream_id: 1,
+    };
+    stream_data.add_sub(stream_A);
+    const stream_B = {
+        subscribed: false,
+        name: "B",
+        stream_id: 2,
+    };
+    stream_data.add_sub(stream_B);
+
+    const buggy_draft = {
+        stream: stream_B.name,
+        stream_id: stream_B.stream_id,
+        topic: undefined,
+        type: "stream",
+        content: "Test stream message",
+        updatedAt: Date.now(),
+    };
+    const data = {id1: buggy_draft};
+    const ls = localstorage();
+    ls.set("drafts", data);
+    const draft_model = drafts.draft_model;
+
+    // An error is logged but the draft isn't fixed in this codepath.
+    blueslip.expect(
+        "error",
+        "Cannot compare strings; at least one value is undefined: undefined, old_topic",
+    );
+    drafts.rename_stream_recipient(
+        stream_B.stream_id,
+        "old_topic",
+        stream_A.stream_id,
+        "new_topic",
+    );
+    const draft = draft_model.getDraft("id1");
+    assert.equal(draft.stream, stream_B.name);
+    assert.equal(draft.topic, undefined);
 });
 
 test("delete_all_drafts", () => {

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -1,5 +1,6 @@
 import _ from "lodash";
 
+import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
 
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
@@ -39,6 +40,10 @@ export function lower_bound(array, value, less) {
 }
 
 export const lower_same = function lower_same(a, b) {
+    if (a === undefined || b === undefined) {
+        blueslip.error(`Cannot compare strings; at least one value is undefined: ${a}, ${b}`);
+        return false;
+    }
     return a.toLowerCase() === b.toLowerCase();
 };
 


### PR DESCRIPTION
This more fully fixes an error state that came out of #22094.

The code causing the error was fixed in #23238 but some
drafts still have undefined topics. This PR catches errors
from undefined topics and also renames undefined topics
to empty string.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
