### PR TITLE
Scroll message view to selected message top before action popover shows when triggered through hotkey.

### DIFF
--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -373,6 +373,19 @@ export function recenter_view($message, {from_scroll = false, force_center = fal
     }
 }
 
+export function view_message_top($message) {
+    // Sets the top of the viewport to the top of the message.
+    // Only applies if the top of the message is out of view above the visible area.
+    const viewport_info = message_viewport_info();
+    const message_top = $message.offset().top;
+    const message_height = $message.safeOuterHeight(true);
+    if (message_top < viewport_info.visible_top) {
+        set_message_position(message_top, message_height, viewport_info, 0);
+        return true;
+    }
+    return false;
+}
+
 export function keep_pointer_in_view() {
     // See message_viewport.recenter_view() for related logic to keep the pointer onscreen.
     // This function mostly comes into place for mouse scrollers, and it

--- a/static/js/popover_menus.js
+++ b/static/js/popover_menus.js
@@ -22,6 +22,7 @@ import {$t} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
+import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
 import * as popover_menus_data from "./popover_menus_data";
 import * as popovers from "./popovers";
@@ -126,6 +127,12 @@ export function toggle_message_actions_menu(message) {
         // It creates bugs with things like keyboard handlers when
         // we get the server response.
         return true;
+    }
+
+    const $selected_row = message_lists.current.selected_row();
+    // If we don't scroll then we should not suppress the scroll hide.
+    if (message_viewport.view_message_top($selected_row)) {
+        popovers.set_suppress_scroll_hide();
     }
 
     const $popover_reference = $(".selected_message .actions_hover .zulip-icon-ellipsis-v-solid");


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The message viewport should now instantly scroll up to align its top with the top of the selected message when it's not visible and the user presses the "I" hotkey. There should be no change to behaviour when the same user action is performed while the message top is visible.

I felt like it made for a better user experience if the scroll wasn't animated. The waiting time for the scroll animation just felt clunky. I also experimented with popper tethering. I believe it possible to solve the problems in issue #23774 in a visually appealing way that does not involve scrolling by making it hover under the floating recipient bar.

Fixes: [#23774](https://github.com/zulip/zulip/issues/23774).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Gif of previous behaviour:
![msedge_PU28uXSAR0](https://user-images.githubusercontent.com/14200637/206935020-09d84ed0-af23-41b3-88e4-db0e71f8cfcc.gif)
Gif of new behaviours:
![msedge_M2NDtmTcmh](https://user-images.githubusercontent.com/14200637/206935054-3de4a755-29d3-43a3-9199-0a37f2466f1f.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
