### PR TITLE
Change font of date in recipient row and date separators.

### DIFF
--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -514,7 +514,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "bottom");
 
-        assert.ok(!message_group2.group_date_divider_html);
+        assert.ok(!message_group2.group_date_html);
         assert_message_groups_list_equal(list._message_groups, [message_group1, message_group2]);
         assert_message_groups_list_equal(result.append_groups, [message_group2]);
         assert.deepEqual(result.prepend_groups, []);
@@ -537,7 +537,7 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.prepend_groups, []);
         assert.deepEqual(result.rerender_groups, []);
         assert.deepEqual(result.append_messages, []);
-        assert.equal(message_group2.group_date_divider_html, "900000000");
+        assert.equal(message_group2.group_date_html, "900000000");
     })();
 
     (function test_append_message_different_day() {
@@ -644,8 +644,7 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "top");
 
-        // We should have a group date divider between the recipient blocks.
-        assert.equal(message_group1.group_date_divider_html, "900000000");
+        assert.equal(message_group1.group_date_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2, message_group1]);
         assert.deepEqual(result.append_groups, []);
         assert_message_groups_list_equal(result.prepend_groups, [message_group2]);
@@ -663,7 +662,6 @@ test("merge_message_groups", () => {
         const list = build_list([message_group1]);
         const result = list.merge_message_groups([message_group2], "top");
 
-        // We should have a group date divider within the single recipient block.
         assert.equal(message_group2.message_containers[1].date_divider_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2]);
         assert.deepEqual(result.append_groups, []);

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -14,11 +14,8 @@ const noop = () => {};
 
 // timerender calls setInterval when imported
 mock_esm("../../static/js/timerender", {
-    render_date(time1, time2) {
-        if (time2 === undefined) {
-            return [{outerHTML: String(time1.getTime())}];
-        }
-        return [{outerHTML: String(time1.getTime()) + " - " + String(time2.getTime())}];
+    render_date(time) {
+        return [{outerHTML: String(time.getTime())}];
     },
     stringify_time(time) {
         return time.toString("h:mm TT");
@@ -540,7 +537,7 @@ test("merge_message_groups", () => {
         assert.deepEqual(result.prepend_groups, []);
         assert.deepEqual(result.rerender_groups, []);
         assert.deepEqual(result.append_messages, []);
-        assert.equal(message_group2.group_date_divider_html, "900000000 - 1000000");
+        assert.equal(message_group2.group_date_divider_html, "900000000");
     })();
 
     (function test_append_message_different_day() {
@@ -648,7 +645,7 @@ test("merge_message_groups", () => {
         const result = list.merge_message_groups([message_group2], "top");
 
         // We should have a group date divider between the recipient blocks.
-        assert.equal(message_group1.group_date_divider_html, "900000000 - 1000000");
+        assert.equal(message_group1.group_date_divider_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2, message_group1]);
         assert.deepEqual(result.append_groups, []);
         assert_message_groups_list_equal(result.prepend_groups, [message_group2]);
@@ -667,7 +664,7 @@ test("merge_message_groups", () => {
         const result = list.merge_message_groups([message_group2], "top");
 
         // We should have a group date divider within the single recipient block.
-        assert.equal(message_group2.message_containers[1].date_divider_html, "900000000 - 1000000");
+        assert.equal(message_group2.message_containers[1].date_divider_html, "900000000");
         assert_message_groups_list_equal(list._message_groups, [message_group2]);
         assert.deepEqual(result.append_groups, []);
         assert.deepEqual(result.prepend_groups, []);

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -222,36 +222,10 @@ run_test("render_date_renders_time_html", () => {
         return $span_stub;
     };
 
-    const $actual = timerender.render_date(message_time, undefined, today);
+    const $actual = timerender.render_date(message_time, today);
     assert.equal($actual.html(), expected_html);
     assert.equal(attrs["data-tippy-content"], "Friday, April 12, 2019");
     assert.equal(attrs.class, "timerender0");
-});
-
-run_test("render_date_renders_time_above_html", () => {
-    const today = date_2019;
-
-    const message_time = today;
-    const message_time_above = add(today, {days: -1});
-
-    const $span_stub = $("<span>");
-
-    let appended_val;
-    $span_stub.append = (...val) => {
-        appended_val = val;
-        return $span_stub;
-    };
-
-    const expected = [
-        $("<i>"),
-        $t({defaultMessage: "Yesterday"}),
-        $("<hr>"),
-        $("<i>"),
-        $t({defaultMessage: "Today"}),
-    ];
-
-    timerender.render_date(message_time, message_time_above, today);
-    assert.deepEqual(appended_val, expected);
 });
 
 run_test("get_full_time", () => {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -111,28 +111,18 @@ function render_group_display_date(group, message_container) {
     group.date = date_element.outerHTML;
 }
 
-function update_group_date_divider(group, message_container, prev) {
+function update_group_date(group, message_container, prev) {
     const time = new Date(message_container.msg.timestamp * 1000);
     const today = new Date();
 
-    // TODO: investigate
-    if (prev !== undefined) {
-        const prev_time = new Date(prev.msg.timestamp * 1000);
-        if (!isSameDay(time, prev_time)) {
-            // NB: group_date_divider_html is HTML, inserted into the document without escaping.
-            group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
-            group.show_group_date_divider = true;
-        }
-    } else {
-        // Show the date in the recipient bar, but not a date separator bar.
-        group.show_group_date_divider = false;
-        group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
-    }
+    // Show the date in the recipient bar if the previous message was from a different day.
+    group.show_recipient_bar_date = !same_day(message_container, prev);
+    group.group_date_html = timerender.render_date(time, today)[0].outerHTML;
 }
 
-function clear_group_date_divider(group) {
-    group.show_group_date_divider = false;
-    group.group_date_divider_html = undefined;
+function clear_group_date(group) {
+    group.show_recipient_bar_date = true;
+    group.group_date_html = undefined;
 }
 
 function clear_message_date_divider(msg) {
@@ -483,7 +473,7 @@ export class MessageListView {
                 current_group = start_group();
                 add_message_container_to_group(message_container);
 
-                update_group_date_divider(current_group, message_container, prev);
+                update_group_date(current_group, message_container, prev);
                 clear_message_date_divider(message_container);
 
                 message_container.include_recipient = true;
@@ -631,7 +621,7 @@ export class MessageListView {
                 !same_day(second_group.message_containers[0], first_group.message_containers[0])
             ) {
                 // The groups did not merge, so we need up update the date row for the old group
-                update_group_date_divider(second_group, curr_msg_container, prev_msg_container);
+                update_group_date(second_group, curr_msg_container, prev_msg_container);
                 // We could add an action to update the date row, but for now rerender the group.
                 message_actions.rerender_groups.push(second_group);
             }
@@ -644,11 +634,11 @@ export class MessageListView {
                 new_message_groups = new_message_groups.slice(1);
             } else if (first_group !== undefined && second_group !== undefined) {
                 if (same_day(prev_msg_container, curr_msg_container)) {
-                    clear_group_date_divider(second_group);
+                    clear_group_date(second_group);
                 } else {
                     // If we just sent the first message on a new day
-                    // in a narrow, make sure we render a date separator.
-                    update_group_date_divider(second_group, curr_msg_container, prev_msg_container);
+                    // in a narrow, make sure we render a date.
+                    update_group_date(second_group, curr_msg_container, prev_msg_container);
                 }
             }
             message_actions.append_groups = new_message_groups;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -106,7 +106,7 @@ function analyze_edit_history(message) {
 function render_group_display_date(group, message_container) {
     const time = new Date(message_container.msg.timestamp * 1000);
     const today = new Date();
-    const date_element = timerender.render_date(time, undefined, today)[0];
+    const date_element = timerender.render_date(time, today)[0];
 
     group.date = date_element.outerHTML;
 }
@@ -115,21 +115,18 @@ function update_group_date_divider(group, message_container, prev) {
     const time = new Date(message_container.msg.timestamp * 1000);
     const today = new Date();
 
+    // TODO: investigate
     if (prev !== undefined) {
         const prev_time = new Date(prev.msg.timestamp * 1000);
         if (!isSameDay(time, prev_time)) {
             // NB: group_date_divider_html is HTML, inserted into the document without escaping.
-            group.group_date_divider_html = timerender.render_date(
-                time,
-                prev_time,
-                today,
-            )[0].outerHTML;
+            group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
             group.show_group_date_divider = true;
         }
     } else {
         // Show the date in the recipient bar, but not a date separator bar.
         group.show_group_date_divider = false;
-        group.group_date_divider_html = timerender.render_date(time, undefined, today)[0].outerHTML;
+        group.group_date_divider_html = timerender.render_date(time, today)[0].outerHTML;
     }
 }
 
@@ -154,16 +151,11 @@ function update_message_date_divider(opts) {
         return;
     }
 
-    const prev_time = new Date(prev_msg_container.msg.timestamp * 1000);
     const curr_time = new Date(curr_msg_container.msg.timestamp * 1000);
     const today = new Date();
 
     curr_msg_container.want_date_divider = true;
-    curr_msg_container.date_divider_html = timerender.render_date(
-        curr_time,
-        prev_time,
-        today,
-    )[0].outerHTML;
+    curr_msg_container.date_divider_html = timerender.render_date(curr_time, today)[0].outerHTML;
 }
 
 function set_timestr(message_container) {
@@ -291,7 +283,7 @@ export class MessageListView {
             return $t(
                 {defaultMessage: "{date} at {time}"},
                 {
-                    date: timerender.render_date(last_edit_time, undefined, today)[0].textContent,
+                    date: timerender.render_date(last_edit_time, today)[0].textContent,
                     time: timerender.stringify_time(last_edit_time),
                 },
             );

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1337,7 +1337,8 @@
     .date_row span::after,
     .streams_subheader span::before,
     .streams_subheader span::after {
-        opacity: 0.2;
+        opacity: 0.5;
+        border-bottom: 1px solid hsl(0, 0%, 100%);
     }
 
     .star:not(.empty-star),

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -378,8 +378,7 @@
     /* these are converting grey things to "new grey" */
     :disabled,
     input:not([type="radio"]):read-only,
-    textarea:read-only,
-    .recipient_row_date {
+    textarea:read-only {
         color: inherit;
         opacity: 0.5;
     }
@@ -518,11 +517,6 @@
         &:hover {
             border-color: hsl(236, 33%, 90%);
         }
-    }
-
-    /* Disable blue link styling for the message timestamp link. */
-    .message_time {
-        color: hsl(236, 33%, 90%);
     }
 
     .emoji-popover .reaction:focus {

--- a/static/styles/message_edit_history.css
+++ b/static/styles/message_edit_history.css
@@ -3,6 +3,18 @@
         float: right;
     }
 
+    .date_row > span {
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+
+        &::before,
+        &::after {
+            width: 100%;
+            margin: 0;
+        }
+    }
+
     .message_time {
         position: static;
     }

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -53,13 +53,13 @@ body,
 :root {
     color-scheme: light;
 
-    --color-message-time: hsl(0, 0%, 20%);
-    --color-recipient-row-date: hsl(0, 0%, 53%);
+    --color-default-text: hsl(0, 0%, 15%);
+    --color-date: hsl(0, 0%, 15%, 0.75);
 }
 
 :root.dark-theme {
-    --color-message-time: hsl(236, 33%, 90%);
-    --color-recipient-row-date: hsl(236, 33%, 90%);
+    --color-default-text: hsl(0, 0%, 100%);
+    --color-date: hsl(0, 0%, 100%, 0.75);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -912,13 +912,16 @@ td.pointer {
 .messagebox-content .message_time {
     display: block;
     font-size: 12px;
-    opacity: 0.4;
-    font-weight: 400;
-    color: var(--color-message-time);
+    font-weight: normal;
+    text-align: right;
+    opacity: 0.6;
+    color: var(--color-default-text);
+    font-feature-settings: "pnum" on, "lnum" on;
+    letter-spacing: 0.02em;
     /* Disable blue link styling for the message timestamp link. */
     &:hover {
         text-decoration: none;
-        color: var(--color-message-time);
+        color: var(--color-default-text);
     }
 
     a& {
@@ -1178,12 +1181,17 @@ td.pointer {
 }
 
 .recipient_row_date {
-    color: var(--color-recipient-row-date);
-    font-size: 12px;
+    color: var(--color-date);
+    font-size: calc(12em / 14);
+    padding: 0 10px;
+    text-align: right;
+    display: flex;
+    align-items: center;
+    font-style: normal;
     font-weight: 600;
-    padding: 3px 11px 2px 10px;
-    height: 17px;
-    line-height: 17px;
+    line-height: 17px; /* identical to box height, or 131% */
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 
     &.hide-date {
         display: none;
@@ -1490,6 +1498,16 @@ div.message_table {
     .date_row {
         /* We only want padding for the date rows between recipient blocks */
         padding-bottom: 0;
+
+        span {
+            font-size: calc(12em / 14);
+            font-style: normal;
+            font-weight: 600;
+            line-height: 17px; /* identical to box height, or 131% */
+            text-align: right;
+            letter-spacing: 0.04em;
+            color: var(--color-date);
+        }
     }
 }
 
@@ -2554,11 +2572,9 @@ select.invite-as {
     padding: 4px;
     overflow: hidden;
     text-transform: uppercase;
-    font-size: 0.8em;
 }
 
-.sub-unsub-message .stream-status,
-.date_row span {
+.sub-unsub-message .stream-status {
     opacity: 0.6;
 }
 
@@ -2580,7 +2596,7 @@ select.invite-as {
     content: " ";
     vertical-align: middle;
     height: 0;
-    opacity: 0.2;
+    opacity: 0.35;
     border-bottom: 1px solid hsl(0, 0%, 0%);
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -52,6 +52,20 @@ body,
 
 :root {
     color-scheme: light;
+
+    --color-message-time: hsl(0, 0%, 20%);
+    --color-recipient-row-date: hsl(0, 0%, 53%);
+}
+
+:root.dark-theme {
+    --color-message-time: hsl(236, 33%, 90%);
+    --color-recipient-row-date: hsl(236, 33%, 90%);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root.color-scheme-automatic {
+        @extend :root.dark-theme;
+    }
 }
 
 input,
@@ -901,7 +915,7 @@ td.pointer {
     opacity: 0.4;
     font-weight: 400;
     /* Disable blue link styling for the message timestamp link. */
-    color: hsl(0, 0%, 20%);
+    color: var(--color-message-time);
     transition: background-color 1.5s ease-in, color 1.5s ease-in;
 
     a& {
@@ -1161,7 +1175,7 @@ td.pointer {
 }
 
 .recipient_row_date {
-    color: hsl(0, 0%, 53%);
+    color: var(--color-recipient-row-date);
     font-size: 12px;
     font-weight: 600;
     padding: 3px 11px 2px 10px;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2546,20 +2546,6 @@ select.invite-as {
 
 .date_row {
     padding-left: 2px;
-
-    .date-direction {
-        display: inline-block;
-        padding-right: 5px;
-    }
-
-    .date-line {
-        display: inline-block;
-        vertical-align: middle;
-        width: 33%;
-        border-top: 1px solid hsl(0, 0%, 88%);
-        border-bottom: 1px solid hsl(0, 0%, 100%);
-        margin: 0 5px;
-    }
 }
 
 .sub-unsub-message span,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -909,14 +909,17 @@ td.pointer {
     overflow-x: clip;
 }
 
-.message_time {
+.messagebox-content .message_time {
     display: block;
     font-size: 12px;
     opacity: 0.4;
     font-weight: 400;
-    /* Disable blue link styling for the message timestamp link. */
     color: var(--color-message-time);
-    transition: background-color 1.5s ease-in, color 1.5s ease-in;
+    /* Disable blue link styling for the message timestamp link. */
+    &:hover {
+        text-decoration: none;
+        color: var(--color-message-time);
+    }
 
     a& {
         z-index: 1;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2540,12 +2540,12 @@ select.invite-as {
 
 .sub-unsub-message,
 .date_row {
-    text-align: center;
     padding-bottom: 10px;
 }
 
 .date_row {
     padding-left: 2px;
+    text-align: right;
 }
 
 .sub-unsub-message span,
@@ -2562,6 +2562,10 @@ select.invite-as {
     opacity: 0.6;
 }
 
+.sub-unsub-message {
+    text-align: center;
+}
+
 .sub-unsub-message span {
     font-size: 1em;
     text-transform: none;
@@ -2575,21 +2579,33 @@ select.invite-as {
     position: relative;
     content: " ";
     vertical-align: middle;
-    width: 50%;
     height: 0;
     opacity: 0.2;
     border-bottom: 1px solid hsl(0, 0%, 0%);
 }
 
 .sub-unsub-message span::before,
+.sub-unsub-message span::after {
+    width: 50%;
+}
+
 .date_row span::before {
-    right: 0.5em;
+    width: 100%;
+}
+
+.date_row span::after {
+    width: 6px;
+    left: 0.25em;
+}
+
+.sub-unsub-message span::before,
+.date_row span::before {
+    right: 0.25em;
     margin-left: -50%;
 }
 
-.sub-unsub-message span::after,
-.date_row span::after {
-    left: 0.5em;
+.sub-unsub-message span::after {
+    left: 0.25em;
     margin-right: -50%;
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2559,7 +2559,7 @@ select.invite-as {
 
 .sub-unsub-message .stream-status,
 .date_row span {
-    opacity: 0.5;
+    opacity: 0.6;
 }
 
 .sub-unsub-message span {
@@ -2577,8 +2577,8 @@ select.invite-as {
     vertical-align: middle;
     width: 50%;
     height: 0;
-    border-top: 1px solid hsl(0, 0%, 88%);
-    border-bottom: 1px solid hsl(0, 0%, 100%);
+    opacity: 0.2;
+    border-bottom: 1px solid hsl(0, 0%, 0%);
 }
 
 .sub-unsub-message span::before,

--- a/static/templates/message_group.hbs
+++ b/static/templates/message_group.hbs
@@ -2,10 +2,6 @@
 
 {{#each message_groups}}
     {{#with this}}
-        {{#if show_group_date_divider}}
-        <div class="date_row no-select">{{{group_date_divider_html}}}</div>
-        {{/if}}
-
         {{#if bookend_top}}
         {{> bookend}}
         {{/if}}

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -77,7 +77,7 @@
                     </template>
                 {{/if}}
             </span>
-            <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date {{#if show_recipient_bar_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
         </div>
     </div>
 </div>
@@ -91,7 +91,7 @@
                 {{#tr}}You and {display_reply_to}{{/tr}}
             </a>
 
-            <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date {{#if show_recipient_bar_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/date.20separators

Contains commits from #23099 and #22661 with an additional commit for deploying to chat.zulip.org.
before:
<img width="616" alt="Screenshot 2022-11-29 at 4 40 31 PM" src="https://user-images.githubusercontent.com/25124304/204514420-691ba8e4-8fc7-4c68-9a50-0646620bd54a.png">
<img width="616" alt="Screenshot 2022-11-29 at 4 40 20 PM" src="https://user-images.githubusercontent.com/25124304/204514434-08c56080-c062-403e-9223-d3f8cee0149b.png">

after:
<img width="616" alt="Screenshot 2022-11-29 at 4 36 29 PM" src="https://user-images.githubusercontent.com/25124304/204514022-b4e0166e-4778-4ab8-ab61-e5586a2ce42b.png">
<img width="616" alt="Screenshot 2022-11-29 at 4 41 31 PM" src="https://user-images.githubusercontent.com/25124304/204514401-f797f548-37cc-4297-88c2-6bb47bcfbd58.png">
