### PR TITLE
User Pills Are Now Displayed in the Dropdown After Being Selected

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -86,7 +86,7 @@ export function initialize() {
                 );
             }
             const suggestions = search_suggestion.get_suggestions(base_query, query);
-            // Update our global search_map hash
+            // Only updates look up table if the string is not an email
             if (!suggestions.strings[0].includes("@"))
                 search_map = suggestions.lookup_table;
             return suggestions.strings;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -87,7 +87,8 @@ export function initialize() {
             }
             const suggestions = search_suggestion.get_suggestions(base_query, query);
             // Update our global search_map hash
-            search_map = suggestions.lookup_table;
+            if (!suggestions.strings[0].includes("@"))
+                search_map = suggestions.lookup_table;
             return suggestions.strings;
         },
         fixed: true,

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -87,8 +87,9 @@ export function initialize() {
             }
             const suggestions = search_suggestion.get_suggestions(base_query, query);
             // Only updates look up table if the string is not an email
-            if (!suggestions.strings[0].includes("@"))
+            if (!suggestions.strings[0].includes("@")) {
                 search_map = suggestions.lookup_table;
+            }
             return suggestions.strings;
         },
         fixed: true,


### PR DESCRIPTION
When users are searched, the suggest pill will continue to be displayed in the dropdown, even after being selected.

Fixes: #23365

![image](https://user-images.githubusercontent.com/64824480/206059376-6af6ba1b-83c6-4040-831a-22ee44c38c56.png)


<details>
<summary>Self-review checklist</summary>


- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
