### PR TITLE
css: Fix hidden unread marker when a user mentioned message is focused.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1401,7 +1401,7 @@ td.pointer {
     left: 2px;
     top: 0;
     opacity: 0;
-    z-index: 1;
+    z-index: 2;
     bottom: 1px;
     transition: all 0.3s ease-out;
 
@@ -3218,7 +3218,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     .message_row.unread {
         .date_row {
             position: relative;
-            z-index: 1;
+            z-index: 3;
             background-color: hsl(0, 0%, 100%);
         }
     }


### PR DESCRIPTION
Increase z-index of unread-marker to always appear above the message and focused outline. Also, z-index of date_row is increased to hide unread marker for it in special conditions.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Mark.20unread.20markers.20absent.3F

Checked for some edge cases like popovers and on-hover icons appearing properly, I was personally scared of making this change.

<img width="746" alt="image" src="https://user-images.githubusercontent.com/25124304/201379040-e67d7da1-9044-4185-88c6-8fb225ee5c28.png">
