### PR TITLE
stream_settings: Fix invisible view stream btn for private streams.

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -303,7 +303,7 @@ export function update_settings_for_subscribed(slim_sub) {
     const sub = stream_settings_data.get_sub_for_settings(slim_sub);
     stream_ui_updates.update_add_subscriptions_elements(sub);
     $(
-        `.subscription_settings[data-stream-id='${CSS.escape(
+        `.stream_settings_header[data-stream-id='${CSS.escape(
             sub.stream_id,
         )}'] #preview-stream-button`,
     ).show();


### PR DESCRIPTION
<!-- Describe your pull request here.-->
If new stream is created as one of the two private options, the view stream button is not visible immediately. It is only visible after page refresh. This pull request will make view stream button immediately.
Fixes: <!-- Issue link, or clear description.--> #22556


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

##### Video screenshot of testing:


https://user-images.githubusercontent.com/53159963/207503114-9ebc63d1-8c73-450e-81e1-ea1e8173ce57.mov


##### Screenshot of passed tests after running tests:

<img width="989" alt="Screen Shot 2022-07-23 at 4 39 27 PM" src="https://user-images.githubusercontent.com/53159963/180622322-b9b46e31-54c2-410d-8b62-c64727e0e091.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
