### PR TITLE
compose: Migrate upload banner to new banner styling.

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -46,11 +46,11 @@ test("feature_check", ({override}) => {
 test("get_item", () => {
     assert.equal(upload.get_item("textarea", {mode: "compose"}), $("#compose-textarea"));
     assert.equal(
-        upload.get_item("send_status_message", {mode: "compose"}),
+        upload.get_item("upload_banner_message", {mode: "compose"}),
         $("#compose_banners .upload_banner .upload_msg"),
     );
     assert.equal(
-        upload.get_item("send_status_close_button", {mode: "compose"}),
+        upload.get_item("upload_banner_close_button", {mode: "compose"}),
         $("#compose_banners .upload_banner .compose_banner_close_button"),
     );
     assert.equal(
@@ -76,11 +76,11 @@ test("get_item", () => {
     assert.equal(upload.get_item("send_button", {mode: "edit", row: 2}), $(".message_edit_save"));
 
     assert.equal(
-        upload.get_item("send_status_identifier", {mode: "edit", row: 11}),
+        upload.get_item("upload_banner_identifier", {mode: "edit", row: 11}),
         `#edit_form_${CSS.escape(11)} .upload_banner`,
     );
     assert.equal(
-        upload.get_item("send_status", {mode: "edit", row: 75}),
+        upload.get_item("upload_banner", {mode: "edit", row: 75}),
         $(`#edit_form_${CSS.escape(75)} .upload_banner`),
     );
 
@@ -89,7 +89,7 @@ test("get_item", () => {
         $(".compose_banner_close_button"),
     );
     assert.equal(
-        upload.get_item("send_status_close_button", {mode: "edit", row: 2}),
+        upload.get_item("upload_banner_close_button", {mode: "edit", row: 2}),
         $(`#edit_form_${CSS.escape(2)} .upload_banner .compose_banner_close_button`),
     );
 
@@ -98,7 +98,7 @@ test("get_item", () => {
         $(".upload_msg"),
     );
     assert.equal(
-        upload.get_item("send_status_message", {mode: "edit", row: 22}),
+        upload.get_item("upload_banner_message", {mode: "edit", row: 22}),
         $(`#edit_form_${CSS.escape(22)} .upload_banner .upload_msg`),
     );
 

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -21,9 +21,9 @@ mock_esm("@uppy/xhr-upload", {default: class XHRUpload {}});
 mock_esm("@uppy/progress-bar", {default: class ProgressBar {}});
 
 const compose_actions = mock_esm("../../static/js/compose_actions");
-const compose_ui = mock_esm("../../static/js/compose_ui");
 mock_esm("../../static/js/csrf", {csrf_token: "csrf_token"});
 
+const compose_ui = zrequire("compose_ui");
 const upload = zrequire("upload");
 
 function test(label, f) {
@@ -185,7 +185,7 @@ test("show_error_message", () => {
     assert.equal($("#compose-error-msg").text(), "translated: An unknown error occurred.");
 });
 
-test("upload_files", ({override, override_rewire}) => {
+test("upload_files", ({override_rewire}) => {
     let uppy_cancel_all_called = false;
     let files = [
         {
@@ -232,13 +232,13 @@ test("upload_files", ({override, override_rewire}) => {
         on_click_close_button_callback = callback;
     };
     let compose_ui_insert_syntax_and_focus_called = false;
-    override(compose_ui, "insert_syntax_and_focus", (syntax, textarea) => {
+    override_rewire(compose_ui, "insert_syntax_and_focus", (syntax, textarea) => {
         assert.equal(syntax, "[translated: Uploading budapest.png…]()");
         assert.equal(textarea, $("#compose-textarea"));
         compose_ui_insert_syntax_and_focus_called = true;
     });
     let compose_ui_autosize_textarea_called = false;
-    override(compose_ui, "autosize_textarea", () => {
+    override_rewire(compose_ui, "autosize_textarea", () => {
         compose_ui_autosize_textarea_called = true;
     });
     let markdown_preview_hide_button_clicked = false;
@@ -289,7 +289,7 @@ test("upload_files", ({override, override_rewire}) => {
             type: "image/png",
         },
     ];
-    override(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
+    override_rewire(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
         assert.equal(old_syntax, "[translated: Uploading budapest.png…]()");
         assert.equal(new_syntax, "");
@@ -505,7 +505,7 @@ test("uppy_events", ({override, override_rewire}) => {
         compose_actions_start_called = true;
     });
     let compose_ui_replace_syntax_called = false;
-    override(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
+    override_rewire(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
         assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(
@@ -515,7 +515,7 @@ test("uppy_events", ({override, override_rewire}) => {
         assert.equal(textarea, $("#compose-textarea"));
     });
     let compose_ui_autosize_textarea_called = false;
-    override(compose_ui, "autosize_textarea", () => {
+    override_rewire(compose_ui, "autosize_textarea", () => {
         compose_ui_autosize_textarea_called = true;
     });
     on_upload_success_callback(file, response);
@@ -601,7 +601,7 @@ test("uppy_events", ({override, override_rewire}) => {
     on_info_visible_callback();
     assert.ok(uppy_cancel_all_called);
     assert.equal($("#compose-error-msg").text(), "Some error message");
-    override(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
+    override_rewire(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
         assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(new_syntax, "");

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -277,9 +277,6 @@ test("upload_files", ({override_rewire}) => {
     upload.upload_files(uppy, config, files);
     assert.equal(add_file_counter, 1);
 
-    set_global("setTimeout", (func) => {
-        func();
-    });
     hide_upload_status_called = false;
     uppy_cancel_all_called = false;
     let compose_ui_replace_syntax_called = false;

--- a/frontend_tests/zjsunit/zjquery_element.js
+++ b/frontend_tests/zjsunit/zjquery_element.js
@@ -229,6 +229,14 @@ function FakeElement(selector, opts) {
             shown = show;
             return $self;
         },
+        toggleClass(class_name, add) {
+            if (add) {
+                classes.set(class_name, true);
+            } else {
+                classes.delete(class_name);
+            }
+            return $self;
+        },
         trigger(ev) {
             event_store.trigger($self, ev);
             return $self;

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -337,11 +337,6 @@ export function initialize() {
             ui_util.blur_active_element();
         }
     });
-    $(".message_edit_form .send-status-close").on("click", function () {
-        const row_id = rows.id($(this).closest(".message_row"));
-        const $send_status = $(`#message-edit-send-status-${CSS.escape(row_id)}`);
-        $send_status.stop(true).fadeOut(200);
-    });
     $("body").on("click", ".message_edit_form .compose_upload_file", function (e) {
         e.preventDefault();
 

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -1,7 +1,8 @@
 import {Uppy} from "@uppy/core";
-import ProgressBar from "@uppy/progress-bar";
 import XHRUpload from "@uppy/xhr-upload";
 import $ from "jquery";
+
+import render_upload_banner from "../templates/compose_banner/upload_banner.hbs";
 
 import * as compose_actions from "./compose_actions";
 import * as compose_state from "./compose_state";
@@ -32,14 +33,16 @@ export function get_item(key, config) {
                 return $("#compose-textarea");
             case "send_button":
                 return $("#compose-send-button");
+            case "banner_container":
+                return $("#compose_banners");
             case "send_status_identifier":
-                return "#compose-send-status";
+                return "#compose_banners .upload_banner";
             case "send_status":
-                return $("#compose-send-status");
+                return $("#compose_banners .upload_banner");
             case "send_status_close_button":
-                return $(".compose-send-status-close");
+                return $("#compose_banners .upload_banner .compose_banner_close_button");
             case "send_status_message":
-                return $("#compose-error-msg");
+                return $("#compose_banners .upload_banner .upload_msg");
             case "file_input_identifier":
                 return "#compose .file_input";
             case "source":
@@ -62,16 +65,20 @@ export function get_item(key, config) {
                 return $(`#edit_form_${CSS.escape(config.row)} .message_edit_content`)
                     .closest(".message_edit_form")
                     .find(".message_edit_save");
+            case "banner_container":
+                return $(`#edit_form_${CSS.escape(config.row)} .banners`);
             case "send_status_identifier":
-                return `#message-edit-send-status-${CSS.escape(config.row)}`;
+                return `#edit_form_${CSS.escape(config.row)} .upload_banner`;
             case "send_status":
-                return $(`#message-edit-send-status-${CSS.escape(config.row)}`);
+                return $(`#edit_form_${CSS.escape(config.row)} .upload_banner`);
             case "send_status_close_button":
-                return $(`#message-edit-send-status-${CSS.escape(config.row)}`).find(
-                    ".send-status-close",
+                return $(
+                    `#edit_form_${CSS.escape(
+                        config.row,
+                    )} .upload_banner .compose_banner_close_button`,
                 );
             case "send_status_message":
-                return $(`#message-edit-send-status-${CSS.escape(config.row)}`).find(".error-msg");
+                return $(`#edit_form_${CSS.escape(config.row)} .upload_banner .upload_msg`);
             case "file_input_identifier":
                 return `#edit_form_${CSS.escape(config.row)} .file_input`;
             case "source":
@@ -90,7 +97,36 @@ export function get_item(key, config) {
 
 export function hide_upload_status(config) {
     get_item("send_button", config).prop("disabled", false);
-    get_item("send_status", config).removeClass("alert-info").hide();
+    get_item("send_status", config).remove();
+}
+
+function show_upload_banner(config, banner_type, banner_text) {
+    // We only show one upload banner at a time per compose box,
+    // and all uploads are combined into the same progress bar.
+    // TODO: It would be nice to separate the error banner into
+    // a different element, so that we can show it at the same
+    // time as the upload bar and other uploads can still continue
+    // when an error occurs.
+    const $upload_banner = get_item("send_status", config);
+    if ($upload_banner.length) {
+        if (banner_type === "error") {
+            // Hide moving bar so that it doesn't do the 1s transition to 0
+            const $moving_bar = $(`${get_item("send_status_identifier", config)} .moving_bar`);
+            $moving_bar.hide();
+            $upload_banner.removeClass("info").addClass("error");
+            // Show it again once the animation is complete.
+            setTimeout(() => $moving_bar.show(), 1000);
+        } else {
+            $upload_banner.removeClass("error").addClass("info");
+        }
+        get_item("send_status_message", config).text(banner_text);
+        return;
+    }
+    const $new_banner = render_upload_banner({
+        banner_type,
+        banner_text,
+    });
+    get_item("banner_container", config).append($new_banner);
 }
 
 export function show_error_message(
@@ -98,11 +134,10 @@ export function show_error_message(
     message = $t({defaultMessage: "An unknown error occurred."}),
 ) {
     get_item("send_button", config).prop("disabled", false);
-    get_item("send_status", config).addClass("alert-error").removeClass("alert-info").show();
-    get_item("send_status_message", config).text(message);
+    show_upload_banner(config, "error", message);
 }
 
-export function upload_files(uppy, config, files) {
+export async function upload_files(uppy, config, files) {
     if (files.length === 0) {
         return;
     }
@@ -128,8 +163,7 @@ export function upload_files(uppy, config, files) {
     }
 
     get_item("send_button", config).prop("disabled", true);
-    get_item("send_status", config).addClass("alert-info").removeClass("alert-error").show();
-    get_item("send_status_message", config).html($("<p>").text($t({defaultMessage: "Uploading…"})));
+    show_upload_banner(config, "info", $t({defaultMessage: "Uploading…"}));
     get_item("send_status_close_button", config).one("click", () => {
         for (const file of uppy.getFiles()) {
             compose_ui.replace_syntax(
@@ -280,7 +314,7 @@ export function setup_upload(config) {
             }
         }
 
-        const has_errors = get_item("send_status", config).hasClass("alert-error");
+        const has_errors = get_item("send_status", config).hasClass("error");
         if (!uploads_in_progress && !has_errors) {
             // Hide upload status for 100ms after the 1s transition to 100%
             // so that the user can see the progress bar at 100%.
@@ -314,6 +348,8 @@ export function setup_upload(config) {
         if (info.type === "error") {
             // The remaining errors are mostly frontend errors like file being too large
             // for upload.
+            // TODO: It would be nice to keep the other uploads going if one fails,
+            // and show both an error message and the upload bar.
             uppy.cancelAll();
             show_error_message(config, info.message);
         }

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -35,13 +35,13 @@ export function get_item(key, config) {
                 return $("#compose-send-button");
             case "banner_container":
                 return $("#compose_banners");
-            case "send_status_identifier":
+            case "upload_banner_identifier":
                 return "#compose_banners .upload_banner";
-            case "send_status":
+            case "upload_banner":
                 return $("#compose_banners .upload_banner");
-            case "send_status_close_button":
+            case "upload_banner_close_button":
                 return $("#compose_banners .upload_banner .compose_banner_close_button");
-            case "send_status_message":
+            case "upload_banner_message":
                 return $("#compose_banners .upload_banner .upload_msg");
             case "file_input_identifier":
                 return "#compose .file_input";
@@ -67,17 +67,17 @@ export function get_item(key, config) {
                     .find(".message_edit_save");
             case "banner_container":
                 return $(`#edit_form_${CSS.escape(config.row)} .banners`);
-            case "send_status_identifier":
+            case "upload_banner_identifier":
                 return `#edit_form_${CSS.escape(config.row)} .upload_banner`;
-            case "send_status":
+            case "upload_banner":
                 return $(`#edit_form_${CSS.escape(config.row)} .upload_banner`);
-            case "send_status_close_button":
+            case "upload_banner_close_button":
                 return $(
                     `#edit_form_${CSS.escape(
                         config.row,
                     )} .upload_banner .compose_banner_close_button`,
                 );
-            case "send_status_message":
+            case "upload_banner_message":
                 return $(`#edit_form_${CSS.escape(config.row)} .upload_banner .upload_msg`);
             case "file_input_identifier":
                 return `#edit_form_${CSS.escape(config.row)} .file_input`;
@@ -97,7 +97,7 @@ export function get_item(key, config) {
 
 export function hide_upload_status(config) {
     get_item("send_button", config).prop("disabled", false);
-    get_item("send_status", config).remove();
+    get_item("upload_banner", config).remove();
 }
 
 function show_upload_banner(config, banner_type, banner_text) {
@@ -107,11 +107,11 @@ function show_upload_banner(config, banner_type, banner_text) {
     // a different element, so that we can show it at the same
     // time as the upload bar and other uploads can still continue
     // when an error occurs.
-    const $upload_banner = get_item("send_status", config);
+    const $upload_banner = get_item("upload_banner", config);
     if ($upload_banner.length) {
         if (banner_type === "error") {
             // Hide moving bar so that it doesn't do the 1s transition to 0
-            const $moving_bar = $(`${get_item("send_status_identifier", config)} .moving_bar`);
+            const $moving_bar = $(`${get_item("upload_banner_identifier", config)} .moving_bar`);
             $moving_bar.hide();
             $upload_banner.removeClass("info").addClass("error");
             // Show it again once the animation is complete.
@@ -119,7 +119,7 @@ function show_upload_banner(config, banner_type, banner_text) {
         } else {
             $upload_banner.removeClass("error").addClass("info");
         }
-        get_item("send_status_message", config).text(banner_text);
+        get_item("upload_banner_message", config).text(banner_text);
         return;
     }
     const $new_banner = render_upload_banner({
@@ -164,7 +164,7 @@ export async function upload_files(uppy, config, files) {
 
     get_item("send_button", config).prop("disabled", true);
     show_upload_banner(config, "info", $t({defaultMessage: "Uploading…"}));
-    get_item("send_status_close_button", config).one("click", () => {
+    get_item("upload_banner_close_button", config).one("click", () => {
         for (const file of uppy.getFiles()) {
             compose_ui.replace_syntax(
                 get_translated_status(file),
@@ -241,7 +241,7 @@ export function setup_upload(config) {
         if (progress === 0) {
             return;
         }
-        $(`${get_item("send_status_identifier", config)} .moving_bar`).css({
+        $(`${get_item("upload_banner_identifier", config)} .moving_bar`).css({
             width: `${progress}%`,
         });
     });
@@ -314,7 +314,7 @@ export function setup_upload(config) {
             }
         }
 
-        const has_errors = get_item("send_status", config).hasClass("error");
+        const has_errors = get_item("upload_banner", config).hasClass("error");
         if (!uploads_in_progress && !has_errors) {
             // Hide upload status for 100ms after the 1s transition to 100%
             // so that the user can see the progress bar at 100%.

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -141,9 +141,7 @@ export function upload_files(uppy, config, files) {
         compose_ui.autosize_textarea(get_item("textarea", config));
         uppy.cancelAll();
         get_item("textarea", config).trigger("focus");
-        setTimeout(() => {
-            hide_upload_status(config);
-        }, 500);
+        hide_upload_status(config);
     });
 
     for (const file of files) {
@@ -204,9 +202,14 @@ export function setup_upload(config) {
         },
     });
 
-    uppy.use(ProgressBar, {
-        target: get_item("send_status_identifier", config),
-        hideAfterFinish: false,
+    uppy.on("progress", (progress) => {
+        // When upload is complete, it resets to 0, but we want to see it at 100%.
+        if (progress === 0) {
+            return;
+        }
+        $(`${get_item("send_status_identifier", config)} .moving_bar`).css({
+            width: `${progress}%`,
+        });
     });
 
     $("body").on("change", get_item("file_input_identifier", config), (event) => {
@@ -279,9 +282,11 @@ export function setup_upload(config) {
 
         const has_errors = get_item("send_status", config).hasClass("alert-error");
         if (!uploads_in_progress && !has_errors) {
+            // Hide upload status for 100ms after the 1s transition to 100%
+            // so that the user can see the progress bar at 100%.
             setTimeout(() => {
                 hide_upload_status(config);
-            }, 500);
+            }, 1100);
         }
     });
 

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -399,10 +399,53 @@
             }
         }
     }
+
+    &.info {
+        background-color: hsl(204, 58%, 92%);
+        border-color: hsla(204, 49%, 29%, 0.4);
+        position: relative;
+        color: hsl(204, 49%, 29%);
+
+        .compose_banner_close_button {
+            color: hsla(204, 49%, 29%, 0.5);
+
+            &:hover {
+                color: hsl(204, 49%, 29%);
+            }
+
+            &:active {
+                color: hsla(204, 49%, 29%, 0.75);
+            }
+        }
+    }
+}
+
+.upload_banner {
+    overflow: hidden;
+
+    &.hidden {
+        display: none;
+    }
+
+    .moving_bar {
+        position: absolute;
+        width: 0;
+        /* The progress updates seem to come every second or so,
+        so this is the smoothest it can probably get. */
+        transition: width 1s ease-in-out;
+        background: hsl(204, 63%, 85%);
+        top: 0;
+        bottom: 0;
+    }
+
+    .upload_msg,
+    .compose_banner_close_button {
+        z-index: 1;
+        position: relative;
+    }
 }
 
 /* Like .nav-tabs > li > a */
-div[id^="message-edit-send-status"],
 #compose-send-status {
     padding: 8px 14px;
     margin-bottom: 8px;

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -251,6 +251,31 @@
                 }
             }
         }
+
+        &.info {
+            background-color: hsl(204, 100%, 12%);
+            border-color: hsla(205, 58%, 69%, 0.4);
+            position: relative;
+            color: hsl(205, 58%, 69%);
+
+            .compose_banner_close_button {
+                color: hsla(205, 58%, 69%, 0.5);
+
+                &:hover {
+                    color: hsl(205, 58%, 69%);
+                }
+
+                &:active {
+                    color: hsla(205, 58%, 69%, 0.75);
+                }
+            }
+        }
+    }
+
+    .upload_banner {
+        .moving_bar {
+            background: hsl(204, 63%, 18%);
+        }
     }
 
     .message_embed .data-container::after {

--- a/static/templates/compose_banner/upload_banner.hbs
+++ b/static/templates/compose_banner/upload_banner.hbs
@@ -1,0 +1,5 @@
+<div class="upload_banner compose_banner {{banner_type}}">
+    <div class="moving_bar"></div>
+    <p class="upload_msg">{{banner_text}}</p>
+    <a role="button" class="zulip-icon zulip-icon-close compose_banner_close_button"></a>
+</div>

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -1,10 +1,7 @@
 {{! Client-side Mustache template for rendering the message edit form. }}
 
 <form id="edit_form_{{message_id}}" class="new-style">
-    <div class="alert" id="message-edit-send-status-{{message_id}}">
-        <span class="send-status-close">&times;</span>
-        <span class="error-msg"></span>
-    </div>
+    <div class="banners"></div>
     <div class="edit-controls">
         {{> copy_message_button message_id=this.message_id}}
         <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -45,6 +45,7 @@ def make_set(files: List[str]) -> Set[str]:
 EXEMPT_FILES = make_set(
     [
         "frontend_tests/zjsunit/mdiff.js",
+        "frontend_tests/zjsunit/zjquery_element.js",
         "static/js/about_zulip.js",
         "static/js/add_subscribers_pill.js",
         "static/js/admin.js",
@@ -205,6 +206,7 @@ EXEMPT_FILES = make_set(
         "static/js/unread.js",
         "static/js/unread_ops.js",
         "static/js/unread_ui.js",
+        "static/js/upload.js",
         "static/js/upload_widget.ts",
         "static/js/user_group_create.js",
         "static/js/user_group_create_members.js",


### PR DESCRIPTION
This affects both the banner in the main compose box and the banner
in the message edit compose box. The use of ProgressBar has been
replaced with a more simple CSS (with light Javascript) solution.


Fixes #22524 (This is the final PR of three that fix this issue.)
Fixes #21480.

**Screenshots and screen captures:**

<img width="879" alt="image" src="https://user-images.githubusercontent.com/5634097/200466495-d7a1913f-8d37-419f-9e54-b11c6cf86fd5.png">

<img width="884" alt="image" src="https://user-images.githubusercontent.com/5634097/200466582-3c004cff-069c-42cf-8b06-363e4dce2867.png">

<img width="876" alt="image" src="https://user-images.githubusercontent.com/5634097/200467170-2f29b2bd-afe6-4f1c-be94-5fdddcd22113.png">

<img width="887" alt="image" src="https://user-images.githubusercontent.com/5634097/200963591-d00230b4-3128-44c3-bf75-b1d6f88e712a.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
