### PR TITLE
Changed topic placeholder text for organizations that allow no-topic messages

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -266,9 +266,11 @@ export function update_placeholder_text() {
         stream: $("#stream_message_recipient_stream").val(),
         topic: $("#stream_message_recipient_topic").val(),
         private_message_recipient: compose_pm_pill.get_emails(),
+        default_no_topic: "general chat"
     };
 
     $("#compose-textarea").attr("placeholder", compose_ui.compute_placeholder_text(opts));
+    $("#stream_message_recipient_topic").attr("placeholder", compose_ui.compute_placeholder_topic(opts));
 }
 
 export function start(msg_type, opts) {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -266,11 +266,14 @@ export function update_placeholder_text() {
         stream: $("#stream_message_recipient_stream").val(),
         topic: $("#stream_message_recipient_topic").val(),
         private_message_recipient: compose_pm_pill.get_emails(),
-        no_topic_default: "general chat"
+        no_topic_default: "general chat",
     };
 
     $("#compose-textarea").attr("placeholder", compose_ui.compute_placeholder_text(opts));
-    $("#stream_message_recipient_topic").attr("placeholder", compose_ui.compute_placeholder_topic(opts));
+    $("#stream_message_recipient_topic").attr(
+        "placeholder",
+        compose_ui.compute_placeholder_topic(opts),
+    );
 }
 
 export function start(msg_type, opts) {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -266,7 +266,7 @@ export function update_placeholder_text() {
         stream: $("#stream_message_recipient_stream").val(),
         topic: $("#stream_message_recipient_topic").val(),
         private_message_recipient: compose_pm_pill.get_emails(),
-        default_no_topic: "general chat"
+        no_topic_default: "general chat"
     };
 
     $("#compose-textarea").attr("placeholder", compose_ui.compute_placeholder_text(opts));

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -89,13 +89,13 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
 
 
 export function compute_placeholder_topic(opts) {
-    // Computes clear placeholder text for the compose box, depending
-    // on what heading values have already been filled out.
+    // Computes clear placeholder text for the topic box, depending
+    // on what is set for the default no topic name.
     //
-    // We return text with the stream and topic name unescaped,
+    // We return text with the default no topic name unescaped,
     // because the caller is expected to insert this into the
     // placeholder field in a way that does HTML escaping.
-    return $t({defaultMessage: 'Enter topic or send to "{default_no_topic}"'}, {default_no_topic: opts.default_no_topic});
+    return $t({defaultMessage: 'Enter topic or send to "{default_topic}"'}, {default_topic: opts.no_topic_default});
 }
 
 export function compute_placeholder_text(opts) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -87,7 +87,6 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
     replace($textarea[0], old_syntax, () => new_syntax, "after-replacement");
 }
 
-
 export function compute_placeholder_topic(opts) {
     // Computes clear placeholder text for the topic box, depending
     // on what is set for the default no topic name.
@@ -95,7 +94,10 @@ export function compute_placeholder_topic(opts) {
     // We return text with the default no topic name unescaped,
     // because the caller is expected to insert this into the
     // placeholder field in a way that does HTML escaping.
-    return $t({defaultMessage: 'Enter topic or send to "{default_topic}"'}, {default_topic: opts.no_topic_default});
+    return $t(
+        {defaultMessage: 'Enter topic or send to "{default_topic}"'},
+        {default_topic: opts.no_topic_default},
+    );
 }
 
 export function compute_placeholder_text(opts) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -87,6 +87,17 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
     replace($textarea[0], old_syntax, () => new_syntax, "after-replacement");
 }
 
+
+export function compute_placeholder_topic(opts) {
+    // Computes clear placeholder text for the compose box, depending
+    // on what heading values have already been filled out.
+    //
+    // We return text with the stream and topic name unescaped,
+    // because the caller is expected to insert this into the
+    // placeholder field in a way that does HTML escaping.
+    return $t({defaultMessage: 'Enter topic or send to "{default_no_topic}"'}, {default_no_topic: opts.default_no_topic});
+}
+
 export function compute_placeholder_text(opts) {
     // Computes clear placeholder text for the compose box, depending
     // on what heading values have already been filled out.

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -452,10 +452,8 @@ input.recipient_box {
 }
 
 #stream_message_recipient_topic.recipient_box {
-    /* This width roughly corresponds to how long of a topic can appear in
-       the left sidebar with a single digit unread count without being
-       cut off. */
-    width: 175px;
+    /* This width roughly corresponds to the maximum length (60 characters) of the topic in the input box. */
+    width: 480px;
 }
 
 #private_message_recipient.recipient_box {

--- a/templates/zerver/help/setting-up-zulip-for-a-class.md
+++ b/templates/zerver/help/setting-up-zulip-for-a-class.md
@@ -228,13 +228,13 @@ stream](/help/create-a-stream#stream-options).
 
 For most classes, the following streams are recommended:
 
-- **\#announcements**: For general announcements about the class. When
+- **#announcements**: For general announcements about the class. When
   creating this stream, [restrict posting
   permissions](/help/stream-sending-policy) so that only course staff
   ([Administrators and moderators](/help/roles-and-permissions) are
   allowed to post.
-- **\#staff (private)**: For discussions among course staff.
-- **\#general**: For random topics, e.g. students forming study groups.
+- **#staff (private)**: For discussions among course staff.
+- **#general**: For random topics, e.g. students forming study groups.
 - A stream for each **lecture** or **unit**, e.g. “Lecture 1: Course
   intro” or “Unit 3: Sorting algorithms”.
 - A stream for each **section**/**tutorial group** (e.g. “Section 1”)
@@ -262,8 +262,8 @@ A few notes:
 !!! tip ""
 
     If using your Zulip organization for a single class, set default
-    streams for new users to include \#announcements, \#general, and
-    all lecture/unit streams.
+    streams for new users to include **#announcements**, **#general**,
+    and all lecture/unit streams.
 
 ## Invite users to join
 
@@ -330,8 +330,9 @@ If you plan to use the same Zulip organization in future terms (either
 for your own classes or for your department), you will likely want to:
 
 - Rename all streams to indicate the class and term in which they were used, e.g.:
-    - \#announcements → \#FA21 - CS101 - announcements
-    - \#CS101 > Lecture 1: Course intro → #FA21 - CS101 > Lecture 1: Course intro
+    - **#announcements** → **#FA21 - CS101 - announcements**
+    - **#CS101 > Lecture 1: Course intro** → **#FA21 - CS101 > Lecture 1: Course
+      intro**
 - If you do *not* want students from future classes to see messages
   from the prior term (e.g. because you posted homework solutions),
   [make all the streams from the class private][make-private]. You’ll


### PR DESCRIPTION
<!-- Describe your pull request here.-->

[Fixes: #23294](https://github.com/zulip/zulip/issues/23294)

In collaboration with [amyxixin](https://github.com/amyxixin)

- [x] Change the topic placeholder text to "Enter topic or send to "general chat"". Note that "general chat" should be a variable, and thus not translatable. (done by [peterwang06](https://github.com/peterwang06))
- [x] Make the topic input field wider to accommodate this phrase (across languages). (Note that extending the topic input field is part of the proposed compose box redesign in any case.) (done by [amyxixin](https://github.com/amyxixin))


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/66888664/206109287-e8ae2b24-656d-4f0b-969c-929a8fa46875.png)

![image](https://user-images.githubusercontent.com/66888664/206110536-14d364b9-aaf3-4a1f-a459-0774da2fedf9.png)

"general chat" is a variable, so that when the name of the [default no-topic name is customizable](https://github.com/zulip/zulip/issues/23292) at an organization level, it will also be reflected here.

The updated field accommodates 60 characters, as defined in maxlength html element.

`<input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="Topic" autocomplete="off" tabindex="0" aria-label="Topic">`

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
