### PR TITLE
settings: Improve column widths in settings > uploaded files.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -707,7 +707,7 @@ div.overlay {
             content: " \f0d8";
             white-space: pre;
             display: inline-block;
-            position: absolute;
+            position: relative;
             padding-top: 3px;
             font: normal normal normal 12px/1 FontAwesome;
             font-size: inherit;

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -248,8 +248,13 @@ select.setting_email_notifications_batching_period_seconds {
 
 #uploaded_files_table > tr > td:nth-of-type(1),
 .upload-file-name {
-    width: 30%;
+    width: 43%;
     word-break: break-all;
+}
+
+.upload-mentioned-in,
+.upload-date {
+    word-break: normal;
 }
 
 #linkifier-settings {
@@ -1719,6 +1724,10 @@ $option_title_width: 180px;
 }
 
 @media (width < $lg_min) {
+    .upload-size {
+        display: none;
+    }
+
     .user-avatar-section,
     .realm-icon-section {
         display: block;

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -10,8 +10,8 @@
         <table class="table table-condensed table-striped wrapped-table">
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="name" class="upload-file-name">{{t "File" }}</th>
-                <th class="active" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
-                <th data-sort="mentioned_in">{{t "Mentioned in" }}</th>
+                <th class="active upload-date" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
+                <th class="upload-mentioned-in" data-sort="mentioned_in">{{t "Mentioned in" }}</th>
                 <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
                 <th class="upload-actions actions">{{t "Actions" }}</th>
             </thead>

--- a/static/templates/settings/uploaded_files_list.hbs
+++ b/static/templates/settings/uploaded_files_list.hbs
@@ -17,7 +17,7 @@
         </div>
         {{/if}}
     </td>
-    <td>{{ size_str }}</td>
+    <td class="upload-size" >{{ size_str }}</td>
     <td class="actions">
         <span class="edit-attachment-buttons">
             <a type="submit" href="/user_uploads/{{path_id}}" class="btn no-style" title="{{t 'Download file' }}" id="download_attachment" download>


### PR DESCRIPTION
- **Earlier:** the column width of `mentioned in` was unnecessarily wide, leaving very little space for file column to show the names of the uploaded items properly.

 **Changes:**
-  the width of the file column to show the names properly, while making sure that the table UI remains consistent in different languages too (tested with Russian language).
- Drop the file size column if the viewport is less than 992px (`lg_min`) to ensure that the size word doesn't break when there are no uploaded files.
- Changed the position of the `date-uploaded` arrow to stay visible in all view ports.

Fixes: #23738

**Screenshots:**

**Before:**
![Screenshot from 2023-01-04 03-24-20](https://user-images.githubusercontent.com/66828942/210447760-dfb5590b-6d00-4ed5-97be-48b87cb8eb7c.png)

**Now:**

![Screenshot from 2023-01-04 03-25-31](https://user-images.githubusercontent.com/66828942/210447862-dbae8a4e-6bfd-49f6-820d-cdb11e3bafea.png)


**File size Column drop:**

![issue](https://user-images.githubusercontent.com/66828942/214394927-c08c286b-2399-4181-a3be-459ef6f46515.gif)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
