### PR TITLE
compose: Always preserve cursor position post replacement in a textarea.

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -153,22 +153,30 @@ run_test("smart_insert", ({override}) => {
 });
 
 run_test("replace_syntax", ({override}) => {
-    $("#compose-textarea").val("abcabc");
-    $("#compose-textarea")[0] = "compose-textarea";
+    const $textbox = make_textbox("aBca$$");
+    $textbox.caret(2);
     override(text_field_edit, "replace", (elt, old_syntax, new_syntax) => {
-        assert.equal(elt, "compose-textarea");
+        assert.equal(elt, "textarea");
         assert.equal(old_syntax, "a");
         assert.equal(new_syntax(), "A");
     });
-    compose_ui.replace_syntax("a", "A");
+    let prev_carat = $textbox.caret();
+    compose_ui.replace_syntax("a", "A", $textbox);
+    assert.equal(prev_carat, $textbox.caret());
 
     override(text_field_edit, "replace", (elt, old_syntax, new_syntax) => {
-        assert.equal(elt, "compose-textarea");
+        assert.equal(elt, "textarea");
         assert.equal(old_syntax, "Bca");
         assert.equal(new_syntax(), "$$\\pi$$");
     });
+
     // Verify we correctly handle `$`s in the replacement syntax
-    compose_ui.replace_syntax("Bca", "$$\\pi$$");
+    // and that on replacing with a different length string, the
+    // cursor is shifted accordingly as expected
+    $textbox.caret(5);
+    prev_carat = $textbox.caret();
+    compose_ui.replace_syntax("Bca", "$$\\pi$$", $textbox);
+    assert.equal(prev_carat + "$$\\pi$$".length - "Bca".length, $textbox.caret());
 });
 
 run_test("compute_placeholder_text", () => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -559,7 +559,6 @@ export function quote_and_reply(opts) {
         //     ```quote
         //     message content
         //     ```
-        const prev_caret = $textarea.caret();
         let content = $t(
             {defaultMessage: "{username} [said]({link_to_message}):"},
             {
@@ -571,25 +570,8 @@ export function quote_and_reply(opts) {
         const fence = fenced_code.get_unused_fence(message.raw_content);
         content += `${fence}quote\n${message.raw_content}\n${fence}`;
 
-        const placeholder_offset = $textarea.val().indexOf(quoting_placeholder);
         compose_ui.replace_syntax(quoting_placeholder, content, $textarea);
         compose_ui.autosize_textarea($("#compose-textarea"));
-
-        // When replacing content in a textarea, we need to move the
-        // cursor to preserve its logical position if and only if the
-        // content we just added was before the current cursor
-        // position.  If we do, we need to move it by the increase in
-        // the length of the content before the placeholder.
-        if (prev_caret >= placeholder_offset + quoting_placeholder.length) {
-            $textarea.caret(prev_caret + content.length - quoting_placeholder.length);
-        } else if (prev_caret > placeholder_offset) {
-            /* In the rare case that our cursor was inside the
-             * placeholder, we treat that as though the cursor was
-             * just after the placeholder. */
-            $textarea.caret(placeholder_offset + content.length + 1);
-        } else {
-            $textarea.caret(prev_caret);
-        }
     }
 
     if (message && message.raw_content) {


### PR DESCRIPTION
Refactored (moved) the code for preserving the cursor's initial logical position from `quote_and_reply()` in `compose_actions.js` which calls `replace_syntax()` directly into `replace_syntax()` in `compose_ui.js`. This ensures that anytime text in a textarea is replaced, the original cursor position is always restored.

Earlier, this was needed to be done separately, and missing that would lead to bugs with the cursor unexpectedly jumping on replacement.

Fixes: #23863.

**Screenshots and screen captures:**

Proof of the cursor staying at the same place even after text replacement:

https://user-images.githubusercontent.com/68962290/207511267-865e243f-602f-4289-aebf-3920bc68fd4c.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
