### PR TITLE
Revert "openapi: Declare items: {} for “inherited” array properties."

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15622,8 +15622,7 @@ components:
             avatar_url: {}
             owner_id:
               nullable: true
-            services:
-              items: {} # https://github.com/p1c2u/openapi-core/issues/380
+            services: {}
     BasicBotBase:
       type: object
       properties:
@@ -15730,8 +15729,7 @@ components:
             avatar_url: {}
             owner_id:
               nullable: true
-            services:
-              items: {} # https://github.com/p1c2u/openapi-core/issues/380
+            services: {}
             email:
               type: string
               description: |


### PR DESCRIPTION
This reverts commit a503d19eaeb2074031441dfa19fdf930952252fa (#20755).

The openapi-core bug was fixed upstream.