### PR TITLE
Refactor save-discard widget code.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -58,7 +58,7 @@ function createSaveButtons(subsection) {
     const $stub_save_button_header = $(`#org-${CSS.escape(subsection)}`);
     const $save_button_controls = $(".save-button-controls");
     const $stub_save_button = $(".save-discard-widget-button.save-button");
-    const $stub_discard_button = $(`#org-discard-${CSS.escape(subsection)}`);
+    const $stub_discard_button = $(".save-discard-widget-button.discard-button");
     const $stub_save_button_text = $(".save-discard-widget-button-text");
     $stub_save_button_header.set_find_results(
         ".subsection-failed-status p",
@@ -70,7 +70,7 @@ function createSaveButtons(subsection) {
     $stub_save_button_header.set_find_results(".save-button-controls", $save_button_controls);
     $stub_save_button_header.set_find_results(
         ".subsection-changes-discard button",
-        $(`#org-discard-${CSS.escape(subsection)}`),
+        $stub_discard_button,
     );
     $save_button_controls.set_find_results(".discard-button", $stub_discard_button);
     const props = {};
@@ -439,7 +439,7 @@ function test_discard_changes_button(discard_changes) {
     const ev = {
         preventDefault: noop,
         stopPropagation: noop,
-        target: "#org-discard-msg-editing",
+        target: ".save-discard-widget-button.discard-button",
     };
 
     page_params.realm_allow_edit_history = true;

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -57,7 +57,7 @@ test("unloaded", () => {
 function createSaveButtons(subsection) {
     const $stub_save_button_header = $(`#org-${CSS.escape(subsection)}`);
     const $save_button_controls = $(".save-button-controls");
-    const $stub_save_button = $(`#org-submit-${CSS.escape(subsection)}`);
+    const $stub_save_button = $(".save-discard-widget-button.save-button");
     const $stub_discard_button = $(`#org-discard-${CSS.escape(subsection)}`);
     const $stub_save_button_text = $(".save-discard-widget-button-text");
     $stub_save_button_header.set_find_results(
@@ -127,10 +127,11 @@ function test_submit_settings_form(override, submit_form) {
     });
 
     let subsection = "other-permissions";
-    ev.currentTarget = `#org-submit-${CSS.escape(subsection)}`;
+    ev.currentTarget = ".save-discard-widget-button.save-button";
     let stubs = createSaveButtons(subsection);
     let $save_button = stubs.$save_button;
-    $save_button.attr("id", `org-submit-${subsection}`);
+    let $save_button_header = stubs.$save_button_header;
+    $save_button_header.attr("id", `org-${subsection}`);
 
     $("#id_realm_waiting_period_threshold").val(10);
 
@@ -195,10 +196,11 @@ function test_submit_settings_form(override, submit_form) {
     assert.deepEqual(data, expected_value);
 
     subsection = "user-defaults";
-    ev.currentTarget = `#org-submit-${CSS.escape(subsection)}`;
+    ev.currentTarget = ".save-discard-widget-button.save-button";
     stubs = createSaveButtons(subsection);
     $save_button = stubs.$save_button;
-    $save_button.attr("id", `org-submit-${subsection}`);
+    $save_button_header = stubs.$save_button_header;
+    $save_button_header.attr("id", `org-${subsection}`);
 
     const $realm_default_language_elem = $("#id_realm_default_language");
     $realm_default_language_elem.val("en");
@@ -224,9 +226,15 @@ function test_submit_settings_form(override, submit_form) {
 }
 
 function test_change_save_button_state() {
-    const {$save_button_controls, $save_button_text, $save_button, $discard_button, props} =
-        createSaveButtons("msg-editing");
-    $save_button.attr("id", "org-submit-msg-editing");
+    const {
+        $save_button_controls,
+        $save_button_text,
+        $save_button,
+        $save_button_header,
+        $discard_button,
+        props,
+    } = createSaveButtons("msg-editing");
+    $save_button_header.attr("id", "org-msg-editing");
 
     {
         settings_org.change_save_button_state($save_button_controls, "unsaved");

--- a/frontend_tests/puppeteer_tests/admin.ts
+++ b/frontend_tests/puppeteer_tests/admin.ts
@@ -5,9 +5,11 @@ import type {ElementHandle, Page} from "puppeteer";
 import * as common from "../puppeteer_lib/common";
 
 async function submit_notifications_stream_settings(page: Page): Promise<void> {
-    await page.waitForSelector('#org-submit-notifications[data-status="unsaved"]', {visible: true});
+    await page.waitForSelector('#org-notifications .save-button[data-status="unsaved"]', {
+        visible: true,
+    });
 
-    const save_button = "#org-submit-notifications";
+    const save_button = "#org-notifications .save-button";
     assert.strictEqual(
         await common.get_text_from_selector(page, save_button),
         "Save changes",
@@ -15,14 +17,16 @@ async function submit_notifications_stream_settings(page: Page): Promise<void> {
     );
     await page.click(save_button);
 
-    await page.waitForSelector('#org-submit-notifications[data-status="saved"]', {visible: true});
+    await page.waitForSelector('#org-notifications .save-button[data-status="saved"]', {
+        visible: true,
+    });
     assert.strictEqual(
-        await common.get_text_from_selector(page, "#org-submit-notifications"),
+        await common.get_text_from_selector(page, "#org-notifications .save-button"),
         "Saved",
         "Saved text didn't appear after saving new stream notifications setting",
     );
 
-    await page.waitForSelector("#org-submit-notifications", {hidden: true});
+    await page.waitForSelector("#org-notifications .save-button", {hidden: true});
 }
 
 async function test_change_new_stream_notifications_setting(page: Page): Promise<void> {
@@ -82,7 +86,7 @@ async function test_change_signup_notifications_stream(page: Page): Promise<void
 }
 
 async function test_permissions_change_save_worked(page: Page): Promise<void> {
-    const saved_status = '#org-submit-stream-permissions[data-status="saved"]';
+    const saved_status = '#org-stream-permissions .save-button[data-status="saved"]';
     await page.waitForSelector(saved_status, {
         visible: true,
     });
@@ -90,7 +94,7 @@ async function test_permissions_change_save_worked(page: Page): Promise<void> {
 }
 
 async function submit_stream_permissions_change(page: Page): Promise<void> {
-    const save_button = "#org-submit-stream-permissions";
+    const save_button = "#org-stream-permissions .save-button";
     await page.waitForSelector(save_button, {visible: true});
     assert.strictEqual(
         await common.get_text_from_selector(page, save_button),
@@ -127,7 +131,7 @@ async function test_changing_create_streams_and_invite_to_stream_policies(
 }
 
 async function test_save_joining_organization_change_worked(page: Page): Promise<void> {
-    const saved_status = '#org-submit-org-join[data-status="saved"]';
+    const saved_status = '#org-join-settings .save-button[data-status="saved"]';
     await page.waitForSelector(saved_status, {
         visible: true,
     });
@@ -135,7 +139,7 @@ async function test_save_joining_organization_change_worked(page: Page): Promise
 }
 
 async function submit_joining_organization_change(page: Page): Promise<void> {
-    const save_button = "#org-submit-org-join";
+    const save_button = "#org-join-settings .save-button";
     await page.waitForSelector(save_button, {visible: true});
     assert.strictEqual(
         await common.get_text_from_selector(page, save_button),
@@ -301,7 +305,7 @@ async function test_authentication_methods(page: Page): Promise<void> {
     });
 
     await page.click(".method_row[data-method='Google'] input[type='checkbox'] + span");
-    const save_button = "#org-submit-auth_settings";
+    const save_button = "#org-auth_settings .save-button";
     assert.strictEqual(await common.get_text_from_selector(page, save_button), "Save changes");
     await page.click(save_button);
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -994,7 +994,7 @@ export function register_save_discard_widget_handlers(
                 data.default_code_block_language = code_block_language_value;
                 break;
             }
-            case "org_join": {
+            case "join_settings": {
                 const org_join_restrictions = $("#id_realm_org_join_restrictions").val();
                 switch (org_join_restrictions) {
                     case "only_selected_domain":
@@ -1082,7 +1082,7 @@ export function register_save_discard_widget_handlers(
             // The organization settings system has some coupled
             // fields that must be submitted together, which is
             // managed by the get_complete_data_for_subsection function.
-            const [, subsection_id] = /^org-submit-(.*)$/.exec($save_button.attr("id"));
+            const [, subsection_id] = /^org-(.*)$/.exec($subsection_elem.attr("id"));
             const subsection = subsection_id.replace(/-/g, "_");
             extra_data = get_complete_data_for_subsection(subsection);
         }

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -1,7 +1,7 @@
 <div id="organization-permissions" data-name="organization-permissions" class="settings-section">
     <form class="form-horizontal admin-realm-form org-permissions-form">
 
-        <div id="org-join" class="settings-subsection-parent">
+        <div id="org-join-settings" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Joining the organization" }}</h3>
                 <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change these settings.' }}"></i>

--- a/static/templates/settings/settings_save_discard_widget.hbs
+++ b/static/templates/settings/settings_save_discard_widget.hbs
@@ -1,7 +1,7 @@
 {{#unless show_only_indicator}}
 <div class="save-button-controls hide">
     <div class="inline-block organization-submission subsection-changes-save">
-        <button class="save-discard-widget-button button primary save-button" id="org-submit-{{section_name}}" data-status="save">
+        <button class="save-discard-widget-button button primary save-button" data-status="save">
             <span class="fa fa-spinner fa-spin save-discard-widget-button-loading"></span>
             <span class="fa fa-check save-discard-widget-button-icon"></span>
             <span class="save-discard-widget-button-text">

--- a/static/templates/settings/settings_save_discard_widget.hbs
+++ b/static/templates/settings/settings_save_discard_widget.hbs
@@ -10,7 +10,7 @@
         </button>
     </div>
     <div class="inline-block subsection-changes-discard">
-        <button class="save-discard-widget-button button discard-button" id="org-discard-{{section_name}}">
+        <button class="save-discard-widget-button button discard-button">
             <span class="fa fa-times save-discard-widget-button-icon"></span>
             <span class="save-discard-widget-button-text">
                 {{t 'Discard' }}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to change the `settings_org.js` code to use subsection id instead of id of save button.
- Second commit is to remove id from save button.
- Third commit is to remove id from discard button.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
