### PR TITLE
informational overlay:Redesign UI of hotkeys info modal to modern one

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -220,7 +220,7 @@
     <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays" aria-hidden="true">
         <div class="overlay-content modal-bg">
             <div class="overlay-tabs">
-                <span class="exit">&times;</span>
+                <span class="exit zulip-icon zulip-icon-close"></span>
             </div>
             <div class="overlay-body">
             </div>

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -72,7 +72,8 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
         let key_text = $(this).text();
 
         if (fn_shortcuts.has(key_text)) {
-            $(this).before("<kbd>Fn</kbd> + ");
+            $(this).wrap('<span class="hotkeys__concurrent">');
+            $(this).before("<kbd>Fn</kbd>");
             $(this).addClass("arrow-key");
         }
 

--- a/web/src/info_overlay.js
+++ b/web/src/info_overlay.js
@@ -23,18 +23,19 @@ export let toggler;
 const markdown_help_rows = [
     {
         markdown: "*italic*",
-        usage_html: "(or <kbd>Ctrl</kbd>+<kbd>I</kbd>)",
+        usage_html: "<span class='hotkeys__concurrent'><kbd>Ctrl</kbd><kbd>I</kbd></span>",
     },
     {
         markdown: "**bold**",
-        usage_html: "(or <kbd>Ctrl</kbd>+<kbd>B</kbd>)",
+        usage_html: "<span class='hotkeys__concurrent'><kbd>Ctrl</kbd><kbd>B</kbd></span>",
     },
     {
         markdown: "~~strikethrough~~",
     },
     {
         markdown: "[Zulip website](https://zulip.org)",
-        usage_html: "(or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>L</kbd>)",
+        usage_html:
+            "<span class='hotkeys__concurrent'><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>L</kbd></span>",
     },
     {
         markdown: `\
@@ -250,7 +251,7 @@ export function set_up_toggler() {
         "notdisplayed",
         !user_settings.escape_navigates_to_default_view,
     );
-    common.adjust_mac_kbd_tags(".hotkeys_table .hotkey kbd");
+    common.adjust_mac_kbd_tags(".hotkeys__table kbd");
     common.adjust_mac_kbd_tags("#markdown-instructions kbd");
 }
 

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -1,4 +1,6 @@
 .informational-overlays {
+    display: grid;
+    place-items: center;
 
     --color-title: hsl(0, 0%, 0%);
     --color-text: hsl(0, 0%, 20%);
@@ -8,47 +10,55 @@
     --color-table-border: hsl(0, 0%, 93%);
 
     .overlay-content {
-        /* because zoom breaks at 525px perhaps due to rounding errors, so add a
-           trivial amount of width so it doesn't break. */
-        width: 550px;
+        width: 90%;
+        max-width: 650px;
         margin: 0 auto;
         position: relative;
-        top: calc((30vh - 50px) / 2);
-        border-radius: 4px;
+        top: unset;
+        border-radius: 6px;
         overflow: hidden;
 
         background-color: hsl(0, 0%, 100%);
     }
 
     .overlay-tabs {
-        padding: 10px 0;
-        border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
+        position: relative;
+        display: flex;
+        flex-flow: row nowrap;
+        align-items: center;
+        gap: 15px;
+        padding: 0 5%;
+        height: 60px;
+        background: hsl(0, 0%, 100%);
+        box-shadow: 0 3px 12px 1px hsla(207, 100%, 11%, 0.08);
+        z-index: 2;
 
         .tab-switcher {
-            margin-left: 15px;
+            flex-grow: 1;
         }
 
         .exit {
-            float: right;
-            font-size: 1.5rem;
-            color: hsl(0, 0%, 67%);
-            font-weight: 600;
-            margin: 0 15px;
+            display: inline-block;
+            font-size: 16px;
+            line-height: 1em;
+            text-align: center;
+            width: 1em;
+            color: hsl(0, 0%, 60%);
             cursor: pointer;
+            order: 1;
         }
     }
 
-    .overlay-modal {
-        padding-bottom: 10px;
+    .modal-body {
+        height: 75vh;
+        max-height: unset;
+        text-align: center;
+        outline: none;
+    }
 
-        .modal-header h3 {
-            font-weight: 300;
-        }
-
-        .modal-body {
-            height: 70vh;
-            text-align: center;
-            outline: none;
+    .simplebar-content {
+        padding: 35px 30px 35px 25px !important;
+    }
 
     a {
         color: var(--color-text-link);

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -1,4 +1,12 @@
 .informational-overlays {
+
+    --color-title: hsl(0, 0%, 0%);
+    --color-text: hsl(0, 0%, 20%);
+    --color-sub-text: hsl(0, 0%, 45%);
+    --color-keyboard: hsl(227, 78%, 59%);
+    --color-text-link: hsl(217, 100%, 50%);
+    --color-table-border: hsl(0, 0%, 93%);
+
     .overlay-content {
         /* because zoom breaks at 525px perhaps due to rounding errors, so add a
            trivial amount of width so it doesn't break. */
@@ -42,18 +50,17 @@
             text-align: center;
             outline: none;
 
-            .help-table {
-                table-layout: fixed;
-            }
+    a {
+        color: var(--color-text-link);
 
-            th {
-                font-weight: 400;
-            }
+        &:hover {
+            color: var(--color-text-link) !important;
         }
     }
 
-    td.operator {
-        font-size: 0.9em;
+    .documentation-link {
+        text-align: center;
+        margin-top: 3rem;
     }
 
     kbd {
@@ -86,76 +93,119 @@
     }
 }
 
-.hotkeys_table {
-    table-layout: fixed;
-    width: 100%;
-    vertical-align: middle;
-    display: table;
-
-    td.definition {
-        /* keeps dividing line at same width for all tables in model. */
-        width: calc(50% - 11px);
-        text-align: right;
-    }
-
-    .hotkey {
-        font-weight: normal;
-    }
-
-    .small_hotkey {
-        font-size: 0.9em !important;
-        line-height: 12px;
-
-        kbd {
-            font-size: 0.9em;
-        }
-    }
-
-    .arrow-key {
-        font-size: 1.36em;
-        line-height: 1;
-        padding: 0 0.2em 0.2em;
-    }
-
-    th {
-        width: 245px;
-        text-align: center;
-        /* aligns table name with dividing line */
-    }
-
-    td:not(.definition) {
-        text-align: left;
-        white-space: normal;
-        font-weight: bold;
+#markdown-instructions {
+    kbd:first-child {
+        margin-left: 0;
     }
 }
 
-#keyboard-shortcuts table {
-    margin-bottom: 10px !important;
+.help-table {
+    width: 100%;
+    margin-bottom: 2rem;
+    color: var(--color-text);
+
+    .operator {
+        width: 30%;
+    }
+
+    tbody {
+        tr {
+            border-collapse: collapse;
+            border-bottom: solid 1px var(--color-table-border);
+
+            &:first-child {
+                border-top: solid 1px var(--color-table-border);
+            }
+        }
+    }
+
+    thead {
+        background: none !important;
+    }
+
+    th {
+        color: var(--color-title);
+        font-size: 1.3rem;
+        line-height: 125%;
+        text-align: left;
+        padding: 0 0 1rem;
+    }
+
+    td {
+        padding: 0.75rem 1rem 0.75rem 0;
+        width: 50%;
+        color: var(--color-text);
+        text-align: left;
+        vertical-align: middle;
+
+        &[colspan] {
+            text-align: center;
+        }
+    }
+}
+
+.hotkeys-table {
+    th {
+        text-align: center;
+    }
+
+    th,
+    td {
+        padding: 0.5rem 0;
+    }
+
+    td {
+        &:not(.definition) {
+            /* contradict top-margin of kbd tag */
+            padding-top: calc(0.5rem - 6px);
+
+            width: 47%;
+            color: var(--color-sub-text);
+            text-align: right;
+        }
+
+        &.definition {
+            padding-left: 0.4rem;
+
+            .emoji {
+                width: 1.35em;
+                height: 1.35em;
+            }
+        }
+    }
 }
 
 @media only screen and (width < $md_min) {
     .informational-overlays {
-        .overlay-content {
-            width: calc(100% - 20px);
-        }
-
-        .tab-switcher {
-            display: flex;
-
-            &.large .ind-tab {
-                width: 100%;
-            }
-        }
-
         .table.table-condensed.table-striped {
             margin-left: auto;
             margin-right: auto;
         }
+    }
+}
 
-        .hotkeys_table {
-            width: 100%;
-            display: table;
+:root.dark-theme {
+    .informational-overlays {
+        --color-title: hsl(0, 0%, 100%);
+        --color-text: hsla(0, 0%, 100%, 0.75);
+        --color-sub-text: hsla(0, 0%, 100%, 0.6);
+        --color-keyboard: hsl(225, 100%, 84%);
+        --color-text-link: hsla(217, 100%, 65%, 1);
+        --color-table-border: hsla(0, 0%, 0%, 0.4);
+
+        .overlay-content {
+            background: hsla(0, 0%, 14%, 1);
         }
+
+        .overlay-tabs {
+            background: hsla(0, 0%, 14%, 1);
+            box-shadow: 0 2px 8px hsla(0, 0%, 0%, 0.45);
+        }
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    html.color-scheme-automatic {
+        @extend :root.dark-theme;
     }
 }

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -55,6 +55,35 @@
     td.operator {
         font-size: 0.9em;
     }
+
+    kbd {
+        font-family: "Source Sans 3", sans-serif;
+        font-feature-settings: "ss01" on;
+        margin: 6px 6px 0;
+        padding: 1px 0.5em;
+        font-size: 14px;
+        font-weight: 400;
+        color: var(--color-keyboard);
+        background: none;
+        border: solid 1.5px var(--color-keyboard);
+        border-radius: 5px;
+        text-shadow: none;
+    }
+
+    .concurrent-hotkeys {
+        display: inline-block;
+        white-space: nowrap;
+
+        kbd {
+            &:not(:first-child) {
+                margin-left: 4px;
+            }
+
+            &:not(:last-child) {
+                margin-right: 0;
+            }
+        }
+    }
 }
 
 .hotkeys_table {

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -10,51 +10,51 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'Reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
+                    <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'New stream message' }}</td>
-                    <td><span class="hotkey"><kbd>C</kbd></span></td>
+                    <td><kbd>C</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'New direct message' }}</td>
-                    <td><span class="hotkey"><kbd>X</kbd></span></td>
+                    <td><kbd>X</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
+                    <td><kbd>Esc</kbd> or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'View drafts' }}</td>
-                    <td><span class="hotkey"><kbd>D</kbd></span></td>
+                    <td><kbd>D</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Next message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
+                    <td><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Last message' }}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
+                    <td><kbd>End</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Next unread topic' }}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
+                    <td><kbd>N</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Next unread direct message' }}</td>
-                    <td><span class="hotkey"><kbd>P</kbd></span></td>
+                    <td><kbd>P</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Initiate a search' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>K</kbd></span> or <span class="concurrent-hotkeys"><kbd>/</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
-                    <td><span class="hotkey"><kbd>?</kbd></span></td>
+                    <td><kbd>?</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Go to default view' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>[</kbd><span id="go-to-default-view-hotkey-help"> or <kbd>Esc</kbd></span></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span><span id="go-to-default-view-hotkey-help"> or <kbd>Esc</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -67,47 +67,47 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'Initiate a search' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>K</kbd></span> or <span class="concurrent-hotkeys"><kbd>/</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Filter streams' }}</td>
-                    <td><span class="hotkey"><kbd>Q</kbd></span></td>
+                    <td><kbd>Q</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Search people' }}</td>
-                    <td><span class="hotkey"><kbd>W</kbd></span></td>
+                    <td><kbd>W</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Previous message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></span></td>
+                    <td><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Next message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
+                    <td><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Scroll up' }}</td>
-                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd></span></td>
+                    <td><kbd>PgUp</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>K</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Scroll down' }}</td>
-                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Shift</kbd> + <kbd>J</kbd> or <kbd>Space</kbd></span></td>
+                    <td><kbd>PgDn</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>J</kbd></span> or <span class="concurrent-hotkeys"><kbd>Space</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Last message' }}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
+                    <td><kbd>End</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'First message' }}</td>
-                    <td><span class="hotkey"><kbd>Home</kbd></span></td>
+                    <td><kbd>Home</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Go back through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">←</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Alt</kbd><kbd class="arrow-key">←</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Go forward through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">→</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Alt</kbd><kbd class="arrow-key">→</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -120,39 +120,44 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'Reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
+                    <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Reply to author' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>R</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>R</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Quote and reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>></kbd></span></td>
+                    <td><kbd>></kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'New stream message' }}</td>
-                    <td><span class="hotkey"><kbd>C</kbd></span></td>
+                    <td><kbd>C</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'New direct message' }}</td>
-                    <td><span class="hotkey"><kbd>X</kbd></span></td>
+                    <td><kbd>X</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Compose a reply @-mentioning author' }}</td>
-                    <td><span class="hotkey"><kbd>@</kbd></span></td>
+                    <td><kbd>@</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Send message' }}</td>
-                    <td><span class="hotkey"><span class="small_hotkey"><kbd>Tab</kbd> then <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd></span></span></td>
+                    <td>
+                        <span class="concurrent-hotkeys">
+                            <span><kbd>Tab</kbd></span> then <kbd>Enter</kbd>
+                        </span>
+                        or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>Enter</kbd></span>
+                    </td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Insert new line' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Enter</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
+                    <td><kbd>Esc</kbd> or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -165,39 +170,39 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'Narrow to stream' }}</td>
-                    <td><span class="hotkey"><kbd>S</kbd></span></td>
+                    <td><kbd>S</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Narrow to all direct messages' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
-                    <td><span class="hotkey"><kbd>Z</kbd></span></td>
+                    <td><kbd>N</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Narrow to next unread topic' }}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
+                    <td><kbd>P</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Narrow to next unread direct message' }}</td>
-                    <td><span class="hotkey"><kbd>P</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>A</kbd></span> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Cycle between stream narrows' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>A</kbd></span> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Narrow to all unmuted messages' }}</td>
-                    <td><span class="hotkey"><kbd>A</kbd></span></td>
+                    <td><kbd>A</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Narrow to current compose box recipient' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>.</kbd></span></td>
+                    <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
                 </tr>
             </table>
         </div>
@@ -210,27 +215,27 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'Edit your last message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd></span></td>
+                    <td><kbd class="arrow-key">←</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t "Show message sender's user card"   }}</td>
-                    <td><span class="hotkey"><kbd>U</kbd></span></td>
+                    <td><kbd>U</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Show images in thread' }}</td>
-                    <td><span class="hotkey"><kbd>V</kbd></span></td>
+                    <td><kbd>V</kbd></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
                     <td class="definition">{{t 'Edit selected message or view source' }}</td>
-                    <td><span class="hotkey"><kbd>E</kbd></span></td>
+                    <td><kbd>E</kbd></td>
                 </tr>
                 <tr id="move-message-hotkey-help">
                     <td class="definition">{{t 'Move messages or topic' }}</td>
-                    <td><span class="hotkey"><kbd>M</kbd></span></td>
+                    <td><kbd>M</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Star selected message' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">
@@ -240,19 +245,19 @@
                           src="../../static/generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>
-                    <td><span class="hotkey"><kbd>+</kbd></span></td>
+                    <td><kbd>+</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Mark as unread from selected message' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>U</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>U</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Collapse/show selected message' }}</td>
-                    <td><span class="hotkey"><kbd>-</kbd></span></td>
+                    <td><kbd>-</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Toggle topic mute' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>M</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>M</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -265,11 +270,11 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'View recent conversations' }}</td>
-                    <td><span class="hotkey"><kbd>T</kbd></span></td>
+                    <td><kbd>T</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Filter topics' }}</td>
-                    <td><span class="hotkey"><kbd>T</kbd></span></td>
+                    <td><kbd>T</kbd></td>
                 </tr>
             </table>
         </div>
@@ -282,15 +287,15 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'View drafts' }}</td>
-                    <td><span class="hotkey"><kbd>D</kbd></span></td>
+                    <td><kbd>D</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Edit selected draft' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd></span></td>
+                    <td><kbd>Enter</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Delete selected draft' }}</td>
-                    <td><span class="hotkey"><kbd>Backspace</kbd></span></td>
+                    <td><kbd>Backspace</kbd></td>
                 </tr>
             </table>
         </div>
@@ -303,19 +308,19 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'Toggle the gear menu' }}</td>
-                    <td><span class="hotkey"><kbd>G</kbd></span></td>
+                    <td><kbd>G</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Open message menu' }}</td>
-                    <td><span class="hotkey"><kbd>I</kbd></span></td>
+                    <td><kbd>I</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Open reactions menu' }}</td>
-                    <td><span class="hotkey"><kbd>:</kbd></span></td>
+                    <td><kbd>:</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
-                    <td><span class="hotkey"><kbd>?</kbd></span></td>
+                    <td><kbd>?</kbd></td>
                 </tr>
             </table>
         </div>
@@ -328,23 +333,23 @@
                 </thead>
                 <tr>
                     <td class="definition">{{t 'Scroll through streams' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></span></td>
+                    <td><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Switch between tabs' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></span></td>
+                    <td><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'View stream messages' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>V</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Subscribe to/unsubscribe from selected stream' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Create new stream' }}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
+                    <td><kbd>N</kbd></td>
                 </tr>
             </table>
         </div>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -2,7 +2,7 @@
   aria-label="{{t 'Keyboard shortcuts' }}">
     <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t "The basics" }}</th>
@@ -59,7 +59,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Navigation' }}</th>
@@ -112,7 +112,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Composing messages' }}</th>
@@ -162,7 +162,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Narrowing' }}</th>
@@ -207,7 +207,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Message actions' }}</th>
@@ -262,7 +262,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Recent conversations' }}</th>
@@ -279,7 +279,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Drafts' }}</th>
@@ -300,7 +300,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Menus' }}</th>
@@ -325,7 +325,7 @@
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered table-condensed">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Streams settings' }}</th>
@@ -353,7 +353,9 @@
                 </tr>
             </table>
         </div>
-        <hr />
-        <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
+
+        <div class="documentation-link">
+            <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
+        </div>
     </div>
 </div>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -1,5 +1,4 @@
-<div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
-  aria-label="{{t 'Keyboard shortcuts' }}">
+<div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog" aria-label="{{t 'Keyboard shortcuts' }}">
     <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div>
             <table class="hotkeys-table help-table">
@@ -9,52 +8,52 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Reply to message' }}</td>
                     <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
+                    <td class="definition">{{t 'Reply to message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New stream message' }}</td>
                     <td><kbd>C</kbd></td>
+                    <td class="definition">{{t 'New stream message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New direct message' }}</td>
                     <td><kbd>X</kbd></td>
+                    <td class="definition">{{t 'New direct message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                     <td><kbd>Esc</kbd> or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span></td>
+                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View drafts' }}</td>
                     <td><kbd>D</kbd></td>
+                    <td class="definition">{{t 'View drafts' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next message' }}</td>
                     <td><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></td>
+                    <td class="definition">{{t 'Next message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Last message' }}</td>
                     <td><kbd>End</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>G</kbd></span></td>
+                    <td class="definition">{{t 'Last message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next unread topic' }}</td>
                     <td><kbd>N</kbd></td>
+                    <td class="definition">{{t 'Next unread topic' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next unread direct message' }}</td>
                     <td><kbd>P</kbd></td>
+                    <td class="definition">{{t 'Next unread direct message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Initiate a search' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>K</kbd></span> or <span class="concurrent-hotkeys"><kbd>/</kbd></span></td>
+                    <td class="definition">{{t 'Initiate a search' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
                     <td><kbd>?</kbd></td>
+                    <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go to default view' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span><span id="go-to-default-view-hotkey-help"> or <kbd>Esc</kbd></span></td>
+                    <td class="definition">{{t 'Go to default view' }}</td>
                 </tr>
             </table>
         </div>
@@ -66,48 +65,48 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Initiate a search' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>K</kbd></span> or <span class="concurrent-hotkeys"><kbd>/</kbd></span></td>
+                    <td class="definition">{{t 'Initiate a search' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Filter streams' }}</td>
                     <td><kbd>Q</kbd></td>
+                    <td class="definition">{{t 'Filter streams' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Search people' }}</td>
                     <td><kbd>W</kbd></td>
+                    <td class="definition">{{t 'Search people' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Previous message' }}</td>
                     <td><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></td>
+                    <td class="definition">{{t 'Previous message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next message' }}</td>
                     <td><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></td>
+                    <td class="definition">{{t 'Next message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Scroll up' }}</td>
                     <td><kbd>PgUp</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>K</kbd></span></td>
+                    <td class="definition">{{t 'Scroll up' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Scroll down' }}</td>
                     <td><kbd>PgDn</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>J</kbd></span> or <span class="concurrent-hotkeys"><kbd>Space</kbd></span></td>
+                    <td class="definition">{{t 'Scroll down' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Last message' }}</td>
                     <td><kbd>End</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>G</kbd></span></td>
+                    <td class="definition">{{t 'Last message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'First message' }}</td>
                     <td><kbd>Home</kbd></td>
+                    <td class="definition">{{t 'First message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go back through viewing history' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Alt</kbd><kbd class="arrow-key">←</kbd></span></td>
+                    <td class="definition">{{t 'Go back through viewing history' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Go forward through viewing history' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Alt</kbd><kbd class="arrow-key">→</kbd></span></td>
+                    <td class="definition">{{t 'Go forward through viewing history' }}</td>
                 </tr>
             </table>
         </div>
@@ -119,45 +118,45 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Reply to message' }}</td>
                     <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
+                    <td class="definition">{{t 'Reply to message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Reply to author' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>R</kbd></span></td>
+                    <td class="definition">{{t 'Reply to author' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Quote and reply to message' }}</td>
                     <td><kbd>></kbd></td>
+                    <td class="definition">{{t 'Quote and reply to message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New stream message' }}</td>
                     <td><kbd>C</kbd></td>
+                    <td class="definition">{{t 'New stream message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New direct message' }}</td>
                     <td><kbd>X</kbd></td>
+                    <td class="definition">{{t 'New direct message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Compose a reply @-mentioning author' }}</td>
                     <td><kbd>@</kbd></td>
+                    <td class="definition">{{t 'Compose a reply @-mentioning author' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Send message' }}</td>
                     <td>
                         <span class="concurrent-hotkeys">
                             <span><kbd>Tab</kbd></span> then <kbd>Enter</kbd>
                         </span>
                         or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>Enter</kbd></span>
                     </td>
+                    <td class="definition">{{t 'Send message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Insert new line' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>Enter</kbd></span></td>
+                    <td class="definition">{{t 'Insert new line' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                     <td><kbd>Esc</kbd> or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span></td>
+                    <td class="definition">{{t 'Cancel compose and save draft' }}</td>
                 </tr>
             </table>
         </div>
@@ -169,40 +168,40 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Narrow to stream' }}</td>
                     <td><kbd>S</kbd></td>
+                    <td class="definition">{{t 'Narrow to stream' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>S</kbd></span></td>
+                    <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to all direct messages' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>P</kbd></span></td>
+                    <td class="definition">{{t 'Narrow to all direct messages' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
                     <td><kbd>N</kbd></td>
+                    <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to next unread topic' }}</td>
                     <td><kbd>P</kbd></td>
+                    <td class="definition">{{t 'Narrow to next unread topic' }}</td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>A</kbd></span> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>D</kbd></span></td>
                     <td class="definition">{{t 'Narrow to next unread direct message' }}</td>
-                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>A</kbd></span> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>A</kbd></span> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>D</kbd></span></td>
                     <td class="definition">{{t 'Cycle between stream narrows' }}</td>
-                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>A</kbd></span> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to all unmuted messages' }}</td>
                     <td><kbd>A</kbd></td>
+                    <td class="definition">{{t 'Narrow to all unmuted messages' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to current compose box recipient' }}</td>
                     <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
+                    <td class="definition">{{t 'Narrow to current compose box recipient' }}</td>
                 </tr>
             </table>
         </div>
@@ -214,30 +213,31 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Edit your last message' }}</td>
                     <td><kbd class="arrow-key">←</kbd></td>
+                    <td class="definition">{{t 'Edit your last message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t "Show message sender's user card"   }}</td>
                     <td><kbd>U</kbd></td>
+                    <td class="definition">{{t "Show message sender's user card" }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Show images in thread' }}</td>
                     <td><kbd>V</kbd></td>
+                    <td class="definition">{{t 'Show images in thread' }}</td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
-                    <td class="definition">{{t 'Edit selected message or view source' }}</td>
                     <td><kbd>E</kbd></td>
+                    <td class="definition">{{t 'Edit selected message or view source' }}</td>
                 </tr>
                 <tr id="move-message-hotkey-help">
-                    <td class="definition">{{t 'Move messages or topic' }}</td>
                     <td><kbd>M</kbd></td>
+                    <td class="definition">{{t 'Move messages or topic' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Star selected message' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>S</kbd></span></td>
+                    <td class="definition">{{t 'Star selected message' }}</td>
                 </tr>
                 <tr>
+                    <td><kbd>+</kbd></td>
                     <td class="definition">
                         {{t 'React to selected message with' }}
                         <img alt=":thumbs_up:"
@@ -245,19 +245,18 @@
                           src="../../static/generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>
-                    <td><kbd>+</kbd></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Mark as unread from selected message' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>U</kbd></span></td>
+                    <td class="definition">{{t 'Mark as unread from selected message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Collapse/show selected message' }}</td>
                     <td><kbd>-</kbd></td>
+                    <td class="definition">{{t 'Collapse/show selected message' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Toggle topic mute' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>M</kbd></span></td>
+                    <td class="definition">{{t 'Toggle topic mute' }}</td>
                 </tr>
             </table>
         </div>
@@ -269,12 +268,12 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'View recent conversations' }}</td>
                     <td><kbd>T</kbd></td>
+                    <td class="definition">{{t 'View recent conversations' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Filter topics' }}</td>
                     <td><kbd>T</kbd></td>
+                    <td class="definition">{{t 'Filter topics' }}</td>
                 </tr>
             </table>
         </div>
@@ -286,16 +285,16 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'View drafts' }}</td>
                     <td><kbd>D</kbd></td>
+                    <td class="definition">{{t 'View drafts' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Edit selected draft' }}</td>
                     <td><kbd>Enter</kbd></td>
+                    <td class="definition">{{t 'Edit selected draft' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Delete selected draft' }}</td>
                     <td><kbd>Backspace</kbd></td>
+                    <td class="definition">{{t 'Delete selected draft' }}</td>
                 </tr>
             </table>
         </div>
@@ -307,20 +306,20 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Toggle the gear menu' }}</td>
                     <td><kbd>G</kbd></td>
+                    <td class="definition">{{t 'Toggle the gear menu' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Open message menu' }}</td>
                     <td><kbd>I</kbd></td>
+                    <td class="definition">{{t 'Open message menu' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Open reactions menu' }}</td>
                     <td><kbd>:</kbd></td>
+                    <td class="definition">{{t 'Open reactions menu' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
                     <td><kbd>?</kbd></td>
+                    <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
                 </tr>
             </table>
         </div>
@@ -332,24 +331,24 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Scroll through streams' }}</td>
                     <td><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></td>
+                    <td class="definition">{{t 'Scroll through streams' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Switch between tabs' }}</td>
                     <td><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></td>
+                    <td class="definition">{{t 'Switch between tabs' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View stream messages' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>V</kbd></span></td>
+                    <td class="definition">{{t 'View stream messages' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Subscribe to/unsubscribe from selected stream' }}</td>
                     <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>S</kbd></span></td>
+                    <td class="definition">{{t 'Subscribe to/unsubscribe from selected stream' }}</td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Create new stream' }}</td>
                     <td><kbd>N</kbd></td>
+                    <td class="definition">{{t 'Create new stream' }}</td>
                 </tr>
             </table>
         </div>

--- a/web/templates/markdown_help.hbs
+++ b/web/templates/markdown_help.hbs
@@ -2,7 +2,7 @@
   aria-label="{{t 'Message formatting' }}">
     <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div id="markdown-instructions">
-            <table class="table table-striped table-condensed table-rounded table-bordered help-table">
+            <table class="help-table">
                 <thead>
                     <tr>
                         <th>{{t "You type" }}</th>
@@ -24,7 +24,8 @@
                 </tbody>
             </table>
         </div>
-        <hr />
-        <a href="/help/format-your-message-using-markdown" target="_blank" rel="noopener noreferrer">{{t "Detailed message formatting documentation" }}</a>
+        <div class="documentation-link">
+            <a href="/help/format-your-message-using-markdown" target="_blank" rel="noopener noreferrer">{{t "Detailed message formatting documentation" }}</a>
+        </div>
     </div>
 </div>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -1,7 +1,7 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog" aria-label="{{t 'Search filters' }}">
     <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div id="operators-instructions">
-            <table class="table table-striped table-condensed table-rounded table-bordered help-table">
+            <table class="help-table">
                 <thead>
                     <tr>
                         <th>{{t "Filter" }}</th>
@@ -159,8 +159,10 @@
                 </tbody>
             </table>
             <p>{{t "You can combine search filters as needed." }}</p>
-            <hr />
-            <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
+
+            <div class="documentation-link" >
+                <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
+            </div>
         </div>
     </div>
 </div>

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -106,7 +106,7 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
     ]);
 
     const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
-    const inserted_fn_key = "<kbd>Fn</kbd> + ";
+    const inserted_fn_key = "<kbd>Fn</kbd>";
 
     override(navigator, "platform", "MacIntel");
 
@@ -122,7 +122,11 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
             $stub.before = ($elem) => {
                 assert.equal($elem, inserted_fn_key);
             };
+            $stub.wrap = ($elem) => {
+                assert.equal($elem, '<span class="hotkeys__concurrent">');
+            };
         }
+
         test_item.$stub = $stub;
         test_item.mac_key = mac_key;
         test_item.adds_arrow_key = fn_shortcuts.has(old_key);


### PR DESCRIPTION
Improve UI of the keyboard shortcuts info modal.
Mainly, reducing using borders.

## Before
<img src="https://user-images.githubusercontent.com/86971544/201510948-0a059b02-d0f5-4506-bd3e-f1ed172f08f9.jpg" width="45%">

## After
<img src="https://user-images.githubusercontent.com/86971544/201511059-86edf67c-506a-4e84-81d8-6dfffffa65ec.jpg" width="35%"><img src="https://user-images.githubusercontent.com/86971544/201511065-1d9b7a74-a583-43b6-8071-b15cea4f2b40.jpg" width="35%">
<img src="https://user-images.githubusercontent.com/86971544/201511063-797f173d-225a-4f93-8e07-251319419a4e.jpg" width="35%"><img src="https://user-images.githubusercontent.com/86971544/201511060-457d1f38-d6fe-45bb-871d-1d3b8abb880b.jpg" width="35%">

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.
- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
