### PR TITLE
help center: Document "Mark messages as unread" on mobile.

### DIFF
--- a/templates/zerver/help/marking-messages-as-unread.md
+++ b/templates/zerver/help/marking-messages-as-unread.md
@@ -32,6 +32,12 @@ There are many ways to use this feature, including:
     You can also mark messages as unread by selecting a message, and using the
     <kbd>Shift</kbd> + <kbd>U</kbd> shortcut.
 
+{tab|mobile}
+
+{!message-long-press-menu.md!}
+
+1. Tap **Mark as unread from here**.
+
 {end_tabs}
 
 ## Related articles


### PR DESCRIPTION
 Documents marking messages as unread via the long-press message menu.

Fixes #23560.

**Screenshots and screen captures:**
<img width="563" alt="image" src="https://user-images.githubusercontent.com/2343554/201808897-de5f6c2a-9f0c-4f2c-934f-bf8e24fd4f14.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.
- [x] Automated tests

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>