### PR TITLE
help center: Document viewing @-mentions.

### DIFF
--- a/static/images/help/mobile-at-sign-icon.svg
+++ b/static/images/help/mobile-at-sign-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-at-sign">
+    <circle cx="12" cy="12" r="4"></circle>
+    <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.92 7.94"></path>
+</svg>

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -81,6 +81,7 @@
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)
 * [Emoji reactions](/help/emoji-reactions)
+* [View your mentions](/help/view-your-mentions)
 * [Star a message](/help/star-a-message)
 * [View and browse images](/help/view-and-browse-images)
 * [View messages sent by a user](/help/view-messages-sent-by-a-user)

--- a/templates/zerver/help/mention-a-user-or-group.md
+++ b/templates/zerver/help/mention-a-user-or-group.md
@@ -72,3 +72,4 @@ streams](/help/stream-notifications).
 
 * [Restrict wildcard mentions](/help/restrict-wildcard-mentions)
 * [Quote and reply](/help/quote-and-reply)
+* [View your mentions](/help/view-your-mentions)

--- a/templates/zerver/help/pm-mention-alert-notifications.md
+++ b/templates/zerver/help/pm-mention-alert-notifications.md
@@ -71,3 +71,4 @@ the alert word is included in a message. Alert words are case-insensitive.
 * [Mobile notifications](/help/mobile-notifications)
 * [Restrict wildcard mentions](/help/restrict-wildcard-mentions)
 * [Stream notifications](/help/stream-notifications)
+* [View your mentions](/help/view-your-mentions)

--- a/templates/zerver/help/star-a-message.md
+++ b/templates/zerver/help/star-a-message.md
@@ -24,9 +24,9 @@ Starred messages have a filled in star (<i class="fa fa-star"></i>) to
 their right.  You can unstar a message using the same instructions
 used to star it.
 
-## Access your starred messages
+## View your starred messages
 
-You can access your starred messages by clicking **Starred messages** in the
+You can view your starred messages by clicking **Starred messages** in the
 left sidebar, or by [searching](/help/search-for-messages) for `is:starred`.
 
 By default, Zulip displays the number of starred messages in the left

--- a/templates/zerver/help/view-your-mentions.md
+++ b/templates/zerver/help/view-your-mentions.md
@@ -1,0 +1,45 @@
+# View your mentions
+
+You can [mention a user or a group](/help/mention-a-user-or-group) to call their
+attention to a message. To make such messages easy to find, Zulip lets you view
+the messages where you were mentioned from a dedicated tab.
+
+!!! warn ""
+
+    Because [silent mentions](/help/mention-a-user-or-group#silently-mention-a-user)
+    are designed not to attract attention, they are excluded from the **Mentions** tab.
+
+## View your mentions
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click **Mentions** in the left sidebar.
+
+1. Browse your mentions. You can click on a message recipient bar to go
+   to the conversation where you were mentioned.
+
+!!! tip ""
+    You can also [search your mentions](/help/search-for-messages) using the
+    `is:mentioned` flag.
+
+{tab|mobile}
+
+1. Tap the **Mentions**
+   (<img src="/static/images/help/mobile-at-sign-icon.svg" alt="at-sign" class="mobile-icon"/>)
+   tab at the top of the app.
+
+1. Browse your mentions. You can tap on a message recipient bar to go
+   to the conversation where you were mentioned.
+
+{end_tabs}
+
+Topics with unread @-mentions are marked with an **@** indicator next to the number
+of unread messages.
+
+## Related articles
+
+* [Mention a user or group](/help/mention-a-user-or-group)
+* [PMs, mentions, and alerts](/help/pm-mention-alert-notifications#pms-mentions-and-alerts)
+* [Reading strategies](/help/reading-strategies)


### PR DESCRIPTION
This PR is based on and replaces #23484.

Fixes https://github.com/zulip/zulip/issues/23422.

Notes:
- Links were manually tested.
- Wording on `/help/star-a-message` is tweaked slightly, as I think "View your mentions/starred messages" is clearer than "Access your...".

**Screenshots and screen captures:**

![Screen Shot 2022-11-08 at 10 01 31 AM](https://user-images.githubusercontent.com/2090066/200642058-0efd9cdc-9617-42b8-95fb-7cc5b0fe0f11.png)


**Star a message** (tweaked from https://zulip.com/help/star-a-message):

![Screen Shot 2022-11-08 at 9 59 24 AM](https://user-images.githubusercontent.com/2090066/200642130-6c48d690-2b11-47e5-ba8e-432339f09f77.png)
