### PR TITLE
Support linkifier precedence with explicit ordering

### DIFF
--- a/frontend_tests/node_tests/markdown_parse.js
+++ b/frontend_tests/node_tests/markdown_parse.js
@@ -230,3 +230,44 @@ run_test("topic links", () => {
         },
     ]);
 });
+
+run_test("topic links repeated", () => {
+    // Links generated from repeated patterns should preserve the order.
+    const topic =
+        "#foo101 https://google.com #foo102 #foo103 https://google.com #foo101 #foo102 #foo103";
+    const topic_links = markdown.get_topic_links({topic, get_linkifier_map});
+    assert.deepEqual(topic_links, [
+        {
+            text: "#foo101",
+            url: "http://foo.com/101",
+        },
+        {
+            text: "https://google.com",
+            url: "https://google.com",
+        },
+        {
+            text: "#foo102",
+            url: "http://foo.com/102",
+        },
+        {
+            text: "#foo103",
+            url: "http://foo.com/103",
+        },
+        {
+            text: "https://google.com",
+            url: "https://google.com",
+        },
+        {
+            text: "#foo101",
+            url: "http://foo.com/101",
+        },
+        {
+            text: "#foo102",
+            url: "http://foo.com/102",
+        },
+        {
+            text: "#foo103",
+            url: "http://foo.com/103",
+        },
+    ]);
+});

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -296,17 +296,15 @@ export function get_topic_links({topic, get_linkifier_map}) {
             }
             // We store the starting index as well, to sort the order of occurrence of the links
             // in the topic, similar to the logic implemented in zerver/lib/markdown/__init__.py
-            links.push({url: link_url, text: match[0], index: topic.indexOf(match[0])});
+            links.push({url: link_url, text: match[0], index: match.index});
         }
     }
 
     // Also make raw URLs navigable
     const url_re = /\b(https?:\/\/[^\s<]+[^\s"'),.:;<\]])/g; // Slightly modified from third/marked.js
-    const matches = topic.match(url_re);
-    if (matches) {
-        for (const match of matches) {
-            links.push({url: match, text: match, index: topic.indexOf(match)});
-        }
+    let match;
+    while ((match = url_re.exec(topic)) !== null) {
+        links.push({url: match[0], text: match[0], index: match.index});
     }
     links.sort((a, b) => a.index - b.index);
     for (const match of links) {

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1338,7 +1338,7 @@ def realm_filters_for_realm(realm_id: int) -> List[Tuple[str, str, int]]:
 @cache_with_key(get_linkifiers_cache_key, timeout=3600 * 24 * 7)
 def linkifiers_for_realm_remote_cache(realm_id: int) -> List[LinkifierDict]:
     linkifiers = []
-    for linkifier in RealmFilter.objects.filter(realm_id=realm_id):
+    for linkifier in RealmFilter.objects.filter(realm_id=realm_id).order_by("id"):
         linkifiers.append(
             LinkifierDict(
                 pattern=linkifier.pattern,

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1340,6 +1340,21 @@ class MarkdownTest(ZulipTestCase):
             ],
         )
 
+        msg.set_topic_name("#111 https://google.com #111 #222 #111 https://google.com #222")
+        converted_topic = topic_links(realm.id, msg.topic_name())
+        self.assertEqual(
+            converted_topic,
+            [
+                {"url": "https://trac.example.com/ticket/111", "text": "#111"},
+                {"url": "https://google.com", "text": "https://google.com"},
+                {"url": "https://trac.example.com/ticket/111", "text": "#111"},
+                {"url": "https://trac.example.com/ticket/222", "text": "#222"},
+                {"url": "https://trac.example.com/ticket/111", "text": "#111"},
+                {"url": "https://google.com", "text": "https://google.com"},
+                {"url": "https://trac.example.com/ticket/222", "text": "#222"},
+            ],
+        )
+
         msg.set_topic_name("#444 #555 #666")
         converted_topic = topic_links(realm.id, msg.topic_name())
         self.assertEqual(


### PR DESCRIPTION
This avoids linkifier patterns from matching overlapping substrings in a topic and thus generating multiple URLs for such matches, by using the linkifier ID to order the patterns. Specifically, if a substring is matched by a pattern, any matches of any parts of that substring with a lower-priority linkifier will be discarded.

As a part of implementing the feature, this also fixes the issue that topics with the same pattern being matched repeatedly (e,g,: "#111 #222 #111 #222") will not preserve the order of the generated links properly.

We can start implementing draggable linkifiers later once this is merged.

Fixes: #23715

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
