### PR TITLE
frontend: Add warning to confirm modal when last user unsubscribes fr…

### DIFF
--- a/static/js/stream_edit_subscribers.js
+++ b/static/js/stream_edit_subscribers.js
@@ -243,10 +243,13 @@ function remove_subscriber({stream_id, target_user_id, $list_entry}) {
     }
 
     if (sub.invite_only && people.is_my_user_id(target_user_id)) {
+        const sub_count = peer_data.get_subscriber_count(stream_id);
+
         const html_body = render_unsubscribe_private_stream_modal({
             message: $t({
                 defaultMessage: "Once you leave this stream, you will not be able to rejoin.",
             }),
+            display_stream_archive_warning: sub_count === 1,
         });
 
         confirm_dialog.launch({

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -22,6 +22,7 @@ import * as message_live_update from "./message_live_update";
 import * as message_view_header from "./message_view_header";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import * as peer_data from "./peer_data";
 import * as people from "./people";
 import * as scroll_util from "./scroll_util";
 import * as search_util from "./search_util";
@@ -971,10 +972,14 @@ export function open_create_stream() {
 }
 
 export function unsubscribe_from_private_stream(sub) {
+    const invite_only = sub.invite_only;
+    const sub_count = peer_data.get_subscriber_count(sub.stream_id);
+
     const html_body = render_unsubscribe_private_stream_modal({
         message: $t({
             defaultMessage: "Once you leave this stream, you will not be able to rejoin.",
         }),
+        display_stream_archive_warning: sub_count === 1 && invite_only,
     });
 
     function unsubscribe_from_stream() {

--- a/static/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
+++ b/static/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
@@ -1,1 +1,4 @@
 <p>{{message}}</p>
+{{#if display_stream_archive_warning}}
+    <p>{{t "Because you are the only subscriber, this stream will be automatically archived." }}</p>
+{{/if}}


### PR DESCRIPTION
Fixes: #23954

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="939" alt="Screenshot 2023-01-03 at 11 11 35 AM" src="https://user-images.githubusercontent.com/72064462/210305230-33c5c9dd-038e-4630-adf8-de6ebcb914f5.png">

<img width="888" alt="Screenshot 2023-01-03 at 11 11 50 AM" src="https://user-images.githubusercontent.com/72064462/210305225-aa370be1-763c-41f5-8581-1676c9b1c56e.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
