### PR TITLE
message_edit: Fix the name of a property being accessed wrongly.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -413,7 +413,7 @@ export function get_available_streams_for_moving_messages(current_stream_id) {
     return stream_data
         .subscribed_subs()
         .filter((stream) => {
-            if (stream.id === current_stream_id) {
+            if (stream.stream_id === current_stream_id) {
                 return true;
             }
             return stream_data.can_post_messages_in_stream(stream);


### PR DESCRIPTION
The `stream_id` property of a stream object was being wrongly accessed as `id`, which does not exist, in the function
`get_available_streams_for_moving_messages()`

This led to the current stream not being rendered in the dropdown list as expected in the `Move Topic` modal when the user does not have the permission to post in the current stream.

Related CZO thread: [#issues>subtle bug - accessing non-existent property of stream](https://chat.zulip.org/#narrow/stream/9-issues/topic/subtle.20bug.20-.20accessing.20non-existent.20property.20of.20stream)

**Screenshots and screen captures:**
Context: The current user is a moderator with permission to move messages across streams but without the permission to post in the current stream (`rwgfa`). 

Before:
![image](https://user-images.githubusercontent.com/68962290/206861965-f89be029-cd0b-487c-8300-07549f6adc32.png)

After:
![image](https://user-images.githubusercontent.com/68962290/206861938-4faa7f9d-777c-4485-815f-e398cb7d87aa.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
