### PR TITLE
compose banner: Add specific functions to clear warnings and errors.

### DIFF
--- a/frontend_tests/node_tests/lib/compose_banner.js
+++ b/frontend_tests/node_tests/lib/compose_banner.js
@@ -9,4 +9,6 @@ exports.mock_banners = () => {
     for (const classname of Object.values(compose_banner.CLASSNAMES)) {
         $(`#compose_banners .${classname}`).remove = () => {};
     }
+    $("#compose_banners .warning").remove = () => {};
+    $("#compose_banners .error").remove = () => {};
 };

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -196,7 +196,8 @@ export function clear_compose_box() {
     $("#compose-textarea").removeData("draft-id");
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);
-    $("#compose_banners").empty();
+    compose_banner.clear_errors();
+    compose_banner.clear_warnings();
     compose_ui.hide_compose_spinner();
 }
 

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -7,6 +7,7 @@ import * as fenced_code from "../shared/js/fenced_code";
 import * as channel from "./channel";
 import * as common from "./common";
 import * as compose from "./compose";
+import * as compose_banner from "./compose_banner";
 import * as compose_fade from "./compose_fade";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
@@ -92,7 +93,8 @@ function show_compose_box(msg_type, opts) {
         $("#private_message_toggle").addClass("active");
     }
     $("#compose-send-status").removeClass(common.status_classes).hide();
-    $("#compose_banners").empty();
+    compose_banner.clear_errors();
+    compose_banner.clear_warnings();
     $("#compose").css({visibility: "visible"});
     // When changing this, edit the 42px in _maybe_autoscroll
     $(".new_message_textarea").css("min-height", "3em");
@@ -119,7 +121,8 @@ function clear_box() {
     $("#compose-textarea").removeData("draft-id");
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);
-    $("#compose_banners").empty();
+    compose_banner.clear_errors();
+    compose_banner.clear_warnings();
 }
 
 export function autosize_message_content() {

--- a/static/js/compose_banner.ts
+++ b/static/js/compose_banner.ts
@@ -39,6 +39,14 @@ function hide_compose_spinner(): void {
     $("#compose-send-button").removeClass("disable-btn");
 }
 
+export function clear_errors(): void {
+    $(`#compose_banners .${ERROR}`).remove();
+}
+
+export function clear_warnings(): void {
+    $(`#compose_banners .${WARNING}`).remove();
+}
+
 export function show_error_message(message: string, classname: string, $bad_input?: JQuery): void {
     $(`#compose_banners .${classname}`).remove();
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -5,6 +5,7 @@ import * as browser_history from "./browser_history";
 import * as common from "./common";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
+import * as compose_banner from "./compose_banner";
 import * as compose_state from "./compose_state";
 import * as condense from "./condense";
 import * as copy_and_paste from "./copy_and_paste";
@@ -311,7 +312,8 @@ export function process_escape_key(e) {
 
             // Clear open compose banners, if present.
             if ($(".compose_banner").length) {
-                $("#compose_banners").empty();
+                compose_banner.clear_errors();
+                compose_banner.clear_warnings();
                 return true;
             }
 


### PR DESCRIPTION
Instead of removing all compose banners, we now remove only warnings and errors -- this makes no difference right now, but this change will allow us to add other compose banners that are cleared at different times.

Prep commit for #23421.

No functional changes


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
