### PR TITLE
Refactor code for organization and stream settings.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -470,7 +470,7 @@ function test_discard_changes_button(discard_changes) {
         "id_realm_message_content_delete_limit_minutes",
     );
 
-    const $discard_button_parent = $(".org-subsection-parent");
+    const $discard_button_parent = $(".settings-subsection-parent");
     $discard_button_parent.find = () => [
         $allow_edit_history,
         $msg_edit_limit_setting,

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -555,9 +555,18 @@ test("set_up", ({override, override_rewire}) => {
     );
     $custom_delete_limit_input.attr("id", "id_realm_message_content_delete_limit_minutes");
 
-    $("#id_realm_message_retention_custom_input").set_parent(
-        $.create("<stub retention period parent>"),
+    const $stub_realm_message_retention_parent = $.create(
+        "<stub message retention setting parent>",
     );
+    const $realm_message_retention_custom_input = $("#id_realm_message_retention_custom_input");
+    $("#id_realm_message_retention_days").set_parent($stub_realm_message_retention_parent);
+    $realm_message_retention_custom_input.set_parent($stub_realm_message_retention_parent);
+    $stub_realm_message_retention_parent.set_find_results(
+        ".message-retention-setting-custom-input",
+        $realm_message_retention_custom_input,
+    );
+    $realm_message_retention_custom_input.attr("id", "id_realm_message_retention_custom_input");
+
     $("#message_content_in_email_notifications_label").set_parent(
         $.create("<stub in-content setting checkbox>"),
     );

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -169,7 +169,6 @@ function test_submit_settings_form(override, submit_form) {
     $invite_to_realm_policy_elem.data = () => "number";
 
     let $subsection_elem = $(`#org-${CSS.escape(subsection)}`);
-    $subsection_elem.closest = () => $subsection_elem;
     $subsection_elem.set_find_results(".prop-element", [
         $bot_creation_policy_elem,
         $email_address_visibility_elem,
@@ -207,7 +206,6 @@ function test_submit_settings_form(override, submit_form) {
     $realm_default_language_elem.data = () => "string";
 
     $subsection_elem = $(`#org-${CSS.escape(subsection)}`);
-    $subsection_elem.closest = () => $subsection_elem;
     $subsection_elem.set_find_results(".prop-element", [$realm_default_language_elem]);
 
     submit_form(ev);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -197,9 +197,8 @@ export function extract_property_name($elem, for_realm_default_settings) {
     return /^id_(.*)$/.exec($elem.attr("id").replace(/-/g, "_"))[1];
 }
 
-function get_subsection_property_elements(element) {
-    const $subsection = $(element).closest(".org-subsection-parent");
-    return Array.from($subsection.find(".prop-element"));
+function get_subsection_property_elements(subsection) {
+    return Array.from($(subsection).find(".prop-element"));
 }
 
 const simple_dropdown_properties = [
@@ -957,7 +956,8 @@ export function register_save_discard_widget_handlers(
     $container.on("click", ".subsection-header .subsection-changes-discard button", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        for (const elem of get_subsection_property_elements(e.target)) {
+        const $subsection = $(e.target).closest(".org-subsection-parent");
+        for (const elem of get_subsection_property_elements($subsection)) {
             discard_property_element_changes(elem, for_realm_default_settings);
         }
         const $save_btn_controls = $(e.target).closest(".save-button-controls");

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -177,12 +177,11 @@ function get_property_value(property_name, for_realm_default_settings) {
 
 export function extract_property_name($elem, for_realm_default_settings) {
     if (for_realm_default_settings) {
-        // We use the name attribute, rather than the ID attribute,
-        // for realm_user_default_settings. This is because the
-        // display/notification settings elements do not always have
-        // IDs, and also the emojiset input is not compatible with the
-        // ID approach.
-        return $elem.attr("name");
+        // ID for realm_user_default_settings elements are of the form
+        // "realm_{settings_name}}" because both user and realm default
+        // settings use the same template and each element should have
+        // unique id.
+        return /^realm_(.*)$/.exec($elem.attr("id").replace(/-/g, "_"))[1];
     }
 
     if ($elem.attr("id").startsWith("id_authmethod")) {
@@ -200,24 +199,6 @@ export function extract_property_name($elem, for_realm_default_settings) {
 
 function get_subsection_property_elements(element) {
     const $subsection = $(element).closest(".org-subsection-parent");
-    if ($subsection.hasClass("theme-settings")) {
-        // Because the emojiset widget has a unique radio button
-        // structure, it needs custom code.
-        const $color_scheme_elem = $subsection.find(".setting_color_scheme");
-        const $display_emoji_reaction_users_elem = $subsection.find(
-            ".display_emoji_reaction_users",
-        );
-        const $emojiset_elem = $subsection.find("input[name='emojiset']:checked");
-        const $user_list_style_elem = $subsection.find("input[name='user_list_style']:checked");
-        const $translate_emoticons_elem = $subsection.find(".translate_emoticons");
-        return [
-            $color_scheme_elem,
-            $emojiset_elem,
-            $user_list_style_elem,
-            $translate_emoticons_elem,
-            $display_emoji_reaction_users_elem,
-        ];
-    }
     return Array.from($subsection.find(".prop-element"));
 }
 
@@ -559,20 +540,10 @@ function discard_property_element_changes(elem, for_realm_default_settings) {
             );
             break;
         case "emojiset":
-            // Because this widget has a radio button structure, it
-            // needs custom reset code.
-            $elem
-                .closest(".org-subsection-parent")
-                .find(`.setting_emojiset_choice[value='${CSS.escape(property_value)}'`)
-                .prop("checked", true);
-            break;
         case "user_list_style":
             // Because this widget has a radio button structure, it
             // needs custom reset code.
-            $elem
-                .closest(".org-subsection-parent")
-                .find(`.setting_user_list_style_choice[value='${CSS.escape(property_value)}']`)
-                .prop("checked", true);
+            $elem.find(`input[value='${CSS.escape(property_value)}']`).prop("checked", true);
             break;
         case "email_notifications_batching_period_seconds":
         case "email_notification_batching_period_edit_minutes":
@@ -744,11 +715,13 @@ export function get_input_element_value(input_elem, input_type) {
             return $input_elem.val().trim();
         case "number":
             return Number.parseInt($input_elem.val().trim(), 10);
-        case "radio-group":
-            if ($input_elem.prop("checked")) {
-                return $input_elem.val().trim();
+        case "radio-group": {
+            const selected_val = $input_elem.find("input:checked").val();
+            if ($input_elem.data("setting-choice-type") === "number") {
+                return Number.parseInt(selected_val, 10);
             }
-            return undefined;
+            return selected_val.trim();
+        }
         case "time-limit":
             return get_time_limit_setting_value($input_elem);
         case "message-retention-setting":
@@ -856,6 +829,10 @@ function check_property_changed(elem, for_realm_default_settings) {
             proposed_val = $(
                 "#org-notifications .language_selection_widget .language_selection_button span",
             ).attr("data-language-code");
+            break;
+        case "emojiset":
+        case "user_list_style":
+            proposed_val = get_input_element_value($elem, "radio-group");
             break;
         default:
             if (current_val !== undefined) {
@@ -1066,12 +1043,10 @@ export function register_save_discard_widget_handlers(
                 if (input_value !== undefined) {
                     let property_name;
                     if (for_realm_default_settings) {
-                        // We use the name attribute, rather than the ID attribute,
-                        // for realm_user_default_settings. This is because the
-                        // display/notification settings elements do not always have
-                        // IDs, and also the emojiset input is not compatible with the
-                        // ID approach.
-                        property_name = $input_elem.attr("name");
+                        property_name = extract_property_name(
+                            $input_elem,
+                            for_realm_default_settings,
+                        );
                     } else if ($input_elem.attr("id").startsWith("id_authmethod")) {
                         // Authentication Method component IDs include authentication method name
                         // for uniqueness, anchored to "id_authmethod" prefix, e.g. "id_authmethodapple_<property_name>".

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -628,7 +628,7 @@ export function change_save_button_state($element, state) {
 
     if (state === "discarded") {
         show_hide_element($element, false, 0, () =>
-            enable_or_disable_save_button($element.closest(".org-subsection-parent")),
+            enable_or_disable_save_button($element.closest(".settings-subsection-parent")),
         );
         return;
     }
@@ -672,13 +672,13 @@ export function change_save_button_state($element, state) {
     $textEl.text(button_text);
     $saveBtn.attr("data-status", data_status);
     if (state === "unsaved") {
-        enable_or_disable_save_button($element.closest(".org-subsection-parent"));
+        enable_or_disable_save_button($element.closest(".settings-subsection-parent"));
     }
     show_hide_element($element, is_show, 800);
 }
 
 export function save_organization_settings(data, $save_button, patch_url) {
-    const $subsection_parent = $save_button.closest(".org-subsection-parent");
+    const $subsection_parent = $save_button.closest(".settings-subsection-parent");
     const $save_btn_container = $subsection_parent.find(".save-button-controls");
     const $failed_alert_elem = $subsection_parent.find(".subsection-failed-status p");
     change_save_button_state($save_btn_container, "saving");
@@ -948,7 +948,7 @@ export function register_save_discard_widget_handlers(
             );
         }
 
-        const $subsection = $(e.target).closest(".org-subsection-parent");
+        const $subsection = $(e.target).closest(".settings-subsection-parent");
         save_discard_widget_status_handler($subsection, for_realm_default_settings);
         return undefined;
     });
@@ -956,7 +956,7 @@ export function register_save_discard_widget_handlers(
     $container.on("click", ".subsection-header .subsection-changes-discard button", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        const $subsection = $(e.target).closest(".org-subsection-parent");
+        const $subsection = $(e.target).closest(".settings-subsection-parent");
         for (const elem of get_subsection_property_elements($subsection)) {
             discard_property_element_changes(elem, for_realm_default_settings);
         }
@@ -1072,7 +1072,7 @@ export function register_save_discard_widget_handlers(
         e.preventDefault();
         e.stopPropagation();
         const $save_button = $(e.currentTarget);
-        const $subsection_elem = $save_button.closest(".org-subsection-parent");
+        const $subsection_elem = $save_button.closest(".settings-subsection-parent");
         let extra_data = {};
 
         if (!for_realm_default_settings) {
@@ -1123,12 +1123,12 @@ export function build_page() {
 
     register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
 
-    $(".org-subsection-parent").on("keydown", "input", (e) => {
+    $(".settings-subsection-parent").on("keydown", "input", (e) => {
         e.stopPropagation();
         if (keydown_util.is_enter_event(e)) {
             e.preventDefault();
             $(e.target)
-                .closest(".org-subsection-parent")
+                .closest(".settings-subsection-parent")
                 .find(".subsection-changes-save button")
                 .trigger("click");
         }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -346,7 +346,7 @@ function set_msg_delete_limit_dropdown() {
 
 function get_message_retention_setting_value($input_elem, for_api_data = true) {
     const select_elem_val = $input_elem.val();
-    if (select_elem_val === "retain_forever") {
+    if (select_elem_val === "unlimited") {
         if (!for_api_data) {
             return settings_config.retain_message_forever;
         }
@@ -362,27 +362,32 @@ function get_message_retention_setting_value($input_elem, for_api_data = true) {
 
 function get_dropdown_value_for_message_retention_setting(setting_value) {
     if (setting_value === settings_config.retain_message_forever) {
-        return "retain_forever";
+        return "unlimited";
     }
 
-    return "retain_for_period";
+    return "custom_period";
 }
 
 function set_message_retention_setting_dropdown() {
-    const value = get_property_value("realm_message_retention_days");
-    const dropdown_val = get_dropdown_value_for_message_retention_setting(value);
-    $("#id_realm_message_retention_days").val(dropdown_val);
+    const property_name = "realm_message_retention_days";
+    const setting_value = get_property_value(property_name, false);
+    const dropdown_val = get_dropdown_value_for_message_retention_setting(setting_value);
+
+    const $dropdown_elem = $(`#id_${CSS.escape(property_name)}`);
+    $dropdown_elem.val(dropdown_val);
+
+    const $custom_input_elem = $dropdown_elem
+        .parent()
+        .find(".message-retention-setting-custom-input")
+        .val("");
+    if (dropdown_val === "custom_period") {
+        $custom_input_elem.val(setting_value);
+    }
 
     change_element_block_display_property(
-        "id_realm_message_retention_custom_input",
-        dropdown_val === "retain_for_period",
+        $custom_input_elem.attr("id"),
+        dropdown_val === "custom_period",
     );
-
-    let custom_input_val = "";
-    if (dropdown_val === "retain_for_period") {
-        custom_input_val = value;
-    }
-    $("#id_realm_message_retention_custom_input").val(custom_input_val);
 }
 
 function set_org_join_restrictions_dropdown() {
@@ -1146,7 +1151,7 @@ export function build_page() {
         const message_retention_setting_dropdown_value = e.target.value;
         change_element_block_display_property(
             "id_realm_message_retention_custom_input",
-            message_retention_setting_dropdown_value === "retain_for_period",
+            message_retention_setting_dropdown_value === "custom_period",
         );
     });
 

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -226,7 +226,7 @@ function create_stream() {
     let message_retention_selection = $(
         "#stream_creation_form select[name=stream_message_retention_setting]",
     ).val();
-    if (message_retention_selection === "retain_for_period") {
+    if (message_retention_selection === "custom_period") {
         message_retention_selection = Number.parseInt(
             $("#stream_creation_form input[name=stream-message-retention-days]").val(),
             10,
@@ -323,7 +323,7 @@ export function show_new_stream_modal() {
 
     // Add listener to .show stream-message-retention-days-input that we've hidden above
     $("#stream_creation_form .stream_message_retention_setting").on("change", (e) => {
-        if (e.target.value === "retain_for_period") {
+        if (e.target.value === "custom_period") {
             $("#stream_creation_form .stream-message-retention-days-input").show();
         } else {
             $("#stream_creation_form .stream-message-retention-days-input").hide();

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -673,16 +673,6 @@ export function initialize() {
     });
 
     $("#manage_streams_container").on(
-        "click",
-        ".close-modal-btn, .close-change-stream-info-modal",
-        (e) => {
-            // This fixes a weird bug in which, subscription_settings hides
-            // unexpectedly by clicking the cancel button in a modal on top of it.
-            e.stopPropagation();
-        },
-    );
-
-    $("#manage_streams_container").on(
         "change",
         "#sub_is_muted_setting .sub_setting_control",
         stream_is_muted_changed,

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -97,7 +97,7 @@ export function get_display_text_for_realm_message_retention_setting() {
 }
 
 function change_stream_message_retention_days_block_display_property(value) {
-    if (value === "retain_for_period") {
+    if (value === "custom_period") {
         $("#stream_privacy_modal .stream-message-retention-days-input").show();
     } else {
         $("#stream_privacy_modal .stream-message-retention-days-input").hide();
@@ -105,7 +105,7 @@ function change_stream_message_retention_days_block_display_property(value) {
 }
 
 function set_stream_message_retention_setting_dropdown(stream) {
-    let value = "retain_for_period";
+    let value = "custom_period";
     if (stream.message_retention_days === null) {
         value = "realm_default";
     } else if (stream.message_retention_days === settings_config.retain_message_forever) {
@@ -434,7 +434,7 @@ function change_stream_privacy(e) {
     let message_retention_days = $(
         "#stream_privacy_modal select[name=stream_message_retention_setting]",
     ).val();
-    if (message_retention_days === "retain_for_period") {
+    if (message_retention_days === "custom_period") {
         message_retention_days = Number.parseInt(
             $("#stream_privacy_modal input[name=stream-message-retention-days]").val(),
             10,

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -448,6 +448,10 @@ div.overlay {
     }
 }
 
+.dependent-settings-block {
+    margin: 15px 0 -5px 23px;
+}
+
 @media (width < $md_min) {
     /* Override Bootstrap's responsive grid to display input at full width */
     .input-append .stream-list-filter {

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -36,6 +36,11 @@ kbd {
     .show-sm {
         display: block !important;
     }
+
+    #settings_page .save-button-controls {
+        display: block;
+        margin: 10px 0 0;
+    }
 }
 
 @media (width < $lg_min) {
@@ -728,5 +733,92 @@ div.overlay {
     .actions {
         width: 1%;
         white-space: nowrap;
+    }
+}
+
+#settings_page {
+    .save-discard-widget-button {
+        border-radius: 5px;
+        border: 1px solid hsl(0, 0%, 80%);
+        padding: 3px 14px 4px 11px;
+        text-decoration: none;
+        color: hsl(0, 0%, 47%);
+        min-width: 80px;
+        /* Limit the height of the button */
+        line-height: 1.2;
+        vertical-align: text-bottom;
+
+        &:hover,
+        &:focus {
+            background-color: hsl(0, 0%, 100%);
+            border: 1px solid hsl(0, 0%, 61%);
+            color: hsl(0, 0%, 18%);
+
+            .save-discard-widget-button-icon {
+                color: hsl(0, 0%, 47%);
+            }
+        }
+
+        &.primary {
+            background-color: hsl(156, 30%, 50%);
+            color: hsl(0, 0%, 100%);
+            border: 1px solid hsl(155, 30%, 50%);
+
+            &:hover,
+            &:focus {
+                background-color: hsl(166, 35%, 57%);
+                border: 1px solid hsl(166, 35%, 57%);
+            }
+
+            .save-discard-widget-button-icon {
+                font-weight: lighter;
+                color: hsl(0, 0%, 100%);
+            }
+
+            &.saving {
+                background-color: hsl(156, 14%, 40%);
+                border-color: hsl(156, 14%, 40%);
+            }
+        }
+
+        .save-discard-widget-button-icon {
+            vertical-align: middle;
+            margin-right: 3px;
+            font-size: 15px;
+            font-weight: 500;
+        }
+
+        .save-discard-widget-button-text {
+            vertical-align: middle;
+            line-height: 1;
+        }
+    }
+
+    .save-button-controls {
+        display: inline;
+        margin-left: 15px;
+
+        &.hide {
+            display: none;
+        }
+    }
+
+    .save-button {
+        margin-right: 5px;
+
+        .save-discard-widget-button-loading {
+            display: none;
+        }
+
+        &.saving {
+            .save-discard-widget-button-icon {
+                display: none;
+            }
+
+            .save-discard-widget-button-loading {
+                display: inline-block;
+                margin-right: 2px;
+            }
+        }
     }
 }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1136,91 +1136,6 @@ $option_title_width: 180px;
     overflow: hidden;
     border-radius: 4px;
 
-    .save-discard-widget-button {
-        border-radius: 5px;
-        border: 1px solid hsl(0, 0%, 80%);
-        padding: 3px 14px 4px 11px;
-        text-decoration: none;
-        color: hsl(0, 0%, 47%);
-        min-width: 80px;
-        /* Limit the height of the button */
-        line-height: 1.2;
-        vertical-align: text-bottom;
-
-        &:hover,
-        &:focus {
-            background-color: hsl(0, 0%, 100%);
-            border: 1px solid hsl(0, 0%, 61%);
-            color: hsl(0, 0%, 18%);
-
-            .save-discard-widget-button-icon {
-                color: hsl(0, 0%, 47%);
-            }
-        }
-
-        &.primary {
-            background-color: hsl(156, 30%, 50%);
-            color: hsl(0, 0%, 100%);
-            border: 1px solid hsl(155, 30%, 50%);
-
-            &:hover,
-            &:focus {
-                background-color: hsl(166, 35%, 57%);
-                border: 1px solid hsl(166, 35%, 57%);
-            }
-
-            .save-discard-widget-button-icon {
-                font-weight: lighter;
-                color: hsl(0, 0%, 100%);
-            }
-
-            &.saving {
-                background-color: hsl(156, 14%, 40%);
-                border-color: hsl(156, 14%, 40%);
-            }
-        }
-
-        .save-discard-widget-button-icon {
-            vertical-align: middle;
-            margin-right: 3px;
-            font-size: 15px;
-            font-weight: 500;
-        }
-
-        .save-discard-widget-button-text {
-            vertical-align: middle;
-            line-height: 1;
-        }
-    }
-
-    .save-button-controls {
-        display: inline;
-        margin-left: 15px;
-
-        &.hide {
-            display: none;
-        }
-    }
-
-    .save-button {
-        margin-right: 5px;
-
-        .save-discard-widget-button-loading {
-            display: none;
-        }
-
-        &.saving {
-            .save-discard-widget-button-icon {
-                display: none;
-            }
-
-            .save-discard-widget-button-loading {
-                display: inline-block;
-                margin-right: 2px;
-            }
-        }
-    }
-
     .admin-realm-time-limit-input {
         width: 5ch;
         text-align: right;
@@ -1833,11 +1748,6 @@ $option_title_width: 180px;
         text-align: center;
         margin: auto;
         float: none;
-    }
-
-    #settings_page .save-button-controls {
-        display: block;
-        margin: 10px 0 0;
     }
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -890,11 +890,6 @@ li.actual-dropdown-menu i {
     padding: 6px 12px;
 }
 
-#settings_content .dependent-block,
-#invite-user .dependent-block {
-    margin: 15px 0 -5px 23px;
-}
-
 .message_area_padder {
     /* The height of the header and the message_view_header plus a small gap */
     margin-top: 57px;

--- a/static/templates/invite_user.hbs
+++ b/static/templates/invite_user.hbs
@@ -39,7 +39,7 @@
                         </select>
                     </div>
                     <p id="expires_on"></p>
-                    <div id="custom-invite-expiration-time" class="dependent-block">
+                    <div id="custom-invite-expiration-time" class="dependent-settings-block">
                         <label for="expires_in">{{t "Custom time" }}</label>
                         <input type="text" autocomplete="off" name="custom-expiration-time" id="custom-expiration-time-input" class="custom-expiration-time inline-block" value="{{time_input}}" maxlength="3"/>
                         <select class="custom-expiration-time" id="custom-expiration-time-unit">

--- a/static/templates/settings/auth_methods_settings_admin.hbs
+++ b/static/templates/settings/auth_methods_settings_admin.hbs
@@ -3,7 +3,7 @@
     <div class='tip'>{{t "Only organization owners can edit these settings."}}</div>
     {{/unless}}
     <form class="form-horizontal admin-realm-form org-authentications-form">
-        <div id="org-auth_settings" class="admin-table-wrapper org-subsection-parent">
+        <div id="org-auth_settings" class="admin-table-wrapper settings-subsection-parent">
             <div class ="subsection-header">
                 <h3>{{t "Authentication methods" }}</h3>
                 {{> settings_save_discard_widget section_name="auth_settings" }}

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -19,7 +19,7 @@
 
         <div class="input-group">
             <label for="twenty_four_hour_time" class="dropdown-title">{{ settings_label.twenty_four_hour_time }}</label>
-            <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element" data-setting-widget-type="string">
+            <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element" id="{{prefix}}twenty_four_hour_time" data-setting-widget-type="string">
                 {{#each twenty_four_hour_time_values}}
                     <option value='{{ this.value }}'>{{ this.description }}</option>
                 {{/each}}
@@ -37,7 +37,7 @@
 
         <div class="input-group">
             <label for="color_scheme" class="dropdown-title">{{t "Color scheme" }}</label>
-            <select name="color_scheme" class="setting_color_scheme prop-element" data-setting-widget-type="number">
+            <select name="color_scheme" class="setting_color_scheme prop-element" id="{{prefix}}color_scheme" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=color_scheme_values}}
             </select>
         </div>
@@ -118,7 +118,7 @@
             <label for="default_view" class="dropdown-title">{{t "Default view" }}
                 {{> ../help_link_widget link="/help/configure-default-view" }}
             </label>
-            <select name="default_view" class="setting_default_view prop-element" data-setting-widget-type="string">
+            <select name="default_view" class="setting_default_view prop-element" id="{{prefix}}default_view" data-setting-widget-type="string">
                 {{> dropdown_options_widget option_values=default_view_values}}
             </select>
         </div>
@@ -133,7 +133,7 @@
             <label for="demote_inactive_streams" class="dropdown-title">{{t "Demote inactive streams" }}
                 {{> ../help_link_widget link="/help/manage-inactive-streams" }}
             </label>
-            <select name="demote_inactive_streams" class="setting_demote_inactive_streams prop-element"  data-setting-widget-type="number">
+            <select name="demote_inactive_streams" class="setting_demote_inactive_streams prop-element" id="{{prefix}}demote_inactive_streams"  data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=demote_inactive_streams_values}}
             </select>
         </div>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -44,10 +44,10 @@
 
         <div class="input-group">
             <label class="emoji-theme title">{{t "Emoji theme" }}</label>
-            <div class="emojiset_choices grey-box">
+            <div class="emojiset_choices grey-box prop-element" id="{{prefix}}emojiset" data-setting-widget-type="radio-group" data-setting-choice-type="string">
                 {{#each settings_object.emojiset_choices}}
                     <label>
-                        <input type="radio" class="setting_emojiset_choice prop-element" name="emojiset" value="{{this.key}}" data-setting-widget-type="radio-group"/>
+                        <input type="radio" class="setting_emojiset_choice" name="emojiset" value="{{this.key}}"/>
                         <span>{{this.text}}</span>
                         <span class="right">
                             {{#if (eq this.key "text") }}
@@ -82,10 +82,10 @@
 
         <div class="input-group">
             <label class="title">{{t "User list style" }}</label>
-            <div class="user_list_style_values grey-box">
+            <div class="user_list_style_values grey-box prop-element" id="{{prefix}}user_list_style" data-setting-widget-type="radio-group" data-setting-choice-type="number">
                 {{#each user_list_style_values}}
                     <label>
-                        <input type="radio" class="setting_user_list_style_choice prop-element" name="user_list_style" value="{{this.code}}" data-setting-widget-type="radio-group"/>
+                        <input type="radio" class="setting_user_list_style_choice" name="user_list_style" value="{{this.code}}"/>
                         <span>{{this.description}}</span>
                         <span class="right preview">
                             {{#if (eq this.code 1)}}

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -1,5 +1,5 @@
 <form class="display-settings-form">
-    <div class="lang-time-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="lang-time-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <!-- this is inline block so that the alert notification can sit beside
         it. If there's not an alert, don't make it inline-block.-->
         <div class="subsection-header inline-block">
@@ -29,7 +29,7 @@
     </div>
 
 
-    <div class="theme-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="theme-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
             <h3 class="light">{{t "Theme" }}</h3>
             {{> settings_save_discard_widget section_name="theme-settings" show_only_indicator=(not for_realm_settings) }}
@@ -108,7 +108,7 @@
         </div>
     </div>
 
-    <div class="advanced-settings {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="advanced-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
             <h3 class="light">{{t "Advanced" }}</h3>
             {{> settings_save_discard_widget section_name="advanced-settings" show_only_indicator=(not for_realm_settings) }}

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -134,7 +134,7 @@
                     <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}
             </select>
-            <div class="dependent-block">
+            <div class="dependent-settings-block">
                 <label for="email_notification_batching_period_edit_minutes" class="inline-block">
                     {{t 'Delay period (minutes)' }}:
                 </label>

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -74,7 +74,7 @@
         </label>
 
         <div class="input-group {{#unless enable_sound_select}}control-label-disabled{{/unless}}">
-            <select name="notification_sound" class="setting_notification_sound prop-element" data-setting-widget-type="string"
+            <select name="notification_sound" class="setting_notification_sound prop-element" id="{{prefix}}notification_sound" data-setting-widget-type="string"
               {{#unless enable_sound_select}}
               disabled
               {{/unless}}>
@@ -90,8 +90,7 @@
 
         <div class="input-group">
             <label for="desktop_icon_count_display" class="dropdown-title">{{ settings_label.desktop_icon_count_display }}</label>
-            <select name="desktop_icon_count_display" class="setting_desktop_icon_count_display prop-element"
-              data-setting-widget-type="number">
+            <select name="desktop_icon_count_display" class="setting_desktop_icon_count_display prop-element" id="{{prefix}}desktop_icon_count_display" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=desktop_icon_count_display_values}}
             </select>
         </div>
@@ -130,7 +129,7 @@
             <label for="email_notifications_batching_period">
                 {{t "Delay before sending message notification emails" }}
             </label>
-            <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element" data-setting-widget-type="time-limit">
+            <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element" id="{{prefix}}email_notifications_batching_period_seconds" data-setting-widget-type="time-limit">
                 {{#each email_notifications_batching_period_values}}
                     <option value="{{ this.value }}">{{ this.description }}</option>
                 {{/each}}

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -1,5 +1,5 @@
 <form class="notification-settings-form">
-    <div class="general_notifications {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="general_notifications {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header inline-block">
             <h3>{{t "Notification triggers" }}</h3>
             {{> settings_save_discard_widget section_name="general-notifiy-settings" show_only_indicator=(not for_realm_settings) }}
@@ -48,7 +48,7 @@
         </table>
     </div>
 
-    <div class="desktop_notifications m-10 {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="desktop_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header inline-block">
             <h3>{{t "Desktop message notifications" }}
@@ -96,7 +96,7 @@
         </div>
     </div>
 
-    <div class="mobile_notifications m-10 {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="mobile_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header inline-block">
             <h3>{{t "Mobile message notifications" }}
@@ -115,7 +115,7 @@
         {{/each}}
     </div>
 
-    <div class="email_message_notifications m-10 {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="email_message_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header inline-block">
             <h3>{{t "Email message notifications" }}
@@ -156,7 +156,7 @@
         {{/each}}
     </div>
 
-    <div class="other_email_notifications m-10 {{#if for_realm_settings}}org-subsection-parent{{else}}subsection-parent{{/if}}">
+    <div class="other_email_notifications m-10 {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
 
         <div class="subsection-header inline-block">
             <h3>{{t "Other emails" }}</h3>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -28,7 +28,7 @@
                         <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
                         <option value="only_selected_domain">{{t "Restrict to a list of domains" }}</option>
                     </select>
-                    <div class="dependent-block">
+                    <div class="dependent-settings-block">
                         <p id="allowed_domains_label" class="inline-block"></p>
                         {{#if is_owner }}
                         <a id="show_realm_domains_modal" role="button">{{t "[Configure]" }}</a>
@@ -46,7 +46,7 @@
                         <option value="custom_days">{{t "Custom" }}</option>
                     </select>
                     {{!-- This setting is hidden unless `custom_days` --}}
-                    <div class="dependent-block">
+                    <div class="dependent-settings-block">
                         <label for="id_realm_waiting_period_threshold" class="inline-block">{{t "Waiting period (days)" }}:</label>
                         <input type="text" id="id_realm_waiting_period_threshold"
                           name="realm_waiting_period_threshold"
@@ -161,7 +161,7 @@
                             <option value="{{value}}">{{text}}</option>
                         {{/each}}
                     </select>
-                    <div class="dependent-block">
+                    <div class="dependent-settings-block">
                         <label for="id_realm_message_content_edit_limit_minutes" class="inline-block realm-time-limit-label">
                             {{t 'Duration editing is allowed after posting (minutes)'}}:&nbsp;
                         </label>
@@ -226,7 +226,7 @@
                             <option value="{{value}}">{{text}}</option>
                         {{/each}}
                     </select>
-                    <div class="dependent-block">
+                    <div class="dependent-settings-block">
                         <label for="id_realm_message_content_delete_limit_minutes" class="inline-block realm-time-limit-label">
                             {{t "Duration deletion is allowed after posting (minutes)" }}:
                         </label>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -1,7 +1,7 @@
 <div id="organization-permissions" data-name="organization-permissions" class="settings-section">
     <form class="form-horizontal admin-realm-form org-permissions-form">
 
-        <div id="org-join" class="org-subsection-parent">
+        <div id="org-join" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Joining the organization" }}</h3>
                 <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change these settings.' }}"></i>
@@ -57,7 +57,7 @@
             </div>
         </div>
 
-        <div id="org-user-identity" class="org-subsection-parent">
+        <div id="org-user-identity" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "User identity" }}</h3>
                 {{> settings_save_discard_widget section_name="user-identity" }}
@@ -91,7 +91,7 @@
             </div>
         </div>
 
-        <div id="org-stream-permissions" class="org-subsection-parent">
+        <div id="org-stream-permissions" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Stream permissions" }}</h3>
                 {{> settings_save_discard_widget section_name="stream-permissions" }}
@@ -140,7 +140,7 @@
             </div>
         </div>
 
-        <div id="org-msg-editing" class="org-subsection-parent">
+        <div id="org-msg-editing" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Message and topic editing" }}
                     {{> ../help_link_widget link="/help/configure-message-editing-and-deletion" }}
@@ -197,7 +197,7 @@
             </div>
         </div>
 
-        <div id="org-msg-deletion" class="org-subsection-parent">
+        <div id="org-msg-deletion" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Message deletion" }}
                     {{> ../help_link_widget link="/help/edit-or-delete-a-message#delete-a-message" }}
@@ -240,7 +240,7 @@
             </div>
         </div>
 
-        <div id="org-other-permissions" class="org-subsection-parent">
+        <div id="org-other-permissions" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Other permissions" }}</h3>
                 {{> settings_save_discard_widget section_name="other-permissions" }}

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -2,7 +2,7 @@
     <form class="form-horizontal admin-realm-form org-profile-form">
         <div class="alert" id="admin-realm-deactivation-status"></div>
 
-        <div id="org-org-profile" class="org-subsection-parent">
+        <div id="org-org-profile" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Organization profile" }}
                     {{> ../help_link_widget link="/help/create-your-organization-profile" }}

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -75,8 +75,8 @@
                       id="id_realm_message_retention_days" class="prop-element"
                       data-setting-widget-type="message-retention-setting"
                       {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
-                        <option value="retain_forever">{{t 'Retain forever' }}</option>
-                        <option value="retain_for_period">{{t 'Retain for N days after posting' }}</option>
+                        <option value="unlimited">{{t 'Retain forever' }}</option>
+                        <option value="custom_period">{{t 'Retain for N days after posting' }}</option>
                     </select>
 
                     <div class="dependent-inline-block">

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -1,7 +1,7 @@
 <div id="organization-settings" data-name="organization-settings" class="settings-section">
     <form class="form-horizontal admin-realm-form org-settings-form">
 
-        <div id="org-notifications" class="org-subsection-parent">
+        <div id="org-notifications" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Automated messages and emails" }}</h3>
                 {{> settings_save_discard_widget section_name="notifications" }}
@@ -57,7 +57,7 @@
             </div>
         </div>
 
-        <div id="org-message-retention" class="org-subsection-parent">
+        <div id="org-message-retention" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Message retention" }}
                     {{> ../help_link_widget link="/help/message-retention-policy" }}
@@ -93,7 +93,7 @@
             </div>
         </div>
 
-        <div id="org-other-settings" class="org-subsection-parent">
+        <div id="org-other-settings" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Other settings" }}</h3>
                 {{> settings_save_discard_widget section_name="other-settings" }}

--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -10,7 +10,7 @@
 
     {{> notification_settings prefix="realm_" for_realm_settings=true}}
 
-    <div class="form-horizontal privacy_settings org-subsection-parent">
+    <div class="form-horizontal privacy_settings settings-subsection-parent">
         <div class="subsection-header inline-block">
             <h3 class="inline-block">{{t "Privacy settings" }}</h3>
             {{> settings_save_discard_widget section_name="privacy-setting" show_only_indicator=false }}
@@ -30,7 +30,7 @@
           help_link="/help/read-receipts"}}
     </div>
 
-    <div class="form-horizontal other_settings org-subsection-parent">
+    <div class="form-horizontal other_settings settings-subsection-parent">
         <div class="subsection-header inline-block">
             <h3 class="inline-block">{{t "Other settings" }}</h3>
             {{> settings_save_discard_widget section_name="other-setting" show_only_indicator=false }}

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -50,12 +50,12 @@
           {{#if disable_message_retention_setting}}disabled{{/if}}>
             <option value="realm_default">{{#tr}}Use organization level settings {org_level_message_retention_setting}{{/tr}}</option>
             <option value="unlimited">{{t 'Retain forever' }}</option>
-            <option value="retain_for_period">{{t 'Retain for N days after posting' }}</option>
+            <option value="custom_period">{{t 'Custom' }}</option>
         </select>
 
-        <div class="dependent-inline-block stream-message-retention-days-input">
+        <div class="dependent-settings-block stream-message-retention-days-input">
             <label class="inline-block">
-                {{t 'N' }}:
+                {{t 'Retention period (days)' }}:
             </label>
             <input type="text" autocomplete="off"
               name="stream-message-retention-days"


### PR DESCRIPTION
This is a prep PR so that we can reuse organizations settings code in #23013.

<!-- Describe your pull request here.-->
- First commit is to remove unused handler.
- Second commit is to move CSS for save-discard widget to `app_components.css`.
- Third commit is to add id for display and notification settings.
- Fourth commit is to refactor code that handles radio-type settings.
- Fifth commit is to pass subsection element to `get_subsection_property_elements`.
- Sixth commit is to rename the `org-subsection-parent` class.
- Seventh commit is to refactor stream message retention setting.
- Eigth commit is to refactor realm message retention setting (no UI or user-visible changes for now).

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-11-18 14-11-42](https://user-images.githubusercontent.com/35494118/202659859-dc427df0-0c6e-494b-86b0-577fff57246a.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
