### PR TITLE
redesign: mention pill colors 

### DIFF
--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -861,14 +861,32 @@
     }
 
     .rendered_markdown {
-        .user-mention,
-        .user-group-mention {
-            background: linear-gradient(
-                to bottom,
-                hsla(0, 0%, 0%, 0.2) 0%,
-                hsla(0, 0%, 0%, 0.1) 100%
-            );
+        .user-group-mention, .user-mention {
             box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.4);
+        }
+
+        .user-mention {
+            background: hsla(240, 52%, 70%, 0.3);
+        }
+
+        .user-group-mention {
+            background: hsla(183, 52%, 40%, 0.3);
+        }
+
+        .user-group-mention:hover {
+            background: hsla(183, 52%, 40%, 0.4)
+        }
+
+        .user-mention:hover {
+            background: hsla(240, 52%, 70%, 0.4);
+        }
+
+        .user-mention-me {
+            color: rgba(194, 194, 255, 1);
+        }
+
+        .user-group-mention.user-mention-me {
+            color: hsla(183, 52%, 63%, 1);
         }
 
         .user-mention-me :not(.silent) {

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -157,7 +157,7 @@
 
     /* Mentions and alert words */
     .user-mention-me :not(.silent) {
-        background-color: hsl(112, 88%, 87%);
+        background: hsla(240, 52%, 45%, 1);
     }
 
     .user-group-mention,
@@ -168,13 +168,33 @@
         margin-right: 2px;
         margin-left: 2px;
         white-space: nowrap;
-        background: linear-gradient(
-            to bottom,
-            hsla(0, 0%, 0%, 0.1) 0%,
-            hsla(0, 0%, 0%, 0) 100%
-        );
         display: inline-block;
         margin-bottom: 1px;
+    }
+
+    .user-mention {
+        background: hsla(240, 58%, 52%, 0.1);
+    }
+
+    .user-mention:hover {
+        background: hsla(240, 58%, 52%, 0.15);
+    }
+
+    .user-group-mention {
+        background: hsla(183, 59%, 38%, 0.1);
+    }
+
+    .user-group-mention:hover {
+        background: hsla(183, 59%, 38%, 0.15);
+    }
+
+    .user-mention-me {
+        color: hsla(240, 52%, 45%, 1);
+        font-weight: 600;
+    }
+
+    .user-group-mention.user-mention-me {
+        color: hsla(183, 52%, 26%, 1);
     }
 
     .alert-word {


### PR DESCRIPTION
Added responsive typography to mention pills in message body. 

Fixes #22022 

<img width="1315" alt="Screen Shot 2022-12-10 at 6 16 40 PM" src="https://user-images.githubusercontent.com/51856745/206879047-0684641e-ae8d-4609-bdf0-ee41c43aa23d.png">
<img width="1321" alt="Screen Shot 2022-12-10 at 6 16 33 PM" src="https://user-images.githubusercontent.com/51856745/206879048-d3eed499-cd48-4493-a26c-86de7a1cefb6.png">



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
