### PR TITLE
Reword user activity info from "Last active:" to "Active"

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -321,7 +321,7 @@ test("title_data", () => {
 
     expected_data = {
         first_line: "Old User",
-        second_line: "translated: Last active: translated: More than 2 weeks ago",
+        second_line: "translated: Active translated: more than 2 weeks ago",
         third_line: "",
         show_you: false,
     };
@@ -457,12 +457,12 @@ test("user_last_seen_time_status", ({override}) => {
     page_params.realm_is_zephyr_mirror_realm = true;
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Last active: translated: Unknown",
+        "translated: Active translated: Unknown",
     );
     page_params.realm_is_zephyr_mirror_realm = false;
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Last active: translated: More than 2 weeks ago",
+        "translated: Active translated: more than 2 weeks ago",
     );
 
     presence.presence_info.set(old_user.user_id, {last_active: 1526137743});
@@ -474,7 +474,7 @@ test("user_last_seen_time_status", ({override}) => {
 
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Last active: May 12",
+        "translated: Active May 12",
     );
 
     set_presence(selma.user_id, "idle");

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -177,8 +177,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
             user_time: undefined,
             user_type: $t({defaultMessage: "Member"}),
             user_circle_class: "user_circle_empty",
-            user_last_seen_time_status:
-                "translated: Last active: translated: More than 2 weeks ago",
+            user_last_seen_time_status: "translated: Active translated: more than 2 weeks ago",
             pm_with_url: "#narrow/pm-with/42-Alice-Smith",
             sent_by_uri: "#narrow/sender/42-Alice-Smith",
             private_message_class: "respond_personal_button",

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -376,13 +376,13 @@ run_test("last_seen_status_from_date", () => {
 
     assert_same({minutes: -30}, $t({defaultMessage: "30 minutes ago"}));
 
-    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "an hour ago"}));
 
     assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
 
     assert_same({hours: -20}, $t({defaultMessage: "20 hours ago"}));
 
-    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -24}, $t({defaultMessage: "yesterday"}));
 
     assert_same({hours: -48}, $t({defaultMessage: "2 days ago"}));
 
@@ -404,13 +404,13 @@ run_test("last_seen_status_from_date", () => {
     // Set base_date to May 1 2016 10.30 PM (months are zero based)
     base_date = new Date(2016, 4, 2, 23, 30);
 
-    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "an hour ago"}));
 
     assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
 
     assert_same({hours: -12}, $t({defaultMessage: "12 hours ago"}));
 
-    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -24}, $t({defaultMessage: "yesterday"}));
 });
 
 run_test("set_full_datetime", () => {

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -120,11 +120,11 @@ export function user_last_seen_time_status(user_id) {
         //
         // We give this vague status for such users; we will get to
         // delete this code when we finish rewriting the presence API.
-        last_seen = $t({defaultMessage: "More than 2 weeks ago"});
+        last_seen = $t({defaultMessage: "more than 2 weeks ago"});
     } else {
         last_seen = timerender.last_seen_status_from_date(last_active_date);
     }
-    return $t({defaultMessage: "Last active: {last_seen}"}, {last_seen});
+    return $t({defaultMessage: "Active {last_seen}"}, {last_seen});
 }
 
 export function info_for(user_id) {

--- a/static/js/timerender.ts
+++ b/static/js/timerender.ts
@@ -120,13 +120,13 @@ export function last_seen_status_from_date(
 
     if (hours < 24) {
         if (hours === 1) {
-            return $t({defaultMessage: "An hour ago"});
+            return $t({defaultMessage: "an hour ago"});
         }
         return $t({defaultMessage: "{hours} hours ago"}, {hours});
     }
 
     if (days_old === 1) {
-        return $t({defaultMessage: "Yesterday"});
+        return $t({defaultMessage: "yesterday"});
     }
 
     if (days_old < 90) {

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -125,6 +125,10 @@ IGNORED_PHRASES = [
     r"he/him",
     r"she/her",
     r"they/them",
+    # Used to show user activity status
+    r"an hour ago",
+    r"more than 2 weeks ago",
+    r"yesterday",
 ]
 
 # Sort regexes in descending order of their lengths. As a result, the


### PR DESCRIPTION
The "Last active:" has been changed to "Active" in static/js/buddy_data.js. In the same file "More than two weeks ago" is changes to "more than two weeks ago" to fit the new user activity status.

In the file static/js/timerender.ts "An hour ago" is changed to "an hour ago" and "Yesterday" is changed to "yesterday". This is also to fit the new user activity status.

In the files frontend_tests/node_tests/buddy_data.js, frontend_tests/node_tests/popovers.js and
frontend_tests/node_tests/timerender.js the test cases are changed to follow the new activity statuses.

<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/issues/22758

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Right sidebar:
<img width="421" alt="Skärmavbild 2022-12-08 kl  16 06 08" src="https://user-images.githubusercontent.com/78347729/206481287-a58c19a6-8382-44e3-95f7-273ef8a744e6.png">

Left sidebar:
<img width="469" alt="Skärmavbild 2022-12-08 kl  16 06 42" src="https://user-images.githubusercontent.com/78347729/206481400-ad9f02c5-511d-48bb-9c85-6e1be10bf060.png">

User profile popover tooltip:
<img width="322" alt="Skärmavbild 2022-12-08 kl  16 07 37" src="https://user-images.githubusercontent.com/78347729/206481588-26ca5434-5c9a-49ec-860d-dbc3f2020796.png">

Full profile modal:
<img width="519" alt="Skärmavbild 2022-12-08 kl  16 08 46" src="https://user-images.githubusercontent.com/78347729/206481850-25816c8d-f645-441d-a961-0f02fd9c3019.png">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
