### PR TITLE
popovers: Add bottom margin to input.

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -792,7 +792,8 @@ ul {
     }
 
     .dropdown-list-widget,
-    .stream_header_colorblock {
+    .stream_header_colorblock,
+    .inline_topic_edit {
         margin-bottom: 10px;
     }
 


### PR DESCRIPTION
This PR adds a bottom margin for .inline_topic_edit, this helps to add a bottom margin when the input wraps to a new line. This works on both the move topic and move messages popovers.

Fixes: #23114

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
It adds 10px margin when the input wraps to a new line
![image](https://user-images.githubusercontent.com/5351407/199646564-e72eec1d-0dd3-4cb8-a8e5-aa0218949642.png)
![image](https://user-images.githubusercontent.com/5351407/199646565-4b09303b-f5ff-4a88-bbb2-cc7b1a027e4a.png)

It behaves the same if it's only one line:
![image](https://user-images.githubusercontent.com/5351407/199646599-88b114fa-4184-43ca-8cfb-be0d9869338f.png)
![image](https://user-images.githubusercontent.com/5351407/199646628-3e5a61af-80e6-4d25-8714-cd3249e8b4b6.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
