### PR TITLE
frontend: Add stream symbol to unsubscribe confirmation modal

### DIFF
--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import render_unsubscribe_private_stream_modal from "../templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs";
+import render_inline_decorated_stream_name from "../templates/inline_decorated_stream_name.hbs";
 import render_stream_member_list_entry from "../templates/stream_settings/stream_member_list_entry.hbs";
 import render_stream_members from "../templates/stream_settings/stream_members.hbs";
 import render_stream_subscription_request_result from "../templates/stream_settings/stream_subscription_request_result.hbs";
@@ -252,6 +253,9 @@ function remove_subscriber({stream_id, target_user_id, $list_entry}) {
 
     if (sub.invite_only && people.is_my_user_id(target_user_id)) {
         const sub_count = peer_data.get_subscriber_count(stream_id);
+        const stream_name_with_privacy_symbol_html = render_inline_decorated_stream_name({
+            stream: sub,
+        });
 
         const html_body = render_unsubscribe_private_stream_modal({
             message: $t({
@@ -262,8 +266,8 @@ function remove_subscriber({stream_id, target_user_id, $list_entry}) {
 
         confirm_dialog.launch({
             html_heading: $t_html(
-                {defaultMessage: "Unsubscribe from {stream_name}"},
-                {stream_name: sub.name},
+                {defaultMessage: "Unsubscribe from <z-link></z-link>"},
+                {"z-link": () => stream_name_with_privacy_symbol_html},
             ),
             html_body,
             on_click: remove_user_from_private_stream,

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import _ from "lodash";
 
 import render_unsubscribe_private_stream_modal from "../templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs";
+import render_inline_decorated_stream_name from "../templates/inline_decorated_stream_name.hbs";
 import render_browse_streams_list from "../templates/stream_settings/browse_streams_list.hbs";
 import render_browse_streams_list_item from "../templates/stream_settings/browse_streams_list_item.hbs";
 import render_selected_stream_title from "../templates/stream_settings/selected_stream_title.hbs";
@@ -999,6 +1000,7 @@ export function open_create_stream() {
 export function unsubscribe_from_private_stream(sub) {
     const invite_only = sub.invite_only;
     const sub_count = peer_data.get_subscriber_count(sub.stream_id);
+    const stream_name_with_privacy_symbol_html = render_inline_decorated_stream_name({stream: sub});
 
     const html_body = render_unsubscribe_private_stream_modal({
         message: $t({
@@ -1020,8 +1022,8 @@ export function unsubscribe_from_private_stream(sub) {
 
     confirm_dialog.launch({
         html_heading: $t_html(
-            {defaultMessage: "Unsubscribe from {stream_name}"},
-            {stream_name: sub.name},
+            {defaultMessage: "Unsubscribe from <z-link></z-link>"},
+            {"z-link": () => stream_name_with_privacy_symbol_html},
         ),
         html_body,
         on_click: unsubscribe_from_stream,


### PR DESCRIPTION
Fixes: #23953

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="589" alt="Screenshot 2023-03-08 at 10 59 04 AM" src="https://user-images.githubusercontent.com/72064462/223627854-beb99977-9fbf-435d-8e52-8cdd65174c46.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
