### PR TITLE
invites: Validation error instead of DB exception on overflowed SMALLINT.

### DIFF
--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -161,6 +161,11 @@ def check_int(var_name: str, val: object) -> int:
 
 
 def check_int_in(possible_values: List[int]) -> Validator[int]:
+    """
+    Assert that the input is an integer and is contained in `possible_values`. If the input is not in
+    `possible_values`, a `ValidationError` is raised containing the failing field's name.
+    """
+
     def validator(var_name: str, val: object) -> int:
         n = check_int(var_name, val)
         if n not in possible_values:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1501,7 +1501,7 @@ class InviteUserTest(InviteUserBase):
         self.login("iago")
         invitee = self.nonreg_email("alice")
         response = self.invite(invitee, ["Denmark"], invite_as=10)
-        self.assert_json_error(response, "Must be invited as an valid type of user")
+        self.assert_json_error(response, "Invalid invite_as")
 
     def test_successful_invite_user_as_guest_from_normal_account(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3220,6 +3220,17 @@ class MultiuseInviteTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Invalid stream ID 54321. No invites were sent.")
 
+    def test_create_multiuse_link_invalid_invite_as_api_call(self) -> None:
+        self.login("iago")
+        result = self.client_post(
+            "/json/invites/multiuse",
+            {
+                "invite_as": orjson.dumps(PreregistrationUser.INVITE_AS["GUEST_USER"] + 1).decode(),
+                "invite_expires_in_minutes": 2 * 24 * 60,
+            },
+        )
+        self.assert_json_error(result, "Invalid invite_as")
+
 
 class EmailUnsubscribeTests(ZulipTestCase):
     def test_error_unsubscribe(self) -> None:

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -46,7 +46,12 @@ def invite_users_backend(
     invite_expires_in_minutes: Optional[int] = REQ(
         json_validator=check_none_or(check_int), default=INVITATION_LINK_VALIDITY_MINUTES
     ),
-    invite_as: int = REQ(json_validator=check_int, default=PreregistrationUser.INVITE_AS["MEMBER"]),
+    invite_as: int = REQ(
+        json_validator=check_int_in(
+            list(PreregistrationUser.INVITE_AS.values()),
+        ),
+        default=PreregistrationUser.INVITE_AS["MEMBER"],
+    ),
     stream_ids: List[int] = REQ(json_validator=check_list(check_int)),
 ) -> HttpResponse:
 
@@ -54,8 +59,6 @@ def invite_users_backend(
         # Guest users case will not be handled here as it will
         # be handled by the decorator above.
         raise JsonableError(_("Insufficient permission"))
-    if invite_as not in PreregistrationUser.INVITE_AS.values():
-        raise JsonableError(_("Must be invited as an valid type of user"))
     check_if_owner_required(invite_as, user_profile)
     if (
         invite_as

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -19,7 +19,7 @@ from zerver.lib.exceptions import JsonableError, OrganizationOwnerRequiredError
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.streams import access_stream_by_id
-from zerver.lib.validator import check_int, check_list, check_none_or
+from zerver.lib.validator import check_int, check_int_in, check_list, check_none_or
 from zerver.models import MultiuseInvite, PreregistrationUser, Stream, UserProfile
 
 # Convert INVITATION_LINK_VALIDITY_DAYS into minutes.
@@ -190,7 +190,12 @@ def generate_multiuse_invite_backend(
     invite_expires_in_minutes: Optional[int] = REQ(
         json_validator=check_none_or(check_int), default=INVITATION_LINK_VALIDITY_MINUTES
     ),
-    invite_as: int = REQ(json_validator=check_int, default=PreregistrationUser.INVITE_AS["MEMBER"]),
+    invite_as: int = REQ(
+        json_validator=check_int_in(
+            list(PreregistrationUser.INVITE_AS.values()),
+        ),
+        default=PreregistrationUser.INVITE_AS["MEMBER"],
+    ),
     stream_ids: Sequence[int] = REQ(json_validator=check_list(check_int), default=[]),
 ) -> HttpResponse:
     check_if_owner_required(invite_as, user_profile)


### PR DESCRIPTION
If `invite_as` is passed as a number outside the range of a PostgreSQL `SMALLINT` field, the database throws an exception. Move this exception to the glass as a validation error to allow better client-side error handling and reduce database round-trips.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>