### PR TITLE
portico: Link to /values + small tweaks

### DIFF
--- a/templates/corporate/history.md
+++ b/templates/corporate/history.md
@@ -46,15 +46,13 @@ was maintained by the project's founder and leader [Tim
 Abbott](/team/#the-core-team) on nights and weekends. In the months following
 the open-source release, the project quickly gained contributors and users.
 
-It soon became clear that guiding the contributor community in
-developing a world-class team chat product would require leadership
-from a dedicated team. Thus, in April 2016, Tim Abbott founded a
-[mission-driven](https://blog.zulip.com/2021/04/28/why-zulip-is-on-github-sponsors/)
-company, Kandra Labs, to steward and financially sustain Zulip’s
-development. Incorporating as a business has helped Zulip attract top
-talent, and has made Zulip eligible for [large innovation
-grants](https://seedfund.nsf.gov/) from the US National Science
-Foundation, which Kandra Labs was awarded in 2017 and 2018.
+It soon became clear that guiding the contributor community in developing a
+world-class team chat product would require leadership from a dedicated team.
+Thus, in April 2016, Tim Abbott founded a [mission-driven](/values/) company,
+Kandra Labs, to steward and financially sustain Zulip’s development.
+Incorporating as a business has helped Zulip attract top talent, and has made
+Zulip eligible for [large innovation grants](https://seedfund.nsf.gov/) from the
+US National Science Foundation, which Kandra Labs was awarded in 2017 and 2018.
 
 ## Early days as an open-source company
 

--- a/templates/corporate/history.md
+++ b/templates/corporate/history.md
@@ -79,7 +79,7 @@ In its early days, the Zulip community was focused on three main goals:
 - **Building a vibrant community around the project**, with effort and
   care dedicated to making it [easy to get
   started](https://zulip.readthedocs.io/en/latest/overview/contributing.html)
-  contributing to Zulip. They Zulip development community gathered at
+  contributing to Zulip. The Zulip development community gathered at
   PyCon sprints [in
   2016](https://blog.zulip.org/2016/10/13/static-types-in-python-oh-mypy/),
   and led the largest PyCon sprint ever [in

--- a/templates/corporate/values.html
+++ b/templates/corporate/values.html
@@ -17,6 +17,10 @@
     <div class="hero">
         <div class="content">
             <h1 class="center">Zulip project values</h1>
+            <p>
+                These values are behind everything we do <br />
+                as we work to build the world’s best team chat software.
+            </p>
         </div>
     </div>
     <div class="main">

--- a/templates/corporate/values.md
+++ b/templates/corporate/values.md
@@ -1,6 +1,3 @@
-On this page, we want to share the values that are behind everything we do as we
-work to build the world’s best team chat software.
-
 ## Building software that will always be there for our users
 
 When choosing software that will be core to how one’s organization operates,
@@ -22,7 +19,7 @@ version as a demo for their non-open-source paid product. In contrast, we are
 committed to keeping Zulip [100% open
 source](https://github.com/zulip/zulip#readme).
 
-When you [self-host Zulip](/self-hosting/), you get you get all the
+When you [self-host Zulip](/self-hosting/), you get all the
 [features](/features/) of our cloud offering. We work hard to [make it
 easy](https://zulip.readthedocs.io/en/latest/production/install.html) to set up
 and run a self-hosted Zulip installation without paying us a dime, which is why

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -148,6 +148,7 @@
         <h3>{{ _("About us") }}</h3>
         <ul>
             <li><a href="/team/">{{ _("Team") }}</a> &amp; <a href="/history/">{{ _("History") }}</a></li>
+            <li><a href="/values/">{{ _("Values") }}</a></li>
             <li><a href="https://twitter.com/zulip/">Twitter</a></li>
             <li><a href="/jobs/">{{ _("Jobs") }}</a></li>
             <li><a href="/attribution">{{ _("Website attributions") }}</a></li>


### PR DESCRIPTION
Other than typo corrections, the only change on the /values page is to move the intro sentence to the top area:

![Screen Shot 2022-11-15 at 10 45 13 AM](https://user-images.githubusercontent.com/2090066/202002435-91a4cb40-d707-495f-bcde-ba05ff2a3bf8.png)

Link to /values from the footer:

![Screen Shot 2022-11-15 at 10 52 05 AM](https://user-images.githubusercontent.com/2090066/202002492-3981511e-3991-4065-8aeb-d3937e70d8a2.png)
