### PR TITLE
compose: Add 2 newlines, not 1, around quoted.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -373,7 +373,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
 
     replaced = false;
     expected_replacement =
-        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting.\n```";
+        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting.\n```\n";
 
     quote_and_reply(opts);
 
@@ -407,7 +407,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
 
     replaced = false;
     expected_replacement =
-        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n````quote\n```\nmultiline code block\nshoudln't mess with quotes\n```\n````";
+        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n````quote\n```\nmultiline code block\nshoudln't mess with quotes\n```\n````\n";
     quote_and_reply(opts);
     assert.ok(replaced);
 });

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -108,7 +108,7 @@ run_test("insert_syntax_and_focus", ({override}) => {
     compose_ui.insert_syntax_and_focus(":octopus:");
 });
 
-run_test("smart_insert", ({override}) => {
+run_test("smart_insert_inline", ({override}) => {
     let $textbox = make_textbox("abc");
     $textbox.caret(4);
     function override_with_expected_syntax(expected_syntax) {
@@ -118,38 +118,60 @@ run_test("smart_insert", ({override}) => {
         });
     }
     override_with_expected_syntax(" :smile: ");
-    compose_ui.smart_insert($textbox, ":smile:");
+    compose_ui.smart_insert_inline($textbox, ":smile:");
 
     override_with_expected_syntax(" :airplane: ");
-    compose_ui.smart_insert($textbox, ":airplane:");
+    compose_ui.smart_insert_inline($textbox, ":airplane:");
 
     $textbox.caret(0);
     override_with_expected_syntax(":octopus: ");
-    compose_ui.smart_insert($textbox, ":octopus:");
+    compose_ui.smart_insert_inline($textbox, ":octopus:");
 
     $textbox.caret($textbox.val().length);
     override_with_expected_syntax(" :heart: ");
-    compose_ui.smart_insert($textbox, ":heart:");
+    compose_ui.smart_insert_inline($textbox, ":heart:");
 
     // Test handling of spaces for ```quote
     $textbox = make_textbox("");
     $textbox.caret(0);
     override_with_expected_syntax("```quote\nquoted message\n```\n");
-    compose_ui.smart_insert($textbox, "```quote\nquoted message\n```\n");
+    compose_ui.smart_insert_inline($textbox, "```quote\nquoted message\n```\n");
 
     $textbox = make_textbox("");
     $textbox.caret(0);
     override_with_expected_syntax("translated: [Quoting…]\n");
-    compose_ui.smart_insert($textbox, "translated: [Quoting…]\n");
+    compose_ui.smart_insert_inline($textbox, "translated: [Quoting…]\n");
 
     $textbox = make_textbox("abc");
     $textbox.caret(3);
     override_with_expected_syntax(" test with space ");
-    compose_ui.smart_insert($textbox, " test with space");
+    compose_ui.smart_insert_inline($textbox, " test with space");
 
     // Note that we don't have any special logic for strings that are
     // already surrounded by spaces, since we are usually inserting things
     // like emojis and file links.
+});
+
+run_test("smart_insert_block", ({override}) => {
+    let $textbox = make_textbox("abc");
+    $textbox.caret(4);
+    function override_with_expected_syntax(expected_syntax) {
+        override(text_field_edit, "insert", (elt, syntax) => {
+            assert.equal(elt, "textarea");
+            assert.equal(syntax, expected_syntax);
+        });
+    }
+
+    // Test handling of spaces for ```quote
+    $textbox = make_textbox("");
+    $textbox.caret(0);
+    override_with_expected_syntax("```quote\nquoted message\n```\n");
+    compose_ui.smart_insert_block($textbox, "```quote\nquoted message\n```\n");
+
+    $textbox = make_textbox("");
+    $textbox.caret(0);
+    override_with_expected_syntax("translated: [Quoting…]\n");
+    compose_ui.smart_insert_block($textbox, "translated: [Quoting…]\n");
 });
 
 run_test("replace_syntax", ({override}) => {
@@ -317,7 +339,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
                 "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n" +
                     "```quote\n" +
                     `${quote_text}\n` +
-                    "```",
+                    "```\n",
             );
         });
     }

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -542,7 +542,7 @@ export function quote_and_reply(opts) {
         // can have other unintended consequences.)
 
         if ($textarea.caret() !== 0) {
-            // Insert a newline before quoted message if there is
+            // Insert 2 newlines before quoted message if there is
             // already some content in the compose box and quoted
             // message is not being inserted at the beginning.
             $textarea.caret("\n");
@@ -551,7 +551,7 @@ export function quote_and_reply(opts) {
         respond_to_message(opts);
     }
 
-    compose_ui.insert_syntax_and_focus(quoting_placeholder + "\n", $textarea);
+    compose_ui.insert_syntax_and_focus(quoting_placeholder + "\n", $textarea, "block");
 
     function replace_content(message) {
         // Final message looks like:
@@ -569,7 +569,7 @@ export function quote_and_reply(opts) {
         );
         content += "\n";
         const fence = fenced_code.get_unused_fence(message.raw_content);
-        content += `${fence}quote\n${message.raw_content}\n${fence}`;
+        content += `${fence}quote\n${message.raw_content}\n${fence}\n`;
 
         const placeholder_offset = $textarea.val().indexOf(quoting_placeholder);
         compose_ui.replace_syntax(quoting_placeholder, content, $textarea);

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -29,11 +29,11 @@ export function autosize_textarea($textarea) {
     }
 }
 
-export function smart_insert($textarea, syntax) {
-    function is_space(c) {
-        return c === " " || c === "\t" || c === "\n";
-    }
+function is_space(c) {
+    return c === " " || c === "\t" || c === "\n";
+}
 
+export function smart_insert_inline($textarea, syntax) {
     const pos = $textarea.caret();
     const before_str = $textarea.val().slice(0, pos);
     const after_str = $textarea.val().slice(pos);
@@ -67,11 +67,39 @@ export function smart_insert($textarea, syntax) {
     autosize_textarea($textarea);
 }
 
-export function insert_syntax_and_focus(syntax, $textarea = $("#compose-textarea")) {
+export function smart_insert_block($textarea, syntax) {
+    function is_newline(c) {
+        return c === "\n" || c === "\r";
+    }
+    const pos = $textarea.caret();
+    const before_str = $textarea.val().slice(0, pos);
+
+    // Replace any number of newlines at the end of the content before
+    // the insert with exactly two newlines.
+    if (pos > 0 && is_newline(before_str.slice(-1))) {
+        $textarea.val(before_str.trimEnd() + "\n\n");
+    }
+
+    // text-field-edit ensures `$textarea` is focused before inserting
+    // the new syntax.
+    insert($textarea[0], syntax);
+
+    autosize_textarea($textarea);
+}
+
+export function insert_syntax_and_focus(
+    syntax,
+    $textarea = $("#compose-textarea"),
+    content_param = "inline",
+) {
     // Generic helper for inserting syntax into the main compose box
     // where the cursor was and focusing the area.  Mostly a thin
-    // wrapper around smart_insert.
-    smart_insert($textarea, syntax);
+    // wrapper around smart_insert_inline & smart_insert_block.
+    if (content_param === "inline") {
+        smart_insert_inline($textarea, syntax);
+    } else if (content_param === "block") {
+        smart_insert_block($textarea, syntax);
+    }
 }
 
 export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-textarea")) {


### PR DESCRIPTION
Fixes: [#23608](https://github.com/zulip/zulip/issues/23608)
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before 1: When quoted text is at the beginning of the message:  
![before-one-newline](https://user-images.githubusercontent.com/99841919/202615565-0ee89c3a-5225-4da5-bb6a-eb4bec7b3870.png)

Before 2: When quoted text is after existing content: 
![before - quote after content](https://user-images.githubusercontent.com/99841919/202615792-c7f062ae-7bd3-45d7-b5e5-16519094eeeb.png)

After 1: When quoted text is at the beginning of the message: 
![quote at beginning of message](https://user-images.githubusercontent.com/99841919/202615337-1e93c4c2-e7f8-4a08-a34e-4a8b1ba2911e.png)

After 2: When quoted text is after existing content:
![quote inserted after existing content](https://user-images.githubusercontent.com/99841919/202615336-b9e44ae9-06cd-4141-a577-c509250a63be.png)

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
