### PR TITLE
demo-orgs: Show demo organization owner name in dev login page.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -818,13 +818,6 @@ input#terminal:checked ~ #tab-terminal {
     min-width: 300px;
 }
 
-.btn-admin {
-    background-color: hsl(0, 0%, 100%);
-    border-color: hsl(198, 100%, 48%);
-    border-style: solid;
-    color: hsl(207, 89%, 54%);
-}
-
 .login-page {
     text-align: center;
 

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -163,27 +163,17 @@ html {
         display: inline-block;
     }
 
-    input[type="submit"] {
-        color: hsl(0, 0%, 67%);
-        border: 1px solid hsl(0, 0%, 87%);
+    .btn-dev-login {
+        color: hsl(170, 41%, 52%);
+        border: 1px solid hsl(170, 41%, 52%);
         border-radius: 4px;
         background-color: transparent;
 
         transition: color 0.3s ease, border 0.3s ease;
 
         &:hover {
-            border-color: hsl(0, 0%, 53%);
-            color: hsl(0, 0%, 27%);
-        }
-
-        &.btn-admin {
-            border-color: hsl(170, 41%, 52%);
-            color: hsl(170, 41%, 52%);
-
-            &:hover {
-                color: hsl(156, 62%, 61%);
-                border-color: hsl(156, 62%, 61%);
-            }
+            color: hsl(156, 62%, 61%);
+            border-color: hsl(156, 62%, 61%);
         }
     }
 }

--- a/templates/zerver/development/dev_login.html
+++ b/templates/zerver/development/dev_login.html
@@ -33,8 +33,14 @@ page can be easily identified in it's respective JavaScript file -->
                     {% if direct_owners %}
                         {% for direct_owner in direct_owners %}
                         <p>
-                            <input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_owner.delivery_email }}" />
+                            <button type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('login-local') }}"
+                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_owner.delivery_email }}">
+                                {% if direct_owner.realm.demo_organization_scheduled_deletion_date %}
+                                    {{ direct_owner.full_name }}
+                                {% else %}
+                                    {{ direct_owner.delivery_email }}
+                                {% endif %}
+                            </button>
                         </p>
                         {% endfor %}
                     {% else %}

--- a/templates/zerver/development/dev_login.html
+++ b/templates/zerver/development/dev_login.html
@@ -26,7 +26,7 @@ page can be easily identified in it's respective JavaScript file -->
                     <h2>{{_('Anonymous user') }}</h2>
                     <p>
                         <input type="submit" formaction="{{ current_realm.uri }}{{ url('login-local') }}"
-                          name="prefers_web_public_view" class="btn-direct btn-admin" value="Anonymous login" />
+                          name="prefers_web_public_view" class="btn-direct btn-dev-login" value="Anonymous login" />
                     </p>
                     {% endif %}
                     <h2>{{_('Owners') }}</h2>
@@ -34,7 +34,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_owner in direct_owners %}
                         <p>
                             <input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_owner.delivery_email }}" />
+                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_owner.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -45,7 +45,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_admin in direct_admins %}
                         <p>
                             <input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.delivery_email }}" />
+                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_admin.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -56,7 +56,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_moderator in direct_moderators %}
                         <p>
                             <input type="submit" formaction="{{ direct_moderator.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_moderator.delivery_email }}" />
+                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_moderator.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -67,7 +67,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for guest_user in guest_users %}
                         <p>
                             <input type="submit" formaction="{{ guest_user.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-admin" value="{{ guest_user.delivery_email }}" />
+                              name="direct_email" class="btn-direct btn-dev-login" value="{{ guest_user.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -81,7 +81,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_user in direct_users %}
                         <p>
                             <input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-admin" value="{{ direct_user.delivery_email }}" />
+                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_user.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -103,13 +103,13 @@ page can be easily identified in it's respective JavaScript file -->
         <div id="devtools-wrapper">
             <div id="devtools-registration">
                 <form name="register_dev_user" action="{{ url('register_dev_user') }}" method="POST">
-                    <input type="submit" class="btn btn-admin" value="Create new user" />
+                    <input type="submit" class="btn btn-dev-login" value="Create new user" />
                 </form>
                 <form name="register_dev_realm" action="{{ url('register_dev_realm') }}" method="POST">
-                    <input type="submit" class="btn btn-admin" value="Create new realm" />
+                    <input type="submit" class="btn btn-dev-login" value="Create new realm" />
                 </form>
                 <form name="register_demo_dev_realm" action="{{ url('register_demo_dev_realm') }}" method="POST">
-                    <input type="submit" class="btn btn-admin" value="Create demo organization" />
+                    <input type="submit" class="btn btn-dev-login" value="Create demo organization" />
                 </form>
             </div>
             <a href="/devtools">Zulip developer tools</a>


### PR DESCRIPTION
Because the plan is to create demo organizations without requiring an email, this preps the dev login page so that when a demo organization is created in the development environment, the organization owner's name will appear on the login button for the owner on the dev login page. Otherwise it would be a blank button with no text until the organization owner's email was set.

**Notes**:
- To show the owner's full name in the button, the HTML element is changed to a button element instead of an input element.
- Because the CSS rule for the visual formatting on the dev login page was based on the HTML element being an input element, I added a prep commit that adjusts the CSS rule to a class that was already doing most of the work. That way these CSS changes definitely do not impact any other portico pages.

**Thoughts/Questions**:
- The focus behavior (border color and size) for these dev login buttons seems to be coming from the browser defaults. I thought maybe it might be nice to add that as well?
- I'm also not a huge fan of the `btn-direct` class name, which is also only used for these dev login buttons. That CSS rule is in `portico.css` vs `portico_signin.css`. The smaller, realm creation buttons do not use this class, but the individual login buttons do.

**Screenshots**:

<details>
<summary>Zulip Dev login page</summary>

![Screenshot from 2022-12-21 18-14-38](https://user-images.githubusercontent.com/63245456/208965120-e89ddd58-c1fe-4f1b-a15e-3982def15961.png)
</details>
<details>
<summary>Demo organization login page</summary>

![Screenshot from 2022-12-21 18-14-51](https://user-images.githubusercontent.com/63245456/208965100-e07c578c-230f-4726-b926-dcdc2bd04cb7.png)
</details>
<details>
<summary>All realms login page</summary>

![Screenshot from 2022-12-21 18-15-15](https://user-images.githubusercontent.com/63245456/208965081-1cde726b-468e-400c-88de-8f9391b80e9d.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
