### PR TITLE
settings: Fix custom input for user email-notification-batching setting.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -24,8 +24,6 @@ import * as settings_ui from "./settings_ui";
 import * as stream_settings_data from "./stream_settings_data";
 import * as ui_report from "./ui_report";
 
-export let parse_time_limit;
-
 const meta = {
     loaded: false,
 };
@@ -766,6 +764,10 @@ function get_auth_method_list_data() {
     return new_auth_methods;
 }
 
+export function parse_time_limit($elem) {
+    return Math.floor(Number.parseFloat(Number($elem.val()), 10).toFixed(1) * 60);
+}
+
 function get_time_limit_setting_value($input_elem, for_api_data = true) {
     const select_elem_val = $input_elem.val();
 
@@ -968,10 +970,6 @@ export function register_save_discard_widget_handlers(
         const $save_btn_controls = $(e.target).closest(".save-button-controls");
         change_save_button_state($save_btn_controls, "discarded");
     });
-
-    parse_time_limit = function parse_time_limit($elem) {
-        return Math.floor(Number.parseFloat(Number($elem.val()), 10).toFixed(1) * 60);
-    };
 
     function get_complete_data_for_subsection(subsection) {
         let data = {};


### PR DESCRIPTION
The custom input was not being shown when changing user email notification batching period setting dropdown to "Custom" option. This was because parse_time_limit was undefined in case orgamization settings was not loaded till then, and the code raised an error.

This PR changes the code to define parse_limit_function at module-level instead of defining it in
`register_save_discard_widget_handlers` which is called only when build_page is called which
happens only when organization settings is opened before changing the notification batching setting.

Fixes #23674.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Peek 2022-11-27 23-08](https://user-images.githubusercontent.com/35494118/204151368-9338ab59-7651-4664-b0a1-b392ecfeea00.gif)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
