### PR TITLE
compose: Fix file link text being selected after upload.

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -152,17 +152,23 @@ run_test("smart_insert", ({override}) => {
     // like emojis and file links.
 });
 
-run_test("replace_syntax", () => {
+run_test("replace_syntax", ({override}) => {
     $("#compose-textarea").val("abcabc");
+    $("#compose-textarea")[0] = "compose-textarea";
+    override(text_field_edit, "replace", (elt, old_syntax, new_syntax) => {
+        assert.equal(elt, "compose-textarea");
+        assert.equal(old_syntax, "a");
+        assert.equal(new_syntax(), "A");
+    });
     compose_ui.replace_syntax("a", "A");
-    assert.equal($("#compose-textarea").val(), "Abcabc");
 
-    compose_ui.replace_syntax(/b/g, "B");
-    assert.equal($("#compose-textarea").val(), "ABcaBc");
-
+    override(text_field_edit, "replace", (elt, old_syntax, new_syntax) => {
+        assert.equal(elt, "compose-textarea");
+        assert.equal(old_syntax, "Bca");
+        assert.equal(new_syntax(), "$$\\pi$$");
+    });
     // Verify we correctly handle `$`s in the replacement syntax
     compose_ui.replace_syntax("Bca", "$$\\pi$$");
-    assert.equal($("#compose-textarea").val(), "A$$\\pi$$Bc");
 });
 
 run_test("compute_placeholder_text", () => {
@@ -253,15 +259,8 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     let textarea_val = "";
     let textarea_caret_pos;
 
-    $("#compose-textarea").val = function (...args) {
-        if (args.length === 0) {
-            return textarea_val;
-        }
-
-        textarea_val = args[0];
-        textarea_caret_pos = textarea_val.length;
-
-        return this;
+    $("#compose-textarea").val = function () {
+        return textarea_val;
     };
 
     $("#compose-textarea").caret = function (arg) {
@@ -289,7 +288,6 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     override(text_field_edit, "insert", (elt, syntax) => {
         assert.equal(elt, "compose-textarea");
         assert.equal(syntax, "translated: [Quoting…]\n");
-        $("#compose-textarea").caret(syntax);
     });
 
     function set_compose_content_with_caret(content) {
@@ -298,14 +296,6 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         textarea_val = content;
         textarea_caret_pos = caret_position;
         $("#compose-textarea").trigger("focus");
-    }
-
-    function get_compose_content_with_caret() {
-        const content =
-            textarea_val.slice(0, textarea_caret_pos) +
-            "%" +
-            textarea_val.slice(textarea_caret_pos); // insert the "%"
-        return content;
     }
 
     function reset_test_state() {
@@ -318,17 +308,27 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
         $("#compose-textarea").trigger("blur");
     }
 
+    function override_with_quote_text(quote_text) {
+        override(text_field_edit, "replace", (elt, old_syntax, new_syntax) => {
+            assert.equal(elt, "compose-textarea");
+            assert.equal(old_syntax, "translated: [Quoting…]");
+            assert.equal(
+                new_syntax(),
+                "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n" +
+                    "```quote\n" +
+                    `${quote_text}\n` +
+                    "```",
+            );
+        });
+    }
+    let quote_text = "Testing caret position";
+    override_with_quote_text(quote_text);
     set_compose_content_with_caret("hello %there"); // "%" is used to encode/display position of focus before change
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "hello \ntranslated: [Quoting…]\n%there");
 
     success_function({
-        raw_content: "Testing caret position",
+        raw_content: quote_text,
     });
-    assert.equal(
-        get_compose_content_with_caret(),
-        "hello \ntranslated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting caret position\n```\n%there",
-    );
 
     reset_test_state();
 
@@ -336,15 +336,12 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     // add a newline before the quoted message.
     set_compose_content_with_caret("%hello there");
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "translated: [Quoting…]\n%hello there");
 
+    quote_text = "Testing with caret initially positioned at 0.";
+    override_with_quote_text(quote_text);
     success_function({
-        raw_content: "Testing with caret initially positioned at 0.",
+        raw_content: quote_text,
     });
-    assert.equal(
-        get_compose_content_with_caret(),
-        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting with caret initially positioned at 0.\n```\n%hello there",
-    );
 
     override_rewire(compose_actions, "respond_to_message", () => {
         // Reset compose state to replicate the re-opening of compose-box.
@@ -359,15 +356,12 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     // quoting a message, the quoted message should be placed
     // at the beginning of compose-box.
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "translated: [Quoting…]\n%");
 
+    quote_text = "Testing with compose-box closed initially.";
+    override_with_quote_text(quote_text);
     success_function({
-        raw_content: "Testing with compose-box closed initially.",
+        raw_content: quote_text,
     });
-    assert.equal(
-        get_compose_content_with_caret(),
-        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting with compose-box closed initially.\n```\n%",
-    );
 
     reset_test_state();
 
@@ -377,15 +371,12 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     // message should start from the beginning of compose-box.
     set_compose_content_with_caret("  \n\n \n %");
     compose_actions.quote_and_reply();
-    assert.equal(get_compose_content_with_caret(), "translated: [Quoting…]\n%");
 
+    quote_text = "Testing with compose-box containing whitespaces and newlines only.";
+    override_with_quote_text(quote_text);
     success_function({
-        raw_content: "Testing with compose-box containing whitespaces and newlines only.",
+        raw_content: quote_text,
     });
-    assert.equal(
-        get_compose_content_with_caret(),
-        "translated: @_**Steve Stephenson|90** [said](https://chat.zulip.org/#narrow/stream/92-learning/topic/Tornado):\n```quote\nTesting with compose-box containing whitespaces and newlines only.\n```\n%",
-    );
 });
 
 run_test("set_compose_box_top", () => {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "spectrum-colorpicker": "^1.8.1",
     "stacktrace-gps": "^3.0.4",
     "style-loader": "^3.2.1",
-    "text-field-edit": "^3.1.0",
+    "text-field-edit": "^3.2.0",
     "tippy.js": "^6.3.7",
     "turndown": "^7.0.0",
     "url-loader": "^4.1.1",

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -84,7 +84,7 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
     // replace() function treating `$`s in new_syntax as special syntax.  See
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
     // for details.
-    replace($textarea[0], old_syntax, () => new_syntax);
+    replace($textarea[0], old_syntax, () => new_syntax, "after-replacement");
 }
 
 export function compute_placeholder_text(opts) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -1,6 +1,6 @@
 import autosize from "autosize";
 import $ from "jquery";
-import {insert, set, wrapSelection} from "text-field-edit";
+import {insert, replace, set, wrapSelection} from "text-field-edit";
 
 import * as common from "./common";
 import {$t} from "./i18n";
@@ -80,17 +80,11 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
     // a string it will only replace the first instance. If `old_syntax` is
     // a RegExp with a global flag, it will replace all instances.
 
-    $textarea.val(
-        $textarea.val().replace(
-            old_syntax,
-            () =>
-                // We need this anonymous function to avoid JavaScript's
-                // replace() function treating `$`s in new_syntax as special syntax.  See
-                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
-                // for details.
-                new_syntax,
-        ),
-    );
+    // We need use anonymous function for `new_syntax` to avoid JavaScript's
+    // replace() function treating `$`s in new_syntax as special syntax.  See
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
+    // for details.
+    replace($textarea[0], old_syntax, () => new_syntax);
 }
 
 export function compute_placeholder_text(opts) {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -212,6 +212,7 @@ export function setup_upload(config) {
     $("body").on("change", get_item("file_input_identifier", config), (event) => {
         const files = event.target.files;
         upload_files(uppy, config, files);
+        get_item("textarea", config).trigger("focus");
         event.target.value = "";
     });
 

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 156
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (213, 0)
+PROVISION_VERSION = (214, 0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9948,10 +9948,10 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-text-field-edit@^3.1.0:
-  version "3.1.9001"
-  resolved "https://registry.yarnpkg.com/text-field-edit/-/text-field-edit-3.1.9001.tgz#479bbc6ed4c5a1dd721118daf9b13fd785cda257"
-  integrity sha512-5xSqH9HMiW4r/YDoz/DMX895elwenTCV/xwjGSmhVol62YFTHivbZi3T0jKm0Oyzj63RA2C0XAnWMQSC0SO/JA==
+text-field-edit@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/text-field-edit/-/text-field-edit-3.2.0.tgz#677f5b3a7cd220d37f6f1b85c51850f60d9da871"
+  integrity sha512-HVgVoOMAIgsXFsGuzkghk0NQPO8DrfNeHtRSbKEUQAkLOeY+Mb2ofK/AGZByxObPNo3vqODyghl+9VXUjHypig==
 
 text-hex@1.0.x:
   version "1.0.0"


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/selection.20after.20upload

The important detail here is that the cursor is after the file link after the upload completes.