### PR TITLE
todo: Fix bug preventing toggling todos with content in composebox.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -149,6 +149,14 @@ export function initialize() {
             return true;
         }
 
+        // Allow toggling of tasks in todo widget
+        if (
+            $target.is(".todo-widget label.checkbox") ||
+            $target.parents(".todo-widget label.checkbox").length > 0
+        ) {
+            return true;
+        }
+
         return false;
     }
 
@@ -1000,6 +1008,7 @@ export function initialize() {
                 // filters or search widgets won't unnecessarily close
                 // compose.
                 !$(e.target).closest("input").length &&
+                !$(e.target).closest(".todo-widget label.checkbox").length &&
                 !$(e.target).closest("textarea").length &&
                 !$(e.target).closest("select").length &&
                 // Clicks inside an overlay, popover, custom


### PR DESCRIPTION
Uptil now, with the composebox expanded and some content in it, when a task in a todo widget was clicked, it did not toggle as expected but focused the composebox, selecting all the text in it.

This is fixed by ensuring the task is a clickable message element and clicking it doesn't collapse the composebox. This has the added benefit of fixing the bug where toggling a task expanded a collapsed composebox.

Fixes: #22928.

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/68962290/210747880-8add548b-07ed-4d0f-9137-c62f241b694f.mp4



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
