### PR TITLE
help center: Document quote-and-reply mobile feature.

### DIFF
--- a/templates/zerver/help/quote-and-reply.md
+++ b/templates/zerver/help/quote-and-reply.md
@@ -17,6 +17,8 @@ to avoid unnecessarily mentioning someone twice.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!message-actions-menu.md!}
 
 1. Click **Quote and reply or forward**.
@@ -26,12 +28,29 @@ to avoid unnecessarily mentioning someone twice.
 
 1. Send your message.
 
-{end_tabs}
-
 !!! keyboard_tip ""
 
     You can also use <kbd>></kbd> to **quote and reply or forward** the
     selected message.
+
+{tab|mobile}
+
+{!message-long-press-menu.md!}
+
+1. Tap **Quote and reply**.
+
+1. *(optional)* Delete any parts of the quoted message that are not
+   relevant to your reply.
+
+1. Send your message.
+
+!!! tip ""
+
+    If you are in a stream view, you can set a different destination
+    topic by tapping the compose box and selecting an existing topic
+    or typing a new topic name.
+
+{end_tabs}
 
 ## Related articles
 


### PR DESCRIPTION
Updates Quote and reply help center article to add instructions for how to use this feature on mobile.

Fixes: #23752.

**Screenshots and screen captures:**

<img width="456" alt="image" src="https://user-images.githubusercontent.com/2343554/210479580-fe527ca3-c3a3-46cf-a3fc-da63acd2fae5.png">


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>