### PR TITLE
send_email: Improve configurability for Zulip outgoing email sender name.

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1789,7 +1789,7 @@ class StripeTest(StripeTestCase):
             self.assertEqual(message.subject, "Support request for zulip")
             self.assertEqual(message.reply_to, ["hamlet@zulip.com"])
             self.assertEqual(self.email_envelope_from(message), settings.NOREPLY_EMAIL_ADDRESS)
-            self.assertIn("Zulip Support <noreply-", self.email_display_from(message))
+            self.assertIn("Zulip support request <noreply-", self.email_display_from(message))
             self.assertIn("Requested by: King Hamlet (Member)", message.body)
             self.assertIn(
                 "Support URL: http://zulip.testserver/activity/support?q=zulip", message.body
@@ -1840,7 +1840,7 @@ class StripeTest(StripeTestCase):
             self.assertEqual(message.subject, "Sponsorship request (Open-source project) for zulip")
             self.assertEqual(message.reply_to, ["hamlet@zulip.com"])
             self.assertEqual(self.email_envelope_from(message), settings.NOREPLY_EMAIL_ADDRESS)
-            self.assertIn("Zulip sponsorship <noreply-", self.email_display_from(message))
+            self.assertIn("Zulip sponsorship request <noreply-", self.email_display_from(message))
             self.assertIn("Requested by: King Hamlet (Member)", message.body)
             self.assertIn(
                 "Support URL: http://zulip.testserver/activity/support?q=zulip", message.body

--- a/corporate/views/support.py
+++ b/corporate/views/support.py
@@ -41,11 +41,11 @@ def support_request(request: HttpRequest) -> HttpResponse:
                 "support_url": get_support_url(user.realm),
                 "user_role": user.get_role_name(),
             }
-
+            # Sent to the server's support team, so this email is not user-facing.
             send_email(
                 "zerver/emails/support_request",
                 to_emails=[FromAddress.SUPPORT],
-                from_name="Zulip Support",
+                from_name="Zulip support request",
                 from_address=FromAddress.tokenized_no_reply_address(),
                 reply_to_email=user.delivery_email,
                 context=email_context,

--- a/corporate/views/upgrade.py
+++ b/corporate/views/upgrade.py
@@ -202,10 +202,11 @@ def sponsorship(
             "paid_users_count": paid_users_count,
             "paid_users_description": paid_users_description,
         }
+        # Sent to the server's support team, so this email is not user-facing.
         send_email(
             "zerver/emails/sponsorship_request",
             to_emails=[FromAddress.SUPPORT],
-            from_name="Zulip sponsorship",
+            from_name="Zulip sponsorship request",
             from_address=FromAddress.tokenized_no_reply_address(),
             reply_to_email=user.delivery_email,
             context=context,

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import Exists, OuterRef
 from django.utils.timezone import now as timezone_now
+from django.utils.translation import gettext as _
 from typing_extensions import TypeAlias
 
 from confirmation.models import one_click_unsubscribe_link
@@ -408,7 +409,7 @@ def bulk_handle_digest_email(user_ids: List[int], cutoff: float) -> None:
             "zerver/emails/digest",
             user.realm,
             to_user_ids=[user.id],
-            from_name="Zulip Digest",
+            from_name=_("{service_name} digest").format(service_name=settings.INSTALLATION_NAME),
             from_address=FromAddress.no_reply_placeholder,
             context=context,
         )

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -379,7 +379,7 @@ def bulk_get_digest_context(
 
 
 def get_digest_context(user: UserProfile, cutoff: float) -> Dict[str, Any]:
-    for _, context in bulk_get_digest_context([user], cutoff):
+    for ignored, context in bulk_get_digest_context([user], cutoff):
         return context
     raise AssertionError("Unreachable")
 

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -574,7 +574,9 @@ def do_send_missedmessage_events_reply_in_zulip(
     )
 
     with override_language(user_profile.default_language):
-        from_name: str = _("Zulip notifications")
+        from_name: str = _("{service_name} notifications").format(
+            service_name=settings.INSTALLATION_NAME
+        )
     from_address = FromAddress.NOREPLY
 
     email_dict = {

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -70,7 +70,9 @@ class FromAddress:
             language = user_profile.default_language
 
         with override_language(language):
-            return _("Zulip Account Security")
+            return _("{service_name} account security").format(
+                service_name=settings.INSTALLATION_NAME
+            )
 
 
 def build_email(

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -194,7 +194,7 @@ class EmailChangeTestCase(ZulipTestCase):
         self.assertEqual(self.email_envelope_from(email_message), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
             self.email_display_from(email_message),
-            rf"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
+            rf"^testserver account security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
 
         self.assertEqual(email_message.extra_headers["List-Id"], "Zulip Dev <zulip.testserver>")
@@ -392,7 +392,7 @@ class EmailChangeTestCase(ZulipTestCase):
         self.assertEqual(self.email_envelope_from(email_message), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
             self.email_display_from(email_message),
-            rf"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
+            rf"^testserver account security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
         self.assertEqual(email_message.extra_headers["List-Id"], "Zulip Dev <zulip.testserver>")
 

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -402,7 +402,7 @@ class TestPasswordRestEmail(ZulipTestCase):
         self.assertEqual(self.email_envelope_from(outbox[0]), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
             self.email_display_from(outbox[0]),
-            rf"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
+            rf"^testserver account security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
         self.assertIn("reset your password", outbox[0].body)
 

--- a/zerver/tests/test_message_notification_emails.py
+++ b/zerver/tests/test_message_notification_emails.py
@@ -131,7 +131,9 @@ class TestMessageNotificationEmails(ZulipTestCase):
             reply_to_emails = ["noreply@testserver"]
         msg = mail.outbox[0]
         assert isinstance(msg, EmailMultiAlternatives)
-        from_email = str(Address(display_name="Zulip notifications", addr_spec=FromAddress.NOREPLY))
+        from_email = str(
+            Address(display_name="testserver notifications", addr_spec=FromAddress.NOREPLY)
+        )
         self.assert_length(mail.outbox, 1)
         self.assertEqual(self.email_envelope_from(msg), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertEqual(self.email_display_from(msg), from_email)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -452,7 +452,7 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(self.email_envelope_from(outbox[0]), settings.NOREPLY_EMAIL_ADDRESS)
         self.assertRegex(
             self.email_display_from(outbox[0]),
-            rf"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
+            rf"^testserver account security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
         self.assertIn("Reactivate your Zulip organization", outbox[0].subject)
         self.assertIn("Dear former administrators", outbox[0].body)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -16,7 +16,6 @@ from django.http import HttpResponse, HttpResponseBase
 from django.template.response import TemplateResponse
 from django.test import Client, override_settings
 from django.utils import translation
-from django.utils.translation import gettext as _
 
 from confirmation import settings as confirmation_settings
 from confirmation.models import Confirmation, one_click_unsubscribe_link
@@ -360,7 +359,7 @@ class PasswordResetTest(ZulipTestCase):
         # The email might be sent in different languages for i18n testing
         self.assertRegex(
             self.email_display_from(message),
-            rf'^{_("Zulip Account Security")} <{self.TOKENIZED_NOREPLY_REGEX}>\Z',
+            rf"^testserver account security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
         self.assertIn(f"{subdomain}.testserver", message.extra_headers["List-Id"])
 

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -485,6 +485,8 @@ WELCOME_EMAIL_SENDER: Optional[Dict[str, str]] = None
 
 # Whether to send periodic digests of activity.
 SEND_DIGEST_EMAILS = True
+# The variable part of email sender names to be used for outgoing emails.
+INSTALLATION_NAME = EXTERNAL_HOST
 
 # Used to change the Zulip logo in portico pages.
 CUSTOM_LOGO_URL: Optional[str] = None

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -101,6 +101,13 @@ EXTERNAL_HOST = "zulip.example.com"
 ## confirmation emails when ADD_TOKENS_TO_NOREPLY_ADDRESS=False.
 # NOREPLY_EMAIL_ADDRESS = "noreply@example.com"
 
+## Emails sent by the Zulip server will use a sender name starting
+## with INSTALLATION_NAME. The default is EXTERNAL_HOST. If INSTALLATION_NAME is
+## "zulip.example.com", email senders names will include:
+## * "zulip.example.com notifications" (message notification emails).
+## * "zulip.example.com account security" (account security emails).
+# INSTALLATION_NAME = "My Zulip Server"
+
 ## Many countries and bulk mailers require certain types of email to display
 ## a physical mailing address to comply with anti-spam legislation.
 ## Non-commercial and non-public-facing installations are unlikely to need


### PR DESCRIPTION
Currently, the **sender names** for outgoing emails sent by Zulip **are hardcoded**. It **should be configurable for self-hosted** systems.

The first commit performs minor upgrade in  'from_name' text for **non user-facing emails**:
* `Zulip Support`
* `Zulip Sponsorship` 

The second **commit makes the 'Zulip' part a variable** in the following email sender names: 
* `Zulip Account Security`
* `Zulip Digest`
* `Zulip Notifications`

by introducing a settings variable `SERVICE_NAME` with the default value as f"{EXTERNAL_HOST} Zulip".

**Note**: Default value can be `{realm_name}` or `{realm_host}` or `EXTERNAL_HOST`. (It is yet to be decided as discussed in the [issue description](https://github.com/zulip/zulip/issues/23857).)

**Update**: Default value = f"{EXTERNAL_HOST} Zulip"

Fixes: #23857

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

`SERVICE_NAME` with its default value

![Screenshot from 2023-01-03 16-02-58](https://user-images.githubusercontent.com/56781761/210344329-617f1eb3-1143-498a-b148-c372f52ff5a3.png)

**non user-facing emails**

![Screenshot from 2023-01-03 16-19-35](https://user-images.githubusercontent.com/56781761/210344586-b3dd2e01-f863-4f9e-9c99-89ea7f49ae26.png)

![Screenshot from 2023-01-03 16-21-03](https://user-images.githubusercontent.com/56781761/210345146-47a50421-f920-4786-96da-76d50d70e68e.png)


`SERVICE_NAME` value updated as `zulip cloud` in `prod_settings_template`.


![Screenshot from 2023-01-03 16-25-40](https://user-images.githubusercontent.com/56781761/210345330-4f585b34-3105-41d6-ac7f-abf5321350ae.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
