### PR TITLE
docs: Improve move content to another stream/topic instructions.

### DIFF
--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -22,7 +22,8 @@ destination streams.
 
 {!topic-actions.md!}
 
-1. Select **Move topic**.
+1. Select **Move topic**. If you do not see this option, you do not have permission
+   to move this topic.
 
 1. Select the destination stream for the topic from the streams dropdown list.
 

--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -48,7 +48,7 @@ destination streams.
 
 {!message-actions-menu.md!}
 
-1. Select **Move message**. If you do not see this option, you do not have permission
+1. Select **Move messages**. If you do not see this option, you do not have permission
    to move this message.
 
 1. Select the destination stream for the message from the streams dropdown list.

--- a/templates/zerver/help/move-content-to-another-stream.md
+++ b/templates/zerver/help/move-content-to-another-stream.md
@@ -51,7 +51,9 @@ destination streams.
 1. Select **Move messages**. If you do not see this option, you do not have permission
    to move this message.
 
-1. Select the destination stream for the message from the streams dropdown list.
+1. Select the destination stream from the streams dropdown list. If
+   the stream input is disabled, you do not have permission to move
+   this message to a different stream.
 
 1. _(optional)_ Change the topic name.
 

--- a/templates/zerver/help/move-content-to-another-topic.md
+++ b/templates/zerver/help/move-content-to-another-topic.md
@@ -22,7 +22,7 @@ for the details on when topic editing is allowed.
 
 {!message-actions-menu.md!}
 
-1. Select **Move message**. If you do not see this option, you do not have permission
+1. Select **Move messages**. If you do not see this option, you do not have permission
    to move this message.
 
 1. Set the destination topic.


### PR DESCRIPTION
As per the discussion in [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Move.20a.20topic.20to.20another.20stream)

The [First commit](https://github.com/zulip/zulip/pull/23710/commits/9c158c0089f83089d9aa12469f3443b45cae7781) **adds a line to make it clear to the user that the user may/mayn't have the permission to use the 
`move topic` option**.

- <details>
  <summary>Updated Instruction</summary>
   <img src="https://user-images.githubusercontent.com/56781761/204824074-37025793-853e-4c46-ac08-6a89a69caca3.png"> 
   </img>
  </details>

The [Second Commit](https://github.com/zulip/zulip/pull/23710/commits/71c99ddba3abfa4e7ebc56e4f2ceb881a3f9965e) **renames "Move message" option to "Move messages" and some minor updates in the instructions**

- <details>
  <summary>Updated Instruction</summary>
   <img src="https://user-images.githubusercontent.com/56781761/204876910-9e8bbea1-2a17-4cbb-ab86-0353b0126e7a.png"> 
   </img>
  </details>
  

- <details>
  <summary>Updated Instruction</summary>
   <img src="https://user-images.githubusercontent.com/56781761/204874955-1fd8789a-7c45-4c2d-99dc-0cc7a08312bb.png"> 
   </img>
  </details>


The [Third Commit](https://github.com/zulip/zulip/pull/23710/commits/946452bc810cdc860e5554c3a828f1d122b8e227) **adds a line to make it clear to the user that the user may/mayn't have the permission to move message(s) between streams.**

- <details>
  <summary>Updated Instruction</summary>
   <img src="https://user-images.githubusercontent.com/56781761/204875815-936a5a52-c1f2-4ded-b082-7355d44335c2.png"> 
   </img>
  </details>

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
