### PR TITLE
drafts: Introduce `getDraftsIdBy...` method to `draft_model`.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -90,6 +90,14 @@ function test(label, f) {
     });
 }
 
+test("draft_model get_drafts_id_by", ({override}) => {
+    assert.deepEqual(drafts.draft_model.getDraftsIdByStreamAndTopic("stream", "topic"), []);
+    assert.deepEqual(drafts.draft_model.getDraftsIdByRecipients("stream", "topic"), []);
+    override(drafts.draft_model, "get", () => ({random_id_1: draft_1, random_id_2: draft_2}));
+    assert.equal(drafts.draft_model.getDraftsIdByStreamAndTopic("stream", "topic").length, 1);
+    assert.equal(drafts.draft_model.getDraftsIdByRecipients("aaron@zulip.com").length, 1);
+});
+
 test("draft_model add", ({override}) => {
     const draft_model = drafts.draft_model;
     const ls = localstorage();

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -103,6 +103,32 @@ export const draft_model = (function () {
         save(drafts);
     };
 
+    exports.getDraftsIdByStreamAndTopic = function (stream, topic) {
+        const drafts = this.get();
+        return Object.keys(drafts)
+            .filter(
+                (draft_id) =>
+                    drafts[draft_id].type === "stream" &&
+                    drafts[draft_id].stream === stream &&
+                    drafts[draft_id].topic === topic,
+            )
+            .sort((draft_a, draft_b) => drafts[draft_a].updatedAt - drafts[draft_b].updatedAt);
+    };
+
+    exports.getDraftsIdByRecipients = function (private_message_recipient) {
+        const drafts = this.get();
+        return Object.keys(drafts)
+            .filter(
+                (draft_id) =>
+                    drafts[draft_id].type === "private" &&
+                    _.isEqual(
+                        drafts[draft_id].private_message_recipient.split(",").sort(),
+                        private_message_recipient.split(",").sort(),
+                    ),
+            )
+            .sort((draft_a, draft_b) => drafts[draft_a].updatedAt - drafts[draft_b].updatedAt);
+    };
+
     return exports;
 })();
 


### PR DESCRIPTION
No functional changes

This is a prep commit for adding a function to restore the last draft based on compose state.

It adds `getDraftsIdByStreamAndTopic` and `getDraftsIdByRecipients` method to easily filter the drafts.