### PR TITLE
Fix up and reorder search filters reference

### DIFF
--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -10,6 +10,15 @@
                 </thead>
                 <tbody>
                     <tr>
+                        <td class="operator"><span class="operator_value">keyword</span></td>
+                        <td class="definition">
+                            {{#tr}}
+                                Search for <z-value></z-value> in the topic or message content.
+                                {{#*inline "z-value"}}<span class="operator_value">keyword</span>{{/inline}}
+                            {{/tr}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">stream:<span class="operator_value">stream</span></td>
                         <td class="definition">
                             {{#tr}}
@@ -25,6 +34,12 @@
                                 Narrow to messages with topic <z-value></z-value>.
                                 {{#*inline "z-value"}}<span class="operator_value">topic</span>{{/inline}}
                             {{/tr}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">is:private</td>
+                        <td class="definition">
+                            {{t 'Narrow to private messages.'}}
                         </td>
                     </tr>
                     <tr>
@@ -46,6 +61,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <td class="operator">streams:public</td>
+                        <td class="definition">
+                            {{t 'Search all public streams in the organization.'}}
+                        </td>
+                    </tr>
+                    <tr>
                         <td class="operator">sender:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
@@ -58,6 +79,54 @@
                         <td class="operator">sender:me</td>
                         <td class="definition">
                             {{t 'Narrow to messages sent by you.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">has:link</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages containing links.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">has:attachment</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages containing uploads.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">has:image</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages containing images.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">is:alerted</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages with alert words.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">is:mentioned</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages that mention you.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">is:starred</td>
+                        <td class="definition">
+                            {{t 'Narrow to starred messages.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">is:resolved</td>
+                        <td class="definition">
+                            {{t 'Narrow to messages in resolved topics.'}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="operator">is:unread</td>
+                        <td class="definition">
+                            {{t 'Narrow to unread messages.'}}
                         </td>
                     </tr>
                     <tr>
@@ -75,75 +144,6 @@
                             {{#tr}}
                                 Narrow to just message ID <z-value></z-value>.
                                 {{#*inline "z-value"}}<span class="operator_value">id</span>{{/inline}}
-                            {{/tr}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">streams:public</td>
-                        <td class="definition">
-                            {{t 'Search all public streams in the organization.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">is:alerted</td>
-                        <td class="definition">
-                            {{t 'Narrow to messages with alert words.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">is:mentioned</td>
-                        <td class="definition">
-                            {{t 'Narrow to messages that mention you.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">is:private</td>
-                        <td class="definition">
-                            {{t 'Narrow to private messages.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">is:starred</td>
-                        <td class="definition">
-                            {{t 'Narrow to starred messages.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">is:unread</td>
-                        <td class="definition">
-                            {{t 'Narrow to unread messages.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">is:resolved</td>
-                        <td class="definition">
-                            {{t 'Narrow to messages in resolved topics.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">has:link</td>
-                        <td class="definition">
-                            {{t 'Narrow to messages containing links.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">has:image</td>
-                        <td class="definition">
-                            {{t 'Narrow to messages containing images.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator">has:attachment</td>
-                        <td class="definition">
-                            {{t 'Narrow to messages containing uploads.'}}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="operator"><span class="operator_value">keyword</span></td>
-                        <td class="definition">
-                            {{#tr}}
-                                Search for <z-value></z-value> in the topic or message content.
-                                {{#*inline "z-value"}}<span class="operator_value">keyword</span>{{/inline}}
                             {{/tr}}
                         </td>
                     </tr>

--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -28,29 +28,29 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">pm-with:<span class="operator_value">email</span></td>
+                        <td class="operator">pm-with:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
                                 Narrow to private messages with <z-value></z-value>.
-                                {{#*inline "z-value"}}<span class="operator_value">email</span>{{/inline}}
+                                {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
                             {{/tr}}
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">group-pm-with:<span class="operator_value">email</span></td>
+                        <td class="operator">group-pm-with:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
                                 Narrow to group private messages with <z-value></z-value>.
-                                {{#*inline "z-value"}}<span class="operator_value">email</span>{{/inline}}
+                                {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
                             {{/tr}}
                         </td>
                     </tr>
                     <tr>
-                        <td class="operator">sender:<span class="operator_value">email</span></td>
+                        <td class="operator">sender:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
                                 Narrow to messages sent by <z-value></z-value>.
-                                {{#*inline "z-value"}}<span class="operator_value">email</span>{{/inline}}
+                                {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
                             {{/tr}}
                         </td>
                     </tr>


### PR DESCRIPTION
All email is replaced with user, as the current search UI has user pills, in the file static/templates/search_operators.hbs. In the same file, the order of filters is changed to match the updated help center pages.

<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/issues/23768

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**
<img width="581" alt="Skärmavbild 2022-12-08 kl  00 20 52" src="https://user-images.githubusercontent.com/78347729/206318341-90bcc7a2-4848-4ca4-970f-3c25626aba22.png">
<img width="563" alt="Skärmavbild 2022-12-08 kl  00 21 11" src="https://user-images.githubusercontent.com/78347729/206318379-251c2fca-a9c9-4979-b601-38ee6d3e03f5.png">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
