### PR TITLE
people: Verify `utcToZonedTime` returns a `Date` before formatting it.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {parseISO} = require("date-fns");
+const date_fns_tz = require("date-fns-tz");
 const _ = require("lodash");
 const MockDate = require("mockdate");
 
@@ -513,6 +514,21 @@ test_people("user_timezone", () => {
 
     user_settings.twenty_four_hour_time = false;
     assert.equal(people.get_user_time(me.user_id), "12:09 AM");
+});
+
+test_people("utcToZonedTime", ({override}) => {
+    MockDate.set(parseISO("20130208T080910").getTime());
+    user_settings.twenty_four_hour_time = true;
+
+    override(date_fns_tz, "utcToZonedTime", () => new Date("2022/10/10 03:24"));
+    assert.equal(people.get_user_time(me.user_id), "3:24");
+
+    override(date_fns_tz, "utcToZonedTime", () => new Date("foo"));
+    blueslip.expect("error", "Got invalid date for timezone: America/Los_Angeles", 2);
+    people.get_user_time(me.user_id);
+
+    override(date_fns_tz, "utcToZonedTime", () => undefined);
+    people.get_user_time(me.user_id);
 });
 
 test_people("user_type", () => {


### PR DESCRIPTION
`current_date` being invalid here could result in `user card` not being displayed to users. So, it is important to verify that the date is valid so that we don't run into any errors.

This fixes (unverified) an issue where user card was not being displayed to some users on Zulip Desktop app because `current_date` was not valid.

discussion: https://chat.zulip.org/#narrow/stream/16-desktop/topic/set.20status.20after.20upgrade.20to.206.2E0