### PR TITLE
stream_list: Persist zoomed in state across redraws.

### DIFF
--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -409,6 +409,18 @@ function set_stream_unread_count(stream_id, count, stream_has_any_unread_mention
 }
 
 export function update_streams_sidebar(force_rerender) {
+    if (!force_rerender && topic_zoom.is_zoomed_in()) {
+        // We do our best to update topics that are displayed
+        // in case user zoomed in. Streams list will be updated,
+        // once the user zooms out. This avoids user being zoomed out
+        // when a new message causes streams to re-arrange.
+        const filter = narrow_state.filter();
+        update_stream_sidebar_for_narrow(filter);
+        topic_zoom.set_pending_stream_list_rerender(true);
+        return;
+    }
+    topic_zoom.set_pending_stream_list_rerender(false);
+
     build_stream_list(force_rerender);
 
     stream_cursor.redraw();

--- a/web/src/topic_zoom.js
+++ b/web/src/topic_zoom.js
@@ -4,6 +4,7 @@ import * as popovers from "./popovers";
 import * as stream_list from "./stream_list";
 import * as topic_list from "./topic_list";
 
+let pending_stream_list_rerender = false;
 let zoomed_in = false;
 
 export function is_zoomed_in() {
@@ -22,7 +23,14 @@ function zoom_in() {
     zoomed_in = true;
 }
 
+export function set_pending_stream_list_rerender(value) {
+    pending_stream_list_rerender = value;
+}
+
 export function zoom_out() {
+    if (pending_stream_list_rerender) {
+        stream_list.update_streams_sidebar(true);
+    }
     const $stream_li = topic_list.get_stream_li();
 
     popovers.hide_all_except_sidebars();

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -146,7 +146,7 @@ li.show-more-topics {
         }
     }
 
-    .inactive_stream {
+    .inactive_stream:not(.active-filter) {
         opacity: 0.5;
     }
 


### PR DESCRIPTION
Fixes #23588

We completely rebuild stream list due to adding, removing, renaming, switching stream narrows etc., we used to lose zoomed in state. This caused a bug where user often comes out of zoomed in state unintentionally.