### PR TITLE
help center: Document viewing read receipts on mobile.

### DIFF
--- a/templates/zerver/help/include/message-long-press-menu.md
+++ b/templates/zerver/help/include/message-long-press-menu.md
@@ -1,0 +1,1 @@
+1. Press and hold a message until the long-press menu appears.

--- a/templates/zerver/help/read-receipts.md
+++ b/templates/zerver/help/read-receipts.md
@@ -18,15 +18,23 @@ their organization.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!message-actions-menu.md!}
 
 3. Click **View read receipts**.
 
+{tab|mobile}
+
+{!message-long-press-menu.md!}
+
+1. Tap **View read receipts**.
+
+{end_tabs}
+
 !!! tip ""
     In addition to a list of names, you will see how many people have read
     the message.
-
-{end_tabs}
 
 ## Configure whether Zulip lets others see when you've read messages
 


### PR DESCRIPTION
Adds instructions for viewing read receipts in the mobile app.

Fixes #23479.

**Screenshots and screen captures:**
- https://zulip.com/help/read-receipts#view-who-has-read-a-message
<img width="636" alt="image" src="https://user-images.githubusercontent.com/2343554/200437852-76e93275-2b31-481f-8b24-8e3314d69a28.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>