### PR TITLE
drafts: Fix flaky test by waiting for compose box to clear.

### DIFF
--- a/frontend_tests/puppeteer_tests/drafts.ts
+++ b/frontend_tests/puppeteer_tests/drafts.ts
@@ -244,7 +244,7 @@ async function test_delete_draft_on_sending(page: Page): Promise<void> {
     console.log("Sending draft.");
     await page.waitForSelector("#compose-send-button", {visible: true});
     await page.click("#compose-send-button");
-    await common.assert_compose_box_content(page, "");
+    await page.waitForSelector('xpath///*[@id="compose-textarea" and normalize-space()=""]');
     await page.waitForSelector(
         `xpath///*[${common.has_class_x("top_left_drafts")}]//*[${common.has_class_x(
             "unread_count",


### PR DESCRIPTION
Fixes flaky test mentioned on CZO here:
https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/main.20failing/near/1478126 Test was introduced here: #23820.

The compose box clear happens after the message is sent, and the test wasn't consistently waiting for the compose box to successfully clear. This change forces a wait.

I haven't yet tested that this doesn't flake, but it has passed locally for me at least once.