### PR TITLE
docs: Remove ": bool" from Writing a new application feature

### DIFF
--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -192,9 +192,9 @@ boolean field, `mandatory_topics`, to the Realm model in
 
  class Realm(models.Model):
      # ...
-     emails_restricted_to_domains: bool = models.BooleanField(default=True)
-     invite_required: bool = models.BooleanField(default=False)
-+    mandatory_topics: bool = models.BooleanField(default=False)
+     emails_restricted_to_domains = models.BooleanField(default=True)
+     invite_required = models.BooleanField(default=False)
++    mandatory_topics = models.BooleanField(default=False)
 ```
 
 The Realm model also contains an attribute, `property_types`, which


### PR DESCRIPTION
A Django plugin has been integrated that removes the need for `: bool`. `Writing a new application feature` tutorial document were updated accordingly.

Fixes: There was no related issue for this fix.

**Screenshots and screen captures:**

**Before changes:**
![before](https://user-images.githubusercontent.com/99841919/200075804-d83df795-e424-47f8-9a64-4c86aa9a1a4e.png)
**After changes:**
![after](https://user-images.githubusercontent.com/99841919/200077027-cdaabbc7-ba7d-494b-ae15-9f5779f3fad4.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
