### PR TITLE
github: Make self-review checklist in PR template collapsible.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,8 @@ Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gi
 
 **Screenshots and screen captures:**
 
-**Self-review checklist**
+<details>
+<summary>Self-review checklist</summary>
 
 <!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
 https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->
@@ -39,3 +40,4 @@ Completed manual review and testing of the following:
 - [ ] Strings and tooltips.
 - [ ] End-to-end functionality of buttons, interactions and flows.
 - [ ] Corner cases, error conditions, and easily imagined bugs.
+</details>


### PR DESCRIPTION
Notes:
- I think there's no way to have bold text on the same line in the summary as the triangle, but it seems fine to me without bolding.
- Because we expect contributors to look at the text of the template, I opted to put the "Self-review checklist" text on the same line as the `<summary>` tags, to minimize the visual impact of those tags in the code.
- There is a risk that having a collapsible checklist will make it more likely that contributors will fail to notice it. However, being able to collapse the checklist is nice during the review process, so it seems worth trying.

<img width="332" alt="Screen Shot 2022-12-02 at 2 10 02 PM" src="https://user-images.githubusercontent.com/2090066/205399277-ead521f5-17a2-451a-85fa-c899e81f59c4.png">

<img width="606" alt="Screen Shot 2022-12-02 at 2 10 32 PM" src="https://user-images.githubusercontent.com/2090066/205399284-5922661b-04a1-4868-8487-80e290aac415.png">
