### PR TITLE
compose: Disable "Message X" button for DMs when DMs are not allowed.

### DIFF
--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -53,6 +53,15 @@ export function get_recipient_label(message) {
     return "";
 }
 
+function update_reply_button_state(disable = false, title) {
+    $(".compose_reply_button").attr("disabled", disable);
+    if (!title) {
+        const title_text = $t({defaultMessage: "Reply to selected message"});
+        title = title_text + " (r)";
+    }
+    $(".compose_reply_button").prop("title", title);
+}
+
 function update_stream_button(btn_text, title) {
     $("#left_bar_compose_stream_button_big").text(btn_text);
     $("#left_bar_compose_stream_button_big").prop("title", title);
@@ -63,17 +72,31 @@ function update_conversation_button(btn_text, title) {
     $("#left_bar_compose_private_button_big").prop("title", title);
 }
 
-function update_buttons(text_stream) {
+function update_buttons(text_stream, disable_reply, title_reply) {
     const title_stream = text_stream + " (c)";
     const text_conversation = $t({defaultMessage: "New direct message"});
     const title_conversation = text_conversation + " (x)";
     update_stream_button(text_stream, title_stream);
     update_conversation_button(text_conversation, title_conversation);
+    update_reply_button_state(disable_reply, title_reply);
 }
 
 export function update_buttons_for_private() {
     const text_stream = $t({defaultMessage: "New stream message"});
-    update_buttons(text_stream);
+    if (
+        !narrow_state.pm_ids_string() ||
+        people.user_can_direct_message(narrow_state.pm_ids_string())
+    ) {
+        update_buttons(text_stream);
+        return;
+    }
+    // disable the [Message X] button when in a private narrow
+    // if the user cannot dm the current recipient
+    const disable_reply = true;
+    const title_reply = $t({
+        defaultMessage: "You are not allowed to send private messages in this organization.",
+    });
+    update_buttons(text_stream, disable_reply, title_reply);
 }
 
 export function update_buttons_for_stream() {

--- a/web/src/people.js
+++ b/web/src/people.js
@@ -702,6 +702,26 @@ export function user_is_bot(user_id) {
     return user.is_bot;
 }
 
+export function user_can_direct_message(recipient_ids_string) {
+    // Common function for checking if a user can send a direct
+    // message to the target user (or group of users) represented by a
+    // user ids string.
+
+    // Regardless of policy, we allow sending private messages to bots.
+    const recipient_ids = user_ids_string_to_ids_array(recipient_ids_string);
+    if (recipient_ids.length === 1 && user_is_bot(recipient_ids[0])) {
+        return true;
+    }
+
+    if (
+        page_params.realm_private_message_policy ===
+        settings_config.private_message_policy_values.disabled.code
+    ) {
+        return false;
+    }
+    return true;
+}
+
 function gravatar_url_for_email(email) {
     const hash = md5(email.toLowerCase());
     const avatar_url = "https://secure.gravatar.com/avatar/" + hash + "?d=identicon";


### PR DESCRIPTION
When in a private narrow, the "Message X" button is disabled if direct messages are not allowed in the organisation and the current recipient is not a bot.

Note that when the recipient is a user group with 1, more or all bots, the button is disabled then too as such PMs are not allowed. Only when the recipient is a single bot, then it's not disabled, as DMs with one bot are allowed even in organisations where DMs are disabled.

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/68962290/226442307-575511fd-6b5e-4ade-be50-f955ec0cfbf5.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
