### PR TITLE
fix: Todo item checkbox.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -74,7 +74,7 @@ export const _get_focus_area = get_focus_area;
 
 export function set_focus(msg_type, opts) {
     const focus_area = get_focus_area(msg_type, opts);
-    if (window.getSelection().toString() === "" || opts.trigger !== "message click") {
+    if (window.getSelection().toString() === "" && opts.trigger !== "message click") {
         const $elt = $(focus_area);
         $elt.trigger("focus").trigger("select");
     }


### PR DESCRIPTION
**Before:**
- While composing a message, if click on the unchecked Todo item checkbox, it doesn't used to work as intended.
- Instead of toggling the checkbox, the text in the compose box highlights.

**Now:**
- While composing a message in the compose box, if you click on the unchecked Todo item checkbox, it works as intended.

Fixes: #22928

**Demo Video:**

**Before:**


https://user-images.githubusercontent.com/66828942/210422935-c421ffa9-9f79-442d-9e05-5ac179b18329.mp4

**After:**

https://user-images.githubusercontent.com/66828942/210420442-000ea7da-5add-4639-a999-cda787d903c1.mp4


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
