### PR TITLE
Portico Header Design Improve:Add proper height and margin of items

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -33,12 +33,11 @@ html {
 
 .header {
     position: relative;
-
     padding: 15px 0;
-    height: 29px;
+    height: 30px;
 
     background-color: hsl(0, 0%, 100%);
-    box-shadow: 0 0 4px hsla(0, 0%, 0%, 0.1);
+    box-shadow: 0 0 12px hsla(0, 0%, 0%, 0.1);
 
     z-index: 100;
 }
@@ -467,14 +466,22 @@ input.text-error {
 /* -- end new footer -- */
 
 .header-main {
+    display: flex;
+    flex-flow: row nowrap;
+    height: 30px;
+
     .logo {
-        display: block;
-        text-decoration: none;
-        position: relative;
-        line-height: 0.8;
+        display: flex;
+        flex-flow: row nowrap;
+        align-items: center;
+        margin-right: auto;
 
         svg {
             vertical-align: -5px;
+        }
+
+        a {
+            line-height: 1;
         }
 
         a,
@@ -484,11 +491,24 @@ input.text-error {
             color: hsl(0, 0%, 20%);
         }
 
-        .light {
-            font-size: 1.2rem;
+        &__subtitle {
+            display: flex;
+            flex-flow: row nowrap;
+            align-items: center;
+
+            font-size: 1.25rem;
             font-weight: 400;
             color: hsl(0, 0%, 20%);
-            opacity: 0.7;
+            opacity: 0.65;
+
+            &::before {
+                content: "";
+                width: 2px;
+                height: 0.85em;
+                margin: 0 0.75rem;
+                border-radius: 2px;
+                background: hsl(0, 0%, 20%);
+            }
         }
     }
 
@@ -893,21 +913,26 @@ input.new-organization-button {
 }
 
 .top-links {
-    text-align: right;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    gap: 0.5rem;
 
     a {
         display: inline-block;
         color: hsl(0, 0%, 100%);
-        padding: 2px 7px 1px 8px;
+        padding: 3px 15px;
+
+        font-size: 0.85rem;
         font-weight: 600;
-        font-size: 16px;
-        transition: all 0.2s ease-in;
-        border-radius: 4px;
+        text-decoration: none;
+
+        border-radius: 5px;
+        background-color: hsl(0, 0%, 20%, 0.1);
+        transition: all 0.15s ease;
 
         &:hover {
-            text-decoration: none;
-            background-color: hsla(0, 0%, 100%, 1);
-            color: hsl(170, 50%, 40%);
+            background-color: hsl(0, 0%, 20%, 0.15);
         }
     }
 }
@@ -1130,7 +1155,7 @@ input.new-organization-button {
         .hamburger {
             display: block;
             position: fixed;
-            top: 70px;
+            top: 80px;
             left: 9px;
             fill: hsl(0, 0%, 100%);
             z-index: 2;
@@ -1251,21 +1276,17 @@ input.new-organization-button {
 @media (width <= 500px) {
     .app.help {
         .sidebar {
-            top: 39px;
-            height: calc(100vh - 39px);
-        }
-
-        .hamburger {
-            top: 50px;
+            top: 65px;
+            height: calc(100vh - 65px);
         }
     }
 
     .help .app-main {
-        margin-top: 39px;
+        margin-top: 65px;
     }
 
     .help .markdown {
-        height: calc(100vh - 39px);
+        height: calc(100vh - 65px);
     }
 
     .error_page .lead {
@@ -1273,21 +1294,40 @@ input.new-organization-button {
         margin-bottom: 10px;
     }
 
-    .brand.logo .light {
-        display: none;
-    }
-
     .center-container {
         display: block;
     }
 
     .header {
-        padding: 4px 0 6px;
+        padding: 11px 0;
+        height: 43px;
     }
 
     .header-main {
         max-width: 100vw;
-        padding: 0 10px;
+        padding: 0 14px;
+        height: 43px;
+
+        .logo {
+            flex-flow: column nowrap;
+            align-items: flex-start;
+            justify-content: center;
+            gap: 5px;
+
+            .brand-logo {
+                height: 21px;
+            }
+
+            &__subtitle {
+                font-size: 11px;
+                line-height: 100%;
+                vertical-align: middle;
+
+                &::before {
+                    content: none;
+                }
+            }
+        }
     }
 
     .footer {
@@ -1314,14 +1354,6 @@ label.label-title {
 .inline-block {
     display: inline-block;
     vertical-align: top;
-}
-
-.float-left {
-    float: left;
-}
-
-.float-right {
-    float: right;
 }
 
 #find_account .form-control {

--- a/templates/zerver/portico-header.html
+++ b/templates/zerver/portico-header.html
@@ -1,47 +1,45 @@
 <div class="header portico-header">
     <div class="header-main" id="top_navbar">
-        <div class="float-left">
-            {% if custom_logo_url %}
-            <a class="brand logo" href="{{ root_domain_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>
-            {% else %}
-            <div class="brand logo">
-                <a href="{{ root_domain_uri }}/">
-                    <svg class="brand-logo" role="img" aria-label="{{ _('Zulip') }}" xmlns="http://www.w3.org/2000/svg" viewBox="68.96 55.62 1742.12 450.43" height="25">
-                        <path fill="hsl(0, 0%, 27%)" d="M473.09 122.97c0 22.69-10.19 42.85-25.72 55.08L296.61 312.69c-2.8 2.4-6.44-1.47-4.42-4.7l55.3-110.72c1.55-3.1-.46-6.91-3.64-6.91H129.36c-33.22 0-60.4-30.32-60.4-67.37 0-37.06 27.18-67.37 60.4-67.37h283.33c33.22-.02 60.4 30.3 60.4 67.35zM129.36 506.05h283.33c33.22 0 60.4-30.32 60.4-67.37 0-37.06-27.18-67.37-60.4-67.37H198.2c-3.18 0-5.19-3.81-3.64-6.91l55.3-110.72c2.02-3.23-1.62-7.1-4.42-4.7L94.68 383.6c-15.53 12.22-25.72 32.39-25.72 55.08 0 37.05 27.18 67.37 60.4 67.37zm522.5-124.15l124.78-179.6v-1.56H663.52v-48.98h190.09v34.21L731.55 363.24v1.56h124.01v48.98h-203.7V381.9zm338.98-230.14V302.6c0 45.09 17.1 68.03 47.43 68.03 31.1 0 48.2-21.77 48.2-68.03V151.76h59.09V298.7c0 80.86-40.82 119.34-109.24 119.34-66.09 0-104.96-36.54-104.96-120.12V151.76h59.48zm244.91 0h59.48v212.25h104.18v49.76h-163.66V151.76zm297 0v262.01h-59.48V151.76h59.48zm90.18 3.5c18.27-3.11 43.93-5.44 80.08-5.44 36.54 0 62.59 7 80.08 20.99 16.72 13.22 27.99 34.99 27.99 60.64 0 25.66-8.55 47.43-24.1 62.2-20.21 19.05-50.15 27.6-85.13 27.6-7.77 0-14.77-.39-20.21-1.17v93.69h-58.7V155.26zm58.7 118.96c5.05 1.17 11.27 1.55 19.83 1.55 31.49 0 50.92-15.94 50.92-42.76 0-24.1-16.72-38.49-46.26-38.49-12.05 0-20.21 1.17-24.49 2.33v77.37z"/>
-                    </svg>
-                </a>
+        {% if custom_logo_url %}
+        <a class="brand logo" href="{{ root_domain_uri }}/"><img draggable="false" src="{{ custom_logo_url }}" class="portico-logo" alt="{{ _('Zulip') }}" content="Zulip" /></a>
+        {% else %}
+        <div class="brand logo">
+            <a href="{{ root_domain_uri }}/">
+                <svg class="brand-logo" role="img" aria-label="{{ _('Zulip') }}" xmlns="http://www.w3.org/2000/svg" viewBox="68.96 55.62 1742.12 450.43" height="25">
+                    <path fill="hsl(0, 0%, 27%)" d="M473.09 122.97c0 22.69-10.19 42.85-25.72 55.08L296.61 312.69c-2.8 2.4-6.44-1.47-4.42-4.7l55.3-110.72c1.55-3.1-.46-6.91-3.64-6.91H129.36c-33.22 0-60.4-30.32-60.4-67.37 0-37.06 27.18-67.37 60.4-67.37h283.33c33.22-.02 60.4 30.3 60.4 67.35zM129.36 506.05h283.33c33.22 0 60.4-30.32 60.4-67.37 0-37.06-27.18-67.37-60.4-67.37H198.2c-3.18 0-5.19-3.81-3.64-6.91l55.3-110.72c2.02-3.23-1.62-7.1-4.42-4.7L94.68 383.6c-15.53 12.22-25.72 32.39-25.72 55.08 0 37.05 27.18 67.37 60.4 67.37zm522.5-124.15l124.78-179.6v-1.56H663.52v-48.98h190.09v34.21L731.55 363.24v1.56h124.01v48.98h-203.7V381.9zm338.98-230.14V302.6c0 45.09 17.1 68.03 47.43 68.03 31.1 0 48.2-21.77 48.2-68.03V151.76h59.09V298.7c0 80.86-40.82 119.34-109.24 119.34-66.09 0-104.96-36.54-104.96-120.12V151.76h59.48zm244.91 0h59.48v212.25h104.18v49.76h-163.66V151.76zm297 0v262.01h-59.48V151.76h59.48zm90.18 3.5c18.27-3.11 43.93-5.44 80.08-5.44 36.54 0 62.59 7 80.08 20.99 16.72 13.22 27.99 34.99 27.99 60.64 0 25.66-8.55 47.43-24.1 62.2-20.21 19.05-50.15 27.6-85.13 27.6-7.77 0-14.77-.39-20.21-1.17v93.69h-58.7V155.26zm58.7 118.96c5.05 1.17 11.27 1.55 19.83 1.55 31.49 0 50.92-15.94 50.92-42.76 0-24.1-16.72-38.49-46.26-38.49-12.05 0-20.21 1.17-24.49 2.33v77.37z" />
+                </svg>
+            </a>
 
-                {% if page_is_help_center %}
-                <span class="light"> | <a href="{{ root_domain_uri }}/help/">{{ doc_root_title }}</a></span>
-                {% endif %}
-                {% if page_is_api_center %}
-                <span class="light"> | <a href="{{ root_domain_uri }}/api/">{{ doc_root_title }}</a></span>
-                {% endif %}
-                {% if page_is_policy_center %}
-                <span class="light"> | <a href="{{ root_domain_uri }}/policies/">{{ doc_root_title }}</a></span>
-                {% endif %}
-            </div>
+            {% if page_is_help_center %}
+            <span class="logo__subtitle"><a href="{{ root_domain_uri }}/help/">{{ doc_root_title }}</a></span>
+            {% endif %}
+            {% if page_is_api_center %}
+            <span class="logo__subtitle"><a href="{{ root_domain_uri }}/api/">{{ doc_root_title }}</a></span>
+            {% endif %}
+            {% if page_is_policy_center %}
+            <span class="logo__subtitle"><a href="{{ root_domain_uri }}/policies/">{{ doc_root_title }}</a></span>
             {% endif %}
         </div>
+        {% endif %}
 
-        <div class="float-right top-links">
+        <div class="top-links">
             {% if user_is_authenticated %}
-                {% include 'zerver/portico-header-dropdown.html' %}
+            {% include 'zerver/portico-header-dropdown.html' %}
             {% else %}
-                {% if login_link_disabled %}
-                {% elif not only_sso %}
-                <a href="{{login_url}}">{{ _('Log in') }}</a>
-                {% endif %}
+            {% if login_link_disabled %}
+            {% elif not only_sso %}
+            <a href="{{login_url}}">{{ _('Log in') }}</a>
+            {% endif %}
             {% endif %}
 
             {% if register_link_disabled %}
             {% elif only_sso %}
-                <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
+            <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
             {% else %}
-                {% if user_is_authenticated %}
-                {% else %}
-                <a href="{{ url('register') }}">{{ _('Sign up') }}</a>
-                {% endif %}
+            {% if user_is_authenticated %}
+            {% else %}
+            <a href="{{ url('register') }}">{{ _('Sign up') }}</a>
+            {% endif %}
             {% endif %}
 
             {% if find_team_link_disabled %}


### PR DESCRIPTION
I improved design of header in portico(help/api/terms and policies) pages.

## Before
<img src="https://user-images.githubusercontent.com/86971544/200290771-7593278c-639c-4489-85ca-b0a47f5ec0fe.jpg" width="80%">
<img src="https://user-images.githubusercontent.com/86971544/200290786-7e23f90b-824e-43ff-b5ea-dfd99d06c266.jpg" width="80%">

## After
<img src="https://user-images.githubusercontent.com/86971544/200291088-80f6702a-8c94-4c6a-b81e-cdb7c551b682.jpg" width="80%">
<img src="https://user-images.githubusercontent.com/86971544/200291095-c7916a72-10d0-425e-a595-2f0f6b198ea5.jpg" width="80%">

## Changes
- Replace vertical line between logo and title with beauty css one.
- Add background and border-radius to buttons
- Gave proper height to the header (especially on a mobile device.)
- Display subtitles on mobile devices as well


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
