### PR TITLE
ci: Skip failure reporting if ZULIP_BOT_KEY not present.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -47,6 +47,8 @@ jobs:
     # the top explain how to build and upload these images.
     # Ubuntu 20.04 ships with Python 3.8.10.
     container: zulip/ci:focal
+    env:
+      ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
 
     steps:
       - name: Add required permissions
@@ -110,10 +112,10 @@ jobs:
         run: tools/ci/generate-failure-message >> $GITHUB_OUTPUT
 
       - name: Report status to CZO
-        if: ${{ failure() && github.repository == 'zulip/zulip' }}
+        if: ${{ failure() && env.ZULIP_BOT_KEY != '' && github.repository == 'zulip/zulip' }}
         uses: zulip/github-actions-zulip/send-message@v1
         with:
-          api-key: ${{ secrets.ZULIP_BOT_KEY }}
+          api-key: ${{ env.ZULIP_BOT_KEY }}
           email: "github-actions-bot@chat.zulip.org"
           organization-url: "https://chat.zulip.org"
           to: "automated testing"
@@ -151,6 +153,8 @@ jobs:
       options: --init
     runs-on: ubuntu-latest
     needs: production_build
+    env:
+      ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
 
     steps:
       - name: Download built production tarball
@@ -215,10 +219,10 @@ jobs:
         run: tools/ci/generate-failure-message >> $GITHUB_OUTPUT
 
       - name: Report status to CZO
-        if: ${{ failure() && github.repository == 'zulip/zulip' }}
+        if: ${{ failure() && env.ZULIP_BOT_KEY != '' && github.repository == 'zulip/zulip' }}
         uses: zulip/github-actions-zulip/send-message@v1
         with:
-          api-key: ${{ secrets.ZULIP_BOT_KEY }}
+          api-key: ${{ env.ZULIP_BOT_KEY }}
           email: "github-actions-bot@chat.zulip.org"
           organization-url: "https://chat.zulip.org"
           to: "automated testing"
@@ -258,6 +262,8 @@ jobs:
       options: --init
     runs-on: ubuntu-latest
     needs: production_build
+    env:
+      ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
 
     steps:
       - name: Download built production tarball
@@ -300,10 +306,10 @@ jobs:
         run: tools/ci/generate-failure-message >> $GITHUB_OUTPUT
 
       - name: Report status to CZO
-        if: ${{ failure() && github.repository == 'zulip/zulip' }}
+        if: ${{ failure() && env.ZULIP_BOT_KEY != '' && github.repository == 'zulip/zulip' }}
         uses: zulip/github-actions-zulip/send-message@v1
         with:
-          api-key: ${{ secrets.ZULIP_BOT_KEY }}
+          api-key: ${{ env.ZULIP_BOT_KEY }}
           email: "github-actions-bot@chat.zulip.org"
           organization-url: "https://chat.zulip.org"
           to: "automated testing"

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -59,6 +59,8 @@ jobs:
       # ensures it written there because we write it to ~/.pgpass.
       HOME: /home/github/
 
+      ZULIP_BOT_KEY: ${{ secrets.ZULIP_BOT_KEY }}
+
     steps:
       - uses: actions/checkout@v3
 
@@ -239,10 +241,10 @@ jobs:
         run: tools/ci/generate-failure-message >> $GITHUB_OUTPUT
 
       - name: Report status to CZO
-        if: ${{ failure() && github.repository == 'zulip/zulip' }}
+        if: ${{ failure() && env.ZULIP_BOT_KEY != '' && github.repository == 'zulip/zulip' }}
         uses: zulip/github-actions-zulip/send-message@v1
         with:
-          api-key: ${{ secrets.ZULIP_BOT_KEY }}
+          api-key: ${{ env.ZULIP_BOT_KEY }}
           email: "github-actions-bot@chat.zulip.org"
           organization-url: "https://chat.zulip.org"
           to: "automated testing"


### PR DESCRIPTION
Fix a regression introduced in #23719 where ZULIP_BOT_KEY is not guarded against empty strings, which can happen when secrets are not provided to forks, or any other time secrets are inaccessible [^1]. While this does leak ZULIP_BOT_KEY to the entire workflow's env, the value could only be dumped to log output in the event that such a print statement gets merged into main (and thus becomes entrusted with secrets), and per discussion on CZO [^2] and in the prior PR [^3], this seems fine.

[^1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets

[^2]: https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/all.20branches.20failing/near/1475096

[^3]: https://github.com/zulip/zulip/pull/23719#discussion_r1037587072

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
