### PR TITLE
drafts: Rename two functions in puppeteer tests for better clarity.

### DIFF
--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -110,7 +110,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
     );
 }
 
-async function test_restore_message_draft(page: Page): Promise<void> {
+async function test_restore_message_draft_via_draft_overlay(page: Page): Promise<void> {
     console.log("Restoring stream message draft");
     await page.click("#drafts_table .message_row:not(.private-message) .restore-draft");
     await wait_for_drafts_to_disappear(page);
@@ -165,7 +165,7 @@ async function test_edited_draft_message(page: Page): Promise<void> {
     );
 }
 
-async function test_restore_private_message_draft(page: Page): Promise<void> {
+async function test_restore_private_message_draft_via_draft_overlay(page: Page): Promise<void> {
     console.log("Restoring private message draft.");
     await page.click(".message_row.private-message .restore-draft");
     await wait_for_drafts_to_disappear(page);
@@ -248,11 +248,11 @@ async function drafts_test(page: Page): Promise<void> {
     await open_drafts_after_markdown_preview(page);
     await test_previously_created_drafts_rendered(page);
 
-    await test_restore_message_draft(page);
+    await test_restore_message_draft_via_draft_overlay(page);
     await edit_stream_message_draft(page);
     await test_edited_draft_message(page);
 
-    await test_restore_private_message_draft(page);
+    await test_restore_private_message_draft_via_draft_overlay(page);
     await test_delete_draft(page);
     await test_save_draft_by_reloading(page);
 }


### PR DESCRIPTION
Soon there will be another way to restore a message draft (opening the composebox for a narrow with a saved draft), and this rename helps specify which specific kind of restoring is happening for these tests.

No functional changes.