### PR TITLE
drafts: Delete the draft if compose box is cleared and closed.

### DIFF
--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -259,6 +259,20 @@ async function test_delete_draft_on_sending(page: Page): Promise<void> {
     await page.waitForSelector("#drafts_table .message_row.private-message", {hidden: true});
 }
 
+async function test_delete_draft_on_clearing_text(page: Page): Promise<void> {
+    console.log("Deleting draft by clearing compose box textarea.");
+    await page.click("#drafts_table .message_row:not(.private-message) .restore-draft");
+    await wait_for_drafts_to_disappear(page);
+    await page.waitForSelector("#stream-message", {visible: true});
+    await page.keyboard.press("Backspace");
+    await page.click("#compose_close");
+    await page.waitForSelector("#stream-message", {hidden: true});
+    await page.click(drafts_button);
+    await wait_for_drafts_to_appear(page);
+    const drafts_count = await get_drafts_count(page);
+    assert.strictEqual(drafts_count, 1, "Draft not deleted.");
+}
+
 async function drafts_test(page: Page): Promise<void> {
     await common.log_in(page);
     await page.click(".top_left_all_messages");
@@ -279,6 +293,7 @@ async function drafts_test(page: Page): Promise<void> {
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
     await test_delete_draft_on_sending(page);
+    await test_delete_draft_on_clearing_text(page);
 }
 
 common.run_test(drafts_test);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -255,17 +255,17 @@ function maybe_notify(no_notify) {
 export function update_draft(opts = {}) {
     const no_notify = opts.no_notify || false;
     const draft = snapshot_message();
+    const draft_id = $("#compose-textarea").data("draft-id");
 
     if (draft === undefined) {
         // The user cleared the compose box, which means
-        // there is nothing to save here.  Don't obliterate
-        // the existing draft yet--the user may have mistakenly
-        // hit delete after select-all or something.
-        // Just do nothing.
+        // there is nothing to save here but delete the
+        // draft if exists.
+        if (draft_id) {
+            draft_model.deleteDraft(draft_id);
+        }
         return undefined;
     }
-
-    const draft_id = $("#compose-textarea").data("draft-id");
 
     if (draft_id !== undefined) {
         // We don't save multiple drafts of the same message;


### PR DESCRIPTION
We used to keep the draft, assuming that clearing the composebox was an accident. Now we want to delete the draft, in preparation for auto-restoring drafts when opening the composebox for narrows with drafts associated with them. If a user opens the composebox and sees a draft they don't want anymore, clearing the box is a way we expect them to try to delete it.

![Kapture 2022-12-10 at 17 16 20](https://user-images.githubusercontent.com/5634097/206881895-8326c7d3-6b9f-4395-880f-15750356a83b.gif)
