### PR TITLE
message_actions: Fix move messages/topic related notification-bugs.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -474,16 +474,17 @@ export function build_move_topic_to_stream_popover(current_stream_id, topic_name
             // there has been no change in the topic name.
             new_topic_name = undefined;
         }
+        if (select_stream_id === current_stream_id) {
+            // We use `undefined` to tell the server that
+            // there has been no change in stream. This is
+            // important for cases when changing stream is
+            // not allowed or when changes other than
+            // stream-change has been made.
+            select_stream_id = undefined;
+        }
 
         let propagate_mode = "change_all";
         if (message !== undefined) {
-            if (select_stream_id === current_stream_id) {
-                // We use `undefined` to tell the server that
-                // there has been no change in stream. This is
-                // important for cases when changing stream is
-                // not allowed.
-                select_stream_id = undefined;
-            }
             // We already have the message_id here which means that modal is opened using
             // message popover.
             propagate_mode = $("#move_topic_modal select.message_edit_topic_propagate").val();
@@ -503,7 +504,7 @@ export function build_move_topic_to_stream_popover(current_stream_id, topic_name
             current_stream_id,
             old_topic_name,
             (message_id) => {
-                if (old_topic_name && select_stream_id) {
+                if (old_topic_name) {
                     message_edit.move_topic_containing_message_to_stream(
                         message_id,
                         select_stream_id,

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -534,7 +534,7 @@ export function build_move_topic_to_stream_popover(current_stream_id, topic_name
     }
 
     function move_topic_on_update() {
-        update_submit_button_disabled_state();
+        update_submit_button_disabled_state(stream_widget.value());
         set_stream_topic_typeahead();
     }
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -504,16 +504,14 @@ export function build_move_topic_to_stream_popover(current_stream_id, topic_name
             current_stream_id,
             old_topic_name,
             (message_id) => {
-                if (old_topic_name) {
-                    message_edit.move_topic_containing_message_to_stream(
-                        message_id,
-                        select_stream_id,
-                        new_topic_name,
-                        send_notification_to_new_thread,
-                        send_notification_to_old_thread,
-                        propagate_mode,
-                    );
-                }
+                message_edit.move_topic_containing_message_to_stream(
+                    message_id,
+                    select_stream_id,
+                    new_topic_name,
+                    send_notification_to_new_thread,
+                    send_notification_to_old_thread,
+                    propagate_mode,
+                );
             },
             (xhr) => {
                 dialog_widget.hide_dialog_spinner();

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -809,16 +809,19 @@ def do_update_message(
     send_event(user_profile.realm, event, users_to_be_notified)
 
     sent_resolve_topic_notification = False
-    if (
-        topic_name is not None
-        and new_stream is None
-        and content is None
-        and len(changed_messages) > 0
-    ):
-        assert stream_being_edited is not None
+    if topic_name is not None and content is None and len(changed_messages) > 0:
+        # When stream is changed and topic is marked as resolved or unresolved
+        # in the same API request, resolved or unresolved notification should
+        # be sent to "new_stream".
+        # In general, it is sent to "stream_being_edited".
+        stream_to_send_resolve_topic_notification = stream_being_edited
+        if new_stream is not None:
+            stream_to_send_resolve_topic_notification = new_stream
+
+        assert stream_to_send_resolve_topic_notification is not None
         sent_resolve_topic_notification = maybe_send_resolve_topic_notifications(
             user_profile=user_profile,
-            stream=stream_being_edited,
+            stream=stream_to_send_resolve_topic_notification,
             old_topic=orig_topic_name,
             new_topic=topic_name,
             changed_messages=changed_messages,


### PR DESCRIPTION
While fixing [issue #22973](https://github.com/zulip/zulip/issues/22973), I found couple of extra bugs. Fixed those in separate commits.

**Bug 1:**
![old-optimized](https://user-images.githubusercontent.com/56781761/207964706-2fe656a6-d38d-4ed6-aabb-5f32991a53ac.gif)

**After the fix**
![new-optimized](https://user-images.githubusercontent.com/56781761/207964979-275e6207-a05f-42a7-81fb-3d5c0e23f64e.gif)

**Bug 2**

When 'resolve|unresolve' and 'change topic' actions occurs in
the same api call using 'topic sidebar icon', only 'topic_moved'
notification is sent.

Both 'topic moved' and 'topic resolved' notification should be generated.

![old](https://user-images.githubusercontent.com/56781761/208026187-82151451-c1b8-4c59-9044-cee9037ef184.gif)

**After the Fix**

**Important**

When we change 'topic name' and/or 'resolve|unresolve' topic using the messages-action `move-message` popover, [`select_stream_id` is set to `undefined`](https://github.com/zulip/zulip/blob/d4d285fc43b9ede7556f30878e28d8f851289bf2/static/js/stream_popover.js#L480). This is not the case when we the same thing via `sidebar-topic-popover`.

While using topic-popover, [select_stream_id](https://github.com/zulip/zulip/blob/d4d285fc43b9ede7556f30878e28d8f851289bf2/static/js/stream_popover.js#L479) is not set to 'undefined',
even if we only change 'topic name' and/or 'resolve|unresolve' topic.
**Resulting in _no_ 'resolved_topic' notification**.

The fix sets 'select_stream_id' to 'undefined' to fix the issue.

![new](https://user-images.githubusercontent.com/56781761/208026258-dd5f6061-9802-4f09-8adc-751f924f7ff7.gif)

**Bug 3** [issue #22973](https://github.com/zulip/zulip/issues/22973)

![older](https://user-images.githubusercontent.com/56781761/208604146-3cbf4285-6a6f-48f2-bbe9-7e9504c6b295.gif)

**After the Fix**

![newer](https://user-images.githubusercontent.com/56781761/208604201-c0f57cb5-9ac6-4ef7-a553-8802418a3447.gif)

**Important**

This commit updates the logic of when and where to send 'topic resolve|unresolve' notification. [Unlike previous logic](https://github.com/zulip/zulip/blob/753deab0872c3113ad81f1e7577f390feab782da/zerver/actions/message_edit.py#L817), notification may be sent even in the case 'new_stream' is not None.

[In general,](https://github.com/zulip/zulip/pull/23886/files#diff-26aa930b41caa2a7e31ee5622de9b7629fbe56f84c27a87315fa8189420d45e2R822) 'topic resolved|unresolved' notification is sent to 'stream_being_edited'. [In this particular case](https://github.com/zulip/zulip/pull/23886/files#diff-26aa930b41caa2a7e31ee5622de9b7629fbe56f84c27a87315fa8189420d45e2R824) ('new_stream' is not None), notification is sent to the 'new_stream' after check.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
