### PR TITLE
tools: Upgrade scrapy's settings.py to the latest version.

### DIFF
--- a/tools/documentation_crawler/documentation_crawler/settings.py
+++ b/tools/documentation_crawler/documentation_crawler/settings.py
@@ -3,9 +3,9 @@
 # For simplicity, this file contains only settings considered important or
 # commonly used. You can find more settings consulting the documentation:
 #
-#     http://doc.scrapy.org/en/latest/topics/settings.html
-#     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
-#     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
+#     https://docs.scrapy.org/en/latest/topics/settings.html
+#     https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
+#     https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 
 BOT_NAME = "documentation_crawler"
 
@@ -30,7 +30,7 @@ ROBOTSTXT_OBEY = False
 # CONCURRENT_REQUESTS = 32
 
 # Configure a delay for requests for the same website (default: 0)
-# See http://scrapy.readthedocs.org/en/latest/topics/settings.html#download-delay
+# See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
 # See also autothrottle settings and docs
 # DOWNLOAD_DELAY = 3
 # The download delay setting will honor only one of:
@@ -40,7 +40,7 @@ ROBOTSTXT_OBEY = False
 # Disable cookies (enabled by default)
 # COOKIES_ENABLED = False
 
-# Disable telnet console (enabled by default)
+# Disable Telnet Console (enabled by default)
 # TELNETCONSOLE_ENABLED = False
 
 # Override the default request headers:
@@ -50,31 +50,31 @@ ROBOTSTXT_OBEY = False
 # }
 
 # Enable or disable spider middlewares
-# See http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
+# See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 # SPIDER_MIDDLEWARES = {
-#    'documentation_crawler.middlewares.MyCustomSpiderMiddleware': 543,
+#    'documentation_crawler.middlewares.DocumentationCrawlerSpiderMiddleware': 543,
 # }
 
 # Enable or disable downloader middlewares
-# See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
+# See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 # DOWNLOADER_MIDDLEWARES = {
-#    'documentation_crawler.middlewares.MyCustomDownloaderMiddleware': 543,
+#    'documentation_crawler.middlewares.DocumentationCrawlerDownloaderMiddleware': 543,
 # }
 
 # Enable or disable extensions
-# See http://scrapy.readthedocs.org/en/latest/topics/extensions.html
+# See https://docs.scrapy.org/en/latest/topics/extensions.html
 # EXTENSIONS = {
 #    'scrapy.extensions.telnet.TelnetConsole': None,
 # }
 
 # Configure item pipelines
-# See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
+# See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 # ITEM_PIPELINES = {
-#    'documentation_crawler.pipelines.SomePipeline': 300,
+#    'documentation_crawler.pipelines.DocumentationCrawlerPipeline': 300,
 # }
 
 # Enable and configure the AutoThrottle extension (disabled by default)
-# See http://doc.scrapy.org/en/latest/topics/autothrottle.html
+# See https://docs.scrapy.org/en/latest/topics/autothrottle.html
 # AUTOTHROTTLE_ENABLED = True
 # The initial download delay
 # AUTOTHROTTLE_START_DELAY = 5
@@ -87,9 +87,13 @@ ROBOTSTXT_OBEY = False
 # AUTOTHROTTLE_DEBUG = False
 
 # Enable and configure HTTP caching (disabled by default)
-# See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
+# See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
 # HTTPCACHE_ENABLED = True
 # HTTPCACHE_EXPIRATION_SECS = 0
 # HTTPCACHE_DIR = 'httpcache'
 # HTTPCACHE_IGNORE_HTTP_CODES = []
 # HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+
+# Set settings whose default value is deprecated to a future-proof value
+REQUEST_FINGERPRINTER_IMPLEMENTATION = "2.7"
+TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"


### PR DESCRIPTION
Fixes a warning caused by using the deprecated `2.6` value of the `REQUEST_FINGERPRINTER_IMPLEMENTATION` setting.

Upgrades `settings.py` to what would have been generated by starting the documentation_crawler project using the `startproject` command of scrapy v2.7.

Potential concerns:
- https://docs.scrapy.org/en/latest/topics/request-response.html#request-fingerprinter-implementation
> If you are using the default value ('2.6') for this setting, and you are using Scrapy components where changing the request fingerprinting algorithm would cause undesired results, you need to carefully decide when to change the value of this setting, or switch the [REQUEST_FINGERPRINTER_CLASS](https://docs.scrapy.org/en/latest/topics/request-response.html#std-setting-REQUEST_FINGERPRINTER_CLASS) setting to a custom request fingerprinter class that implements the 2.6 request fingerprinting algorithm and does not log this warning ( [Writing your own request fingerprinter](https://docs.scrapy.org/en/latest/topics/request-response.html#request-fingerprinter) includes an example implementation of such a class).

> Scenarios where changing the request fingerprinting algorithm may cause undesired results include, for example, using the HTTP cache middleware (see [HttpCacheMiddleware](https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#scrapy.downloadermiddlewares.httpcache.HttpCacheMiddleware)). Changing the request fingerprinting algorithm would invalidate the current cache, requiring you to redownload all requests again.

> Otherwise, set [REQUEST_FINGERPRINTER_IMPLEMENTATION](https://docs.scrapy.org/en/latest/topics/request-response.html#std-setting-REQUEST_FINGERPRINTER_IMPLEMENTATION) to '2.7' in your settings to switch already to the request fingerprinting implementation that will be the only request fingerprinting implementation available in a future version of Scrapy, and remove the deprecation warning triggered by using the default value ('2.6').



- https://docs.scrapy.org/en/latest/topics/settings.html#twisted-reactor
> Changed in version 2.7: The [startproject](https://docs.scrapy.org/en/latest/topics/commands.html#std-command-startproject) command now sets this setting to twisted.internet.asyncioreactor.AsyncioSelectorReactor in the generated settings.py file.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>


