### PR TITLE
Live update for group events.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -239,13 +239,22 @@ run_test("user groups", ({override}) => {
     event = event_fixtures.user_group__update;
     {
         const stub = make_stub();
+        const user_group_settings_ui_stub = make_stub();
+
         override(user_groups, "update", stub.f);
+        override(user_groups_settings_ui, "update_group", user_group_settings_ui_stub.f);
+
         dispatch(event);
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("event");
+        assert.equal(user_group_settings_ui_stub.num_calls, 1);
+
+        let args = stub.get_args("event");
         assert_same(args.event.group_id, event.group_id);
         assert_same(args.event.data.name, event.data.name);
         assert_same(args.event.data.description, event.data.description);
+
+        args = user_group_settings_ui_stub.get_args("group_id");
+        assert_same(args.group_id, event.group_id);
     }
 });
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -78,6 +78,8 @@ const ui = mock_esm("../../static/js/ui");
 const unread_ops = mock_esm("../../static/js/unread_ops");
 const user_events = mock_esm("../../static/js/user_events");
 const user_groups = mock_esm("../../static/js/user_groups");
+const overlays = mock_esm("../../static/js/overlays");
+const user_groups_settings_ui = mock_esm("../../static/js/user_groups_settings_ui");
 mock_esm("../../static/js/giphy");
 
 const electron_bridge = set_global("electron_bridge", {});
@@ -162,10 +164,20 @@ run_test("user groups", ({override}) => {
     override(settings_user_groups_legacy, "reload", noop);
     {
         const stub = make_stub();
+        const user_group_settings_ui_stub = make_stub();
+
         override(user_groups, "add", stub.f);
+        override(overlays, "groups_open", () => true);
+        override(user_groups_settings_ui, "add_group_to_table", user_group_settings_ui_stub.f);
+
         dispatch(event);
+
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("group");
+        assert.equal(user_group_settings_ui_stub.num_calls, 1);
+
+        let args = stub.get_args("group");
+        assert_same(args.group, event.group);
+        args = user_group_settings_ui_stub.get_args("group");
         assert_same(args.group, event.group);
     }
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -78,6 +78,7 @@ const ui = mock_esm("../../static/js/ui");
 const unread_ops = mock_esm("../../static/js/unread_ops");
 const user_events = mock_esm("../../static/js/user_events");
 const user_groups = mock_esm("../../static/js/user_groups");
+const user_group_edit = mock_esm("../../static/js/user_group_edit");
 const overlays = mock_esm("../../static/js/overlays");
 const user_groups_settings_ui = mock_esm("../../static/js/user_groups_settings_ui");
 mock_esm("../../static/js/giphy");
@@ -186,9 +187,17 @@ run_test("user groups", ({override}) => {
         const stub = make_stub();
         override(user_groups, "get_user_group_from_id", stub.f);
         override(user_groups, "remove", noop);
+        const user_group_edit_stub = make_stub();
+        override(user_group_edit, "handle_deleted_group", user_group_edit_stub.f);
+
         dispatch(event);
+
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("group_id");
+        assert.equal(user_group_edit_stub.num_calls, 1);
+
+        let args = stub.get_args("group_id");
+        assert_same(args.group_id, event.group_id);
+        args = user_group_edit_stub.get_args("group_id");
         assert_same(args.group_id, event.group_id);
     }
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -205,11 +205,16 @@ run_test("user groups", ({override}) => {
     {
         const stub = make_stub();
         override(user_groups, "add_members", stub.f);
+        const user_group_edit_stub = make_stub();
+        override(user_group_edit, "handle_member_edit_event", user_group_edit_stub.f);
         dispatch(event);
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("group_id", "user_ids");
+        assert.equal(user_group_edit_stub.num_calls, 1);
+        let args = stub.get_args("group_id", "user_ids");
         assert_same(args.group_id, event.group_id);
         assert_same(args.user_ids, event.user_ids);
+        args = user_group_edit_stub.get_args("group_id");
+        assert_same(args.group_id, event.group_id);
     }
 
     event = event_fixtures.user_group__add_subgroups;
@@ -227,11 +232,16 @@ run_test("user groups", ({override}) => {
     {
         const stub = make_stub();
         override(user_groups, "remove_members", stub.f);
+        const user_group_edit_stub = make_stub();
+        override(user_group_edit, "handle_member_edit_event", user_group_edit_stub.f);
         dispatch(event);
         assert.equal(stub.num_calls, 1);
-        const args = stub.get_args("group_id", "user_ids");
+        assert.equal(user_group_edit_stub.num_calls, 1);
+        let args = stub.get_args("group_id", "user_ids");
         assert_same(args.group_id, event.group_id);
         assert_same(args.user_ids, event.user_ids);
+        args = user_group_edit_stub.get_args("group_id");
+        assert_same(args.group_id, event.group_id);
     }
 
     event = event_fixtures.user_group__remove_subgroups;

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -40,7 +40,7 @@ export function streams_open() {
 }
 
 export function groups_open() {
-    return (open_overlay_name = "groups");
+    return open_overlay_name === "group_subscriptions";
 }
 
 export function lightbox_open() {

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -39,6 +39,10 @@ export function streams_open() {
     return open_overlay_name === "subscriptions";
 }
 
+export function groups_open() {
+    return (open_overlay_name = "groups");
+}
+
 export function lightbox_open() {
     return open_overlay_name === "lightbox";
 }

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -776,6 +776,7 @@ export function dispatch_normal_event(event) {
                     break;
                 case "update":
                     user_groups.update(event);
+                    user_groups_settings_ui.update_group(event.group_id);
                     break;
                 default:
                     blueslip.error("Unexpected event type user_group/" + event.op);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -67,6 +67,7 @@ import * as submessage from "./submessage";
 import * as typing_events from "./typing_events";
 import * as unread_ops from "./unread_ops";
 import * as user_events from "./user_events";
+import * as user_group_edit from "./user_group_edit";
 import * as user_groups from "./user_groups";
 import * as user_groups_settings_ui from "./user_groups_settings_ui";
 import {user_settings} from "./user_settings";
@@ -760,6 +761,7 @@ export function dispatch_normal_event(event) {
                     }
                     break;
                 case "remove":
+                    user_group_edit.handle_deleted_group(event.group_id);
                     user_groups.remove(user_groups.get_user_group_from_id(event.group_id));
                     break;
                 case "add_members":

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -766,9 +766,11 @@ export function dispatch_normal_event(event) {
                     break;
                 case "add_members":
                     user_groups.add_members(event.group_id, event.user_ids);
+                    user_group_edit.handle_member_edit_event(event.group_id);
                     break;
                 case "remove_members":
                     user_groups.remove_members(event.group_id, event.user_ids);
+                    user_group_edit.handle_member_edit_event(event.group_id);
                     break;
                 case "add_subgroups":
                     user_groups.add_subgroups(event.group_id, event.direct_subgroup_ids);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -68,6 +68,7 @@ import * as typing_events from "./typing_events";
 import * as unread_ops from "./unread_ops";
 import * as user_events from "./user_events";
 import * as user_groups from "./user_groups";
+import * as user_groups_settings_ui from "./user_groups_settings_ui";
 import {user_settings} from "./user_settings";
 import * as user_status from "./user_status";
 
@@ -754,6 +755,9 @@ export function dispatch_normal_event(event) {
             switch (event.op) {
                 case "add":
                     user_groups.add(event.group);
+                    if (overlays.groups_open()) {
+                        user_groups_settings_ui.add_group_to_table(event.group);
+                    }
                     break;
                 case "remove":
                     user_groups.remove(user_groups.get_user_group_from_id(event.group_id));

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -272,8 +272,8 @@ function create_stream() {
         error(xhr) {
             const msg = JSON.parse(xhr.responseText).msg;
             if (msg.includes("access")) {
-                // If we can't access the stream, we can safely assume it's
-                // a duplicate stream that we are not invited to.
+                // If we can't access the stream, we can safely
+                // assume it's a duplicate stream that we are not invited to.
                 //
                 // BUG: This check should be using error codes, not
                 // parsing the error string, so it works correctly

--- a/static/js/user_group_create.js
+++ b/static/js/user_group_create.js
@@ -13,7 +13,7 @@ import * as user_group_settings_ui from "./user_groups_settings_ui";
 class UserGroupMembershipError {
     report_no_members_to_user_group() {
         $("#user_group_membership_error").text(
-            $t({defaultMessage: "You cannot create a user_group with no members!"}),
+            $t({defaultMessage: "You cannot create a user group with no members!"}),
         );
         $("#user_group_membership_error").show();
     }

--- a/static/js/user_group_create.js
+++ b/static/js/user_group_create.js
@@ -10,6 +10,20 @@ import * as user_group_create_members_data from "./user_group_create_members_dat
 import * as user_groups from "./user_groups";
 import * as user_group_settings_ui from "./user_groups_settings_ui";
 
+let created_group_name;
+
+export function reset_name() {
+    created_group_name = undefined;
+}
+
+export function set_name(group_name) {
+    created_group_name = group_name;
+}
+
+export function get_name() {
+    return created_group_name;
+}
+
 class UserGroupMembershipError {
     report_no_members_to_user_group() {
         $("#user_group_membership_error").text(
@@ -101,6 +115,7 @@ function create_user_group() {
     const data = {};
     const group_name = $("#create_user_group_name").val().trim();
     const description = $("#create_user_group_description").val().trim();
+    set_name(group_name);
 
     // Even though we already check to make sure that while typing the user cannot enter
     // newline characters (by pressing the Enter key) it would still be possible to copy
@@ -142,6 +157,7 @@ function create_user_group() {
                 xhr,
                 $(".user_group_create_info"),
             );
+            reset_name();
             loading.destroy_indicator($("#user_group_creating_indicator"));
         },
     });

--- a/static/js/user_group_create_members.js
+++ b/static/js/user_group_create_members.js
@@ -101,7 +101,6 @@ export function build_widgets() {
                 user_id,
                 full_name: user.full_name,
                 is_current_user: user_id === current_user_id,
-                disabled: user_id === current_user_id,
             };
             return render_new_user_group_user(item);
         },

--- a/static/js/user_group_edit.js
+++ b/static/js/user_group_edit.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import render_confirm_delete_user from "../templates/confirm_dialog/confirm_delete_user.hbs";
 import render_change_user_group_info_modal from "../templates/user_group_settings/change_user_group_info_modal.hbs";
 import render_user_group_settings from "../templates/user_group_settings/user_group_settings.hbs";
 
@@ -7,6 +8,7 @@ import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as components from "./components";
+import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
@@ -15,6 +17,7 @@ import * as people from "./people";
 import * as settings_data from "./settings_data";
 import * as settings_ui from "./settings_ui";
 import * as ui from "./ui";
+import * as ui_report from "./ui_report";
 import * as user_group_edit_members from "./user_group_edit_members";
 import * as user_group_ui_updates from "./user_group_ui_updates";
 import * as user_groups from "./user_groups";
@@ -121,6 +124,19 @@ export function setup_group_settings(node) {
     show_settings_for(node);
 }
 
+function open_right_panel_empty() {
+    $(".group-row.active").removeClass("active");
+    user_group_settings_ui.show_user_group_settings_pane.nothing_selected();
+    browser_history.update("#groups");
+}
+
+export function handle_deleted_group(group_id) {
+    if (!hash_util.is_editing_group(group_id)) {
+        return;
+    }
+    open_right_panel_empty();
+}
+
 export function open_group_edit_panel_for_row(group_row) {
     const group = get_user_group_for_target(group_row);
 
@@ -161,6 +177,46 @@ export function initialize() {
                     .addClass("save-button")
                     .attr("data-group-id", user_group_id);
             },
+        });
+    });
+
+    $("#manage_groups_container").on("click", ".group_settings_header .btn-danger", () => {
+        const active_group_data = user_group_settings_ui.get_active_data();
+        const group_id = active_group_data.id;
+        const user_group = user_groups.get_user_group_from_id(group_id);
+
+        if (!user_group || !can_edit(group_id)) {
+            return;
+        }
+        function delete_user_group() {
+            channel.del({
+                url: "/json/user_groups/" + group_id,
+                data: {
+                    id: group_id,
+                },
+                success() {
+                    active_group_data.$row.remove();
+                },
+                error(xhr) {
+                    ui_report.error(
+                        $t_html({defaultMessage: "Failed"}),
+                        xhr,
+                        $(".group_change_property_info"),
+                    );
+                },
+            });
+        }
+
+        const html_body = render_confirm_delete_user({
+            group_name: user_group.name,
+        });
+
+        const user_group_name = user_group.name;
+
+        confirm_dialog.launch({
+            html_heading: $t_html({defaultMessage: "Delete {user_group_name}?"}, {user_group_name}),
+            html_body,
+            on_click: delete_user_group,
         });
     });
 

--- a/static/js/user_group_edit.js
+++ b/static/js/user_group_edit.js
@@ -12,6 +12,7 @@ import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
+import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as settings_data from "./settings_data";
@@ -81,6 +82,44 @@ function show_membership_settings(group) {
         group,
         $parent_container: $member_container,
     });
+}
+
+function enable_group_edit_settings(group) {
+    if (!hash_util.is_editing_group(group.id)) {
+        return;
+    }
+    const $edit_container = get_edit_container(group);
+    $edit_container.find("#open_group_info_modal").show();
+    $edit_container.find(".member-list .actions").show();
+    user_group_ui_updates.update_add_members_elements(group);
+}
+
+function disable_group_edit_settings(group) {
+    if (!hash_util.is_editing_group(group.id)) {
+        return;
+    }
+    const $edit_container = get_edit_container(group);
+    $edit_container.find("#open_group_info_modal").hide();
+    $edit_container.find(".member-list .actions").hide();
+    user_group_ui_updates.update_add_members_elements(group);
+}
+
+export function handle_member_edit_event(group_id) {
+    if (!overlays.groups_open()) {
+        return;
+    }
+    const group = user_groups.get_user_group_from_id(group_id);
+
+    // update members list.
+    const members = Array.from(group.members);
+    user_group_edit_members.update_member_list_widget(group_id, members);
+
+    // update_settings buttons.
+    if (can_edit(group_id)) {
+        enable_group_edit_settings(group);
+    } else {
+        disable_group_edit_settings(group);
+    }
 }
 
 export function update_settings_pane(group) {

--- a/static/js/user_group_edit.js
+++ b/static/js/user_group_edit.js
@@ -80,6 +80,12 @@ function show_membership_settings(group) {
     });
 }
 
+export function update_settings_pane(group) {
+    const $edit_container = get_edit_container(group);
+    $edit_container.find(".group-name").text(group.name);
+    $edit_container.find(".group-description").text(group.description);
+}
+
 export function show_settings_for(node) {
     const group = get_user_group_for_target(node);
     const html = render_user_group_settings({

--- a/static/js/user_group_edit_members.js
+++ b/static/js/user_group_edit_members.js
@@ -8,6 +8,7 @@ import * as add_subscribers_pill from "./add_subscribers_pill";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
+import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import {page_params} from "./page_params";
@@ -19,6 +20,7 @@ import * as user_groups from "./user_groups";
 
 export let pill_widget;
 let current_group_id;
+let member_list_widget;
 
 function get_potential_members() {
     const group = user_groups.get_user_group_from_id(current_group_id);
@@ -32,6 +34,15 @@ function get_potential_members() {
     }
 
     return people.filter_all_users(is_potential_member);
+}
+
+export function update_member_list_widget(group_id, member_ids) {
+    if (!hash_util.is_editing_group(group_id)) {
+        return;
+    }
+    const users = people.get_users_from_ids(member_ids);
+    people.sort_but_pin_current_user_on_top(users);
+    member_list_widget.replace_list_data(users);
 }
 
 function format_member_list_elem(person) {
@@ -85,7 +96,7 @@ export function enable_member_management({group, $parent_container}) {
         get_potential_subscribers: get_potential_members,
     });
 
-    make_list_widget({
+    member_list_widget = make_list_widget({
         $parent_container,
         name: "user_group_members",
         user_ids: Array.from(group.members),

--- a/static/js/user_groups_settings_ui.js
+++ b/static/js/user_groups_settings_ui.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_browse_user_groups_list_item from "../templates/user_group_settings/browse_user_groups_list_item.hbs";
+import render_user_group_settings from "../templates/user_group_settings/user_group_settings.hbs";
 import render_user_group_settings_overlay from "../templates/user_group_settings/user_group_settings_overlay.hbs";
 
 import * as blueslip from "./blueslip";
@@ -13,7 +14,10 @@ import * as scroll_util from "./scroll_util";
 import * as settings_data from "./settings_data";
 import * as ui from "./ui";
 import * as user_group_create from "./user_group_create";
+import * as user_group_edit from "./user_group_edit";
 import * as user_groups from "./user_groups";
+
+let group_list_widget;
 
 export function set_up_click_handlers() {
     $("#groups_overlay").on("click", ".left #clear_search_group_name", (e) => {
@@ -62,6 +66,10 @@ export function row_for_group_id(group_id) {
     return $(`.group-row[data-group-id='${CSS.escape(group_id)}']`);
 }
 
+export function is_group_already_present(group) {
+    return row_for_group_id(group.id).length > 0;
+}
+
 export function get_active_data() {
     const $active_row = $("div.group-row.active");
     const valid_active_id = Number.parseInt($active_row.attr("data-group-id"), 10);
@@ -93,6 +101,36 @@ export function switch_to_group_row(group_id) {
 function show_right_section() {
     $(".right").addClass("show");
     $(".user-groups-header").addClass("slide-left");
+}
+
+export function add_group_to_table(group) {
+    if (is_group_already_present(group)) {
+        // If a group is already listed/added in groups modal,
+        // then we simply return.
+        // This can happen in some corner cases (which might
+        // be backend bugs) where a realm administrator may
+        // get two user_group-add events.
+        return;
+    }
+
+    const settings_html = render_user_group_settings({
+        group,
+        can_edit: user_group_edit.can_edit(group.id),
+    });
+
+    group_list_widget.replace_list_data(user_groups.get_realm_user_groups());
+    ui.get_content_element($("#manage_groups_container .settings")).append($(settings_html));
+
+    // TODO: Address issue for visibility of newely created group.
+    if (user_group_create.get_name() === group.name) {
+        // This `user_group_create.get_name()` check tells us whether the
+        // group was just created in this browser window; it's a hack
+        // to work around the server_events code flow not having a
+        // good way to associate with this request because the group
+        // ID isn't known yet.
+        row_for_group_id(group.id).trigger("click");
+        user_group_create.reset_name();
+    }
 }
 
 export function change_state(section) {
@@ -132,7 +170,7 @@ export function setup_page(callback) {
         const $container = $("#manage_groups_container .user-groups-list");
         const user_groups_list = user_groups.get_realm_user_groups();
 
-        ListWidget.create($container, user_groups_list, {
+        group_list_widget = ListWidget.create($container, user_groups_list, {
             name: "user-groups-overlay",
             modifier(item) {
                 item.is_member = user_groups.is_direct_member_of(

--- a/static/js/user_groups_settings_ui.js
+++ b/static/js/user_groups_settings_ui.js
@@ -133,6 +133,24 @@ export function add_group_to_table(group) {
     }
 }
 
+export function update_group(group_id) {
+    if (!overlays.groups_open()) {
+        return;
+    }
+    const group = user_groups.get_user_group_from_id(group_id);
+    const $group_row = row_for_group_id(group_id);
+    // update left side pane
+    $group_row.find(".group-name").text(group.name);
+    $group_row.find(".description").text(group.description);
+
+    if (get_active_data().id === group.id) {
+        // update right side pane
+        user_group_edit.update_settings_pane(group);
+        // update settings title
+        $("#groups_overlay .user-group-info-title").text(group.name);
+    }
+}
+
 export function change_state(section) {
     if (!section) {
         show_user_group_settings_pane.nothing_selected();

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -460,6 +460,7 @@
         background-color: transparent;
     }
 
+    .create_user_group_plus_button,
     .create_stream_plus_button {
         color: hsl(0, 0%, 100%);
         background-color: hsla(0, 0%, 0%, 0.2);

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -716,6 +716,10 @@ h4.user_group_setting_subsection_title {
         #stream_creation_form {
             margin: 0;
 
+            .user_group_create_info.show {
+                margin: 5px;
+            }
+
             #user_group_creating_indicator,
             #stream_creating_indicator {
                 &:not(:empty) {

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -73,6 +73,7 @@
     margin-right: 10px;
 }
 
+.create_user_group_plus_button,
 .create_stream_plus_button {
     font-size: 24px;
     font-weight: 500;
@@ -93,6 +94,12 @@
         position: relative;
         top: -5px;
     }
+}
+
+.create_user_group_button {
+    position: relative;
+    top: 7px;
+    margin: 0 7px 0 0;
 }
 
 #create_user_group_description,

--- a/static/templates/user_group_settings/user_group_members.hbs
+++ b/static/templates/user_group_settings/user_group_members.hbs
@@ -23,9 +23,7 @@
                     <th>{{t "Name" }}</th>
                     <th>{{t "Email" }}</th>
                     <th>{{t "User ID" }}</th>
-                    {{#if can_edit}}
-                    <th class="actions">{{t "Actions" }}</th>
-                    {{/if}}
+                    <th class="actions" {{#unless can_edit}}style="display:none"{{/unless}}>{{t "Actions" }}</th>
                 </thead>
                 <tbody class="member_table"></tbody>
             </table>

--- a/static/templates/user_group_settings/user_group_settings.hbs
+++ b/static/templates/user_group_settings/user_group_settings.hbs
@@ -1,5 +1,10 @@
 <div class="group_settings_header" data-group-id="{{group.id}}">
     <div class="tab-container"></div>
+    <div class="button-group">
+        {{#if can_edit}}
+        <button class="button small rounded btn-danger deactivate" type="button" name="delete_button"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
+        {{/if}}
+    </div>
 </div>
 <div class="user_group_settings_wrapper hide" data-group-id="{{group.id}}">
     <div class="inner-box">

--- a/static/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/static/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -15,6 +15,12 @@
                     <button type="button" class="btn clear_search_button" id="clear_search_group_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
+                    <div id="add_new_user_group"  class="tippy-zulip-tooltip" data-tippy-content="{{t 'Create new user group' }}" data-tippy-placement="bottom">
+                        <button class="create_user_group_button create_user_group_plus_button">
+                            <span>+</span>
+                        </button>
+                        <div class="float-clear"></div>
+                    </div>
                 </div>
                 <div class="user-groups-list" data-simplebar>
                 </div>


### PR DESCRIPTION
Add live updates for following group events on `#groups` overlay:
- add event
- update event
- Remove event
- add_members
- remove members

Includes commits for other minor fixes as well.

**Screenshots and screen captures:**
![Peek 2022-12-06 12-26](https://user-images.githubusercontent.com/63504956/205842659-862fdd43-f95c-4518-b41c-eaead65b7667.gif)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
