### PR TITLE
Issue 23266 - Improve handling of long bot owner names in bot management modal

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1538,6 +1538,15 @@ $option_title_width: 180px;
         }
     }
 
+    .dropdown-toggle span {
+        /* Uses ellipsis to truncate text after 20 characters. */
+        display: inline-block;
+        max-width: 20ch;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+
     button.multiselect_btn {
         /* Matches the dropdown input margin so as to keep it aligned */
         margin-left: 9px;


### PR DESCRIPTION
This pull request addresses the handling of long bot owner names in the bot management modal. Fixes #23266 

Fixes: 
-Check the length of the owner name being displayed and abbreviate the name if necessary, adding '...' to show the user the name is abbreviated.

**Screenshots and screen captures:**
<img width="1386" alt="Screen Shot 2022-11-11 at 3 41 46 PM" src="https://user-images.githubusercontent.com/55263208/201538071-f33a0b4e-980e-411c-a252-bdffd29579e4.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
