### PR TITLE
compose: Increase click target area around banner close button.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -279,7 +279,6 @@
 .compose_banner {
     margin-bottom: 20px;
     border-radius: 5px;
-    padding-right: 11px;
     border: 1px solid;
     display: flex;
     align-items: center;
@@ -307,14 +306,18 @@
         margin-bottom: 4.5px;
         height: 32px;
         white-space: nowrap;
+
+        /* Extra margin to ensure the layout is identical when there is no
+           close button. */
+        &.right_edge {
+            margin-right: 10px;
+        }
     }
 
     .compose_banner_close_button {
         font-size: 17px;
         text-decoration: none;
-        margin-left: 10px;
-        margin-top: 12px;
-        margin-bottom: 12px;
+        padding: 12px 10px;
     }
 
     &.warning {

--- a/static/templates/compose_banner/compose_banner.hbs
+++ b/static/templates/compose_banner/compose_banner.hbs
@@ -9,7 +9,7 @@
     <div class="banner_content">{{> @partial-block}}</div>
     {{/if}}
     {{#if button_text}}
-    <button class="compose_banner_action_button" >{{button_text}}</button>
+    <button class="compose_banner_action_button{{#if hide_close_button}} right_edge{{/if}}" >{{button_text}}</button>
     {{/if}}
     {{#if hide_close_button}}
     {{!-- hide_close_button is null by default, and false if explicitly set as false. --}}


### PR DESCRIPTION
Using padding instead of margin allows a wider area around the button where the user can click from to still functionally click the button.