### PR TITLE
added Pin topic option to sidebar

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -65,7 +65,7 @@ Try narrowing from the message view:
   - narrow to a group PM
 - Click on the Zulip logo
   - narrow to a topic
-  - click on the Zulip logo (and verify you're in the Recent conversations view)
+  - click on the Zulip logo (and verify you're in the  view)
 
 ### Messagebox
 

--- a/static/templates/topic_list_item.hbs
+++ b/static/templates/topic_list_item.hbs
@@ -1,5 +1,11 @@
 <li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
+        {{#if is_pinned}}
+            <span class="sidebar-pinned-topic">
+                <i class="fa fa-thumb-tack"></i>
+            </span>
+        {{/if}}
+
         <span class="sidebar-topic-check">
             {{topic_resolved_prefix}}
         </span>

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -47,6 +47,23 @@
         </a>
     </li>
 
+    {{#unless is_pinned}}
+    <li>
+        <a tabindex="0" class="sidebar-popover-pin-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-thumb-tack" aria-hidden="true"></i>
+            {{t "Pin topic"}}
+        </a>
+    </li>
+    {{else}}
+    <li>
+        <a tabindex="0" class="sidebar-popover-unpin-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-thumb-tack" aria-hidden="true"></i>
+            {{t "Unpin topic"}}
+        </a>
+    </li>
+    {{/unless}}
+
+
     {{#if can_move_topic}}
     <hr />
 


### PR DESCRIPTION
Added frontend changes to include "Pin Topic/Unpin Topic" option in sidebar menu and display pin when a topic is pinned

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
