### PR TITLE
narrow-banner: Fix empty narrow banner titles with user's full name.

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -388,7 +388,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated HTML: You have no private messages with Example Bot yet.",
+            "translated: You have no private messages with Example Bot yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -414,7 +414,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated HTML: You have no private messages with Alice Smith yet.",
+            "translated: You have no private messages with Alice Smith yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -487,7 +487,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated HTML: You have no group private messages with Alice Smith yet.",
+            "translated: You have no group private messages with Alice Smith yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -497,9 +497,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated HTML: You haven't received any messages sent by Raymond yet.",
-        ),
+        empty_narrow_html("translated: You haven't received any messages sent by Raymond yet."),
     );
 
     set_filter([["sender", "sinwar@example.com"]]);

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -328,7 +328,7 @@ function pick_empty_narrow_banner() {
                     };
                 }
                 return {
-                    title: $t_html(
+                    title: $t(
                         {
                             defaultMessage: "You have no private messages with {person} yet.",
                         },
@@ -366,7 +366,7 @@ function pick_empty_narrow_banner() {
             const sender = people.get_by_email(first_operand);
             if (sender) {
                 return {
-                    title: $t_html(
+                    title: $t(
                         {
                             defaultMessage:
                                 "You haven't received any messages sent by {person} yet.",
@@ -398,7 +398,7 @@ function pick_empty_narrow_banner() {
                 };
             }
             return {
-                title: $t_html(
+                title: $t(
                     {
                         defaultMessage: "You have no group private messages with {person} yet.",
                     },


### PR DESCRIPTION
Fixes an issue introduced in 6b4ab21 when we started using the user's full name for empty narrow titles in a single operator narrow of either "pm-with", "group-pm-with" or "sender".

Now, for these empty narrow titles, any `'`, `&` or `<` characters in the user's full name are not escaped. Other characters would that have been escaped by `$t_html` are already not allowed in a user's full name on the backend (`"` and `>`).

---

**Screenshots and screen captures:**

#### group-pm-with `Cordelia, Lear's daughter`
<details>
<summary>CURRENT</summary>

![Screenshot from 2022-11-22 14-00-49](https://user-images.githubusercontent.com/63245456/203324597-1f858b3e-d154-421f-a2b0-cf85f390e591.png)
</details>
<details>
<summary>UPDATED</summary>

![Screenshot from 2022-11-22 13-58-13](https://user-images.githubusercontent.com/63245456/203325048-7281da25-570e-4853-8edf-1cec5ef4313b.png)
</details>

#### sender `Bert & Ernie`
<details>
<summary>CURRENT</summary>

![Screenshot from 2022-11-22 14-00-42](https://user-images.githubusercontent.com/63245456/203324577-7b53475d-0746-4632-8ce9-b8d4b5e741dc.png)
</details>
<details>
<summary>UPDATED</summary>

![Screenshot from 2022-11-22 13-58-24](https://user-images.githubusercontent.com/63245456/203325004-8d84ce35-2da8-40a2-b72b-7b58e5488250.png)
</details>

#### pm-with `i <3 zulip`
<details>
<summary>CURRENT</summary>

![Screenshot from 2022-11-22 14-01-02](https://user-images.githubusercontent.com/63245456/203324539-70932d01-f02c-4a22-ac76-92fe98128711.png)
</details>
<details>
<summary>UPDATED</summary>

![Screenshot from 2022-11-22 13-58-00](https://user-images.githubusercontent.com/63245456/203325084-8f1592e3-2e79-4b79-b7b3-37a7b384102c.png)
</details>

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
