### PR TITLE
[5.x] do_deactivate_user: Revoke sessions in transaction.on_commit().

### DIFF
--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -162,20 +162,28 @@ def do_deactivate_user(
 
         transaction.on_commit(lambda: delete_user_sessions(user_profile))
 
-    event = dict(
-        type="realm_user",
-        op="remove",
-        person=dict(user_id=user_profile.id, full_name=user_profile.full_name),
-    )
-    send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
-
-    if user_profile.is_bot:
-        event = dict(
-            type="realm_bot",
+        event_remove_user = dict(
+            type="realm_user",
             op="remove",
-            bot=dict(user_id=user_profile.id, full_name=user_profile.full_name),
+            person=dict(user_id=user_profile.id, full_name=user_profile.full_name),
         )
-        send_event(user_profile.realm, event, bot_owner_user_ids(user_profile))
+        transaction.on_commit(
+            lambda: send_event(
+                user_profile.realm, event_remove_user, active_user_ids(user_profile.realm_id)
+            )
+        )
+
+        if user_profile.is_bot:
+            event_remove_bot = dict(
+                type="realm_bot",
+                op="remove",
+                bot=dict(user_id=user_profile.id, full_name=user_profile.full_name),
+            )
+            transaction.on_commit(
+                lambda: send_event(
+                    user_profile.realm, event_remove_bot, bot_owner_user_ids(user_profile)
+                )
+            )
 
 
 @transaction.atomic(durable=True)

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -160,7 +160,8 @@ def do_deactivate_user(
         if settings.BILLING_ENABLED:
             update_license_ledger_if_needed(user_profile.realm, event_time)
 
-    delete_user_sessions(user_profile)
+        transaction.on_commit(lambda: delete_user_sessions(user_profile))
+
     event = dict(
         type="realm_user",
         op="remove",

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1216,7 +1216,8 @@ class InactiveUserTest(ZulipTestCase):
         """
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
-        do_deactivate_user(user_profile, acting_user=None)
+        with self.captureOnCommitCallbacks(execute=True):
+            do_deactivate_user(user_profile, acting_user=None)
 
         result = self.client_post(
             "/json/messages",

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1579,7 +1579,8 @@ class ActivateTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(Session.objects.filter(pk=session_key).count(), 1)
 
-        do_deactivate_user(user, acting_user=None)
+        with self.captureOnCommitCallbacks(execute=True):
+            do_deactivate_user(user, acting_user=None)
         self.assertEqual(Session.objects.filter(pk=session_key).count(), 0)
 
         result = self.client_get("/json/users")


### PR DESCRIPTION
Backport to 5.x of #23181.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
