### PR TITLE
register page:Add link for login page

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -88,6 +88,9 @@ page can be easily identified in it's respective JavaScript file -->
                             </form>
                         </div>
                         {% endfor %}
+                        <div class="register-form-login-redirect actions">
+                            {{ _('Already have an account?') }}<a class="register-link" href="/login/"> {{ _('Log in') }}</a>
+                        </div>
                     {% endif %}
                 </div>
             </div>

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -875,6 +875,18 @@ button#register_auth_button_gitlab {
     text-align: left;
 }
 
+.register-page-container .register-form-login-redirect {
+    margin-top: 10px;
+    float: right;
+    font-size: 17px;
+    font-weight: normal;
+
+    .register-link {
+        font-size: 17px;
+        margin-left: 5px;
+    }
+}
+
 .back-to-login-wrapper .back-to-login {
     display: flex;
     gap: 5px;


### PR DESCRIPTION
I added "Already have an account? Login" to bottom of the register page.
This change makes it easier to move from the registration page to the login page.

### Before
<img src="https://user-images.githubusercontent.com/86971544/201500844-efa1f317-cbfd-4611-a2e4-4d0bc02166f0.jpg" width="70%">

### After
<img src="https://user-images.githubusercontent.com/86971544/201500841-90ee36f2-83d7-4f72-ab87-34906f8eca73.jpg" width="70%">

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
