### PR TITLE
narrow-banner: Update default empty banner text to be more general.

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -214,7 +214,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: There are no messages here.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -278,7 +278,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: Nothing's been sent here yet!", ""),
+        empty_narrow_html("translated: There are no messages here.", ""),
     );
     page_params.is_spectator = false;
 
@@ -517,7 +517,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: There are no messages here.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -528,7 +528,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: There are no messages here.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );
@@ -546,7 +546,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: Nothing's been sent here yet!",
+            "translated: There are no messages here.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
         ),
     );

--- a/static/js/narrow_banner.js
+++ b/static/js/narrow_banner.js
@@ -66,7 +66,7 @@ function retrieve_search_query_data() {
 
 function pick_empty_narrow_banner() {
     const default_banner = {
-        title: $t({defaultMessage: "Nothing's been sent here yet!"}),
+        title: $t({defaultMessage: "There are no messages here."}),
         // Spectators cannot start a conversation.
         html: page_params.is_spectator
             ? ""


### PR DESCRIPTION
Updates the default empty narrow banner text to be more generally applicable, particularly in the case when all messages have been moved to a new topic.

"Nothing's been sent here yet!" => "There are no messages here."

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/48-mobile/topic/mobile.20unread.20update.20and.20scroll.20position/near/1472809).

---

**Screenshots and screen captures:**

<details>
<summary>New topic - go to conversation</summary>

### Recent conversations - start composing ...
![Screenshot from 2022-12-08 12-45-00](https://user-images.githubusercontent.com/63245456/206438892-3b16a611-0f8e-4df1-b5d5-4cfb266f37da.png)

### New topic narrow ...
![Screenshot from 2022-12-08 12-24-35](https://user-images.githubusercontent.com/63245456/206438950-5520f8e8-6dc9-44a9-ae59-9d810649df29.png)
</details>
<details>
<summary>All messages moved to new topic</summary>

### Topic with moved messages link ...
![Screenshot from 2022-12-08 12-24-07](https://user-images.githubusercontent.com/63245456/206438960-4fc5afb1-534e-4e5a-aa1a-a0fd4e9a980e.png)

### Previous topic - now empty because all messages have been moved ...
![Screenshot from 2022-12-08 12-23-54](https://user-images.githubusercontent.com/63245456/206438913-2bd61a13-bf34-4313-9b4b-8bb5808ed6a4.png)
</details>
<details>
<summary>Sent by user x - all public streams narrow</summary>

### Search for messages sent by user ...
![Screenshot from 2022-12-08 12-45-42](https://user-images.githubusercontent.com/63245456/206438917-6aeaeae8-5ca1-46c9-87ae-0fbfa759b6fa.png)

### Extend search to all public streams ...
![Screenshot from 2022-12-08 12-45-38](https://user-images.githubusercontent.com/63245456/206438884-5f2d0486-710e-4958-88e4-6a66a0c70fa0.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
