### PR TITLE
settings_org: Refactor code for dropdown list widget settings.

### DIFF
--- a/static/templates/settings/dropdown_list_widget.hbs
+++ b/static/templates/settings/dropdown_list_widget.hbs
@@ -1,5 +1,5 @@
 <div class="input-group dropdown-list-widget" id="{{widget_name}}_widget">
-    <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}" aria-labelledby="{{widget_name}}_label">
+    <span class="{{widget_name}}_setting dropup actual-dropdown-menu prop-element" id="id_{{widget_name}}" aria-labelledby="{{widget_name}}_label" data-setting-widget-type="dropdown-list-widget" {{#if value_type}}data-setting-value-type="{{value_type}}"{{/if}}>
         {{#if label}}
         <label id="{{widget_name}}_label" class="dropdown-title">
             {{ label }}

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -40,13 +40,15 @@
               widget_name="realm_notifications_stream_id"
               list_placeholder=(t 'Filter streams')
               reset_button_text=(t '[Disable]')
-              label=admin_settings_label.realm_notifications_stream }}
+              label=admin_settings_label.realm_notifications_stream
+              value_type="number" }}
 
             {{> dropdown_list_widget
               widget_name="realm_signup_notifications_stream_id"
               list_placeholder=(t 'Filter streams')
               reset_button_text=(t '[Disable]')
-              label=admin_settings_label.realm_signup_notifications_stream }}
+              label=admin_settings_label.realm_signup_notifications_stream
+              value_type="number" }}
             <div class="realm_default_language">
                 {{> language_selection_widget
                   section_name="realm_default_language"
@@ -126,7 +128,8 @@
                   widget_name="realm_default_code_block_language"
                   list_placeholder=(t 'Filter languages')
                   reset_button_text=(t '[Unset]')
-                  label=admin_settings_label.realm_default_code_block_language }}
+                  label=admin_settings_label.realm_default_code_block_language
+                  value_type="string" }}
 
                 {{> settings_checkbox
                   setting_name="realm_message_content_allowed_in_email_notifications"


### PR DESCRIPTION
This PR refactors the code for dropdown list widget settings such that we can reuse the added functions for further settings that will use `dropdown_list_widget`.
This change will be helpful when we will add group-based settings and change some of the existing role-based settings to be group-based.

We add a new function `get_widget_for_dropdown_list_settings` to get the widget variable from setting name. The functions to get and set the setting value use `get_widget_for_dropdown_list_settings` function to get the widget and then gets or sets the setting value accordingly.

We also add `data-setting-widget-type` and `data-setting-value-type` attributes to the element like other settings.

The `data-setting-widget-type` attr is used by `get_input_element_value` to use `get_dropdown_list_widget_setting_value` function for dropdown-list-widget settings.

The `data-setting-value-type` attribute is used to parse the setting value to correct types in `get_dropdown_list_widget_setting_value` function.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
