### PR TITLE
contributor docs: Add guidance on claiming a second issue.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,6 +340,15 @@ labels.
   have a new feature you'd like to add, you can start a conversation [in our
   development community](https://zulip.com/development-community/#where-do-i-send-my-message)
   explaining the feature idea and the problem that you're hoping to solve.
+- **I'm waiting for the next round of review on my PR. Can I pick up another
+  issue in the meantime?** Someone's first Zulip PR often requires quite a bit
+  of iteration, so please go through at least one round of feedback before
+  picking up a second issue. After that, sure! If
+  [Zulipbot](https://github.com/zulip/zulipbot) does not allow you to claim an
+  issue, you can post a comment describing the status of your other work on the
+  issue you're interested in, and asking for the issue to be assigned to you.
+  Note that addressing feedback on in-progress PRs should always take priority
+  over starting a new PR.
 - **I think my PR is done, but it hasn't been merged yet. What's going on?**
   1. **Double-check that you have addressed all the feedback**, including any comments
      on [Git commit


### PR DESCRIPTION
![Screen Shot 2022-11-28 at 11 06 57 AM](https://user-images.githubusercontent.com/2090066/204360321-d48618ed-c813-458e-b85a-31ee3e62aca8.png)

- Please feel free to tweak the wording.
- This seemed like a reasonable place to put the question, but I could also imagine having it higher up in the bulleted list.