### PR TITLE
help center: Create a dedicated page for All messages.

### DIFF
--- a/templates/zerver/help/all-messages.md
+++ b/templates/zerver/help/all-messages.md
@@ -1,0 +1,16 @@
+# All messages
+
+{!all-messages.md!}
+
+!!! keyboard_tip ""
+
+    Use <kbd>S</kbd> (narrow to stream) or <kbd>Shift</kbd> +
+    <kbd>S</kbd> (narrow to conversation) to zoom in, and <kbd>A</kbd> to
+    get back to **All messages**.
+
+
+## Related articles
+* [Reading strategies](/help/reading-strategies)
+* [Recent conversations](/help/recent-conversations)
+* [Configure default view](/help/configure-default-view)
+* [Reading topics](/help/reading-topics)

--- a/templates/zerver/help/configure-default-view.md
+++ b/templates/zerver/help/configure-default-view.md
@@ -6,7 +6,7 @@ keyboard shortcuts.
 
 The default views available in Zulip are
 [Recent conversations](/help/recent-conversations) and
-[All messages](/help/reading-strategies#all-messages). See
+[All messages](/help/all-messages). See
 [Reading strategies](/help/reading-strategies) for recommendations
 on how to use these views.
 
@@ -20,7 +20,7 @@ shortcut.
 Organization administrators can [set the default view for their
 organization](/help/configure-default-new-user-settings) to
 [**Recent conversations**](/help/recent-conversations) or
-[**All messages**](/help/reading-strategies#all-messages).
+[**All messages**](/help/all-messages).
 **Recent conversations** is especially recommended for high-traffic
 organizations, and is configured by default.
 
@@ -68,4 +68,5 @@ shortcut.
 
 * [Reading strategies](/help/reading-strategies)
 * [Recent conversations](/help/recent-conversations)
+* [All messages](/help/all-messages)
 * [Keyboard shortcuts](/help/keyboard-shortcuts)

--- a/templates/zerver/help/include/all-messages.md
+++ b/templates/zerver/help/include/all-messages.md
@@ -1,0 +1,20 @@
+The **All messages** view is a feed of all the unmuted messages you have
+received, which combines stream messages and private messages. It's a great way
+to see new messages as they come in.
+
+You can configure **All messages** to be the [default
+view](/help/configure-default-view#configure-default-view) for the Zulip web app.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Open **All messages** from the left sidebar or with the
+   <kbd>A</kbd> keyboard shortcut.
+
+{tab|mobile}
+
+1. Tap the **All messages**
+   tab in the upper left corner of the app.
+
+{end_tabs}

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -77,6 +77,7 @@
 ## Reading messages
 * [Reading strategies](/help/reading-strategies)
 * [Recent conversations](/help/recent-conversations)
+* [All messages](/help/all-messages)
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -92,7 +92,7 @@ in the Zulip app to add more to your repertoire as needed.
 * **Cycle between stream narrows**: <kbd>Shift</kbd> + <kbd>A</kbd>
   (previous) and <kbd>Shift</kbd> + <kbd>D</kbd> (next)
 
-* **Narrow to all messages**: <kbd>A</kbd> — Shows all unmuted messages.
+* **Narrow to All messages**: <kbd>A</kbd> — Shows all unmuted messages.
 
 * **Narrow to current compose box recipient**: <kbd>Ctrl</kbd> + <kbd>.</kbd>
 
@@ -159,7 +159,7 @@ in the Zulip app to add more to your repertoire as needed.
 * **Collapse/show message**: <kbd>-</kbd>
 
 * **Toggle topic mute**: <kbd>Shift</kbd> + <kbd>M</kbd> — Muted topics
-  don't show up in any views (including All messages), and don't contribute
+  don't show up in any views (including **All messages**), and don't contribute
   to unread counts. Read more about [muting topics](/help/mute-a-topic).
 
 ## Recent conversations

--- a/templates/zerver/help/reading-strategies.md
+++ b/templates/zerver/help/reading-strategies.md
@@ -44,15 +44,7 @@ shortcut](/help/keyboard-shortcuts).
 
 ## All messages
 
-If you're all caught up, it can be useful to have a single place to keep
-track of all messages coming in.
-
-* Click on **All messages** near the top left corner of the app, or hit
-  <kbd>A</kbd>.
-
-* You can use <kbd>S</kbd> (narrow to stream) or <kbd>Shift</kbd> +
-  <kbd>S</kbd> (narrow to topic) to zoom in, and <kbd>A</kbd> to get back
-  to All messages.
+{!all-messages.md!}
 
 ## Starring messages for later
 

--- a/templates/zerver/help/recent-conversations.md
+++ b/templates/zerver/help/recent-conversations.md
@@ -11,3 +11,5 @@
 * [Finding a topic to read](/help/finding-a-topic-to-read)
 * [Reading topics](/help/reading-topics)
 * [Reading strategies](/help/reading-strategies)
+* [All messages](/help/all-messages)
+* [Configure default view](/help/configure-default-view)


### PR DESCRIPTION
This should be mergeable as-is, but I wasn't sure how to get the All messages icon for mobile to appear here, which we should definitely do.

I tried: `( <img src="/static/shared/icons/globe.svg" alt="All messages" class="mobile-icon"/> )`

However, I think because the icon is all white, it didn't actually show up. @drrosa Could you please submit a follow-up PR to fix this?

Notes:
- Since by default `Esc` goes to Recent conversations, I used the dedicated `A` shortcut key in these instructions.

----


**Current**: https://zulip.com/help/reading-strategies#all-messages

## New (on the reading strategies page)
<img width="881" alt="Screen Shot 2022-12-14 at 1 14 45 PM" src="https://user-images.githubusercontent.com/2090066/207715884-93749aad-0547-4807-9e81-16b1150b0468.png">
<img width="889" alt="Screen Shot 2022-12-14 at 1 14 38 PM" src="https://user-images.githubusercontent.com/2090066/207715892-d066fa83-5ae5-42bb-a6ce-b83c59b21e38.png">



## New dedicated page


<img width="1267" alt="Screen Shot 2022-12-14 at 1 14 27 PM" src="https://user-images.githubusercontent.com/2090066/207715987-9ccaab0c-d1c8-43ee-a59c-721c0393febb.png">
