### PR TITLE
compose: Migrate "sent!" banners to new banner style

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -34,7 +34,6 @@ const compose_fade = mock_esm("../../static/js/compose_fade");
 const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
 const loading = mock_esm("../../static/js/loading");
 const markdown = mock_esm("../../static/js/markdown");
-const notifications = mock_esm("../../static/js/notifications");
 const reminder = mock_esm("../../static/js/reminder");
 const rendered_markdown = mock_esm("../../static/js/rendered_markdown");
 const resize = mock_esm("../../static/js/resize");
@@ -44,6 +43,7 @@ const transmit = mock_esm("../../static/js/transmit");
 const upload = mock_esm("../../static/js/upload");
 
 const compose_ui = zrequire("compose_ui");
+const notifications = zrequire("notifications");
 const compose_closed_ui = zrequire("compose_closed_ui");
 const compose_state = zrequire("compose_state");
 const compose = zrequire("compose");
@@ -293,7 +293,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
 test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     mock_banners();
-    override(notifications, "clear_compose_notifications", () => {});
+    override_rewire(notifications, "clear_compose_notifications", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
     let show_button_spinner_called = false;
@@ -342,7 +342,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
 
 test_ui("finish", ({override, override_rewire, mock_template}) => {
     mock_banners();
-    override(notifications, "clear_compose_notifications", () => {});
+    override_rewire(notifications, "clear_compose_notifications", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
     let show_button_spinner_called = false;

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -43,7 +43,7 @@ const transmit = mock_esm("../../static/js/transmit");
 const upload = mock_esm("../../static/js/upload");
 
 const compose_ui = zrequire("compose_ui");
-const notifications = zrequire("notifications");
+const compose_banner = zrequire("compose_banner");
 const compose_closed_ui = zrequire("compose_closed_ui");
 const compose_state = zrequire("compose_state");
 const compose = zrequire("compose");
@@ -293,7 +293,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
 test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     mock_banners();
-    override_rewire(notifications, "clear_compose_notifications", () => {});
+    override_rewire(compose_banner, "clear_message_sent_banners", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
     let show_button_spinner_called = false;
@@ -342,7 +342,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
 
 test_ui("finish", ({override, override_rewire, mock_template}) => {
     mock_banners();
-    override_rewire(notifications, "clear_compose_notifications", () => {});
+    override_rewire(compose_banner, "clear_message_sent_banners", () => {});
     override(reminder, "is_deferred_delivery", () => false);
     override(document, "to_$", () => $("document-stub"));
     let show_button_spinner_called = false;

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -30,9 +30,7 @@ const hash_util = mock_esm("../../static/js/hash_util");
 const narrow_state = mock_esm("../../static/js/narrow_state", {
     set_compose_defaults: noop,
 });
-mock_esm("../../static/js/notifications", {
-    clear_compose_notifications: noop,
-});
+
 mock_esm("../../static/js/reload_state", {
     is_in_progress: () => false,
 });

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -13,6 +13,7 @@ mock_esm("../../static/js/resize", {
 const all_messages_data = mock_esm("../../static/js/all_messages_data");
 const channel = mock_esm("../../static/js/channel");
 const compose_actions = mock_esm("../../static/js/compose_actions");
+const compose_banner = mock_esm("../../static/js/compose_banner");
 const compose_closed_ui = mock_esm("../../static/js/compose_closed_ui");
 const hashchange = mock_esm("../../static/js/hashchange");
 const message_fetch = mock_esm("../../static/js/message_fetch");
@@ -71,13 +72,13 @@ function test_helper() {
         };
     }
 
+    stub(compose_banner, "clear_message_sent_banners");
     stub(compose_actions, "on_narrow");
     stub(compose_closed_ui, "update_reply_recipient_label");
     stub(hashchange, "save_narrow");
     stub(message_scroll, "hide_indicators");
     stub(message_scroll, "show_loading_older");
     stub(message_scroll, "hide_top_of_narrow_notices");
-    stub(notifications, "clear_compose_notifications");
     stub(notifications, "redraw_title");
     stub(search, "update_button_visibility");
     stub(stream_list, "handle_narrow_activated");
@@ -186,7 +187,7 @@ run_test("basics", () => {
     helper.assert_events([
         [message_scroll, "hide_top_of_narrow_notices"],
         [message_scroll, "hide_indicators"],
-        [notifications, "clear_compose_notifications"],
+        [compose_banner, "clear_message_sent_banners"],
         [notifications, "redraw_title"],
         [unread_ops, "process_visible"],
         [hashchange, "save_narrow"],

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -19,7 +19,6 @@ import * as loading from "./loading";
 import * as markdown from "./markdown";
 import * as message_edit from "./message_edit";
 import * as narrow from "./narrow";
-import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as reminder from "./reminder";
@@ -308,7 +307,7 @@ export function finish() {
     clear_preview_area();
     clear_invites();
     clear_private_stream_alert();
-    notifications.clear_compose_notifications();
+    compose_banner.clear_message_sent_banners();
 
     const message_content = compose_state.message_content();
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -19,7 +19,6 @@ import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
-import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as recent_topics_ui from "./recent_topics_ui";
@@ -292,7 +291,7 @@ export function start(msg_type, opts) {
     if (reload_state.is_in_progress()) {
         return;
     }
-    notifications.clear_compose_notifications();
+    compose_banner.clear_message_sent_banners();
     expand_compose_box();
 
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
@@ -384,7 +383,7 @@ export function cancel() {
     hide_box();
     $("#compose_close").hide();
     clear_box();
-    notifications.clear_compose_notifications();
+    compose_banner.clear_message_sent_banners();
     compose.abort_xhr();
     compose.abort_video_callbacks(undefined);
     compose_state.set_message_type(false);

--- a/static/js/compose_banner.ts
+++ b/static/js/compose_banner.ts
@@ -7,7 +7,13 @@ import render_stream_does_not_exist_error from "../templates/compose_banner/stre
 export const WARNING = "warning";
 export const ERROR = "error";
 
+const MESSAGE_SENT_CLASSNAMES = {
+    sent_scroll_to_view: "sent_scroll_to_view",
+    narrow_to_recipient: "narrow_to_recipient",
+};
+
 export const CLASSNAMES = {
+    ...MESSAGE_SENT_CLASSNAMES,
     // warnings
     topic_resolved: "topic_resolved",
     recipient_not_subscribed: "recipient_not_subscribed",
@@ -31,6 +37,12 @@ export const CLASSNAMES = {
     generic_compose_error: "generic_compose_error",
     user_not_subscribed: "user_not_subscribed",
 };
+
+export function clear_message_sent_banners(): void {
+    for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {
+        $(`#compose_banners .${classname}`).remove();
+    }
+}
 
 // TODO: Replace with compose_ui.hide_compose_spinner() when it is converted to ts.
 function hide_compose_spinner(): void {

--- a/static/js/compose_banner.ts
+++ b/static/js/compose_banner.ts
@@ -3,6 +3,11 @@ import $ from "jquery";
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 import render_stream_does_not_exist_error from "../templates/compose_banner/stream_does_not_exist_error.hbs";
 
+export let scroll_to_message_banner_message_id: number | null = null;
+export function set_scroll_to_message_banner_message_id(val: number | null): void {
+    scroll_to_message_banner_message_id = val;
+}
+
 // banner types
 export const WARNING = "warning";
 export const ERROR = "error";
@@ -42,6 +47,7 @@ export function clear_message_sent_banners(): void {
     for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {
         $(`#compose_banners .${classname}`).remove();
     }
+    scroll_to_message_banner_message_id = null;
 }
 
 // TODO: Replace with compose_ui.hide_compose_spinner() when it is converted to ts.

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import _ from "lodash";
 
+import * as compose_banner from "./compose_banner";
 import * as floating_recipient_bar from "./floating_recipient_bar";
 import * as hash_util from "./hash_util";
 import * as loading from "./loading";
@@ -9,7 +10,6 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_banner from "./narrow_banner";
 import * as narrow_state from "./narrow_state";
-import * as notifications from "./notifications";
 import * as recent_topics_util from "./recent_topics_util";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
@@ -195,12 +195,12 @@ export function scroll_finished() {
         return;
     }
 
-    if (notifications.scroll_to_message_banner_message_id !== null) {
+    if (compose_banner.scroll_to_message_banner_message_id !== null) {
         const $message_row = message_lists.current.get_row(
-            notifications.scroll_to_message_banner_message_id,
+            compose_banner.scroll_to_message_banner_message_id,
         );
         if ($message_row.length > 0 && !message_viewport.is_message_below_viewport($message_row)) {
-            notifications.clear_compose_notifications();
+            compose_banner.clear_message_sent_banners();
         }
     }
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -4,6 +4,7 @@ import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as compose_actions from "./compose_actions";
+import * as compose_banner from "./compose_banner";
 import * as compose_closed_ui from "./compose_closed_ui";
 import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
@@ -417,7 +418,7 @@ export function activate(raw_operators, opts) {
 
     // most users aren't going to send a bunch of a out-of-narrow messages
     // and expect to visit a list of narrows, so let's get these out of the way.
-    notifications.clear_compose_notifications();
+    compose_banner.clear_message_sent_banners();
 
     // Open tooltips are only interesting for current narrow,
     // so hide them when activating a new one.

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -164,8 +164,6 @@ export function is_window_focused() {
     return window_focused;
 }
 
-export let scroll_to_message_banner_message_id = null;
-
 export function notify_above_composebox(
     banner_text,
     classname,
@@ -182,7 +180,7 @@ export function notify_above_composebox(
             link_text,
         }),
     );
-    clear_compose_notifications();
+    compose_banner.clear_message_sent_banners();
     $("#compose_banners").append($notification);
 }
 
@@ -626,7 +624,7 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
                     link_msg_id,
                     link_text,
                 );
-                scroll_to_message_banner_message_id = link_msg_id;
+                compose_banner.set_scroll_to_message_banner_message_id(link_msg_id);
             }
 
             // This is the HAPPY PATH--for most messages we do nothing
@@ -684,11 +682,6 @@ export function notify_messages_outside_current_search(messages) {
     }
 }
 
-export function clear_compose_notifications() {
-    compose_banner.clear_message_sent_banners();
-    scroll_to_message_banner_message_id = null;
-}
-
 export function reify_message_id(opts) {
     const old_id = opts.old_id;
     const new_id = opts.new_id;
@@ -701,7 +694,7 @@ export function reify_message_id(opts) {
 
         if (message_id === old_id) {
             $elem.data("message-id", new_id);
-            scroll_to_message_banner_message_id = new_id;
+            compose_banner.set_scroll_to_message_banner_message_id(new_id);
         }
     }
 }
@@ -724,7 +717,7 @@ export function register_click_handlers() {
             const message_id = $(e.currentTarget).data("message-id");
             message_lists.current.select_id(message_id);
             navigate.scroll_to_selected();
-            clear_compose_notifications();
+            compose_banner.clear_message_sent_banners();
             e.stopPropagation();
             e.preventDefault();
         },

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -166,16 +166,16 @@ export function is_window_focused() {
 export let scroll_to_message_banner_message_id = null;
 
 export function notify_above_composebox(
-    note,
-    link_class,
+    banner_text,
+    classname,
     above_composebox_narrow_url,
     link_msg_id,
     link_text,
 ) {
     const $notification = $(
         render_message_sent_banner({
-            note,
-            link_class,
+            banner_text,
+            classname,
             above_composebox_narrow_url,
             link_msg_id,
             link_text,
@@ -610,16 +610,16 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
             continue;
         }
 
-        let reason = get_local_notify_mix_reason(message);
+        let banner_text = get_local_notify_mix_reason(message);
 
         const link_msg_id = message.id;
 
-        if (!reason) {
+        if (!banner_text) {
             if (need_user_to_scroll) {
-                reason = $t({defaultMessage: "Sent!"});
+                banner_text = $t({defaultMessage: "Sent!"});
                 const link_text = $t({defaultMessage: "Scroll down to view your message."});
                 notify_above_composebox(
-                    reason,
+                    banner_text,
                     "compose_notification_scroll_to_message",
                     // Don't display a URL on hover for the "Scroll to bottom" link.
                     null,
@@ -635,15 +635,15 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
         }
 
         const above_composebox_narrow_url = get_above_composebox_narrow_url(message);
-        const link_class = "compose_notification_narrow_by_topic";
+        const classname = "compose_notification_narrow_by_topic";
         const link_text = $t(
             {defaultMessage: "Narrow to {message_recipient}"},
             {message_recipient: get_message_header(message)},
         );
 
         notify_above_composebox(
-            reason,
-            link_class,
+            banner_text,
+            classname,
             above_composebox_narrow_url,
             link_msg_id,
             link_text,

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -320,6 +320,24 @@
         padding: 12px 10px;
     }
 
+    &.success {
+        background-color: hsl(147, 43%, 92%);
+        border: 1px solid hsla(147, 57%, 25%, 0.4);
+        color: hsl(147, 57%, 25%);
+
+        .compose_banner_close_button {
+            color: hsla(147, 57%, 25%, 0.5);
+
+            &:hover {
+                color: hsl(147, 57%, 25%);
+            }
+
+            &:active {
+                color: hsla(147, 57%, 25%, 0.75);
+            }
+        }
+    }
+
     &.warning {
         background-color: hsl(50, 75%, 92%);
         border-color: hsla(38, 44%, 27%, 0.4);
@@ -412,31 +430,6 @@ div[id^="message-edit-send-status"],
 .compose-send-status-close:hover {
     cursor: pointer;
     opacity: 0.4;
-}
-
-#out-of-view-notification {
-    position: relative;
-    margin-bottom: 6px;
-
-    background-color: hsla(152, 51%, 63%, 0.25);
-    border: 1px solid hsla(0, 0%, 0%, 0.1);
-    border-radius: 4px;
-
-    .close {
-        position: absolute;
-        right: 8px;
-        top: 4px;
-        font-size: 17px;
-        font-weight: bold;
-        color: hsl(0, 0%, 0%);
-        text-shadow: 0 1px 0 hsl(0, 0%, 100%);
-        opacity: 0.2;
-    }
-}
-
-.compose-notifications-content {
-    padding: 4px 22px;
-    text-align: center;
 }
 
 .composition-area {

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -172,6 +172,24 @@
     }
 
     .compose_banner {
+        &.success {
+            background-color: hsl(147, 100%, 8%);
+            border-color: hsla(149, 48%, 52%, 0.4);
+            color: hsl(147, 51%, 55%);
+
+            .compose_banner_close_button {
+                color: hsl(147, 51%, 55%, 0.5);
+
+                &:hover {
+                    color: hsl(147, 51%, 55%);
+                }
+
+                &:active {
+                    color: hsl(147, 51%, 55%, 0.75);
+                }
+            }
+        }
+
         &.warning {
             background-color: hsl(53, 100%, 11%);
             border-color: hsla(38, 44%, 60%, 0.4);
@@ -1287,10 +1305,6 @@
     .star:not(.empty-star),
     .empty-star:hover {
         color: hsla(126, 66%, 72%, 0.75);
-    }
-
-    #out-of-view-notification {
-        border: 1px solid hsl(144, 45%, 62%);
     }
 
     #bots_lists_navbar .active a {

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -51,7 +51,6 @@
             <span class="compose-send-status-close">&times;</span>
             <span id="compose-error-msg"></span>
         </div>
-        <div id="out-of-view-notification" class="notification-alert"></div>
         <div class="composition-area">
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}

--- a/static/templates/compose_banner/message_sent_banner.hbs
+++ b/static/templates/compose_banner/message_sent_banner.hbs
@@ -1,4 +1,4 @@
 <div class="compose-notifications-content">
-    {{note}} {{#if link_class}}<a {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} class="{{link_class}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
+    {{banner_text}} {{#if link_text}}<a {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} class="{{classname}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
     <button type="button" class="out-of-view-notification-close close">&times;</button>
 </div>

--- a/static/templates/compose_banner/message_sent_banner.hbs
+++ b/static/templates/compose_banner/message_sent_banner.hbs
@@ -1,4 +1,7 @@
-<div class="compose-notifications-content">
-    {{banner_text}} {{#if link_text}}<a {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} class="{{classname}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
-    <button type="button" class="out-of-view-notification-close close">&times;</button>
+<div class="above_compose_banner compose_banner success {{classname}}">
+    <p>
+        {{banner_text}}
+        {{#if link_text}} <a class="above_compose_banner_action_link" {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
+    </p>
+    <a role="button" class="zulip-icon zulip-icon-close compose_banner_close_button"></a>
 </div>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -61,6 +61,7 @@ EXEMPT_FILES = make_set(
         "static/js/click_handlers.js",
         "static/js/compose.js",
         "static/js/compose_actions.js",
+        "static/js/compose_banner.ts",
         "static/js/compose_closed_ui.js",
         "static/js/compose_fade.js",
         "static/js/compose_state.js",


### PR DESCRIPTION
Part two of fixing https://github.com/zulip/zulip/issues/22524.

**Screenshots and screen captures:**

<img width="864" alt="image" src="https://user-images.githubusercontent.com/5634097/211176249-859bb5cb-a0d2-4a27-9c0c-160c20abe165.png">

<img width="851" alt="image" src="https://user-images.githubusercontent.com/5634097/211176259-0666ce7a-50d2-4dad-b48f-9c18ef7c721c.png">

<img width="840" alt="image" src="https://user-images.githubusercontent.com/5634097/211176264-bc001284-00ff-4296-83e4-e4249606cd93.png">


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
