### PR TITLE
Update min width of role and name column.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -355,8 +355,12 @@ td .button {
     }
 }
 
+.user_name_row{
+    max-width: 120px;
+}
+
 .user_role {
-    min-width: 95px;
+    min-width: 100px;
 }
 
 .button,

--- a/static/templates/settings/admin_user_list.hbs
+++ b/static/templates/settings/admin_user_list.hbs
@@ -1,5 +1,5 @@
 <tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
-    <td>
+    <td class="user_name_row">
         <span class="user_name" >{{full_name}} {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
         <i class="fa fa-ban deactivated-user-icon" title="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
     </td>


### PR DESCRIPTION
Set minimum width for role column in users list and name column, deactivated users list and bots list such that role value always fits in one line.

Fixes: [#23218](https://github.com/zulip/zulip/issues/23218) 

**Screenshots and screen captures**
**Russian before max-width the name column**
<img width="751" alt="proof1" src="https://user-images.githubusercontent.com/101876673/203345106-285d9757-0819-4741-b61a-5ae4612dd383.png">
**After**
<img width="751" alt="afterrowname" src="https://user-images.githubusercontent.com/101876673/203345141-c59f9b85-f84c-4bbb-bcc6-bdea84efdc7c.png">
**English**
<img width="751" alt="english" src="https://user-images.githubusercontent.com/101876673/203345173-2c852e08-8bd1-4acb-b60f-121e461e7ecc.png">
Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.