### PR TITLE
integrations-docs: Remove `settings_html` and `subscriptions_html` from `add_api_uri_context`.

### DIFF
--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -420,27 +420,29 @@ Second, you need to write the actual documentation content in
 ```md
 Learn how Zulip integrations work with this simple Hello World example!
 
-The Hello World webhook will use the `test` stream, which is
-created by default in the Zulip dev environment. If you are running
-Zulip in production, you should make sure that this stream exists.
+1.  The Hello World webhook will use the `test` stream, which is created
+    by default in the Zulip development environment. If you are running
+    Zulip in production, you should make sure that this stream exists.
 
-Next, on your {{ settings_html|safe }}, create a Hello World bot.
-Construct the URL for the Hello World bot using the API key and
-stream name:
+1.  {!create-bot-construct-url.md!}
 
-`{{ api_url }}/v1/external/helloworld?api_key=abcdefgh&stream=test`
 
-To trigger a notification using this webhook, use
-`send_webhook_fixture_message` from the Zulip command line:
+1.  To trigger a notification using this example webhook, you can use
+    `send_webhook_fixture_message` from a [Zulip development
+    environment](https://zulip.readthedocs.io/en/latest/development/overview.html):
 
-    (zulip-py3-venv) vagrant@vagrant:/srv/zulip$
-    ./manage.py send_webhook_fixture_message \
-        --fixture=zerver/tests/fixtures/helloworld/hello.json \
-        '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'
+    ```
+        (zulip-py3-venv) vagrant@vagrant:/srv/zulip$
+        ./manage.py send_webhook_fixture_message \
+        > --fixture=zerver/tests/fixtures/helloworld/hello.json \
+        > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=abcdefgh&stream=stream%20name;'
+    ```
 
-Or, use curl:
+    Or, use curl:
 
-    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key\=&lt;api_key&gt;
+    ```
+    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key=abcdefgh&stream=stream%20name;
+    ```
 
 {!congrats.md!}
 
@@ -448,9 +450,10 @@ Or, use curl:
 
 ```
 
-`{!congrats.md!}` is an example of a Markdown macro. Zulip has a macro-based
-Markdown/Jinja2 framework that includes macros for common instructions in
-Zulip's webhooks/integrations documentation.
+`{!create-bot-construct-url.md!}` and `{!congrats.md!}` are examples of
+a Markdown macro. Zulip has a macro-based Markdown/Jinja2 framework that
+includes macros for common instructions in Zulip's webhooks/integrations
+documentation.
 
 See
 [our guide on documenting an integration][integration-docs-guide]

--- a/templates/zerver/integrations/mercurial.md
+++ b/templates/zerver/integrations/mercurial.md
@@ -1,14 +1,12 @@
 Get Zulip notifications when you `hg push`!
 
-{!create-stream.md!}
+1. {!create-stream.md!}
 
-Next, on your {{ settings_html|safe }}, create a Mercurial bot.
-
-Then:
+1. {!create-an-incoming-webhook.md!}
 
 1.  {!download-python-bindings.md!}
 
-2.  Edit the `hg/.hgrc` configuration file for this default Mercurial
+1.  Edit the `hg/.hgrc` configuration file for this default Mercurial
 repository and add the following sections, using the credentials for
 your Mercurial bot and setting the appropriate path to the integration
 hook if it installs in a different location on this system:
@@ -22,7 +20,7 @@ hook if it installs in a different location on this system:
         stream = "commits"
         site = {{ api_url }}
 
-3.  Add the directory where the `zulip_changegroup.py` script was
+1.  Add the directory where the `zulip_changegroup.py` script was
 installed to the environment variable `PYTHONPATH`.  For example, if
 you installed the Zulip Python bindings at the system level, it'd be:
 

--- a/templates/zerver/integrations/redmine.md
+++ b/templates/zerver/integrations/redmine.md
@@ -24,7 +24,7 @@ The Zulip plugin is now registered with Redmine!
 
 ### Global settings
 
-1. On your {{ settings_html|safe }}, create a new Redmine bot.
+1. {!create-an-incoming-webhook.md!}
 
 2. Log in to your Redmine instance, click on **Administration** in the top-left
 corner, then click on **Plugins**.

--- a/templates/zerver/integrations/rss.md
+++ b/templates/zerver/integrations/rss.md
@@ -10,7 +10,7 @@ RSS integration!
 
 1.  {!create-stream.md!}
 
-1.  Next, on your {{ settings_html|safe }}, create an RSS bot.
+1.  {!create-an-incoming-webhook.md!}
 
 1.  {!download-python-bindings.md!}
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -369,28 +369,6 @@ class IntegrationTest(ZulipTestCase):
         self.assertEqual(context["api_url"], "http://mysubdomain.testserver/api")
         self.assertTrue(context["html_settings_links"])
 
-    def test_html_settings_links(self) -> None:
-        context: Dict[str, Any] = {}
-        with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
-            add_api_uri_context(context, HostRequestMock())
-        self.assertEqual(context["settings_html"], "Zulip settings page")
-        self.assertEqual(context["subscriptions_html"], "streams page")
-
-        context = {}
-        with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
-            add_api_uri_context(context, HostRequestMock(host="mysubdomain.testserver"))
-        self.assertEqual(context["settings_html"], '<a href="/#settings">Zulip settings page</a>')
-        self.assertEqual(
-            context["subscriptions_html"], '<a target="_blank" href="/#streams">streams page</a>'
-        )
-
-        context = {}
-        add_api_uri_context(context, HostRequestMock())
-        self.assertEqual(context["settings_html"], '<a href="/#settings">Zulip settings page</a>')
-        self.assertEqual(
-            context["subscriptions_html"], '<a target="_blank" href="/#streams">streams page</a>'
-        )
-
 
 class AboutPageTest(ZulipTestCase):
     @skipUnless(settings.ZILENCER_ENABLED, "requires zilencer")

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -56,14 +56,6 @@ def add_api_uri_context(context: Dict[str, Any], request: HttpRequest) -> None:
     context["zulip_url"] = zulip_url
 
     context["html_settings_links"] = html_settings_links
-    if html_settings_links:
-        settings_html = '<a href="/#settings">Zulip settings page</a>'
-        subscriptions_html = '<a target="_blank" href="/#streams">streams page</a>'
-    else:
-        settings_html = "Zulip settings page"
-        subscriptions_html = "streams page"
-    context["settings_html"] = settings_html
-    context["subscriptions_html"] = subscriptions_html
 
 
 class ApiURLView(TemplateView):

--- a/zerver/webhooks/helloworld/doc.md
+++ b/zerver/webhooks/helloworld/doc.md
@@ -3,29 +3,27 @@ Learn how Zulip integrations work with this simple Hello World example!
 This webhook is Zulip's official [example
 integration](/api/incoming-webhooks-walkthrough).
 
-1.  The Hello World webhook will use the `test` stream, which is
-    by default in the Zulip dev environment. If you are running
+1.  The Hello World webhook will use the `test` stream, which is created
+    by default in the Zulip development environment. If you are running
     Zulip in production, you should make sure that this stream exists.
 
-1.  Next, on your {{ settings_html|safe }}, create a Hello World bot.
-    the URL for the Hello World bot using the API key and
-    stream name:
+1.  {!create-bot-construct-url.md!}
 
-    `{{ api_url }}/v1/external/helloworld?api_key=abcdefgh&stream=test`
-
-1.  To trigger a notification using this webhook, you can use
+1.  To trigger a notification using this example webhook, you can use
     `send_webhook_fixture_message` from a [Zulip development
     environment](https://zulip.readthedocs.io/en/latest/development/overview.html):
 
+    ```
         (zulip-py3-venv) vagrant@vagrant:/srv/zulip$
         ./manage.py send_webhook_fixture_message \
         > --fixture=zerver/tests/fixtures/helloworld/hello.json \
-        > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'
+        > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=abcdefgh&stream=stream%20name;'
+    ```
 
     Or, use curl:
 
     ```
-    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key\=&lt;api_key&gt;
+    curl -X POST -H "Content-Type: application/json" -d '{ "featured_title":"Marilyn Monroe", "featured_url":"https://en.wikipedia.org/wiki/Marilyn_Monroe" }' http://localhost:9991/api/v1/external/helloworld\?api_key=abcdefgh&stream=stream%20name;
     ```
 
 {!congrats.md!}


### PR DESCRIPTION
The first two commits remove the last uses of `settings_html` in favor of the current macros and styles for integrations documentation:
- 1st commit: Focuses on updating and improving the documentation for the example **Hello World** integration.
- 2nd commit: Updates `redmine`, `RSS` and `mercurial` docs to use current macros and styles.

The 3rd commit removes `settings_html` and `subscriptions_html` from  `add_api_uri_context`, as well as related backend docs tests.

---

**Notes**:
- In https://github.com/zulip/zulip/commit/e9e2721aa2bbc21881229b80298a69378dfbeb78, the use of `{{ settings_html|safe }}` was removed from the shared "create a bot" documentation macro files.
- The last use of `{{ subscriptions_html|safe }}` appears to have been removed in 0c94f27f1357b9d5.
- These are prep commits for work on updating the help center directory structure. See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/help.20center.20directory.20structure/near/1436396).
- Question: Do we want to update or remove the screenshot for the create an incoming webhook point? See screenshot below to compare to the screenshots in the integrations documentation currently. I'm not convinced that we need the image at all though as the instruction without it would be pretty clear.

<details>
<summary>Current bot type dropdown menu</summary>

![Screenshot from 2022-11-28 19-54-44](https://user-images.githubusercontent.com/63245456/204358036-444ac825-722a-4f84-b989-bba78d09be44.png)
</details>

---

**Screenshots and screen captures:**

<details>
<summary>Hello World integration documentation</summary>

[Current documentation](https://zulip.com/integrations/doc/helloworld)
![Screenshot from 2022-11-28 18-15-16](https://user-images.githubusercontent.com/63245456/204356050-38b7382b-e535-4f3f-a197-12938a37febf.png)

</details>
<details>
<summary>Incoming webhook tutorial - step 6: documentation</summary>

[Current generic documentation](https://zulip.com/api/incoming-webhooks-walkthrough#step-6-create-documentation)
[Current CZO documentation - note the `settings_html` link](https://chat.zulip.org/api/incoming-webhooks-walkthrough#step-6-create-documentation)
![Screenshot from 2022-11-28 18-15-49](https://user-images.githubusercontent.com/63245456/204356089-e1d2ee55-fbc7-491f-b446-2d4705132d10.png)

</details>
<details>
<summary>Mercurial integration documentation</summary>

[Current documentation](https://zulip.com/integrations/doc/mercurial)
![Screenshot from 2022-11-28 18-16-45](https://user-images.githubusercontent.com/63245456/204356137-271b765b-6598-43db-ae01-69de2a0fdc03.png)

</details>
<details>
<summary>Redmine integration documentation</summary>

[Current documentation](https://zulip.com/integrations/doc/redmine)
![Screenshot from 2022-11-28 18-17-06](https://user-images.githubusercontent.com/63245456/204356177-f517a043-7c44-4922-835a-34781918a30f.png)

</details>
<details>
<summary>RSS integration doc</summary>

[Current documentation](https://zulip.com/integrations/doc/rss)
![Screenshot from 2022-11-28 18-17-25](https://user-images.githubusercontent.com/63245456/204356207-6e094bd2-cedd-488e-9277-27712ffa052b.png)

</details>

---


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
