### PR TITLE
[prototype] integrations: Convert webhook instructions to URL widget.

### DIFF
--- a/zerver/webhooks/clubhouse/doc.md
+++ b/zerver/webhooks/clubhouse/doc.md
@@ -2,13 +2,15 @@ Get Zulip notifications for your Clubhouse Stories and Epics!
 
 1. {!create-stream.md!}
 
-1. {!create-bot-construct-url.md!}
+1. {!create-an-incoming-webhook.md!}
+
+1. [Generate the URL]() for your bot.
 
 1. Go to your Clubhouse Dashboard, and click on the settings icon in
    the top-right corner. Click on **Integrations**, and select **Webhooks**.
    Click **+ Add New Webhook**.
 
-1. Set **Payload URL** to the URL constructed above, and click
+1. Set **Payload URL** to the URL generated above, and click
    **Add New Webhook**.
 
 {!congrats.md!}


### PR DESCRIPTION
This is just a prototype of what an integration page could look like after we make a widget for generating a URL for an incoming webhook integration. This PR is not intended for integration.

Current page: https://zulip.com/integrations/doc/clubhouse

New: 
![Screen Shot 2022-11-28 at 3 40 22 PM](https://user-images.githubusercontent.com/2090066/204404044-af83f426-b4d5-4831-90a3-990917c78632.png)
