### PR TITLE
message_edit: Use single letter truncation indicator

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -134,14 +134,10 @@ def maybe_send_resolve_topic_notifications(
     changed_messages: List[Message],
 ) -> bool:
     """Returns True if resolve topic notifications were in fact sent."""
-
     # Note that topics will have already been stripped in check_update_message.
     #
     # This logic is designed to treat removing a weird "✔ ✔✔ "
     # prefix as unresolving the topic.
-    if old_topic.lstrip(RESOLVED_TOPIC_PREFIX) != new_topic.lstrip(RESOLVED_TOPIC_PREFIX):
-        return False
-
     topic_resolved: bool = new_topic.startswith(RESOLVED_TOPIC_PREFIX) and not old_topic.startswith(
         RESOLVED_TOPIC_PREFIX
     )

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -538,6 +538,10 @@ def do_update_message(
                 user_id for user_id in new_stream_sub_ids if user_id not in old_stream_sub_ids
             ]
 
+    # We save the full topic name so that checks that require comparison
+    # between the original topic and the topic name passed into this function
+    # will not be affected by the potential truncation of topic_name below.
+    pre_truncation_topic_name = topic_name
     if topic_name is not None:
         topic_name = truncate_topic(topic_name)
         target_message.set_topic_name(topic_name)
@@ -865,9 +869,9 @@ def do_update_message(
             new_stream is not None
             or not sent_resolve_topic_notification
             or (
-                topic_name is not None
+                pre_truncation_topic_name is not None
                 and orig_topic_name.lstrip(RESOLVED_TOPIC_PREFIX)
-                != topic_name.lstrip(RESOLVED_TOPIC_PREFIX)
+                != pre_truncation_topic_name.lstrip(RESOLVED_TOPIC_PREFIX)
             )
         ):
             if moved_all_visible_messages:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -194,7 +194,7 @@ def normalize_body(body: str) -> str:
 
 
 def truncate_topic(topic: str) -> str:
-    return truncate_content(topic, MAX_TOPIC_NAME_LENGTH, "...")
+    return truncate_content(topic, MAX_TOPIC_NAME_LENGTH, "…")
 
 
 def messages_for_ids(

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -17,7 +17,7 @@ from zerver.actions.reactions import do_add_reaction
 from zerver.actions.realm_settings import do_change_realm_plan_type, do_set_realm_property
 from zerver.actions.streams import do_change_stream_post_policy, do_deactivate_stream
 from zerver.actions.users import do_change_user_role
-from zerver.lib.message import MessageDict, has_message_access, messages_for_ids
+from zerver.lib.message import MessageDict, has_message_access, messages_for_ids, truncate_topic
 from zerver.lib.test_classes import ZulipTestCase, get_topic_messages
 from zerver.lib.test_helpers import cache_tries_captured, queries_captured
 from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, TOPIC_NAME
@@ -28,7 +28,16 @@ from zerver.lib.user_topics import (
     topic_is_muted,
 )
 from zerver.lib.utils import assert_is_not_none
-from zerver.models import Message, Realm, Stream, UserMessage, UserProfile, get_realm, get_stream
+from zerver.models import (
+    MAX_TOPIC_NAME_LENGTH,
+    Message,
+    Realm,
+    Stream,
+    UserMessage,
+    UserProfile,
+    get_realm,
+    get_stream,
+)
 
 if TYPE_CHECKING:
     from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
@@ -2721,6 +2730,57 @@ class EditMessageTest(EditMessageTestCase):
         messages = get_topic_messages(user_profile, stream, "edited")
         self.assert_length(messages, 1)
         self.assertEqual(messages[0].content, "First")
+
+    def test_notify_resolve_topic_long_name(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login("hamlet")
+        stream = self.make_stream("public stream")
+        self.subscribe(user_profile, stream.name)
+        # Marking topics with a long name as resolved causes the new topic name to be truncated.
+        # We want to avoid having code paths believing that the topic is "moved" instead of
+        # "resolved" in this edge case.
+        topic_name = "a" * MAX_TOPIC_NAME_LENGTH
+        msg_id = self.send_stream_message(
+            user_profile, stream.name, topic_name=topic_name, content="First"
+        )
+
+        resolved_topic = RESOLVED_TOPIC_PREFIX + topic_name
+        result = self.client_patch(
+            "/json/messages/" + str(msg_id),
+            {
+                "topic": resolved_topic,
+                "propagate_mode": "change_all",
+            },
+        )
+        self.assert_json_success(result)
+
+        new_topic_name = truncate_topic(resolved_topic)
+        messages = get_topic_messages(user_profile, stream, new_topic_name)
+        self.assert_length(messages, 2)
+        self.assertEqual(messages[0].content, "First")
+        self.assertEqual(
+            messages[1].content,
+            f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as resolved.",
+        )
+
+        # Note that we are removing the prefix from the already truncated topic,
+        # so unresolved_topic_name will not be the same as the original topic_name
+        unresolved_topic_name = new_topic_name.replace(RESOLVED_TOPIC_PREFIX, "")
+        result = self.client_patch(
+            "/json/messages/" + str(msg_id),
+            {
+                "topic": unresolved_topic_name,
+                "propagate_mode": "change_all",
+            },
+        )
+        self.assert_json_success(result)
+
+        messages = get_topic_messages(user_profile, stream, unresolved_topic_name)
+        self.assert_length(messages, 3)
+        self.assertEqual(
+            messages[2].content,
+            f"@_**{user_profile.full_name}|{user_profile.id}** has marked this topic as unresolved.",
+        )
 
     def test_notify_resolve_and_move_topic(self) -> None:
         user_profile = self.example_user("hamlet")

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -17,7 +17,7 @@ from zerver.actions.reactions import do_add_reaction
 from zerver.actions.realm_settings import do_change_realm_plan_type, do_set_realm_property
 from zerver.actions.streams import do_change_stream_post_policy, do_deactivate_stream
 from zerver.actions.users import do_change_user_role
-from zerver.lib.message import MessageDict, has_message_access, messages_for_ids, truncate_topic
+from zerver.lib.message import MessageDict, has_message_access, messages_for_ids
 from zerver.lib.test_classes import ZulipTestCase, get_topic_messages
 from zerver.lib.test_helpers import cache_tries_captured, queries_captured
 from zerver.lib.topic import RESOLVED_TOPIC_PREFIX, TOPIC_NAME
@@ -2754,7 +2754,7 @@ class EditMessageTest(EditMessageTestCase):
         )
         self.assert_json_success(result)
 
-        new_topic_name = truncate_topic(resolved_topic)
+        new_topic_name = "✔ " + "a" * 57 + "…"
         messages = get_topic_messages(user_profile, stream, new_topic_name)
         self.assert_length(messages, 2)
         self.assertEqual(messages[0].content, "First")

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -974,7 +974,7 @@ class MessagePOSTTest(ZulipTestCase):
         self.assert_json_success(result)
 
         sent_message = self.get_last_message()
-        self.assertEqual(sent_message.topic_name(), "A" * (MAX_TOPIC_NAME_LENGTH - 3) + "...")
+        self.assertEqual(sent_message.topic_name(), "A" * (MAX_TOPIC_NAME_LENGTH - 1) + "…")
 
     def test_send_forged_message_as_not_superuser(self) -> None:
         self.login("hamlet")

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -352,7 +352,7 @@ A trivial change that should probably be ignored.
         )
 
     def test_merge_request_reopened_event_message(self) -> None:
-        expected_topic = "my-awesome-project / MR #1 Update the README with author ..."
+        expected_topic = "my-awesome-project / MR #1 Update the README with author na…"
         expected_message = "Eeshan Garg reopened [MR #1](https://gitlab.com/eeshangarg/my-awesome-project/merge_requests/1)."
 
         self.check_webhook(
@@ -360,7 +360,7 @@ A trivial change that should probably be ignored.
         )
 
     def test_merge_request_approved_event_message(self) -> None:
-        expected_topic = "my-awesome-project / MR #1 Update the README with author ..."
+        expected_topic = "my-awesome-project / MR #1 Update the README with author na…"
         expected_message = "Eeshan Garg approved [MR #1](https://gitlab.com/eeshangarg/my-awesome-project/merge_requests/1)."
 
         self.check_webhook(
@@ -601,7 +601,7 @@ A trivial change that should probably be ignored.
         self.check_webhook("system_hook__merge_request_closed", expected_topic, expected_message)
 
     def test_merge_request_unapproved_event_message(self) -> None:
-        expected_topic = "my-awesome-project / MR #1 Update the README with author ..."
+        expected_topic = "my-awesome-project / MR #1 Update the README with author na…"
         expected_message = "Eeshan Garg unapproved [MR #1](https://gitlab.com/eeshangarg/my-awesome-project/merge_requests/1)."
 
         self.check_webhook(

--- a/zerver/webhooks/zendesk/tests.py
+++ b/zerver/webhooks/zendesk/tests.py
@@ -38,7 +38,7 @@ class ZenDeskHookTests(WebhookTestCase):
         self.TICKET_TITLE = "Test ticket" + "!" * 80
         self.MESSAGE = "some message"
         self.do_test(
-            expected_topic="#4: Test ticket" + "!" * 42 + "...",
+            expected_topic="#4: Test ticket" + "!" * 44 + "…",
             expected_message="some message",
         )
 

--- a/zerver/webhooks/zendesk/view.py
+++ b/zerver/webhooks/zendesk/view.py
@@ -2,16 +2,11 @@
 from django.http import HttpRequest, HttpResponse
 
 from zerver.decorator import authenticated_rest_api_view
+from zerver.lib.message import truncate_content
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
-
-
-def truncate(string: str, length: int) -> str:
-    if len(string) > length:
-        string = string[: length - 3] + "..."
-    return string
 
 
 @authenticated_rest_api_view(webhook_client_name="Zendesk")
@@ -28,6 +23,6 @@ def api_zendesk_webhook(
     ticket_id and ticket_title to create a subject. And passes with zendesk
     user's configured message to zulip.
     """
-    subject = truncate(f"#{ticket_id}: {ticket_title}", 60)
+    subject = truncate_content(f"#{ticket_id}: {ticket_title}", 60, "…")
     check_send_webhook_message(request, user_profile, subject, message)
     return json_success(request)


### PR DESCRIPTION
This is a follow-up to #23544.

We save more space for the truncated topic name by switching from
"..." to "…" to indicate truncation.

Note: verify that this will not cause emails to be sent to different topics than the ones truncated before the change.

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
