### PR TITLE
help center: Update documentation on reading private messages.

### DIFF
--- a/templates/zerver/help/include/reading-pms.md
+++ b/templates/zerver/help/include/reading-pms.md
@@ -1,8 +1,9 @@
 {start_tabs}
 
-1. Click on **Private messages** in the left sidebar.
+1. If the **Private messages** section in the left sidebar is collapsed, click
+   on it to expand it.
 
-1. Click on a conversation in the left sidebar under **Private messages**.
+1. Click on a conversation under **Private messages**.
 
 1. Read the conversation, scrolling down with the mouse or by pressing
    <kbd>PgDn</kbd>.
@@ -15,7 +16,12 @@
 1. Click on the next conversation in the left sidebar, or use the
    <kbd>P</kbd> key to go to the next unread conversation.
 
-1. To go to older unread conversations, use the <kbd>P</kbd> key or scroll
-   down in the **Private messages** section of the left sidebar to view.
+1. To view all your private message conversations, click the **more
+   conversations** link at the bottom of the **Private messages** section.
+
+!!! tip ""
+
+    You can also find recent PMs in the [**Recent
+    conversations**](/help/recent-conversations) tab by selecting the **Include PMs** option.
 
 {end_tabs}


### PR DESCRIPTION
- Describe the new PMs section in the left sidebar.
- Mention Recent conversations.

Fixes #23420.

Notes:
- https://zulip.com/help/reading-topics has a dedicated "Via recent topics" instructions tab, but I don't think that's needed here, as Recent conversations is not the best way to specifically read your PMs. 

Current:
- https://zulip.com/help/reading-pms
- https://zulip.com/help/getting-started-with-zulip#reading-private-messages

![Screen Shot 2022-11-08 at 1 43 58 PM](https://user-images.githubusercontent.com/2090066/200682230-2c777b87-07ac-45a5-96c7-a2d1594ecbd6.png)

