### PR TITLE
timerender: Set minutes to 0 in time picker UI for global time.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -11,9 +11,9 @@ const {run_test} = require("../zjsunit/test");
 const $ = require("../zjsunit/zjquery");
 const {user_settings} = require("../zjsunit/zpage_params");
 
-user_settings.twenty_four_hour_time = true;
-
 const timerender = zrequire("timerender");
+
+user_settings.twenty_four_hour_time = true;
 
 function get_date(time_ISO, DOW) {
     const time = new Date(time_ISO);
@@ -266,11 +266,19 @@ run_test("get_timestamp_for_flatpickr", () => {
     // Freeze time for testing.
     MockDate.set(date_2017.getTime());
 
+    const current_timestamp = new Date();
+
     // Invalid timestamps should show current time.
-    assert.equal(func("random str").valueOf(), Date.now());
+    const invalid_timestamp = func("invalid");
+    assert.ok(invalid_timestamp instanceof Date);
+    assert.strictEqual(invalid_timestamp.getHours(), current_timestamp.getHours());
+    assert.strictEqual(invalid_timestamp.getMinutes(), 0);
 
     // Valid ISO timestamps should return the timestamp.
-    assert.equal(func(date_2017.toISOString()).valueOf(), date_2017.getTime());
+    const valid_timestamp = func(date_2017.toISOString());
+    assert.ok(valid_timestamp instanceof Date);
+    assert.strictEqual(valid_timestamp.getHours(), current_timestamp.getHours());
+    assert.strictEqual(valid_timestamp.getMinutes(), 0);
 
     // Restore the Date object.
     MockDate.reset();

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -659,10 +659,12 @@ export function initialize() {
                 compose_ui.insert_syntax_and_focus(timestr, $target_textarea);
             };
 
+            const dateWithoutMinutes = new Date();
+            dateWithoutMinutes.setMinutes(0, 0);
             flatpickr.show_flatpickr(
                 $(compose_click_target)[0],
                 on_timestamp_selection,
-                new Date(),
+                dateWithoutMinutes,
                 {
                     // place the time picker above the icon and center it horizontally
                     position: "above center",

--- a/static/js/timerender.ts
+++ b/static/js/timerender.ts
@@ -294,6 +294,8 @@ export function get_timestamp_for_flatpickr(timestring: string): Date {
             timestamp = new Date();
         }
     }
+    // set timestamp minutes to 0
+    timestamp.setMinutes(0, 0);
     return timestamp;
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Instance of a date is created and set minutes to 00. 

There are two ways to pick time while you are in compose box. 
- First way is by typing `<time:` in the compose box and global timepicker will appear. 
- Second way is by clicking on the little clock icon on the bottom icons bar of compose box. 
- Setting the minutes to 00 in `timerender.ts` will set the minutes to 00 when you open timepicker by typing `<time:`.  
- Setting the minutes to 00 in `compose.js` file will set the minutes to 00 when you click on the clock icon. 


(Note:- Please look at screenrecording below to see both ways of picking time.)

Fixes: <!-- Issue link, or clear description.-->
#23874

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


**Screenshots and screen captures:**

https://user-images.githubusercontent.com/53159963/208218876-62f30912-de58-4dcb-9e80-44d9abddcf78.mov

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
