### PR TITLE
help center: Update list of fields in full profile.

### DIFF
--- a/templates/zerver/help/view-someones-profile.md
+++ b/templates/zerver/help/view-someones-profile.md
@@ -1,12 +1,40 @@
 # View someone's profile
 
-A user's profile includes their name, email, role, the date they joined,
-when they were last active, and any
-[custom profile fields](/help/custom-profile-fields) they've filled out.
+A user's profile displays key information about the user.
 
-It also contains additional tabs showing a user's subscribed streams
-and user groups. Note that the information in those tabs is limited to
-streams for which [you can see all subscribers](/help/stream-permissions).
+## Information in a user's profile
+
+{start_tabs}
+
+{tab|desktop-web}
+
+- Their name.
+- Their email address, if you [have
+  permission](/help/restrict-visibility-of-email-addresses) to view it.
+- Their user ID.
+- Their [role](/help/roles-and-permissions) in the organization.
+- The date they joined the organization.
+- Their current [local time](/help/change-your-timezone).
+- Their [availability](/help/status-and-availability#availability).
+- Any [custom profile fields](/help/custom-profile-fields) they've filled out.
+
+Additional tabs showing:
+
+- The streams that the user is subscribed to. Note that the list is limited to
+  streams for which you have [permission to see all
+  subscribers](/help/stream-permissions).
+- The [user groups](/help/user-groups) to which they belong.
+
+{tab|mobile}
+
+- Their name.
+- Their email address, if you [have
+  permission](/help/restrict-visibility-of-email-addresses) to view it.
+- Their current [local time](/help/change-your-timezone).
+- Their [status and availability](/help/status-and-availability).
+- Any [custom profile fields](/help/custom-profile-fields) they've filled out.
+
+{end_tabs}
 
 ## View someone's profile
 


### PR DESCRIPTION
Also add documentation on what fields are shown in the mobile app.

Only the first section has been updated; no changes below "View someone's profile".

(Note that showing the user's email on mobile is brand new in https://github.com/zulip/zulip-mobile/pull/5515.)

Current page: https://zulip.com/help/view-someones-profile

Updated:

<details>
<summary>Web app</summary>

![Screen Shot 2022-11-04 at 2 01 48 PM](https://user-images.githubusercontent.com/2090066/200074941-9a4b25a2-9937-4bba-bad3-ba35133f2d9b.png)
</details>

<details>
<summary>Mobile</summary>
![Screen Shot 2022-11-04 at 2 02 03 PM](https://user-images.githubusercontent.com/2090066/200074976-ab7a6e8e-704d-4b83-930c-f102aba50393.png)


</details>