### PR TITLE
Update file ordering system

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -107,7 +107,7 @@ function render_attachments_ui() {
             },
         },
         $parent_container: $("#attachments-settings").expectOne(),
-        init_sort: ["numeric", "create_time"],
+        init_sort: ["numeric", "create_time", true],
         sort_fields: {
             mentioned_in: sort_mentioned_in,
         },

--- a/static/js/list_widget.js
+++ b/static/js/list_widget.js
@@ -297,7 +297,7 @@ export function create($container, list, opts) {
     // will use set_reverse_mode() to sort in reverse order.
     widget.set_sorting_function = function (sorting_function, prop, reverse) {
         if (reverse) {
-            widget.set_reverse_mode(reverse);   
+            widget.set_reverse_mode(reverse);
         }
         if (typeof sorting_function === "function") {
             meta.sorting_function = sorting_function;

--- a/static/js/list_widget.js
+++ b/static/js/list_widget.js
@@ -292,8 +292,13 @@ export function create($container, list, opts) {
 
     // the sorting function is either the function or string that calls the
     // function to sort the list by. The prop is used for generic functions
-    // that can be called to sort with a particular prop.
-    widget.set_sorting_function = function (sorting_function, prop) {
+    // that can be called to sort with a particular prop. In addition,
+    // this function has a reverse parameter which, if set to true,
+    // will use set_reverse_mode() to sort in reverse order.
+    widget.set_sorting_function = function (sorting_function, prop, reverse) {
+        if (reverse) {
+            widget.set_reverse_mode(reverse);   
+        }
         if (typeof sorting_function === "function") {
             meta.sorting_function = sorting_function;
         } else if (typeof sorting_function === "string") {

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -10,7 +10,7 @@
         <table class="table table-condensed table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="name" class="upload-file-name">{{t "File" }}</th>
-                <th class="active" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
+                <th class="active descend" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
                 <th data-sort="mentioned_in">{{t "Mentioned in" }}</th>
                 <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
                 <th class="upload-actions actions">{{t "Actions" }}</th>


### PR DESCRIPTION
Fixes: Changes file uploads section to display file uploads in reverse sorted order by creation time. This is preferable since users most likely want to see their most recently uploaded files first.