### PR TITLE
create-database: Hide harmless "non-existant database" warnings.

### DIFF
--- a/scripts/setup/create-database
+++ b/scripts/setup/create-database
@@ -14,20 +14,18 @@ POSTGRES_USER="${POSTGRES_USER:-postgres}"
 DATABASE_NAME=$(crudini --get /etc/zulip/zulip.conf postgresql database_name 2>/dev/null || echo zulip)
 DATABASE_USER=$(crudini --get /etc/zulip/zulip.conf postgresql database_user 2>/dev/null || echo zulip)
 
-# This psql command may fail because the Zulip database doesn’t exist,
-# hence the &&.
-if records="$(
-    cd / # Make sure the current working directory is readable by postgres
-    su "$POSTGRES_USER" -c "psql -v ON_ERROR_STOP=1 -Atc 'SELECT COUNT(*) FROM $DATABASE_NAME.zerver_message;' $DATABASE_USER"
-)" && [ "$records" -gt 200 ]; then
-    set +x
-    echo "WARNING: This will delete your Zulip database which currently contains $records messages."
-    read -p "Do you want to proceed? [y/N] " -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
+if [ "$(su "$POSTGRES_USER" -c "cd / && psql -v ON_ERROR_STOP=1 -Atc \"SELECT 1 FROM pg_database WHERE datname='$DATABASE_NAME';\"")" = "1" ]; then
+    records="$(su "$POSTGRES_USER" -c "cd / && psql -v ON_ERROR_STOP=1 -Atc 'SELECT COUNT(*) FROM $DATABASE_NAME.zerver_message;' $DATABASE_USER")"
+    if [ "$records" -gt 200 ]; then
+        set +x
+        echo "WARNING: This will delete your Zulip database which currently contains $records messages."
+        read -p "Do you want to proceed? [y/N] " -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+        set -x
     fi
-    set -x
 fi
 
 # Shut down all services to ensure a quiescent state.


### PR DESCRIPTION
During installation on a new host, `create-database` attempts to verify that there isn't a bunch of data already in the database which is it about to drop and recreate.  In the most common case, this statement emits a scary-looking warning, since the database does not exist yet:

```
+ /home/zulip/deployments/current/scripts/setup/create-database
+ POSTGRES_USER=postgres
++ crudini --get /etc/zulip/zulip.conf postgresql database_name
++ echo zulip
+ DATABASE_NAME=zulip
++ crudini --get /etc/zulip/zulip.conf postgresql database_user
++ echo zulip
+ DATABASE_USER=zulip
++ cd /
++ su postgres -c 'psql -v ON_ERROR_STOP=1 -Atc '\''SELECT COUNT(*) FROM zulip.zerver_message;'\'' zulip'
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "zulip" does not exist
```

This warning message is normal and expected; hide it.  This also hides any other error messages from the query, but other types of failures talking to PostgreSQL will come up again shortly below.  We are also happy to hide errors in the event that the database exists but the tables we expect aren't present, as we will be clearing out that state below.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
