### PR TITLE
url_preview: Fix some URL previews unavailable

### DIFF
--- a/zerver/lib/url_preview/parsers/generic.py
+++ b/zerver/lib/url_preview/parsers/generic.py
@@ -41,13 +41,20 @@ class GenericParser(BaseParser):
 
     def _get_image(self) -> Optional[str]:
         """
-        Finding a first image after the h1 header.
+        Finding a first image after (or before) the h1 header.
         Presumably it will be the main image.
         """
         soup = self._soup
         first_h1 = soup.find("h1")
         if first_h1:
+            # Normally, we find the first image after the h1 header.
+            # This is because it would presumably be the main image
+            # for the url. However, some websites do not contain
+            # an image after but before, so we need to look for
+            # a picture in both directions.
             first_image = first_h1.find_next_sibling("img", src=True)
+            if not isinstance(first_image, Tag) or first_image["src"] == "":
+                first_image = first_h1.find_previous_sibling("img", src=True)
             if isinstance(first_image, Tag) and first_image["src"] != "":
                 assert isinstance(first_image["src"], str)
                 try:

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -67,7 +67,7 @@ def valid_content_type(url: str) -> bool:
     if not content_type or content_type.startswith("text/html"):
         # Verify that the content is actually HTML if the server claims it is
         content_type = guess_mimetype_from_content(response)
-    return content_type.startswith("text/html")
+    return content_type.startswith("text/html") or content_type.startswith("text/xml")
 
 
 def catch_network_errors(func: Callable[..., Any]) -> Callable[..., Any]:


### PR DESCRIPTION
1. The first issue with the old code is that it neglects the case when the url has "text/xml" content type based on `guess_mimetype_from_content()` function. Thus, we appended this "text/xml" as a valid content type as well. A screenshot of a debugging message from `guess_mimetype_from_content(response)` and `valid_content_type("https://arxiv.org")` output and  is attachted.

<img width="259" alt="Screen Shot 2022-12-07 at 2 36 20 AM" src="https://user-images.githubusercontent.com/65670964/206116968-33c559a5-e51b-4f60-8732-0eeb7f111ac9.png">

2. In addition, the old code only searches for the first image after the first `<h1>`, resulting in some failures in finding an image. This revision adds a search to the siblings before the first `<h1>` to look for an image. For example, here are some debugging messages after inputting "[https://arxiv.org](https://arxiv.org/abs/2211.06956)":

<img width="591" alt="Screen Shot 2022-12-07 at 2 35 52 AM" src="https://user-images.githubusercontent.com/65670964/206116891-845fa924-ee2a-4251-bd0a-9d716598b719.png">

<!-- Describe your pull request here.-->

Fixes #23664

**Screenshots and screen captures:**
<img width="540" alt="Screen Shot 2022-12-07 at 2 28 09 AM" src="https://user-images.githubusercontent.com/65670964/206115425-2d4edadf-b063-4286-8a8c-364d6eac60b4.png">

- [x] Solved some URL preview not showing issues, including `https://arxiv.org*`
- [ ] Whether we want to have a preview even though there is no available image from that URL. For exmaple, "https://www.jstor.org/stable/2006904#metadata_info_tab_contents" currently does not have a preview due to a lack of the image. However, on slack , it shows this:
<img width="458" alt="Screen Shot 2022-12-07 at 2 31 16 AM" src="https://user-images.githubusercontent.com/65670964/206116017-aa3516de-6646-43f0-8013-7b67df333f15.png">

<details>
<summary>Self-review checklist</summary>

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
