### PR TITLE
tools: Remove obsolete `_set_error_state` method in `UnusedImagesLinterSpider`.

### DIFF
--- a/tools/documentation_crawler/documentation_crawler/spiders/check_help_documentation.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/check_help_documentation.py
@@ -33,11 +33,10 @@ class UnusedImagesLinterSpider(BaseDocumentationSpider):
             exception_message = (
                 "The following images are not used in documentation and can be removed: {}"
             )
-            self._set_error_state()
             unused_images_relatedpath = [
                 os.path.join(self.images_path, img) for img in unused_images
             ]
-            raise Exception(exception_message.format(", ".join(unused_images_relatedpath)))
+            self.logger.error(exception_message.format(", ".join(unused_images_relatedpath)))
 
 
 class HelpDocumentationSpider(UnusedImagesLinterSpider):


### PR DESCRIPTION
In 2f547ea, the custom `has_error` logic in `BaseDocumentationSpider` was removed in favor of checking whether any errors were logged.

One reference to that method was missed in `UnusedImagesLinterSpider` and went unremarked as no images were added to the documentation that were not used.

Replaces that reference with an error log.

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
