### PR TITLE
help center: Document viewing @-mentions.

### DIFF
--- a/static/images/help/mobile-at-sign-icon.svg
+++ b/static/images/help/mobile-at-sign-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-at-sign">
+    <circle cx="12" cy="12" r="4"></circle>
+    <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.92 7.94"></path>
+</svg>

--- a/static/images/help/mobile-inbox-icon.svg
+++ b/static/images/help/mobile-inbox-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-inbox">
+    <polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline>
+    <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"></path>
+</svg>

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -81,6 +81,7 @@
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)
 * [Emoji reactions](/help/emoji-reactions)
+* [View your mentions](/help/view-your-mentions)
 * [Star a message](/help/star-a-message)
 * [View and browse images](/help/view-and-browse-images)
 * [View messages sent by a user](/help/view-messages-sent-by-a-user)

--- a/templates/zerver/help/mention-a-user-or-group.md
+++ b/templates/zerver/help/mention-a-user-or-group.md
@@ -72,3 +72,4 @@ streams](/help/stream-notifications).
 
 * [Restrict wildcard mentions](/help/restrict-wildcard-mentions)
 * [Quote and reply](/help/quote-and-reply)
+* [View your mentions](/help/view-your-mentions)

--- a/templates/zerver/help/view-your-mentions.md
+++ b/templates/zerver/help/view-your-mentions.md
@@ -1,0 +1,37 @@
+# View your mentions
+
+Zulip keeps track of messages where you have been mentioned and displays the
+number of all your unread @-mentions to allow you to use this feature as an
+inbox of messages you'd like to come back to.
+
+## Access your mentions
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click **@ Mentions** in the left sidebar.
+
+!!! tip ""
+
+    Topics in the left sidebar and **Recent conversations** with unread @-mentions
+    have an **@** indicator next to the number of unread messages.
+
+{tab|mobile}
+
+1. Tap the **@ Mentions**
+   (<img src="/static/images/help/mobile-at-sign-icon.svg" alt="at-sign" class="mobile-icon"/>)
+   tab at the top of the app.
+
+!!! tip ""
+
+    Topics in the **Inbox**
+    (<img src="/static/images/help/mobile-inbox-icon.svg" alt="inbox" class="mobile-icon"/>)
+    tab with unread @-mentions have an **@** indicator next to the number of unread messages.
+
+{end_tabs}
+
+## Related articles
+
+* [Reading strategies](/help/reading-strategies)
+* [Mention a user or group](/help/mention-a-user-or-group)


### PR DESCRIPTION
Adds "View your mentions" page to document how to access @-mentions and the @ indicator for unread @-mentions on desktop/web and mobile.

Fixes #23422.

**Screenshots and screen captures:**

<img width="781" alt="image" src="https://user-images.githubusercontent.com/2343554/200453819-b86225ef-e66b-48de-83eb-1568be751636.png">

<img width="549" alt="image" src="https://user-images.githubusercontent.com/2343554/200452151-a435a812-58eb-44cb-9382-de2ddfe691d1.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>