### PR TITLE
removed-word-to-alert-confirmation

### DIFF
--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -86,7 +86,10 @@ run_test("remove_alert_word", ({override_rewire}) => {
     // test success
     success_func();
     assert.ok($alert_word_status.hasClass("alert-success"));
-    assert.equal($alert_word_status_text.text(), "translated: Alert word removed successfully!");
+    assert.equal(
+        $alert_word_status_text.text(),
+        `translated: Alert word "translated: zot" removed successfully!`,
+    );
     assert.ok($alert_word_status.visible());
 });
 

--- a/frontend_tests/puppeteer_tests/settings.ts
+++ b/frontend_tests/puppeteer_tests/settings.ts
@@ -322,7 +322,7 @@ async function delete_alert_word(page: Page, word: string): Promise<void> {
 async function test_alert_word_deletion(page: Page, word: string): Promise<void> {
     await delete_alert_word(page, word);
     const status_text = await get_alert_words_status_text(page);
-    assert.strictEqual(status_text, "Alert word removed successfully!");
+    assert.strictEqual(status_text, `Alert word "${word}" removed successfully!`);
     await close_alert_words_status(page);
 }
 

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -70,7 +70,10 @@ function remove_alert_word(alert_word) {
         data: {alert_words: JSON.stringify(words_to_be_removed)},
         success() {
             update_alert_word_status(
-                $t({defaultMessage: "Alert word removed successfully!"}),
+                $t(
+                    {defaultMessage: `Alert word "{alert_word}" removed successfully!`},
+                    {alert_word},
+                ),
                 false,
             );
         },

--- a/static/templates/settings/alert_word_settings.hbs
+++ b/static/templates/settings/alert_word_settings.hbs
@@ -4,18 +4,18 @@
             {{t "Alert words allow you to be notified as if you were @-mentioned when certain words or phrases are used in Zulip. Alert words are not case sensitive."}}
         </p>
     </form>
-    <div class="alert" id="alert_word_status" role="alert">
-        <button type="button" class="close close-alert-word-status" aria-label="{{t 'Close' }}">
-            <span aria-hidden="true">&times;</span>
-        </button>
-        <span class="alert_word_status_text"></span>
-    </div>
     <button class="button rounded sea-green" id="open-add-alert-word-modal" type="button">
         {{t 'Add alert word'}}
     </button>
 
     <div class="settings_panel_list_header">
         <h3>{{t "Alert words"}}</h3>
+    </div>
+    <div class="alert" id="alert_word_status" role="alert">
+        <button type="button" class="close close-alert-word-status" aria-label="{{t 'Close' }}">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        <span class="alert_word_status_text"></span>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #22813 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![Screenshot from 2022-11-10 16-11-47](https://user-images.githubusercontent.com/99073049/201072382-009ed26d-1b28-4953-8a10-358b40315936.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
