### PR TITLE
docs: Document better configuration for Zoom redirect URL

### DIFF
--- a/docs/production/video-calls.md
+++ b/docs/production/video-calls.md
@@ -22,8 +22,9 @@ installation, you'll need to register a custom Zoom app as follows:
 
 1. Inside the Zoom app management page:
 
-   - On the **App Credentials** tab, set both the **Redirect URL for
-     OAuth** and the **Whitelist URL** to
+   - On the **App Credentials** tab, set the **Redirect URL for
+     OAuth** to `htps://zulip.example.com/help/start-a-call` and the
+     **Whitelist URL** to
      `https://zulip.example.com/calls/zoom/complete` (replacing
      `zulip.example.com` by your main Zulip hostname).
    - On the **Scopes** tab, add the `meeting:write` scope.


### PR DESCRIPTION
This gives a more reasonable result when a user tries to “add” the application from within the Zoom marketplace.

I think this reflects the current configuration of our Zulip Cloud app on the Zoom marketplace (@timabbott can you check?).