### PR TITLE
help center: Document user cards

### DIFF
--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -94,6 +94,7 @@
 
 ## People
 * [Status and availability](/help/status-and-availability)
+* [User cards](/help/user-cards)
 * [View someone's profile](/help/view-someones-profile)
 * [Private messages](/help/private-messages)
 

--- a/templates/zerver/help/marking-messages-as-unread.md
+++ b/templates/zerver/help/marking-messages-as-unread.md
@@ -1,10 +1,21 @@
 # Marking messages as unread
 
-Zulip lets you manually mark messages as unread, which makes it easy to return
-to a conversation later.
+Zulip lets you manually mark messages as unread. Specifically, Zulip offers a
+**Mark as unread from here** option, which lets you mark the selected message
+and all newer messages in your current view as unread.
 
-Specifically, Zulip offers a **Mark as unread from here** option, which lets you
-mark the selected message and all newer messages in your current view as unread.
+There are many ways to use this feature, including:
+
+- When you don't have time to read a conversation carefully, or to follow up on
+  action items, mark messages as unread to return to them later.
+
+- You can mark messages as unread when you [subscribe to a
+  stream](/help/browse-and-subscribe-to-streams). This makes it
+  [convenient](/help/reading-strategies) to review all the recent
+  conversations in that stream.
+
+- Mark the results of your [search](/help/search-for-messages) as unread to
+  review them at leisure.
 
 ## Mark as unread from selected message
 

--- a/templates/zerver/help/user-cards.md
+++ b/templates/zerver/help/user-cards.md
@@ -1,0 +1,44 @@
+# User cards
+
+In the web and desktop apps, user cards contain basic information about a user
+or bot. User cards are also a handy starting point for actions such as a [viewing a
+user's profile](/help/view-someones-profile) or [viewing the messages they've
+sent](/help/view-messages-sent-by-a-user).
+
+## Information in a user's card
+
+{start_tabs}
+
+- Their avatar.
+- Their name.
+- Their email address, if you [have
+  permission](/help/restrict-visibility-of-email-addresses) to view it.
+- Their [role](/help/roles-and-permissions) in the organization.
+- The custom profile fields
+  [selected](/help/custom-profile-fields#display-custom-fields-on-user-card) by
+  administrators to be featured on user cards.
+- Their current [local time](/help/change-your-timezone).
+- Their [status and availability](/help/status-and-availability).
+
+{end_tabs}
+
+## View someone's user card
+
+{start_tabs}
+
+{!right-sidebar-user-card.md!}
+
+!!! tip ""
+
+    You can also click on a user's profile picture or name on a message they sent.
+
+!!! keyboard_tip ""
+
+    Alternatively, open someone's **user card** by selecting a message they sent, and
+    using the <kbd>U</kbd> shortcut.
+
+{end_tabs}
+
+## Related articles
+
+- [View someone's profile](/help/view-someones-profile)

--- a/templates/zerver/help/view-someones-profile.md
+++ b/templates/zerver/help/view-someones-profile.md
@@ -66,3 +66,4 @@ Additional tabs showing:
 
 * [Edit your profile](/help/edit-your-profile)
 * [Custom profile fields](/help/custom-profile-fields)
+* [User cards](/help/user-cards)


### PR DESCRIPTION
Following up on #23554, this PR creates a help center page on user cards (`/help/user-cards`).

Links were manually tested.

As a follow up, we should probably link to this page from more places.


![Screen Shot 2022-11-14 at 1 26 25 PM](https://user-images.githubusercontent.com/2090066/201769057-73ec9564-53cb-4e90-8afb-8804efa68292.png)
