### PR TITLE
compose notifications: Add # before stream name in notification header.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -531,7 +531,7 @@ export function send_test_notification(content) {
 // Handlebars templates that will do further escaping.
 function get_message_header(message) {
     if (message.type === "stream") {
-        return message.stream + " > " + message.topic;
+        return `#${message.stream} > ${message.topic}`;
     }
     if (message.display_recipient.length > 2) {
         return $t(


### PR DESCRIPTION
Previously there was no # before the stream name in the "sent!" outside of narrow banner. This commit adds it.

<img width="798" alt="image" src="https://user-images.githubusercontent.com/5634097/206317229-46ec7077-e905-4c4d-b5b5-29e9ac7921dd.png">
