### PR TITLE
Migrate to new Transifex CLI

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,32 +1,39 @@
+# Migrated from transifex-client format with `tx migrate`
+#
+# See https://developers.transifex.com/docs/using-the-client which hints at
+# this format, but in general, the headings are in the format of:
+#
+# [o:<org>:p:<project>:r:<resource>]
+
 [main]
 host = https://www.transifex.com
 lang_map = zh-Hans: zh_Hans, zh-Hant: zh_Hant
 
-[zulip.djangopo]
+[o:zulip:p:zulip:r:djangopo]
 file_filter = locale/<lang>/LC_MESSAGES/django.po
 source_file = locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO
 
-[zulip.translationsjson]
-file_filter = locale/<lang>/translations.json
-source_file = locale/en/translations.json
-source_lang = en
-type = KEYVALUEJSON
-
-[zulip.mobile]
+[o:zulip:p:zulip:r:mobile]
 file_filter = locale/<lang>/mobile.json
 source_file = locale/en/mobile.json
 source_lang = en
 type = KEYVALUEJSON
 
-[zulip-test.djangopo]
+[o:zulip:p:zulip:r:translationsjson]
+file_filter = locale/<lang>/translations.json
+source_file = locale/en/translations.json
+source_lang = en
+type = KEYVALUEJSON
+
+[o:zulip:p:zulip-test:r:djangopo]
 file_filter = locale/<lang>/LC_MESSAGES/django.po
 source_file = locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO
 
-[zulip-test.translationsjson]
+[o:zulip:p:zulip-test:r:translationsjson]
 file_filter = locale/<lang>/translations.json
 source_file = locale/en/translations.json
 source_lang = en

--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -314,18 +314,17 @@ located at `.tx/config`.
 ## Transifex CLI setup
 
 In order to be able to run `tx pull` (and `tx push` as well, if you're a
-maintainer), you have to specify your Transifex credentials in a config
-file, located at `~/.transifexrc`.
+maintainer), you have to specify your Transifex API Token, [generated in
+Transifex's web interface][transifex-api-token], in a config file located at
+`~/.transifexrc`.
 
 You can find details on how to set it up [here][transifexrc], but it should
 look similar to this (with your credentials):
 
 ```ini
 [https://www.transifex.com]
-username = user
-token =
-password = p@ssw0rd
-hostname = https://www.transifex.com
+rest_hostname = https://rest.api.transifex.com
+token = 1/abcdefg...
 ```
 
 This basically identifies you as a Transifex user, so you can access your
@@ -338,5 +337,6 @@ organizations from the command line.
 [icu messageformat]: https://formatjs.io/docs/intl-messageformat
 [helpers]: https://handlebarsjs.com/guide/block-helpers.html
 [transifex]: https://transifex.com
+[transifex-api-token]: https://www.transifex.com/user/settings/api/
 [transifexrc]: https://docs.transifex.com/client/client-configuration#transifexrc
 [html-templates]: ../subsystems/html-css.md#html-templates

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -424,9 +424,9 @@ def main(options: argparse.Namespace) -> NoReturn:
             sys.exit(1)
 
     # Install shellcheck.
-    run_as_root(["tools/setup/install-shellcheck"])
+    run_as_root([*proxy_env, "tools/setup/install-shellcheck"])
     # Install shfmt.
-    run_as_root(["tools/setup/install-shfmt"])
+    run_as_root([*proxy_env, "tools/setup/install-shfmt"])
 
     # Install transifex-cli.
     run_as_root([*proxy_env, "tools/setup/install-transifex-cli"])

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -109,7 +109,6 @@ COMMON_DEPENDENCIES = [
     "ca-certificates",  # Explicit dependency in case e.g. curl is already installed
     "puppet",  # Used by lint (`puppet parser validate`)
     "gettext",  # Used by makemessages i18n
-    "transifex-client",  # Needed to sync translations from transifex
     "curl",  # Used for testing our API documentation
     "moreutils",  # Used for sponge command
     "unzip",  # Needed for Slack import
@@ -428,6 +427,9 @@ def main(options: argparse.Namespace) -> NoReturn:
     run_as_root(["tools/setup/install-shellcheck"])
     # Install shfmt.
     run_as_root(["tools/setup/install-shfmt"])
+
+    # Install transifex-cli.
+    run_as_root([*proxy_env, "tools/setup/install-transifex-cli"])
 
     setup_venvs.main()
 

--- a/tools/setup/install-transifex-cli
+++ b/tools/setup/install-transifex-cli
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# As of 07 December 2022, per https://pkgs.org/download/transifex-cli, only
+# Void Linux and KaOS package the new Go-based Transifex CLI officially, so our
+# safest bet is to pull the binaries from GitHub Releases directly for now.
+#
+# These binaries do not dynamically link to anything, and thus should work on
+# glibc and musl (Alpine, Void, etc.) systems equally well.
+set -euo pipefail
+
+version=1.6.4
+arch="$(uname -m)"
+
+case $arch in
+    x86_64)
+        tarball="tx-linux-amd64.tar.gz"
+        sha256=954207aba3da6139886922c8927c67098a51602c3d78558864f164a791c39e77
+        ;;
+
+    aarch64)
+        tarball="tx-linux-arm64.tar.gz"
+        sha256=2d0a115edef8e2fda6c1a431d28fe3541de073c35dc1ec677ffff0e6d1dd7a08
+        ;;
+esac
+
+check_version() {
+    out="$(tx --version)" && [ "$out" = "TX Client, version=${version}" ]
+}
+
+if ! check_version 2>/dev/null; then
+    tmpdir="$(mktemp -d)"
+    trap 'rm -r "$tmpdir"' EXIT
+    cd "$tmpdir"
+    curl_opts=(-fLO --retry 3)
+    curl "${curl_opts[@]}" "https://github.com/transifex/cli/releases/download/v${version}/${tarball}"
+    sha256sum -c <<<"$sha256 $tarball"
+    tar -xzf "$tarball" --no-same-owner tx
+    install -Dm755 tx /usr/local/bin/tx
+    check_version
+fi


### PR DESCRIPTION
Since we're already on borrowed time (`transifex-client` [went EOL at the end of November](https://github.com/transifex/transifex-client/)), change the provisioner to pull the new Go-based CLI instead of the `transifex-client` system package (which [seems to be packaged almost nowhere](https://pkgs.org/download/transifex-cli)).

I did a quick test based on `tools/i18n/push-translations` locally, using `tx pull -s -r zulip.djangopo,zulip.translationsjson`. Seems to work great.

I didn't bother with an uninstall step for the old `transifex-client` package: `/usr/local/bin` is almost always ahead of `/usr/bin` (which itself is almost always the destination of system-wide packages on Linuxes) in `$PATH`, so the migration should be clean. In the event these `$PATH` assumptions are wrong on an individual system, the provisioner will fail due to the `check_version` in the new install script, which will provide a fairly intuitive clue for debugging (in CZO, or whatever).

Finally, there's an unrelated drive-by fix to the provision script to respect proxy settings when setting up the shell tooling, since I noticed JS tooling had such additions (and they also worked fine on the transifex installer).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
