### PR TITLE
Update test_push_notifications.py

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1642,6 +1642,25 @@ class TestAPNs(PushNotificationTest):
             self.assertEqual(
                 [notification_drop_log, mobile_notifications_not_configured_log], logger.output
             )
+   
+    def test_configured(self) -> None:
+        self.setup_apns_tokens()
+        with mock.patch(
+            "zerver.lib.push_notifications.get_apns_context"
+        ) as mock_get, self.assertLogs("zerver.lib.push_notifications", level="DEBUG") as logger:
+            mock_get.return_value = None
+            self.send()
+            notification_drop_log = (
+                "DEBUG:zerver.lib.push_notifications:"
+                "APNs: Dropping a notification because nothing configured.  "
+                "Set PUSH_NOTIFICATION_BOUNCER_URL (or APNS_CERT_FILE)."
+            )
+
+            from zerver.lib.push_notifications import initialize_push_notifications
+
+            initialize_push_notifications()
+            settings.DEVELOPMENT = True
+            settings.TEST_SUITE = False
 
     def test_success(self) -> None:
         self.setup_apns_tokens()


### PR DESCRIPTION
Addresses Issue #7089, improving test coverage.

One of the files that needed to include more coverage for the excluded lines was zerver/lib/notifications.py which has about 8 lines of generally easy to generate corner cases. This PR attempts minimizes that number and improve overall coverage. 
