### PR TITLE
api-docs: Return 404 for direct `/api-doc-template` call.

### DIFF
--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -137,6 +137,14 @@ class DocPageTest(ZulipTestCase):
         )
         self.assertEqual(result.status_code, 404)
 
+        result = self.client_get(
+            # This template shouldn't be accessed directly.
+            "/api/api-doc-template",
+            follow=True,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(result.status_code, 404)
+
         # Test some API doc endpoints for specific content and metadata.
         self._test("/api/", "The Zulip API")
         self._test("/api/api-keys", "be careful with it")

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -110,6 +110,15 @@ class MarkdownDirectoryView(ApiURLView):
                 endpoint_method=None,
             )
 
+        if path == "/zerver/api/api-doc-template.md":
+            # This template shouldn't be accessed directly.
+            return DocumentationArticle(
+                article_path=self.path_template % ("missing",),
+                article_http_status=404,
+                endpoint_path=None,
+                endpoint_method=None,
+            )
+
         # The following is a somewhat hacky approach to extract titles from articles.
         # Hack: `context["article"] has a leading `/`, so we use + to add directories.
         article_path = os.path.join(settings.DEPLOY_ROOT, "templates") + path


### PR DESCRIPTION
We use `templates/zerver/api/api-doc-template.md` as a base template for the documented API endpoints in `zerver/openapi/zulip.yaml`.

Previously, if this template was called as an endpoint, then it would fail an assertion check and send server error. Now we check for specifically for that potential path and return a 404 error response for no existing article.

Fixes #21876.

---

**Screenshots and screen captures:**

![Screenshot from 2022-11-07 20-38-45](https://user-images.githubusercontent.com/63245456/200399365-e4fe3791-7d42-4a1e-8e4b-3b7729fc06df.png)

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
