### PR TITLE
recent-conversations: Update logic for processing messages.

### DIFF
--- a/static/js/recent_topics_data.js
+++ b/static/js/recent_topics_data.js
@@ -4,9 +4,6 @@ import {get_key_from_message} from "./recent_topics_util";
 export const topics = new Map(); // Key is stream-id:topic.
 
 export function process_message(msg) {
-    // This function returns if topic_data
-    // has changed or not.
-
     // Initialize topic and pm data
     // Key for private message is the user id's
     // to whom the message is begin sent.
@@ -34,7 +31,6 @@ export function process_message(msg) {
     // message fetched in the topic. Ideally we would want this to be attached
     // to topic info fetched from backend, which is currently not a thing.
     topic_data.participated = is_ours || topic_data.participated;
-    return true;
 }
 
 function get_sorted_topics() {

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -298,17 +298,10 @@ export function process_messages(messages) {
     // the UX can be bad if user wants to scroll down the list as
     // the UI will be returned to the beginning of the list on every
     // update.
-    //
-    // Only rerender if topic_data actually
-    // changed.
-    let topic_data_changed = false;
-    for (const msg of messages) {
-        if (process_message(msg)) {
-            topic_data_changed = true;
+    if (messages.length > 0) {
+        for (const msg of messages) {
+            process_message(msg);
         }
-    }
-
-    if (topic_data_changed) {
         complete_rerender();
     }
 }


### PR DESCRIPTION
As of 550a32b, when private messages were added to recent conversations, `recent_topics_data.process_message` will always return `true`.

**Notes**:
- Updates `recent_topics_data.process_message` for no return value.
- Also, removes the `topic_data_changed` logic from `recent_topics_ui.process_messages` and instead checks for messages to process before updating the data and calling the rerender.
  - As of the commit noted above, the only condition where `topic_data_changed` has been false is when no messages were passed to `recent_topics_data.process_message`.
  - `recent_topics_ui.complete_rerender` first checks for whether the recent conversations view is visible before rerendering.
  - Another option here would be to update `recent_topics_data.process_message` to return `false` if/when no topic data was changed/updated. If nothing else, we should update the comments in both functions to reflect what's currently going on.

@amanagr - It'd be great to get your thoughts / review on these updates.

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
