### PR TITLE
account-settings: Move disabled change email tooltip to button.

### DIFF
--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -56,6 +56,20 @@ run_test("email_for_user_settings", () => {
     assert.equal(email(isaac), isaac.delivery_email);
 });
 
+run_test("user_can_change_email", () => {
+    const can_change_email = settings_data.user_can_change_email;
+
+    page_params.is_admin = true;
+    assert.equal(can_change_email(), true);
+
+    page_params.is_admin = false;
+    page_params.realm_email_changes_disabled = true;
+    assert.equal(can_change_email(), false);
+
+    page_params.realm_email_changes_disabled = false;
+    assert.equal(can_change_email(), true);
+});
+
 run_test("user_can_change_name", () => {
     const can_change_name = settings_data.user_can_change_name;
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -753,11 +753,11 @@ test("misc", ({override_rewire}) => {
 
     page_params.realm_email_changes_disabled = false;
     settings_account.update_email_change_display();
-    assert.ok(!$("#change_email").prop("disabled"));
+    assert.ok(!$("#change_email_button").prop("disabled"));
 
     page_params.realm_email_changes_disabled = true;
     settings_account.update_email_change_display();
-    assert.ok($("#change_email").prop("disabled"));
+    assert.ok($("#change_email_button").prop("disabled"));
 
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = false;
@@ -783,7 +783,7 @@ test("misc", ({override_rewire}) => {
     assert.equal($(".change_name_tooltip").is(":visible"), false);
 
     settings_account.update_email_change_display();
-    assert.ok(!$("#change_email").prop("disabled"));
+    assert.ok(!$("#change_email_button").prop("disabled"));
 
     override_rewire(stream_settings_data, "get_streams_for_settings_page", () => [
         {name: "some_stream", stream_id: 75},

--- a/static/js/page_params.ts
+++ b/static/js/page_params.ts
@@ -22,6 +22,7 @@ export const page_params: {
     realm_delete_own_message_policy: number;
     realm_edit_topic_policy: number;
     realm_email_address_visibility: number;
+    realm_email_changes_disabled: boolean;
     realm_enable_spectator_access: boolean;
     realm_invite_to_realm_policy: number;
     realm_invite_to_stream_policy: number;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -98,6 +98,7 @@ export function build_page() {
         display_settings: settings_config.get_all_display_settings(),
         user_can_change_name: settings_data.user_can_change_name(),
         user_can_change_avatar: settings_data.user_can_change_avatar(),
+        user_can_change_email: settings_data.user_can_change_email(),
         user_role_text: people.get_user_type(page_params.user_id),
         default_language_name: settings_display.user_default_language_name,
         realm_push_notifications_enabled: page_params.realm_push_notifications_enabled,

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -60,7 +60,7 @@ export function update_name_change_display() {
 }
 
 export function update_email_change_display() {
-    if (page_params.realm_email_changes_disabled && !page_params.is_admin) {
+    if (!settings_data.user_can_change_email()) {
         $("#change_email_button").prop("disabled", true);
         $(".change_email_tooltip").show();
     } else {
@@ -648,7 +648,7 @@ export function set_up() {
     $("#change_email_button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        if (!page_params.realm_email_changes_disabled || page_params.is_admin) {
+        if (settings_data.user_can_change_email()) {
             dialog_widget.launch({
                 html_heading: $t_html({defaultMessage: "Change email"}),
                 html_body: render_change_email_modal(),

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -62,10 +62,10 @@ export function update_name_change_display() {
 export function update_email_change_display() {
     if (!settings_data.user_can_change_email()) {
         $("#change_email_button").prop("disabled", true);
-        $(".change_email_tooltip").show();
+        $("#change_email_button_container").addClass("email_changes_disabled_tooltip");
     } else {
         $("#change_email_button").prop("disabled", false);
-        $(".change_email_tooltip").hide();
+        $("#change_email_button_container").removeClass("email_changes_disabled_tooltip");
     }
 }
 

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -32,7 +32,7 @@ import {user_settings} from "./user_settings";
 let password_quality; // Loaded asynchronously
 
 export function update_email(new_email) {
-    const $email_input = $("#change_email");
+    const $email_input = $("#change_email_button");
 
     if ($email_input) {
         $email_input.text(new_email);
@@ -61,10 +61,10 @@ export function update_name_change_display() {
 
 export function update_email_change_display() {
     if (page_params.realm_email_changes_disabled && !page_params.is_admin) {
-        $("#change_email").prop("disabled", true);
+        $("#change_email_button").prop("disabled", true);
         $(".change_email_tooltip").show();
     } else {
-        $("#change_email").prop("disabled", false);
+        $("#change_email_button").prop("disabled", false);
         $(".change_email_tooltip").hide();
     }
 }
@@ -606,7 +606,7 @@ export function set_up() {
         e.stopPropagation();
         const $change_email_error = $("#change_email_modal").find("#dialog_error");
         const data = {};
-        data.email = $("#change_email_container").find("input[name='email']").val();
+        data.email = $("#change_email_form").find("input[name='email']").val();
 
         const opts = {
             success_continuation() {
@@ -640,12 +640,12 @@ export function set_up() {
     }
 
     function change_email_post_render() {
-        const $input_elem = $("#change_email_container").find("input[name='email']");
-        const email = $("#change_email").text().trim();
+        const $input_elem = $("#change_email_form").find("input[name='email']");
+        const email = $("#change_email_button").text().trim();
         $input_elem.val(email);
     }
 
-    $("#change_email").on("click", (e) => {
+    $("#change_email_button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         if (!page_params.realm_email_changes_disabled || page_params.is_admin) {
@@ -655,11 +655,11 @@ export function set_up() {
                 html_submit_button: $t_html({defaultMessage: "Change"}),
                 loading_spinner: true,
                 id: "change_email_modal",
-                form_id: "change_email_container",
+                form_id: "change_email_form",
                 on_click: do_change_email,
                 post_render: change_email_post_render,
                 on_shown() {
-                    $("#change_email_container input").trigger("focus");
+                    $("#change_email_form input").trigger("focus");
                 },
             });
         }

--- a/static/js/settings_data.ts
+++ b/static/js/settings_data.ts
@@ -108,6 +108,16 @@ export function user_can_change_avatar(): boolean {
     return true;
 }
 
+export function user_can_change_email(): boolean {
+    if (page_params.is_admin) {
+        return true;
+    }
+    if (page_params.realm_email_changes_disabled) {
+        return false;
+    }
+    return true;
+}
+
 export function user_can_change_logo(): boolean {
     return page_params.is_admin && page_params.zulip_plan_is_not_limited;
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -399,6 +399,15 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ["#change_email_button_container.email_changes_disabled_tooltip"],
+        content: $t({defaultMessage: "Email address changes are disabled in this organization."}),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
         target: "#pm_tooltip_container",
         onShow(instance) {
             if ($(".private_messages_container").hasClass("zoom-in")) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -167,7 +167,7 @@ h3,
 }
 
 #change_email_modal {
-    #change_email_container {
+    #change_email_form {
         margin: 0;
     }
 }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -50,7 +50,6 @@ h3,
     }
 }
 
-.email-change-form,
 .user-name-section {
     .settings-info-icon {
         position: relative;
@@ -158,6 +157,18 @@ h3,
 .user-avatar-section {
     .inline-block {
         box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.1);
+    }
+}
+
+#change_email_button_container {
+    &.email_changes_disabled_tooltip {
+        cursor: not-allowed;
+    }
+}
+
+#change_email_button {
+    &:disabled {
+        pointer-events: none;
     }
 }
 

--- a/static/templates/change_email_modal.hbs
+++ b/static/templates/change_email_modal.hbs
@@ -1,4 +1,4 @@
-<form id="change_email_container" class="new-style">
+<form id="change_email_form" class="new-style">
     <label for="email">{{t "New email" }}</label>
     <input type="text" name="email" value="{{ page_params.delivery_email }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -8,7 +8,7 @@
                 <form class="email-change-form grid">
                     <div class="input-group">
                         <label class="inline-block title">{{t "Email" }}</label>
-                        <button id='change_email' type="button" class="button btn-link small rounded inline-block"
+                        <button id="change_email_button" type="button" class="button btn-link small rounded inline-block"
                           {{#if (and page_params.realm_email_changes_disabled (not page_params.is_admin))}}disabled="disabled"{{/if}}>
                             {{page_params.delivery_email}}
                             <i class="fa fa-pencil"></i>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -8,12 +8,12 @@
                 <form class="email-change-form grid">
                     <div class="input-group">
                         <label class="inline-block title">{{t "Email" }}</label>
-                        <button id="change_email_button" type="button" class="button btn-link small rounded inline-block"
-                          {{#if (and page_params.realm_email_changes_disabled (not page_params.is_admin))}}disabled="disabled"{{/if}}>
+                        <button id="change_email_button" type="button" class="button btn-link small rounded inline-block" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
                             {{page_params.delivery_email}}
                             <i class="fa fa-pencil"></i>
                         </button>
-                        <i class="tippy-zulip-tooltip fa fa-question-circle change_email_tooltip settings-info-icon" {{#if (or (not page_params.realm_email_changes_disabled) page_params.is_admin)}}style="display: none;"{{/if}} data-tippy-content="{{t 'Email address changes are disabled in this organization.' }}"></i>
+                        <i class="tippy-zulip-tooltip fa fa-question-circle change_email_tooltip settings-info-icon" {{#if user_can_change_email}}style="display: none;"{{/if}} data-tippy-content="{{t 'Email address changes are disabled in this organization.' }}">
+                        </i>
                     </div>
                 </form>
 

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -5,15 +5,15 @@
             <div id="user_details_section">
                 <h3 class="inline-block">{{t "Account" }}</h3>
                 <div class="alert-notification" id="account-settings-status"></div>
-                <form class="email-change-form grid">
+                <form class="grid">
                     <div class="input-group">
                         <label class="inline-block title">{{t "Email" }}</label>
-                        <button id="change_email_button" type="button" class="button btn-link small rounded inline-block" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
-                            {{page_params.delivery_email}}
-                            <i class="fa fa-pencil"></i>
-                        </button>
-                        <i class="tippy-zulip-tooltip fa fa-question-circle change_email_tooltip settings-info-icon" {{#if user_can_change_email}}style="display: none;"{{/if}} data-tippy-content="{{t 'Email address changes are disabled in this organization.' }}">
-                        </i>
+                        <div id="change_email_button_container" class="inline-block {{#unless user_can_change_email}}email_changes_disabled_tooltip{{/unless}}">
+                            <button id="change_email_button" type="button" class="button btn-link small rounded inline-block" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
+                                {{page_params.delivery_email}}
+                                <i class="fa fa-pencil"></i>
+                            </button>
+                        </div>
                     </div>
                 </form>
 


### PR DESCRIPTION
When an organization disables email changes, we deactivate the change email button for non-admin users in the **Personal Account & Privacy** tab.

Currently, we show an icon when the button is disabled so that users can hover and see a tooltip with information about why their email cannot be changed. This removes the icon and moves the hover tooltip to the disabled button itself.

**Notes**:
- There is a prep commit that simplifies the logic for disabling the button in the handlebars template.
- I know that disabling buttons is not great for accessibility. I'm not sure if moving the tooltip to the deactivated button has a noticeable negative consequence on that front or if it's the same.
- I moved the tooltip from the default "tippy-zulip-tooltip" to a specific case in `static/js/tippy.js` so that the live update behavior for the tooltip would still work if/when an admin changed the setting.

---

**Screenshots and screen captures:**

<details>
<summary>Disabled email changes - hovering</summary>

![Screenshot from 2022-12-09 18-17-46](https://user-images.githubusercontent.com/63245456/206759580-9b7e03fc-88ae-4c37-b0da-f50e230852bc.png)
</details>
<details>
<summary>Disabled email changes - not hovering</summary>

![Screenshot from 2022-12-09 18-17-50](https://user-images.githubusercontent.com/63245456/206759585-a77db81f-12d6-4176-8c1a-79916a0e1d35.png)
</details>
<details>
<summary>When email changes are not disabled - no tooltip on hover</summary>

![Screenshot from 2022-12-09 18-18-20](https://user-images.githubusercontent.com/63245456/206759588-76f71b68-b863-46bb-9d3f-730a7ab3ca12.png)
</details>
<details>
<summary>Non-admin user (left) compared to admin user (right)</summary>

![Screenshot from 2022-12-09 18-20-02](https://user-images.githubusercontent.com/63245456/206759594-c35dc681-8ece-463a-89c0-0e79a80f6df7.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
