### PR TITLE
Rename "operators" to "filters" in "Search operators" reference.

### DIFF
--- a/docs/subsystems/full-text-search.md
+++ b/docs/subsystems/full-text-search.md
@@ -7,8 +7,8 @@ supports English text, but there is an experimental
 full-text search for all languages.
 
 The user interface and feature set for Zulip's full-text search is
-documented in the "Search operators" documentation section in the Zulip
-app's gear menu.
+documented in the in-app "Search filters" reference which can be
+accessed from the Zulip app's gear menu.
 
 ## The default full-text search implementation
 

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -531,7 +531,7 @@ Make sure that these options launch appropriate help screens:
 
 - Proofread and try a couple random options:
   - Message formatting
-  - Search operators
+  - Search filters
 - Make sure help launches in a separate browser tab:
   - Desktop and mobile apps
   - Integrations

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -44,7 +44,7 @@ function make_tab(i) {
             [
                 "translated: Keyboard shortcuts",
                 "translated: Message formatting",
-                "translated: Search operators",
+                "translated: Search filters",
             ][i],
         );
     };
@@ -189,7 +189,7 @@ run_test("basics", () => {
         values: [
             {label: $t({defaultMessage: "Keyboard shortcuts"}), key: "keyboard-shortcuts"},
             {label: $t({defaultMessage: "Message formatting"}), key: "message-formatting"},
-            {label: $t({defaultMessage: "Search operators"}), key: "search-operators"},
+            {label: $t({defaultMessage: "Search filters"}), key: "search-operators"},
         ],
         html_class: "stream_sorter_toggle",
         callback(name, key) {
@@ -238,13 +238,13 @@ run_test("basics", () => {
     assert.equal(env.tabs[0].class, "first");
     assert.equal(env.tabs[1].class, "middle");
     assert.equal(env.tabs[2].class, "last selected");
-    assert.deepEqual(callback_args, ["translated: Search operators", "search-operators"]);
-    assert.equal(widget.value(), "translated: Search operators");
+    assert.deepEqual(callback_args, ["translated: Search filters", "search-operators"]);
+    assert.equal(widget.value(), "translated: Search filters");
     assert.equal(widget.value(), callback_value);
 
     // try to crash the key handler
     env.keydown_f.call(env.tabs[env.focused_tab], RIGHT_KEY);
-    assert.equal(widget.value(), "translated: Search operators");
+    assert.equal(widget.value(), "translated: Search filters");
 
     callback_args = undefined;
 
@@ -264,7 +264,7 @@ run_test("basics", () => {
     widget.disable_tab("message-formatting");
 
     env.keydown_f.call(env.tabs[env.focused_tab], RIGHT_KEY);
-    assert.equal(widget.value(), "translated: Search operators");
+    assert.equal(widget.value(), "translated: Search filters");
 
     callback_args = undefined;
 

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -26,7 +26,7 @@ link:  Usage statistics
 link:  Help center
 info:  Keyboard shortcuts
 info:  Message formatting
-info:  Search operators
+info:  Search filters
 hash:  About Zulip
 ---
 link:  Desktop & mobile apps

--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -214,7 +214,7 @@ export function set_up_toggler() {
         values: [
             {label: $t({defaultMessage: "Keyboard shortcuts"}), key: "keyboard-shortcuts"},
             {label: $t({defaultMessage: "Message formatting"}), key: "message-formatting"},
-            {label: $t({defaultMessage: "Search operators"}), key: "search-operators"},
+            {label: $t({defaultMessage: "Search filters"}), key: "search-operators"},
         ],
         callback(name, key) {
             $(".overlay-modal").hide();

--- a/static/templates/gear_menu.hbs
+++ b/static/templates/gear_menu.hbs
@@ -100,7 +100,7 @@
             </li>
             <li role="presentation">
                 <a tabindex="0" role="menuitem" data-overlay-trigger="search-operators">
-                    <i class="fa fa-search" aria-hidden="true"></i> {{t 'Search operators' }}
+                    <i class="fa fa-search" aria-hidden="true"></i> {{t 'Search filters' }}
                 </a>
             </li>
             <li class="divider only-visible-for-spectators" role="presentation"></li>

--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -1,10 +1,10 @@
-<div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog" aria-label="{{t 'Search operators' }}">
+<div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog" aria-label="{{t 'Search filters' }}">
     <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div id="operators-instructions">
             <table class="table table-striped table-condensed table-rounded table-bordered help-table">
                 <thead>
                     <tr>
-                        <th>{{t "Operator" }}</th>
+                        <th>{{t "Filter" }}</th>
                         <th>{{t "Effect" }}</th>
                     </tr>
                 </thead>
@@ -158,9 +158,9 @@
                     </tr>
                 </tbody>
             </table>
-            <p>{{t "You can combine search operators as needed." }}</p>
+            <p>{{t "You can combine search filters as needed." }}</p>
             <hr />
-            <a href="help/search-for-messages#search-operators" target="_blank" rel="noopener noreferrer">{{t "Detailed search operators documentation" }}</a>
+            <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
         </div>
     </div>
 </div>

--- a/templates/corporate/development-community.md
+++ b/templates/corporate/development-community.md
@@ -219,7 +219,7 @@ you.
 ## Searching for past conversations
 
 To look for previous threads about something, we recommend using the
-following [search operators](/help/search-for-messages):
+following [search filters](/help/search-for-messages#search-filters):
 `streams:public <your keyword(s)>`.
 
 This will search the full history of all public streams for `<your

--- a/templates/corporate/features.html
+++ b/templates/corporate/features.html
@@ -159,7 +159,7 @@
             <p>
                 Search is both snappy and smart, helping you look for
                 text, people, and threads of conversation, with advanced
-                search operators for fine-grained control.
+                search filters for fine-grained control.
             </p>
         </a>
         <a class="feature-block" href="/help/stream-permissions" target="_blank" rel="noopener noreferrer">

--- a/templates/zerver/help/resolve-a-topic.md
+++ b/templates/zerver/help/resolve-a-topic.md
@@ -15,7 +15,7 @@ Marking a topic as resolved:
   you resolved the topic. This message will be marked as unread
   only for users who had participated in the topic.
 * Changes whether the topic appears when using the `is:resolved` and
-  `-is:resolved` [search operators](/help/search-for-messages).
+  `-is:resolved` [search filters](/help/search-for-messages#search-filters).
 
 Marking a topic as unresolved removes the ✔ and also triggers an
 automated notice from the notification bot.


### PR DESCRIPTION
Changes all the uses of the word "operators" to "filters" in the in-app "Search operators" reference to align with the updated help center documentation.

Fixes #23767.

**Screenshots and screen captures:**

<img width="240" alt="image" src="https://user-images.githubusercontent.com/2343554/206617168-6b11ac44-1342-4653-9b69-e6013176b3ba.png">

<img width="543" alt="image" src="https://user-images.githubusercontent.com/2343554/206617683-12fef954-dc14-4499-9272-de1284ed7ea8.png">

<img width="549" alt="image" src="https://user-images.githubusercontent.com/2343554/206618185-729ca72a-850e-444d-9401-68fc972fc4bf.png">

<img width="839" alt="206619652-9aa02cb5-bcf6-45ef-9a57-35c731960c12" src="https://user-images.githubusercontent.com/2343554/206619858-dbc5bbc5-0ac4-4199-9d95-4be141e241ff.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>