### PR TITLE
user-events: Update account settings display if `is_admin` is changed.

### DIFF
--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -11,6 +11,7 @@ const message_live_update = mock_esm("../../static/js/message_live_update");
 const settings_account = mock_esm("../../static/js/settings_account", {
     update_email() {},
     update_full_name() {},
+    update_account_settings_display() {},
 });
 
 mock_esm("../../static/js/activity", {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -80,6 +80,12 @@ export function update_avatar_change_display() {
     }
 }
 
+export function update_account_settings_display() {
+    update_name_change_display();
+    update_email_change_display();
+    update_avatar_change_display();
+}
+
 export function update_send_read_receipts_tooltip() {
     if (page_params.realm_enable_read_receipts) {
         $("#send_read_receipts_label .settings-info-icon").hide();

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -89,6 +89,7 @@ export const update_person = function update(person) {
             settings_profile_fields.maybe_disable_widgets();
             settings_streams.maybe_disable_widgets();
             settings_realm_user_settings_defaults.maybe_disable_widgets();
+            settings_account.update_account_settings_display();
         }
 
         if (


### PR DESCRIPTION
There are a few account settings that are possibly deactivated if a user is not an administrator (email, name and avatar changes), depending on the organization's policy for changing those settings.

When a user's role is updated to become (or no longer be) an admin, the display for these account settings may need to be updated.

Adds `settings_account.update_account_settings_display` to the functions called in `user_events.update_person` if the active user's role is changed to or from an administrator role.

**Notes**:
- I'm not sure if/how this behavior will be impacted on the updates for user groups. But for now, it seemed like having these display settings live updated in the user's account settings **Profile** and **Account & privacy** tabs would be better than not.

**Screenshots and screen captures:**

<details>
<summary>GIF screencast before changes</summary>

*User profile settings are not updated when role is changed.*
![Peek 2023-01-03 14-24](https://user-images.githubusercontent.com/63245456/210419074-e8de5f02-5c49-4a42-ad6b-cc90dbc2f61f.gif)
</details>
<details>
<summary>GIF screencast after changes</summary>

*Note that the avatar hover behavior is a separate issue that I address in #23964.*
![Peek 2023-01-03 14-27](https://user-images.githubusercontent.com/63245456/210419088-6abbff33-4128-4a89-bd1d-f775c32a291c.gif)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
