### PR TITLE
image-upload-widget: Fix avatar changes disabled hover behavior.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -762,19 +762,19 @@ test("misc", ({override_rewire}) => {
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.ok($("#user-avatar-upload-widget .image_upload_button").is(":visible"));
+    assert.ok(!$("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.ok(!$("#user-avatar-upload-widget .image_upload_button").is(":visible"));
+    assert.ok($("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.ok(!$("#user-avatar-upload-widget .image_upload_button").is(":visible"));
+    assert.ok($("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.ok(!$("#user-avatar-upload-widget .image_upload_button").is(":visible"));
+    assert.ok($("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
 
     // If organization admin, these UI elements are never disabled.
     page_params.is_admin = true;
@@ -784,6 +784,9 @@ test("misc", ({override_rewire}) => {
 
     settings_account.update_email_change_display();
     assert.ok(!$("#change_email_button").prop("disabled"));
+
+    settings_account.update_avatar_change_display();
+    assert.ok(!$("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
 
     override_rewire(stream_settings_data, "get_streams_for_settings_page", () => [
         {name: "some_stream", stream_id: 75},

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -74,6 +74,10 @@ export function build_user_avatar_widget(upload_function) {
         $("#user-avatar-source").hide();
     }
 
+    if (!settings_data.user_can_change_avatar) {
+        return undefined;
+    }
+
     $("#user-avatar-upload-widget .image-delete-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -104,15 +108,11 @@ export function build_user_avatar_widget(upload_function) {
         });
     });
 
-    if (settings_data.user_can_change_avatar()) {
-        return upload_widget.build_direct_upload_widget(
-            get_file_input,
-            $("#user-avatar-upload-widget .image_file_input_error").expectOne(),
-            $("#user-avatar-upload-widget .image_upload_button").expectOne(),
-            upload_function,
-            page_params.max_avatar_file_size_mib,
-        );
-    }
-
-    return undefined;
+    return upload_widget.build_direct_upload_widget(
+        get_file_input,
+        $("#user-avatar-upload-widget .image_file_input_error").expectOne(),
+        $("#user-avatar-upload-widget .image_upload_button").expectOne(),
+        upload_function,
+        page_params.max_avatar_file_size_mib,
+    );
 }

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -71,12 +71,11 @@ export function update_email_change_display() {
 
 export function update_avatar_change_display() {
     if (!settings_data.user_can_change_avatar()) {
-        // We disable this widget by simply hiding its edit UI.
-        $("#user-avatar-upload-widget .image_upload_button").hide();
-        $(".user-avatar-section .settings-info-icon").show();
+        $("#user-avatar-upload-widget .image_upload_button").addClass("hide");
+        $("#user-avatar-upload-widget .image-disabled").removeClass("hide");
     } else {
-        $("#user-avatar-upload-widget .image_upload_button").show();
-        $(".user-avatar-section .settings-info-icon").hide();
+        $("#user-avatar-upload-widget .image_upload_button").removeClass("hide");
+        $("#user-avatar-upload-widget .image-disabled").addClass("hide");
     }
 }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -55,6 +55,8 @@ export function maybe_disable_widgets() {
         .find("input, textarea, button, select")
         .prop("disabled", true);
 
+    $(".organization-box [data-name='organization-profile']").find(".image_upload_button").hide();
+
     $(".organization-box [data-name='organization-settings']")
         .find("input, textarea, button, select")
         .prop("disabled", true);

--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -12,7 +12,7 @@
         height: 100%;
     }
 
-    .image-upload-background {
+    .image-hover-background {
         content: "";
         background-color: hsla(0, 0%, 0%, 0.6);
         height: 100%;
@@ -130,7 +130,11 @@
             opacity: 1;
         }
 
-        .image-upload-background {
+        .image-disabled-text {
+            visibility: visible;
+        }
+
+        .image-hover-background {
             display: block;
         }
     }
@@ -147,12 +151,6 @@
     .image-block {
         width: 200px;
         height: 200px;
-    }
-
-    &:hover {
-        .image-disabled-text {
-            visibility: visible;
-        }
     }
 }
 

--- a/static/styles/image_upload_widget.css
+++ b/static/styles/image_upload_widget.css
@@ -117,6 +117,10 @@
         border-radius: 5px;
     }
 
+    .hide {
+        display: none;
+    }
+
     &:hover {
         .image-upload-text {
             visibility: visible;

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -1,12 +1,14 @@
 <div id="{{widget}}-upload-widget" class="inline-block image_upload_widget">
+    {{#if disabled_text}}
     <div class="image-disabled {{#if is_editable_by_current_user}}hide{{/if}}">
-        <div class="image-upload-background"></div>
+        <div class="image-hover-background"></div>
         <span class="image-disabled-text flex" aria-label="{{ disabled_text }}" role="button" tabindex="0">
             {{ disabled_text }}
         </span>
     </div>
+    {{/if}}
     <div class="image_upload_button {{#unless is_editable_by_current_user}}hide{{/unless}}">
-        <div class="image-upload-background"></div>
+        <div class="image-hover-background"></div>
         <button class="image-delete-button" aria-label="{{ delete_text }}" role="button" tabindex="0">
             &times;
         </button>

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -64,7 +64,7 @@
         <p>{{t "A wide image (200×25 pixels) for the upper left corner of the app." }}</p>
         <div class="realm-logo-group">
             <div class="realm-logo-block realm-logo-section">
-                <h5 class="realm-logo-title">{{t 'Day logo' }}</h5>
+                <h5 class="realm-logo-title">{{t "Light theme logo" }}</h5>
                 {{> image_upload_widget
                   widget = "realm-day-logo"
                   upload_text = (t "Upload logo")
@@ -73,7 +73,7 @@
                   image = realm_logo_url }}
             </div>
             <div class="realm-logo-block realm-logo-section">
-                <h5 class="realm-logo-title">{{t 'Night logo' }}</h5>
+                <h5 class="realm-logo-title">{{t "Dark theme logo" }}</h5>
                 {{> image_upload_widget
                   widget = "realm-night-logo"
                   upload_text = (t "Upload logo")


### PR DESCRIPTION
Currently, if an organization has disabled users from changing their avatars, the CSS rules do not hide the text / button for updating or deleting the current avatar/profile picture. Also, on the organization profile page, non-admin users see the text / button for updating and deleting the organization image and logos.

Fixes #23844.

**Current screenshots**:

<details>
<summary>User avatar - changes disabled</summary>

![Screenshot from 2023-01-03 17-02-11](https://user-images.githubusercontent.com/63245456/210406285-e657a226-ad58-42df-9a95-d4198e481e27.png)
</details>
<details>
<summary>Organization profile - non-admin user</summary>

![Screenshot from 2023-01-03 17-02-54](https://user-images.githubusercontent.com/63245456/210406159-c598bc29-cced-451f-b338-f5cbcaff061d.png)
![Screenshot from 2023-01-03 17-02-58](https://user-images.githubusercontent.com/63245456/210406163-cf10607b-e614-4394-885f-a53916ae1d47.png)
![Screenshot from 2023-01-03 17-03-02](https://user-images.githubusercontent.com/63245456/210406164-3407aeb4-f513-4328-978b-8f245b62e6b4.png)
</details>

Note that even though the user sees the button text, the user cannot interact with these buttons and change the images.

---

**Changes**:
- The first commit adds a more specific CSS rule for the image upload widgets so that the `hide` class is setting display to none correctly.
- The second commit updates the live update function in `settings_account.js` for when the organization updates/changes the realm/server setting `avatar_changes_disabled`.
- The third commit moves the image-disabled-text CSS rule to be more general so that the cursor is set to `not-allowed` for the organization profile settings images for non-admin users.
- The fourth commit updates the names for the logos in the organization profile tab since that was something I noted while working on these changes and seemed related / worth doing.

**Screenshots and screen captures:**

<details>
<summary>Non-admin user avatar - changes disabled</summary>

![Screenshot from 2023-01-03 17-00-13](https://user-images.githubusercontent.com/63245456/210406721-1076c92b-5dcb-437b-86ab-8aefc3b299de.png)
</details>
<details>
<summary>Admin users - changes disabled</summary>

*This is also what non-admin users see if changes are not disabled.*
![Screenshot from 2023-01-03 17-00-22](https://user-images.githubusercontent.com/63245456/210406780-61435340-b139-4689-9319-ce03c522c1e4.png)
![Screenshot from 2023-01-03 17-01-16](https://user-images.githubusercontent.com/63245456/210406787-03ef4ae6-4e7a-4674-9192-593849bfd2bf.png)
</details>
<details>
<summary>Organization profile - non-admin user</summary>

*Note changes to logo titles.*
![Screenshot from 2023-01-03 17-03-22](https://user-images.githubusercontent.com/63245456/210407370-0ab083bf-44f5-4086-93b7-1651c611d1c1.png)
![Screenshot from 2023-01-03 17-03-28](https://user-images.githubusercontent.com/63245456/210407393-acbfd261-f0b9-4413-a28c-2f713ba2c3e4.png)
![Screenshot from 2023-01-03 17-03-31](https://user-images.githubusercontent.com/63245456/210407399-62b36bfd-7bf4-42af-8474-9b162ad4c9ee.png)

</details>
<details>
<summary>Organization profile - admin user</summary>

*Note changes to logo titles.*
![Screenshot from 2023-01-03 17-04-11](https://user-images.githubusercontent.com/63245456/210407260-d526fdf2-b195-4b99-88e0-8134b8b5385b.png)
![Screenshot from 2023-01-03 17-04-15](https://user-images.githubusercontent.com/63245456/210407271-d00f6168-48e9-451a-a0e0-457354b282cf.png)
![Screenshot from 2023-01-03 17-04-18](https://user-images.githubusercontent.com/63245456/210407045-743d4604-31d4-44be-bc15-32f45be0602d.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
