### PR TITLE
left_sidebar: Add login link to left sidebar for logged-out users.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -316,6 +316,7 @@ li.show-more-topics {
     }
 }
 
+#login-link-container,
 #subscribe-to-more-streams {
     text-decoration: none;
     margin: 5px auto 5.5px 10px;

--- a/static/templates/left_sidebar.hbs
+++ b/static/templates/left_sidebar.hbs
@@ -101,6 +101,13 @@
                 {{#unless is_guest }}
                     <div id="subscribe-to-more-streams"></div>
                 {{/unless}}
+                <div id="login-link-container" class="only-visible-for-spectators">
+                    <a class="login_button">
+                        <i class="fa fa-sign-in" aria-hidden="true"></i>
+                        {{~!-- squash whitespace --~}}
+                        {{t 'Log in to browse more streams'}}
+                    </a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
It can sometimes be unclear to logged-out users why they are not seeing all their subscribed streams in the left sidebar.

To reduce the chances of users being confused, added a login link at the bottom of the streams list for logged-out users.

To avoid leaking any information, the link is shown regardless of whether or not there are actually any additional streams in the organization.

Fixes #22844.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/87542880/204156975-63a7b2a5-8c12-482f-8652-12619590e47f.png)


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
