### PR TITLE
messagebox: Redesign focus rectangle and unread marker.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -924,6 +924,10 @@
         background-color: hsla(8, 78%, 43%, 0.15);
     }
 
+    .selected_message .messagebox-content {
+        border-color: hsla(217, 64%, 59%, 0.7);
+    }
+
     .rendered_markdown {
         .user-mention,
         .user-group-mention {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -1,7 +1,8 @@
 $avatar_column_width: 46px;
-$distance_of_text_elements_from_message_box_top: 8.5px;
-$distance_of_non_text_elements_from_message_box_top: 6px;
-$sender_name_distance_below_flex_center: 3px;
+$distance_of_text_elements_from_message_box_top: 5px;
+$distance_of_non_text_elements_from_message_box_top_with_sender_info: 5px;
+$distance_of_non_text_elements_from_message_box_top_without_sender_info: 2px;
+$sender_name_distance_below_flex_center: 2px;
 
 .message_row {
     .messagebox .messagebox-content {
@@ -40,7 +41,8 @@ $sender_name_distance_below_flex_center: 3px;
             /* We need to position it from top and not vertically centered since we want it
                to have the same position from top when user is editing the message. */
             position: relative;
-            top: $distance_of_non_text_elements_from_message_box_top;
+            /* This won't have an effect when there is sender info, because that uses flexbox. */
+            top: $distance_of_non_text_elements_from_message_box_top_without_sender_info;
             padding: 0;
 
             @media (width < $sm_min) {
@@ -80,7 +82,8 @@ $sender_name_distance_below_flex_center: 3px;
         .message_content {
             grid-row-start: 1;
             grid-column-start: 2;
-            padding: 4px 0 1px;
+            padding: 0;
+            padding-top: 2px;
         }
 
         .message_reactions {
@@ -126,7 +129,6 @@ $sender_name_distance_below_flex_center: 3px;
         */
         .messagebox .messagebox-content {
             grid-template-rows: 25px repeat(3, auto);
-            padding-top: 2px;
 
             .message_content {
                 padding-top: 0;
@@ -208,7 +210,7 @@ $sender_name_distance_below_flex_center: 3px;
                     /* Let user profile picture take extra height without
                        having any affect on height of the container. */
                     position: absolute;
-                    margin-top: $distance_of_non_text_elements_from_message_box_top;
+                    margin-top: $distance_of_non_text_elements_from_message_box_top_with_sender_info;
                 }
 
                 .sender_name {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1066,6 +1066,11 @@ td.pointer {
     cursor: pointer;
     vertical-align: top;
     border: none;
+    /* 3px on all sides because outline doesn't have a border-box option. */
+    /* +2px on the left to account for the stream-color line and unread marker. */
+    /* +1px on the right to make left/right more balanced, since the unread marker
+       is not visible most of the time. */
+    padding: 3px 4px 3px 5px;
 
     &:hover .message_controls,
     &:focus-within .message_controls,
@@ -1336,7 +1341,7 @@ td.pointer {
     display: block;
     position: absolute;
     height: 100%;
-    left: 2px;
+    left: 1px;
     top: 0;
     opacity: 0;
     z-index: 2;
@@ -1354,7 +1359,7 @@ td.pointer {
 
 .unread-marker-fill {
     background-color: hsl(107, 74%, 29%);
-    width: 3px;
+    width: 2px;
     height: 100%;
 }
 
@@ -1363,23 +1368,14 @@ td.pointer {
     opacity: 1;
 }
 
-.message_header + .selected_message {
-    /* Sticky message header overlaps 1px with the box-shadow, so we add another
-       2px wide box-shadow 1px below from top to compensate for that. */
-    .messagebox-content {
-        box-shadow: inset 0 1px 0 2px hsl(215, 47%, 50%),
-            inset 0 0 0 2px hsl(215, 47%, 50%), 0 0 0 1px hsl(215, 47%, 50%);
-    }
-}
-
 .selected_message {
     .messagebox {
         z-index: 1;
     }
 
     .messagebox-content {
-        box-shadow: inset 0 0 0 2px hsl(215, 47%, 50%),
-            0 0 0 1px hsl(215, 47%, 50%);
+        outline: 1px solid hsla(217, 64%, 59%, 0.6);
+        border-radius: 4px;
     }
 }
 

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -3,10 +3,10 @@
   role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     {{#if want_date_divider}}
-    <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 3px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
+    <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
     {{/if}}
     <div class="messagebox"
-      {{#if msg/is_stream}}style="box-shadow: inset 3px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>
+      {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>
         <div class="messagebox-content">
             {{> message_body}}
         </div>


### PR DESCRIPTION
Step 5 of #22059. This change replaces the box shadow focus rectangle with a more subtle light blue rectangle.
[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/redesign.3A.20.20focus.20rectangle)

Note that this change adds `3px` of height to the messagebox to make space for the new rectangle. More discussion on that [here](https://chat.zulip.org/#narrow/stream/101-design/topic/redesign.3A.20.20focus.20rectangle/near/1491642).

**Screenshots and screen captures:**

(these are out of date, I can update them with the extra 3px of padding, but for now, see [here](https://chat.zulip.org/#narrow/stream/101-design/topic/redesign.3A.20.20focus.20rectangle/near/1491642) for exact padding)

[Figma here](https://www.figma.com/file/jbNOiBWvbtLuHaiTj4CW0G/Zulip-Web-App?t=4e95dJqLf40EKMmL-0)

<img width="841" alt="image" src="https://user-images.githubusercontent.com/5634097/212220203-e1803f43-def3-4729-ae11-e9d0e41ffbb3.png">

<img width="842" alt="image" src="https://user-images.githubusercontent.com/5634097/212220267-9fc93037-004b-4b57-930b-2f7acc64c2fe.png">

<img width="829" alt="image" src="https://user-images.githubusercontent.com/5634097/212220342-e5b4e462-5ee1-4303-88f6-b90df2e40c9b.png">

<img width="845" alt="image" src="https://user-images.githubusercontent.com/5634097/212220381-bf82e173-a6a9-4048-8396-b20f49e963f3.png">

<img width="829" alt="image" src="https://user-images.githubusercontent.com/5634097/212220445-7b02142d-a327-4d0d-96e9-a581378aa8f7.png">


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
