### PR TITLE
shared: Bump version to 0.0.16

### DIFF
--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zulip/shared",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "license": "Apache-2.0",
   "scripts": {
     "version": "tools/npm-version",


### PR DESCRIPTION
Once this is merged, we should tag the merged commit with `shared-0.0.16`.