### PR TITLE
Improve wording of retention period options

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -396,11 +396,6 @@ td .button {
     }
 }
 
-.dependent-inline-block {
-    display: inline-block;
-    margin: 0 0 0 10px !important;
-}
-
 .no-margin {
     margin: 0;
 }

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -78,12 +78,12 @@
                       data-setting-widget-type="message-retention-setting"
                       {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
                         <option value="unlimited">{{t 'Retain forever' }}</option>
-                        <option value="custom_period">{{t 'Retain for N days after posting' }}</option>
+                        <option value="custom_period">{{t 'Custom' }}</option>
                     </select>
 
                     <div class="dependent-inline-block">
                         <label for="id_realm_message_retention_custom_input" class="inline-block realm-time-limit-label">
-                            {{t 'N' }}:
+                            {{t 'Retention period (days)' }}:
                         </label>
                         <input type="text" id="id_realm_message_retention_custom_input" autocomplete="off"
                           name="realm_message_retention_custom_input"

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -81,7 +81,7 @@
                         <option value="custom_period">{{t 'Custom' }}</option>
                     </select>
 
-                    <div class="dependent-inline-block">
+                    <div class="dependent-settings-block">
                         <label for="id_realm_message_retention_custom_input" class="inline-block realm-time-limit-label">
                             {{t 'Retention period (days)' }}:
                         </label>


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/23532
- [x] Replaced the "Retain for N days after posting" option with "Custom"

- [x] Only show the spot for entering the time if that option is selected (this was implemented by #23616)

- [x] Labeled the custom time like we do for message editing: "Retention period (days): [ ]"

- [x] Added a newline for the "Custom" option as the prompt text is long. This comforms with other settings.

**Screenshots and screen captures:**
<img width="507" alt="Screen Shot 2022-12-18 at 2 42 25 PM" src="https://user-images.githubusercontent.com/65670964/208316187-e24fcd48-d165-490d-a3f2-b7565d4873d4.png">