### PR TITLE
deactivated_user: Change the empty PM / group PM view text and compose_box.

### DIFF
--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -95,6 +95,10 @@ function get_num_unread(user_id) {
 }
 
 export function user_last_seen_time_status(user_id) {
+    if (people.verify_non_active_human_id(Number.parseInt(user_id, 10))) {
+        return $t({defaultMessage: "User is deactivated"});
+    }
+
     const status = presence.get_status(user_id);
     if (status === "active") {
         return $t({defaultMessage: "Active now"});

--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import * as compose_actions from "./compose_actions";
 import {$t, $t_html} from "./i18n";
 import {narrow_error} from "./narrow_error";
 import * as narrow_state from "./narrow_state";
@@ -333,6 +334,24 @@ function pick_empty_narrow_banner() {
                         ),
                     };
                 }
+                if (people.verify_non_active_human_id(user_ids[0])) {
+                    return {
+                        title: $t(
+                            {
+                                defaultMessage: "You have no direct messages with {person}.",
+                            },
+                            {person: people.get_by_user_id(user_ids[0]).full_name},
+                        ),
+                        html: $t_html(
+                            {
+                                defaultMessage:
+                                    "{person} is no longer active in this organization.",
+                            },
+                            {person: people.get_by_user_id(user_ids[0]).full_name},
+                        ),
+                    };
+                }
+
                 return {
                     title: $t(
                         {
@@ -350,6 +369,19 @@ function pick_empty_narrow_banner() {
                                     "",
                                 )}</a>`,
                         },
+                    ),
+                };
+            }
+            if (compose_actions.check_pm_deactivated(false, user_ids).is_user_id_deactivated) {
+                return {
+                    title: $t({
+                        defaultMessage: "You have no direct messages with these users.",
+                    }),
+                    html: $t_html(
+                        {
+                            defaultMessage: "{person} is no longer active in this organization.",
+                        },
+                        {person: people.get_names_for_deactivated_users(user_ids)[0]},
                     ),
                 };
             }
@@ -411,6 +443,23 @@ function pick_empty_narrow_banner() {
                     }),
                 };
             }
+            if (people.verify_non_active_human_id(person_in_dms.user_id)) {
+                return {
+                    title: $t(
+                        {
+                            defaultMessage: "You have no direct messages including {person}.",
+                        },
+                        {person: person_in_dms.full_name},
+                    ),
+                    html: $t_html(
+                        {
+                            defaultMessage: "{person} is no longer active in this organization.",
+                        },
+                        {person: person_in_dms.full_name},
+                    ),
+                };
+            }
+
             return {
                 title: $t(
                     {

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -1038,6 +1038,23 @@ export function get_bot_ids(): number[] {
 
     return bot_ids;
 }
+export function verify_non_active_human_id(user_id: number): boolean {
+    if (non_active_user_dict.has(user_id)) {
+        return true;
+    }
+
+    return false;
+}
+
+export function get_names_for_deactivated_users(user_ids: number[]): string[] {
+    const filtered_deactivated_users: string[] = user_ids.map((user_id) => {
+        if (verify_non_active_human_id(user_id)) {
+            return get_by_user_id(user_id)?.full_name ?? "";
+        }
+        return "";
+    });
+    return filtered_deactivated_users.filter((full_name) => full_name !== "");
+}
 
 export function get_active_human_count(): number {
     let count = 0;

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -935,7 +935,7 @@ export function register_click_handlers() {
         e.preventDefault();
     });
 
-    $("body").on("click", ".info_popover_actions .sidebar-popover-reactivate-user", (e) => {
+    $("body").on("click", ".sidebar-popover-reactivate-user", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         hide_all();
         e.stopPropagation();

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -9,6 +9,7 @@ import * as bot_data from "./bot_data";
 import * as browser_history from "./browser_history";
 import {buddy_list} from "./buddy_list";
 import * as compose from "./compose";
+import * as compose_closed_ui from "./compose_closed_ui";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_recipient from "./compose_recipient";
 import * as composebox_typeahead from "./composebox_typeahead";
@@ -446,6 +447,7 @@ export function dispatch_normal_event(event) {
                     if (event.person.is_bot) {
                         settings_users.redraw_bots_list();
                     }
+                    compose_closed_ui.update_reply_button_deactivated_users();
                     break;
                 case "remove":
                     people.deactivate(event.person);
@@ -456,6 +458,7 @@ export function dispatch_normal_event(event) {
                     if (people.user_is_bot(event.person.user_id)) {
                         settings_users.update_bot_data(event.person.user_id);
                     }
+                    compose_closed_ui.update_reply_button_deactivated_users();
                     break;
                 case "update":
                     user_events.update_person(event.person);

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -21,6 +21,12 @@
 <template id="compose_reply_button_disabled_tooltip_template">
     {{t 'You are not allowed to send direct messages in this organization.' }}
 </template>
+<template id="compose_reply_button_disabled_for_deactivated_user_tooltip_template">
+    {{t 'Cannot send message to a deactivated user.' }}
+</template>
+<template id="compose_reply_button_disabled_for_deactivated_users_tooltip_template">
+    {{t 'Cannot send a message to a group that contains a deactivated user.' }}
+</template>
 <template id="left_bar_compose_mobile_button_tooltip_template">
     {{t 'New message' }}
     {{tooltip_hotkey_hints "C"}}

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -67,6 +67,12 @@ const old_user = {
     email: "old_user@example.com",
 };
 
+const deactivated_user = {
+    user_id: 1006,
+    full_name: "Deactivated user",
+    email: "deactivated_user@example.com",
+};
+
 const bot = {
     user_id: 55555,
     full_name: "Red Herring Bot",
@@ -451,6 +457,12 @@ test("level", () => {
 });
 
 test("user_last_seen_time_status", ({override}) => {
+    people.deactivate(deactivated_user);
+    assert.equal(
+        buddy_data.user_last_seen_time_status(deactivated_user.user_id),
+        "translated: User is deactivated",
+    );
+
     set_presence(selma.user_id, "active");
     set_presence(me.user_id, "active");
 

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -186,8 +186,16 @@ test("start", ({override, override_rewire, mock_template}) => {
     stream_data.clear_subscriptions();
 
     // Start direct message
+    const pm_recipient = {
+        user_id: 101,
+        email: "foo@example.com",
+        full_name: "Foo",
+    };
+
+    people.add_active_user(pm_recipient);
+
     compose_defaults = {
-        private_message_recipient: "foo@example.com",
+        private_message_recipient: pm_recipient.email,
     };
 
     opts = {

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -703,6 +703,8 @@ run_test("realm_domains", ({override}) => {
 
 run_test("realm_user", ({override}) => {
     override(settings_account, "maybe_update_deactivate_account_button", noop);
+    let selected_message;
+    override(message_lists.current, "selected_message", () => selected_message);
     let event = event_fixtures.realm_user__add;
     dispatch({...event});
     const added_person = people.get_by_user_id(event.person.user_id);

--- a/web/tests/example4.test.js
+++ b/web/tests/example4.test.js
@@ -59,11 +59,13 @@ const activity = mock_esm("../src/activity");
 const message_live_update = mock_esm("../src/message_live_update");
 const pm_list = mock_esm("../src/pm_list");
 const settings_users = mock_esm("../src/settings_users");
+const compose_closed_ui = mock_esm("../src/compose_closed_ui");
 
 // Use real versions of these modules.
 const people = zrequire("people");
 const server_events_dispatch = zrequire("server_events_dispatch");
 
+const noop = () => {};
 const bob = {
     email: "bob@example.com",
     user_id: 33,
@@ -79,7 +81,7 @@ run_test("add users with event", ({override}) => {
         op: "add",
         person: bob,
     };
-
+    override(compose_closed_ui, "update_reply_button_deactivated_users", noop);
     assert.ok(!people.is_known_user_id(bob.user_id));
 
     // We need to override a stub here before dispatching the event.

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -300,6 +300,7 @@ test_people("basics", () => {
 
     // Now deactivate isaac
     people.deactivate(isaac);
+    assert.equal(people.verify_non_active_human_id(isaac.user_id), true);
     assert.equal(people.get_non_active_human_ids().length, 1);
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(people.is_active_user_for_popover(isaac.user_id), false);
@@ -1267,6 +1268,14 @@ test_people("get_realm_active_human_users", () => {
     humans = people.get_realm_active_human_users();
     assert.equal(humans.length, 1);
     assert.deepEqual(humans, [me]);
+});
+
+test_people("get_names_for_deactivated_users", () => {
+    people.add_active_user(steven);
+    people.add_active_user(isaac);
+    people.deactivate(isaac);
+    const users = [steven.user_id, isaac.user_id];
+    assert.deepEqual(people.get_names_for_deactivated_users(users), ["Isaac Newton"]);
 });
 
 // reset to native Date()


### PR DESCRIPTION
**If the user is deactivated**:

- change empty PM/group PM view text.
- keep the compose_box closed and blocked for the PM with deactivated user or a group containing a deactivated user.
- block the compose_box in `all_message_narrow` and `recent conversations narrow` if the recipient of the selected message is deactivated.
- Change the text to:

       - pm-with:
         Line 1: You have no direct messages with {person}
         Line 2: [user's name] is no longer active in this organization.

      - group pm-with:
         Line 1: You have no direct messages with these users.
         Line 2: [user's name] is no longer active in this organization.

      - dm-including:
        Line 1: You have no direct messages including {person}.
        Line 2: [user's name] is no longer active in this organization.

- Keep the compose box as-is, rather than opening it up for the "pm-with:" search, as we currently do.
- Change the text of user status tooltip to `User is deactivated`

----------------------------------------

**Fixes** #23408. **Fixes** #22278.
**CZO:** [Thread](https://chat.zulip.org/#narrow/stream/101-design/topic/pm.20with.20deactivated.20user.20behaviour.20.2323899/near/1482943)

----------------------------------------
- **King Hamlit  is deactivated**

### DEMO: 

<details>
<summary>Before:</summary>
<br>

https://user-images.githubusercontent.com/66828942/208317489-803e886e-01e3-4157-8fd1-e0f2c3180f15.mp4
</details>

 

### After:

---------------------------------------------------

<details>
<summary>All message narrow:</summary>
<br>

![all_messages_narrow](https://user-images.githubusercontent.com/66828942/234410788-e95572c7-27e8-4cf5-bce7-b9d33a54b95f.gif)



</details>


<details>
<summary>pm-with-deactivated-user:</summary>
<br>


![pm_with_deactivated_user](https://user-images.githubusercontent.com/66828942/234410815-48edc420-3977-4d43-bf30-0b807ce394c6.gif)


</details>


<details>
<summary>group-pm-having-deactivated-user:</summary>
<br>


![group-pm](https://user-images.githubusercontent.com/66828942/234410878-4ff004c9-b987-49d1-bc21-71adf5213c12.gif)


</details>

<details>
<summary>narrow-banner-change:</summary>
<br>

![Screenshot from 2023-04-26 02-41-35](https://user-images.githubusercontent.com/66828942/234410950-dd2fd3b6-5893-41de-bfab-93bdc43c8423.png)



<br>

![Screenshot from 2023-04-26 02-41-43](https://user-images.githubusercontent.com/66828942/234410979-649c7357-7254-4396-a4e4-aa3a71834af5.png)

<br>

![Screenshot from 2023-04-26 03-06-15](https://user-images.githubusercontent.com/66828942/234411018-9a0a202a-d4de-41ab-9a12-2bcb8595c2d1.png)


</details>

<details>
<summary>User status tooltip:</summary>
<br>

![Screenshot from 2023-03-18 06-51-20](https://user-images.githubusercontent.com/66828942/226075726-6e8a59a4-9b3f-4e79-a141-40345e6216b7.png)


</details>

------------------------------

<details>
<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
