### PR TITLE
message-feed:Fix narrow banner on All messages screen

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -26,7 +26,7 @@ export class MessageList {
         const table_name = opts.table_name;
         this.view = new MessageListView(this, table_name, collapse_messages);
         this.table_name = table_name;
-        this.narrowed = this.table_name === "zfilt";
+        this.narrowed = true; // Making narrowed true for all tables including home
         this.num_appends = 0;
         this.reading_prevented = false;
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -174,7 +174,12 @@ export function update_narrow_title(filter) {
 export function reset_ui_state() {
     // Resets the state of various visual UI elements that are
     // a function of the current narrow.
-    narrow_banner.hide_empty_narrow_message();
+    // Checls the current narrow and updates the UI accordingly.
+    if (message_lists.current.data && message_lists.current.data._all_items.length === 0) {
+        narrow_banner.show_empty_narrow_message();
+    } else {
+        narrow_banner.hide_empty_narrow_message();
+    }
     message_scroll.hide_top_of_narrow_notices();
     message_scroll.hide_indicators();
     unread_ui.reset_mark_as_read_turned_off_banner();

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -21,7 +21,7 @@ export function update_is_muted(sub, value) {
             saved_ypos = message_viewport.scrollTop();
         } else if (
             message_lists.home === message_lists.current &&
-            message_lists.current.selected_row().offset() !== null
+            message_lists.current.selected_row().offset() !== undefined
         ) {
             msg_offset = message_lists.current.selected_row().offset().top;
         }

--- a/templates/zerver/help/include/all-messages.md
+++ b/templates/zerver/help/include/all-messages.md
@@ -15,6 +15,7 @@ view](/help/configure-default-view#configure-default-view) for the Zulip web app
 {tab|mobile}
 
 1. Tap the **All messages**
+   (<img src="/static/images/help/mobile-globe-icon.svg" alt="globe" class="mobile-icon"/>)
    tab in the upper left corner of the app.
 
 {end_tabs}


### PR DESCRIPTION
Made changes in reset_ui_state to check if message list is empty or not and on the basis of this narror banner will be shown. Changed narrowed value to true in message list, so that All messages acts like other streams.

Fixes #23701

**Screenshots and screen captures:**

Original Behavior

![204607852-6189b30a-e252-48ef-8766-e299b1bbde1e](https://user-images.githubusercontent.com/96344003/209562194-5ec32b4c-66f6-4f59-b087-86fc029eb8e3.png)


New Behavior after the changes

![Screenshot_20230103_002931](https://user-images.githubusercontent.com/96344003/210270069-bad155c7-f192-43cb-98bb-3f765c3f8d3f.png)



Unlike older tables, home was not acting in the same way during rerendering. So, I made changes in reset_ui_state method, so that in case of no message narrow banner appears.

<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
