### PR TITLE
api-docs: Small API example response updates

### DIFF
--- a/templates/zerver/api/api-doc-template.md
+++ b/templates/zerver/api/api-doc-template.md
@@ -26,6 +26,6 @@
 
 {generate_response_description(API_ENDPOINT_NAME)}
 
-#### Example response
+#### Example response(s)
 
 {generate_code_example|API_ENDPOINT_NAME|fixture}

--- a/templates/zerver/api/mark-all-as-read.md
+++ b/templates/zerver/api/mark-all-as-read.md
@@ -24,7 +24,7 @@
 
 {generate_response_description(/mark_all_as_read:post)}
 
-#### Example response
+#### Example response(s)
 
 {generate_code_example|/mark_all_as_read:post|fixture}
 
@@ -54,7 +54,7 @@
 
 {generate_response_description(/mark_all_as_read:post)}
 
-#### Example response
+#### Example response(s)
 
 {generate_code_example|/mark_stream_as_read:post|fixture}
 
@@ -84,6 +84,6 @@
 
 {generate_response_description(/mark_all_as_read:post)}
 
-#### Example response
+#### Example response(s)
 
 {generate_code_example|/mark_topic_as_read:post|fixture}

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -72,6 +72,6 @@ file.
 
 {generate_response_description(/messages:post)}
 
-#### Example response
+#### Example response(s)
 
 {generate_code_example|/messages:post|fixture}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5193,12 +5193,8 @@ paths:
               schema:
                 allOf:
                   - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
                   - additionalProperties: false
-                    description: |
-                      When a request is successful, this endpoint returns a dictionary
-                      containing the following (in addition to the `msg` and `result` keys
-                      present in all Zulip API responses).
-                      A typical successful JSON response may look like:
                     properties:
                       result: {}
                       msg: {}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4824,13 +4824,8 @@ paths:
               schema:
                 allOf:
                   - $ref: "#/components/schemas/JsonSuccessBase"
+                  - $ref: "#/components/schemas/SuccessDescription"
                   - additionalProperties: false
-                    description: |
-                      When all of the drafts in the request are valid, this endpoint will return
-                      an array of the IDs for the drafts that were just created in the same
-                      order as they were requested. If any of the drafts failed the validation
-                      step, then none of the drafts will be created and we would not get this
-                      status code. The typical JSON response in such a case is:
                     properties:
                       result: {}
                       msg: {}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8082,7 +8082,6 @@ paths:
                   - $ref: "#/components/schemas/JsonSuccessBase"
                   - $ref: "#/components/schemas/SuccessDescription"
                   - additionalProperties: false
-                    description: MANUALLY
                     properties:
                       result: {}
                       msg: {}


### PR DESCRIPTION
These are all small clean-ups and tweaks to the API documentation that I had as a prep commit to my work on returning an ignored parameters for all endpoints. And all of which seemed good to pull out and get merged.

**Notes**:
- Use default example response description for JSON success for `create-drafts` and `get-messages` endpoint documentation.
- Remove unused (probably just something missed when moving the API documentation over to the current system) description for response in `get-subscription-status` endpoint
- Update sub-header to be **Example response(s)** because often we give both success and error examples.

---

**Screenshots and screen captures:**

<details>
<summary>Create drafts</summary>

[current documentation](https://zulip.com/api/create-drafts#response)
![Screenshot from 2022-11-07 20-47-02](https://user-images.githubusercontent.com/63245456/200400920-9ad599e9-2038-4962-94de-ff791ff2b2d8.png)
</details>

<details>
<summary>Get messages</summary>

[current documentation](https://zulip.com/api/get-messages#response)
![Screenshot from 2022-11-07 20-55-26](https://user-images.githubusercontent.com/63245456/200402665-901f24c0-260d-472b-ba10-3705b196679a.png)
</details>

<details>
<summary>Get subscription status</summary>

**Note no visible change from removing unused description**
[current documentation](https://zulip.com/api/get-subscription-status#response)
![Screenshot from 2022-11-07 20-48-24](https://user-images.githubusercontent.com/63245456/200401271-c2c828c1-63a0-4e11-945d-288bf2931e1d.png)
</details>

<details>
<summary>Send a message</summary>

[current documentation](https://zulip.com/api/send-message#response)
![Screenshot from 2022-11-07 20-49-55](https://user-images.githubusercontent.com/63245456/200401416-4c9f2905-2116-4472-b376-900b2010d1de.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
