### PR TITLE
Reload newly subscribed stream

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -18,6 +18,7 @@ import * as dialog_widget from "./dialog_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as keydown_util from "./keydown_util";
+import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
@@ -489,6 +490,24 @@ export function initialize() {
         }
 
         stream_settings_ui.sub_or_unsub(sub);
+        const topic = narrow_state.topic();
+        // Refresh the view only if the stream is unsubscribed before
+        // and subscribed now
+        if (!sub.subscribed) {
+            if (topic === undefined) {
+                narrow.activate([{operator: "stream", operand: sub.name}], {
+                    trigger: "subscribe button",
+                });
+            } else {
+                narrow.activate(
+                    [
+                        {operator: "stream", operand: sub.name},
+                        {operator: "topic", operand: topic},
+                    ],
+                    {trigger: "subscribe button"},
+                );
+            }
+        }
     });
 
     $("#manage_streams_container").on("click", ".change-stream-privacy", (e) => {
@@ -701,6 +720,30 @@ export function initialize() {
         }
         stream_ui_updates.update_regular_sub_settings(sub);
 
+        const topic = narrow_state.topic();
+        // Refresh the view only if the stream is unsubscribed before
+        // and subscribed now
+        if (!sub.subscribed) {
+            const opened_sub = narrow_state.stream_sub();
+            // The opened stream is not the same as the selected stream to update,
+            // then do not need to refresh the message view of the former.
+            if (opened_sub === undefined || opened_sub.stream_id !== sub.stream_id) {
+                return;
+            }
+            if (topic === undefined) {
+                narrow.activate([{operator: "stream", operand: sub.name}], {
+                    trigger: "subscribe button",
+                });
+            } else {
+                narrow.activate(
+                    [
+                        {operator: "stream", operand: sub.name},
+                        {operator: "topic", operand: topic},
+                    ],
+                    {trigger: "subscribe button"},
+                );
+            }
+        }
         e.preventDefault();
         e.stopPropagation();
     });


### PR DESCRIPTION
Fixes: #23692 
Implemented a page reload after the user clicks on "Subscribe" botton in the message view to avoid confusion due to missing messages.
- [x] Reload newly subscribed stream

**Screenshots and screen captures:**
<img width="815" alt="Screen Shot 2022-11-30 at 8 10 41 PM" src="https://user-images.githubusercontent.com/65670964/204941713-9c4a8b5d-496d-4a5e-9bd1-f1bc2edb7c86.png">
After clicking on "Subscribe", the page will be refreshed.
<img width="819" alt="Screen Shot 2022-11-30 at 8 17 36 PM" src="https://user-images.githubusercontent.com/65670964/204942544-28e1109e-fa1d-4db7-b25c-043d0da4d217.png">