### PR TITLE
populate_db: Generate embedded links in topic names.

### DIFF
--- a/zerver/lib/generate_test_data.py
+++ b/zerver/lib/generate_test_data.py
@@ -27,12 +27,18 @@ def generate_topics(num_topics: int) -> List[str]:
     for _ in itertools.repeat(None, num_single_word_topics):
         topics.append(random.choice(config["nouns"]))
 
+    # Make embed link topics account for 5% of total topics.
+    # Make sure there is at least one
+    num_embed_link_topics = max(1, num_topics // 20)
+    for _ in itertools.repeat(None, num_embed_link_topics):
+        topics.append(random.choice(config["url-in-topics"]))
+
     sentence = ["adjectives", "nouns", "connectors", "verbs", "adverbs"]
     for pos in sentence:
         # Add an empty string so that we can generate variable length topics.
         config[pos].append("")
 
-    for _ in itertools.repeat(None, num_topics - num_single_word_topics):
+    for _ in itertools.repeat(None, num_topics - num_single_word_topics - num_embed_link_topics):
         generated_topic = [random.choice(config[pos]) for pos in sentence]
         topic = " ".join(filter(None, generated_topic))
         topics.append(topic)

--- a/zerver/tests/fixtures/config.generate_data.json
+++ b/zerver/tests/fixtures/config.generate_data.json
@@ -35,6 +35,15 @@
         "\n```python\ndef concat(*args, sep='/'):\n    return sep.join(args)\n```",
         "\n```\n(map + [1 2 3] [4 5 6])\n ;;=> (5 7 9)\n```"
       ],
+      "url-in-topics": [
+        "https://zulip.com/",
+        "https://zulip.com/development-community/",
+        "https://zulip.readthedocs.io/en/latest/index.html",
+        "https://github.com/zulip",
+        "https://github.com/zulip/zulip/issues/14991",
+        "https://github.com/zulip/zulip/pull/23772",
+        "https://twitter.com/zulip"
+      ],
 
       "quote-blocks": [
         "```quote\nBe yourself; everyone else is already taken.\n -- Oscar Wilde\n```",


### PR DESCRIPTION
The PR should resolve one task of ISSUE #14991, by generating embedded links in 5% of topic names. The following two screenshots confirm that embedded links are added in some topic names. 

Testing plan: 
- `./manage.py populate_db`
- `./tools/run-dev.py`

<img width="1916" alt="image-1" src="https://user-images.githubusercontent.com/51082971/206120632-115d87a9-5d22-477c-a6ef-64a3d8c6bb89.png">
<img width="1909" alt="image-2" src="https://user-images.githubusercontent.com/51082971/206120639-0ebbd480-287c-4499-961c-36e255d147ff.png">


