### PR TITLE
help center: Drop extraneous Desktop/Web tab from /help/emoji-reactions.

### DIFF
--- a/templates/zerver/help/emoji-reactions.md
+++ b/templates/zerver/help/emoji-reactions.md
@@ -85,8 +85,6 @@ so](#toggle-whether-names-of-reacting-users-are-displayed) is enabled.
 
 {start_tabs}
 
-{tab|desktop-web}
-
 {settings_tab|display-settings}
 
 1. Under **Theme**, toggle **Display names of reacting users when few users have


### PR DESCRIPTION
It is better not to use a tab in the instructions for how to "Toggle whether names of reacting users are displayed", as this setting applies to both web/desktop and mobile apps.

The instructions themselves still indicate that the setting is controlled via the web/desktop app.

Current page: https://zulip.com/help/emoji-reactions

Update:
![Screen Shot 2022-11-07 at 2 38 29 PM](https://user-images.githubusercontent.com/2090066/200430638-7447b13e-ce78-4903-8634-9ff096360543.png)
