### PR TITLE
Added a check to confirm if local storage is supported before retrieving key value from it

### DIFF
--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -32,6 +32,11 @@ const ls = {
 
     getData(version, name) {
         const key = this.formGetter(version, name);
+
+        if (!localstorage.supported()) {
+            return undefined;
+        }
+
         let data = localStorage.getItem(key);
         data = ls.parseJSON(data);
 

--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -33,10 +33,6 @@ const ls = {
     getData(version, name) {
         const key = this.formGetter(version, name);
 
-        if (!localstorage.supported()) {
-            return undefined;
-        }
-
         let data = localStorage.getItem(key);
         data = ls.parseJSON(data);
 
@@ -119,6 +115,9 @@ export const localstorage = function () {
         },
 
         get(name) {
+            if (!localstorage.supported()) {
+                return undefined;
+            }
             const data = ls.getData(_data.VERSION, name);
 
             if (data) {


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/23316

When local storage is disabled on Firefox (setting **dom.storage.enabled** to False in **about:config**), Zulip will throw an Uncaught TypeError on line 35 of localstorage.js. This error is shown in the screenshot below. This error is caused by line 35 using `.getItem(key)` on local storage, regardless of whether local storage is supported on the browser or not. The new changes added an if-statement to ensure that local storage is supported before calling `.getItem(key)` on it, therefore preventing the Uncaught TypeError.

<img width="639" alt="image" src="https://user-images.githubusercontent.com/59936188/203634765-47ce5167-c6aa-4a18-a923-76db316e6244.png">

Checklist:
- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).
- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.
- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
