### PR TITLE
Private Messages: Scroll the left-sidebar container to desired pm whe…

### DIFF
--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -4,6 +4,7 @@ import _ from "lodash";
 import * as pm_list_data from "./pm_list_data";
 import * as pm_list_dom from "./pm_list_dom";
 import * as resize from "./resize";
+import * as scroll_util from "./scroll_util";
 import * as topic_zoom from "./topic_zoom";
 import * as ui from "./ui";
 import * as ui_util from "./ui_util";
@@ -123,6 +124,20 @@ function unhighlight_all_private_messages_view() {
     $(".private_messages_container").removeClass("active_private_messages_section");
 }
 
+function scroll_pm_into_view($target_li) {
+    const $container = $("#left_sidebar_scroll_container");
+    const pm_header_height = $("#private_messages_section_header").outerHeight();
+    if ($target_li.length > 0) {
+        scroll_util.scroll_element_into_container($target_li, $container, pm_header_height);
+    }
+}
+
+function scroll_all_private_into_view() {
+    const $container = $("#left_sidebar_scroll_container");
+    const $scroll_element = ui.get_scroll_element($container);
+    $scroll_element.scrollTop(0);
+}
+
 export function handle_narrow_activated(filter) {
     const active_filter = filter;
     const is_all_private_message_view = _.isEqual(active_filter.sorted_term_types(), [
@@ -131,11 +146,21 @@ export function handle_narrow_activated(filter) {
     const narrow_to_private_messages_section = active_filter.operands("pm-with").length !== 0;
 
     if (is_all_private_message_view) {
+        // In theory, this should get expanded when we scroll to the
+        // top, but empirically that doesn't occur, so we just ensure the
+        // section is expanded before scrolling.
+        expand();
         highlight_all_private_messages_view();
+        scroll_all_private_into_view();
     } else {
         unhighlight_all_private_messages_view();
     }
     if (narrow_to_private_messages_section) {
+        const current_user_ids_string = pm_list_data.get_active_user_ids_string();
+        const $active_filter_li = $(
+            `li[data-user-ids-string='${CSS.escape(current_user_ids_string)}']`,
+        );
+        scroll_pm_into_view($active_filter_li);
         update_private_messages();
     }
 }

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -36,6 +36,9 @@ const unread_ops = mock_esm("../src/unread_ops");
 mock_esm("../src/recent_topics_util", {
     is_visible() {},
 });
+mock_esm("../src/pm_list", {
+    handle_narrow_activated() {},
+});
 
 //
 // We have strange hacks in narrow.activate to sleep 0


### PR DESCRIPTION
…n not in view.

Fixes #23609: scroll selected pm when not in view by using the scroll_util module to scroll the left-sidebar-container inside pm_list.js which is used in a similar fashion in stream_list.js.

<!-- Describe your pull request here.-->

Fixes: #23609: Scroll selected pm when not in view.
Major changes:
1. Imported the scroll_util module inside `pm_list.js`.
2. Created two new functions inside `pm_list.js` to increase code reuse - `get_user_id()` and `get_user_li()`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Screencasts showing the differences are attached below:
![zulip - early behaviour](https://user-images.githubusercontent.com/95919665/208834832-38ac1942-22d2-40f5-a501-d6f8c1b00249.gif)
Above is the original behavior

-----------------------------------------------------------------------------------------------
![zulip - new behaviour ](https://user-images.githubusercontent.com/95919665/208834972-52c05bbf-3070-448e-acc6-9b5e7e988619.gif)
 Above is the new behavior after code changes.
<details>


<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
