### PR TITLE
eslint: Enable object-shorthand avoidExplicitReturnArrows option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,7 +101,7 @@
         "no-useless-concat": "error",
         "no-useless-constructor": "error",
         "no-var": "error",
-        "object-shorthand": "error",
+        "object-shorthand": ["error", "always", {"avoidExplicitReturnArrows": true}],
         "one-var": ["error", "never"],
         "prefer-arrow-callback": "error",
         "prefer-const": [

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -322,7 +322,7 @@ test("handlers", ({override, mock_template}) => {
     (function test_click_filter() {
         init();
         const e = {
-            stopPropagation: () => {},
+            stopPropagation() {},
         };
 
         const handler = $(".user-list-filter").get_on_handler("focus");

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -22,7 +22,7 @@ run_test("rerender_alert_words_ui", ({mock_template}) => {
     alert_words_ui.reset();
     const ListWidget = mock_esm("../../static/js/list_widget", {
         modifier: noop,
-        create: (container, words, opts) => {
+        create(container, words, opts) {
             const alert_words = [];
             ListWidget.modifier = opts.modifier;
             for (const word of words) {
@@ -104,7 +104,7 @@ run_test("close_status_message", ({override_rewire}) => {
     $alert.show();
 
     const event = {
-        preventDefault: () => {},
+        preventDefault() {},
         currentTarget: ".close-alert-word-status",
     };
 

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -15,7 +15,7 @@ const document = dom.window.document;
 const location = set_global("location", {});
 
 const helpers = mock_esm("../../static/js/billing/helpers", {
-    set_tab: () => {},
+    set_tab() {},
 });
 
 zrequire("billing/billing");
@@ -49,7 +49,7 @@ run_test("card_update", ({override}) => {
 
     const update_card_click_handler = $("#update-card-button").get_on_handler("click");
     override(helpers, "create_ajax_request", card_change_ajax);
-    update_card_click_handler({preventDefault: () => {}});
+    update_card_click_handler({preventDefault() {}});
     assert.ok(create_ajax_request_called);
 });
 
@@ -72,7 +72,7 @@ run_test("planchange", ({override}) => {
     const change_plan_status_click_handler = $("#change-plan-status").get_on_handler("click");
 
     override(helpers, "create_ajax_request", plan_change_ajax);
-    change_plan_status_click_handler({preventDefault: () => {}});
+    change_plan_status_click_handler({preventDefault() {}});
     assert.ok(create_ajax_request_called);
 });
 
@@ -97,7 +97,7 @@ run_test("licensechange", ({override}) => {
     const confirm_license_update_click_handler = $("#confirm-license-update-button").get_on_handler(
         "click",
     );
-    confirm_license_update_click_handler({preventDefault: () => {}});
+    confirm_license_update_click_handler({preventDefault() {}});
     assert.ok(create_ajax_request_called);
 
     let confirm_license_modal_shown = false;
@@ -114,19 +114,20 @@ run_test("licensechange", ({override}) => {
     create_ajax_request_called = false;
     const update_licenses_button_click_handler =
         $("#update-licenses-button").get_on_handler("click");
-    update_licenses_button_click_handler({preventDefault: () => {}});
+    update_licenses_button_click_handler({preventDefault() {}});
     assert.ok(create_ajax_request_called);
     assert.ok(!confirm_license_modal_shown);
 
     $("#new_licenses_input").val = () => 25;
     create_ajax_request_called = false;
-    update_licenses_button_click_handler({preventDefault: () => {}});
+    update_licenses_button_click_handler({preventDefault() {}});
     assert.ok(!create_ajax_request_called);
     assert.ok(confirm_license_modal_shown);
 
     override(helpers, "is_valid_input", () => false);
     const event = {
-        preventDefault: /* istanbul ignore next */ () => {
+        /* istanbul ignore next */
+        preventDefault() {
             throw new Error("unexpected preventDefault call");
         },
     };
@@ -154,7 +155,7 @@ run_test("licensechange", ({override}) => {
         create_ajax_request_called = true;
     }
     override(helpers, "create_ajax_request", licenses_at_next_renewal_change_ajax);
-    update_next_renewal_licenses_button_click_handler({preventDefault: () => {}});
+    update_next_renewal_licenses_button_click_handler({preventDefault() {}});
     assert.ok(create_ajax_request_called);
 });
 

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -74,7 +74,7 @@ run_test("create_ajax_request", ({override}) => {
     $(form_error).show = () => {
         state.form_error_show += 1;
         return {
-            text: (msg) => {
+            text(msg) {
                 assert.equal(msg, "response_message");
             },
         };

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -14,14 +14,14 @@ const xhr_401 = {
 
 let login_to_access_shown = false;
 mock_esm("../../static/js/spectators", {
-    login_to_access: () => {
+    login_to_access() {
         login_to_access_shown = true;
     },
 });
 
 set_global("window", {
     location: {
-        replace: () => {},
+        replace() {},
     },
 });
 

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -9,7 +9,7 @@ const $ = require("../zjsunit/zjquery");
 const noop = () => {};
 
 mock_esm("tippy.js", {
-    default: (arg) => {
+    default(arg) {
         arg._tippy = {setContent: noop};
         return arg._tippy;
     },
@@ -158,8 +158,8 @@ run_test("show password", () => {
     }
 
     const ev = {
-        preventDefault: () => {},
-        stopPropagation: () => {},
+        preventDefault() {},
+        stopPropagation() {},
     };
 
     set_attribute("password");

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -14,7 +14,7 @@ const {page_params, user_settings} = require("../zjsunit/zpage_params");
 const noop = () => {};
 
 set_global("document", {
-    querySelector: () => {},
+    querySelector() {},
 });
 set_global("navigator", {});
 set_global(
@@ -439,7 +439,7 @@ test_ui("initialize", ({override}) => {
         assert.equal(config.mode, "compose");
         setup_upload_called = true;
         return {
-            cancelAll: () => {
+            cancelAll() {
                 uppy_cancel_all_called = true;
             },
         };

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -459,7 +459,7 @@ run_test("format_text", ({override}) => {
 
     const $textarea = $("#compose-textarea");
     $textarea.get = () => ({
-        setSelectionRange: () => {},
+        setSelectionRange() {},
     });
 
     function init_textarea(val, range) {

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -486,7 +486,7 @@ test_ui("test_check_overflow_text", () => {
     );
     assert.ok($send_button.prop("disabled"));
 
-    $("#compose-send-status").stop = () => ({fadeOut: () => {}});
+    $("#compose-send-status").stop = () => ({fadeOut() {}});
 
     // Indicator should show orange colored text
     $textarea.val("a".repeat(9000 + 1));

--- a/frontend_tests/node_tests/compose_video.js
+++ b/frontend_tests/node_tests/compose_video.js
@@ -16,7 +16,7 @@ mock_esm("../../static/js/resize", {
     watch_manual_resize() {},
 });
 set_global("document", {
-    querySelector: () => {},
+    querySelector() {},
 });
 set_global("navigator", {});
 set_global(
@@ -82,8 +82,8 @@ test("videos", ({override}) => {
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault: () => {},
-            stopPropagation: () => {},
+            preventDefault() {},
+            stopPropagation() {},
             target: {
                 to_$: () => $textarea,
             },
@@ -106,8 +106,8 @@ test("videos", ({override}) => {
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault: () => {},
-            stopPropagation: () => {},
+            preventDefault() {},
+            stopPropagation() {},
             target: {
                 to_$: () => $textarea,
             },
@@ -144,8 +144,8 @@ test("videos", ({override}) => {
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault: () => {},
-            stopPropagation: () => {},
+            preventDefault() {},
+            stopPropagation() {},
             target: {
                 to_$: () => $textarea,
             },
@@ -173,7 +173,7 @@ test("videos", ({override}) => {
         channel.post = (payload) => {
             assert.equal(payload.url, "/json/calls/zoom/create");
             payload.success({url: "example.zoom.com"});
-            return {abort: () => {}};
+            return {abort() {}};
         };
 
         handler(ev);
@@ -190,8 +190,8 @@ test("videos", ({override}) => {
         $textarea.set_parents_result(".message_edit_form", []);
 
         const ev = {
-            preventDefault: () => {},
-            stopPropagation: () => {},
+            preventDefault() {},
+            stopPropagation() {},
             target: {
                 to_$: () => $textarea,
             },

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -41,15 +41,15 @@ let tippy_args;
 let tippy_show_called;
 let tippy_destroy_called;
 mock_esm("tippy.js", {
-    default: (sel, opts) => {
+    default(sel, opts) {
         assert.equal(sel, tippy_sel);
         assert.deepEqual(opts, tippy_args);
         return [
             {
-                show: () => {
+                show() {
                     tippy_show_called = true;
                 },
-                destroy: () => {
+                destroy() {
                     tippy_destroy_called = true;
                 },
             },

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -14,7 +14,7 @@ mock_esm("../../static/js/list_widget", {
 });
 
 mock_esm("tippy.js", {
-    default: (arg) => {
+    default(arg) {
         arg._tippy = {setContent: noop, placement: noop, destroy: noop};
         return arg._tippy;
     },
@@ -39,7 +39,7 @@ run_test("basic_functions", () => {
         widget_name: "my_setting",
         data: ["one", "two", "three"].map((x) => ({name: x, value: x})),
         value: "one",
-        on_update: (val) => {
+        on_update(val) {
             updated_value = val;
         },
         default_text: $t({defaultMessage: "not set"}),
@@ -106,7 +106,7 @@ run_test("basic MDLW functions", () => {
         data: ["one", "two", "three", "four"].map((x) => ({name: x, value: x})),
         value: ["one"],
         limit: 2,
-        on_update: (val) => {
+        on_update(val) {
             updated_value = val;
         },
         default_text: $t({defaultMessage: "not set"}),

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -16,11 +16,11 @@ const notifications = mock_esm("../../static/js/notifications");
 let disparities = [];
 
 mock_esm("../../static/js/ui", {
-    show_failed_message_success: () => {},
+    show_failed_message_success() {},
 });
 
 mock_esm("../../static/js/sent_messages", {
-    mark_disparity: (local_id) => {
+    mark_disparity(local_id) {
         disparities.push(local_id);
     },
 });
@@ -28,9 +28,9 @@ mock_esm("../../static/js/sent_messages", {
 const message_store = mock_esm("../../static/js/message_store", {
     get: () => ({failed_request: true}),
 
-    update_booleans: () => {},
+    update_booleans() {},
 
-    set_message_booleans: () => {},
+    set_message_booleans() {},
 });
 
 const noop = () => {};

--- a/frontend_tests/node_tests/event_status.js
+++ b/frontend_tests/node_tests/event_status.js
@@ -17,7 +17,7 @@ run_test("initialize_retry_with_another_card_link_click_handler", ({override}) =
         assert.equal(method, "POST");
         set_global("window", {
             location: {
-                replace: (new_location) => {
+                replace(new_location) {
                     assert.equal(new_location, "stripe_session_url");
                 },
             },
@@ -26,7 +26,7 @@ run_test("initialize_retry_with_another_card_link_click_handler", ({override}) =
     });
     event_status.initialize_retry_with_another_card_link_click_handler();
     const retry_click_handler = $("#retry-with-another-card-link").get_on_handler("click");
-    retry_click_handler({preventDefault: () => {}});
+    retry_click_handler({preventDefault() {}});
 });
 
 run_test("check_status", async ({override}) => {
@@ -77,7 +77,7 @@ run_test("check_status", async ({override}) => {
     });
     set_global("window", {
         location: {
-            replace: (new_location) => {
+            replace(new_location) {
                 assert.equal(
                     new_location,
                     "/billing/event_status?stripe_payment_intent_id=spid_1A",
@@ -108,7 +108,7 @@ run_test("check_status", async ({override}) => {
     });
     set_global("window", {
         location: {
-            replace: (new_location) => {
+            replace(new_location) {
                 assert.equal(
                     new_location,
                     "/billing/event_status?stripe_payment_intent_id=spid_1B",
@@ -138,7 +138,7 @@ run_test("check_status", async ({override}) => {
     });
     set_global("window", {
         location: {
-            replace: (new_location) => {
+            replace(new_location) {
                 assert.equal(new_location, "/billing");
             },
         },
@@ -165,7 +165,7 @@ run_test("check_status", async ({override}) => {
     });
     set_global("window", {
         location: {
-            replace: (new_location) => {
+            replace(new_location) {
                 assert.equal(new_location, "/billing?onboarding=true");
             },
         },
@@ -192,7 +192,7 @@ run_test("check_status", async ({override}) => {
     });
     set_global("window", {
         location: {
-            replace: (new_location) => {
+            replace(new_location) {
                 assert.equal(new_location, "/billing#payment-method");
             },
         },
@@ -300,7 +300,7 @@ run_test("check_status", async ({override}) => {
     });
     set_global("window", {
         location: {
-            replace: (new_location) => {
+            replace(new_location) {
                 assert.equal(new_location, "/billing/");
             },
         },

--- a/frontend_tests/node_tests/example5.js
+++ b/frontend_tests/node_tests/example5.js
@@ -63,7 +63,7 @@ function test_helper({override}) {
     const events = [];
 
     return {
-        redirect: (module, func_name) => {
+        redirect(module, func_name) {
             override(module, func_name, () => {
                 events.push([module, func_name]);
             });

--- a/frontend_tests/node_tests/fetch_status.js
+++ b/frontend_tests/node_tests/fetch_status.js
@@ -6,11 +6,11 @@ const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 
 mock_esm("../../static/js/message_scroll", {
-    hide_loading_older: () => {},
+    hide_loading_older() {},
 
-    show_loading_older: () => {},
-    hide_loading_newer: () => {},
-    show_loading_newer: () => {},
+    show_loading_older() {},
+    hide_loading_newer() {},
+    show_loading_newer() {},
 });
 
 const {FetchStatus} = zrequire("fetch_status");

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -12,7 +12,7 @@ let $window_stub;
 set_global("to_$", () => $window_stub);
 
 mock_esm("../../static/js/search", {
-    update_button_visibility: () => {},
+    update_button_visibility() {},
 });
 set_global("document", "document-stub");
 const history = set_global("history", {});
@@ -30,7 +30,7 @@ const stream_settings_ui = mock_esm("../../static/js/stream_settings_ui");
 const ui_util = mock_esm("../../static/js/ui_util");
 const ui_report = mock_esm("../../static/js/ui_report");
 mock_esm("../../static/js/top_left_corner", {
-    handle_narrow_deactivated: () => {},
+    handle_narrow_deactivated() {},
 });
 set_global("favicon", {});
 
@@ -152,10 +152,10 @@ function test_helper({override, change_tab}) {
     }
 
     return {
-        clear_events: () => {
+        clear_events() {
             events = [];
         },
-        assert_events: (expected_events) => {
+        assert_events(expected_events) {
             assert.deepEqual(events, expected_events);
         },
         get_narrow_terms: () => narrow_terms,

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -168,7 +168,7 @@ run_test("copy from pill", ({mock_template}) => {
     const e = {
         originalEvent: {
             clipboardData: {
-                setData: (format, text) => {
+                setData(format, text) {
                     assert.equal(format, "text/plain");
                     copied_text = text;
                 },
@@ -204,7 +204,7 @@ run_test("paste to input", ({mock_template}) => {
     const e = {
         originalEvent: {
             clipboardData: {
-                getData: (format) => {
+                getData(format) {
                     assert.equal(format, "text/plain");
                     return paste_text;
                 },
@@ -257,14 +257,14 @@ run_test("arrows on pills", ({mock_template}) => {
 
     const $pill_stub = {
         prev: () => ({
-            trigger: (type) => {
+            trigger(type) {
                 if (type === "focus") {
                     prev_focused = true;
                 }
             },
         }),
         next: () => ({
-            trigger: (type) => {
+            trigger(type) {
                 if (type === "focus") {
                     next_focused = true;
                 }
@@ -303,7 +303,7 @@ run_test("left arrow on input", ({mock_template}) => {
 
     $container.set_find_results(".pill", {
         last: () => ({
-            trigger: (type) => {
+            trigger(type) {
                 if (type === "focus") {
                     last_pill_focused = true;
                 }
@@ -469,7 +469,7 @@ run_test("insert_remove", ({mock_template}) => {
     let next_pill_focused = false;
 
     const $next_pill_stub = {
-        trigger: (type) => {
+        trigger(type) {
             if (type === "focus") {
                 next_pill_focused = true;
             }
@@ -520,7 +520,7 @@ run_test("exit button on pill", ({mock_template}) => {
     let next_pill_focused = false;
 
     const $next_pill_stub = {
-        trigger: (type) => {
+        trigger(type) {
             if (type === "focus") {
                 next_pill_focused = true;
             }
@@ -534,7 +534,7 @@ run_test("exit button on pill", ({mock_template}) => {
 
     const exit_button_stub = {
         to_$: () => ({
-            closest: (sel) => {
+            closest(sel) {
                 assert.equal(sel, ".pill");
                 return $curr_pill_stub;
             },
@@ -569,7 +569,7 @@ run_test("misc things", () => {
 
     const input_stub = {
         to_$: () => ({
-            removeClass: (cls) => {
+            removeClass(cls) {
                 assert.equal(cls, "shake");
                 shake_class_removed = true;
             },

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -13,7 +13,8 @@ run_test("test_early_returns", () => {
     const opts = {
         $elem: $stub,
         handlers: {
-            ArrowLeft: /* istanbul ignore next */ () => {
+            /* istanbul ignore next */
+            ArrowLeft() {
                 throw new Error("do not dispatch this with alt key");
             },
         },

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -8,13 +8,13 @@ const $ = require("../zjsunit/zjquery");
 
 set_global("Image", class Image {});
 mock_esm("../../static/js/overlays", {
-    close_overlay: () => {},
+    close_overlay() {},
 
-    close_active: () => {},
-    open_overlay: () => {},
+    close_active() {},
+    open_overlay() {},
 });
 mock_esm("../../static/js/popovers", {
-    hide_all: () => {},
+    hide_all() {},
 });
 const rows = mock_esm("../../static/js/rows");
 

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -17,7 +17,7 @@ run_test("config errors", () => {
 function basic_conf({first_key, prev_key, next_key}) {
     const list = {
         scroll_container_sel: "whatever",
-        find_li: () => {},
+        find_li() {},
         first_key,
         prev_key,
         next_key,
@@ -72,7 +72,7 @@ run_test("single item list", ({override}) => {
 
     const $li_stub = {
         length: 1,
-        addClass: () => {},
+        addClass() {},
     };
 
     override(conf.list, "find_li", () => $li_stub);

--- a/frontend_tests/node_tests/list_widget.js
+++ b/frontend_tests/node_tests/list_widget.js
@@ -25,7 +25,7 @@ mock_jquery((arg) => {
         addClass() {
             return this;
         },
-        replace: (regex, string) => {
+        replace(regex, string) {
             arg = arg.replace(regex, string);
         },
         html: () => arg,
@@ -285,7 +285,7 @@ run_test("no filtering", () => {
     const opts = {
         modifier: (item) => div(item),
         $simplebar_container: $scroll_container,
-        callback_after_render: () => {
+        callback_after_render() {
             callback_called = true;
         },
     };
@@ -329,15 +329,15 @@ function sort_button(opts) {
         closest: lookup(".progressive-table-wrapper", {
             data: lookup("list-widget", opts.list_name),
         }),
-        addClass: (cls) => {
+        addClass(cls) {
             classList.add(cls);
         },
         hasClass: (cls) => classList.has(cls),
-        removeClass: (cls) => {
+        removeClass(cls) {
             classList.delete(cls);
         },
         siblings: lookup(".active", {
-            removeClass: (cls) => {
+            removeClass(cls) {
                 assert.equal(cls, "active");
                 $button.siblings_deactivated = true;
             },
@@ -528,7 +528,7 @@ run_test("clear_event_handlers", () => {
     const opts = {
         name: "list-we-create-twice",
         $parent_container: $sort_container,
-        modifier: () => {},
+        modifier() {},
         filter: {
             $element: $filter_element,
             predicate: /* istanbul ignore next */ () => true,
@@ -640,7 +640,7 @@ run_test("replace_list_data w/filter update", () => {
         modifier: (n) => "(" + n.toString() + ")",
         filter: {
             predicate: (n) => n % 2 === 0,
-            onupdate: () => {
+            onupdate() {
                 num_updates += 1;
             },
         },
@@ -722,7 +722,7 @@ run_test("render item", () => {
             // Return a JQuery stub for the original HTML.
             // We want this to be called when we replace
             // the existing HTML with newly rendered HTML.
-            replaceWith: (html) => {
+            replaceWith(html) {
                 assert.equal(new_html, html);
                 called = true;
                 $container.$appended_data.replace(regex, new_html);
@@ -786,7 +786,7 @@ run_test("render item", () => {
     const widget_2 = ListWidget.create($container, list, {
         name: "replace-list",
         modifier: (item) => `<tr data-item=${item.value}>${item.text}</tr>\n`,
-        get_item: (item) => {
+        get_item(item) {
             get_item_called = true;
             return item;
         },

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -844,7 +844,7 @@ test("missing unicode emojis", ({override}) => {
 test("katex_throws_unexpected_exceptions", ({override_rewire}) => {
     const message = {raw_content: "$$a$$"};
     override_rewire(markdown, "katex", {
-        renderToString: () => {
+        renderToString() {
             throw new Error("some-exception");
         },
     });

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -38,14 +38,14 @@ const message_helper = mock_esm("../../static/js/message_helper");
 const message_lists = mock_esm("../../static/js/message_lists");
 const message_util = mock_esm("../../static/js/message_util");
 const stream_list = mock_esm("../../static/js/stream_list", {
-    maybe_scroll_narrow_into_view: () => {},
+    maybe_scroll_narrow_into_view() {},
 });
 mock_esm("../../static/js/message_scroll", {
     show_loading_older: noop,
     hide_loading_older: noop,
     show_loading_newer: noop,
     hide_loading_newer: noop,
-    update_top_of_narrow_notices: () => {},
+    update_top_of_narrow_notices() {},
 });
 set_global("document", "document-stub");
 

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -9,9 +9,9 @@ const channel = mock_esm("../../static/js/channel");
 const ui = mock_esm("../../static/js/ui");
 
 mock_esm("../../static/js/starred_messages", {
-    add: () => {},
+    add() {},
     get_starred_msg_ids: () => [1, 2, 3, 4, 5],
-    remove: () => {},
+    remove() {},
 });
 
 const message_flags = zrequire("message_flags");

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -19,7 +19,7 @@ const settings_config = zrequire("settings_config");
 
 const compose_pm_pill = mock_esm("../../static/js/compose_pm_pill");
 mock_esm("../../static/js/spectators", {
-    login_to_access: () => {},
+    login_to_access() {},
 });
 
 function empty_narrow_html(title, html, search_data) {

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -7,7 +7,7 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
 mock_esm("../../static/js/resize", {
-    resize_stream_filters_container: () => {},
+    resize_stream_filters_container() {},
 });
 
 const all_messages_data = mock_esm("../../static/js/all_messages_data");
@@ -38,7 +38,7 @@ const typing_events = mock_esm("../../static/js/typing_events");
 const ui_util = mock_esm("../../static/js/ui_util");
 const unread_ops = mock_esm("../../static/js/unread_ops");
 mock_esm("../../static/js/recent_topics_util", {
-    is_visible: () => {},
+    is_visible() {},
 });
 
 //
@@ -98,13 +98,13 @@ function test_helper() {
     $("#mark_as_read_turned_off_banner").toggleClass = () => {};
 
     return {
-        clear: () => {
+        clear() {
             events = [];
         },
-        push_event: (event) => {
+        push_event(event) {
             events.push(event);
         },
-        assert_events: (expected_events) => {
+        assert_events(expected_events) {
             assert.deepEqual(events, expected_events);
         },
     };

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -44,15 +44,15 @@ function test_with(fixture) {
             has_found_newest: () => fixture.has_found_newest,
         },
         empty: () => fixture.empty,
-        all_messages: () => {
+        all_messages() {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages;
         },
-        first: () => {
+        first() {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages[0];
         },
-        last: () => {
+        last() {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages.at(-1);
         },

--- a/frontend_tests/node_tests/pm_list_data.js
+++ b/frontend_tests/node_tests/pm_list_data.js
@@ -199,7 +199,7 @@ test("get_active_user_ids_string", () => {
 
     function set_filter_result(emails) {
         const active_filter = {
-            operands: (operand) => {
+            operands(operand) {
                 assert.equal(operand, "pm-with");
                 return emails;
             },
@@ -216,7 +216,7 @@ test("get_active_user_ids_string", () => {
 
 function private_filter() {
     return {
-        operands: (operand) => {
+        operands(operand) {
             assert.equal(operand, "is");
             return ["private", "starred"];
         },
@@ -247,7 +247,7 @@ test("get_list_info", ({override}) => {
     // Filter` rather than creating a mock.
     function set_filter_result(emails) {
         const active_filter = {
-            operands: (operand) => {
+            operands(operand) {
                 assert.equal(operand, "pm-with");
                 return emails;
             },

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -42,7 +42,7 @@ let expected_data_to_replace_in_list_widget;
 const ListWidget = mock_esm("../../static/js/list_widget", {
     modifier: noop,
 
-    create: (container, mapped_topic_values, opts) => {
+    create(container, mapped_topic_values, opts) {
         const formatted_topics = [];
         ListWidget.modifier = opts.modifier;
         for (const item of mapped_topic_values) {
@@ -64,7 +64,7 @@ const ListWidget = mock_esm("../../static/js/list_widget", {
 
     hard_redraw: noop,
     filter_and_sort: noop,
-    replace_list_data: (data) => {
+    replace_list_data(data) {
         assert.notEqual(
             expected_data_to_replace_in_list_widget,
             undefined,
@@ -94,7 +94,7 @@ mock_esm("../../static/js/message_view_header", {
     render_title_area: noop,
 });
 mock_esm("../../static/js/user_topics", {
-    is_topic_muted: (stream_id, topic) => {
+    is_topic_muted(stream_id, topic) {
         if (stream_id === stream1 && topic === topic7) {
             return true;
         }
@@ -128,7 +128,7 @@ mock_esm("../../static/js/timerender", {
     get_full_datetime: () => "date at time",
 });
 mock_esm("../../static/js/sub_store", {
-    get: (stream) => {
+    get(stream) {
         if (stream === stream5) {
             // No data is available for deactivated streams
             return undefined;
@@ -146,7 +146,7 @@ mock_esm("../../static/js/top_left_corner", {
     narrow_to_recent_topics: noop,
 });
 mock_esm("../../static/js/unread", {
-    num_unread_for_topic: (stream_id, topic) => {
+    num_unread_for_topic(stream_id, topic) {
         if (stream_id === 1 && topic === "topic-1") {
             return 0;
         }

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -368,7 +368,7 @@ function assert_clipboard_setup() {
     assert.equal(clipboard_args[0], "copy-code-stub");
     const text = clipboard_args[1].text({
         to_$: () => ({
-            siblings: (arg) => {
+            siblings(arg) {
                 assert.equal(arg, "code");
                 return {
                     text: () => "text",

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -47,7 +47,7 @@ const custom_profile_field_types = {
 
 page_params.custom_profile_field_types = custom_profile_field_types;
 
-mock_esm("sortablejs", {Sortable: {create: () => {}}});
+mock_esm("sortablejs", {Sortable: {create() {}}});
 
 const settings_profile_fields = zrequire("settings_profile_fields");
 

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -26,10 +26,10 @@ const message_view_header = mock_esm("../../static/js/message_view_header", {
     maybe_rerender_title_area_for_stream() {},
 });
 mock_esm("../../static/js/recent_topics_ui", {
-    complete_rerender: () => {},
+    complete_rerender() {},
 });
 mock_esm("../../static/js/settings_notifications", {
-    update_page: () => {},
+    update_page() {},
 });
 
 mock_esm("../../static/js/overlays", {streams_open: () => true});

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -379,7 +379,7 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     mock_template("filter_topics", false, () => "filter-topics-stub");
     let filter_topics_appended = false;
     $stream_li1.children = () => ({
-        append: (html) => {
+        append(html) {
             assert.equal(html, "filter-topics-stub");
             filter_topics_appended = true;
         },

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -30,10 +30,10 @@ function make_cursor_helper() {
     const events = [];
 
     stream_list.__Rewire__("stream_cursor", {
-        reset: () => {
+        reset() {
             events.push("reset");
         },
-        clear: () => {
+        clear() {
             events.push("clear");
         },
     });

--- a/frontend_tests/node_tests/stream_settings_ui.js
+++ b/frontend_tests/node_tests/stream_settings_ui.js
@@ -13,7 +13,7 @@ const ui = mock_esm("../../static/js/ui", {
 });
 
 mock_esm("../../static/js/hash_util", {
-    by_stream_url: () => {},
+    by_stream_url() {},
     get_current_hash_section: () => denmark_stream_id,
 });
 

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -27,12 +27,12 @@ run_test("scrub_realm", () => {
 
     let submit_form_called = false;
     $fake_this.form = {
-        submit: () => {
+        submit() {
             submit_form_called = true;
         },
     };
     const event = {
-        preventDefault: () => {},
+        preventDefault() {},
     };
 
     window.prompt = () => "zulip";

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -7,7 +7,7 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 
 mock_esm("../../static/js/resize", {
-    resize_stream_filters_container: () => {},
+    resize_stream_filters_container() {},
 });
 
 const {Filter} = zrequire("../js/filter");

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -195,10 +195,10 @@ test("upload_files", ({override, override_rewire}) => {
     ];
     let uppy_add_file_called = false;
     const uppy = {
-        cancelAll: () => {
+        cancelAll() {
             uppy_cancel_all_called = true;
         },
-        addFile: (params) => {
+        addFile(params) {
             uppy_add_file_called = true;
             assert.equal(params.source, "compose-file-input");
             assert.equal(params.name, "budapest.png");
@@ -325,11 +325,11 @@ test("uppy_config", () => {
         assert.ok("exceedsSize" in config.locale.strings);
 
         return {
-            setMeta: (params) => {
+            setMeta(params) {
                 uppy_set_meta_called = true;
                 assert.equal(params.csrfmiddlewaretoken, "csrf_token");
             },
-            use: (func, params) => {
+            use(func, params) {
                 const func_name = func.name;
                 if (func_name === "XHRUpload") {
                     uppy_used_xhrupload = true;
@@ -348,7 +348,7 @@ test("uppy_config", () => {
                     assert.fail(`Missing tests for ${func_name}`);
                 }
             },
-            on: () => {},
+            on() {},
         };
     };
     upload.setup_upload({mode: "compose"});
@@ -385,7 +385,7 @@ test("file_drop", ({override_rewire}) => {
 
     let prevent_default_counter = 0;
     const drag_event = {
-        preventDefault: () => {
+        preventDefault() {
             prevent_default_counter += 1;
         },
     };
@@ -399,7 +399,7 @@ test("file_drop", ({override_rewire}) => {
 
     const files = ["file1", "file2"];
     const drop_event = {
-        preventDefault: () => {
+        preventDefault() {
             prevent_default_counter += 1;
         },
         originalEvent: {
@@ -429,7 +429,7 @@ test("copy_paste", ({override_rewire}) => {
                 items: [
                     {
                         kind: "file",
-                        getAsFile: () => {
+                        getAsFile() {
                             get_as_file_called = true;
                         },
                     },
@@ -465,16 +465,16 @@ test("uppy_events", ({override, override_rewire}) => {
 
     uppy_stub = function () {
         return {
-            setMeta: () => {},
-            use: () => {},
-            cancelAll: () => {
+            setMeta() {},
+            use() {},
+            cancelAll() {
                 uppy_cancel_all_called = true;
             },
-            on: (event_name, callback) => {
+            on(event_name, callback) {
                 callbacks[event_name] = callback;
             },
             getFiles: () => [...files],
-            removeFile: (file_id) => {
+            removeFile(file_id) {
                 files = files.filter((file) => file.id !== file_id);
             },
             getState: () => ({

--- a/frontend_tests/node_tests/user_search.js
+++ b/frontend_tests/node_tests/user_search.js
@@ -15,10 +15,10 @@ const _document = {
 
 const fake_buddy_list = {
     scroll_container_sel: "#whatever",
-    find_li: () => {},
-    first_key: () => {},
-    prev_key: () => {},
-    next_key: () => {},
+    find_li() {},
+    first_key() {},
+    prev_key() {},
+    next_key() {},
 };
 
 mock_esm("../../static/js/buddy_list", {

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -129,7 +129,7 @@ run_test("server", () => {
 
     user_status.server_update_status({
         status_text: "out to lunch",
-        success: () => {
+        success() {
             called = true;
         },
     });

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -71,13 +71,13 @@ run_test("attribute updates", () => {
         return {
             children: () => [],
 
-            attr: (k, v) => {
+            attr(k, v) {
                 assert.equal(k, "color");
                 assert.equal(v, "red");
                 updated = true;
             },
 
-            removeAttr: (k) => {
+            removeAttr(k) {
                 assert.equal(k, "id");
                 removed = true;
             },
@@ -184,10 +184,10 @@ run_test("partial updates", () => {
 
     find = () => ({
         children: () => ({
-            eq: (i) => {
+            eq(i) {
                 assert.equal(i, 0);
                 return {
-                    replaceWith: (html) => {
+                    replaceWith(html) {
                         patched_html = html;
                     },
                 };

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -90,7 +90,7 @@ test("activate", ({override}) => {
         message: {
             id: 2001,
         },
-        post_to_server: (data) => {
+        post_to_server(data) {
             assert.equal(data.msg_type, "widget");
             assert.equal(data.data, "test_data");
         },

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -46,7 +46,7 @@ assert.notEqual(files.length, 0, "No tests found");
 
 // Set up our namespace helpers.
 const window = new Proxy(global, {
-    set: (obj, prop, value) => {
+    set(obj, prop, value) {
         namespace.set_global(prop, value);
         return true;
     },

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -51,7 +51,7 @@ function make_zjquery() {
         // that you'd find on a "real" jQuery object.  Sometimes we
         // expects devs to create their own stubs.
         const handler = {
-            get: (target, key) => {
+            get(target, key) {
                 // Handle the special case of equality checks, which
                 // we can infer by assert.equal trying to access the
                 // "stack" key.

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -614,13 +614,13 @@ export function initialize() {
             arrow: true,
             placement,
             showOnCreate: true,
-            onHidden: (instance) => {
+            onHidden(instance) {
                 instance.destroy();
                 if (is_custom_observer_needed) {
                     observer.disconnect();
                 }
             },
-            onShow: (instance) => {
+            onShow(instance) {
                 if (!is_custom_observer_needed) {
                     return;
                 }

--- a/static/js/deprecated_feature_notice.js
+++ b/static/js/deprecated_feature_notice.js
@@ -44,7 +44,7 @@ export function maybe_show_deprecation_notice(key) {
             html_heading: $t_html({defaultMessage: "Deprecation notice"}),
             html_body: message,
             html_submit_button: $t_html({defaultMessage: "Got it"}),
-            on_click: () => {},
+            on_click() {},
             close_on_submit: true,
             focus_submit_on_open: true,
             single_footer_button: true,

--- a/static/js/dialog_widget.js
+++ b/static/js/dialog_widget.js
@@ -153,7 +153,7 @@ export function launch(conf) {
 
     overlays.open_modal("dialog_widget_modal", {
         autoremove: true,
-        on_show: () => {
+        on_show() {
             if (conf.focus_submit_on_open) {
                 $submit_button.trigger("focus");
             }

--- a/static/js/flatpickr.js
+++ b/static/js/flatpickr.js
@@ -30,7 +30,7 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
         formatDate: (date) => formatISO(date),
         disableMobile: true,
         time_24hr: user_settings.twenty_four_hour_time,
-        onKeyDown: (selectedDates, dateStr, instance, event) => {
+        onKeyDown(selectedDates, dateStr, instance, event) {
             if (is_numeric_key(event.key)) {
                 // Don't attempt to get_keydown_hotkey for numeric inputs
                 // as it would return undefined.

--- a/static/js/giphy.js
+++ b/static/js/giphy.js
@@ -101,7 +101,7 @@ async function renderGIPHYGrid(targetEl) {
                 // Hide the creator attribution that appears over a
                 // GIF; nice in principle but too distracting.
                 hideAttribution: true,
-                onGifClick: (props) => {
+                onGifClick(props) {
                     let $textarea = $("#compose-textarea");
                     if (edit_message_id !== undefined) {
                         $textarea = $(
@@ -115,7 +115,7 @@ async function renderGIPHYGrid(targetEl) {
                     );
                     hide_giphy_popover();
                 },
-                onGifVisible: (gif, e) => {
+                onGifVisible(gif, e) {
                     // Set tabindex for all the GIFs that
                     // are visible to the user. This allows
                     // user to navigate the GIFs using tab.
@@ -134,7 +134,7 @@ async function renderGIPHYGrid(targetEl) {
     window.addEventListener("resize", resizeRender, false);
     const remove = render();
     return {
-        remove: () => {
+        remove() {
             remove();
             window.removeEventListener("resize", resizeRender, false);
         },

--- a/static/js/i18n.ts
+++ b/static/js/i18n.ts
@@ -14,7 +14,8 @@ export const intl = createIntl(
         locale: page_params.request_language,
         defaultLocale: "en",
         messages: page_params.translation_data,
-        onError: /* istanbul ignore next */ (error) => {
+        /* istanbul ignore next */
+        onError(error) {
             // Ignore complaints about untranslated strings that were
             // added since the last sync-translations run.
             if (error.code !== IntlErrorCode.MISSING_TRANSLATION) {

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -153,11 +153,11 @@ export function show_history(message) {
         html_body: rendered_message_history,
         html_submit_button: $t_html({defaultMessage: "Close"}),
         id: "message-edit-history",
-        on_click: () => {},
+        on_click() {},
         close_on_submit: true,
         focus_submit_on_open: true,
         single_footer_button: true,
-        post_render: () => {
+        post_render() {
             fetch_and_render_message_history(message);
         },
     });

--- a/static/js/read_receipts.js
+++ b/static/js/read_receipts.js
@@ -17,7 +17,7 @@ export function show_user_list(message_id) {
     $("body").append(render_read_receipts_modal());
     overlays.open_modal("read_receipts_modal", {
         autoremove: true,
-        on_show: () => {
+        on_show() {
             const message = message_store.get(message_id);
             if (message.sender_email === "notification-bot@zulip.com") {
                 $("#read_receipts_modal .read_receipts_info").text(
@@ -79,7 +79,7 @@ export function show_user_list(message_id) {
                 });
             }
         },
-        on_hide: () => {
+        on_hide() {
             // Ensure any user info popovers are closed
             popovers.hide_all();
         },

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -438,7 +438,7 @@ export function set_up() {
         $("#api_key_status").hide();
         overlays.open_modal("api_key_modal", {
             autoremove: true,
-            on_show: () => {
+            on_show() {
                 $("#get_api_key_password").trigger("focus");
             },
         });
@@ -658,7 +658,7 @@ export function set_up() {
                 form_id: "change_email_container",
                 on_click: do_change_email,
                 post_render: change_email_post_render,
-                on_shown: () => {
+                on_shown() {
                     $("#change_email_container input").trigger("focus");
                 },
             });

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -144,7 +144,7 @@ export function launch_default_language_setting_modal() {
         focus_submit_on_open: true,
         single_footer_button: true,
         post_render: default_language_modal_post_render,
-        on_click: () => {},
+        on_click() {},
     });
 }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -887,7 +887,7 @@ export function init_dropdown_widgets() {
             name: x.name,
             value: x.stream_id.toString(),
         })),
-        on_update: () => {
+        on_update() {
             save_discard_widget_status_handler($("#org-notifications"));
         },
         default_text: $t({defaultMessage: "Disabled"}),
@@ -913,7 +913,7 @@ export function init_dropdown_widgets() {
             value: x,
         })),
         value: page_params.realm_default_code_block_language,
-        on_update: () => {
+        on_update() {
             save_discard_widget_status_handler($("#org-other-settings"));
         },
         default_text: $t({defaultMessage: "No language set"}),

--- a/static/js/settings_realm_domains.js
+++ b/static/js/settings_realm_domains.js
@@ -142,11 +142,11 @@ export function show_realm_domains_modal() {
         html_body: realm_domains_table_body,
         html_submit_button: $t_html({defaultMessage: "Close"}),
         id: "realm_domains_modal",
-        on_click: () => {},
+        on_click() {},
         close_on_submit: true,
         focus_submit_on_open: true,
         single_footer_button: true,
-        post_render: () => {
+        post_render() {
             setup_realm_domains_modal_handlers();
             populate_realm_domains_table(page_params.realm_domains);
         },

--- a/static/js/spectators.js
+++ b/static/js/spectators.js
@@ -31,7 +31,7 @@ export function login_to_access(empty_narrow) {
 
     overlays.open_modal("login_to_access_modal", {
         autoremove: true,
-        on_hide: () => {
+        on_hide() {
             browser_history.return_to_web_public_hash();
         },
     });

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -372,7 +372,7 @@ export function set_up_handlers() {
             confirm_dialog.launch({
                 html_heading: $t_html({defaultMessage: "Large number of subscribers"}),
                 html_body,
-                on_click: () => {
+                on_click() {
                     create_stream();
                 },
             });

--- a/static/js/stream_create_subscribers.js
+++ b/static/js/stream_create_subscribers.js
@@ -105,7 +105,7 @@ export function build_widgets() {
             },
         },
         $simplebar_container,
-        html_selector: (user_id) => {
+        html_selector(user_id) {
             const user = people.get_by_user_id(user_id);
             return $(`#${CSS.escape("user_checkbox_" + user.user_id)}`);
         },

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -527,7 +527,7 @@ export function initialize() {
             close_on_submit: true,
             id: "stream_privacy_modal",
             on_click: change_stream_privacy,
-            post_render: () => {
+            post_render() {
                 $("#stream_privacy_modal .dialog_submit_button").attr("data-stream-id", stream_id);
                 set_stream_message_retention_setting_dropdown(stream);
 
@@ -536,7 +536,7 @@ export function initialize() {
                     change_stream_message_retention_days_block_display_property(dropdown_value);
                 });
             },
-            on_show: () => {
+            on_show() {
                 stream_settings_ui.hide_or_disable_stream_privacy_options_if_required(
                     $("#stream_privacy_modal"),
                 );
@@ -564,7 +564,7 @@ export function initialize() {
             html_body: change_stream_info_modal,
             id: "change_stream_info_modal",
             on_click: save_stream_info,
-            post_render: () => {
+            post_render() {
                 $("#change_stream_info_modal .dialog_submit_button")
                     .addClass("save-button")
                     .attr("data-stream-id", stream_id);
@@ -646,7 +646,7 @@ export function initialize() {
             id: "copy_email_address_modal",
             html_submit_button: $t_html({defaultMessage: "Copy address"}),
             help_link: "/help/message-a-stream-by-email#configuration-options",
-            on_click: () => {},
+            on_click() {},
             close_on_submit: true,
         });
         $("#show-sender").prop("checked", true);

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -837,7 +837,7 @@ export function register_topic_handlers() {
             html_heading: $t_html({defaultMessage: "Delete topic"}),
             help_link: "/help/delete-a-topic",
             html_body,
-            on_click: () => {
+            on_click() {
                 message_edit.delete_topic(stream_id, topic);
             },
         });

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -118,7 +118,7 @@ export class TaskData {
         },
 
         strike: {
-            outbound: (key) => {
+            outbound(key) {
                 const event = {
                     type: "strike",
                     key,

--- a/static/js/user_group_create_members.js
+++ b/static/js/user_group_create_members.js
@@ -113,7 +113,7 @@ export function build_widgets() {
             },
         },
         $simplebar_container,
-        html_selector: (user_id) => {
+        html_selector(user_id) {
             const user = people.get_by_user_id(user_id);
             return $(`#${CSS.escape("user_checkbox_" + user.user_id)}`);
         },

--- a/static/js/user_group_edit.js
+++ b/static/js/user_group_edit.js
@@ -150,7 +150,7 @@ export function initialize() {
             html_body: change_user_group_info_modal,
             id: "change_group_info_modal",
             on_click: save_group_info,
-            post_render: () => {
+            post_render() {
                 $("#change_group_info_modal .dialog_submit_button")
                     .addClass("save-button")
                     .attr("data-group-id", user_group_id);

--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -40,7 +40,7 @@ export function open_user_status_modal() {
         id: "set_user_status_modal",
         on_click: submit_new_status,
         post_render: user_status_post_render,
-        on_shown: () => {
+        on_shown() {
             input_field().trigger("focus");
         },
     });


### PR DESCRIPTION
This is equivalent in the absence of `this` (which ESLint knows to check for).

https://eslint.org/docs/latest/rules/object-shorthand