### PR TITLE
search_bar: Reset text in search_bar while navigating.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -32,6 +32,7 @@ import {
     is_visible,
     set_visible,
 } from "./recent_topics_util";
+import * as search from "./search";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as sub_store from "./sub_store";
@@ -875,6 +876,7 @@ export function show() {
     message_view_header.render_title_area();
     narrow.handle_middle_pane_transition();
     pm_list.handle_narrow_deactivated();
+    search.clear_search_form();
 
     complete_rerender();
 }


### PR DESCRIPTION
Text in the search bar reset every time, the user switches between recent topics and other streams.
Fixes: #20956.

### Changes:

**1. Reset text in the search bar while navigating around streams.**

Current preview:

https://user-images.githubusercontent.com/66828942/201452287-12078bfb-9217-406d-8842-017d5f8c12fe.mp4

New preview:

https://user-images.githubusercontent.com/66828942/201455077-168be035-b9d7-4126-a29c-1c614791e805.mp4








**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
