### PR TITLE
settings: Fix background-color of save-discard widget in dark theme.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -740,7 +740,8 @@ div.overlay {
     }
 }
 
-.save-button-controls {
+#stream_settings .save-button-controls,
+#settings_page .save-button-controls {
     display: inline;
     margin-left: 15px;
 

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -762,7 +762,6 @@ div.overlay {
 
         &:hover,
         &:focus {
-            background-color: hsl(0, 0%, 100%);
             border: 1px solid hsl(0, 0%, 61%);
             color: hsl(0, 0%, 18%);
 

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -763,10 +763,9 @@ div.overlay {
         &:hover,
         &:focus {
             border: 1px solid hsl(0, 0%, 61%);
-            color: hsl(0, 0%, 18%);
 
-            .save-discard-widget-button-icon {
-                color: hsl(0, 0%, 47%);
+            .discard-button.save-discard-widget-button-text {
+                color: hsl(0, 0%, 18%);
             }
         }
 

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1402,7 +1402,13 @@
     #settings_page,
     #stream_settings {
         .save-button-controls .discard-button {
-            color: inherit;
+            color: hsl(0, 0%, 80%);
+
+            &:hover {
+                .save-discard-widget-button-text {
+                    color: hsl(0, 0%, 100%);
+                }
+            }
         }
     }
 }

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -1398,6 +1398,13 @@
             background-color: hsla(0, 0%, 100%, 0.1);
         }
     }
+
+    #settings_page,
+    #stream_settings {
+        .save-button-controls .discard-button {
+            color: inherit;
+        }
+    }
 }
 
 @supports (-moz-appearance: none) {


### PR DESCRIPTION
The correct background-color for buttons of save-discard widget was not being applied and instead almost transparent color was applied to dark-theme CSS rules. This commit adds ID to the selector such that CSS in app_components.css is preferred over dark-theme css.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2022-12-26 17-07-44](https://user-images.githubusercontent.com/35494118/209544833-75f5b92f-cdd3-4f14-8e98-0bdd461fc564.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
