### PR TITLE
css: Fix height issue for stream and user group creation forms.

### DIFF
--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -675,30 +675,20 @@ h4.user_group_setting_subsection_title {
 
 #groups_overlay,
 #subscription_overlay {
-    #user-group-creation {
-        max-height: calc(100% - 102px);
-
-        .user-group-creation-body {
-            padding: 15px;
-        }
-    }
-
-    #stream-creation {
-        .stream-creation-body {
-            height: calc(95vh - 155px);
-            padding: 15px;
-
-            @media (width < $md_min) {
-                height: calc(95vh - 115px);
-            }
-        }
-    }
-
     #user-group-creation,
     #stream-creation {
         overflow: auto;
         outline: none;
         -webkit-overflow-scrolling: touch;
+
+        .user-group-creation-body,
+        .stream-creation-body {
+            /*
+                45px (.subscriptions-header) +  44px (.display-type) + 60px (.modal-footer) + 15px (padding for .simplebar-content)
+            */
+            height: calc(95vh - 164px);
+            padding: 15px 15px 0;
+        }
 
         .modal-footer {
             position: absolute;


### PR DESCRIPTION
Due to incorrect heights set for user-group creation and stream creation body we had a UI bug because of which bottom part of user group and stream creation forms were slightly visible through the bottom.

It was due to somewhat fussy css height rules and incorrect height calculations for that UI.

[#issues > overlapping user list](https://chat.zulip.org/#narrow/stream/9-issues/topic/overlapping.20user.20list)

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
1. Stream creation UI:
![image](https://user-images.githubusercontent.com/63504956/200190516-5356ffd7-d248-4b59-80b3-60b15bd06b18.png)

2. User group creation UI:
![image](https://user-images.githubusercontent.com/63504956/200190571-e91dfe22-c746-487d-8e3f-0ef71352dab3.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
