### PR TITLE
registration: Add google analytics to realm creation process.

### DIFF
--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -124,6 +124,7 @@ from zerver.views.registration import (
     create_realm,
     find_account,
     get_prereg_key_and_redirect,
+    new_realm_send_confirm,
     realm_redirect,
 )
 from zerver.views.report import (
@@ -569,8 +570,7 @@ i18n_urls = [
     ),
     path(
         "accounts/new/send_confirm/<email>",
-        TemplateView.as_view(template_name="zerver/accounts_send_confirm.html"),
-        {"realm_creation": True},
+        new_realm_send_confirm,
         name="new_realm_send_confirm",
     ),
     path("accounts/register/", accounts_register, name="accounts_register"),


### PR DESCRIPTION
Track `create_realm` and `new_realm_send_confirm` using google analytics.
This will help us track the number of users who want to create a new Zulip organization.

discussion: https://chat.zulip.org/#narrow/stream/107-kandra/topic/Google.20Analytics.20changes

I verified by searching for requests to google in the networks tab.
<img width="763" alt="Screenshot 2022-12-08 at 3 42 37 PM" src="https://user-images.githubusercontent.com/25124304/206420623-89000376-e24d-478e-9db0-a66261115091.png">

