### PR TITLE
narrow: Show empty narrow when all stream topics muted.

### DIFF
--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -37,16 +37,6 @@ function process_result(data, opts) {
         ui_report.hide_error($("#connection-error"));
     }
 
-    if (
-        messages.length === 0 &&
-        message_lists.current === message_list.narrowed &&
-        message_list.narrowed.empty()
-    ) {
-        // Even after trying to load more messages, we have no
-        // messages to display in this narrow.
-        narrow_banner.show_empty_narrow_message();
-    }
-
     messages = messages.map((message) => message_helper.process_new_message(message));
 
     // In some rare situations, we expect to discover new unread
@@ -62,6 +52,12 @@ function process_result(data, opts) {
 
     if (messages.length !== 0) {
         message_util.add_old_messages(messages, opts.msg_list);
+    }
+
+    if (message_lists.current === message_list.narrowed && message_list.narrowed.empty()) {
+        // Even after loading more messages, we have
+        // no messages to display in this narrow.
+        narrow_banner.show_empty_narrow_message();
     }
 
     huddle_data.process_loaded_messages(messages);


### PR DESCRIPTION
Previously, if a user had muted all existing topics in a stream and then navigated to that stream narrow view, no empty narrow banner title / text was shown. Now the default empty narrow is shown in that case.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20with.20all.20topics.20muted/near/1464912).

**Notes (out of date, see update comment below)**:
- The 1st commit adds a check in `narrow.activate`, after the messages have been updated and processed, to show the empty narrow banner if the current message list is empty.
  - I added the check in the same place as other visual updates to the main message feed, such as `message_view_header.initialize`, which is towards the end of the flow for this process.
  - I thought about adding the show empty narrow banner call to `narrow.update_selection`, since that function already is part of `narrow.activate` and checks / returns early for `message_list.narrow.empty()`. In the end, it felt clearer to add it to where the other UI visual elements were being updated / initialized.
- The 2nd commit removes the check from `message_fetch.process_results`. I put this in a separate commit as it might impact something I haven't considering in my testing.
  - This check covers the situation where the server does not return any messages for a narrow, but does not cover the situation where the user has flagged all the messages as muted via topics.
  - If we keep this check, then it just becomes duplicated by the check added in the previous commit.

---

**Screenshots and screen captures:**

<details>
<summary>CURRENT: Stream narrow with all topics muted</summary>

![Screenshot from 2022-11-16 20-21-23](https://user-images.githubusercontent.com/63245456/202274465-007bc9fa-69da-4b28-a286-8815dfaacc11.png)

</details>

<details>
<summary>UPDATED: Stream narrow with all topics muted</summary>

![Screenshot from 2022-11-16 20-18-38](https://user-images.githubusercontent.com/63245456/202274029-1c53188e-5a3b-4331-ba6e-17be6529595e.png)

</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
