### PR TITLE
corporate: Remove Senior Full Stack Engineer opening from /jobs page.

### DIFF
--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -33,7 +33,6 @@
                 <ul>
                     <li><a href="#mobile">Senior Mobile Engineer</a></li>
                     <li><a href="#frontend">Senior Frontend Engineer</a></li>
-                    <li><a href="#fullstack">Senior Full Stack Engineer</a></li>
                     <li><a href="#marketing">Marketing/Growth Lead</a></li>
                 </ul>
             </div>
@@ -297,82 +296,6 @@
                 </p>
                 <br />
                 <hr />
-
-                <h2 id="fullstack">Senior Full Stack Engineer</h2>
-                <p>
-                    We’re looking for an engineer to join our small
-                    core team and help define the future of team chat.
-                </p>
-                <p>
-                    This job is remote, or partially in-person in our San Francisco, CA office.
-                </p>
-                <h3>We'd especially like to get to know you if:</h3>
-                <ul>
-                    <li>
-                        <strong>You love giving a code review, and love receiving one.</strong>
-                        We’re an open-source project welcoming contributions from people with
-                        a wide range of experience.
-                    </li>
-                    <li>
-                        <strong>You communicate with clarity and precision.</strong>
-                        You’ll be doing this a lot in code, comments, code reviews, and chat
-                        conversations. We care about this almost as much as your technical
-                        skills.
-                    </li>
-                    <li>
-                        <strong>You can empathize with the many different types of users</strong>
-                        who rely on Zulip, and see the product from their perspective — and do
-                        the same thing for the project's contributors.
-                    </li>
-                </ul>
-
-                <h3>You will:</h3>
-                <ul>
-                    <li>Design new features and subsystems, write design proposals for
-                        discussion, and build them.
-                    </li>
-                    <li>Diagnose and fix bugs small and large and across several layers of our
-                        stack, including spelunking in third-party dependencies to find the
-                        best possible solution.
-                    </li>
-                    <li>Share your expertise (both newly-acquired and longstanding) with the
-                        rest of the team, through short- and long-form written communication.
-                    </li>
-                    <li>Write primarily Python, JavaScript, HTML, and CSS.</li>
-                </ul>
-
-                <h3>Extra credit for any of the following:</h3>
-                <ul>
-                    <li>You have 5+ years of software engineering experience in a variety of
-                        settings: backend services, or build systems, or desktop GUI software
-                        — you name it.
-                    </li>
-                    <li>You have experience designing systems for other people to build
-                        different pieces of, coaching people in writing high-quality code, or
-                        other aspects of technical leadership.
-                    </li>
-                    <li>You have spent time maintaining and debugging long-running, highly
-                        scalable server systems.
-                    </li>
-                    <li>You have the UI design skills to spot where a UI can be improved;
-                        better yet, to design a better one.
-                    </li>
-                    <li>You have experience doing large codebase migrations in web apps in a way
-                        that minimizes regressions.
-                    </li>
-                    <li>You have contributed to open-source projects; better yet, maintained a
-                        project and helped many people contribute to it.
-                    </li>
-                </ul>
-                <p>
-                    Learn more about <a href="/jobs/#how-we-work">how we
-                    work</a>, or apply by sending your resume and a brief cover
-                    letter explaining what makes you excited about this role to
-                    <a href="mailto:jobs@zulip.com">jobs@zulip.com</a>.
-                </p>
-                <br />
-                <hr />
-
 
                 <h2 id="marketing">Marketing/Growth Lead (full-time or part-time)</h2>
                 <p>


### PR DESCRIPTION
![Screen Shot 2022-11-14 at 5 07 22 PM](https://user-images.githubusercontent.com/2090066/201801414-4535dd7f-6e17-4e1f-826f-56b81ab91906.png)
