### PR TITLE
Email integration

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -183,6 +183,8 @@ def construct_zulip_body(
 
 
 def send_zulip(sender: UserProfile, stream: Stream, topic: str, content: str) -> None:
+    if len(topic) > 60:
+        content = f"Subject: {topic}\n{content}"
     internal_send_stream_message(
         sender,
         stream,


### PR DESCRIPTION
Addresses issue #10539, email integration 

Include subject line as first line of message if longer than 60 characters
Modifies email_mirror.py with if statement to check for this and test_email_mirror.py to ensure this worked when the subject is in fact longer than 60 characters. 