### PR TITLE
modals: Don't close the modals on selecting something inside the modal.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -182,6 +182,22 @@ export function open_modal(selector, conf = {}) {
         }
     });
 
+    $micromodal.find(".modal__overlay").on("click", (e) => {
+        /* Micromodal's data-micromodal-close feature doesn't check for
+           range selections; this means dragging a selection of text in an
+           input inside the modal too far will weirdly close the modal.
+           See https://github.com/ghosh/Micromodal/issues/505.
+           Work around this with our own implementation. */
+        if (!$(e.target).is(".modal__overlay")) {
+            return;
+        }
+
+        if (document.getSelection().type === "Range") {
+            return;
+        }
+        close_modal(selector);
+    });
+
     Micromodal.show(selector, {
         disableFocus: true,
         openClass: "modal--opening",

--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -1,5 +1,5 @@
 <div class="micromodal" id="dialog_widget_modal" aria-hidden="true">
-    <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+    <div class="modal__overlay" tabindex="-1">
         <div {{#if id}}id="{{id}}" {{/if}}class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title" data-simplebar>
             <header class="modal__header">
                 <h1 class="modal__title dialog_heading">

--- a/static/templates/login_to_access.hbs
+++ b/static/templates/login_to_access.hbs
@@ -1,5 +1,5 @@
 <div class="micromodal" id="login_to_access_modal" aria-hidden="true">
-    <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+    <div class="modal__overlay" tabindex="-1">
         <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="login_to_access_modal_label">
             <header class="modal__header">
                 <h1 class="modal__title" id="login_to_access_modal_label">

--- a/static/templates/read_receipts_modal.hbs
+++ b/static/templates/read_receipts_modal.hbs
@@ -1,5 +1,5 @@
 <div class="micromodal" id="read_receipts_modal" aria-hidden="true">
-    <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+    <div class="modal__overlay" tabindex="-1">
         <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="read_receipts_modal_label">
             <header class="modal__header">
                 <h1 class="modal__title" id="read_receipts_modal_label">

--- a/static/templates/settings/api_key_modal.hbs
+++ b/static/templates/settings/api_key_modal.hbs
@@ -1,5 +1,5 @@
 <div class="micromodal" id="api_key_modal" aria-hidden="true">
-    <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+    <div class="modal__overlay" tabindex="-1">
         <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="api_key_modal_label">
             <header class="modal__header">
                 <h1 class="modal__title" id="api_key_modal_label">

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -1,5 +1,5 @@
 <div class="micromodal" id="user-profile-modal" data-user-id="{{user_id}}" aria-hidden="true">
-    <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+    <div class="modal__overlay" tabindex="-1">
         <div class="modal__container new-style" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <div class="modal__header">
                 <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">


### PR DESCRIPTION
Modals are closed when selecting something inside the modal if mouse is dragged outside the modal. This happens as leaving the mouse after dragging it outside the modal induces a click even outside the modal and the current behavior is to close the modal on clicking outside it.

We remove the "data-micromodal-close" attribute from "modal__overlay" element which is responsible for closing the modal. And we add click handler which closes the modal on clicking outside the modal but does not closes it when the mouse is dragged outside while selecting something.

Fixes #23350.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![micromodal-overlay](https://user-images.githubusercontent.com/35494118/201292731-25083852-9c15-4023-8e0d-ea0d744fa97b.gif)



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
