### PR TITLE
fix typo in code-style.md.

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -141,7 +141,7 @@ You should work with the IDs instead:
 ```python
 obj: UserProfile = get_user_profile_by_id(17)
 some_objs = UserProfile.objects.get(id=17)
-assert obj.id in set([o.id for i in some_objs])
+assert obj.id in set([o.id for o in some_objs])
 ```
 
 ### user_profile.save()


### PR DESCRIPTION
<!-- fixed typo in code-style.md-->

Fixes: <!--for loop was using i, changed it to o as o.id was used in for loop.-->

