### PR TITLE
Designmenu

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -521,7 +521,7 @@ input.text-error {
                 content: "\25B2";
                 position: absolute;
                 top: -4px;
-                right: 11px;
+                right: 12px;
                 font-size: 2em;
                 color: hsl(0, 0%, 100%);
                 line-height: 0;

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -521,9 +521,9 @@ input.text-error {
                 content: "\25B2";
                 position: absolute;
                 top: -4px;
-                right: 9px;
-                font-size: 0.5em;
-                color: hsl(0, 0%, 87%);
+                right: 11px;
+                font-size: 2.0em;
+                color: hsl(0, 0%, 100%);
                 line-height: 0;
                 transform: scale(1.8, 1);
             }

--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -522,7 +522,7 @@ input.text-error {
                 position: absolute;
                 top: -4px;
                 right: 11px;
-                font-size: 2.0em;
+                font-size: 2em;
                 color: hsl(0, 0%, 100%);
                 line-height: 0;
                 transform: scale(1.8, 1);


### PR DESCRIPTION
Triangles on the navigation menu have been improved.

Fixes: Remove up-triangles from landing page menus #23247

The size and colour of the triangles have been modified accordingly to match the dropdown menu. (lines 524 to 526 modified in static/styles/portico/portico.css)

![Image1-zulip](https://user-images.githubusercontent.com/116274283/203526086-2afa9bf6-bf32-4d29-a05e-30e2df316930.png)

