### PR TITLE
settings: show current avatar in bot editing form

### DIFF
--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -21,13 +21,16 @@ export function build_bot_create_widget() {
     const $input_error = $("#bot_avatar_file_input_error");
     const $clear_button = $("#bot_avatar_clear_button");
     const $upload_button = $("#bot_avatar_upload_button");
-
+    const $preview_text = $("#add_bot_preview_text");
+    const $preview_image = $("#add_bot_preview_image");
     return upload_widget.build_widget(
         get_file_input,
         $file_name_field,
         $input_error,
         $clear_button,
         $upload_button,
+        $preview_text,
+        $preview_image,
     );
 }
 
@@ -40,6 +43,8 @@ export function build_bot_edit_widget($target) {
     const $input_error = $target.find(".edit_bot_avatar_error");
     const $clear_button = $target.find(".edit_bot_avatar_clear_button");
     const $upload_button = $target.find(".edit_bot_avatar_upload_button");
+    const $preview_text = $target.find(".edit_bot_avatar_preview_text");
+    const $preview_image = $target.find(".edit_bot_avatar_preview_image");
 
     return upload_widget.build_widget(
         get_file_input,
@@ -47,6 +52,8 @@ export function build_bot_edit_widget($target) {
         $input_error,
         $clear_button,
         $upload_button,
+        $preview_text,
+        $preview_image,
     );
 }
 

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -345,6 +345,7 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
         full_name: bot.full_name,
         user_role_values: settings_config.user_role_values,
         disable_role_dropdown: !page_params.is_admin || (bot.is_owner && !page_params.is_owner),
+        bot_avatar_url: bot.avatar_url,
     });
 
     let owner_widget;
@@ -449,6 +450,16 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
                 }),
             );
         }
+
+        // Hide the avatar if the user has uploaded an image
+        $("#bot-edit-form").on("input", ".edit_bot_avatar_file_input", () => {
+            $("#current_bot_avatar_image").hide();
+        });
+
+        // Show the avatar if the user has cleared the image
+        $("#bot-edit-form").on("click", ".edit_bot_avatar_clear_button", () => {
+            $("#current_bot_avatar_image").show();
+        });
 
         $("#bot-edit-form").on("click", ".deactivate_bot_button", (e) => {
             e.preventDefault();

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -657,6 +657,10 @@ input[type="checkbox"] {
     #emoji_preview_text {
         margin-top: 6px;
     }
+
+    #emoji_preview_image {
+        object-fit: cover;
+    }
 }
 
 #emoji_file_input_error {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -858,6 +858,26 @@ input[type="checkbox"] {
     #bot-role-select:disabled {
         opacity: 1;
     }
+
+    #current_bot_avatar_image {
+        margin: 5px 0 8px;
+    }
+
+    .edit_bot_avatar_preview_text {
+        display: none;
+    }
+}
+
+#add_bot_preview_text {
+    display: none;
+}
+
+.edit_bot_avatar_preview_image,
+#add_bot_preview_image {
+    height: 100px;
+    object-fit: cover;
+    width: 100px;
+    margin: 2px 0 8px;
 }
 
 #add-alert-word {

--- a/static/templates/settings/add_new_bot_form.hbs
+++ b/static/templates/settings/add_new_bot_form.hbs
@@ -63,6 +63,9 @@
             <label for="bot_avatar_file_input">Avatar</label>
             <div id="bot_avatar_file"></div>
             <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload avatar' }}" />
+            <div id="add_bot_preview_text">
+                <img id="add_bot_preview_image" />
+            </div>
             <button class="button white rounded small btn-danger" style="display: none;" id="bot_avatar_clear_button">{{t "Clear avatar" }}</button>
             <button class="button white rounded" id="bot_avatar_upload_button">{{t "Choose avatar" }}</button> ({{t "Optional" }})
         </div>

--- a/static/templates/settings/edit_bot_form.hbs
+++ b/static/templates/settings/edit_bot_form.hbs
@@ -31,9 +31,14 @@
         </div>
         <div class="input-group edit-avatar-section">
             <label>Avatar</label>
+            {{!-- Shows the current avatar --}}
+            <img src="{{bot_avatar_url}}" id="current_bot_avatar_image" />
             <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{t 'Upload profile picture' }}" />
             <div class="edit_bot_avatar_file"></div>
-            <button type="button" class="button white rounded edit_bot_avatar_upload_button">{{t "Choose avatar" }}</button>
+            <div class="edit_bot_avatar_preview_text">
+                <img class="edit_bot_avatar_preview_image" />
+            </div>
+            <button type="button" class="button white rounded edit_bot_avatar_upload_button">{{t "Change avatar" }}</button>
             <button type="button" class="button white rounded edit_bot_avatar_clear_button" style="display: none;">{{t "Clear profile picture" }}</button>
             <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
         </div>


### PR DESCRIPTION
Whenever bot-edit-form is opened the current avatar of the bot is fetched and shown. Also, during bot creation and updation user can preview the avatar that he/she has selected for the bot. During updation if user clears the avatar, then it reverts back to the original avatar.

Fixes #23023

**Screenshots and screen captures:**

Previous behavior-

![prev_behavior](https://user-images.githubusercontent.com/96344003/210418689-04713521-3e85-4312-b762-5c1a1f7f9572.png)


New behavior-

https://user-images.githubusercontent.com/96344003/210533826-298a73c7-d0b4-4a6e-b3bd-dd6ed2fba5f3.mov

![create_bot](https://user-images.githubusercontent.com/96344003/210533890-82a22df2-2896-47ac-89a6-4db9c3b00e3d.png)

![edit_bot](https://user-images.githubusercontent.com/96344003/212135948-7c4acf84-cbfb-4a25-b6fa-b714143bf5ca.png)

![edit_bot2](https://user-images.githubusercontent.com/96344003/212135954-09df17d4-369f-4d66-885a-ad38f86fe863.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
