### PR TITLE
composebox: Switch styling for compose banner to more generic classnames

### DIFF
--- a/frontend_tests/puppeteer_tests/mention.ts
+++ b/frontend_tests/puppeteer_tests/mention.ts
@@ -30,7 +30,7 @@ async function test_mention(page: Page): Promise<void> {
     await page.click("#compose-send-button");
 
     await page.waitForSelector("#compose_banners .wildcard_warning", {visible: true});
-    await page.click("#compose_banners .wildcard_warning .compose_banner_action_button");
+    await page.click("#compose_banners .wildcard_warning .composebox_banner_action_button");
     await page.waitForSelector(".wildcard_warning", {hidden: true});
 
     await common.check_messages_sent(page, "zhome", [["Verona > Test mention all", ["@all"]]]);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -451,7 +451,7 @@ export function initialize() {
 
     $("#compose_banners").on(
         "click",
-        `.${compose_banner.CLASSNAMES.wildcard_warning} .compose_banner_action_button`,
+        `.${compose_banner.CLASSNAMES.wildcard_warning} .composebox_banner_action_button`,
         (event) => {
             event.preventDefault();
             compose_validate.clear_wildcard_warnings();
@@ -463,7 +463,7 @@ export function initialize() {
     const user_not_subscribed_classname = `.${compose_banner.CLASSNAMES.user_not_subscribed}`;
     $("#compose_banners").on(
         "click",
-        `${user_not_subscribed_classname} .compose_banner_action_button`,
+        `${user_not_subscribed_classname} .composebox_banner_action_button`,
         (event) => {
             event.preventDefault();
 
@@ -479,7 +479,7 @@ export function initialize() {
 
     $("#compose_banners").on(
         "click",
-        `.${compose_banner.CLASSNAMES.topic_resolved} .compose_banner_action_button`,
+        `.${compose_banner.CLASSNAMES.topic_resolved} .composebox_banner_action_button`,
         (event) => {
             event.preventDefault();
 
@@ -496,7 +496,7 @@ export function initialize() {
 
     $("#compose_banners").on(
         "click",
-        `.${compose_banner.CLASSNAMES.recipient_not_subscribed} .compose_banner_action_button`,
+        `.${compose_banner.CLASSNAMES.recipient_not_subscribed} .composebox_banner_action_button`,
         (event) => {
             event.preventDefault();
 
@@ -534,7 +534,7 @@ export function initialize() {
         const classname_selector = `.${classname}`;
         $("#compose_banners").on(
             "click",
-            `${classname_selector} .compose_banner_close_button`,
+            `${classname_selector} .composebox_banner_close_button`,
             (event) => {
                 event.preventDefault();
                 $(event.target).parents(classname_selector).remove();

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -277,7 +277,7 @@
     display: none;
 }
 
-.compose_banner {
+.composebox_banner {
     margin-bottom: 20px;
     border-radius: 5px;
     padding-right: 11px;
@@ -298,7 +298,7 @@
         flex-grow: 1;
     }
 
-    .compose_banner_action_button {
+    .composebox_banner_action_button {
         border: none;
         border-radius: 4px;
         padding: 5px 10px;
@@ -310,7 +310,7 @@
         white-space: nowrap;
     }
 
-    .compose_banner_close_button {
+    .composebox_banner_close_button {
         font-size: 17px;
         text-decoration: none;
         margin-left: 10px;
@@ -323,7 +323,7 @@
         border-color: hsla(38, 44%, 27%, 0.4);
         color: hsl(38, 44%, 27%);
 
-        .compose_banner_close_button {
+        .composebox_banner_close_button {
             color: hsla(38, 44%, 27%, 0.5);
 
             &:hover {
@@ -335,7 +335,7 @@
             }
         }
 
-        .compose_banner_action_button {
+        .composebox_banner_action_button {
             background-color: hsla(38, 44%, 27%, 0.1);
             color: inherit;
 
@@ -354,7 +354,7 @@
         border-color: hsla(3, 57%, 33%, 0.4);
         color: hsl(4, 58%, 33%);
 
-        .compose_banner_close_button {
+        .composebox_banner_close_button {
             color: hsla(4, 58%, 33%, 0.5);
 
             &:hover {
@@ -366,7 +366,7 @@
             }
         }
 
-        .compose_banner_action_button {
+        .composebox_banner_action_button {
             background-color: hsla(3, 57%, 33%, 0.1);
             color: inherit;
 

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -171,13 +171,13 @@
         opacity: 0.4;
     }
 
-    .compose_banner {
+    .composebox_banner {
         &.warning {
             background-color: hsl(53, 100%, 11%);
             border-color: hsla(38, 44%, 60%, 0.4);
             color: hsl(50, 45%, 61%);
 
-            .compose_banner_close_button {
+            .composebox_banner_close_button {
                 color: hsl(50, 45%, 61%, 0.5);
 
                 &:hover {
@@ -189,7 +189,7 @@
                 }
             }
 
-            .compose_banner_action_button {
+            .composebox_banner_action_button {
                 background-color: hsla(50, 45%, 61%, 0.1);
                 color: inherit;
 
@@ -208,7 +208,7 @@
             border-color: hsla(3, 73%, 74%, 0.4);
             color: hsl(3, 73%, 74%);
 
-            .compose_banner_close_button {
+            .composebox_banner_close_button {
                 color: hsla(3, 73%, 74%, 0.5);
 
                 &:hover {
@@ -220,7 +220,7 @@
                 }
             }
 
-            .compose_banner_action_button {
+            .composebox_banner_action_button {
                 background-color: hsla(3, 73%, 74%, 0.1);
                 color: inherit;
 

--- a/static/templates/compose_banner/compose_banner.hbs
+++ b/static/templates/compose_banner/compose_banner.hbs
@@ -1,5 +1,5 @@
 <div
-  class="compose_banner {{banner_type}} {{classname}}"
+  class="compose_banner composebox_banner {{banner_type}} {{classname}}"
   {{#if user_id}}data-user-id="{{user_id}}"{{/if}}
   {{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}}
   {{#if topic_name}}data-topic-name="{{topic_name}}"{{/if}}>
@@ -9,11 +9,11 @@
     <div class="banner_content">{{> @partial-block}}</div>
     {{/if}}
     {{#if button_text}}
-    <button class="compose_banner_action_button" >{{button_text}}</button>
+    <button class="composebox_banner_action_button" >{{button_text}}</button>
     {{/if}}
     {{#if hide_close_button}}
     {{!-- hide_close_button is null by default, and false if explicitly set as false. --}}
     {{else}}
-    <a role="button" class="zulip-icon zulip-icon-close compose_banner_close_button"></a>
+    <a role="button" class="zulip-icon zulip-icon-close composebox_banner_close_button"></a>
     {{/if}}
 </div>


### PR DESCRIPTION
No visible changes.

This is a prep commit for adding a new banner by the composebox that functionally is different than the compose banners (which are for during message composition) but share the same styling.

One type of banner will be for errors and warnings during composition (existing new banners) and the new type of banner will be "sent!" success messages. They are cleared at different times, so it feels helpful to keep them in separate containers. This new generic classname will likely also be used for the upload banner.

Part of fixing https://github.com/zulip/zulip/issues/22524. A commit separated out of #23421 