### PR TITLE
help center: Document Participants column in Recent conversations.

### DIFF
--- a/templates/zerver/help/include/recent-conversations.md
+++ b/templates/zerver/help/include/recent-conversations.md
@@ -12,3 +12,7 @@ messages sent while you were away.
    have sent messages to.
 
 {end_tabs}
+
+!!! tip ""
+
+    The **Participants** column shows which users recently sent a message (newest on the left).


### PR DESCRIPTION
[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Participants.20in.20Recent.20conversations/near/1472770)

Questions:
- I made this change just on the recent conversations page, not on the other pages that describe recent conversations:

```
templates/zerver/help/finding-a-topic-to-read.md:{!recent-conversations.md!}
templates/zerver/help/getting-started-with-zulip.md:{!recent-conversations.md!}
templates/zerver/help/reading-strategies.md:{!recent-conversations.md!}
```

Let me know if you think this bit of info is important enough to include in our first introduction to Zulip.

Current page: https://zulip.com/help/recent-conversations

Updated: 
<img width="902" alt="Screen Shot 2022-12-02 at 2 01 13 PM" src="https://user-images.githubusercontent.com/2090066/205397624-30fc8c15-a4ce-4fd7-92f8-7726aadc9c6b.png">
