### PR TITLE
styles: Don’t clip tall characters in stream and topic names

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -153,11 +153,11 @@ li.show-more-topics {
         }
 
         .stream-name {
-            display: inline-block;
-            overflow: hidden;
+            flex: auto;
+            overflow-x: clip;
             text-overflow: ellipsis;
             position: relative;
-            width: 100%;
+            min-width: 0;
             padding-right: 2px;
         }
 
@@ -458,10 +458,10 @@ li.top_left_recent_topics {
 
 .conversation-partners,
 .topic-name {
-    display: block;
-    width: calc(100% - 5px);
+    flex: auto;
+    min-width: 0;
     white-space: nowrap;
-    overflow: hidden;
+    overflow-x: clip;
     text-overflow: ellipsis;
     padding-right: 2px;
 }

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -136,27 +136,16 @@ li.show-more-topics {
     }
 
     .subscription_block {
-        padding: 0;
         margin-right: 25px;
         margin-left: $far_left_gutter_size;
         display: flex;
-        justify-content: space-between;
         align-items: center;
         white-space: nowrap;
-        text-overflow: ellipsis;
-        overflow: hidden;
-
-        &::after {
-            content: "";
-            display: block;
-            clear: both;
-        }
 
         .stream-name {
             flex: auto;
             overflow-x: clip;
             text-overflow: ellipsis;
-            position: relative;
             min-width: 0;
             padding-right: 2px;
         }
@@ -571,7 +560,6 @@ li.topic-list-item {
 .pm-box,
 .topic-box {
     display: flex;
-    justify-content: center;
     padding-top: 1px;
     cursor: pointer;
     align-items: center;


### PR DESCRIPTION
Fixes #23867.