### PR TITLE
api: Link to new rate-limiting configuration documentation.

### DIFF
--- a/templates/zerver/api/rest-error-handling.md
+++ b/templates/zerver/api/rest-error-handling.md
@@ -32,8 +32,9 @@ HTTP headers in all API responses:
   have any rate limits applied to it (and thus could do a burst of
   `X-RateLimit-Limit` requests).
 
-Zulip's rate limiting rules are configurable, and can vary by server
-and over time. The default configuration currently limits:
+[Zulip's rate limiting rules are configurable][rate-limiting-rules],
+and can vary by server and over time. The default configuration
+currently limits:
 
 * Every user is limited to 200 total API requests per minute.
 * Separate, much lower limits for authentication/login attempts.
@@ -41,3 +42,5 @@ and over time. The default configuration currently limits:
 When the Zulip server has configured multiple rate limits that apply
 to a given request, the values returned will be for the strictest
 limit.
+
+[rate-limiting-rules]: https://zulip.readthedocs.io/en/latest/production/security-model.html#rate-limiting


### PR DESCRIPTION
From https://github.com/zulip/zulip/pull/22956#issuecomment-1306091433:
> I added a link to the /api/ documentation page on rate limiting error codes; we probably want to cross-link that, but might be easiest to do that in a follow-up PR, because CI will fail if we try to add links to a page that doesn't exist on ReadTheDocs yet.

This is that follow-up.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
