### PR TITLE
url_preview: Fix url-previews not shown for some webpages

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -719,18 +719,15 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             self.add_oembed_data(root, link, extracted_data)
             return
 
-        if extracted_data.image is None:
-            # Don't add an embed if an image is not found
-            return
-
         container = SubElement(root, "div")
         container.set("class", "message_embed")
 
-        img_link = get_camo_url(extracted_data.image)
-        img = SubElement(container, "a")
-        img.set("style", "background-image: url(" + css_escape(img_link) + ")")
-        img.set("href", link)
-        img.set("class", "message_embed_image")
+        if extracted_data.image:
+            img_link = get_camo_url(extracted_data.image)
+            img = SubElement(container, "a")
+            img.set("style", "background-image: url(" + css_escape(img_link) + ")")
+            img.set("href", link)
+            img.set("class", "message_embed_image")
 
         data_container = SubElement(container, "div")
         data_container.set("class", "data-container")

--- a/zerver/lib/url_preview/parsers/__init__.py
+++ b/zerver/lib/url_preview/parsers/__init__.py
@@ -1,4 +1,5 @@
 from zerver.lib.url_preview.parsers.generic import GenericParser
 from zerver.lib.url_preview.parsers.open_graph import OpenGraphParser
+from zerver.lib.url_preview.parsers.twitter_card import TwitterCardParser
 
-__all__ = ["OpenGraphParser", "GenericParser"]
+__all__ = ["OpenGraphParser", "GenericParser", "TwitterCardParser"]

--- a/zerver/lib/url_preview/parsers/generic.py
+++ b/zerver/lib/url_preview/parsers/generic.py
@@ -41,13 +41,20 @@ class GenericParser(BaseParser):
 
     def _get_image(self) -> Optional[str]:
         """
-        Finding a first image after the h1 header.
+        Finding a first image after (or before) the h1 header.
         Presumably it will be the main image.
         """
         soup = self._soup
         first_h1 = soup.find("h1")
         if first_h1:
+            # Normally, we find the first image after the h1 header.
+            # This is because it would presumably be the main image
+            # for the url. However, some websites do not contain
+            # an image after but before, so we need to look for
+            # a picture in both directions.
             first_image = first_h1.find_next_sibling("img", src=True)
+            if not isinstance(first_image, Tag) or first_image["src"] == "":
+                first_image = first_h1.find_previous_sibling("img", src=True)
             if isinstance(first_image, Tag) and first_image["src"] != "":
                 assert isinstance(first_image["src"], str)
                 try:

--- a/zerver/lib/url_preview/parsers/twitter_card.py
+++ b/zerver/lib/url_preview/parsers/twitter_card.py
@@ -1,0 +1,33 @@
+from urllib.parse import urlparse
+
+from zerver.lib.url_preview.types import UrlEmbedData
+
+from .base import BaseParser
+
+
+class TwitterCardParser(BaseParser):
+    def extract_data(self) -> UrlEmbedData:
+        meta = self._soup.findAll("meta")
+
+        data = UrlEmbedData()
+
+        for tag in meta:
+            if not tag.has_attr("name"):
+                continue
+            if not tag.has_attr("content"):
+                continue
+
+            if tag["name"] == "twitter:title":
+                data.title = tag["content"]
+            elif tag["name"] == "twitter:description":
+                data.description = tag["content"]
+            elif tag["name"] == "twitter:image":
+                try:
+                    # We use urlparse and not URLValidator because we
+                    # need to support relative URLs.
+                    urlparse(tag["content"])
+                except ValueError:
+                    continue
+                data.image = tag["content"]
+
+        return data

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -12,7 +12,7 @@ from zerver.lib.cache import cache_with_key, preview_url_cache_key
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.url_preview.oembed import get_oembed_data
-from zerver.lib.url_preview.parsers import GenericParser, OpenGraphParser
+from zerver.lib.url_preview.parsers import GenericParser, OpenGraphParser, TwitterCardParser
 from zerver.lib.url_preview.types import UrlEmbedData, UrlOEmbedData
 
 # Based on django.core.validators.URLValidator, with ftp support removed.
@@ -106,7 +106,7 @@ def get_link_embed_data(
     if data is None:
         data = UrlEmbedData()
 
-    for parser_class in (OpenGraphParser, GenericParser):
+    for parser_class in (OpenGraphParser, TwitterCardParser, GenericParser):
         parser = parser_class(response.content, response.headers.get("Content-Type"))
         data.merge(parser.extract_data())
 

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -67,7 +67,7 @@ def valid_content_type(url: str) -> bool:
     if not content_type or content_type.startswith("text/html"):
         # Verify that the content is actually HTML if the server claims it is
         content_type = guess_mimetype_from_content(response)
-    return content_type.startswith("text/html")
+    return content_type.startswith("text/html") or content_type.startswith("text/xml")
 
 
 def catch_network_errors(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -294,6 +294,24 @@ class GenericParserTestCase(ZulipTestCase):
         self.assertEqual(result.description, "Description text")
         self.assertEqual(result.image, "http://test.com/test.jpg")
 
+    def test_extract_image_before_heading(self) -> None:
+        html = b"""
+          <html>
+            <body>
+                <img src="http://test.com/test.jpg">
+                <h1>Main header</h1>
+                <div>
+                    <p>Description text</p>
+                </div>
+            </body>
+          </html>
+        """
+        parser = GenericParser(html, "text/html; charset=UTF-8")
+        result = parser.extract_data()
+        self.assertEqual(result.title, "Main header")
+        self.assertEqual(result.description, "Description text")
+        self.assertEqual(result.image, "http://test.com/test.jpg")
+
     def test_extract_bad_image(self) -> None:
         html = b"""
           <html>

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -722,8 +722,14 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNotNone(cached_data.title)
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
+        preview_url = (
+            f'<p><a href="{url}">{url}</a></p>\n'
+            f'<div class="message_embed"><div class="data-container">'
+            f'<div class="message_embed_title"><a href="{url}" title="The Rock">The Rock</a>'
+            f'</div><div class="message_embed_description">Description text</div></div></div>'
+        )
         self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
+            preview_url,
             msg.rendered_content,
         )
 
@@ -761,8 +767,14 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNotNone(cached_data.title)
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
+        preview_url = (
+            f'<p><a href="{url}">{url}</a></p>\n'
+            f'<div class="message_embed"><div class="data-container">'
+            f'<div class="message_embed_title"><a href="{url}" title="The Rock">The Rock</a>'
+            f'</div><div class="message_embed_description">Description text</div></div></div>'
+        )
         self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
+            preview_url,
             msg.rendered_content,
         )
 
@@ -798,8 +810,14 @@ class PreviewTestCase(ZulipTestCase):
         self.assertIsNotNone(cached_data.title)
         self.assertIsNone(cached_data.image)
         msg = Message.objects.select_related("sender").get(id=msg_id)
+        preview_url = (
+            f'<p><a href="{url}">{url}</a></p>\n'
+            f'<div class="message_embed"><div class="data-container">'
+            f'<div class="message_embed_title"><a href="{url}" title="The Rock">The Rock</a>'
+            f'</div><div class="message_embed_description">Description text</div></div></div>'
+        )
         self.assertEqual(
-            '<p><a href="http://test.org/foo.html">http://test.org/foo.html</a></p>',
+            preview_url,
             msg.rendered_content,
         )
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Fixes: #23664

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- [x] Show title and description if found, even though an image isn't found.
![noimageurlpreview](https://user-images.githubusercontent.com/58552561/207035388-01df16f2-51ca-469f-9add-79da4569f5d3.png)
- [x] Support url preview for content-type text/xml. (Also, the image here is coming from twitter:image meta tag. So, the TwitterCard Parser that has been added as one of the fixed is also being tested in this example.)
![Screenshot 2022-12-19 00:30:00](https://user-images.githubusercontent.com/58552561/208314525-468a8779-d7d3-4b80-96ac-cdd3d90ff6ab.png)
![Screenshot 2022-12-18 23:57:38](https://user-images.githubusercontent.com/58552561/208314435-4142c3f5-6813-492a-8f7a-d8a198f7476a.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
