### PR TITLE
api-docs: Clean up instances of  lowercase "id" in descriptive text.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17018,7 +17018,7 @@ components:
           example:
             {
               "code": "BAD_EVENT_QUEUE_ID",
-              "msg": "Bad event queue id: fb67bf8a-c031-47cc-84cf-ed80accacda8",
+              "msg": "Bad event queue ID: fb67bf8a-c031-47cc-84cf-ed80accacda8",
               "queue_id": "fb67bf8a-c031-47cc-84cf-ed80accacda8",
               "result": "error",
             }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -466,7 +466,7 @@ paths:
                                         bot_owner_id:
                                           type: integer
                                           description: |
-                                            The user id of the new bot owner.
+                                            The user ID of the new bot owner.
                                     - type: object
                                       additionalProperties: false
                                       description: |
@@ -1475,7 +1475,7 @@ paths:
                                 attachment:
                                   type: object
                                   description: |
-                                    Dictionary containing the id of the deleted attachment.
+                                    Dictionary containing the ID of the deleted attachment.
                                   additionalProperties: false
                                   properties:
                                     id:
@@ -2014,7 +2014,7 @@ paths:
                                     type: object
                                     additionalProperties: false
                                     description: |
-                                      Object containing the user id and timestamp of a muted user.
+                                      Object containing the user ID and timestamp of a muted user.
                                     properties:
                                       id:
                                         type: integer
@@ -2439,7 +2439,7 @@ paths:
                                     type: object
                                     additionalProperties: false
                                     description: |
-                                      Object containing the user id and email of a recipient.
+                                      Object containing the user ID and email of a recipient.
                                     properties:
                                       user_id:
                                         type: integer
@@ -2555,7 +2555,7 @@ paths:
                                     type: object
                                     additionalProperties: false
                                     description: |
-                                      Object containing the user id and email of a recipient.
+                                      Object containing the user ID and email of a recipient.
                                     properties:
                                       user_id:
                                         type: integer
@@ -2641,7 +2641,7 @@ paths:
                                 messages:
                                   type: array
                                   description: |
-                                    Array containing the ids of all messages to which
+                                    Array containing the IDs of all messages to which
                                     the flag was added.
                                   items:
                                     type: integer
@@ -3479,7 +3479,7 @@ paths:
                                   allOf:
                                     - description: |
                                         Object containing details about the changed bot.
-                                        It contains two properties: the user id of the bot and
+                                        It contains two properties: the user ID of the bot and
                                         the property to be changed. The changed property is one
                                         of the remaining properties listed below.
                                     - $ref: "#/components/schemas/BasicBot"
@@ -4348,7 +4348,7 @@ paths:
                             - type: object
                               additionalProperties: false
                               description: |
-                                Event containing the id of a deleted draft.
+                                Event containing the ID of a deleted draft.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -6690,7 +6690,7 @@ paths:
         - name: realm_id_str
           in: path
           description: |
-            The realm id.
+            The realm ID.
           schema:
             type: integer
           example: 1
@@ -10038,8 +10038,8 @@ paths:
 
                           An array of objects; each object describes a type of custom profile field
                           that could be configured on this Zulip server. Each custom profile type
-                          has a id and the `type` property of a custom profile field is equal
-                          to one of these ids.
+                          has an ID and the `type` property of a custom profile field is equal
+                          to one of these IDs.
 
                           This attribute is only useful for clients containing UI for changing
                           the set of configured custom profile fields in a Zulip organization.
@@ -10065,7 +10065,7 @@ paths:
                             id:
                               type: integer
                               description: |
-                                The id of the custom profile field type.
+                                The ID of the custom profile field type.
                             name:
                               type: string
                               description: |
@@ -10197,7 +10197,7 @@ paths:
                           type: object
                           additionalProperties: false
                           description: |
-                            Object containing the user id and timestamp of a muted user.
+                            Object containing the user ID and timestamp of a muted user.
                           properties:
                             id:
                               type: integer
@@ -10305,7 +10305,7 @@ paths:
 
                           The second element is the URL with which the
                           pattern matching string should be linkified with and the third element
-                          is the id of the realm filter.
+                          is the ID of the realm filter.
 
                           **Changes**: Deprecated in Zulip 4.0 (feature level 54), replaced by
                           the `realm_linkifiers` key instead.
@@ -10406,7 +10406,7 @@ paths:
                             max_message_id:
                               type: integer
                               description: |
-                                The highest message id of the conversation, intended to support sorting
+                                The highest message ID of the conversation, intended to support sorting
                                 the conversations by recency.
                             user_ids:
                               type: array
@@ -10533,7 +10533,7 @@ paths:
                                 other_user_id:
                                   type: integer
                                   description: |
-                                    The user id of the other participant in this non-group private
+                                    The user ID of the other participant in this non-group private
                                     message conversation. Will be your own user ID for messages
                                     that you sent to only yourself.
                                 sender_id:
@@ -10550,7 +10550,7 @@ paths:
                                 message_ids:
                                   type: array
                                   description: |
-                                    The message ids of the recent unread PM messages sent by the other user.
+                                    The message IDs of the recent unread PM messages sent by the other user.
                                   items:
                                     type: integer
                           streams:
@@ -10577,11 +10577,11 @@ paths:
                                 stream_id:
                                   type: integer
                                   description: |
-                                    The id of the stream to which the message was sent.
+                                    The ID of the stream to which the message was sent.
                                 unread_message_ids:
                                   type: array
                                   description: |
-                                    The message ids of the recent unread messages sent in this stream.
+                                    The message IDs of the recent unread messages sent in this stream.
                                   items:
                                     type: integer
                           huddles:
@@ -10606,14 +10606,14 @@ paths:
                                 message_ids:
                                   type: array
                                   description: |
-                                    The message ids of the recent unread messages which have been sent in
+                                    The message IDs of the recent unread messages which have been sent in
                                     this group.
                                   items:
                                     type: integer
                           mentions:
                             type: array
                             description: |
-                              Array containing the ids of all messages in which the user has been mentioned.
+                              Array containing the IDs of all messages in which the user has been mentioned.
                               For muted streams, wildcard mentions will not be considered for this array.
                             items:
                               type: integer
@@ -10636,7 +10636,7 @@ paths:
                         description: |
                           Present if `starred_messages` is present in `fetch_event_types`.
 
-                          Array containing the ids of all messages which have been
+                          Array containing the IDs of all messages which have been
                           [starred](/help/star-a-message) by the user.
                       streams:
                         type: array
@@ -10696,7 +10696,7 @@ paths:
                         additionalProperties:
                           description: |
                             `{user_id}`: Object containing the status details of a user
-                            with the key of the object being the id of the user.
+                            with the key of the object being the ID of the user.
                           type: object
                           additionalProperties: false
                           properties:
@@ -14816,7 +14816,7 @@ paths:
         - name: delete
           in: query
           description: |
-            The list of user ids to be removed from the user group.
+            The list of user IDs to be removed from the user group.
           content:
             application/json:
               schema:
@@ -14828,7 +14828,7 @@ paths:
         - name: add
           in: query
           description: |
-            The list of user ids to be added to the user group.
+            The list of user IDs to be added to the user group.
           content:
             application/json:
               schema:
@@ -14942,7 +14942,7 @@ paths:
                         "result": "error",
                       }
                     description: |
-                      An example JSON error response for an invalid user group id:
+                      An example JSON error response for an invalid user group ID:
 
   /user_groups:
     get:
@@ -14983,7 +14983,7 @@ paths:
                             id:
                               type: integer
                               description: |
-                                The user group's integer id.
+                                The user group's integer ID.
                             members:
                               type: array
                               description: |
@@ -15013,8 +15013,7 @@ paths:
 
                                 **Changes**: New in Zulip 5.0 (feature level 93).
                         description: |
-                          A list of `user_group` objects, which contain a `description`, a `name`,
-                          their `id` and the list of members of the user group.
+                          A list of `user_group` objects.
                     example:
                       {
                         "msg": "",
@@ -15059,7 +15058,7 @@ paths:
         - name: delete
           in: query
           description: |
-            The list of user group ids to be removed from the user group.
+            The list of user group IDs to be removed from the user group.
           content:
             application/json:
               schema:
@@ -15071,7 +15070,7 @@ paths:
         - name: add
           in: query
           description: |
-            The list of user group ids to be added to the user group.
+            The list of user group IDs to be added to the user group.
           content:
             application/json:
               schema:
@@ -15570,7 +15569,7 @@ components:
           type: integer
           nullable: true
           description: |
-            The id of the first message in the stream.
+            The ID of the first message in the stream.
 
             Intended to help clients determine whether they need to display
             UI like the "more topics" widget that would suggest the stream
@@ -15616,7 +15615,7 @@ components:
         user_id:
           type: integer
           description: |
-            The user id of the bot.
+            The user ID of the bot.
         full_name:
           type: string
           description: |
@@ -15649,7 +15648,7 @@ components:
           type: integer
           nullable: true
           description: |
-            The user id of the bot's owner.
+            The user ID of the bot's owner.
 
             Null if the bot has no owner.
         services:
@@ -15936,11 +15935,11 @@ components:
         id:
           type: integer
           description: |
-            The id of the export.
+            The ID of the export.
         acting_user_id:
           type: integer
           description: |
-            The id of the user who did the export.
+            The ID of the user who did the export.
         export_time:
           type: number
           description: |
@@ -15985,14 +15984,14 @@ components:
           items:
             type: integer
           description: |
-            Array containing the id of the users who are
+            Array containing the ID of the users who are
             members of this user group.
         direct_subgroup_ids:
           type: array
           items:
             type: integer
           description: |
-            Array containing the id of the direct_subgroups of
+            Array containing the ID of the direct_subgroups of
             this user group.
 
             **Changes**: New in Zulip 6.0 (feature level 131).
@@ -16204,7 +16203,7 @@ components:
           type: integer
           nullable: true
           description: |
-            The id of the first message in the stream.
+            The ID of the first message in the stream.
 
             Intended to help clients determine whether they need to display
             UI like the "more topics" widget that would suggest the stream
@@ -16245,7 +16244,7 @@ components:
         id:
           type: integer
           description: |
-            id of the default stream group.
+            The ID of the default stream group.
         streams:
           type: array
           description: |
@@ -16881,8 +16880,8 @@ components:
         type: object
         additionalProperties: false
         description: |
-          `{id}`: Object with data about what value user filled in the custom
-          profile field with id `id`.
+          `{id}`: Object with data about what value the user filled in the custom
+          profile field with that ID.
         properties:
           value:
             type: string
@@ -17457,7 +17456,7 @@ components:
       name: principals
       in: query
       description: |
-        A list of user ids (preferred) or Zulip display email
+        A list of user IDs (preferred) or Zulip display email
         addresses of the users to be subscribed to or unsubscribed
         from the streams specified in the `subscriptions` parameter. If
         not provided, then the requesting user/bot is subscribed.

--- a/zerver/tornado/exceptions.py
+++ b/zerver/tornado/exceptions.py
@@ -12,4 +12,4 @@ class BadEventQueueIdError(JsonableError):
 
     @staticmethod
     def msg_format() -> str:
-        return _("Bad event queue id: {queue_id}")
+        return _("Bad event queue ID: {queue_id}")


### PR DESCRIPTION
Audits the `zulip.yaml` file for instances of lowercase "id" in descriptive text and updates them to be "ID".

Also, updates the `msg` text of `BAD_EVENT_QUEUE_ID` to be "Bad event queue ID: ...".

<details>
<summary>Diff of current main to changes</summary>

```diff
diff -r -B -u current_api_html/delete-queue.html new_api_html/delete-queue.html
--- current_api_html/delete-queue.html	2022-11-29 16:49:53.137444377 +0100
+++ new_api_html/delete-queue.html	2022-11-30 16:11:59.275471556 +0100
@@ -337,7 +337,7 @@
 associated queue has already been deleted:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_EVENT_QUEUE_ID"</span><span class="p">,</span><span class="w"></span>
-<span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Bad event queue id: fb67bf8a-c031-47cc-84cf-ed80accacda8"</span><span class="p">,</span><span class="w"></span>
+<span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Bad event queue ID: fb67bf8a-c031-47cc-84cf-ed80accacda8"</span><span class="p">,</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"queue_id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fb67bf8a-c031-47cc-84cf-ed80accacda8"</span><span class="p">,</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"result"</span><span class="p">:</span><span class="w"> </span><span class="s2">"error"</span><span class="w"></span>
 <span class="p">}</span><span class="w"></span>
diff -r -B -u current_api_html/get-events.html new_api_html/get-events.html
--- current_api_html/get-events.html	2022-11-29 16:49:53.013443647 +0100
+++ new_api_html/get-events.html	2022-11-30 16:11:59.111470565 +0100
@@ -610,7 +610,7 @@
 </li>
 <li>
 <p><code>bot_owner_id</code>: <span class="api-field-type">integer</span></p>
-<p>The user id of the new bot owner.</p>
+<p>The user ID of the new bot owner.</p>
 </li>
 </ul>
 </li>
@@ -905,7 +905,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -1626,8 +1626,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
@@ -1889,7 +1889,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -2022,7 +2022,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -2549,7 +2549,7 @@
 </li>
 <li>
 <p><code>attachment</code>: <span class="api-field-type">object</span></p>
-<p>Dictionary containing the id of the deleted attachment.</p>
+<p>Dictionary containing the ID of the deleted attachment.</p>
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
@@ -2867,7 +2867,7 @@
 </li>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
-<p>id of the default stream group.</p>
+<p>The ID of the default stream group.</p>
 </li>
 <li>
 <p><code>streams</code>: <span class="api-field-type">(object)[]</span></p>
@@ -2946,7 +2946,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -3117,7 +3117,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -3882,7 +3882,7 @@
 </li>
 <li>
 <p><code>messages</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>Array containing the ids of all messages to which
+<p>Array containing the IDs of all messages to which
 the flag was added.</p>
 </li>
 <li>
@@ -4037,12 +4037,12 @@
 </li>
 <li>
 <p><code>members</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>Array containing the id of the users who are
+<p>Array containing the ID of the users who are
 members of this user group.</p>
 </li>
 <li>
 <p><code>direct_subgroup_ids</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>Array containing the id of the direct_subgroups of
+<p>Array containing the ID of the direct_subgroups of
 this user group.</p>
 <p><strong>Changes</strong>: New in Zulip 6.0 (feature level 131).
 Introduced in feature level 127 as <code>subgroups</code>, but
@@ -4666,11 +4666,11 @@
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
-<p>The id of the export.</p>
+<p>The ID of the export.</p>
 </li>
 <li>
 <p><code>acting_user_id</code>: <span class="api-field-type">integer</span></p>
-<p>The id of the user who did the export.</p>
+<p>The ID of the user who did the export.</p>
 </li>
 <li>
 <p><code>export_time</code>: <span class="api-field-type">number</span></p>
@@ -4739,7 +4739,7 @@
 <ul>
 <li>
 <p><code>user_id</code>: <span class="api-field-type">integer</span></p>
-<p>The user id of the bot.</p>
+<p>The user ID of the bot.</p>
 </li>
 <li>
 <p><code>full_name</code>: <span class="api-field-type">string</span></p>
@@ -4769,7 +4769,7 @@
 </li>
 <li>
 <p><code>owner_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The user id of the bot's owner.</p>
+<p>The user ID of the bot's owner.</p>
 <p>Null if the bot has no owner.</p>
 </li>
 <li>
@@ -4844,13 +4844,13 @@
 <li>
 <p><code>bot</code>: <span class="api-field-type">object</span></p>
 <p>Object containing details about the changed bot.
-It contains two properties: the user id of the bot and
+It contains two properties: the user ID of the bot and
 the property to be changed. The changed property is one
 of the remaining properties listed below.</p>
 <ul>
 <li>
 <p><code>user_id</code>: <span class="api-field-type">integer</span></p>
-<p>The user id of the bot.</p>
+<p>The user ID of the bot.</p>
 </li>
 <li>
 <p><code>full_name</code>: <span class="api-field-type">string</span></p>
@@ -4880,7 +4880,7 @@
 </li>
 <li>
 <p><code>owner_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The user id of the bot's owner.</p>
+<p>The user ID of the bot's owner.</p>
 <p>Null if the bot has no owner.</p>
 </li>
 <li>
@@ -5761,7 +5761,7 @@
 <span class="p">}</span><span class="w"></span>
 </code></pre></div>
 <div class="api-argument"><p class="api-argument-name"><h3 id="drafts-remove"> <span class="api-argument-required"> drafts</span> <span class="api-argument-deprecated">op: remove</span></h3></p></div>
-<p>Event containing the id of a deleted draft.</p>
+<p>Event containing the ID of a deleted draft.</p>
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
@@ -5850,7 +5850,7 @@
 <p>The following is the error response in such case:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_EVENT_QUEUE_ID"</span><span class="p">,</span><span class="w"></span>
-<span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Bad event queue id: fb67bf8a-c031-47cc-84cf-ed80accacda8"</span><span class="p">,</span><span class="w"></span>
+<span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Bad event queue ID: fb67bf8a-c031-47cc-84cf-ed80accacda8"</span><span class="p">,</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"queue_id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"fb67bf8a-c031-47cc-84cf-ed80accacda8"</span><span class="p">,</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"result"</span><span class="p">:</span><span class="w"> </span><span class="s2">"error"</span><span class="w"></span>
 <span class="p">}</span><span class="w"></span>
diff -r -B -u current_api_html/get-own-user.html new_api_html/get-own-user.html
--- current_api_html/get-own-user.html	2022-11-29 16:49:47.161409157 +0100
+++ new_api_html/get-own-user.html	2022-11-30 16:11:52.675431649 +0100
@@ -410,8 +410,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
diff -r -B -u current_api_html/get-stream-by-id.html new_api_html/get-stream-by-id.html
--- current_api_html/get-stream-by-id.html	2022-11-29 16:49:46.077402768 +0100
+++ new_api_html/get-stream-by-id.html	2022-11-30 16:11:51.535424758 +0100
@@ -362,7 +362,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
diff -r -B -u current_api_html/get-streams.html new_api_html/get-streams.html
--- current_api_html/get-streams.html	2022-11-29 16:49:45.989402249 +0100
+++ new_api_html/get-streams.html	2022-11-30 16:11:51.443424201 +0100
@@ -448,7 +448,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
diff -r -B -u current_api_html/get-subscriptions.html new_api_html/get-subscriptions.html
--- current_api_html/get-subscriptions.html	2022-11-29 16:49:45.265397981 +0100
+++ new_api_html/get-subscriptions.html	2022-11-30 16:11:50.503418520 +0100
@@ -492,7 +492,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
diff -r -B -u current_api_html/get-user-by-email.html new_api_html/get-user-by-email.html
--- current_api_html/get-user-by-email.html	2022-11-29 16:49:47.469410973 +0100
+++ new_api_html/get-user-by-email.html	2022-11-30 16:11:52.999433608 +0100
@@ -467,8 +467,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
diff -r -B -u current_api_html/get-user-groups.html new_api_html/get-user-groups.html
--- current_api_html/get-user-groups.html	2022-11-29 16:49:48.753418540 +0100
+++ new_api_html/get-user-groups.html	2022-11-30 16:11:54.475442531 +0100
@@ -298,8 +298,7 @@
 <ul>
 <li>
 <p><code>user_groups</code>: <span class="api-field-type">(object)[]</span></p>
-<p>A list of <code>user_group</code> objects, which contain a <code>description</code>, a <code>name</code>,
-their <code>id</code> and the list of members of the user group.</p>
+<p>A list of <code>user_group</code> objects.</p>
 <ul>
 <li>
 <p><code>description</code>: <span class="api-field-type">string</span></p>
@@ -307,7 +306,7 @@
 </li>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
-<p>The user group's integer id.</p>
+<p>The user group's integer ID.</p>
 </li>
 <li>
 <p><code>members</code>: <span class="api-field-type">(integer)[]</span></p>
diff -r -B -u current_api_html/get-user.html new_api_html/get-user.html
--- current_api_html/get-user.html	2022-11-29 16:49:47.341410218 +0100
+++ new_api_html/get-user.html	2022-11-30 16:11:52.823432544 +0100
@@ -460,8 +460,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
diff -r -B -u current_api_html/get-users.html new_api_html/get-users.html
--- current_api_html/get-users.html	2022-11-29 16:49:47.041408450 +0100
+++ new_api_html/get-users.html	2022-11-30 16:11:52.583431093 +0100
@@ -472,8 +472,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
diff -r -B -u current_api_html/register-queue.html new_api_html/register-queue.html
--- current_api_html/register-queue.html	2022-11-29 16:49:52.029437847 +0100
+++ new_api_html/register-queue.html	2022-11-30 16:11:58.179464928 +0100
@@ -659,8 +659,8 @@
 <p>Present if <code>custom_profile_fields</code> is present in <code>fetch_event_types</code>.</p>
 <p>An array of objects; each object describes a type of custom profile field
 that could be configured on this Zulip server. Each custom profile type
-has a id and the <code>type</code> property of a custom profile field is equal
-to one of these ids.</p>
+has an ID and the <code>type</code> property of a custom profile field is equal
+to one of these IDs.</p>
 <p>This attribute is only useful for clients containing UI for changing
 the set of configured custom profile fields in a Zulip organization.</p>
 <ul>
@@ -683,7 +683,7 @@
 <ul>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
-<p>The id of the custom profile field type.</p>
+<p>The ID of the custom profile field type.</p>
 </li>
 <li>
 <p><code>name</code>: <span class="api-field-type">string</span></p>
@@ -965,7 +965,7 @@
 the pattern that should be linkified on matching.</p>
 <p>The second element is the URL with which the
 pattern matching string should be linkified with and the third element
-is the id of the realm filter.</p>
+is the ID of the realm filter.</p>
 <p><strong>Changes</strong>: Deprecated in Zulip 4.0 (feature level 54), replaced by
 the <code>realm_linkifiers</code> key instead.</p>
 </li>
@@ -1016,12 +1016,12 @@
 </li>
 <li>
 <p><code>members</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>Array containing the id of the users who are
+<p>Array containing the ID of the users who are
 members of this user group.</p>
 </li>
 <li>
 <p><code>direct_subgroup_ids</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>Array containing the id of the direct_subgroups of
+<p>Array containing the ID of the direct_subgroups of
 this user group.</p>
 <p><strong>Changes</strong>: New in Zulip 6.0 (feature level 131).
 Introduced in feature level 127 as <code>subgroups</code>, but
@@ -1051,7 +1051,7 @@
 <ul>
 <li>
 <p><code>user_id</code>: <span class="api-field-type">integer</span></p>
-<p>The user id of the bot.</p>
+<p>The user ID of the bot.</p>
 </li>
 <li>
 <p><code>full_name</code>: <span class="api-field-type">string</span></p>
@@ -1081,7 +1081,7 @@
 </li>
 <li>
 <p><code>owner_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The user id of the bot's owner.</p>
+<p>The user ID of the bot's owner.</p>
 <p>Null if the bot has no owner.</p>
 </li>
 <li>
@@ -1167,7 +1167,7 @@
 <ul>
 <li>
 <p><code>max_message_id</code>: <span class="api-field-type">integer</span></p>
-<p>The highest message id of the conversation, intended to support sorting
+<p>The highest message ID of the conversation, intended to support sorting
 the conversations by recency.</p>
 </li>
 <li>
@@ -1347,7 +1347,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -1539,7 +1539,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -1641,7 +1641,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -1699,7 +1699,7 @@
 <ul>
 <li>
 <p><code>other_user_id</code>: <span class="api-field-type">integer</span></p>
-<p>The user id of the other participant in this non-group private
+<p>The user ID of the other participant in this non-group private
 message conversation. Will be your own user ID for messages
 that you sent to only yourself.</p>
 </li>
@@ -1714,7 +1714,7 @@
 </li>
 <li>
 <p><code>message_ids</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>The message ids of the recent unread PM messages sent by the other user.</p>
+<p>The message IDs of the recent unread PM messages sent by the other user.</p>
 </li>
 </ul>
 </li>
@@ -1733,11 +1733,11 @@
 </li>
 <li>
 <p><code>stream_id</code>: <span class="api-field-type">integer</span></p>
-<p>The id of the stream to which the message was sent.</p>
+<p>The ID of the stream to which the message was sent.</p>
 </li>
 <li>
 <p><code>unread_message_ids</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>The message ids of the recent unread messages sent in this stream.</p>
+<p>The message IDs of the recent unread messages sent in this stream.</p>
 </li>
 </ul>
 </li>
@@ -1755,14 +1755,14 @@
 </li>
 <li>
 <p><code>message_ids</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>The message ids of the recent unread messages which have been sent in
+<p>The message IDs of the recent unread messages which have been sent in
 this group.</p>
 </li>
 </ul>
 </li>
 <li>
 <p><code>mentions</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>Array containing the ids of all messages in which the user has been mentioned.
+<p>Array containing the IDs of all messages in which the user has been mentioned.
 For muted streams, wildcard mentions will not be considered for this array.</p>
 </li>
 <li>
@@ -1781,7 +1781,7 @@
 <li>
 <p><code>starred_messages</code>: <span class="api-field-type">(integer)[]</span></p>
 <p>Present if <code>starred_messages</code> is present in <code>fetch_event_types</code>.</p>
-<p>Array containing the ids of all messages which have been
+<p>Array containing the IDs of all messages which have been
 <a href="/help/star-a-message">starred</a> by the user.</p>
 </li>
 <li>
@@ -1864,7 +1864,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -1963,7 +1963,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -2001,7 +2001,7 @@
 </li>
 <li>
 <p><code>id</code>: <span class="api-field-type">integer</span></p>
-<p>id of the default stream group.</p>
+<p>The ID of the default stream group.</p>
 </li>
 <li>
 <p><code>streams</code>: <span class="api-field-type">(object)[]</span></p>
@@ -2080,7 +2080,7 @@
 </li>
 <li>
 <p><code>first_message_id</code>: <span class="api-field-type">integer | null</span></p>
-<p>The id of the first message in the stream.</p>
+<p>The ID of the first message in the stream.</p>
 <p>Intended to help clients determine whether they need to display
 UI like the "more topics" widget that would suggest the stream
 has older history that can be accessed.</p>
@@ -2121,7 +2121,7 @@
 <li>
 <p><code>{user_id}</code>: <span class="api-field-type">object</span></p>
 <p>Object containing the status details of a user
-with the key of the object being the id of the user.</p>
+with the key of the object being the ID of the user.</p>
 <ul>
 <li>
 <p><code>away</code>: <span class="api-field-type">boolean</span></p>
@@ -4171,8 +4171,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
@@ -4316,8 +4316,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
@@ -4597,8 +4597,8 @@
 <ul>
 <li>
 <p><code>{id}</code>: <span class="api-field-type">object</span></p>
-<p>Object with data about what value user filled in the custom
-profile field with id <code>id</code>.</p>
+<p>Object with data about what value the user filled in the custom
+profile field with that ID.</p>
 <ul>
 <li>
 <p><code>value</code>: <span class="api-field-type">string</span></p>
diff -r -B -u current_api_html/remove-user-group.html new_api_html/remove-user-group.html
--- current_api_html/remove-user-group.html	2022-11-29 16:49:49.061420355 +0100
+++ new_api_html/remove-user-group.html	2022-11-30 16:11:54.735444103 +0100
@@ -303,7 +303,7 @@
 <span class="w">    </span><span class="nt">"result"</span><span class="p">:</span><span class="w"> </span><span class="s2">"success"</span><span class="w"></span>
 <span class="p">}</span><span class="w"></span>
 </code></pre></div>
-<p>An example JSON error response for an invalid user group id:</p>
+<p>An example JSON error response for an invalid user group ID:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span><span class="w"></span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Invalid user group"</span><span class="p">,</span><span class="w"></span>
diff -r -B -u current_api_html/subscribe.html new_api_html/subscribe.html
--- current_api_html/subscribe.html	2022-11-29 16:49:45.453399089 +0100
+++ new_api_html/subscribe.html	2022-11-30 16:11:50.675419559 +0100
@@ -368,7 +368,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>[&quot;ZOE@zulip.com&quot;]</code>
     </div>
-    <div class="api-description"><p>A list of user ids (preferred) or Zulip display email
+    <div class="api-description"><p>A list of user IDs (preferred) or Zulip display email
 addresses of the users to be subscribed to or unsubscribed
 from the streams specified in the <code>subscriptions</code> parameter. If
 not provided, then the requesting user/bot is subscribed.</p>
diff -r -B -u current_api_html/unsubscribe.html new_api_html/unsubscribe.html
--- current_api_html/unsubscribe.html	2022-11-29 16:49:45.569399773 +0100
+++ new_api_html/unsubscribe.html	2022-11-30 16:11:50.855420647 +0100
@@ -352,7 +352,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>[&quot;ZOE@zulip.com&quot;]</code>
     </div>
-    <div class="api-description"><p>A list of user ids (preferred) or Zulip display email
+    <div class="api-description"><p>A list of user IDs (preferred) or Zulip display email
 addresses of the users to be subscribed to or unsubscribed
 from the streams specified in the <code>subscriptions</code> parameter. If
 not provided, then the requesting user/bot is subscribed.</p>
diff -r -B -u current_api_html/update-user-group-members.html new_api_html/update-user-group-members.html
--- current_api_html/update-user-group-members.html	2022-11-29 16:49:49.145420851 +0100
+++ new_api_html/update-user-group-members.html	2022-11-30 16:11:54.847444781 +0100
@@ -305,7 +305,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>[10]</code>
     </div>
-    <div class="api-description"><p>The list of user ids to be removed from the user group.</p></div>
+    <div class="api-description"><p>The list of user IDs to be removed from the user group.</p></div>
     <hr>
 </div>
 <div class="api-argument" id="parameter-add">
@@ -313,7 +313,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>[12, 13]</code>
     </div>
-    <div class="api-description"><p>The list of user ids to be added to the user group.</p></div>
+    <div class="api-description"><p>The list of user IDs to be added to the user group.</p></div>
     <hr>
 </div>
 
diff -r -B -u current_api_html/update-user-group-subgroups.html new_api_html/update-user-group-subgroups.html
--- current_api_html/update-user-group-subgroups.html	2022-11-29 16:49:49.237421392 +0100
+++ new_api_html/update-user-group-subgroups.html	2022-11-30 16:11:54.991445652 +0100
@@ -288,7 +288,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>[10]</code>
     </div>
-    <div class="api-description"><p>The list of user group ids to be removed from the user group.</p></div>
+    <div class="api-description"><p>The list of user group IDs to be removed from the user group.</p></div>
     <hr>
 </div>
 <div class="api-argument" id="parameter-add">
@@ -296,7 +296,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>[8, 9]</code>
     </div>
-    <div class="api-description"><p>The list of user group ids to be added to the user group.</p></div>
+    <div class="api-description"><p>The list of user group IDs to be added to the user group.</p></div>
     <hr>
 </div>
 
```
</details>

---

Remaining count of words starting with `id` in file: 129
- ` id:` = 98 (properties, parameters, etc.)
- ` ids:` = 1 (property)
- ` idle` = 3
- ` ide...` = 25
- ` id]` = 1 (deprecation note)
- `- id` = 1 (required field)

---

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
