### PR TITLE
decorator: Put back check for dev env in `ignore_unhashable_lru_cache`.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -756,6 +756,11 @@ class IgnoreUnhashableLruCacheWrapper(Generic[ParamT, ReturnT]):
         self.cache_clear = cached_function.cache_clear
 
     def __call__(self, *args: ParamT.args, **kwargs: ParamT.kwargs) -> ReturnT:
+        if settings.DEVELOPMENT and not settings.TEST_SUITE:  # nocoverage
+            # In the development environment, we want every file
+            # change to refresh the source files from disk.
+            return self.function(*args, **kwargs)
+
         if self.key_prefix != KEY_PREFIX:
             # Clear cache when cache.KEY_PREFIX changes. This is used in
             # tests.


### PR DESCRIPTION
Prior to 53231aa, the `ignore_unhashable_lru_cache` decorator had a check for the development environment so that changes a contributor was making to any documentation template/page could be seen on refreshing the browser.

The original check was added in 3d8e45f.

Currently, refreshing the browser only worked if there was an unhashable argument, which is true for all help center and API docs. This mainly affected the policy documentation and corporate website pages.

In this PR, I put the check back in `IgnoreUnhashableLruCacheWrapper` class at the start of the `__call__` function.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/49-development-help/topic/changes.20to.20.2Emd.20files.20not.20showing.20up/near/1444662).

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
