### PR TITLE
bootstrap: Stop using the Bootstrap form-horizontal CSS class.

### DIFF
--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -43,7 +43,7 @@
             </div>
         </div>
 
-        <div class="form-horizontal" id="privacy_settings_box">
+        <div id="privacy_settings_box">
             <h3 class="inline-block">{{t "Privacy" }}</h3>
             <div class="alert-notification privacy-setting-status"></div>
             <div class="input-group">
@@ -79,7 +79,7 @@
 
         <hr class="settings_separator" />
 
-        <div class="form-horizontal" id="api_key_button_box">
+        <div id="api_key_button_box">
             <h3>{{t "API key" }}</h3>
 
             <div class="input-group">

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -5,7 +5,7 @@
     <p class="add-emoji-text {{#unless can_add_emojis}}hide{{/unless}}">
         {{#tr}}Add extra emoji for members of the {realm_name} organization.{{/tr}}
     </p>
-    <form class="form-horizontal admin-emoji-form {{#unless can_add_emojis}}hide{{/unless}}">
+    <form class="admin-emoji-form {{#unless can_add_emojis}}hide{{/unless}}">
         <div class="add-new-emoji-box grey-box">
             <div class="new-emoji-form">
                 <div class="settings-section-title new-emoji-section-title no-padding">{{t "Add a new emoji" }}</div>

--- a/static/templates/settings/linkifier_settings_admin.hbs
+++ b/static/templates/settings/linkifier_settings_admin.hbs
@@ -42,7 +42,7 @@
         </p>
 
         {{#if is_admin}}
-        <form class="form-horizontal admin-linkifier-form">
+        <form class="admin-linkifier-form">
             <div class="add-new-linkifier-box grey-box">
                 <div class="new-linkifier-form wrapper">
                     <div class="settings-section-title new-linkifier-section-title">{{t "Add a new linkifier" }}</div>

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -125,7 +125,7 @@
             {{> settings_save_discard_widget section_name="email-message-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
-        <div class="input-group form-horizontal time-limit-setting">
+        <div class="input-group time-limit-setting">
 
             <label for="email_notifications_batching_period">
                 {{t "Delay before sending message notification emails" }}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -1,5 +1,5 @@
 <div id="organization-permissions" data-name="organization-permissions" class="settings-section">
-    <form class="form-horizontal admin-realm-form org-permissions-form">
+    <form class="admin-realm-form org-permissions-form">
 
         <div id="org-join" class="org-subsection-parent">
             <div class="subsection-header">

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -1,5 +1,5 @@
 <div id="organization-profile" data-name="organization-profile" class="settings-section">
-    <form class="form-horizontal admin-realm-form org-profile-form">
+    <form class="admin-realm-form org-profile-form">
         <div class="alert" id="admin-realm-deactivation-status"></div>
 
         <div id="org-org-profile" class="org-subsection-parent">

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -1,5 +1,5 @@
 <div id="organization-settings" data-name="organization-settings" class="settings-section">
-    <form class="form-horizontal admin-realm-form org-settings-form">
+    <form class="admin-realm-form org-settings-form">
 
         <div id="org-notifications" class="org-subsection-parent">
             <div class="subsection-header">

--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -10,7 +10,7 @@
 
     {{> notification_settings prefix="realm_" for_realm_settings=true}}
 
-    <div class="form-horizontal privacy_settings org-subsection-parent">
+    <div class="privacy_settings org-subsection-parent">
         <div class="subsection-header inline-block">
             <h3 class="inline-block">{{t "Privacy settings" }}</h3>
             {{> settings_save_discard_widget section_name="privacy-setting" show_only_indicator=false }}
@@ -30,7 +30,7 @@
           help_link="/help/read-receipts"}}
     </div>
 
-    <div class="form-horizontal other_settings org-subsection-parent">
+    <div class="other_settings org-subsection-parent">
         <div class="subsection-header inline-block">
             <h3 class="inline-block">{{t "Other settings" }}</h3>
             {{> settings_save_discard_widget section_name="other-setting" show_only_indicator=false }}

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -22,7 +22,7 @@
         </ul>
 
         {{#if is_admin}}
-        <form class="form-horizontal admin-playground-form">
+        <form class="admin-playground-form">
             <div class="add-new-playground-box grey-box">
                 <div class="new-playground-form wrapper">
                     <div class="settings-section-title">

--- a/static/templates/settings/profile_settings.hbs
+++ b/static/templates/settings/profile_settings.hbs
@@ -18,8 +18,7 @@
                         </div>
                     </div>
                 </div>
-
-                <form class="form-horizontal timezone-setting-form">
+                <form class="timezone-setting-form">
                     <div class="input-group grid">
                         <label for="timezone" class="dropdown-title inline-block">{{t "Time zone" }}</label>
                         <div class="alert-notification timezone-setting-status"></div>
@@ -37,7 +36,7 @@
                     </div>
                 </form>
 
-                <form class="form-horizontal custom-profile-fields-form grid"></form>
+                <form class="custom-profile-fields-form grid"></form>
                 <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
                     {{t 'Preview profile' }}
                     <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview profile' }}"></i>


### PR DESCRIPTION
According to the initial solution proposed for the problem by [Tim Abbott](https://chat.zulip.org/#narrow/stream/6-frontend/topic/issue-.2322954), Bootstrap dependencies of `form-horizontal` were removed in 10 out of 21 files that have the class in question. All 10 modified files are in `static/templates/settings`. 

To verify such changes I analyzed both the "before" and "after" visuals of them and did the test of filling out the forms after the removal of the class, and such forms continued to work normally.

Fixes: Part of [#22954](https://github.com/zulip/zulip/issues/22954).

**Self-review checklist**

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
