### PR TITLE
help center: Mention stream section labels.

### DIFF
--- a/templates/zerver/help/manage-inactive-streams.md
+++ b/templates/zerver/help/manage-inactive-streams.md
@@ -1,9 +1,9 @@
 # Manage inactive streams
 
-In normal Zulip usage, streams fall in and out of use. By default,
-Zulip automatically moves streams that haven't been used in a while to
-the bottom of your streams list in the left sidebar.  This helps
-prevent low-traffic streams from cluttering the left sidebar.
+In normal Zulip usage, streams fall in and out of use. By default, Zulip
+automatically moves streams that haven't been used in a while to the
+**Inactive** section at the bottom of your streams list in the left sidebar.
+This helps prevent low-traffic streams from cluttering the left sidebar.
 
 You can configure Zulip to move (demote) inactive streams more or less
 aggressively. This is an advanced setting; you can safely ignore it if this

--- a/templates/zerver/help/pin-a-stream.md
+++ b/templates/zerver/help/pin-a-stream.md
@@ -1,8 +1,8 @@
 # Pin a stream
 
-Pinning a stream moves it to the top of the left sidebar. We recommend
-pinning important streams if you have more streams than fit in the left
-sidebar.
+Pinning a stream moves it to the **Pinned** section at the top of your streams
+list in the left sidebar. You can pin the streams you pay close attention to,
+which is especially handy if you are subscribed to a large number of streams.
 
 ## Pin a stream
 


### PR DESCRIPTION
Updates the relevant help center articles to reflect that the sections for Pinned and Inactive streams in the left sidebar now have labels.

Fixes #23423.

**Screenshots and screen captures:**
- https://zulip.com/help/manage-inactive-streams
<img width="664" alt="image" src="https://user-images.githubusercontent.com/2343554/200072151-356dc246-e1cf-436c-9813-76776b2b513f.png">

- https://zulip.com/help/pin-a-stream
<img width="663" alt="image" src="https://user-images.githubusercontent.com/2343554/200072342-05b1b06a-6115-45c5-9f0d-1ed531ea540c.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>