### PR TITLE
Tweaks for release tooling

### DIFF
--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -61,7 +61,7 @@ cd "$BASEDIR"
 git checkout-index -f -a --prefix "$OUTPUT_DIR/$prefix/"
 
 # Add the Git version information file
-if [[ "$version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+if [[ "$version" =~ ^[0-9]+\.[0-9]+(-[0-9a-z]+)?$ ]]; then
     # We override the merge-base, to avoid having to push the commits before building the tarball.
     OVERRIDE_MERGE_BASE="$version" ./tools/cache-zulip-git-version
     generated_version=$(head -n1 zulip-git-version)

--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -61,19 +61,16 @@ cd "$BASEDIR"
 git checkout-index -f -a --prefix "$OUTPUT_DIR/$prefix/"
 
 # Add the Git version information file
-./tools/cache-zulip-git-version
 if [[ "$version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    # We override the merge-base, to avoid having to push the commits before building the tarball.
+    OVERRIDE_MERGE_BASE="$version" ./tools/cache-zulip-git-version
     generated_version=$(head -n1 zulip-git-version)
-    base_version=$(head -n2 zulip-git-version | tail -n1)
     if [ "$generated_version" != "$version" ]; then
         echo "Version $version looks like a release version, but is not tagged yet!  Got $generated_version"
         exit 1
     fi
-    if [ "$base_version" != "$version" ]; then
-        remote="$(git config zulip.zulipRemote)" || remote=upstream
-        echo "Commit for $version have not been pushed to remote $remote -- 'branched from' reports $base_version, not $version"
-        exit 1
-    fi
+else
+    ./tools/cache-zulip-git-version
 fi
 mv zulip-git-version "$OUTPUT_DIR/$prefix/"
 

--- a/tools/cache-zulip-git-version
+++ b/tools/cache-zulip-git-version
@@ -5,9 +5,13 @@ cd "$(dirname "$0")/.."
 remote="$(git config zulip.zulipRemote)" || remote=upstream
 {
     git describe --always --tags --match='[0-9]*'
-    branches="$(git for-each-ref --format='%(objectname)' "refs/remotes/$remote/main" "refs/remotes/$remote/*.x" "refs/remotes/$remote/*-branch")"
-    mapfile -t branches <<<"$branches"
-    if merge_base="$(git merge-base -- HEAD "${branches[@]}")"; then
-        git describe --always --tags --match='[0-9]*' -- "$merge_base"
+    if [ -z "${OVERRIDE_MERGE_BASE+x}" ]; then
+        branches="$(git for-each-ref --format='%(objectname)' "refs/remotes/$remote/main" "refs/remotes/$remote/*.x" "refs/remotes/$remote/*-branch")"
+        mapfile -t branches <<<"$branches"
+        if merge_base="$(git merge-base -- HEAD "${branches[@]}")"; then
+            git describe --always --tags --match='[0-9]*' -- "$merge_base"
+        fi
+    else
+        echo "$OVERRIDE_MERGE_BASE"
     fi
 } >zulip-git-version

--- a/tools/release
+++ b/tools/release
@@ -57,8 +57,9 @@ fi
 # Check the date is correct for the release
 release_line=$(grep -x -E -m 1 -o "### $version -- ([0-9-]+)" docs/overview/changelog.md) \
     || fail "docs/overview/changelog.md does not contain a line for $version"
-[ "$release_line" == "### $version -- $(TZ=America/Los_Angeles date +%F)" ] \
-    || fail "Date in docs/overview/changelog.md does not match $(date +%F)"
+expected_date="$(TZ=America/Los_Angeles date +%F)"
+[ "$release_line" == "### $version -- $expected_date" ] \
+    || fail "Date in docs/overview/changelog.md does not match '$expected_date'"
 
 extract_version() {
     setting="$1"

--- a/tools/release
+++ b/tools/release
@@ -27,11 +27,12 @@ branch=$(git rev-parse --abbrev-ref HEAD)
 is_major_release=
 if [[ "$version" =~ ^[0-9]+\.0$ ]]; then
     [ "$branch" == "main" ] \
-        || fail "Did not expect $version to be released from $branch"
+        || fail "Did not expect $version to be released from $branch, expected main"
     is_major_release=1
 else
-    [ "$branch" == "$(echo "$version" | perl -ple 's/\..*/.x/')" ] \
-        || fail "Did not expect $version to be released from $branch"
+    expected_branch="$(echo "$version" | perl -ple 's/\..*/.x/')"
+    [ "$branch" == "$expected_branch" ] \
+        || fail "Did not expect $version to be released from $branch, expected $expected_branch"
 fi
 
 # shellcheck source=lib/git-tools.bash

--- a/tools/release
+++ b/tools/release
@@ -16,13 +16,18 @@ fail() {
 version="$1"
 
 # Check version is a form we expect
-[[ "$version" =~ ^[0-9]+\.[0-9]+$ ]] \
+[[ "$version" =~ ^[0-9]+\.[0-9]+(-[a-z0-9]+)?$ ]] \
     || fail "Version $version does not look like a full release!"
 
 # Check we're on `main` or `\d+\.x`
 branch=$(git rev-parse --abbrev-ref HEAD)
-[ "$branch" == "main" ] || [[ "$branch" =~ ^[0-9]+\.x$ ]] \
+[ "$branch" == "main" ] || [[ "$branch" =~ ^[0-9]+\.x$ ]] || [ "$branch" == "${version}-branch" ] \
     || fail "Current branch '$branch' is not 'main' or a release branch"
+
+is_prerelease=
+if [[ "$version" =~ -[0-9a-z]+$ ]]; then
+    is_prerelease=1
+fi
 
 is_major_release=
 if [[ "$version" =~ ^[0-9]+\.0$ ]]; then
@@ -30,7 +35,11 @@ if [[ "$version" =~ ^[0-9]+\.0$ ]]; then
         || fail "Did not expect $version to be released from $branch, expected main"
     is_major_release=1
 else
-    expected_branch="$(echo "$version" | perl -ple 's/\..*/.x/')"
+    if [ -n "$is_prerelease" ]; then
+        expected_branch="${version}-branch"
+    else
+        expected_branch="$(echo "$version" | perl -ple 's/\..*/.x/')"
+    fi
     [ "$branch" == "$expected_branch" ] \
         || fail "Did not expect $version to be released from $branch, expected $expected_branch"
 fi
@@ -72,19 +81,22 @@ extract_version() {
 # Check ZULIP_VERSION and LATEST_RELEASE_VERSION are set appropriately
 [ "$(extract_version "ZULIP_VERSION")" == "$version" ] \
     || fail "ZULIP_VERSION in version.py does not match $version"
-[ "$(extract_version "LATEST_RELEASE_VERSION")" == "$version" ] \
-    || fail "LATEST_RELEASE_VERSION in version.py does not match $version"
 
-if [ -n "$is_major_release" ]; then
-    [ "$(extract_version "LATEST_MAJOR_VERSION")" == "$version" ] \
-        || fail "LATEST_MAJOR_VERSION in version.py does not match $version"
+if [ -z "$is_prerelease" ]; then
+    [ "$(extract_version "LATEST_RELEASE_VERSION")" == "$version" ] \
+        || fail "LATEST_RELEASE_VERSION in version.py does not match $version"
 
-    # Check that there is an API version bump, which is documented
-    changed_api_level=$(git diff-tree -G API_FEATURE_LEVEL HEAD -- version.py)
-    [ -n "$changed_api_level" ] || fail "$version did not adjust API_FEATURE_LEVEL in version.py"
-    feature_level="$(extract_version "API_FEATURE_LEVEL")"
-    grep -q -F -x "**Feature level $feature_level**" templates/zerver/api/changelog.md \
-        || fail "Feature level $feature_level is not documented in templates/zerver/api/changelog.md"
+    if [ -n "$is_major_release" ]; then
+        [ "$(extract_version "LATEST_MAJOR_VERSION")" == "$version" ] \
+            || fail "LATEST_MAJOR_VERSION in version.py does not match $version"
+
+        # Check that there is an API version bump, which is documented
+        changed_api_level=$(git diff-tree -G API_FEATURE_LEVEL HEAD -- version.py)
+        [ -n "$changed_api_level" ] || fail "$version did not adjust API_FEATURE_LEVEL in version.py"
+        feature_level="$(extract_version "API_FEATURE_LEVEL")"
+        grep -q -F -x "**Feature level $feature_level**" templates/zerver/api/changelog.md \
+            || fail "Feature level $feature_level is not documented in templates/zerver/api/changelog.md"
+    fi
 fi
 
 # Check we are auth'd to Github, so we can upload the release
@@ -121,7 +133,12 @@ git push "$remote" "$branch:$branch"
 git push "$remote" "$version"
 
 # Upload to Github
+params=()
+if [ -n "$is_prerelease" ]; then
+    params+=("--prerelease")
+fi
 gh release create "$version" \
     --title "Zulip Server $version" \
     --notes-file <(echo "$changelog") \
+    "${params[@]}" \
     "$TARBALL"

--- a/tools/release
+++ b/tools/release
@@ -102,10 +102,6 @@ sleep 15
 
 git tag "$version"
 
-# Commits need to be pushed to the remote so that "branched from" is correct
-remote="$(git config zulip.zulipRemote)" || remote=upstream
-git push "$remote" "$branch:$branch"
-
 OUTPUT_DIR=$(mktemp -d)
 export OUTPUT_DIR
 
@@ -119,6 +115,9 @@ fi
 
 ./tools/upload-release "$TARBALL"
 
+# Push the commits
+remote="$(git config zulip.zulipRemote)" || remote=upstream
+git push "$remote" "$branch:$branch"
 git push "$remote" "$version"
 
 # Upload to Github


### PR DESCRIPTION
This allows creating `6.0-rc2` style tags, as well as reorders the steps such that the release commits and tag are only pushed if the tarball was successfully uploaded.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
