### PR TITLE
invites: Add defensive assert in do_get_invites_controlled_by_user.

### DIFF
--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -298,6 +298,10 @@ def do_get_invites_controlled_by_user(user_profile: UserProfile) -> List[Dict[st
     for confirmation_obj in multiuse_confirmation_objs:
         invite = confirmation_obj.content_object
         assert invite is not None
+
+        # This should be impossible, because revoking a multiuse invite
+        # deletes the Confirmation object, so it couldn't have been fetched above.
+        assert invite.status != confirmation_settings.STATUS_REVOKED
         invites.append(
             dict(
                 invited_by_user_id=invite.referred_by.id,


### PR DESCRIPTION
https://github.com/zulip/zulip/pull/22920#issuecomment-1314629936

This is a follow-up to d201229df8a547e0a0d4c15baa69dc56dc7d4499. do_get_invites_controlled_by_user queries for Confirmations when finding multiuse invites controlled by a user. This means that a revoked multiuse invite cannot really be fetched here, because do_revoke_multi_use_invite deletes the Confirmation object when revoking the invitations. However, having a defensive assert here should be useful to make this doesn't secretly break in the future if the query used changes or if there are unexpected revoked multiuse invites with an existing Confirmations for any (buggy) reason.

```
def do_revoke_multi_use_invite(multiuse_invite: MultiuseInvite) -> None:
    realm = multiuse_invite.referred_by.realm

    content_type = ContentType.objects.get_for_model(MultiuseInvite)
    with transaction.atomic():
        Confirmation.objects.filter(
            content_type=content_type, object_id=multiuse_invite.id
        ).delete()
        multiuse_invite.status = confirmation_settings.STATUS_REVOKED
        multiuse_invite.save(update_fields=["status"])
    notify_invites_changed(realm)
```