### PR TITLE
Do not allow unsubscribed admins/owners to change settings of a private stream.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 163**
+
+* [`PATCH /streams/{stream_id}`](/api/update-stream): Only subscribed
+  organization administrators can change the `stream_post_policy`
+  and `message_retention_days` settings for a private stream now.
+
 **Feature level 162**
 
 * [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 162
+API_FEATURE_LEVEL = 163
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14519,6 +14519,15 @@ paths:
         - Stream [permissions](/help/stream-permissions), including
           [privacy](/help/change-the-privacy-of-a-stream) and [who can
           send](/help/stream-sending-policy).
+
+        For private streams, only organization administrators who are subscribed to the stream
+        can change its permissions.
+
+        **Changes**: Prior to Zulip 7.0 (feature level 163), organization administrators were
+        allowed to change `stream_post_policy` and `message_retention_days` setting even for
+        a private stream that they were not subscribed to. Now, only organization
+        administrators who are subscribed to the stream can change these permissions for a
+        private stream.
       x-curl-examples-parameters:
         oneOf:
           - type: include

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -351,6 +351,10 @@ def update_stream_backend(
     if message_retention_days is not None:
         if not user_profile.is_realm_owner:
             raise OrganizationOwnerRequiredError
+
+        if sub is None and stream.invite_only:
+            raise JsonableError(_("Invalid stream ID"))
+
         user_profile.realm.ensure_not_on_limited_plan()
         new_message_retention_days_value = parse_message_retention_days(
             message_retention_days, Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP
@@ -382,6 +386,9 @@ def update_stream_backend(
         if is_announcement_only:
             stream_post_policy = Stream.STREAM_POST_POLICY_ADMINS
     if stream_post_policy is not None:
+        if sub is None and stream.invite_only:
+            raise JsonableError(_("Invalid stream ID"))
+
         do_change_stream_post_policy(stream, stream_post_policy, acting_user=user_profile)
 
     if can_remove_subscribers_group_id is not None:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -323,8 +323,9 @@ def update_stream_backend(
 
         # We require even realm administrators to be actually
         # subscribed to make a private stream public, via this
-        # stricted access_stream check.
-        access_stream_by_id(user_profile, stream_id)
+        # check.
+        if sub is None and stream.invite_only:
+            raise JsonableError(_("Invalid stream ID"))
 
     # Enforce restrictions on creating web-public streams. Since these
     # checks are only required when changing a stream to be


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to not allow unsubscribed admins to change stream-post-policy and unsubscribed owners to change message-retention-days for a private stream.
- Second commit is just a refactor commit.

<!-- Issue link, or clear description.--> 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
