### PR TITLE
help center: Add a detail to /help/mute-a-stream.

### DIFF
--- a/templates/zerver/help/mute-a-stream.md
+++ b/templates/zerver/help/mute-a-stream.md
@@ -5,7 +5,8 @@ notifications, unless you are
 [mentioned](/help/mention-a-user-or-group). Messages from muted streams
 do not generate [alert word](/help/pm-mention-alert-notifications#alert-words) notifications.
 
-Muted streams still appear in the left sidebar, though they are grayed out.
+Muted streams still appear in the left sidebar, but they are grayed out and
+sorted to the bottom of their section.
 
 !!! warn ""
 


### PR DESCRIPTION
Indicate that muted streams are sorted to the bottom of their section.

Current page: https://zulip.com/help/mute-a-stream
Updated:

![Screen Shot 2022-11-02 at 4 26 53 PM](https://user-images.githubusercontent.com/2090066/199621051-414c0b40-cb21-4e66-9827-a6fdbc63b83b.png)
