### PR TITLE
help center: Improve documentation on the ? in-app reference.

### DIFF
--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -3,9 +3,10 @@
 [//]: # (All screenshots here require line-height: 22px and font-size: 16px in .message-content.)
 [//]: # (Requires some additional fiddling for the LaTeX picture, inline code span, and maybe a few others.)
 
-Zulip uses a variant of
-[GitHub Flavored Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)
-to allow you to easily format your messages.
+Zulip uses a variant of Markdown to allow you to easily format your
+messages. There is a convenient [**message formatting
+reference**](#message-formatting-reference) in the Zulip app that you
+can use whenever you need a reminder of the formatting syntax below.
 
 * [Emphasis](#emphasis)
 * [Lists](#lists)
@@ -279,15 +280,16 @@ Under the line
 
 ![Markdown paragraph](/static/images/help/markdown-paragraph.png)
 
-## In-app help
+## Message formatting reference
 
-A summary of the formatting syntax is available in-app.
+A summary of the formatting syntax above is available in the Zulip app.
 
 {start_tabs}
 
 {!start-composing.md!}
 
-1. Click <i class="fa fa-question"></i> at the bottom of the compose box.
+1. Click the **question mark** (<i class="fa fa-question"></i>) icon at the
+   bottom of the compose box.
 
 {end_tabs}
 

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -1,8 +1,9 @@
 # Keyboard shortcuts
 
 Everything in Zulip can be done with the mouse, but mastering a few keyboard
-shortcuts will change your experience of the app. Start with the basics
-below, and add more to your repertoire as needed.
+shortcuts will change your experience of the app. Start with the basics below,
+and use the convenient [**keyboard shortcuts reference**](#keyboard-shortcuts-reference)
+in the Zulip app to add more to your repertoire as needed.
 
 * [The basics](#the-basics)
 * [Navigation](#navigation)
@@ -219,3 +220,19 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 * **View stream messages**: <kbd>Shift</kbd> + <kbd>V</kbd>
 
 * **Toggle subscription**: <kbd>Shift</kbd> + <kbd>S</kbd>
+
+
+## Keyboard shortcuts reference
+
+A summary of the keyboard shortcuts above is available in the Zulip app.
+
+{start_tabs}
+
+1. Click the **keyboard** (<i class="fa fa-keyboard-o"></i>) icon at the bottom
+   of the app, just below the right sidebar.
+
+{end_tabs}
+
+## Related articles
+
+* [Reading strategies](/help/reading-strategies)

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -1,7 +1,10 @@
 # Searching for messages
 
-Zulip has a powerful search engine under its hood. You can search for messages using
-keywords and filters via the search bar at the top of the app.
+It's easy to find the right conversation with Zulip's powerful full-text search.
+You can search for messages using keywords and filters via the search bar at the
+top of the app. There is a convenient [**search filters reference**](#search-filters-reference)
+in the Zulip app that you can use whenever you need a reminder of the search
+filters below.
 
 ## Keyword search
 
@@ -142,6 +145,19 @@ access to in the selected stream(s).  For example:
 When you search Zulip, the URL shown in the address bar of the Zulip web app is a
 permanent link to your search. You can share this link with others, and they
 will see *their own* search results for your query.
+
+## Search filters reference
+
+A summary of the search filters above is available in the Zulip app.
+
+{start_tabs}
+
+1. Click the **keyboard** (<i class="fa fa-keyboard-o"></i>) icon at the bottom
+   of the app, just below the right sidebar.
+
+1. Switch to the **Search filters** tab.
+
+{end_tabs}
 
 ## Related articles
 


### PR DESCRIPTION
Adds a sentence at the end of the intro section of each help center page explaining that you can pull up a [Keyboard shortcuts](https://zulip.com/help/keyboard-shortcuts), [Message formatting](https://zulip.com/help/format-your-message-using-markdown), and [Search filters reference](https://zulip.com/help/search-for-messages) from inside the app.

Adds/updates the in-app help section at the bottom of the page with instructions for opening the reference.

Adds Related Articles section to the **Keyboard shortcuts** page.

Fixes #23758.

**Questions:**

- Should we rephrase the first sentence of the intro in the **Searching for messages** page? Any ideas?

> We might want to consider rewriting [the phrase "Zulip has a powerful search engine under its hood"] in a follow-up pass; it looks like we wrote that back in 2018 (6880af6c2e3b4e598f385e3c2efb2eba4e2ce226).
_Originally posted by @timabbott in https://github.com/zulip/zulip/pull/23690#discussion_r1038661809_.

- Also, we are using the term search filters in the documentation, but the in-app reference tab is still called **Search operators**.

- Should we change the title "Format your messages" > "Format your messages using Markdown" so that it matches de sidebar index?
      
**Screenshots and screen captures:**

<img width="672" alt="image" src="https://user-images.githubusercontent.com/2343554/206349460-710e9327-1c55-463d-9484-4a44acf6e2d8.png">

<img width="478" alt="image" src="https://user-images.githubusercontent.com/2343554/206349575-b9d6ad8e-debd-47b7-82d0-74213ddac00e.png">

<img width="661" alt="image" src="https://user-images.githubusercontent.com/2343554/206349958-e70e8c45-47a3-40f1-b561-ead60b52bba8.png">

<img width="480" alt="image" src="https://user-images.githubusercontent.com/2343554/206350024-26c22e58-2a44-49f2-ba35-2792e758e807.png">

<img width="681" alt="image" src="https://user-images.githubusercontent.com/2343554/206349725-09bc32b6-4978-420f-9e47-dfb65880255f.png">

<img width="478" alt="image" src="https://user-images.githubusercontent.com/2343554/206349805-ad480970-8320-4376-84db-f120d520a454.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>