### PR TITLE
Fixes: #23532, #23692

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -489,6 +489,7 @@ export function initialize() {
         }
 
         stream_settings_ui.sub_or_unsub(sub);
+        window.location.reload();
     });
 
     $("#manage_streams_container").on("click", ".change-stream-privacy", (e) => {

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -76,12 +76,12 @@
                       data-setting-widget-type="message-retention-setting"
                       {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
                         <option value="unlimited">{{t 'Retain forever' }}</option>
-                        <option value="custom_period">{{t 'Retain for N days after posting' }}</option>
+                        <option value="custom_period">{{t 'Custom' }}</option>
                     </select>
 
                     <div class="dependent-inline-block">
                         <label for="id_realm_message_retention_custom_input" class="inline-block realm-time-limit-label">
-                            {{t 'N' }}:
+                            {{t 'Retention period (days)' }}:
                         </label>
                         <input type="text" id="id_realm_message_retention_custom_input" autocomplete="off"
                           name="realm_message_retention_custom_input"


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/23532
- [x] Replaced the "Retain for N days after posting" option with "Custom"

- [x] Only show the spot for entering the time if that option is selected (this was implemented by #23616)

- [x] Labeled the custom time like we do for message editing: "Retention period (days): [ ]"

**Screenshots and screen captures:**
<img width="488" alt="Screen Shot 2022-11-30 at 6 39 17 PM" src="https://user-images.githubusercontent.com/65670964/204931353-539221fb-e431-4894-bbae-7547f3459b7f.png">

Fixes: #23692 
Implemented a page reload after the user clicks on "Subscribe" botton in the message view to avoid confusion due to missing messages.
- [x] Reload newly subscribed stream

**Screenshots and screen captures:**
<img width="815" alt="Screen Shot 2022-11-30 at 8 10 41 PM" src="https://user-images.githubusercontent.com/65670964/204941713-9c4a8b5d-496d-4a5e-9bd1-f1bc2edb7c86.png">
After clicking on "Subscribe", the page will be refreshed.
<img width="819" alt="Screen Shot 2022-11-30 at 8 17 36 PM" src="https://user-images.githubusercontent.com/65670964/204942544-28e1109e-fa1d-4db7-b25c-043d0da4d217.png">
