### PR TITLE
css: Apply negative spread radius to message box-shadows.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1386,7 +1386,21 @@ td.pointer {
     .messagebox,
     .date_row {
         background-color: hsla(192, 19%, 75%, 0.2);
-        box-shadow: inset 2px 0 0 0 hsl(0, 0%, 27%), -1px 0 0 0 hsl(0, 0%, 27%);
+        /* The 5th parameter here is a spread-radius, which, when negative,
+         * causes the shadow to shrink (be smaller than the target
+         * element), resulting in a visual width of 3px-1px=2px. This
+         * is a workaround for a regression found in Electron
+         * v18.3.15+ where the box-shadow with spread-radius >= 0
+         * would cause horizontal separator lines to appear between
+         * messages in the color of the left ruler. The root cause of
+         * that regression is yet unknown.
+         *
+         * Similar CSS for stream messages is present directly in the
+         * Handlebars templates, since the color used there is the
+         * stream's configured color.
+         */
+        box-shadow: inset 3px 0 0 -1px hsl(0, 0%, 27%),
+            -1px 0 0 0 hsl(0, 0%, 27%);
     }
 }
 

--- a/static/templates/single_message.hbs
+++ b/static/templates/single_message.hbs
@@ -3,10 +3,10 @@
   role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     {{#if want_date_divider}}
-    <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
+    <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 3px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
     {{/if}}
     <div class="messagebox {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
-      {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>
+      {{#if msg/is_stream}}style="box-shadow: inset 3px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>
         <div class="messagebox-content">
             {{> message_body}}
         </div>


### PR DESCRIPTION
This fixes a visual regression in newer Electron builds (without regressing Firefox) for which I still don't entirely know the root cause, where extra "borders" were being applied to messages in both streams and PMs. Applying a negative "spread radius" to the box-shadow properties of these elements, and moving that pixel to the "horizontal shadow" aspect of the property (which is used to create the left-side "ruler" effect), restores the expected look and feel.

Tested in qutebrowser (Chromium 87-based), Electron v18+v19, and Firefox 107.

Refs (and should unblock) zulip/zulip-desktop#1251, where the issue was initially found.

**Screenshots and screen captures:**

Expected behaviour, light theme qutebrowser (Chromium v87):

![screenshot-2022-12-14-21:38:14Z](https://user-images.githubusercontent.com/799439/207722915-9edd99f9-220f-4b28-a8fd-b5f3c9f213da.png)

Before, light+dark themes, Electron v18.3.15:

![screenshot-2022-12-14-21:37:16Z](https://user-images.githubusercontent.com/799439/207722621-62338a8b-8808-4c84-8e34-26be90fff44e.png)

![screenshot-2022-12-14-21:38:37Z](https://user-images.githubusercontent.com/799439/207722998-5658c892-351a-44f1-87be-f980aa59c197.png)
![screenshot-2022-12-14-21:41:30Z](https://user-images.githubusercontent.com/799439/207723032-badb02b9-985b-4cee-8fbc-9f9b953ffc88.png)

After, Electron v18:

![screenshot-2022-12-14-21:54:18Z](https://user-images.githubusercontent.com/799439/207723212-06497262-16d6-43cf-b0a5-25dd294b508f.png)
![screenshot-2022-12-14-21:54:43Z](https://user-images.githubusercontent.com/799439/207723276-956b3f58-5b9e-436c-98fe-fd5af5fd0938.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
