### PR TITLE
compatiblity: Delete obsolete compatibility code.

### DIFF
--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -96,29 +96,6 @@ class WorkerTest(ZulipTestCase):
         )
         fake_client.enqueue("user_activity", data)
 
-        # The block below adds an event using the old format,
-        # having the client name instead of id, to test the queue
-        # worker handles it correctly. That compatibility code can
-        # be deleted in a later release, and this test should then be cleaned up.
-        data_old_format = dict(
-            user_profile_id=user.id,
-            client="ios",
-            time=time.time(),
-            query="send_message",
-        )
-        fake_client.enqueue("user_activity", data_old_format)
-
-        with simulated_queue_client(fake_client):
-            worker = queue_processors.UserActivityWorker()
-            worker.setup()
-            worker.start()
-            activity_records = UserActivity.objects.filter(
-                user_profile=user.id,
-                client=get_client("ios"),
-            )
-            self.assert_length(activity_records, 1)
-            self.assertEqual(activity_records[0].count, 2)
-
         # Now process the event a second time and confirm count goes
         # up. Ideally, we'd use an event with a slightly newer
         # time, but it's not really important.
@@ -132,7 +109,7 @@ class WorkerTest(ZulipTestCase):
                 client=get_client("ios"),
             )
             self.assert_length(activity_records, 1)
-            self.assertEqual(activity_records[0].count, 3)
+            self.assertEqual(activity_records[0].count, 2)
 
     def test_missed_message_worker(self) -> None:
         cordelia = self.example_user("cordelia")
@@ -454,23 +431,6 @@ class WorkerTest(ZulipTestCase):
                     ]
                     * 2,
                 )
-
-            # This verifies the compatibility code for the `message_id` -> `message_ids`
-            # conversion for "remove" events.
-            with patch(
-                "zerver.worker.queue_processors.handle_remove_push_notification"
-            ) as mock_handle_remove, patch(
-                "zerver.worker.queue_processors.initialize_push_notifications"
-            ):
-                event_new = dict(
-                    user_profile_id=10,
-                    message_id=33,
-                    type="remove",
-                )
-                fake_client.enqueue("missedmessage_mobile_notifications", event_new)
-                worker.start()
-                # The `message_id` field should have been converted to a list with a single element.
-                mock_handle_remove.assert_called_once_with(10, [33])
 
     @patch("zerver.worker.queue_processors.mirror_email")
     def test_mirror_worker(self, mock_mirror_email: MagicMock) -> None:


### PR DESCRIPTION
Both of these compatibility blocks can be deleted, since you can't upgrade directly to any supported release from the versions where the old event formats would be used.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
