### PR TITLE
help center: Rename "Format your messages" > "Message formatting".

### DIFF
--- a/templates/zerver/help/create-a-poll.md
+++ b/templates/zerver/help/create-a-poll.md
@@ -27,4 +27,4 @@ send a message that both has a poll and has any other content.
 
 ## Related articles
 
-* [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Message formatting](/help/format-your-message-using-markdown)

--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -1,4 +1,4 @@
-# Format your messages
+# Message formatting
 
 [//]: # (All screenshots here require line-height: 22px and font-size: 16px in .message-content.)
 [//]: # (Requires some additional fiddling for the LaTeX picture, inline code span, and maybe a few others.)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -58,7 +58,7 @@
 * [Open the compose box](/help/open-the-compose-box)
 * [Mastering the compose box](/help/mastering-the-compose-box)
 * [Resize the compose box](/help/resize-the-compose-box)
-* [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Message formatting](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)
 * [Typing notifications](/help/typing-notifications)
 * [Preview messages before sending](/help/preview-your-message-before-sending)

--- a/templates/zerver/help/link-to-a-message-or-conversation.md
+++ b/templates/zerver/help/link-to-a-message-or-conversation.md
@@ -119,5 +119,5 @@ message](/help/quote-and-reply).
 ## Related articles
 
 * [Add a custom linkifier](/help/add-a-custom-linkifier)
-* [Format your messages using Markdown](/help/format-your-message-using-markdown)
+* [Message formatting](/help/format-your-message-using-markdown)
 * [Linking to your organization](/help/linking-to-zulip)

--- a/templates/zerver/help/mastering-the-compose-box.md
+++ b/templates/zerver/help/mastering-the-compose-box.md
@@ -71,6 +71,6 @@ Zulip so that the <kbd>Enter</kbd> key sends your message.
 ## Related articles
 
 * [Resize the compose box](/help/resize-the-compose-box)
-* [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Message formatting](/help/format-your-message-using-markdown)
 * [Preview messages before sending](/help/preview-your-message-before-sending)
 * [Messaging tips and tricks](/help/messaging-tips)

--- a/templates/zerver/help/preview-your-message-before-sending.md
+++ b/templates/zerver/help/preview-your-message-before-sending.md
@@ -14,6 +14,6 @@ Click the **pencil and paper** (<i class="fa fa-edit"></i>) icon to resume editi
 
 ## Related articles
 
-* [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Message formatting](/help/format-your-message-using-markdown)
 * [Resize the compose box](/help/resize-the-compose-box)
 * [Mastering the compose box](/help/mastering-the-compose-box)

--- a/templates/zerver/help/using-zulip-for-a-class.md
+++ b/templates/zerver/help/using-zulip-for-a-class.md
@@ -93,5 +93,4 @@ for each question, it's easy to have several discussions at once.
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 * [Setting up your organization](/help/getting-your-organization-started-with-zulip)
-* [Format messages using Markdown](/help/format-your-message-using-markdown)
-
+* [Message formatting](/help/format-your-message-using-markdown)

--- a/templates/zerver/help/view-the-markdown-source-of-a-message.md
+++ b/templates/zerver/help/view-the-markdown-source-of-a-message.md
@@ -15,5 +15,5 @@ formatted, or to copy the Markdown source for a reply.
 
 ## Related articles
 
-* [Format messages using Markdown](/help/format-your-message-using-markdown)
+* [Message formatting](/help/format-your-message-using-markdown)
 * [Edit or delete a message](/help/edit-or-delete-a-message)


### PR DESCRIPTION
Consolidates the article's name in the left sidebar and page title.

**Questions:**
- Since we are already changing the titles to be more user-friendly, should we leave the link to the page as it is given there was a [question about SEO benefits](https://github.com/zulip/zulip/pull/23764#issuecomment-1343284972) or do we also want to change the link to `/help/message-formatting`?

**Screenshots and screen captures:**
- https://zulip.com/help/format-your-message-using-markdown
<img width="931" alt="image" src="https://user-images.githubusercontent.com/2343554/206603017-fcdbd297-61b4-435b-9b84-a24ba180414d.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>
