### PR TITLE
rest: Restrict access to json views via basic auth.

### DIFF
--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -176,7 +176,7 @@ def rest_dispatch(request: HttpRequest, /, **kwargs: object) -> HttpResponse:
 
     # most clients (mobile, bots, etc) use HTTP basic auth and REST calls, where instead of
     # username:password, we use email:apiKey
-    elif "Authorization" in request.headers:
+    elif request.path.startswith("/api") and "Authorization" in request.headers:
         # Wrap function with decorator to authenticate the user before
         # proceeding
         target_function = authenticated_rest_api_view(

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -56,11 +56,11 @@ class EventsEndpointTest(ZulipTestCase):
         # events_register code paths
         user = self.example_user("hamlet")
         with mock.patch("zerver.views.events_register.do_events_register", return_value={}):
-            result = self.api_post(user, "/json/register")
+            result = self.api_post(user, "/api/v1/register")
         self.assert_json_success(result)
 
         with mock.patch("zerver.lib.events.request_event_queue", return_value=None):
-            result = self.api_post(user, "/json/register")
+            result = self.api_post(user, "/api/v1/register")
         self.assert_json_error(result, "Could not allocate event queue")
 
         return_event_queue = "15:11"
@@ -75,13 +75,13 @@ class EventsEndpointTest(ZulipTestCase):
         with mock.patch("zerver.lib.events.reactivate_user_if_soft_deactivated") as fa:
             with stub_event_queue_user_events(return_event_queue, return_user_events):
                 result = self.api_post(
-                    user, "/json/register", dict(event_types=orjson.dumps([event_type]).decode())
+                    user, "/api/v1/register", dict(event_types=orjson.dumps([event_type]).decode())
                 )
                 self.assertEqual(fa.call_count, 1)
 
         with stub_event_queue_user_events(return_event_queue, return_user_events):
             result = self.api_post(
-                user, "/json/register", dict(event_types=orjson.dumps([event_type]).decode())
+                user, "/api/v1/register", dict(event_types=orjson.dumps([event_type]).decode())
             )
 
         result_dict = self.assert_json_success(result)
@@ -94,7 +94,7 @@ class EventsEndpointTest(ZulipTestCase):
 
         with stub_event_queue_user_events(return_event_queue, return_user_events):
             result = self.api_post(
-                user, "/json/register", dict(event_types=orjson.dumps([event_type]).decode())
+                user, "/api/v1/register", dict(event_types=orjson.dumps([event_type]).decode())
             )
 
         result_dict = self.assert_json_success(result)
@@ -109,7 +109,7 @@ class EventsEndpointTest(ZulipTestCase):
         with stub_event_queue_user_events(return_event_queue, return_user_events):
             result = self.api_post(
                 user,
-                "/json/register",
+                "/api/v1/register",
                 dict(
                     event_types=orjson.dumps([event_type]).decode(),
                     fetch_event_types=orjson.dumps(["message"]).decode(),
@@ -128,7 +128,7 @@ class EventsEndpointTest(ZulipTestCase):
         with stub_event_queue_user_events(return_event_queue, return_user_events):
             result = self.api_post(
                 user,
-                "/json/register",
+                "/api/v1/register",
                 dict(
                     fetch_event_types=orjson.dumps([event_type]).decode(),
                     event_types=orjson.dumps(["message"]).decode(),
@@ -187,11 +187,11 @@ class EventsEndpointTest(ZulipTestCase):
         self.assertEqual(normal_user.role, UserProfile.ROLE_MEMBER)
 
         with mock.patch("zerver.views.events_register.do_events_register", return_value={}):
-            result = self.api_post(normal_user, "/json/register", dict(all_public_streams="true"))
+            result = self.api_post(normal_user, "/api/v1/register", dict(all_public_streams="true"))
         self.assert_json_success(result)
 
         with mock.patch("zerver.views.events_register.do_events_register", return_value={}):
-            result = self.api_post(guest_user, "/json/register", dict(all_public_streams="true"))
+            result = self.api_post(guest_user, "/api/v1/register", dict(all_public_streams="true"))
         self.assert_json_error(result, "User not authorized for this query")
 
     def test_events_get_events_endpoint_guest_cant_use_all_public_streams_param(self) -> None:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -80,7 +80,7 @@ class MessagePOSTTest(ZulipTestCase):
     ) -> None:
         if error_msg is None:
             msg_id = self.send_stream_message(user, stream_name)
-            result = self.api_get(user, "/json/messages/" + str(msg_id))
+            result = self.api_get(user, "/api/v1/messages/" + str(msg_id))
             self.assert_json_success(result)
         else:
             with self.assertRaisesRegex(JsonableError, error_msg):
@@ -787,7 +787,7 @@ class MessagePOSTTest(ZulipTestCase):
         """
         result = self.api_post(
             self.mit_user("starnine"),
-            "/json/messages",
+            "/api/v1/messages",
             {
                 "type": "private",
                 "sender": self.mit_email("sipbtest"),
@@ -807,7 +807,7 @@ class MessagePOSTTest(ZulipTestCase):
         """
         result = self.api_post(
             self.mit_user("starnine"),
-            "/json/messages",
+            "/api/v1/messages",
             {
                 "type": "private",
                 "sender": self.mit_email("sipbtest"),
@@ -1779,7 +1779,7 @@ class StreamMessagesTest(ZulipTestCase):
         with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=sub_count):
             if not test_fails:
                 msg_id = self.send_stream_message(sender, "test_stream", content)
-                result = self.api_get(sender, "/json/messages/" + str(msg_id))
+                result = self.api_get(sender, "/api/v1/messages/" + str(msg_id))
                 self.assert_json_success(result)
 
             else:

--- a/zerver/tests/test_read_receipts.py
+++ b/zerver/tests/test_read_receipts.py
@@ -14,7 +14,7 @@ class TestReadReceipts(ZulipTestCase):
     def mark_message_read(self, user: UserProfile, message_id: int) -> None:
         result = self.api_post(
             user,
-            "/json/messages/flags",
+            "/api/v1/messages/flags",
             {"messages": orjson.dumps([message_id]).decode(), "op": "add", "flag": "read"},
         )
         self.assert_json_success(result)

--- a/zerver/tests/test_realm_playgrounds.py
+++ b/zerver/tests/test_realm_playgrounds.py
@@ -13,7 +13,7 @@ class RealmPlaygroundTests(ZulipTestCase):
             "url_prefix": "https://python.example.com",
         }
         # Now send a POST request to the API endpoint.
-        resp = self.api_post(iago, "/json/realm/playgrounds", payload)
+        resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_success(resp)
 
         # Check if the actual object exists
@@ -38,7 +38,7 @@ class RealmPlaygroundTests(ZulipTestCase):
             },
         ]
         for payload in data:
-            resp = self.api_post(iago, "/json/realm/playgrounds", payload)
+            resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
             self.assert_json_success(resp)
 
         realm = get_realm("zulip")
@@ -57,12 +57,12 @@ class RealmPlaygroundTests(ZulipTestCase):
             "pygments_language": "Python",
             "url_prefix": "https://invalid-url",
         }
-        resp = self.api_post(iago, "/json/realm/playgrounds", payload)
+        resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_error(resp, "url_prefix is not a URL")
 
         payload["url_prefix"] = "https://python.example.com"
         payload["pygments_language"] = "a$b$c"
-        resp = self.api_post(iago, "/json/realm/playgrounds", payload)
+        resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_error(resp, "Invalid characters in pygments language")
 
     def test_create_already_existing_playground(self) -> None:
@@ -73,10 +73,10 @@ class RealmPlaygroundTests(ZulipTestCase):
             "pygments_language": "Python",
             "url_prefix": "https://python.example.com",
         }
-        resp = self.api_post(iago, "/json/realm/playgrounds", payload)
+        resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_success(resp)
 
-        resp = self.api_post(iago, "/json/realm/playgrounds", payload)
+        resp = self.api_post(iago, "/api/v1/realm/playgrounds", payload)
         self.assert_json_error(
             resp, "Realm playground with this Realm, Pygments language and Name already exists."
         )
@@ -84,10 +84,10 @@ class RealmPlaygroundTests(ZulipTestCase):
     def test_not_realm_admin(self) -> None:
         hamlet = self.example_user("hamlet")
 
-        resp = self.api_post(hamlet, "/json/realm/playgrounds")
+        resp = self.api_post(hamlet, "/api/v1/realm/playgrounds")
         self.assert_json_error(resp, "Must be an organization administrator")
 
-        resp = self.api_delete(hamlet, "/json/realm/playgrounds/1")
+        resp = self.api_delete(hamlet, "/api/v1/realm/playgrounds/1")
         self.assert_json_error(resp, "Must be an organization administrator")
 
     def test_delete_realm_playground(self) -> None:
@@ -102,9 +102,9 @@ class RealmPlaygroundTests(ZulipTestCase):
         playground_id = do_add_realm_playground(realm, acting_user=iago, **playground_info)
         self.assertTrue(RealmPlayground.objects.filter(name="Python playground").exists())
 
-        result = self.api_delete(iago, f"/json/realm/playgrounds/{playground_id + 1}")
+        result = self.api_delete(iago, f"/api/v1/realm/playgrounds/{playground_id + 1}")
         self.assert_json_error(result, "Invalid playground")
 
-        result = self.api_delete(iago, f"/json/realm/playgrounds/{playground_id}")
+        result = self.api_delete(iago, f"/api/v1/realm/playgrounds/{playground_id}")
         self.assert_json_success(result)
         self.assertFalse(RealmPlayground.objects.filter(name="Python").exists())

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -423,7 +423,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
             content=content_with_group_mention,
         )
 
-        result = self.api_post(sender, "/json/messages", payload)
+        result = self.api_post(sender, "/api/v1/messages", payload)
 
         self.assert_json_success(result)
 


### PR DESCRIPTION
Previously, test cases or clients accessing json views using HTTP Basic
Auth will be accepted, while we intended to only allow clients
authenticated with a session cookie to access these views.

This adds a check on the accessed path to avoid this possibility.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

[Context](https://chat.zulip.org/#narrow/stream/3-backend/topic/api_*.20methods.20in.20tests.20still.20pass.20against.20.2Fjson.20URLs)

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.
