### PR TITLE
cache: Decline to store querysets, with an error.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -170,13 +170,12 @@ def cache_with_key(
 
             val = func(*args, **kwargs)
             if isinstance(val, QuerySet):  # type: ignore[misc] # https://github.com/typeddjango/django-stubs/issues/704
-                logging.warning(
-                    "cache_with_key attempted to store a full QuerySet object -- flattening using list()",
+                logging.error(
+                    "cache_with_key attempted to store a full QuerySet object -- declining to cache",
                     stack_info=True,
                 )
-                val = list(val)
-
-            cache_set(key, val, cache_name=cache_name, timeout=timeout)
+            else:
+                cache_set(key, val, cache_name=cache_name, timeout=timeout)
 
             return val
 


### PR DESCRIPTION
As we have seen no further cases of this in production since #23215, increase the severity to an error, and switch from returning a list (which is not type-safe if the function declares a QuerySet return) to returning the QuerySet without caching.

Failing to store the result in the cache, with an error, seems superior to raising an exception; in both cases the next request will redo the work, but we are guaranteed a worse user experience if we 500 the request.

Ref https://github.com/zulip/zulip/pull/23215#discussion_r994186493

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
