### PR TITLE
Add empty private messages to sidebar.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -31,6 +31,8 @@ import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
 import * as unread_ops from "./unread_ops";
 import * as util from "./util";
+import * as pm_conversations from "./pm_conversations";
+import * as pm_list from "./pm_list";
 
 export function blur_compose_inputs() {
     $(".message_comp").find("input, textarea, button, #private_message_recipient").trigger("blur");
@@ -165,6 +167,10 @@ function composing_to_current_private_message_narrow() {
 }
 
 export function update_narrow_to_recipient_visibility() {
+    // Remove any conversations with no messages from PMs when the
+    // narrow view is changed
+    pm_conversations.recent.removeEmptyConvo();
+
     const message_type = compose_state.get_message_type();
     if (message_type === "stream") {
         const stream_name = compose_state.stream_name();
@@ -359,6 +365,11 @@ export function start(msg_type, opts) {
 }
 
 export function cancel() {
+    // Remove any empty conversations from PMs when the compose-box
+    // is closed
+    pm_conversations.recent.removeEmptyConvo();
+    pm_list.update_private_messages();
+
     // As user closes the compose box, restore the compose box max height
     if (compose_ui.is_full_size()) {
         compose_ui.make_compose_box_original_size();

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -44,6 +44,7 @@ import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
 import * as util from "./util";
 import * as widgetize from "./widgetize";
+import * as pm_conversations from "./pm_conversations";
 
 let unnarrow_times;
 
@@ -937,6 +938,20 @@ export function by_recipient(target_id, opts) {
 
 // Called by the narrow_to_compose_target hotkey.
 export function to_compose_target() {
+    // If the target has not been in a convo before, then add temp convo marker
+    // to the top
+    const recipient_string = compose_state.private_message_recipient();
+
+    let user_ids = [];
+    recipient_string.split(",").forEach(function (user_email) {
+        user_ids.unshift(people.get_user_id(user_email))
+    });
+
+    // if unique combination of users, then add to list
+    if(!pm_conversations.recent.recent_message_ids.has(user_ids)){
+      pm_conversations.recent.initInsert(user_ids);
+    }
+
     if (!compose_state.composing()) {
         return;
     }

--- a/static/js/pm_conversations.js
+++ b/static/js/pm_conversations.js
@@ -31,6 +31,30 @@ class RecentPrivateMessages {
     recent_message_ids = new FoldDict(); // key is user_ids_string
     recent_private_messages = [];
 
+    // taking care of conversation before any message has been sent
+
+    // remove convo if its max_message_id is null, i.e. it is
+    // a temporary convo
+    removeEmptyConvo(){
+        let convoList = this.recent_private_messages;
+        for (let i = 0; i < convoList.length; i++) {
+            if(!convoList[i]['max_message_id']){
+                convoList.splice(i, i+1);
+                break;
+            }
+        }
+    }
+
+    initInsert(user_ids){
+        const user_ids_string = user_ids.join(",");
+        let conversation = {
+            user_ids_string,
+            max_message_id: null,
+        };
+        //adds to top of recent private messages list
+        this.recent_private_messages.unshift(conversation);
+      }
+
     insert(user_ids, message_id) {
         if (user_ids.length === 0) {
             // The server sends [] for self-PMs.

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -8,6 +8,7 @@ import * as topic_zoom from "./topic_zoom";
 import * as ui from "./ui";
 import * as ui_util from "./ui_util";
 import * as vdom from "./vdom";
+import * as pm_conversations from "./pm_conversations";
 
 let prior_dom;
 


### PR DESCRIPTION
Fixed #22769

Previously, when starting a new private message, the pm did not show up in the left side bar unless a message had been sent yet. We have now fixed it so that when starting a new private message, if you click the "Go to Conversation" button (near the message box),
<img width="44" alt="Screen Shot 2022-12-11 at 4 12 25 PM" src="https://user-images.githubusercontent.com/82304689/206931917-7f4b4e7c-8bea-4942-8873-233140e34865.png">
the conversation will be added to the list on the left side and highlighted (as shown below with King Hamlet). If you did not type and send a message, and you click outside of the conversation, the pm then disappears from the list (as shown below by clicking on Zulip Default Bot).
<img width="1788" alt="Screen Shot 2022-12-11 at 4 13 00 PM" src="https://user-images.githubusercontent.com/82304689/206931959-1e237273-d943-4702-bfd2-59aff4381767.png">
<img width="1790" alt="Screen Shot 2022-12-11 at 4 14 12 PM" src="https://user-images.githubusercontent.com/82304689/206931968-b7350b73-8942-48ef-b696-2eb6868f0d4c.png">
