### PR TITLE
compose: Limit compose box start for private messages if org has disabled PMs policy.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -5,6 +5,9 @@ const {strict: assert} = require("assert");
 const {mock_esm, set_global, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
+const {page_params} = require("../zjsunit/zpage_params");
+
+const settings_config = zrequire("settings_config");
 
 const noop = () => {};
 
@@ -443,6 +446,22 @@ test("on_narrow", ({override, override_rewire}) => {
     let narrowed_by_pm_reply;
     override(narrow_state, "narrowed_by_pm_reply", () => narrowed_by_pm_reply);
 
+    const steve = {
+        user_id: 90,
+        email: "steve@example.com",
+        full_name: "Steve Stephenson",
+        is_bot: false,
+    };
+    people.add_active_user(steve);
+
+    const bot = {
+        user_id: 91,
+        email: "bot@example.com",
+        full_name: "Steve's bot",
+        is_bot: true,
+    };
+    people.add_active_user(bot);
+
     let cancel_called = false;
     override_rewire(compose_actions, "cancel", () => {
         cancel_called = true;
@@ -479,6 +498,24 @@ test("on_narrow", ({override, override_rewire}) => {
         start_called = true;
     });
     narrowed_by_pm_reply = true;
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.disabled.code;
+    compose_actions.on_narrow({
+        force_close: false,
+        trigger: "not-search",
+        private_message_recipient: "steve@example.com",
+    });
+    assert.ok(!start_called);
+
+    compose_actions.on_narrow({
+        force_close: false,
+        trigger: "not-search",
+        private_message_recipient: "bot@example.com",
+    });
+    assert.ok(start_called);
+
+    page_params.realm_private_message_policy =
+        settings_config.private_message_policy_values.by_anyone.code;
     compose_actions.on_narrow({
         force_close: false,
         trigger: "not-search",

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -632,9 +632,11 @@ export function on_narrow(opts) {
 
     if (narrow_state.narrowed_by_pm_reply()) {
         opts = fill_in_opts_from_current_narrowed_view("private", opts);
-        // Do not open compose box if triggered by search and invalid recipient
-        // is present.
-        if (opts.trigger === "search" && !opts.private_message_recipient) {
+        // Do not open compose box if an invalid recipient is present.
+        if (!opts.private_message_recipient) {
+            if (compose_state.composing()) {
+                cancel();
+            }
             return;
         }
         // Do not open compose box if organization has disabled sending

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -25,6 +25,7 @@ import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload_state from "./reload_state";
 import * as resize from "./resize";
+import * as settings_config from "./settings_config";
 import * as spectators from "./spectators";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
@@ -635,6 +636,23 @@ export function on_narrow(opts) {
         // is present.
         if (opts.trigger === "search" && !opts.private_message_recipient) {
             return;
+        }
+        // Do not open compose box if organization has disabled sending
+        // private messages and recipient is not a bot.
+        if (
+            page_params.realm_private_message_policy ===
+                settings_config.private_message_policy_values.disabled.code &&
+            opts.private_message_recipient
+        ) {
+            const emails = opts.private_message_recipient.split(",");
+            if (emails.length !== 1 || !people.get_by_email(emails[0]).is_bot) {
+                // If we are navigating between private message conversations,
+                // we want the compose box to close for non-bot users.
+                if (compose_state.composing()) {
+                    cancel();
+                }
+                return;
+            }
         }
         start("private");
         return;


### PR DESCRIPTION
As noted [here](https://github.com/zulip/zulip/pull/23400#issuecomment-1298865662), when an organization has disabled sending private messages, the default behavior shouldn't be that the compose box opens for private message narrows ("pm-with") with a single operator.

We do still open the compose box for a private message conversation with a single bot user as that is still an available action for a user with the organization setting.

Also, updates the compose box to not open for any private message narrow with an invalid user. Previously, this check also depended on the narrow being triggered by search, but this state can be reached through other triggers such as a hash change when navigating back/forward through the session.

Finally, if the compose box was open to a private message conversation, but without content, in the view prior to the current invalid view (due to an invalid user or due to the org policy), we close the compose box.

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
