### PR TITLE
Normalize shortened SHA generation for integrations.

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -327,7 +327,7 @@ def get_release_event_message(
 
 
 def get_short_sha(sha: str) -> str:
-    return sha[:7]
+    return sha[:11]
 
 
 def get_all_committers(commits_data: List[Dict[str, Any]]) -> List[Tuple[str, int]]:

--- a/zerver/webhooks/azuredevops/tests.py
+++ b/zerver/webhooks/azuredevops/tests.py
@@ -11,13 +11,13 @@ class AzuredevopsHookTests(WebhookTestCase):
 
     def test_push_event_message(self) -> None:
         expected_topic = "test-zulip / main"
-        expected_message = "Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GC51515957669f93c543df09f8f3e7f47c3613c879&targetVersion=GCb0ce2f2009c3c87dbefadf61d7eb2c0697a6f369&_a=files) 1 commit to branch main.\n\n* Modify readme ([b0ce2f2](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/b0ce2f2009c3c87dbefadf61d7eb2c0697a6f369))"
+        expected_message = "Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GC51515957669f93c543df09f8f3e7f47c3613c879&targetVersion=GCb0ce2f2009c3c87dbefadf61d7eb2c0697a6f369&_a=files) 1 commit to branch main.\n\n* Modify readme ([b0ce2f2009c](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/b0ce2f2009c3c87dbefadf61d7eb2c0697a6f369))"
         self.check_webhook("code_push", expected_topic, expected_message)
 
     def test_push_event_message_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="main,dev")
         expected_topic = "test-zulip / main"
-        expected_message = "Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GC51515957669f93c543df09f8f3e7f47c3613c879&targetVersion=GCb0ce2f2009c3c87dbefadf61d7eb2c0697a6f369&_a=files) 1 commit to branch main.\n\n* Modify readme ([b0ce2f2](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/b0ce2f2009c3c87dbefadf61d7eb2c0697a6f369))"
+        expected_message = "Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GC51515957669f93c543df09f8f3e7f47c3613c879&targetVersion=GCb0ce2f2009c3c87dbefadf61d7eb2c0697a6f369&_a=files) 1 commit to branch main.\n\n* Modify readme ([b0ce2f2009c](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/b0ce2f2009c3c87dbefadf61d7eb2c0697a6f369))"
         self.check_webhook("code_push", expected_topic, expected_message)
 
     @patch("zerver.lib.webhooks.common.check_send_webhook_message")
@@ -39,20 +39,20 @@ class AzuredevopsHookTests(WebhookTestCase):
 
     def test_push_multiple_committers(self) -> None:
         expected_topic = "test-zulip / main"
-        expected_message = "Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GCcc21b940719cc372b364d932eb39e528b0ec2a91&targetVersion=GC0929a3404b39f6e39076a640779b2c1c961e19b5&_a=files) 2 commits to branch main. Commits by Itachi Sensei (1) and Yuro Itaki (1).\n\n* Add reply ([0929a34](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/0929a3404b39f6e39076a640779b2c1c961e19b5))\n* Add how are you ([819ce8d](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/819ce8de51bedfc250c202edcaee0ce8dc70bf3b))"
+        expected_message = "Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GCcc21b940719cc372b364d932eb39e528b0ec2a91&targetVersion=GC0929a3404b39f6e39076a640779b2c1c961e19b5&_a=files) 2 commits to branch main. Commits by Itachi Sensei (1) and Yuro Itaki (1).\n\n* Add reply ([0929a3404b3](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/0929a3404b39f6e39076a640779b2c1c961e19b5))\n* Add how are you ([819ce8de51b](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/819ce8de51bedfc250c202edcaee0ce8dc70bf3b))"
         self.check_webhook("code_push__multiple_committers", expected_topic, expected_message)
 
     def test_push_multiple_committers_with_others(self) -> None:
         expected_topic = "test-zulip / main"
-        commits_info = "* Add how are you ([819ce8d](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/819ce8de51bedfc250c202edcaee0ce8dc70bf3b))\n"
-        expected_message = f"Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GCcc21b940719cc372b364d932eb39e528b0ec2a91&targetVersion=GC0929a3404b39f6e39076a640779b2c1c961e19b5&_a=files) 6 commits to branch main. Commits by Itachi Sensei (2), Yuro Itaki (2), Jonas Nielsen (1) and others (1).\n\n* Add reply ([0929a34](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/0929a3404b39f6e39076a640779b2c1c961e19b5))\n{commits_info * 4}* Add reply ([0929a34](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/0929a3404b39f6e39076a640779b2c1c961e19b5))"
+        commits_info = "* Add how are you ([819ce8de51b](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/819ce8de51bedfc250c202edcaee0ce8dc70bf3b))\n"
+        expected_message = f"Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GCcc21b940719cc372b364d932eb39e528b0ec2a91&targetVersion=GC0929a3404b39f6e39076a640779b2c1c961e19b5&_a=files) 6 commits to branch main. Commits by Itachi Sensei (2), Yuro Itaki (2), Jonas Nielsen (1) and others (1).\n\n* Add reply ([0929a3404b3](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/0929a3404b39f6e39076a640779b2c1c961e19b5))\n{commits_info * 4}* Add reply ([0929a3404b3](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/0929a3404b39f6e39076a640779b2c1c961e19b5))"
         self.check_webhook(
             "code_push__multiple_committers_with_others", expected_topic, expected_message
         )
 
     def test_push_commits_more_than_limit(self) -> None:
         expected_topic = "test-zulip / main"
-        commits_info = "* Modify readme ([b0ce2f2](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/b0ce2f2009c3c87dbefadf61d7eb2c0697a6f369))\n"
+        commits_info = "* Modify readme ([b0ce2f2009c](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/commit/b0ce2f2009c3c87dbefadf61d7eb2c0697a6f369))\n"
         expected_message = f"Yuro Itaki [pushed](https://dev.azure.com/ttchong/test-zulip/_git/test-zulip/branchCompare?baseVersion=GC51515957669f93c543df09f8f3e7f47c3613c879&targetVersion=GCb0ce2f2009c3c87dbefadf61d7eb2c0697a6f369&_a=files) 50 commits to branch main.\n\n{commits_info * COMMITS_LIMIT}[and {50 - COMMITS_LIMIT} more commit(s)]"
         self.check_webhook("code_push__commits_more_than_limit", expected_topic, expected_message)
 

--- a/zerver/webhooks/beanstalk/tests.py
+++ b/zerver/webhooks/beanstalk/tests.py
@@ -13,7 +13,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_topic = "work-test / master"
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
-* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
+* add some stuff ([e50508df24c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
         self.api_stream_message(
             self.test_user, "git_singlecommit", expected_topic, expected_message, content_type=None
         )
@@ -23,7 +23,7 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_topic = "work-test / master"
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 1 commit to branch master.
 
-* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
+* add some stuff ([e50508df24c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))"""
         self.api_stream_message(
             self.test_user, "git_singlecommit", expected_topic, expected_message, content_type=None
         )
@@ -32,9 +32,9 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_topic = "work-test / master"
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (2) and Tomasz Kolek (1).
 
-* Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
-* Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
-* More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
+* Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
+* Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
+* More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
         self.api_stream_message(
             self.test_user,
             "git_multiple_committers",
@@ -48,9 +48,9 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_topic = "work-test / master"
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master. Commits by Leo Franchi (2) and Tomasz Kolek (1).
 
-* Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
-* Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
-* More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
+* Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
+* Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
+* More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
         self.api_stream_message(
             self.test_user,
             "git_multiple_committers",
@@ -63,9 +63,9 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_topic = "work-test / master"
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master.
 
-* Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
-* Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
-* More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
+* Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
+* Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
+* More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
         self.api_stream_message(
             self.test_user, "git_multiple", expected_topic, expected_message, content_type=None
         )
@@ -75,15 +75,15 @@ class BeanstalkHookTests(WebhookTestCase):
         expected_topic = "work-test / master"
         expected_message = """Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 3 commits to branch master.
 
-* Added new file ([edf529c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
-* Filled in new file with some stuff ([c2a191b](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
-* More work to fix some bugs ([2009815](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
+* Added new file ([edf529c7a64](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/edf529c7))
+* Filled in new file with some stuff ([c2a191b9e79](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/c2a191b9))
+* More work to fix some bugs ([20098158e20](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/20098158))"""
         self.api_stream_message(
             self.test_user, "git_multiple", expected_topic, expected_message, content_type=None
         )
 
     def test_git_more_than_limit(self) -> None:
-        commits_info = "* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
+        commits_info = "* add some stuff ([e50508df24c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
         expected_topic = "work-test / master"
         expected_message = f"""Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 
@@ -98,7 +98,7 @@ class BeanstalkHookTests(WebhookTestCase):
 
     def test_git_more_than_limit_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,development")
-        commits_info = "* add some stuff ([e50508d](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
+        commits_info = "* add some stuff ([e50508df24c](http://lfranchi-svn.beanstalkapp.com/work-test/changesets/e50508df))\n"
         expected_topic = "work-test / master"
         expected_message = f"""Leo Franchi [pushed](http://lfranchi-svn.beanstalkapp.com/work-test) 50 commits to branch master.
 

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -14,14 +14,14 @@ class BitbucketHookTests(WebhookTestCase):
     def test_bitbucket_on_push_event(self) -> None:
         fixture_name = "push"
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
-        commit_info = "* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
+        commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
         expected_message = f"kolaszek pushed 1 commit to branch master.\n\n{commit_info}"
         self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket_on_push_event_without_user_info(self) -> None:
         fixture_name = "push_without_user_info"
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
-        commit_info = "* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
+        commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
         expected_message = (
             f"Someone pushed 1 commit to branch master. Commits by eeshangarg (1).\n\n{commit_info}"
         )
@@ -32,14 +32,14 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(
             payload=self.get_body(fixture_name), branches="master,development"
         )
-        commit_info = "* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
+        commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))"
         expected_message = f"kolaszek pushed 1 commit to branch master.\n\n{commit_info}"
         self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket_on_push_commits_above_limit_event(self) -> None:
         fixture_name = "push_commits_above_limit"
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
-        commit_info = "* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
+        commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
         expected_message = f"kolaszek pushed 50 commits to branch master.\n\n{commit_info * 20}[and 30 more commit(s)]"
         self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 
@@ -48,7 +48,7 @@ class BitbucketHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(
             payload=self.get_body(fixture_name), branches="master,development"
         )
-        commit_info = "* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
+        commit_info = "* c ([25f93d22b71](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))\n"
         expected_message = f"kolaszek pushed 50 commits to branch master.\n\n{commit_info * 20}[and 30 more commit(s)]"
         self.api_stream_message(self.test_user, fixture_name, TOPIC_BRANCH_EVENTS, expected_message)
 

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -16,52 +16,52 @@ class Bitbucket2HookTests(WebhookTestCase):
     WEBHOOK_DIR_NAME = "bitbucket2"
 
     def test_bitbucket2_on_push_event(self) -> None:
-        commit_info = "* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"
+        commit_info = "* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"
         expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{commit_info}"
         self.check_webhook("push", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers(self) -> None:
-        commit_info = "* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
-        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Ben (2) and Tomasz (1).\n\n{commit_info*2}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        commit_info = "* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Ben (2) and Tomasz (1).\n\n{commit_info*2}* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook("push_multiple_committers", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others(self) -> None:
-        commit_info = "* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
-        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{commit_info*9}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        commit_info = "* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{commit_info*9}* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook(
             "push_multiple_committers_with_others", TOPIC_BRANCH_EVENTS, expected_message
         )
 
     def test_bitbucket2_on_push_commits_multiple_committers_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,development")
-        commit_info = "* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
-        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Ben (2) and Tomasz (1).\n\n{commit_info*2}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        commit_info = "* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Ben (2) and Tomasz (1).\n\n{commit_info*2}* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook("push_multiple_committers", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others_filtered_by_branches(
         self,
     ) -> None:
         self.url = self.build_webhook_url(branches="master,development")
-        commit_info = "* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
-        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{commit_info*9}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        commit_info = "* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n"
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{commit_info*9}* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook(
             "push_multiple_committers_with_others", TOPIC_BRANCH_EVENTS, expected_message
         )
 
     def test_bitbucket2_on_push_event_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,development")
-        commit_info = "* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"
+        commit_info = "* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"
         expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{commit_info}"
         self.check_webhook("push", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_above_limit_event(self) -> None:
-        commit_info = "* a ([6f161a7](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n"
+        commit_info = "* a ([6f161a7bced](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n"
         expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master.\n\n{(commit_info * 5)}[and more commit(s)]"
         self.check_webhook("push_commits_above_limit", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_above_limit_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,development")
-        commit_info = "* a ([6f161a7](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n"
+        commit_info = "* a ([6f161a7bced](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n"
         expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master.\n\n{(commit_info * 5)}[and more commit(s)]"
 
         self.check_webhook("push_commits_above_limit", TOPIC_BRANCH_EVENTS, expected_message)
@@ -84,7 +84,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.check_webhook("fork", TOPIC, expected_message)
 
     def test_bitbucket2_on_commit_comment_created_event(self) -> None:
-        expected_message = "Tomasz [commented](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74#comment-3354963) on [32c4ea1](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74):\n~~~ quote\nNice fix!\n~~~"
+        expected_message = "Tomasz [commented](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74#comment-3354963) on [32c4ea19aa3](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74):\n~~~ quote\nNice fix!\n~~~"
         self.check_webhook("commit_comment_created", TOPIC, expected_message)
 
     def test_bitbucket2_on_commit_status_changed_event(self) -> None:
@@ -321,7 +321,7 @@ class Bitbucket2HookTests(WebhookTestCase):
             message=msg,
             stream_name=self.STREAM_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
-            content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
+            content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
         )
 
         msg = self.get_last_message()
@@ -351,7 +351,7 @@ class Bitbucket2HookTests(WebhookTestCase):
             message=msg,
             stream_name=self.STREAM_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
-            content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
+            content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96adc644](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
         )
 
         msg = self.get_last_message()

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -88,7 +88,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.check_webhook("commit_comment_created", TOPIC, expected_message)
 
     def test_bitbucket2_on_commit_status_changed_event(self) -> None:
-        expected_message = "[System mybuildtool](https://my-build-tool.com/builds/MY-PROJECT/BUILD-777) changed status of [9fec847](https://bitbucket.org/kolaszek/repository-name/commits/9fec847784abb10b2fa567ee63b85bd238955d0e) to SUCCESSFUL."
+        expected_message = "[System mybuildtool](https://my-build-tool.com/builds/MY-PROJECT/BUILD-777) changed status of [9fec847784a](https://bitbucket.org/kolaszek/repository-name/commits/9fec847784abb10b2fa567ee63b85bd238955d0e) to SUCCESSFUL."
         self.check_webhook("commit_status_changed", TOPIC, expected_message)
 
     def test_bitbucket2_on_issue_created_event(self) -> None:

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -25,6 +25,7 @@ from zerver.lib.webhooks.git import (
     get_push_commits_event_message,
     get_push_tag_event_message,
     get_remove_branch_event_message,
+    get_short_sha,
 )
 from zerver.models import UserProfile
 
@@ -293,7 +294,7 @@ def get_commit_status_changed_body(payload: WildValue, include_title: bool) -> s
 
     commit_info = "[{short_commit_id}]({repo_url}/commits/{commit_id})".format(
         repo_url=get_repository_url(payload["repository"]),
-        short_commit_id=commit_id[:7],
+        short_commit_id=get_short_sha(commit_id),
         commit_id=commit_id,
     )
 

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -25,15 +25,15 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     # Core repo events:
     def test_commit_comment_added(self) -> None:
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) commented on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907):\n~~~ quote\nJust an arbitrary comment on a commit.\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) commented on [508d1b67f1f](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907):\n~~~ quote\nJust an arbitrary comment on a commit.\n~~~"""
         self.check_webhook("commit_comment_added", TOPIC, expected_message)
 
     def test_commit_comment_edited(self) -> None:
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) edited their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907):\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) edited their comment on [508d1b67f1f](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907):\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
         self.check_webhook("commit_comment_edited", TOPIC, expected_message)
 
     def test_commit_comment_deleted(self) -> None:
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907):\n~~~ quote\n~~Just an arbitrary comment on a commit. Nothing to see here...~~\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted their comment on [508d1b67f1f](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907):\n~~~ quote\n~~Just an arbitrary comment on a commit. Nothing to see here...~~\n~~~"""
         self.check_webhook("commit_comment_deleted", TOPIC, expected_message)
 
     def test_bitbucket3_repo_forked(self) -> None:

--- a/zerver/webhooks/circleci/tests.py
+++ b/zerver/webhooks/circleci/tests.py
@@ -10,7 +10,7 @@ class CircleCiHookTests(WebhookTestCase):
         expected_topic = "circleci-test"
         expected_message = """
 Build [#5](https://circleci.com/bb/Hypro999/circleci-test/5) of `build`/`workflow` on branch `unstable` has failed.
-- **Commits (3):** [6b5361c166](https://bitbucket.org/Hypro999/circleci-test/commits/6b5361c1661581d975e84b68904ae9bfba75d5e5) ... [eaa88f9eac](https://bitbucket.org/Hypro999/circleci-test/commits/eaa88f9eac0fad86c46a8fe35462fe2c904d84b1)
+- **Commits (3):** [6b5361c1661](https://bitbucket.org/Hypro999/circleci-test/commits/6b5361c1661581d975e84b68904ae9bfba75d5e5) ... [eaa88f9eac0](https://bitbucket.org/Hypro999/circleci-test/commits/eaa88f9eac0fad86c46a8fe35462fe2c904d84b1)
 - **Pull request:** https://bitbucket.org/Hypro999/circleci-test/pull-requests/1
 - **Author:** Hemanth V. Alluri
 """.strip()
@@ -22,7 +22,7 @@ Build [#5](https://circleci.com/bb/Hypro999/circleci-test/5) of `build`/`workflo
         expected_topic = "zulip"
         expected_message = """
 Build [#1429](https://circleci.com/gh/Hypro999/zulip/1429) of `bionic-backend-frontend`/`Ubuntu 18.04 Bionic (Python 3.6, backend+frontend)` on branch `circleci` has failed.
-- **Commits (2):** [73900eeb69 ... 5326f9ea40](https://github.com/Hypro999/zulip/compare/73900eeb69adbf0b83dc487e8eda90661b524eff...5326f9ea4084a01cc2bf1a461b9ad819b4ffdd14)
+- **Commits (2):** [73900eeb69a ... 5326f9ea408](https://github.com/Hypro999/zulip/compare/73900eeb69adbf0b83dc487e8eda90661b524eff...5326f9ea4084a01cc2bf1a461b9ad819b4ffdd14)
 
 - **Author:** Hemanth V. Alluri (Hypro999)
 - **Committer:** Hemanth V. Alluri (Hypro999)
@@ -35,7 +35,7 @@ Build [#1429](https://circleci.com/gh/Hypro999/zulip/1429) of `bionic-backend-fr
         expected_topic = "zulip"
         expected_message = """
 Build [#1431](https://circleci.com/gh/Hypro999/zulip/1431) of `bionic-production-build`/`Production` on branch `circleci` has succeeded.
-- **Commits (2):** [73900eeb69 ... 5326f9ea40](https://github.com/Hypro999/zulip/compare/73900eeb69adbf0b83dc487e8eda90661b524eff...5326f9ea4084a01cc2bf1a461b9ad819b4ffdd14)
+- **Commits (2):** [73900eeb69a ... 5326f9ea408](https://github.com/Hypro999/zulip/compare/73900eeb69adbf0b83dc487e8eda90661b524eff...5326f9ea4084a01cc2bf1a461b9ad819b4ffdd14)
 
 - **Authors:** Gintoki Sakata (ShiroYasha999), Hemanth V. Alluri (Hypro999)
 - **Committers:** Hemanth V. Alluri (Hypro999), Sadaharu
@@ -50,7 +50,7 @@ Build [#1431](https://circleci.com/gh/Hypro999/zulip/1431) of `bionic-production
         expected_topic = "zulip"
         expected_message = """
 Build [#1420](https://circleci.com/gh/Hypro999/zulip/1420) of `bionic-production-install`/`Production` on branch `circleci` was canceled.
-- **Commit:** [b0d6197fb4](https://github.com/Hypro999/zulip/commit/b0d6197fb4cacaf917adca77f77354882ee80621)
+- **Commit:** [b0d6197fb4c](https://github.com/Hypro999/zulip/commit/b0d6197fb4cacaf917adca77f77354882ee80621)
 
 - **Author:** Hemanth V. Alluri (Hypro999)
 - **Committer:** Hemanth V. Alluri (Hypro999)

--- a/zerver/webhooks/circleci/view.py
+++ b/zerver/webhooks/circleci/view.py
@@ -5,6 +5,7 @@ from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.validator import WildValue, check_int, check_none_or, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
+from zerver.lib.webhooks.git import get_short_sha
 from zerver.models import UserProfile
 
 outcome_to_formatted_status_map = {
@@ -48,15 +49,15 @@ def get_commit_range_info(payload: WildValue) -> str:
     num_commits = len(commits)
 
     if num_commits == 1:
-        commit_id = commits[0]["commit"].tame(check_string)[:10]
+        commit_id = get_short_sha(commits[0]["commit"].tame(check_string))
         commit_url = commits[0]["commit_url"].tame(check_string)
         return f"- **Commit:** [{commit_id}]({commit_url})"
 
     vcs_provider = payload["user"]["vcs_type"].tame(check_string)  # Same as payload["why"]?
     first_commit_id = commits[0]["commit"].tame(check_string)
-    shortened_first_commit_id = first_commit_id[:10]
+    shortened_first_commit_id = get_short_sha(first_commit_id)
     last_commit_id = commits[-1]["commit"].tame(check_string)
-    shortened_last_commit_id = last_commit_id[:10]
+    shortened_last_commit_id = get_short_sha(last_commit_id)
     if vcs_provider == "github":
         # Then use GitHub's commit range feature to form the appropriate url.
         vcs_url = payload["vcs_url"].tame(check_string)

--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -12,11 +12,11 @@ class GiteaHookTests(WebhookTestCase):
         expected_topic = "test / d"
         expected_message = """kostekIV [pushed](https://try.gitea.io/kostekIV/test/compare/21138d2ca0ce18f8e037696fdbe1b3f0c211f630...2ec0c971d04723523aa20f2b378f8b419b47d4ec) 5 commits to branch d.
 
-* commit ([2ec0c97](https://try.gitea.io/kostekIV/test/commit/2ec0c971d04723523aa20f2b378f8b419b47d4ec))
-* commit ([6cb1701](https://try.gitea.io/kostekIV/test/commit/6cb1701c8b0114ad716f4cd49153076e7109cb85))
-* commit ([6773eab](https://try.gitea.io/kostekIV/test/commit/6773eabc0778a3e38997c06a13f5f0c48b67e5dc))
-* commit ([337402c](https://try.gitea.io/kostekIV/test/commit/337402cf675ce7082ddcd23d06a116c85241825a))
-* commit ([0a38cad](https://try.gitea.io/kostekIV/test/commit/0a38cad3fac3a13bb78b738d13f15ce9cc3343fa))"""
+* commit ([2ec0c971d04](https://try.gitea.io/kostekIV/test/commit/2ec0c971d04723523aa20f2b378f8b419b47d4ec))
+* commit ([6cb1701c8b0](https://try.gitea.io/kostekIV/test/commit/6cb1701c8b0114ad716f4cd49153076e7109cb85))
+* commit ([6773eabc077](https://try.gitea.io/kostekIV/test/commit/6773eabc0778a3e38997c06a13f5f0c48b67e5dc))
+* commit ([337402cf675](https://try.gitea.io/kostekIV/test/commit/337402cf675ce7082ddcd23d06a116c85241825a))
+* commit ([0a38cad3fac](https://try.gitea.io/kostekIV/test/commit/0a38cad3fac3a13bb78b738d13f15ce9cc3343fa))"""
         self.check_webhook("push__5_commits", expected_topic, expected_message)
 
     def test_new_branch(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -232,11 +232,11 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("page_build__errored", TOPIC_REPO, expected_message)
 
     def test_status_msg(self) -> None:
-        expected_message = "[9049f12](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success."
+        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to success."
         self.check_webhook("status", TOPIC_REPO, expected_message)
 
     def test_status_with_target_url_msg(self) -> None:
-        expected_message = "[9049f12](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status)."
+        expected_message = "[9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b) changed its status to [success](https://example.com/build/status)."
         self.check_webhook("status__with_target_url", TOPIC_REPO, expected_message)
 
     def test_pull_request_review_msg(self) -> None:
@@ -346,7 +346,7 @@ class GitHubWebhookTest(WebhookTestCase):
     def test_check_run(self) -> None:
         expected_topic = "hello-world / checks"
         expected_message = """
-Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))
+Check [randscape](http://github.com/github/hello-world/runs/4) completed (success). ([d6fde92930d](http://github.com/github/hello-world/commit/d6fde92930d4715a2b49857d24b940956b26d2d3))
 """.strip()
         self.check_webhook("check_run__completed", expected_topic, expected_message)
 

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -44,57 +44,57 @@ class GitHubWebhookTest(WebhookTestCase):
         )
 
     def test_push_1_commit(self) -> None:
-        expected_message = "baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes.\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
+        expected_message = "baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes.\n\n* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
         self.check_webhook("push__1_commit", TOPIC_BRANCH, expected_message)
 
     def test_push_1_commit_without_username(self) -> None:
-        expected_message = "eeshangarg [pushed](https://github.com/eeshangarg/public-repo/compare/0383613da871...2e8cf535fb38) 1 commit to branch changes. Commits by John Snow (1).\n\n* Update the README ([2e8cf53](https://github.com/eeshangarg/public-repo/commit/2e8cf535fb38a3dab2476cdf856efda904ad4c94))"
+        expected_message = "eeshangarg [pushed](https://github.com/eeshangarg/public-repo/compare/0383613da871...2e8cf535fb38) 1 commit to branch changes. Commits by John Snow (1).\n\n* Update the README ([2e8cf535fb3](https://github.com/eeshangarg/public-repo/commit/2e8cf535fb38a3dab2476cdf856efda904ad4c94))"
         self.check_webhook("push__1_commit_without_username", TOPIC_BRANCH, expected_message)
 
     def test_push_1_commit_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url("master,changes")
-        expected_message = "baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes.\n\n* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
+        expected_message = "baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 1 commit to branch changes.\n\n* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"
         self.check_webhook("push__1_commit", TOPIC_BRANCH, expected_message)
 
     def test_push_multiple_comitters(self) -> None:
-        commits_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz (3), Ben (2) and baxterthehacker (1).\n\n{commits_info * 5}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
+        commits_info = "* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
+        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz (3), Ben (2) and baxterthehacker (1).\n\n{commits_info * 5}* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
 
         self.check_webhook("push__multiple_committers", TOPIC_BRANCH, expected_message)
 
     def test_push_multiple_comitters_with_others(self) -> None:
-        commits_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz (4), Ben (3), James (2) and others (1).\n\n{commits_info * 9}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
+        commits_info = "* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
+        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz (4), Ben (3), James (2) and others (1).\n\n{commits_info * 9}* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
 
         self.check_webhook("push__multiple_committers_with_others", TOPIC_BRANCH, expected_message)
 
     def test_push_multiple_comitters_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url("master,changes")
-        commits_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz (3), Ben (2) and baxterthehacker (1).\n\n{commits_info * 5}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
+        commits_info = "* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
+        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 6 commits to branch changes. Commits by Tomasz (3), Ben (2) and baxterthehacker (1).\n\n{commits_info * 5}* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
 
         self.check_webhook("push__multiple_committers", TOPIC_BRANCH, expected_message)
 
     def test_push_multiple_comitters_with_others_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url("master,changes")
-        commits_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
-        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz (4), Ben (3), James (2) and others (1).\n\n{commits_info * 9}* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
+        commits_info = "* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
+        expected_message = f"""baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 10 commits to branch changes. Commits by Tomasz (4), Ben (3), James (2) and others (1).\n\n{commits_info * 9}* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))"""
 
         self.check_webhook("push__multiple_committers_with_others", TOPIC_BRANCH, expected_message)
 
     def test_push_50_commits(self) -> None:
-        commit_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
+        commit_info = "* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
         expected_message = f"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes.\n\n{commit_info * COMMITS_LIMIT}[and 30 more commit(s)]"
         self.check_webhook("push__50_commits", TOPIC_BRANCH, expected_message)
 
     def test_push_50_commits_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,changes")
-        commit_info = "* Update README.md ([0d1a26e](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
+        commit_info = "* Update README.md ([0d1a26e67d8](https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c))\n"
         expected_message = f"baxterthehacker [pushed](https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f) 50 commits to branch changes.\n\n{commit_info * COMMITS_LIMIT}[and 30 more commit(s)]"
         self.check_webhook("push__50_commits", TOPIC_BRANCH, expected_message)
 
     def test_commit_comment_msg(self) -> None:
-        expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b#commitcomment-11056394) on [9049f12](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b):\n~~~ quote\nThis is a really good change! :+1:\n~~~"
+        expected_message = "baxterthehacker [commented](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b#commitcomment-11056394) on [9049f1265b7](https://github.com/baxterthehacker/public-repo/commit/9049f1265b7d61be4a8904a9a27120d2064dab3b):\n~~~ quote\nThis is a really good change! :+1:\n~~~"
         self.check_webhook("commit_comment", TOPIC_REPO, expected_message)
 
     def test_create_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -32,6 +32,7 @@ from zerver.lib.webhooks.git import (
     get_push_commits_event_message,
     get_push_tag_event_message,
     get_release_event_message,
+    get_short_sha,
 )
 from zerver.models import UserProfile
 
@@ -419,7 +420,7 @@ def get_status_body(helper: Helper) -> str:
     else:
         status = payload["state"].tame(check_string)
     return "[{}]({}) changed its status to {}.".format(
-        payload["sha"].tame(check_string)[:7],  # TODO
+        get_short_sha(payload["sha"].tame(check_string)),
         payload["commit"]["html_url"].tame(check_string),
         status,
     )
@@ -566,7 +567,7 @@ Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}
         "name": payload["check_run"]["name"].tame(check_string),
         "html_url": payload["check_run"]["html_url"].tame(check_string),
         "status": payload["check_run"]["status"].tame(check_string),
-        "short_hash": payload["check_run"]["head_sha"].tame(check_string)[:7],
+        "short_hash": get_short_sha(payload["check_run"]["head_sha"].tame(check_string)),
         "commit_url": "{}/commit/{}".format(
             payload["repository"]["html_url"].tame(check_string),
             payload["check_run"]["head_sha"].tame(check_string),

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -12,12 +12,12 @@ class GitlabHookTests(WebhookTestCase):
     def test_push_event_specified_topic(self) -> None:
         self.url = self.build_webhook_url("topic=Specific%20topic")
         expected_topic = "Specific topic"
-        expected_message = "[[my-awesome-project](https://gitlab.com/tomaszkolek0/my-awesome-project)] Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = "[[my-awesome-project](https://gitlab.com/tomaszkolek0/my-awesome-project)] Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.check_webhook("push_hook", expected_topic, expected_message)
 
     def test_push_event_message(self) -> None:
         expected_topic = "my-awesome-project / tomek"
-        expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.check_webhook("push_hook", expected_topic, expected_message)
 
     def test_push_local_branch_without_commits(self) -> None:
@@ -30,25 +30,25 @@ class GitlabHookTests(WebhookTestCase):
     def test_push_event_message_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,tomek")
         expected_topic = "my-awesome-project / tomek"
-        expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek.\n\n* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.check_webhook("push_hook", expected_topic, expected_message)
 
     def test_push_multiple_committers(self) -> None:
         expected_topic = "my-awesome-project / tomek"
-        expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Ben (1) and Tomasz Kolek (1).\n\n* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        expected_message = "Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 2 commits to branch tomek. Commits by Ben (1) and Tomasz Kolek (1).\n\n* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n* c ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.check_webhook("push_hook__push_multiple_committers", expected_topic, expected_message)
 
     def test_push_multiple_committers_with_others(self) -> None:
         expected_topic = "my-awesome-project / tomek"
-        commit_info = "* b ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))\n"
-        expected_message = f"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 7 commits to branch tomek. Commits by Ben (3), baxterthehacker (2), James (1) and others (1).\n\n{commit_info * 6}* b ([eb6ae1e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
+        commit_info = "* b ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))\n"
+        expected_message = f"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 7 commits to branch tomek. Commits by Ben (3), baxterthehacker (2), James (1) and others (1).\n\n{commit_info * 6}* b ([eb6ae1e591e](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9))"
         self.check_webhook(
             "push_hook__push_multiple_committers_with_others", expected_topic, expected_message
         )
 
     def test_push_commits_more_than_limit_event_message(self) -> None:
         expected_topic = "my-awesome-project / tomek"
-        commits_info = "* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n"
+        commits_info = "* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n"
         expected_message = f"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek.\n\n{commits_info * COMMITS_LIMIT}[and {50 - COMMITS_LIMIT} more commit(s)]"
         self.check_webhook(
             "push_hook__push_commits_more_than_limit", expected_topic, expected_message
@@ -57,7 +57,7 @@ class GitlabHookTests(WebhookTestCase):
     def test_push_commits_more_than_limit_message_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,tomek")
         expected_topic = "my-awesome-project / tomek"
-        commits_info = "* b ([66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n"
+        commits_info = "* b ([66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7))\n"
         expected_message = f"Tomasz Kolek [pushed](https://gitlab.com/tomaszkolek0/my-awesome-project/compare/5fcdd5551fc3085df79bece2c32b1400802ac407...eb6ae1e591e0819dc5bf187c6bfe18ec065a80e9) 50 commits to branch tomek.\n\n{commits_info * COMMITS_LIMIT}[and {50 - COMMITS_LIMIT} more commit(s)]"
         self.check_webhook(
             "push_hook__push_commits_more_than_limit", expected_topic, expected_message
@@ -225,7 +225,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_note_commit_event_message(self) -> None:
         expected_topic = "my-awesome-project"
-        expected_message = "Tomasz Kolek [commented](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7#note_14169211) on [66abd2d](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7):\n~~~ quote\nnice commit\n~~~"
+        expected_message = "Tomasz Kolek [commented](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7#note_14169211) on [66abd2da288](https://gitlab.com/tomaszkolek0/my-awesome-project/commit/66abd2da28809ffa128ed0447965cf11d7f863a7):\n~~~ quote\nnice commit\n~~~"
 
         self.check_webhook("note_hook__commit_note", expected_topic, expected_message)
 
@@ -554,7 +554,7 @@ A trivial change that should probably be ignored.
 
     def test_system_push_event_message(self) -> None:
         expected_topic = "gitlab / master"
-        expected_message = "John Smith [pushed](http://test.example.com/gitlab/gitlab/compare/95790bf891e76fee5e1747ab589903a6a1f80f22...da1560886d4f094c3e6c9ef40349f7d38b5d27d7) 1 commit to branch master. Commits by Test User (1).\n\n* Add simple search to projects in public area ([c5feabd](https://test.example.com/gitlab/gitlab/-/commit/c5feabde2d8cd023215af4d2ceeb7a64839fc428))"
+        expected_message = "John Smith [pushed](http://test.example.com/gitlab/gitlab/compare/95790bf891e76fee5e1747ab589903a6a1f80f22...da1560886d4f094c3e6c9ef40349f7d38b5d27d7) 1 commit to branch master. Commits by Test User (1).\n\n* Add simple search to projects in public area ([c5feabde2d8](https://test.example.com/gitlab/gitlab/-/commit/c5feabde2d8cd023215af4d2ceeb7a64839fc428))"
         self.check_webhook("system_hook__push_hook", expected_topic, expected_message)
 
     def test_system_merge_request_created_without_assignee_event_message(self) -> None:

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -13,20 +13,20 @@ class GogsHookTests(WebhookTestCase):
         expected_topic = "try-git / master"
         expected_message = """john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 1 commit to branch master. Commits by John (1).
 
-* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
+* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
         self.check_webhook("push", expected_topic, expected_message)
 
     def test_push_multiple_committers(self) -> None:
-        commit_info = "* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
+        commit_info = "* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
         expected_topic = "try-git / master"
-        expected_message = f"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin (1) and John (1).\n\n{commit_info}* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
+        expected_message = f"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin (1) and John (1).\n\n{commit_info}* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
         self.check_webhook("push__commits_multiple_committers", expected_topic, expected_message)
 
     def test_push_multiple_committers_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,development")
-        commit_info = "* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
+        commit_info = "* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
         expected_topic = "try-git / master"
-        expected_message = f"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin (1) and John (1).\n\n{commit_info}* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
+        expected_message = f"""john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 2 commits to branch master. Commits by Benjamin (1) and John (1).\n\n{commit_info}* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
         self.check_webhook("push__commits_multiple_committers", expected_topic, expected_message)
 
     def test_push_filtered_by_branches(self) -> None:
@@ -34,19 +34,19 @@ class GogsHookTests(WebhookTestCase):
         expected_topic = "try-git / master"
         expected_message = """john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 1 commit to branch master. Commits by John (1).
 
-* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
+* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))"""
         self.check_webhook("push", expected_topic, expected_message)
 
     def test_push_commits_more_than_limits(self) -> None:
         expected_topic = "try-git / master"
-        commits_info = "* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
+        commits_info = "* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
         expected_message = f"john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 30 commits to branch master. Commits by John (30).\n\n{commits_info * COMMITS_LIMIT}[and {30 - COMMITS_LIMIT} more commit(s)]"
         self.check_webhook("push__commits_more_than_limits", expected_topic, expected_message)
 
     def test_push_commits_more_than_limits_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,development")
         expected_topic = "try-git / master"
-        commits_info = "* Webhook Test ([d8fce16](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
+        commits_info = "* Webhook Test ([d8fce16c72a](http://localhost:3000/john/try-git/commit/d8fce16c72a2ff56a5afc8a08645a6ce45491794))\n"
         expected_message = f"john [pushed](http://localhost:3000/john/try-git/compare/479e6b772b7fba19412457483f50b201286d0103...d8fce16c72a2ff56a5afc8a08645a6ce45491794) 30 commits to branch master. Commits by John (30).\n\n{commits_info * COMMITS_LIMIT}[and {30 - COMMITS_LIMIT} more commit(s)]"
         self.check_webhook("push__commits_more_than_limits", expected_topic, expected_message)
 

--- a/zerver/webhooks/rhodecode/tests.py
+++ b/zerver/webhooks/rhodecode/tests.py
@@ -11,13 +11,13 @@ class RhodecodeHookTests(WebhookTestCase):
 
     def test_push_event_message(self) -> None:
         expected_topic = "u/yuroitaki/zulip-testing / master"
-        expected_message = "yuroitaki pushed 1 commit to branch master. Commits by Yuro Itaki <yuroitaki@email.com> (1).\n\n* Modify README ([2b8c0eb](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/2b8c0ebf50710bc2e1cdb6a33071dd2435ad667c))"
+        expected_message = "yuroitaki pushed 1 commit to branch master. Commits by Yuro Itaki <yuroitaki@email.com> (1).\n\n* Modify README ([2b8c0ebf507](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/2b8c0ebf50710bc2e1cdb6a33071dd2435ad667c))"
         self.check_webhook("push", expected_topic, expected_message)
 
     def test_push_event_message_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches="master,dev")
         expected_topic = "u/yuroitaki/zulip-testing / master"
-        expected_message = "yuroitaki pushed 1 commit to branch master. Commits by Yuro Itaki <yuroitaki@email.com> (1).\n\n* Modify README ([2b8c0eb](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/2b8c0ebf50710bc2e1cdb6a33071dd2435ad667c))"
+        expected_message = "yuroitaki pushed 1 commit to branch master. Commits by Yuro Itaki <yuroitaki@email.com> (1).\n\n* Modify README ([2b8c0ebf507](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/2b8c0ebf50710bc2e1cdb6a33071dd2435ad667c))"
         self.check_webhook("push", expected_topic, expected_message)
 
     @patch("zerver.lib.webhooks.common.check_send_webhook_message")
@@ -37,24 +37,24 @@ class RhodecodeHookTests(WebhookTestCase):
 
     def test_push_multiple_committers(self) -> None:
         expected_topic = "u/yuroitaki/zulip-testing / master"
-        expected_message = "yuroitaki pushed 2 commits to branch master. Commits by Itachi Sensei <itachisensei@email.com> (1) and Yuro Itaki <yuroitaki@email.com> (1).\n\n* Add test.py ([b0d892e](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/b0d892e1cdd4236b1f74debca1772ea330ff5acd))\n* Modify test.py ([6dbae5f](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/6dbae5f842f80ccb05508a1de7aace9d0f327473))"
+        expected_message = "yuroitaki pushed 2 commits to branch master. Commits by Itachi Sensei <itachisensei@email.com> (1) and Yuro Itaki <yuroitaki@email.com> (1).\n\n* Add test.py ([b0d892e1cdd](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/b0d892e1cdd4236b1f74debca1772ea330ff5acd))\n* Modify test.py ([6dbae5f842f](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/6dbae5f842f80ccb05508a1de7aace9d0f327473))"
         self.check_webhook("push__multiple_committers", expected_topic, expected_message)
 
     def test_push_multiple_committers_with_others(self) -> None:
         expected_topic = "u/yuroitaki/zulip-testing / master"
-        commits_info = "* Modify test.py ([6dbae5f](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/6dbae5f842f80ccb05508a1de7aace9d0f327473))\n"
-        expected_message = f"yuroitaki pushed 6 commits to branch master. Commits by Itachi Sensei <itachisensei@email.com> (2), Yuro Itaki <yuroitaki@email.com> (2), Jonas Nielsen <jonasnielsen@email.com> (1) and others (1).\n\n* Add test.py ([b0d892e](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/b0d892e1cdd4236b1f74debca1772ea330ff5acd))\n{commits_info * 4}* Add test.py ([b0d892e](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/b0d892e1cdd4236b1f74debca1772ea330ff5acd))"
+        commits_info = "* Modify test.py ([6dbae5f842f](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/6dbae5f842f80ccb05508a1de7aace9d0f327473))\n"
+        expected_message = f"yuroitaki pushed 6 commits to branch master. Commits by Itachi Sensei <itachisensei@email.com> (2), Yuro Itaki <yuroitaki@email.com> (2), Jonas Nielsen <jonasnielsen@email.com> (1) and others (1).\n\n* Add test.py ([b0d892e1cdd](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/b0d892e1cdd4236b1f74debca1772ea330ff5acd))\n{commits_info * 4}* Add test.py ([b0d892e1cdd](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/b0d892e1cdd4236b1f74debca1772ea330ff5acd))"
         self.check_webhook(
             "push__multiple_committers_with_others", expected_topic, expected_message
         )
 
     def test_push_commits_more_than_limit(self) -> None:
         expected_topic = "u/yuroitaki/zulip-testing / master"
-        commits_info = "* Modify README ([2b8c0eb](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/2b8c0ebf50710bc2e1cdb6a33071dd2435ad667c))\n"
+        commits_info = "* Modify README ([2b8c0ebf507](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/2b8c0ebf50710bc2e1cdb6a33071dd2435ad667c))\n"
         expected_message = f"yuroitaki pushed 50 commits to branch master. Commits by Yuro Itaki <yuroitaki@email.com> (50).\n\n{commits_info * COMMITS_LIMIT}[and {50 - COMMITS_LIMIT} more commit(s)]"
         self.check_webhook("push__commits_more_than_limit", expected_topic, expected_message)
 
     def test_push_remove_branch(self) -> None:
         expected_topic = "u/yuroitaki/zulip-testing / dev"
-        expected_message = "yuroitaki pushed 1 commit to branch dev. Commits by Yuro Itaki <yuroitaki@email.com> (1).\n\n* Deleted branch dev ([delete_](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/delete_branch=%3Edev))"
+        expected_message = "yuroitaki pushed 1 commit to branch dev. Commits by Yuro Itaki <yuroitaki@email.com> (1).\n\n* Deleted branch dev ([delete_bran](https://code.rhodecode.com/u/yuroitaki/zulip-testing/changeset/delete_branch=%3Edev))"
         self.check_webhook("push__remove_branch", expected_topic, expected_message)

--- a/zerver/webhooks/semaphore/tests.py
+++ b/zerver/webhooks/semaphore/tests.py
@@ -19,7 +19,7 @@ class SemaphoreHookTests(WebhookTestCase):
         expected_topic = "knighthood/master"  # repo/branch
         expected_message = """
 [Build 314](https://semaphoreci.com/donquixote/knighthood/branches/master/builds/314) passed:
-* **Commit**: [a490b8d: Create user account for Rocinante](https://github.com/donquixote/knighthood/commit/a490b8d508ebbdab1d77a5c2aefa35ceb2d62daf)
+* **Commit**: [a490b8d508e: Create user account for Rocinante](https://github.com/donquixote/knighthood/commit/a490b8d508ebbdab1d77a5c2aefa35ceb2d62daf)
 * **Author**: don@lamancha.com
 """.strip()
         self.check_webhook(
@@ -33,7 +33,7 @@ class SemaphoreHookTests(WebhookTestCase):
         expected_topic = "knighthood/master"
         expected_message = """
 [Deploy 17](https://semaphoreci.com/donquixote/knighthood/servers/lamancha-271/deploys/17) of [build 314](https://semaphoreci.com/donquixote/knighthood/branches/master/builds/314) passed:
-* **Commit**: [a490b8d: Create user account for Rocinante](https://github.com/donquixote/knighthood/commit/a490b8d508ebbdab1d77a5c2aefa35ceb2d62daf)
+* **Commit**: [a490b8d508e: Create user account for Rocinante](https://github.com/donquixote/knighthood/commit/a490b8d508ebbdab1d77a5c2aefa35ceb2d62daf)
 * **Author**: don@lamancha.com
 * **Server**: lamancha-271
 """.strip()
@@ -50,7 +50,7 @@ class SemaphoreHookTests(WebhookTestCase):
         expected_topic = "notifications/rw/webhook_impl"  # repo/branch
         expected_message = """
 [Notifications](https://semaphore.semaphoreci.com/workflows/acabe58e-4bcc-4d39-be06-e98d71917703) pipeline **stopped**:
-* **Commit**: [(2d9f5fc)](https://github.com/renderedtext/notifications/commit/2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563) Implement webhooks for SemaphoreCI
+* **Commit**: [(2d9f5fcec1c)](https://github.com/renderedtext/notifications/commit/2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563) Implement webhooks for SemaphoreCI
 * **Branch**: rw/webhook_impl
 * **Author**: [radwo](https://github.com/radwo)
 """.strip()
@@ -62,7 +62,7 @@ class SemaphoreHookTests(WebhookTestCase):
         expected_topic = "notifications/rw/webhook_impl"  # repo/branch
         expected_message = """
 [Notifications](https://semaphore.semaphoreci.com/workflows/acabe58e-4bcc-4d39-be06-e98d71917703) pipeline **stopped**:
-* **Commit**: (2d9f5fc) Implement webhooks for SemaphoreCI
+* **Commit**: (2d9f5fcec1c) Implement webhooks for SemaphoreCI
 * **Branch**: rw/webhook_impl
 * **Author**: radwo
 """.strip()

--- a/zerver/webhooks/semaphore/view.py
+++ b/zerver/webhooks/semaphore/view.py
@@ -9,6 +9,7 @@ from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.validator import WildValue, check_int, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
+from zerver.lib.webhooks.git import get_short_sha
 from zerver.models import UserProfile
 
 # Semaphore Classic templates
@@ -129,7 +130,7 @@ def semaphore_classic(payload: WildValue) -> Tuple[str, str, str, str]:
             build_number=build_number,
             build_url=build_url,
             status=result,
-            commit_hash=commit_id[:7],
+            commit_hash=get_short_sha(commit_id),
             commit_message=message,
             commit_url=commit_url,
             email=author_email,
@@ -147,7 +148,7 @@ def semaphore_classic(payload: WildValue) -> Tuple[str, str, str, str]:
             build_number=build_number,
             build_url=build_url,
             status=result,
-            commit_hash=commit_id[:7],
+            commit_hash=get_short_sha(commit_id),
             commit_message=message,
             commit_url=commit_url,
             email=author_email,
@@ -181,7 +182,7 @@ def semaphore_2(payload: WildValue) -> Tuple[str, str, Optional[str], str]:
         context.update(
             branch_name=branch_name,
             commit_id=commit_id,
-            commit_hash=commit_id[:7],
+            commit_hash=get_short_sha(commit_id),
             commit_message=summary_line(payload["revision"]["commit_message"].tame(check_string)),
             commit_url=GITHUB_URL_TEMPLATES["commit"].format(
                 repo_url=repo_url, commit_id=commit_id

--- a/zerver/webhooks/solano/tests.py
+++ b/zerver/webhooks/solano/tests.py
@@ -14,7 +14,7 @@ class SolanoHookTests(WebhookTestCase):
         expected_message = """
 Build update (see [build log](https://ci.solanolabs.com:443/reports/3316175)):
 * **Author**: solano-ci[bot]@users.noreply.github.com
-* **Commit**: [5f43840](github.com/fazerlicourice7/solano/commit/5f438401eb7cc7268cbc28438bfa70bb99f48a03)
+* **Commit**: [5f438401eb7](github.com/fazerlicourice7/solano/commit/5f438401eb7cc7268cbc28438bfa70bb99f48a03)
 * **Status**: failed :thumbs_down:
 """.strip()
 
@@ -33,7 +33,7 @@ Build update (see [build log](https://ci.solanolabs.com:443/reports/3316175)):
         expected_message = """
 Build update (see [build log](https://ci.solanolabs.com:443/reports/3316723)):
 * **Author**: Unknown
-* **Commit**: [5d0b92e](bitbucket.org/fazerlicourice7/test/commits/5d0b92e26448a9e91db794bfed4b8c3556eabc4e)
+* **Commit**: [5d0b92e2644](bitbucket.org/fazerlicourice7/test/commits/5d0b92e26448a9e91db794bfed4b8c3556eabc4e)
 * **Status**: failed :thumbs_down:
 """.strip()
 
@@ -52,7 +52,7 @@ Build update (see [build log](https://ci.solanolabs.com:443/reports/3316723)):
         expected_message = """
 Build update (see [build log](https://ci.solanolabs.com:443/reports/3317799)):
 * **Author**: solano-ci[bot]@users.noreply.github.com
-* **Commit**: [191d34f](github.com/anirudhjain75/scipy/commit/191d34f9da8ff7279b051cd68e44223253e18408)
+* **Commit**: [191d34f9da8](github.com/anirudhjain75/scipy/commit/191d34f9da8ff7279b051cd68e44223253e18408)
 * **Status**: running :arrows_counterclockwise:
 """.strip()
 

--- a/zerver/webhooks/solano/view.py
+++ b/zerver/webhooks/solano/view.py
@@ -7,6 +7,7 @@ from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.validator import WildValue, check_string, to_wild_value
 from zerver.lib.webhooks.common import check_send_webhook_message
+from zerver.lib.webhooks.git import get_short_sha
 from zerver.models import UserProfile
 
 MESSAGE_TEMPLATE = """
@@ -63,7 +64,7 @@ def api_solano_webhook(
     body = MESSAGE_TEMPLATE.format(
         author=author,
         build_log_url=build_log,
-        commit_id=commit_id[:7],
+        commit_id=get_short_sha(commit_id),
         commit_url=commit_url,
         status=status,
         emoji=emoji,


### PR DESCRIPTION
This unifies the length of the shortened SHA our integrations generate,
and ensures that they are long enough for projects of various sizes with
a chosen value defined in get_short_sha.

Fixes #23475

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

