### PR TITLE
polls: Replace `choice` with `option` in the poll editing UI.

### DIFF
--- a/static/templates/widgets/poll_widget.hbs
+++ b/static/templates/widgets/poll_widget.hbs
@@ -15,8 +15,8 @@
     <ul class="poll-widget">
     </ul>
     <div class="poll-option-bar">
-        <input type="text" class="poll-option" placeholder="{{t 'New choice'}}" />
-        <button class="poll-option">{{t "Add choice" }}</button>
+        <input type="text" class="poll-option" placeholder="{{t 'New option'}}" />
+        <button class="poll-option">{{t "Add option" }}</button>
     </div>
     <br />
 </div>


### PR DESCRIPTION
All instances of `choice` have been replaced with `option` in the UI for editing a poll. In code, `option` was already being used. This ensures the same terminology is used across the code, the UI and the related help center article.

**Screenshots and screen captures:**

Before:
![image](https://user-images.githubusercontent.com/68962290/207407182-18a53822-fe6d-49cb-b020-6ca03593fe76.png)

After:
![image](https://user-images.githubusercontent.com/68962290/207407395-b86f60dc-45e3-451c-8040-666fe0ef96e9.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
