### PR TITLE
setting(user): Sort Uploaded files with newest on top.

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -108,6 +108,7 @@ function render_attachments_ui() {
         },
         $parent_container: $("#attachments-settings").expectOne(),
         init_sort: ["numeric", "create_time"],
+        initially_descending_sort: true,
         sort_fields: {
             mentioned_in: sort_mentioned_in,
         },

--- a/static/js/list_widget.js
+++ b/static/js/list_widget.js
@@ -443,6 +443,11 @@ export function create($container, list, opts) {
         widget.set_sorting_function(...opts.init_sort);
     }
 
+    if (opts.initially_descending_sort) {
+        widget.set_reverse_mode(true);
+        opts.$simplebar_container.find(".active").addClass("descend");
+    }
+
     widget.clean_redraw();
 
     // Save the instance for potential future retrieval if a name is provided.


### PR DESCRIPTION
When a user opens the [Setting > Uploaded files] initially in the 'Data Uploaded' column, files are sorted from oldest to newest. Instead, sort this panel from newest to oldest. Because it's more likely that the user is interested in their recently uploaded files, e.g. if they uploaded something by accident.

Created a separate sorting function 'descend_numeric_sort' that sorts the files from newest to oldest.

Fixes: #23737.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
