### PR TITLE
left_sidebar: Fix section divider not shown when all streams are muted.

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -145,13 +145,16 @@ export function build_stream_list(force_rerender) {
     const any_pinned_streams = stream_groups.pinned_streams.length > 0;
     const any_normal_streams = stream_groups.normal_streams.length > 0;
     const any_dormant_streams = stream_groups.dormant_streams.length > 0;
+    const any_muted_pinned_streams = stream_groups.muted_pinned_streams.length > 0;
+    const any_muted_normal_streams = stream_groups.muted_active_streams.length > 0;
+    
     const need_section_subheaders =
-        (any_pinned_streams ? 1 : 0) +
-            (any_normal_streams ? 1 : 0) +
+        (any_normal_streams || any_muted_normal_streams ? 1 : 0) +
+            (any_pinned_streams || any_muted_pinned_streams ? 1 : 0) +
             (any_dormant_streams ? 1 : 0) >=
-        2;
+        2;    
 
-    if (any_pinned_streams && need_section_subheaders) {
+    if ((any_pinned_streams || any_muted_pinned_streams) && need_section_subheaders) {
         elems.push(
             render_stream_subheader({
                 subheader_name: $t({
@@ -169,7 +172,7 @@ export function build_stream_list(force_rerender) {
         add_sidebar_li(stream_id);
     }
 
-    if (any_normal_streams && need_section_subheaders) {
+    if ((any_normal_streams || any_muted_normal_streams) && need_section_subheaders) {
         elems.push(
             render_stream_subheader({
                 subheader_name: $t({


### PR DESCRIPTION
Fixes  #23241.

This bug is related to this PR https://github.com/zulip/zulip/pull/22859. That fix https://github.com/zulip/zulip/commit/dd39a9747d968a1a4cf8e07edc821008a3f55d7c  doesn't consider the muted streams while implementing the logic for when to show/not show the section divider.

@timabbott can you review this one?

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


https://user-images.githubusercontent.com/87542880/201369286-74e08940-15a7-4f9f-a75e-65f9dee67607.mp4



**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
