### PR TITLE
Update language for user profile and user card

### DIFF
--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -59,7 +59,7 @@ export function field_type_id_to_string(type_id) {
     return undefined;
 }
 
-// Checking custom profile field type is valid for showing display in profile summary checkbox field.
+// Checking custom profile field type is valid for showing display on user card checkbox field.
 function is_valid_to_display_in_summary(field_type) {
     if (field_type === field_types.LONG_TEXT.id || field_type === field_types.USER.id) {
         return false;
@@ -246,7 +246,7 @@ function set_up_create_field_form() {
         $("#profile_field_hint").val(default_hint);
     }
 
-    // Not showing "display in profile summary" option for long text/user profile field.
+    // Not showing "display on user card" option for long text/user profile field.
     if (is_valid_to_display_in_summary(profile_field_type)) {
         $("#profile_field_display_in_profile_summary").closest(".input-group").show();
         const check_display_in_profile_summary_by_default =
@@ -310,8 +310,7 @@ function open_custom_profile_field_form_modal() {
         clear_form_data();
 
         // If we already have 2 custom profile fields configured to be
-        // displayed in the user profile summary, disable the input to
-        // change it.
+        // displayed on the user card, disable the input to change it.
         $("#add-new-custom-profile-field-form #profile_field_display_in_profile_summary").prop(
             "disabled",
             display_in_profile_summary_fields_limit_reached,
@@ -469,8 +468,8 @@ function open_edit_form_modal(e) {
     function set_initial_values_of_profile_field() {
         const $profile_field_form = $("#edit-custom-profile-field-form-" + field_id);
 
-        // If its passes or equals the max limit we are disabling option for display custom profile field
-        // in user profile summary and adding tooptip except already checked field.
+        // If it exceeds or equals the max limit, we are disabling option for display custom
+        // profile field on user card and adding tooptip, unless the field is already checked.
         if (display_in_profile_summary_fields_limit_reached && !field.display_in_profile_summary) {
             $profile_field_form
                 .find("input[name=display_in_profile_summary]")
@@ -565,8 +564,8 @@ function open_edit_form_modal(e) {
     });
 }
 
-// If passes or equals the max limit, we are disabling option for
-// display custom profile field in user profile summary and adding tooltip.
+// If exceeds or equals the max limit, we are disabling option for
+// display custom profile field on user card and adding tooltip.
 function update_profile_fields_checkboxes() {
     // Disabling only uncheck checkboxes in table, so user should able uncheck checked checkboxes.
     $("#admin_profile_fields_table .display_in_profile_summary_checkbox_false").prop(

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -386,7 +386,7 @@ export function initialize() {
             "#add-new-custom-profile-field-form .display_in_profile_summary_tooltip",
         ],
         content: $t({
-            defaultMessage: "Only 2 custom profile fields can be displayed in the profile summary.",
+            defaultMessage: "Only 2 custom profile fields can be displayed on the user card.",
         }),
         appendTo: () => document.body,
         onTrigger(instance) {

--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -36,7 +36,7 @@ function initialize_bot_owner(element_id, bot_id) {
     const user_pills = new Map();
     const bot = people.get_by_user_id(bot_id);
     const bot_owner = people.get_bot_owner_user(bot);
-    // Bot owner's pill displaying on bots full profile modal.
+    // Bot owner's pill displaying on bot's profile modal.
     if (bot_owner) {
         const $pill_container = $(element_id)
             .find(

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -209,7 +209,7 @@
                     <td><span class="hotkey"><kbd class="arrow-key">←</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t "Show message sender's profile"   }}</td>
+                    <td class="definition">{{t "Show message sender's user card"   }}</td>
                     <td><span class="hotkey"><kbd>U</kbd></span></td>
                 </tr>
                 <tr>

--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,13 +1,13 @@
 <span class="message_sender no-select">
     <span class="sender_info_hover">
-        <span title="{{t 'View user profile' }} (u)">
+        <span title="{{t 'View user card' }} (u)">
             {{> message_avatar}}
         </span>
     </span>
 
     <span class="sender-status">
         <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">
-            <span title="{{t 'View user profile' }} (u)" >
+            <span title="{{t 'View user card' }} (u)" >
                 {{msg/sender_full_name}}
             </span>
         </span>

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -2,7 +2,7 @@
     {{#unless status_message}}
     <span class="message_sender sender_info_hover no-select">
         {{#if include_sender}}
-        <span title="{{t 'View user profile' }} (u)">
+        <span title="{{t 'View user card' }} (u)">
             {{> message_avatar ~}}
             <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
             {{#if sender_is_bot}}

--- a/static/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/static/templates/settings/add_new_custom_profile_field_form.hbs
@@ -40,7 +40,7 @@
             <label class="checkbox profile_field_display_label" for="profile_field_display_in_profile_summary">
                 <input type="checkbox" id="profile_field_display_in_profile_summary" name="display_in_profile_summary"/>
                 <span></span>
-                {{t 'Display in profile summary' }}
+                {{t 'Display on user card' }}
             </label>
         </div>
     </div>

--- a/static/templates/settings/edit_custom_profile_field_form.hbs
+++ b/static/templates/settings/edit_custom_profile_field_form.hbs
@@ -41,7 +41,7 @@
             <label class="checkbox edit_profile_field_display_label" for="edit_display_in_profile_summary_{{id}}">
                 <input class="edit_display_in_profile_summary" type="checkbox" id="edit_display_in_profile_summary_{{id}}" name="display_in_profile_summary" {{#if display_in_profile_summary}} checked="checked" {{/if}}/>
                 <span></span>
-                {{t 'Display in profile summary' }}
+                {{t 'Display on user card' }}
             </label>
         </div>
     {{/if}}

--- a/static/templates/settings/profile_field_settings_admin.hbs
+++ b/static/templates/settings/profile_field_settings_admin.hbs
@@ -13,7 +13,7 @@
                 <th>{{t "Hint" }}</th>
                 <th>{{t "Type" }}</th>
                 {{#if is_admin}}
-                <th class="display">{{t "Summary"}}</th>
+                <th class="display">{{t "Card"}}</th>
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </tbody>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -139,7 +139,7 @@
                 {{#if is_me}}
                     <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View your profile{{/tr}}
                 {{else}}
-                    <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View full profile{{/tr}}
+                    <i class="fa fa-user" aria-hidden="true"></i> {{#tr}}View profile{{/tr}}
                 {{/if}}
             </a>
         </li>

--- a/templates/zerver/help/add-or-remove-users-from-a-stream.md
+++ b/templates/zerver/help/add-or-remove-users-from-a-stream.md
@@ -79,7 +79,7 @@ This method is useful if you need to remove one user from multiple streams.
 
 {start_tabs}
 
-{!right-sidebar-view-full-profile.md!}
+{!right-sidebar-view-profile.md!}
 
 1. Select the **Streams** tab.
 

--- a/templates/zerver/help/change-a-users-name.md
+++ b/templates/zerver/help/change-a-users-name.md
@@ -12,7 +12,7 @@ Organization administrators can always change any user's name.
 
 {start_tabs}
 
-{tab|via-user-profile}
+{tab|via-user-card}
 
 {!manage-this-user.md!}
 

--- a/templates/zerver/help/change-a-users-role.md
+++ b/templates/zerver/help/change-a-users-role.md
@@ -19,7 +19,7 @@ organization](/help/deactivate-your-organization) instead).
 
 {start_tabs}
 
-{tab|via-user-profile}
+{tab|via-user-card}
 
 {!manage-this-user.md!}
 

--- a/templates/zerver/help/custom-profile-fields.md
+++ b/templates/zerver/help/custom-profile-fields.md
@@ -56,13 +56,13 @@ There are several different types of fields available.
 * **Person picker**: For selecting one or more users, like "Manager" or
     "Direct reports".
 
-## Display custom fields in user profile summaries
+## Display custom fields on user card
 
-Organizations may find it useful to display additional fields in a user's
-profile summary, such as pronouns, GitHub username, job title, team, etc.
+Organizations may find it useful to display additional fields on the
+user card, such as pronouns, GitHub username, job title, team, etc.
 
 All field types other than "Long text" or "Person" have a checkbox option
-that controls whether to display a custom field in a user's profile summary.
+that controls whether to display a custom field on the user card.
 There's a limit to the number of custom profile fields that can be displayed
 at a time. If the maximum number of fields is already selected, all unselected
 checkboxes will be disabled.
@@ -74,14 +74,14 @@ checkboxes will be disabled.
 1. In the **Actions** column, click the **pencil** (<i class="fa fa-pencil"></i>)
    icon for the profile field you want to edit.
 
-1. Toggle **Display in profile summary**.
+1. Toggle **Display on user card**.
 
 4. Click **Save changes**.
 
 !!! tip ""
 
     You can also choose which custom profile fields will be displayed by toggling
-    the checkboxes in the **Summary** column of the **Custom profile fields** table.
+    the checkboxes in the **Card** column of the **Custom profile fields** table.
 
 {end_tabs}
 

--- a/templates/zerver/help/deactivate-or-reactivate-a-user.md
+++ b/templates/zerver/help/deactivate-or-reactivate-a-user.md
@@ -32,7 +32,7 @@ When you deactivate a user:
 
 {start_tabs}
 
-{tab|via-user-profile}
+{tab|via-user-card}
 
 {!manage-this-user.md!}
 

--- a/templates/zerver/help/include/manage-this-user.md
+++ b/templates/zerver/help/include/manage-this-user.md
@@ -1,3 +1,3 @@
-{!profile-summary-three-dot-menu.md!}
+{!user-card-three-dot-menu.md!}
 
 1. Click **Manage this user**.

--- a/templates/zerver/help/include/right-sidebar-user-card.md
+++ b/templates/zerver/help/include/right-sidebar-user-card.md
@@ -1,4 +1,4 @@
 1. Hover over a user's name in the right sidebar.
 
 1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
-   to the right of their name.
+   to the right of their name to open their **user card**.

--- a/templates/zerver/help/include/right-sidebar-view-full-profile.md
+++ b/templates/zerver/help/include/right-sidebar-view-full-profile.md
@@ -1,3 +1,3 @@
-{!right-sidebar-profile-menu.md!}
+{!right-sidebar-user-card.md!}
 
 1. Click **View full profile**.

--- a/templates/zerver/help/include/right-sidebar-view-profile.md
+++ b/templates/zerver/help/include/right-sidebar-view-profile.md
@@ -1,3 +1,3 @@
 {!right-sidebar-user-card.md!}
 
-1. Click **View full profile**.
+1. Click **View profile**.

--- a/templates/zerver/help/include/self-user-actions-menu.md
+++ b/templates/zerver/help/include/self-user-actions-menu.md
@@ -1,3 +1,0 @@
-1. Hover over your name in the right sidebar.
-
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).

--- a/templates/zerver/help/include/self-user-card.md
+++ b/templates/zerver/help/include/self-user-card.md
@@ -1,4 +1,4 @@
-{!right-sidebar-profile-menu.md!}
+1. Hover over your name in the right sidebar.
 
 1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
-   in the user's profile summary.
+   to open your **user card**.

--- a/templates/zerver/help/include/user-card-three-dot-menu.md
+++ b/templates/zerver/help/include/user-card-three-dot-menu.md
@@ -1,0 +1,3 @@
+{!right-sidebar-user-card.md!}
+
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) in the user card.

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -139,7 +139,7 @@ below, and add more to your repertoire as needed.
 
 ### For a selected message (outlined in blue)
 
-* **Show sender's profile**: <kbd>U</kbd>
+* **Show message sender's user card**: <kbd>U</kbd>
 
 * **View image**: <kbd>V</kbd>
 

--- a/templates/zerver/help/manage-user-stream-subscriptions.md
+++ b/templates/zerver/help/manage-user-stream-subscriptions.md
@@ -9,7 +9,7 @@
 
 {start_tabs}
 
-{!right-sidebar-view-full-profile.md!}
+{!right-sidebar-view-profile.md!}
 
 1. Select the **Streams** tab.
 
@@ -46,7 +46,7 @@ stream](/help/unsubscribe-from-a-stream).
 
 {start_tabs}
 
-{!right-sidebar-view-full-profile.md!}
+{!right-sidebar-view-profile.md!}
 
 1. Select the **Streams** tab.
 

--- a/templates/zerver/help/mention-a-user-or-group.md
+++ b/templates/zerver/help/mention-a-user-or-group.md
@@ -23,7 +23,7 @@ messages and alert words.
 
 {start_tabs}
 
-{!right-sidebar-profile-menu.md!}
+{!right-sidebar-user-card.md!}
 
 1. Select **Copy mention syntax** to add it to your clipboard.
 
@@ -35,7 +35,8 @@ messages and alert words.
 
 {start_tabs}
 
-1. Click on a user's profile picture or name on a message they sent.
+1. Click on a user's profile picture or name on a message they sent
+   to open their **user card**.
 
 1. Select **Reply mentioning user** to start a reply to the conversation
    with a mention inserted into the compose box.

--- a/templates/zerver/help/mute-a-user.md
+++ b/templates/zerver/help/mute-a-user.md
@@ -51,7 +51,7 @@ have the following effects:
 
 {start_tabs}
 
-{!profile-summary-three-dot-menu.md!}
+{!user-card-three-dot-menu.md!}
 
 1. Click **Mute this user**.
 
@@ -60,7 +60,8 @@ have the following effects:
 !!! Tip ""
 
     You can also click on a user's profile picture or name on a
-    message they sent, and skip to step 3.
+    message they sent to open their **user card**, and skip to
+    step 3.
 
 {end_tabs}
 

--- a/templates/zerver/help/private-messages.md
+++ b/templates/zerver/help/private-messages.md
@@ -29,8 +29,9 @@ and do not appear in your list of streams.
 
 !!! tip ""
 
-    You can also click on any user in the right sidebar, or click on a
-    user's profile picture or name, and select **Send private message**.
+      You can also click on any user in the right sidebar to start composing
+      a private message to them. Or open their **user card** by clicking on
+      their profile picture or name, and select **Send private message**.
 
 {tab|mobile}
 

--- a/templates/zerver/help/status-and-availability.md
+++ b/templates/zerver/help/status-and-availability.md
@@ -23,7 +23,7 @@ You can set a status emoji, status message, or both.
 
 {tab|desktop-web}
 
-{!self-user-actions-menu.md!}
+{!self-user-card.md!}
 
 1. Click **Set a status**.
 
@@ -52,8 +52,8 @@ and compose box.
 
 You can view status messages by hovering over your or anyone else's name in the
 left or right sidebar, or by clicking the user's name or avatar in the main
-message feed. If someone hasn't set a message as part of their status, then no
-status message will appear.
+message feed to open their **user card**. If someone hasn't set a message as
+part of their status, then no status message will appear.
 
 ## Availability
 
@@ -88,7 +88,7 @@ the UI will be frozen as the approximate time you enabled this setting.
 
 {tab|desktop-web}
 
-{!self-user-actions-menu.md!}
+{!self-user-card.md!}
 
 1. To enable, you'll select **Go invisible**.
 

--- a/templates/zerver/help/view-messages-sent-by-a-user.md
+++ b/templates/zerver/help/view-messages-sent-by-a-user.md
@@ -7,7 +7,7 @@ including yourself.
 
 {start_tabs}
 
-{!right-sidebar-profile-menu.md!}
+{!right-sidebar-user-card.md!}
 
 1. Select **View messages sent** to view all messages sent by this user.
 
@@ -17,7 +17,7 @@ including yourself.
 
 {start_tabs}
 
-{!self-user-actions-menu.md!}
+{!self-user-card.md!}
 
 1. Select **View messages sent** to view all the messages you've sent.
 
@@ -33,7 +33,7 @@ including yourself.
 
 {start_tabs}
 
-{!self-user-actions-menu.md!}
+{!self-user-card.md!}
 
 1. Select **View messages with yourself** to view messages you sent to
    yourself.

--- a/templates/zerver/help/view-someones-profile.md
+++ b/templates/zerver/help/view-someones-profile.md
@@ -42,7 +42,7 @@ Additional tabs showing:
 
 {tab|desktop-web}
 
-{!right-sidebar-view-full-profile.md!}
+{!right-sidebar-view-profile.md!}
 
 !!! Tip ""
 

--- a/templates/zerver/help/view-someones-profile.md
+++ b/templates/zerver/help/view-someones-profile.md
@@ -47,7 +47,8 @@ Additional tabs showing:
 !!! Tip ""
 
     You can also click on a user's profile picture or name on a
-    message they sent, and skip to the last step.
+    message they sent to open their **user card**, and skip to
+    the last step.
 
 {tab|mobile}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -75,7 +75,7 @@ TAB_SECTION_LABELS = {
     "public-streams": "Public streams",
     "private-streams": "Private streams",
     "web-public-streams": "Web-public streams",
-    "via-user-profile": "Via the user's profile",
+    "via-user-card": "Via user card",
     "via-organization-settings": "Via organization settings",
     "via-personal-settings": "Via personal settings",
     "default-subdomain": "Default subdomain",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15593,7 +15593,7 @@ components:
         display_in_profile_summary:
           type: boolean
           description: |
-            Whether the custom profile field, display or not in the user profile summary.
+            Whether the custom profile field, display or not on the user card.
 
             Currently it's value not allowed to be `true` of `Long text` and `Person picker`
             [profile field types](/help/custom-profile-fields#profile-field-types).

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9817,7 +9817,7 @@ paths:
                           An array of dictionaries where each dictionary contains the
                           details of a single custom profile field that is available to users
                           in this Zulip organization. This must be combined with the custom profile
-                          field values on individual user objects to display users' full profiles.
+                          field values on individual user objects to display users' profiles.
                         items:
                           $ref: "#/components/schemas/CustomProfileField"
                       custom_profile_field_types:


### PR DESCRIPTION
Updates the web-app and documentation for user-facing uses of:
- "profile summary" to be "user card"
- "full profile" to be "profile"

Fixes #23530.

---

**Notes**:
- The 1st commit focuses on the "user card" update. The 2nd commit focuses on the "profile" update. They can be squashed before merging.
- In the issue description, there was a reference to "profile card" when discussing updating the help center references, which I assumed was a typo and that we wanted to use "user card" as stated at the top of the issue.
- This pull request focuses on user-facing updates. There are some follow-up items to consider:
  - The server/backend code has references to "profile summary" as part of some json error responses that is not updated by these changes. And the CustomProfileField model has a `display_in_profile_summary` field as well.
  - The frontend code also has various references to `display_in_profile_summary`

---

**Screenshots and screen captures:**

<details>
<summary>Web app updates</summary>

### Me message hover
![Screenshot from 2022-11-14 18-32-24](https://user-images.githubusercontent.com/63245456/201727921-d973a7bd-be36-4a63-b100-7862c7bd2328.png)
![Screenshot from 2022-11-14 18-32-28](https://user-images.githubusercontent.com/63245456/201727922-a9c262ed-d4cd-43a4-8b08-6428b6ba0c6e.png)

### Normal message hover
![Screenshot from 2022-11-14 18-32-32](https://user-images.githubusercontent.com/63245456/201727927-600df0b7-f2d1-433a-ba08-743013b69f2e.png)
![Screenshot from 2022-11-14 18-32-35](https://user-images.githubusercontent.com/63245456/201727929-0530092d-b555-4cb5-a4ea-f94beac225c9.png)

### Keyboard help menu
![Screenshot from 2022-11-14 18-33-18](https://user-images.githubusercontent.com/63245456/201727935-742d455b-337e-495a-b4b5-c91273861475.png)

### Custom profile org settings
![Screenshot from 2022-11-14 18-33-58](https://user-images.githubusercontent.com/63245456/201727939-fb82660c-11a0-435d-8152-5b400cd2f286.png)

### User card
![Screenshot from 2022-11-14 18-34-44](https://user-images.githubusercontent.com/63245456/201727942-015025f6-2f2e-40b1-8afb-91e5114a7102.png)

### Edit custom profile field modal
![Screenshot from 2022-11-14 18-35-26](https://user-images.githubusercontent.com/63245456/201727947-47791e73-6673-4f43-8eb2-23b4a1d156be.png)

### Add custom profile field modal
![Screenshot from 2022-11-14 18-35-37](https://user-images.githubusercontent.com/63245456/201727953-04274e7a-3816-4b44-8e85-7b6546897244.png)
</details>

<details>
<summary>Help center updates</summary>

### Custom profile fields
[Current documentation](https://zulip.com/help/custom-profile-fields#display-custom-fields-in-user-profile-summaries)
![Screenshot from 2022-11-14 18-43-01](https://user-images.githubusercontent.com/63245456/201729420-fb4045a7-29ba-4e8a-893a-d84b78078bdc.png)

### Keyboard shortcuts
[Current documentation](https://zulip.com/help/keyboard-shortcuts#message-actions)
![Screenshot from 2022-11-14 18-44-48](https://user-images.githubusercontent.com/63245456/201729752-4207569b-6137-4c3b-8a45-373f94328d69.png)

### Add or remove users from stream
[Current documentation](https://zulip.com/help/add-or-remove-users-from-a-stream#from-a-users-profile-alternate-method)
![Screenshot from 2022-11-14 18-46-46](https://user-images.githubusercontent.com/63245456/201730280-d109075b-d388-4dec-9ba7-2090d54b3016.png)

### Change a user's role
[Current documentation](https://zulip.com/help/change-a-users-role#change-a-users-role_1)
![Screenshot from 2022-11-14 18-48-42](https://user-images.githubusercontent.com/63245456/201730635-642127a6-f5ba-4c12-ae20-e541fcbd68ac.png)

### View messages sent by a user
[Current documentation](https://zulip.com/help/view-messages-sent-by-a-user)
![Screenshot from 2022-11-14 18-51-11](https://user-images.githubusercontent.com/63245456/201731053-f22071cf-510a-4ece-8021-165514a0b9dc.png)


</details>

<details>
<summary>API docs updates - Register queue</summary>

![Screenshot from 2022-11-14 18-42-03](https://user-images.githubusercontent.com/63245456/201729180-6e71f8b1-1a50-4b98-bb76-09cc696fe6a7.png)
![Screenshot from 2022-11-14 18-42-20](https://user-images.githubusercontent.com/63245456/201729182-d760dc78-2a23-4169-93a8-f87385955433.png)

</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
