### PR TITLE
Fix to #15029

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,19 @@ All notable changes to the Zulip server are documented in this file.
 
 ### Unreleased
 
+### 1.4.2 - 2016-09-27
+- Upgraded Django to version 1.8.15 (with the Zulip patches applied),
+  fixing a CSRF vulnerability in Django (see
+  https://www.djangoproject.com/weblog/2016/sep/26/security-releases/),
+  and a number of other Django bugs from past Django stable releases
+  that largely affects parts of Django that are not used by Zulip.
+- Fixed buggy logrotate configuration.
+
+### 1.4.1 - 2016-09-03
+- Fixed settings bug upgrading from pre-1.4.0 releases to 1.4.0.
+- Fixed local file uploads integration being broken for new 1.4.0
+  installations.
+
 ### 1.4 - 2016-08-25
 
 - Migrated Zulip's python dependencies to be installed via a virtualenv,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,9 @@ All notable changes to the Zulip server are documented in this file.
 
 ### Unreleased
 
+### 1.4.3 - 2017-01-29
+- CVE-2017-0881: Users could subscribe to invite-only streams.
+
 ### 1.4.2 - 2016-09-27
 - Upgraded Django to version 1.8.15 (with the Zulip patches applied),
   fixing a CSRF vulnerability in Django (see

--- a/puppet/zulip/files/logrotate/zulip
+++ b/puppet/zulip/files/logrotate/zulip
@@ -1,7 +1,7 @@
 /var/log/zulip/server.log /var/log/zulip/workers.log /var/log/zulip/manage.log {
 	missingok
 	rotate 10
-	size 1GB
+	size 1G
 	compress
 	delaycompress
 	notifempty

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,6 @@
 -r ipython.txt
 # Django itself; we use a slightly patched version
-git+https://github.com/zulip/truncated-django.git
+git+https://github.com/zulip/truncated-django-1.8.15.git@cbf4fa3aef1b17f37d75a70e57f9b69a0f99ed5c#egg=Django==1.8.15
 
 GitPython==0.3.2.1
 

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -42,6 +42,14 @@ if not args.skip_puppet:
     subprocess.check_call(["apt-get", "update"])
     subprocess.check_call(["apt-get", "-y", "upgrade"])
 
+if not os.path.exists((os.path.join(deploy_path, "zproject/prod_settings"))):
+    subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
+                           os.path.join(deploy_path, "zproject/prod_settings.py")])
+
+# delete local_settings.py symlink if it exists, as it is now prod_settings.py
+if os.path.exists((os.path.join(deploy_path, "zproject/local_settings.py"))):
+    subprocess.check_call(["rm", os.path.join(deploy_path, "zproject/local_settings.py")])
+
 subprocess.check_call([os.path.join(deploy_path, "scripts", "lib", "create-production-venv"),
                        os.path.join(deploy_path, "zulip-venv")])
 

--- a/tools/travis/success-http-headers.txt
+++ b/tools/travis/success-http-headers.txt
@@ -24,7 +24,6 @@ Reusing existing connection to localhost:443.
   Content-Type: text/html; charset=utf-8
   Transfer-Encoding: chunked
   Connection: keep-alive
-  Cache-Control: max-age=0
   Strict-Transport-Security: max-age=15768000
 Length: unspecified [text/html]
 Saving to: ‘/tmp/index.html’

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -447,7 +447,7 @@ def stream_exists_backend(request, user_profile, stream_name, autosubscribe):
     result = {"exists": bool(stream)}
     if stream is not None:
         recipient = get_recipient(Recipient.STREAM, stream.id)
-        if autosubscribe:
+        if not stream.invite_only and autosubscribe:
             bulk_add_subscriptions([stream], [user_profile])
         result["subscribed"] = Subscription.objects.filter(user_profile=user_profile,
                                                            recipient=recipient,

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -155,7 +155,7 @@ INLINE_IMAGE_PREVIEW = True
 # https://github.com/zulip/zulip/issues/291 for discussion of a better
 # solution that won't be automatically reverted by the Zulip upgrade
 # script), and then restart nginx.
-LOCAL_UPLOADS_DIR = "/home/zulip/var/uploads"
+LOCAL_UPLOADS_DIR = "/home/zulip/uploads"
 #S3_AUTH_UPLOADS_BUCKET = ""
 #S3_AVATAR_BUCKET = ""
 


### PR DESCRIPTION
Wrote an automatic venv activation script to tools/ directory. Still need to find script that runs setup for Vagrant files

Fixes: https://github.com/zulip/zulip/issues/15029 

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
[write_venv.zip](https://github.com/zulip/zulip/files/10214353/write_venv.zip)
