### PR TITLE
Improve organization of Display settings menu. Fixes #23288

### DIFF
--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -69,15 +69,15 @@ export const default_view_values = {
 export const color_scheme_values = {
     automatic: {
         code: 1,
-        description: $t({defaultMessage: "Sync with computer"}),
+        description: $t({defaultMessage: "Automatic (follows system settings)"}),
     },
     night: {
         code: 2,
-        description: $t({defaultMessage: "Dark theme"}),
+        description: $t({defaultMessage: "Light"}),
     },
     day: {
         code: 3,
-        description: $t({defaultMessage: "Light theme"}),
+        description: $t({defaultMessage: "Dark"}),
     },
 };
 

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -26,6 +26,13 @@
             </select>
         </div>
 
+         <div class="input-group">
+            <label for="color_scheme" class="dropdown-title">{{t "Color scheme" }}</label>
+            <select name="color_scheme" class="setting_color_scheme prop-element" id="{{prefix}}color_scheme" data-setting-widget-type="number">
+                {{> dropdown_options_widget option_values=color_scheme_values}}
+            </select>
+        </div>
+
     </div>
 
 
@@ -35,12 +42,7 @@
             {{> settings_save_discard_widget section_name="theme-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
-        <div class="input-group">
-            <label for="color_scheme" class="dropdown-title">{{t "Color scheme" }}</label>
-            <select name="color_scheme" class="setting_color_scheme prop-element" id="{{prefix}}color_scheme" data-setting-widget-type="number">
-                {{> dropdown_options_widget option_values=color_scheme_values}}
-            </select>
-        </div>
+       
 
         <div class="input-group">
             <label class="emoji-theme title">{{t "Emoji theme" }}</label>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -26,7 +26,7 @@
             </select>
         </div>
 
-         <div class="input-group">
+        <div class="input-group">
             <label for="color_scheme" class="dropdown-title">{{t "Theme" }}</label>
             <select name="color_scheme" class="setting_color_scheme prop-element" id="{{prefix}}color_scheme" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=color_scheme_values}}
@@ -41,8 +41,6 @@
             <h3 class="light">{{t "Emoji" }}</h3>
             {{> settings_save_discard_widget section_name="theme-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
-
-       
 
         <div class="input-group">
             <label class="emoji-theme title">{{t "Emoji theme" }}</label>
@@ -82,7 +80,6 @@
           label=settings_label.display_emoji_reaction_users
           prefix=prefix}}
 
-        
     </div>
 
     <div class="advanced-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -27,7 +27,7 @@
         </div>
 
          <div class="input-group">
-            <label for="color_scheme" class="dropdown-title">{{t "Color scheme" }}</label>
+            <label for="color_scheme" class="dropdown-title">{{t "Theme" }}</label>
             <select name="color_scheme" class="setting_color_scheme prop-element" id="{{prefix}}color_scheme" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=color_scheme_values}}
             </select>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -82,6 +82,15 @@
           label=settings_label.display_emoji_reaction_users
           prefix=prefix}}
 
+        
+    </div>
+
+    <div class="advanced-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
+        <div class="subsection-header">
+            <h3 class="light">{{t "Advanced" }}</h3>
+            {{> settings_save_discard_widget section_name="advanced-settings" show_only_indicator=(not for_realm_settings) }}
+        </div>
+
         <div class="input-group">
             <label class="title">{{t "User list style" }}</label>
             <div class="user_list_style_values grey-box prop-element" id="{{prefix}}user_list_style" data-setting-widget-type="radio-group" data-setting-choice-type="number">
@@ -107,13 +116,6 @@
                     </label>
                 {{/each}}
             </div>
-        </div>
-    </div>
-
-    <div class="advanced-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
-        <div class="subsection-header">
-            <h3 class="light">{{t "Advanced" }}</h3>
-            {{> settings_save_discard_widget section_name="advanced-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
         <div class="input-group thinner setting-next-is-related">

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -4,7 +4,7 @@
         it. If there's not an alert, don't make it inline-block.-->
         <div class="subsection-header inline-block">
             {{#if for_realm_settings}}
-            <h3>{{t "Time" }}</h3>
+            <h3>{{t "General" }}</h3>
             {{else}}
             <h3>{{t "General" }}</h3>
             {{/if}}

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -31,7 +31,7 @@
 
     <div class="theme-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">
         <div class="subsection-header">
-            <h3 class="light">{{t "Theme" }}</h3>
+            <h3 class="light">{{t "Emoji" }}</h3>
             {{> settings_save_discard_widget section_name="theme-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -6,7 +6,7 @@
             {{#if for_realm_settings}}
             <h3>{{t "Time" }}</h3>
             {{else}}
-            <h3>{{t "Language and time" }}</h3>
+            <h3>{{t "General" }}</h3>
             {{/if}}
             {{> settings_save_discard_widget section_name="lang-time-settings" show_only_indicator=(not for_realm_settings) }}
         </div>

--- a/templates/zerver/help/change-the-time-format.md
+++ b/templates/zerver/help/change-the-time-format.md
@@ -9,7 +9,7 @@ format (e.g. 5:00 PM) or a 24-hour format (e.g. 17:00).
 
 {settings_tab|display-settings}
 
-1. Under **Language and time**, select your preferred option from the
+1. Under **General**, select your preferred option from the
 **Time format** dropdown.
 
 {end_tabs}

--- a/templates/zerver/help/change-your-language.md
+++ b/templates/zerver/help/change-your-language.md
@@ -13,7 +13,7 @@ messages you receive.
 
 {settings_tab|display-settings}
 
-1. Under **Language and time**, click the button under **Language**.
+1. Under **General**, click the button under **Language**.
 
 1. Select a language.
 

--- a/templates/zerver/help/dark-theme.md
+++ b/templates/zerver/help/dark-theme.md
@@ -9,13 +9,13 @@ for working in a dark space.
 
 {settings_tab|display-settings}
 
-2. Under **Theme**, configure **Color scheme**.
+2. Under **General**, configure **Theme**.
 
 {end_tabs}
 
-The default is **Sync with computer**, which detects which theme to use based
+The default is **Automatic (follows system settings)**, which detects which theme to use based
 on the color scheme used by your operating system.
 
-You can also specify **Dark theme** or **Light theme** if you'd like
+You can also specify the theme to be **Light** or **Dark** if you'd like
 Zulip to use the same color scheme regardless of your operating system
 configuration.

--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -21,7 +21,7 @@ automatically by Zulip.
 
 {settings_tab|display-settings}
 
-1. Under **Theme**, select **Convert emoticons before sending**.
+1. Under **Emoji**, select **Convert emoticons before sending**.
 
 {end_tabs}
 


### PR DESCRIPTION
Improve organization of Display settings menu. Change the first section header to "General" and second section header to "Emoji". Move the color scheme selector to the General section, rename it "Theme" and rename the theme options. Move the "User list style" setting to the top of the Advanced section. Make sure all the changes above are also applied to Organization settings > Sefault User Settings. Update all the relevant help center documentation to reflect the above changes.

Fixes: #23288

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="1069" alt="Skärmavbild 2022-12-19 kl  12 33 53" src="https://user-images.githubusercontent.com/112871049/208508226-393144ac-7aef-4be3-869f-e1930567e5e7.png">

<img width="667" alt="Skärmavbild 2022-12-19 kl  13 22 15" src="https://user-images.githubusercontent.com/112871049/208508269-ee7f17bb-ffd7-4de2-8358-de0cf8fd5f92.png">
<img width="679" alt="Skärmavbild 2023-01-08 kl  22 58 47" src="https://user-images.githubusercontent.com/112871049/211221285-da0b2ed5-c11c-429a-9c97-0936c4921006.png">
<img width="839" alt="Skärmavbild 2023-01-08 kl  23 02 02" src="https://user-images.githubusercontent.com/112871049/211221287-961ced23-c704-4b7f-9af8-80da70df2ed5.png">
<img width="838" alt="Skärmavbild 2023-01-08 kl  23 02 21" src="https://user-images.githubusercontent.com/112871049/211221289-4f089595-b53c-4290-bc2c-691b731b6e77.png">
<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
