### PR TITLE
message_feed_ui: Add banner when messages in unsubscribed streams not marked as read.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -54,6 +54,7 @@ import * as stream_data from "./stream_data";
 import * as stream_popover from "./stream_popover";
 import * as ui_report from "./ui_report";
 import * as unread_ops from "./unread_ops";
+import { display_not_subscribed_banner } from "./unread_ui";
 import * as user_groups from "./user_groups";
 import * as user_profile from "./user_profile";
 import {user_settings} from "./user_settings";
@@ -956,6 +957,7 @@ export function hide_playground_links_popover() {
 }
 
 export function register_click_handlers() {
+
     $("#main_div").on("click", ".actions_hover", function (e) {
         const $row = $(this).closest(".message_row");
         e.stopPropagation();
@@ -1233,11 +1235,24 @@ export function register_click_handlers() {
     $("body").on("click", ".mark_as_unread", (e) => {
         hide_actions_popover();
         const message_id = $(e.currentTarget).data("message-id");
+        const message = message_lists.current.get(message_id);
+
+        if(message.type === "stream"){
+            const subscribed_to_stream = stream_data.is_subscribed(message.stream_id);
+            const stream_name = stream_data.maybe_get_stream_name(message.stream_id);
+
+            if(subscribed_to_stream){
+                display_not_subscribed_banner(stream_name);
+            }
+        } else {
+            $("#mark_as_unread_fail_banner").toggleClass("invisible", true);
+        }
 
         unread_ops.mark_as_unread_from_here(message_id);
 
         e.stopPropagation();
         e.preventDefault();
+
     });
 
     $("body").on("click", ".respond_button", (e) => {

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_mark_as_read_turned_off_banner from "../templates/mark_as_read_turned_off_banner.hbs";
+import render_mark_as_unread_fail_banner from "../templates/mark_as_unread_fail_banner.hbs";
 
 import * as activity from "./activity";
 import * as message_lists from "./message_lists";
@@ -110,12 +111,36 @@ export function should_display_bankruptcy_banner() {
     return false;
 }
 
+export function display_not_subscribed_banner(stream_name) {
+    hide_not_subscribed_banner(false);
+
+    document.querySelector("#mark_as_unread_fail_banner_content").innerHTML =
+    "Because you are not subscribed to #"+stream_name+
+    ", messages in this stream were not marked as unread.";
+
+    $("#mark_banner_read").on("click", () => {
+        hide_not_subscribed_banner(true);
+    });
+    $("#mark_banner_close").on("click", () => {
+        hide_not_subscribed_banner(true);
+    });
+}
+
+export function hide_not_subscribed_banner(bool) {
+    $("#mark_as_unread_fail_banner").toggleClass("invisible", bool);
+}
+
 export function initialize() {
     update_unread_counts();
 
+    $("#mark_as_unread_fail_banner").html(render_mark_as_unread_fail_banner());
+    hide_not_subscribed_banner(true);
+
     $("#mark_as_read_turned_off_banner").html(render_mark_as_read_turned_off_banner());
     hide_mark_as_read_turned_off_banner();
+
     $("#mark_view_read").on("click", () => {
+
         // Mark all messages in the current view as read.
         //
         // BUG: This logic only supports marking messages visible in

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1281,11 +1281,15 @@ td.pointer {
     padding-right: 4px;
 }
 
+#unread_banners {
+    display:block;
+}
+
 #mark_as_read_turned_off_banner {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 8px 8px 8px 14px;
+    padding: 8px;
     column-gap: 10px;
 
     #mark_as_read_turned_off_content {
@@ -1298,6 +1302,32 @@ td.pointer {
     }
 
     #mark_as_read_close {
+        align-self: flex-start;
+        margin-top: -5px;
+        /* override bootstrap */
+        top: 0;
+        right: 0;
+        position: static;
+    }
+}
+
+#mark_as_unread_fail_banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px;
+    column-gap: 10px;
+
+    #mark_as_unread_fail_banner_content {
+        margin: 0;
+        flex-grow: 1;
+    }
+
+    #mark_as_read_controls {
+        display: flex;
+    }
+
+    #mark_banner_close {
         align-self: flex-start;
         margin-top: -5px;
         /* override bootstrap */

--- a/static/templates/mark_as_unread_fail_banner.hbs
+++ b/static/templates/mark_as_unread_fail_banner.hbs
@@ -1,0 +1,9 @@
+<p id="mark_as_unread_fail_banner_content">
+    {{t '...' }}
+</p>
+<div id="mark_as_read_controls">
+    <button id="mark_banner_read" class="btn btn-warning" title="{{t 'Mark as read' }}">
+        {{t 'Mark as read' }}
+    </button>
+</div>
+<button type="button" id="mark_banner_close" class="close">×</button>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -191,7 +191,11 @@
                         </div>
                         <div id="typing_notifications">
                         </div>
-                        <div id="mark_as_read_turned_off_banner" class="alert home-error-bar">
+                        <div id="unread_banners">
+                            <div id="mark_as_unread_fail_banner" class="alert home-error-bar invisible" >
+                            </div>
+                            <div id="mark_as_read_turned_off_banner" class="alert home-error-bar" >
+                            </div>
                         </div>
                         <div id="bottom_whitespace">
                         </div>


### PR DESCRIPTION
Added a banner to notify the user that messages in unsubscribed streams were not marked as unread when the user chooses the option "Mark as unread from here" in an interleaved view.

Previously the user was not informed that these messages in the unsubscribed streams were not marked as unread.

Fixes: #23470
<img width="693" alt="issue23470" src="https://user-images.githubusercontent.com/111575815/206011662-a52fd791-1e5a-47a4-af79-f3e30d916b7b.png">
