### PR TITLE
fix #22769: Show empty conversation in left sidebar

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -21,6 +21,8 @@ import * as narrow_state from "./narrow_state";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as pm_conversations from "./pm_conversations";
+import * as pm_list from "./pm_list";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload_state from "./reload_state";
@@ -163,6 +165,10 @@ function composing_to_current_private_message_narrow() {
 }
 
 export function update_narrow_to_recipient_visibility() {
+    // Remove any conversations with no messages from PMs when the
+    // narrow view is changed
+    pm_conversations.recent.removeEmptyConvo();
+
     const message_type = compose_state.get_message_type();
     if (message_type === "stream") {
         const stream_name = compose_state.stream_name();
@@ -357,6 +363,11 @@ export function start(msg_type, opts) {
 }
 
 export function cancel() {
+    // Remove any empty conversations from PMs when the compose-box
+    // is closed
+    pm_conversations.recent.removeEmptyConvo();
+    pm_list.update_private_messages();
+
     // As user closes the compose box, restore the compose box max height
     if (compose_ui.is_full_size()) {
         compose_ui.make_compose_box_original_size();

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -26,6 +26,7 @@ import * as narrow_state from "./narrow_state";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as pm_conversations from "./pm_conversations";
 import * as pm_list from "./pm_list";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
@@ -937,6 +938,22 @@ export function by_recipient(target_id, opts) {
 
 // Called by the narrow_to_compose_target hotkey.
 export function to_compose_target() {
+    // If the target has not been in a convo before, then add temp convo marker
+    // to the top
+    const recipient_string = compose_state.private_message_recipient();
+
+    const user_ids = [];
+    const recipient_split = recipient_string.split(",");
+
+    for (const user_email of recipient_split) {
+        user_ids.unshift(people.get_user_id(user_email));
+    }
+
+    // if unique combination of users, then add to list
+    if (!pm_conversations.recent.recent_message_ids.has(user_ids)) {
+        pm_conversations.recent.initInsert(user_ids);
+    }
+
     if (!compose_state.composing()) {
         return;
     }

--- a/static/js/pm_conversations.js
+++ b/static/js/pm_conversations.js
@@ -31,6 +31,30 @@ class RecentPrivateMessages {
     recent_message_ids = new FoldDict(); // key is user_ids_string
     recent_private_messages = [];
 
+    // taking care of conversation before any message has been sent
+
+    // remove convo if its max_message_id is null, i.e. it is
+    // a temporary convo
+    removeEmptyConvo() {
+        const convoList = this.recent_private_messages;
+        for (let i = 0; i < convoList.length; i += 1) {
+            if (!convoList[i].max_message_id) {
+                convoList.splice(i, i + 1);
+                break;
+            }
+        }
+    }
+
+    initInsert(user_ids) {
+        const user_ids_string = user_ids.join(",");
+        const conversation = {
+            user_ids_string,
+            max_message_id: null,
+        };
+        // adds to top of recent private messages list
+        this.recent_private_messages.unshift(conversation);
+    }
+
     insert(user_ids, message_id) {
         if (user_ids.length === 0) {
             // The server sends [] for self-PMs.

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -212,6 +212,7 @@ export function setup_upload(config) {
     $("body").on("change", get_item("file_input_identifier", config), (event) => {
         const files = event.target.files;
         upload_files(uppy, config, files);
+        get_item("textarea", config).trigger("focus");
         event.target.value = "";
     });
 


### PR DESCRIPTION
Fixed https://github.com/zulip/zulip/issues/22769

Previously, when starting a new private message, the pm did not show up in the left side bar unless a message had been sent yet. We have now fixed it so that when starting a new private message, if you click the "Go to Conversation" button (near the message box),
<img width="44" alt="go_to_convo" src="https://user-images.githubusercontent.com/62992282/207737373-68001ee1-fa18-4c16-933a-f95998145420.png">
the conversation will be added to the list on the left side and highlighted (as shown below with King Hamlet). If you did not type and send a message, and you click outside of the conversation, the pm then disappears from the list (as shown below by clicking on Zulip Default Bot).
<img width="1788" alt="ui_1" src="https://user-images.githubusercontent.com/62992282/207737398-a31471ea-455b-4f84-893e-7d5d152c43d5.png">
<img width="1790" alt="ui_2" src="https://user-images.githubusercontent.com/62992282/207737404-6f051a33-d903-4448-ba00-d55106d5e318.png">
