### PR TITLE
drafts: Add function to restore the last draft based on compose state.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -321,6 +321,36 @@ export function restore_draft(draft_id) {
     $("#compose-textarea").data("draft-id", draft_id);
 }
 
+export function restore_last_draft_based_on_compose_state() {
+    const message_type = compose_state.get_message_type();
+    if (!message_type || compose_state.message_content()) {
+        return;
+    }
+
+    let last_draft_id;
+    if (message_type === "private") {
+        const recipient = compose_state.private_message_recipient();
+        if (recipient) {
+            last_draft_id = draft_model.getDraftsIdByRecipients(recipient).pop();
+        }
+    } else {
+        const stream = compose_state.stream_name();
+        const topic = compose_state.topic();
+        if (stream && topic) {
+            last_draft_id = draft_model.getDraftsIdByStreamAndTopic(stream, topic).pop();
+        }
+    }
+
+    const draft = draft_model.getDraft(last_draft_id);
+    if (!draft) {
+        return;
+    }
+
+    compose_state.message_content(draft.content);
+    compose_ui.autosize_textarea($("#compose-textarea"));
+    $("#compose-textarea").trigger("select").data("draft-id", last_draft_id);
+}
+
 const DRAFT_LIFETIME = 30;
 
 export function remove_old_drafts() {


### PR DESCRIPTION
This is a prep commit for restoring the last draft in the composebox, when it's opened, if a draft exists for the composebox's narrow.

No functional changes. PR #22104 has more context on how it will be used.
