### PR TITLE
oneclick: Wait in a loop until the image build droplet gets an IP.

### DIFF
--- a/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
+++ b/tools/oneclickapps/prepare_digital_ocean_one_click_app_release.py
@@ -44,7 +44,16 @@ def sleep_until_droplet_action_is_completed(
                 break
         if incomplete:
             time.sleep(5)
-    droplet.load()
+
+    # Sometimes the droplet does not yet have an .ip_address value
+    # (the attribute is None) after .load()ing the droplet. We cannot
+    # proceed without the IP, so we wait in a loop until the IP is
+    # returned to us.
+    while True:
+        droplet.load()
+        if droplet.ip_address:
+            break
+        time.sleep(5)
 
 
 def set_api_request_retry_limits(api_object: digitalocean.baseapi.BaseAPI) -> None:


### PR DESCRIPTION
The script will fail if we process with a droplet object with no .ip_address, which can sometimes happen if we just droplet.load(). Sometimes that gives droplet.ip_address set to None. If we wait in a loop, we eventuall get the .ip_address set.

