### PR TITLE
account-settings: Disable deactivate account if user is the only owner.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -642,6 +642,7 @@ run_test("realm_domains", ({override}) => {
 });
 
 run_test("realm_user", ({override}) => {
+    override(settings_account, "maybe_update_deactivate_account_button", noop);
     let event = event_fixtures.realm_user__add;
     dispatch({...event});
     const added_person = people.get_by_user_id(event.person.user_id);

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -590,6 +590,20 @@ test_people("set_custom_profile_field_data", () => {
     assert.equal(person.profile_data[field.id].rendered_value, "<p>Field value</p>");
 });
 
+test_people("is_current_user_only_owner", () => {
+    const person = people.get_by_email(me.email);
+    person.is_owner = false;
+    page_params.is_owner = false;
+    assert.ok(!people.is_current_user_only_owner());
+
+    person.is_owner = true;
+    page_params.is_owner = true;
+    assert.ok(people.is_current_user_only_owner());
+
+    people.add_active_user(realm_owner);
+    assert.ok(!people.is_current_user_only_owner());
+});
+
 test_people("recipient_counts", () => {
     const user_id = 99;
     assert.equal(people.get_recipient_count({user_id}), 0);

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -825,6 +825,23 @@ export function is_active_user_for_popover(user_id) {
     return false;
 }
 
+export function is_current_user_only_owner() {
+    if (!page_params.is_owner || page_params.is_bot) {
+        return false;
+    }
+
+    let active_owners = 0;
+    for (const person of active_user_dict.values()) {
+        if (person.is_owner && !person.is_bot) {
+            active_owners += 1;
+        }
+        if (active_owners > 1) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export function filter_all_persons(pred) {
     const ret = [];
     for (const person of people_by_user_id_dict.values()) {

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -429,15 +429,18 @@ export function dispatch_normal_event(event) {
             switch (event.op) {
                 case "add":
                     people.add_active_user(event.person);
+                    settings_account.maybe_update_deactivate_account_button();
                     break;
                 case "remove":
                     people.deactivate(event.person);
                     stream_events.remove_deactivated_user_from_all_streams(event.person.user_id);
                     settings_users.update_view_on_deactivate(event.person.user_id);
                     buddy_list.maybe_remove_key({key: event.person.user_id});
+                    settings_account.maybe_update_deactivate_account_button();
                     break;
                 case "update":
                     user_events.update_person(event.person);
+                    settings_account.maybe_update_deactivate_account_button();
                     break;
                 default:
                     blueslip.error("Unexpected event type realm_user/" + event.op);

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -106,6 +106,7 @@ export function build_page() {
         send_read_receipts_tooltip: $t({
             defaultMessage: "Read receipts are currently disabled in this organization.",
         }),
+        user_is_only_organization_owner: people.is_current_user_only_owner(),
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -86,6 +86,23 @@ export function update_account_settings_display() {
     update_avatar_change_display();
 }
 
+export function maybe_update_deactivate_account_button() {
+    if (!page_params.is_owner) {
+        return;
+    }
+
+    const $deactivate_account_container = $("#deactivate_account_container");
+    if ($deactivate_account_container) {
+        if (people.is_current_user_only_owner()) {
+            $("#user_deactivate_account_button").prop("disabled", true);
+            $deactivate_account_container.addClass("only_organization_owner_tooltip");
+        } else {
+            $("#user_deactivate_account_button").prop("disabled", false);
+            $deactivate_account_container.removeClass("only_organization_owner_tooltip");
+        }
+    }
+}
+
 export function update_send_read_receipts_tooltip() {
     if (page_params.realm_enable_read_receipts) {
         $("#send_read_receipts_label .settings-info-icon").hide();

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -408,6 +408,18 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ["#deactivate_account_container.only_organization_owner_tooltip"],
+        content: $t({
+            defaultMessage:
+                "Because you are the only organization owner, you cannot deactivate your account.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
         target: "#pm_tooltip_container",
         onShow(instance) {
             if ($(".private_messages_container").hasClass("zoom-in")) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -183,6 +183,18 @@ h3,
     }
 }
 
+#deactivate_account_container {
+    &.only_organization_owner_tooltip {
+        cursor: not-allowed;
+    }
+}
+
+#user_deactivate_account_button {
+    &:disabled {
+        pointer-events: none;
+    }
+}
+
 .admin-realm-description {
     height: 16em;
     width: 100%;

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -36,9 +36,12 @@
                 </form>
 
                 <div class="input-group">
-                    <button type="submit" class="button rounded btn-danger" id="user_deactivate_account_button">
-                        {{t 'Deactivate account' }}
-                    </button>
+                    <div id="deactivate_account_container" class="inline-block {{#if user_is_only_organization_owner}}only_organization_owner_tooltip{{/if}}">
+                        <button type="submit" class="button rounded btn-danger" id="user_deactivate_account_button"
+                          {{#if user_is_only_organization_owner}}disabled="disabled"{{/if}}>
+                            {{t 'Deactivate account' }}
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Disables the deactivate account button in the user's account and privacy settings tab if they are the only organization owner. Adds a tooltip with the 'fa fa-info-circle' icon when the button is deactivated.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/6-frontend/topic/deactivate.20user.20button.2Fmodal/near/1474195).

**Notes**:
- Loops over the active users in the organization to get the count of org owners, which might have performance issues in organizations with a large number of active users. Not sure what a reasonable `populate_db` with extra users for testing this in the dev environment might be.
- The variable name `only_organization_owner` made sense to me in the template with the if/unless statements, but there might be a clearer naming option I didn't consider.

---

**Screenshots and screen captures:**

<details>
<summary>Deactivate account button - tooltip if disabled</summary>

![Screenshot from 2022-12-08 16-42-07](https://user-images.githubusercontent.com/63245456/206495277-e2e90c98-7807-4e0d-999b-667d68c6f1fc.png)
</details>
<details>
<summary>Deactivate account button - disabled</summary>

![Screenshot from 2022-12-08 16-42-13](https://user-images.githubusercontent.com/63245456/206495285-7ff43fee-c685-4b3c-bcda-7d7d470c6334.png)
</details>
<details>
<summary>Compare Iago (left) who is admin to Desdemona (right) who is the only organization admin</summary>

![Screenshot from 2022-12-08 16-42-55](https://user-images.githubusercontent.com/63245456/206495287-e09afe1c-22db-4969-9990-aa7a064e978f.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
