### PR TITLE
compose: Add url to 'scroll down' sent banner.

### DIFF
--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -9,6 +9,7 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_banner from "./narrow_banner";
 import * as narrow_state from "./narrow_state";
+import * as notifications from "./notifications";
 import * as recent_topics_util from "./recent_topics_util";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
@@ -192,6 +193,15 @@ export function scroll_finished() {
 
     if (recent_topics_util.is_visible()) {
         return;
+    }
+
+    if (notifications.scroll_to_message_banner_message_id !== null) {
+        const $message_row = message_lists.current.get_row(
+            notifications.scroll_to_message_banner_message_id,
+        );
+        if ($message_row.length > 0 && !message_viewport.is_message_below_viewport($message_row)) {
+            notifications.clear_compose_notifications();
+        }
     }
 
     if (update_selection_on_next_scroll) {

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -373,6 +373,12 @@ export function recenter_view($message, {from_scroll = false, force_center = fal
     }
 }
 
+export function is_message_below_viewport($message_row) {
+    const info = message_viewport_info();
+    const offset = $message_row.offset();
+    return offset.top >= info.visible_bottom;
+}
+
 export function keep_pointer_in_view() {
     // See message_viewport.recenter_view() for related logic to keep the pointer onscreen.
     // This function mostly comes into place for mouse scrollers, and it

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -163,6 +163,8 @@ export function is_window_focused() {
     return window_focused;
 }
 
+export let scroll_to_message_banner_message_id = null;
+
 export function notify_above_composebox(
     note,
     link_class,
@@ -624,6 +626,7 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
                     link_msg_id,
                     link_text,
                 );
+                scroll_to_message_banner_message_id = link_msg_id;
             }
 
             // This is the HAPPY PATH--for most messages we do nothing
@@ -686,6 +689,7 @@ export function clear_compose_notifications() {
     $("#out-of-view-notification").empty();
     $("#out-of-view-notification").stop(true, true);
     $("#out-of-view-notification").hide();
+    scroll_to_message_banner_message_id = null;
 }
 
 export function reify_message_id(opts) {
@@ -700,6 +704,7 @@ export function reify_message_id(opts) {
 
         if (message_id === old_id) {
             $elem.data("message-id", new_id);
+            scroll_to_message_banner_message_id = new_id;
         }
     }
 }
@@ -715,7 +720,7 @@ export function register_click_handlers() {
         const message_id = $(e.currentTarget).data("message-id");
         message_lists.current.select_id(message_id);
         navigate.scroll_to_selected();
-        $("#out-of-view-notification").hide();
+        clear_compose_notifications();
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -612,7 +612,6 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
 
         let reason = get_local_notify_mix_reason(message);
 
-        const above_composebox_narrow_url = get_above_composebox_narrow_url(message);
         const link_msg_id = message.id;
 
         if (!reason) {
@@ -622,7 +621,8 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
                 notify_above_composebox(
                     reason,
                     "compose_notification_scroll_to_message",
-                    above_composebox_narrow_url,
+                    // Don't display a URL on hover for the "Scroll to bottom" link.
+                    null,
                     link_msg_id,
                     link_text,
                 );
@@ -634,6 +634,7 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
             continue;
         }
 
+        const above_composebox_narrow_url = get_above_composebox_narrow_url(message);
         const link_class = "compose_notification_narrow_by_topic";
         const link_text = $t(
             {defaultMessage: "Narrow to {message_recipient}"},

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -624,9 +624,6 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
                     link_msg_id,
                     link_text,
                 );
-                setTimeout(() => {
-                    $("#out-of-view-notification").hide();
-                }, 3000);
             }
 
             // This is the HAPPY PATH--for most messages we do nothing
@@ -718,6 +715,7 @@ export function register_click_handlers() {
         const message_id = $(e.currentTarget).data("message-id");
         message_lists.current.select_id(message_id);
         navigate.scroll_to_selected();
+        $("#out-of-view-notification").hide();
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -611,11 +611,19 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
         let reason = get_local_notify_mix_reason(message);
 
         const above_composebox_narrow_url = get_above_composebox_narrow_url(message);
+        const link_msg_id = message.id;
 
         if (!reason) {
             if (need_user_to_scroll) {
-                reason = $t({defaultMessage: "Sent! Scroll down to view your message."});
-                notify_above_composebox(reason, "", above_composebox_narrow_url, null, "");
+                reason = $t({defaultMessage: "Sent!"});
+                const link_text = $t({defaultMessage: "Scroll down to view your message."});
+                notify_above_composebox(
+                    reason,
+                    "compose_notification_scroll_to_message",
+                    above_composebox_narrow_url,
+                    link_msg_id,
+                    link_text,
+                );
                 setTimeout(() => {
                     $("#out-of-view-notification").hide();
                 }, 3000);
@@ -626,7 +634,6 @@ export function notify_local_mixes(messages, need_user_to_scroll) {
             continue;
         }
 
-        const link_msg_id = message.id;
         const link_class = "compose_notification_narrow_by_topic";
         const link_text = $t(
             {defaultMessage: "Narrow to {message_recipient}"},

--- a/static/templates/compose_banner/message_sent_banner.hbs
+++ b/static/templates/compose_banner/message_sent_banner.hbs
@@ -1,4 +1,4 @@
 <div class="compose-notifications-content">
-    {{note}} {{#if link_class}}<a href="{{above_composebox_narrow_url}}" class="{{link_class}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
+    {{note}} {{#if link_class}}<a {{#if above_composebox_narrow_url}}href="{{above_composebox_narrow_url}}"{{/if}} class="{{link_class}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
     <button type="button" class="out-of-view-notification-close close">&times;</button>
 </div>


### PR DESCRIPTION
Fixes #19857.

<img width="744" alt="image" src="https://user-images.githubusercontent.com/5634097/216194160-920075d9-9ae7-47f8-93a7-70ddac52c03b.png">


Since there are no existing tests for `out-of-view-notification`, I didn't spend time setting that up in this PR.