### PR TITLE
compose banner: Rename banner shown after message is sent.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
 
-import render_compose_notification from "../templates/compose_notification.hbs";
+import render_message_sent_banner from "../templates/compose_banner/message_sent_banner.hbs";
 
 import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
@@ -171,7 +171,7 @@ export function notify_above_composebox(
     link_text,
 ) {
     const $notification = $(
-        render_compose_notification({
+        render_message_sent_banner({
             note,
             link_class,
             above_composebox_narrow_url,

--- a/static/templates/compose_banner/message_sent_banner.hbs
+++ b/static/templates/compose_banner/message_sent_banner.hbs
@@ -1,4 +1,3 @@
-{{! Content of sent-message notifications }}
 <div class="compose-notifications-content">
     {{note}} {{#if link_class}}<a href="{{above_composebox_narrow_url}}" class="{{link_class}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
     <button type="button" class="out-of-view-notification-close close">&times;</button>


### PR DESCRIPTION
This is both more clear regarding what the banner does, and is now in the same folder as the other compose banners.

No functional changes