### PR TITLE
left_sidebar: Add border radius to selected stream list items.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -375,6 +375,7 @@ li.active-sub-filter {
     .topic-list .filter-topics,
     > .bottom_left_row {
         background-color: hsl(202, 56%, 91%);
+        border-radius: 4px;
     }
 }
 


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20selection.20area

before:

<img width="414" alt="Screenshot 2022-11-29 at 12 58 13 AM" src="https://user-images.githubusercontent.com/25124304/204364106-5f937e2f-87e3-4c29-87f5-4196579d0523.png">

after:
<img width="414" alt="Screenshot 2022-11-29 at 12 58 04 AM" src="https://user-images.githubusercontent.com/25124304/204364117-ae663a13-7697-46e5-b7c6-83ba586e36af.png">
