### PR TITLE
contributor docs: Link to GitHub's blog post on commit discipline.

### DIFF
--- a/docs/contributing/commit-discipline.md
+++ b/docs/contributing/commit-discipline.md
@@ -81,6 +81,9 @@ you need to do a refactoring partway through writing the feature. When that
 happens, we recommend you stash your partial feature, do the refactoring,
 commit it, and then unstash and finish implementing your feature.
 
+For additional guidance on how to structure your commits (and why it matters!),
+check out GitHub's excellent [blog post](https://github.blog/2022-06-30-write-better-commits-build-better-projects).
+
 ## Commit messages
 
 First, check out


### PR DESCRIPTION
On https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html:

![Screen Shot 2023-01-03 at 6 02 31 PM](https://user-images.githubusercontent.com/2090066/210472089-5fec8066-0db5-47a3-b2c2-998d1b0fc384.png)

If we wanted to, we could also link to https://github.blog/2022-06-30-write-better-commits-build-better-projects/#code-review from https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#code-review-checklist, but the change here might be good enough.

Another place I considered is https://zulip.readthedocs.io/en/latest/contributing/reviewable-prs.html