### PR TITLE
user_groups: Remove unused remove_user_from_user_group.

### DIFF
--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -99,13 +99,6 @@ def get_direct_user_groups(user_profile: UserProfile) -> List[UserGroup]:
     return list(user_profile.direct_groups.all())
 
 
-def remove_user_from_user_group(user_profile: UserProfile, user_group: UserGroup) -> int:
-    num_deleted, _ = UserGroupMembership.objects.filter(
-        user_profile=user_profile, user_group=user_group
-    ).delete()
-    return num_deleted
-
-
 def create_user_group(
     name: str,
     members: List[UserProfile],

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -6,10 +6,11 @@ import orjson
 from django.http import HttpRequest, HttpResponse
 
 from zerver.actions.streams import do_change_subscription_property
+from zerver.actions.user_groups import remove_members_from_user_group
 from zerver.actions.user_topics import do_mute_topic
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import HostRequestMock, dummy_handler, mock_queue_publish
-from zerver.lib.user_groups import create_user_group, remove_user_from_user_group
+from zerver.lib.user_groups import create_user_group
 from zerver.models import Recipient, Stream, Subscription, UserProfile, get_stream
 from zerver.tornado.event_queue import (
     ClientDescriptor,
@@ -451,8 +452,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                 already_notified={"email_notified": True, "push_notified": True},
             )
         destroy_event_queue(user_profile, client_descriptor.event_queue.id)
-        remove_user_from_user_group(user_profile, hamlet_and_cordelia)
-        remove_user_from_user_group(cordelia, hamlet_and_cordelia)
+        remove_members_from_user_group(hamlet_and_cordelia, [user_profile.id, cordelia.id])
 
         # Test the hook with a stream message with stream_push_notify
         change_subscription_properties(user_profile, stream, sub, {"push_notifications": True})


### PR DESCRIPTION
`remove_user_from_user_group`'s only caller has been removed in 271333301d3ca662ee5c1497fa3fa9829aaf93d1.
Its usage has been superseded by `remove_members_from_user_group`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
