### PR TITLE
org-settings: Fix jquery id selector for join organization settings.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -44,7 +44,7 @@ export function maybe_disable_widgets() {
     if (page_params.is_admin) {
         $("#deactivate_realm_button").prop("disabled", true);
         $("#org-message-retention").find("input, select").prop("disabled", true);
-        $("#org-join").find("input, select").prop("disabled", true);
+        $("#org-join-settings").find("input, select").prop("disabled", true);
         $("#id_realm_invite_required_label").parent().addClass("control-label-disabled");
         return;
     }

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -5,7 +5,7 @@
             <div class="subsection-header">
                 <h3>{{t "Joining the organization" }}</h3>
                 <i class="fa fa-info-circle settings-info-icon realm_message_retention_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can change these settings.' }}"></i>
-                {{> settings_save_discard_widget section_name="org-join" }}
+                {{> settings_save_discard_widget section_name="join-settings" }}
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">


### PR DESCRIPTION
Fixes the id used to select and disable the properties for org admins on the organization permissions settings tab.

Follow-up to #19428.

---

**Notes**:
- The backend returns an error if an admin tries to update these settings, so this change just updates the frontend to disable these settings so that error doesn't happen.
- The icon for these fields being disabled is not part of the header, so it's inconsistent with the other instances of settings headers with help links or info tooltips. Compare the 'Disable organization' setting on the Organization profile tab to this section, see 3rd screenshot below. This could be updated as a follow-up to this PR.

---

**Screenshots and screen captures:**

<details>
<summary>Iago - admin - fields disabled</summary>

![Screenshot from 2022-12-08 16-07-23](https://user-images.githubusercontent.com/63245456/206484882-2bcdc3e7-f735-445b-8c03-956c8560a5b0.png)
</details>
<details>
<summary>Desdemona - owner - can update settings</summary>

![Screenshot from 2022-12-08 16-08-16](https://user-images.githubusercontent.com/63245456/206484892-77665b16-2a2e-4ae3-a6bb-d73890ac56c8.png)
</details>
<details>
<summary>Deactivate organization section - for follow-up note</summary>

![Screenshot from 2022-12-08 16-28-15](https://user-images.githubusercontent.com/63245456/206486386-375c742d-71be-4a6d-9f34-6b06aee25a7f.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
