### PR TITLE
compose_ui: Revert changes for replace_syntax done in 1ca4566eb2.

### DIFF
--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -1,6 +1,6 @@
 import autosize from "autosize";
 import $ from "jquery";
-import {insert, replace, set, wrapSelection} from "text-field-edit";
+import {insert, set, wrapSelection} from "text-field-edit";
 
 import * as common from "./common";
 import {$t} from "./i18n";
@@ -80,11 +80,17 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
     // a string it will only replace the first instance. If `old_syntax` is
     // a RegExp with a global flag, it will replace all instances.
 
-    // We need use anonymous function for `new_syntax` to avoid JavaScript's
-    // replace() function treating `$`s in new_syntax as special syntax.  See
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
-    // for details.
-    replace($textarea[0], old_syntax, () => new_syntax);
+    $textarea.val(
+        $textarea.val().replace(
+            old_syntax,
+            () =>
+                // We need this anonymous function to avoid JavaScript's
+                // replace() function treating `$`s in new_syntax as special syntax.  See
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
+                // for details.
+                new_syntax,
+        ),
+    );
 }
 
 export function compute_placeholder_text(opts) {


### PR DESCRIPTION
This commit reverts the changes for replace_syntax in 1ca4566eb2 and we again use JS replace instead of replace from text-field-edit.

We do this change because replace from text-field-edit leaves the replaced text selected, which we don't want. This change is temporary and we can probably use replace method from text-field-edit once this issue is fixed in upstream.

Discussion - https://chat.zulip.org/#narrow/stream/9-issues/topic/selection.20after.20upload
<!-- Describe your pull request here.-->
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
