### PR TITLE
css: Remove Bootsrap CSS reset for hr elements

### DIFF
--- a/static/styles/components.css
+++ b/static/styles/components.css
@@ -136,3 +136,10 @@ input::-ms-reveal {
         }
     }
 }
+
+hr.separator {
+    margin: 20px 0;
+    border: 0;
+    border-top: 1px solid hsl(0, 0%, 93%);
+    border-bottom: 1px solid hsl(0, 0%, 100%);
+}

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -7,7 +7,7 @@
             <span class="hotkey-hint">(>)</span>
         </a>
     </li>
-    <hr />
+    <hr class="separator" />
     {{/if}}
 
     {{#if editability_menu_item}}
@@ -38,7 +38,7 @@
     {{/if}}
 
     {{#if (or editability_menu_item move_message_menu_item should_display_delete_option)}}
-    <hr />
+    <hr class="separator" />
     {{/if}}
 
     {{#if should_display_add_reaction_option}}
@@ -48,7 +48,7 @@
             {{#tr}}Add emoji reaction{{/tr}}
         </a>
     </li>
-    <hr />
+    <hr class="separator" />
     {{/if}}
 
     {{#if should_display_mark_as_unread}}
@@ -97,7 +97,7 @@
     {{/if}}
 
     {{#if (or should_display_mark_as_unread should_display_reminder_option should_display_hide_option should_display_collapse should_display_uncollapse)}}
-    <hr />
+    <hr class="separator" />
     {{/if}}
 
     {{#if view_source_menu_item}}

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -344,7 +344,7 @@
                 </tr>
             </table>
         </div>
-        <hr />
+        <hr class="separator" />
         <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
     </div>
 </div>

--- a/static/templates/markdown_help.hbs
+++ b/static/templates/markdown_help.hbs
@@ -24,7 +24,7 @@
                 </tbody>
             </table>
         </div>
-        <hr />
+        <hr class="separator" />
         <a href="/help/format-your-message-using-markdown" target="_blank" rel="noopener noreferrer">{{t "Detailed message formatting documentation" }}</a>
     </div>
 </div>

--- a/static/templates/message_edit_history.hbs
+++ b/static/templates/message_edit_history.hbs
@@ -17,5 +17,5 @@
         {{/if}}
         <div class="message_author"><div class="author_details">{{ edited_by_notice }}</div></div>
     </div>
-    <hr />
+    <hr class="separator" />
 {{/each}}

--- a/static/templates/read_receipts_modal.hbs
+++ b/static/templates/read_receipts_modal.hbs
@@ -7,7 +7,7 @@
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
-            <hr/>
+            <hr class="separator"/>
             <main class="modal__content">
                 <div class="alert" id="read_receipts_error"></div>
                 <div class="read_receipts_info">

--- a/static/templates/search_operators.hbs
+++ b/static/templates/search_operators.hbs
@@ -159,7 +159,7 @@
                 </tbody>
             </table>
             <p>{{t "You can combine search filters as needed." }}</p>
-            <hr />
+            <hr class="separator" />
             <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
         </div>
     </div>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -77,7 +77,7 @@
             </div>
         </div>
 
-        <hr class="settings_separator" />
+        <hr class="separator settings_separator" />
 
         <div class="form-horizontal" id="api_key_button_box">
             <h3>{{t "API key" }}</h3>

--- a/static/templates/settings/edit_custom_profile_field_form.hbs
+++ b/static/templates/settings/edit_custom_profile_field_form.hbs
@@ -12,7 +12,7 @@
     <div class="input-group">
         <label for="profile_field_choices_edit">{{t "Field choices" }}</label>
         <div class="profile-field-choices" name="profile_field_choices_edit">
-            <hr />
+            <hr class="separator" />
             <div class="edit_profile_field_choices_container">
                 {{#each choices}}
                     {{> profile_field_choice }}

--- a/static/templates/stream_settings/copy_email_address_modal.hbs
+++ b/static/templates/stream_settings/copy_email_address_modal.hbs
@@ -5,7 +5,7 @@
         </p>
         {{#each tags}}
             {{#if (eq this.name "prefer-html") }}
-            <hr />
+            <hr class="separator" />
             {{/if}}
             <div class="input-group" id="{{this.name}}-input-group">
                 <label class="checkbox">
@@ -15,7 +15,7 @@
                 <label class="inline" for="{{this.name}}">{{{this.description}}}</label>
             </div>
         {{/each}}
-        <hr />
+        <hr class="separator" />
         <p class="stream-email-header">
             {{t "Stream email address:"}}
         </p>

--- a/static/templates/stream_sidebar_actions.hbs
+++ b/static/templates/stream_sidebar_actions.hbs
@@ -11,7 +11,7 @@
         </p>
     </li>
 
-    <hr />
+    <hr class="separator" />
 
     {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
     <li>

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -6,7 +6,7 @@
         </p>
     </li>
 
-    <hr />
+    <hr class="separator" />
 
     {{#unless topic_muted}}
     <li class="hidden-for-spectators">
@@ -48,7 +48,7 @@
     </li>
 
     {{#if can_move_topic}}
-    <hr />
+    <hr class="separator" />
 
     <li>
         <a tabindex="0" class="sidebar-popover-move-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">

--- a/static/templates/user_group_info_popover_content.hbs
+++ b/static/templates/user_group_info_popover_content.hbs
@@ -5,7 +5,7 @@
         {{group_description}}
     </div>
 </div>
-<hr />
+<hr class="separator" />
 <ul class="nav nav-list member-list" data-simplebar data-simplebar-auto-hide="false">
     {{#each members}}
         <li>
@@ -20,7 +20,7 @@
         </li>
     {{/each}}
 </ul>
-<hr />
+<hr class="separator" />
 <ul class="nav nav-list manage-group">
     <li>
         <a href="#organization/user-groups-admin">

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -77,7 +77,7 @@
     <li class="only-visible-for-spectators">{{#tr}}Joined {date_joined}{{/tr}}</li>
 
     {{#if (or (and user_time is_active) is_me status_content_available) }}
-        <hr />
+        <hr class="separator" />
     {{/if}}
     {{#if (and user_time is_active)}}
         <li class="hidden-for-spectators local_time">{{#tr}}{user_time} local time{{/tr}}</li>
@@ -133,7 +133,7 @@
 
 
     {{#unless spectator_view}}
-        <hr />
+        <hr class="separator" />
         <li>
             <a tabindex="0" class="view_full_user_profile">
                 {{#if is_me}}
@@ -174,7 +174,7 @@
             </a>
         </li>
         {{/if}}
-        <hr />
+        <hr class="separator" />
         <li>
             <a href="{{ pm_with_url }}" class="narrow_to_private_messages">
                 <i class="fa fa-envelope" aria-hidden="true"></i>

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -289,12 +289,6 @@ ol ul {
 li {
   line-height: 20px;
 }
-hr {
-  margin: 20px 0;
-  border: 0;
-  border-top: 1px solid #eeeeee;
-  border-bottom: 1px solid #ffffff;
-}
 blockquote {
   padding: 0 0 0 15px;
   margin: 0 0 20px;

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -41,11 +41,11 @@
             <b>Date joined</b>: {{ user.date_joined|timesince }} ago<br />
             <b>Is active</b>: {{ user.is_active }}<br />
             <b>Role</b>: {{ user.get_role_name() }}<br />
-            <hr />
+            <hr class="separator" />
             <div>
                 {% include "analytics/realm_details.html" %}
             </div>
-            <hr />
+            <hr class="separator" />
         </div>
         {% endfor %}
 
@@ -98,7 +98,7 @@
             {% endif %}
             <br />
             {% if show_realm_details %}
-            <hr />
+            <hr class="separator" />
             <div>
                 {% include "analytics/realm_details.html" %}
             </div>

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -180,7 +180,7 @@
                     </h3>
                     {% endif %}
                 </div>
-                <hr />
+                <hr class="separator" />
                 <div class="support-link">
                     <p>
                         Contact <a href="mailto:support@zulip.com">support@zulip.com</a>

--- a/templates/corporate/communities.html
+++ b/templates/corporate/communities.html
@@ -79,7 +79,7 @@
                                 </div>
                             </a>
                         {% endfor %}
-                        <hr />
+                        <hr class="separator" />
                         <div class="eligible_realm_end_notice">
                             <p>Learn how Zulip can be a <a href="/for/communities">home for your community</a>.</p>
                         </div>

--- a/templates/corporate/for/education.html
+++ b/templates/corporate/for/education.html
@@ -254,7 +254,7 @@
                                 <div class="description">
                                     Recommended for a typical class.
                                 </div>
-                                <hr />
+                                <hr class="separator" />
                                 <ul class="feature-list">
                                     <li>All features on this page</li>
                                     <li>10,000 messages of search history</li>
@@ -282,7 +282,7 @@
                                 <div class="description">
                                     For large classes and departments.
                                 </div>
-                                <hr />
+                                <hr class="separator" />
                                 <ul class="feature-list">
                                     <li>Priority commercial support</li>
                                     <li>Unlimited search history</li>

--- a/templates/corporate/hello.html
+++ b/templates/corporate/hello.html
@@ -514,7 +514,7 @@
                 </div>
             </div>
 
-            <hr />
+            <hr class="separator" />
 
             <div class="company-container">
                 <header>

--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -201,7 +201,7 @@
                 </p>
 
                 <br />
-                <hr />
+                <hr class="separator" />
 
                 <h2 id="frontend">Senior Frontend Engineer</h2>
                 <p>
@@ -294,7 +294,7 @@
                     <a href="mailto:jobs@zulip.com">jobs@zulip.com</a>.
                 </p>
                 <br />
-                <hr />
+                <hr class="separator" />
 
                 <h2>How to apply for a job</h2>
                 <p>

--- a/templates/corporate/pricing_model.html
+++ b/templates/corporate/pricing_model.html
@@ -14,7 +14,7 @@
                         <div class="description">
                             Best for light use.
                         </div>
-                        <hr />
+                        <hr class="separator" />
                         <ul class="feature-list">
                             <li>10,000 messages of search history</li>
                             <li>File storage up to 5 GB total</li>
@@ -49,7 +49,7 @@
                         <div class="description">
                             Your team's collaboration hub.
                         </div>
-                        <hr />
+                        <hr class="separator" />
                         <ul class="feature-list">
                             <li>Unlimited search history</li>
                             <li>File storage up to 10 GB per user</li>
@@ -116,7 +116,7 @@
                         <div class="description">
                             Retain full control over your data.
                         </div>
-                        <hr />
+                        <hr class="separator" />
                         <ul class="feature-list">
                             <li>All Zulip Cloud features included</li>
                             <li>Friendly community support</li>
@@ -146,7 +146,7 @@
                         <div class="description">
                             For mission-critical installations.
                         </div>
-                        <hr />
+                        <hr class="separator" />
                         <ul class="feature-list">
                             <li>All Free features included</li>
                             <li>Professional support with SLAs</li>

--- a/templates/corporate/self-hosting.html
+++ b/templates/corporate/self-hosting.html
@@ -284,7 +284,7 @@
                                 <div class="description">
                                     Retain full control over your data.
                                 </div>
-                                <hr />
+                                <hr class="separator" />
                                 <ul class="feature-list">
                                     <li>All Zulip Cloud features included</li>
                                     <li>Friendly community support</li>
@@ -314,7 +314,7 @@
                                 <div class="description">
                                     For mission-critical installations.
                                 </div>
-                                <hr />
+                                <hr class="separator" />
                                 <ul class="feature-list">
                                     <li>All self service features included</li>
                                     <li>Professional support with SLAs</li>

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -64,7 +64,7 @@
                                 {% endif %}
                                 {% if onboarding and free_trial_days %}
                                 <p><b>Not ready to start your trial?</b> <a href="/">Continue with the Zulip Cloud Free plan</a>.</p>
-                                <hr />
+                                <hr class="separator" />
                                 <h2>Zulip Cloud Standard free trial</h2>
                                 {% endif %}
                                 <div class="payment-schedule">
@@ -184,7 +184,7 @@
                             <form id="invoice-form" method="post">
                                 {% if onboarding and free_trial_days %}
                                 <p><b>Not ready to start your trial?</b> <a href="/">Continue with the Zulip Cloud Free plan</a>.</p>
-                                <hr />
+                                <hr class="separator" />
                                 <h2>Zulip Cloud Standard free trial</h2>
                                 {% endif %}
                                 <input type="hidden" name="signed_seat_count" value="{{ signed_seat_count }}" />

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -33,7 +33,7 @@ page can be easily identified in it's respective JavaScript file -->
                     </div>
 
                     <div class="invite-required">
-                        <hr />
+                        <hr class="separator" />
                         <i class="fa fa-lock"></i>{{ _("You need an invitation to join this organization.") }}
                     </div>
                 </div>

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -44,7 +44,7 @@
             {% endif %}
 
             <div id="footer" class="documentation-footer">
-                <hr />
+                <hr class="separator" />
                 {% if corporate_enabled %}
                     {% if page_is_policy_center %}
                     <p>Please contact {{ support_email_html_tag }} with any questions about Zulip's policies.</p>

--- a/templates/zerver/email.html
+++ b/templates/zerver/email.html
@@ -23,4 +23,4 @@
 <div class="email-text" style="display: none;">
     <pre>{{ body }}</pre>
 </div>
-<hr />
+<hr class="separator" />

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -84,7 +84,7 @@
                             </h4>
                         </a>
                         {% endfor %}
-                        <hr />
+                        <hr class="separator" />
                         <h3>{% trans %}Custom integrations{% endtrans %}</h3>
                         <a href="/api/incoming-webhooks-overview">
                             <h4>{% trans %}Incoming webhooks{% endtrans %}</h4>
@@ -124,7 +124,7 @@
                             </a>
                             {% endif %}
                         {% endfor %}
-                        <hr />
+                        <hr class="separator" />
                         <div class="integration-request center">
                             <p>Don't see an integration you need? We'd love to help.</p>
                             <a href="/api/integrations-overview" class="button green">

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -201,7 +201,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 {% endif %}
             </fieldset>
             {% if default_stream_groups %}
-            <hr />
+            <hr class="separator" />
             <div class="default-stream-groups">
                 <p class="margin">{{ _('What are you interested in?') }}</p>
                 {% for default_stream_group in default_stream_groups %}
@@ -227,7 +227,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 </div>
                 {% endfor %}
             </div>
-            <hr />
+            <hr class="separator" />
             {% endif %}
 
             <div class="input-group margin terms-of-service">


### PR DESCRIPTION
This PR is part of the efforts to [remove Bootstrap CSS resets](https://chat.zulip.org/#narrow/stream/6-frontend/topic/bootstrap.20CSS.20reset.20removal). The scope of the change here is the removal of the Bootstrap CSS resets for `<hr>` elements.

@timabbott and I started working on this in a pair programming session. Initially, we were going to target the `<hr>` elements with selectors matching existing classes used by parent containers (e.g. `.popover hr`). However, it turned out if we were going to do so, we'd have to duplicate the styles in at least 3 rule sets.

So the idea came up to create a separator component, i.e. a template that contains only the  styled `<hr>` element and including this template everywhere where we have an `<hr>` element. But then we wouldn't be able to reuse this component across client-side (Handlbars) and server-side (jinja2) templates. Let alone that the boilerplate to include the template would be more verbose than typing out `<hr class="separator">` which is the solution we ended up with.

For reference, the changes to the `.html` and `.hbs` files have been performed with following command:

    sed -Ei 's/(<\s*hr)/\1 class="separator"/' $(git grep '<\s*hr\b' | cut -d: -f1 | sort -u | grep -E '(html|hbs)$')

I tested the following components verifying that there are no visual changes:
* three dot menu in streams list
* three dot menu in messages
* logged out jobs page

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] ~~Automated tests~~ verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] ~~Responsiveness and internationalization.~~ (n/a)
- [ ] ~~Strings and tooltips.~~ (n/a)
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
