### PR TITLE
stream_list: Fix update unread counts. 

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -420,6 +420,15 @@ export function update_streams_sidebar(force_rerender) {
 }
 
 export function update_dom_with_unread_counts(counts) {
+    if (!counts.stream_count.size) {
+        // No messages are unread in any stream.
+        // To ensure the UI reflects the same, update all subscribed streams
+        // with 0 unread count.
+        const streams = stream_data.subscribed_stream_ids();
+        for (const stream of streams) {
+            set_stream_unread_count(stream, 0, false);
+        }
+    }
     // counts.stream_count maps streams to counts
     for (const [stream_id, count] of counts.stream_count) {
         const stream_has_any_unread_mention_messages =

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -672,6 +672,7 @@ export function mark_as_read(message_id) {
 }
 
 export function declare_bankruptcy() {
+    // This function is only used in tests.
     unread_pm_counter.clear();
     unread_topic_counter.clear();
     unread_mentions_counter.clear();

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -1,4 +1,7 @@
+import $ from "jquery";
+
 import * as channel from "./channel";
+import {$t_html} from "./i18n";
 import * as message_flags from "./message_flags";
 import * as message_list from "./message_list";
 import * as message_lists from "./message_lists";
@@ -10,13 +13,15 @@ import * as people from "./people";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload from "./reload";
+import * as ui_report from "./ui_report";
 import * as unread from "./unread";
 import * as unread_ui from "./unread_ui";
 
 export function mark_all_as_read() {
-    unread.declare_bankruptcy();
-    unread_ui.update_unread_counts();
-
+    ui_report.success(
+        $t_html({defaultMessage: "Marking all messages as read..."}),
+        $("#reloading-application"),
+    );
     channel.post({
         url: "/json/mark_all_as_read",
         success: () => {
@@ -35,6 +40,13 @@ export function mark_all_as_read() {
                 save_narrow: true,
                 save_compose: true,
             });
+        },
+        error(xhr) {
+            ui_report.error(
+                $t_html({defaultMessage: "Unable to mark all messages as read. Please try again!"}),
+                xhr,
+                $("#reloading-application"),
+            );
         },
     });
 }


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/23406

`update_dom_with_unread_counts` doesn't account for `counts` `Map`
being empty, implying that there are no unread counts. This resulted
in unread counts for streams not being updated before a reload in
case bankruptcy is declared and the reload fails or doesn't
happen due to an error.