### PR TITLE
[5.x] Remove RabbitMQ from Docker CI images

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -173,9 +173,7 @@ jobs:
           restore-keys: v1-yarn-deps-${{ matrix.os }}
 
       - name: Install production
-        run: |
-          sudo service rabbitmq-server restart
-          sudo /tmp/production-install ${{ matrix.extra-args }}
+        run: sudo /tmp/production-install ${{ matrix.extra-args }}
 
       - name: Verify install
         run: sudo /tmp/production-verify ${{ matrix.extra-args }}

--- a/tools/ci/Dockerfile
+++ b/tools/ci/Dockerfile
@@ -42,7 +42,9 @@ RUN apt-get update \
     puppet \
     python3-dev \
     python3-pip \
-    rabbitmq-server \
+# We do not pre-install rabbitmq-server, as doing so fixes the
+# nodename to be the current hostname, which varies.  Letting Zulip
+# install rabbitmq allows it to fix the nodename to 'localhost'.
     redis-server \
     sudo \
     supervisor \

--- a/tools/ci/Dockerfile.prod
+++ b/tools/ci/Dockerfile.prod
@@ -16,6 +16,7 @@ RUN cd $(mktemp -d) \
   && tar -xf "zulip-server-$VERSION.tar.gz" \
   && sudo service rabbitmq-server start \
   && sudo service rabbitmq-server status \
-  && sudo -s "./zulip-server-$VERSION/scripts/setup/install" --self-signed-cert --hostname 127.0.0.1 --email circleci@example.com
+  && sudo -s "./zulip-server-$VERSION/scripts/setup/install" --self-signed-cert --hostname 127.0.0.1 --email circleci@example.com \
+  && sudo service rabbitmq-server stop
 
 CMD ["/bin/sh"]

--- a/tools/ci/Dockerfile.prod
+++ b/tools/ci/Dockerfile.prod
@@ -6,16 +6,11 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-# Remove already existing rabbitmq mnesia directory files
-RUN sudo rm -rf /var/lib/rabbitmq/mnesia/*
-
 # Download the release tarball, start rabbitmq server and install the server
 ARG VERSION
 RUN cd $(mktemp -d) \
   && curl -fLO "https://download.zulip.com/server/zulip-server-$VERSION.tar.gz" \
   && tar -xf "zulip-server-$VERSION.tar.gz" \
-  && sudo service rabbitmq-server start \
-  && sudo service rabbitmq-server status \
   # Version 3.4 predates ddb9d16132a6336b384bf674c4c950cd75d83e5c and 9d57fa97597ec176a8357d6620ab9e670ee19f4e
   && perl -pi -e 's/pgrep -f epmd/which pgrep && pgrep -x epmd/' zulip-server-$VERSION/puppet/zulip/manifests/rabbit.pp \
   && sudo -s "./zulip-server-$VERSION/scripts/setup/install" --self-signed-cert --hostname 127.0.0.1 --email circleci@example.com \

--- a/tools/ci/Dockerfile.prod
+++ b/tools/ci/Dockerfile.prod
@@ -16,6 +16,8 @@ RUN cd $(mktemp -d) \
   && tar -xf "zulip-server-$VERSION.tar.gz" \
   && sudo service rabbitmq-server start \
   && sudo service rabbitmq-server status \
+  # Version 3.4 predates ddb9d16132a6336b384bf674c4c950cd75d83e5c and 9d57fa97597ec176a8357d6620ab9e670ee19f4e
+  && perl -pi -e 's/pgrep -f epmd/which pgrep && pgrep -x epmd/' zulip-server-$VERSION/puppet/zulip/manifests/rabbit.pp \
   && sudo -s "./zulip-server-$VERSION/scripts/setup/install" --self-signed-cert --hostname 127.0.0.1 --email circleci@example.com \
   && sudo service rabbitmq-server stop
 

--- a/tools/ci/production-upgrade
+++ b/tools/ci/production-upgrade
@@ -5,28 +5,16 @@
 set -e
 set -x
 
-# Structurally, this script should just call upgrade-zulip.  However,
-# because of a set of issues that result in the previously installed
-# GitHub Actions Docker containers not actually working on boot, we
-# need to do some preparatory steps. It is a goal to delete these
-# steps.
-
-# Reinstall rabbitmq-server.
-#
-# * For rabbitmq-server, we likely need to do this to work around the
-# hostname changing on reboot causing RabbitMQ to not boot.
-sudo apt-get -y purge rabbitmq-server
-sudo apt-get -y install rabbitmq-server
+# Start the services that would be running on a working Zulip host;
+# since this is a container, these services are not started
+# automatically.
 
 # Start the postgresql service.
 sudo service postgresql start
 
 # Starting the rabbitmq-server
-if ! sudo service rabbitmq-server start; then
-    echo
-    echo "Starting rabbitmq-server failed. Trying again:"
-    sudo service rabbitmq-server start
-fi
+epmd -daemon
+sudo service rabbitmq-server start
 
 # Start the supervisor
 sudo service supervisor start


### PR DESCRIPTION
Backport to 5.x:

- #22090
- #23279