### PR TITLE
help center: Mention "Scroll to bottom" to mark Topics and PMs as read.

### DIFF
--- a/templates/zerver/help/include/reading-pms.md
+++ b/templates/zerver/help/include/reading-pms.md
@@ -8,8 +8,9 @@
    <kbd>PgDn</kbd>.
 
 1. If the conversation is not of interest, you can
-   [mark all messages as read](/help/marking-messages-as-read) or do so
-   by jumping to the end using the <kbd>End</kbd> key.
+   [mark all messages as read](/help/marking-messages-as-read) by
+   jumping to the bottom with the **Scroll to bottom**
+   (<i class="fa fa-chevron-down"></i>) button or the <kbd>End</kbd> shortcut.
 
 1. Click on the next conversation in the left sidebar, or use the
    <kbd>P</kbd> key to go to the next unread conversation.

--- a/templates/zerver/help/include/reading-topics.md
+++ b/templates/zerver/help/include/reading-topics.md
@@ -11,8 +11,9 @@
    <kbd>PgDn</kbd>.
 
 1. If the topic is not of interest, you can
-   [mark all messages as read](/help/marking-messages-as-read) or
-   do so by jumping to the end using the <kbd>End</kbd> key.
+   [mark all messages as read](/help/marking-messages-as-read) by
+   jumping to the bottom with the **Scroll to bottom**
+   (<i class="fa fa-chevron-down"></i>) button or the <kbd>End</kbd> shortcut.
 
 1. You can then click on another topic in the left sidebar, use the
    <kbd>N</kbd> key to go to the next unread topic, or go back to the
@@ -29,8 +30,9 @@
    <kbd>PgDn</kbd>.
 
 1. If the topic is not of interest, you can
-   [mark all messages as read](/help/marking-messages-as-read) or do
-   so by jumping to the end using the <kbd>End</kbd> key.
+   [mark all messages as read](/help/marking-messages-as-read) by
+   jumping to the bottom with the **Scroll to bottom**
+   (<i class="fa fa-chevron-down"></i>) button or the <kbd>End</kbd> shortcut.
 
 1. Click on the next topic in the left sidebar, or use the <kbd>N</kbd>
    key to go to the next unread topic.


### PR DESCRIPTION
Updates "Reading Topics" and "Reading PMs" where only the keyboard shortcut for this action is mentioned.

Fixes #23425.

**Screenshots and screen captures:**
- https://zulip.com/help/reading-topics
<img width="548" alt="image" src="https://user-images.githubusercontent.com/2343554/200095315-b2e53e3c-acdc-4fd6-92eb-6fb64f902365.png">
<img width="540" alt="image" src="https://user-images.githubusercontent.com/2343554/200095332-babc76ec-d527-4e2a-86c4-ed9de9001458.png">

- https://zulip.com/help/reading-pms
<img width="550" alt="image" src="https://user-images.githubusercontent.com/2343554/200095345-8e33acbc-c40f-48cd-8559-4db266bb3e28.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>