### PR TITLE
shared: Fix typeahead.js.flow to add Emoji['reaction_type'].

### DIFF
--- a/static/shared/js/typeahead.js.flow
+++ b/static/shared/js/typeahead.js.flow
@@ -1,6 +1,11 @@
 // @flow strict
 
-export type Emoji = {emoji_name: string, emoji_code: string, ...};
+export type Emoji = {
+    emoji_name: string,
+    emoji_code: string,
+    reaction_type: "unicode_emoji" | "realm_emoji" | "zulip_extra_emoji",
+    ...
+};
 
 // declare export var popular_emojis
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

The emoji matcher uses this property in is_unicode_emoji.

It doesn't quite make sense to be talking about "reaction types" here -- we might use this for a message-reactions UI, but we might just as reasonably use it for emoji UI in message composing. Ah,
well: I guess that's just a bit of messiness that we can deal with.

**Screenshots and screen captures:**

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
