### PR TITLE
Use `can_remove_subscribers_group` setting to check if user is allowed to unsubscribe others.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 161**
+
+* [`PATCH /streams/{stream_id}`](/api/update-stream): Added
+  `can_remove_subscribers_group_id` parameter to support
+  changing `can_remove_subscribers_group` setting.
+
 **Feature level 160**
 
 * [`POST /api/v1/jwt/fetch_api_key`]: New API endpoint to fetch API

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -25,6 +25,10 @@ format used by the Zulip server that they are interacting with.
 * [`PATCH /streams/{stream_id}`](/api/update-stream): Added
   `can_remove_subscribers_group_id` parameter to support
   changing `can_remove_subscribers_group` setting.
+* [`POST /users/me/subscriptions`](/api/subscribe): Added
+  `can_remove_subscribers_group_id` parameter to set
+  `can_remove_subscribers_group` setting while creating
+  streams.
 
 **Feature level 160**
 

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -130,14 +130,6 @@ run_test("user_can_change_logo", () => {
     assert.equal(can_change_logo(), false);
 });
 
-run_test("user_can_unsubscribe_other_users", () => {
-    page_params.is_admin = true;
-    assert.equal(settings_data.user_can_unsubscribe_other_users(), true);
-
-    page_params.is_admin = false;
-    assert.equal(settings_data.user_can_unsubscribe_other_users(), false);
-});
-
 function test_policy(label, policy, validation_func) {
     run_test(label, () => {
         page_params.is_admin = true;

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -48,6 +48,14 @@ const admins_group = {
     direct_subgroup_ids: new Set([]),
 };
 
+const moderators_group = {
+    name: "Members",
+    id: 2,
+    members: new Set([2]),
+    is_system_group: true,
+    direct_subgroup_ids: new Set([1]),
+};
+
 function test(label, f) {
     run_test(label, (helpers) => {
         page_params.is_admin = false;
@@ -57,7 +65,7 @@ function test(label, f) {
         people.add_active_user(me);
         people.initialize_current_user(me.user_id);
         stream_data.clear_subscriptions();
-        user_groups.initialize({realm_user_groups: [admins_group]});
+        user_groups.initialize({realm_user_groups: [admins_group, moderators_group]});
         f(helpers);
     });
 }
@@ -450,10 +458,12 @@ test("stream_settings", () => {
     });
     stream_data.update_stream_post_policy(sub, 1);
     stream_data.update_message_retention_setting(sub, -1);
+    stream_data.update_can_remove_subscribers_group_id(sub, moderators_group.id);
     assert.equal(sub.invite_only, false);
     assert.equal(sub.history_public_to_subscribers, false);
     assert.equal(sub.stream_post_policy, stream_data.stream_post_policy_values.everyone.code);
     assert.equal(sub.message_retention_days, -1);
+    assert.equal(sub.can_remove_subscribers_group_id, moderators_group.id);
 
     // For guest user only retrieve subscribed streams
     sub_rows = stream_settings_data.get_updated_unsorted_subs();

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -243,6 +243,17 @@ test("update_property", ({override}) => {
         assert.equal(args.sub.stream_id, stream_id);
         assert.equal(args.val, 20);
     }
+
+    // Test stream can_remove_subscribers_group_id change event
+    {
+        const stub = make_stub();
+        override(stream_settings_ui, "update_can_remove_subscribers_group_id", stub.f);
+        stream_events.update_property(stream_id, "can_remove_subscribers_group_id", 3);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("sub", "val");
+        assert.equal(args.sub.stream_id, stream_id);
+        assert.equal(args.val, 3);
+    }
 });
 
 test("marked_unsubscribed (code coverage)", () => {

--- a/frontend_tests/node_tests/stream_settings_ui.js
+++ b/frontend_tests/node_tests/stream_settings_ui.js
@@ -21,8 +21,18 @@ set_global("page_params", {});
 
 const stream_data = zrequire("stream_data");
 const stream_settings_ui = zrequire("stream_settings_ui");
+const user_groups = zrequire("user_groups");
 
 run_test("redraw_left_panel", ({mock_template}) => {
+    const admins_group = {
+        name: "Admins",
+        id: 1,
+        members: new Set([1]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([]),
+    };
+    user_groups.initialize({realm_user_groups: [admins_group]});
+
     // set-up sub rows stubs
     const denmark = {
         elem: "denmark",
@@ -33,6 +43,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         subscribers: [1],
         stream_weekly_traffic: null,
         color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
     };
     const poland = {
         elem: "poland",
@@ -43,6 +54,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         subscribers: [1, 2, 3],
         stream_weekly_traffic: 13,
         color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
     };
     const pomona = {
         elem: "pomona",
@@ -53,6 +65,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         subscribers: [],
         stream_weekly_traffic: 0,
         color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
     };
     const cpp = {
         elem: "cpp",
@@ -63,6 +76,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         subscribers: [1, 2],
         stream_weekly_traffic: 6,
         color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
     };
     const zzyzx = {
         elem: "zzyzx",
@@ -73,6 +87,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         subscribers: [1, 2],
         stream_weekly_traffic: 6,
         color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
     };
 
     const sub_row_data = [denmark, poland, pomona, cpp, zzyzx];

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -242,3 +242,123 @@ run_test("is_user_in_group", () => {
     blueslip.expect("error", "Could not find subgroup with ID 9999");
     assert.equal(user_groups.is_user_in_group(admins.id, 6), false);
 });
+
+run_test("get_realm_user_groups_for_dropdown_list_widget", () => {
+    const owners = {
+        name: "@role:owners",
+        description: "foo",
+        id: 1,
+        members: new Set([1]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([]),
+    };
+    const admins = {
+        name: "@role:administrators",
+        description: "foo",
+        id: 2,
+        members: new Set([2]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([1]),
+    };
+    const moderators = {
+        name: "@role:moderators",
+        description: "foo",
+        id: 3,
+        members: new Set([3]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([2]),
+    };
+    const members = {
+        name: "@role:members",
+        description: "foo",
+        id: 4,
+        members: new Set([4]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([6]),
+    };
+    const everyone = {
+        name: "@role:everyone",
+        description: "foo",
+        id: 5,
+        members: new Set([]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([4]),
+    };
+    const full_members = {
+        name: "@role:fullmembers",
+        description: "foo",
+        id: 6,
+        members: new Set([5]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([3]),
+    };
+    const internet = {
+        name: "@role:internet",
+        id: 7,
+        members: new Set([]),
+        is_system_group: true,
+        direct_subgroup_ids: new Set([5]),
+    };
+
+    assert.throws(() => user_groups.get_realm_user_groups_for_dropdown_list_widget(false, false), {
+        name: "Error",
+        message: "Unknown group name: @role:internet",
+    });
+
+    let expected_groups_list = [
+        {name: "translated: Admins, moderators, members and guests", value: "5"},
+        {name: "translated: Admins, moderators and members", value: "4"},
+        {name: "translated: Admins, moderators and full members", value: "6"},
+        {name: "translated: Admins and moderators", value: "3"},
+        {name: "translated: Admins", value: "2"},
+        {name: "translated: Owners", value: "1"},
+    ];
+
+    user_groups.initialize({
+        realm_user_groups: [owners, admins, moderators, members, everyone, full_members, internet],
+    });
+
+    assert.deepEqual(
+        user_groups.get_realm_user_groups_for_dropdown_list_widget(true, false),
+        expected_groups_list,
+    );
+
+    expected_groups_list = [
+        {name: "translated: Everyone on the internet", value: "7"},
+        {name: "translated: Admins, moderators, members and guests", value: "5"},
+        {name: "translated: Admins, moderators and members", value: "4"},
+        {name: "translated: Admins, moderators and full members", value: "6"},
+        {name: "translated: Admins and moderators", value: "3"},
+        {name: "translated: Admins", value: "2"},
+    ];
+    assert.deepEqual(
+        user_groups.get_realm_user_groups_for_dropdown_list_widget(false, true),
+        expected_groups_list,
+    );
+
+    expected_groups_list = [
+        {name: "translated: Admins, moderators, members and guests", value: "5"},
+        {name: "translated: Admins, moderators and members", value: "4"},
+        {name: "translated: Admins, moderators and full members", value: "6"},
+        {name: "translated: Admins and moderators", value: "3"},
+        {name: "translated: Admins", value: "2"},
+    ];
+    assert.deepEqual(
+        user_groups.get_realm_user_groups_for_dropdown_list_widget(true, true),
+        expected_groups_list,
+    );
+
+    expected_groups_list = [
+        {name: "translated: Everyone on the internet", value: "7"},
+        {name: "translated: Admins, moderators, members and guests", value: "5"},
+        {name: "translated: Admins, moderators and members", value: "4"},
+        {name: "translated: Admins, moderators and full members", value: "6"},
+        {name: "translated: Admins and moderators", value: "3"},
+        {name: "translated: Admins", value: "2"},
+        {name: "translated: Owners", value: "1"},
+    ];
+    assert.deepEqual(
+        user_groups.get_realm_user_groups_for_dropdown_list_widget(false, false),
+        expected_groups_list,
+    );
+});

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -801,3 +801,34 @@ export const desktop_icon_count_display_values = {
         description: $t({defaultMessage: "None"}),
     },
 };
+
+export const system_user_groups_list = [
+    {
+        name: "@role:internet",
+        display_name: $t({defaultMessage: "Everyone on the internet"}),
+    },
+    {
+        name: "@role:everyone",
+        display_name: $t({defaultMessage: "Admins, moderators, members and guests"}),
+    },
+    {
+        name: "@role:members",
+        display_name: $t({defaultMessage: "Admins, moderators and members"}),
+    },
+    {
+        name: "@role:fullmembers",
+        display_name: $t({defaultMessage: "Admins, moderators and full members"}),
+    },
+    {
+        name: "@role:moderators",
+        display_name: $t({defaultMessage: "Admins and moderators"}),
+    },
+    {
+        name: "@role:administrators",
+        display_name: $t({defaultMessage: "Admins"}),
+    },
+    {
+        name: "@role:owners",
+        display_name: $t({defaultMessage: "Owners"}),
+    },
+];

--- a/static/js/settings_data.ts
+++ b/static/js/settings_data.ts
@@ -197,10 +197,6 @@ export function user_can_subscribe_other_users(): boolean {
     return user_has_permission(page_params.realm_invite_to_stream_policy);
 }
 
-export function user_can_unsubscribe_other_users(): boolean {
-    return page_params.is_admin;
-}
-
 export function user_can_create_private_streams(): boolean {
     return user_has_permission(page_params.realm_create_private_stream_policy);
 }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -553,6 +553,8 @@ export function get_widget_for_dropdown_list_settings(property_name) {
             return signup_notifications_stream_widget;
         case "realm_default_code_block_language":
             return default_code_language_widget;
+        case "can_remove_subscribers_group_id":
+            return stream_edit.can_remove_subscribers_group_widget;
         default:
             blueslip.error("No dropdown list widget for property: " + property_name);
             return null;
@@ -592,6 +594,7 @@ export function discard_property_element_changes(elem, for_realm_default_setting
         case "realm_notifications_stream_id":
         case "realm_signup_notifications_stream_id":
         case "realm_default_code_block_language":
+        case "can_remove_subscribers_group_id":
             set_dropdown_list_widget_setting_value(property_name, property_value);
             break;
         case "realm_default_language":
@@ -875,6 +878,7 @@ export function check_property_changed(elem, for_realm_default_settings, sub) {
         case "realm_notifications_stream_id":
         case "realm_signup_notifications_stream_id":
         case "realm_default_code_block_language":
+        case "can_remove_subscribers_group_id":
             proposed_val = get_dropdown_list_widget_setting_value($elem, false);
             break;
         case "email_notifications_batching_period_seconds":

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -245,6 +245,12 @@ function create_stream() {
     const user_ids = stream_create_subscribers.get_principals();
     data.principals = JSON.stringify(user_ids);
 
+    const can_remove_subscribers_group_id = Number.parseInt(
+        stream_settings_ui.new_stream_can_remove_subscribers_group_widget.value(),
+        10,
+    );
+    data.can_remove_subscribers_group_id = can_remove_subscribers_group_id;
+
     loading.make_indicator($("#stream_creating_indicator"), {
         text: $t({defaultMessage: "Creating stream..."}),
     });
@@ -421,4 +427,6 @@ export function set_up_handlers() {
             e.preventDefault();
         }
     });
+
+    stream_settings_ui.new_stream_can_remove_subscribers_group_widget.setup();
 }

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -462,6 +462,10 @@ export function update_message_retention_setting(sub, message_retention_days) {
     sub.message_retention_days = message_retention_days;
 }
 
+export function update_can_remove_subscribers_group_id(sub, can_remove_subscribers_group_id) {
+    sub.can_remove_subscribers_group_id = can_remove_subscribers_group_id;
+}
+
 export function receives_notifications(stream_id, notification_name) {
     const sub = sub_store.get(stream_id);
     if (sub === undefined) {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -8,6 +8,7 @@ import * as people from "./people";
 import * as settings_config from "./settings_config";
 import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
+import * as user_groups from "./user_groups";
 import {user_settings} from "./user_settings";
 import * as util from "./util";
 
@@ -554,6 +555,36 @@ export function can_view_subscribers(sub) {
 export function can_subscribe_others(sub) {
     // User can add other users to stream if stream is public or user is subscribed to stream.
     return !page_params.is_guest && (!sub.invite_only || sub.subscribed);
+}
+
+export function can_unsubscribe_others(sub) {
+    // Whether the current user has permission to remove other users
+    // from the stream. Organization administrators can remove users
+    // from any stream; additionally, users who can access the stream
+    // and are in the stream's can_remove_subscribers_group can do so
+    // as well.
+    //
+    // TODO: The API allows the current user to remove bots that it
+    // administers from streams; so we might need to refactor this
+    // logic to accept a target_user_id parameter in order to support
+    // that in the UI.
+
+    // A user must be able to view subscribers in a stream in order to
+    // remove them. This check may never fire in practice, since the
+    // UI for removing subscribers generally is a list of the stream's
+    // subscribers.
+    if (!can_view_subscribers(sub)) {
+        return false;
+    }
+
+    if (page_params.is_admin) {
+        return true;
+    }
+
+    return user_groups.is_user_in_group(
+        sub.can_remove_subscribers_group_id,
+        people.my_current_user_id(),
+    );
 }
 
 export function can_post_messages_in_stream(stream) {

--- a/static/js/stream_edit_subscribers.js
+++ b/static/js/stream_edit_subscribers.js
@@ -23,13 +23,13 @@ export let pill_widget;
 let current_stream_id;
 let subscribers_list_widget;
 
-function format_member_list_elem(person) {
+function format_member_list_elem(person, user_can_remove_subscribers) {
     return render_stream_member_list_entry({
         name: person.full_name,
         user_id: person.user_id,
         is_current_user: person.user_id === page_params.user_id,
         email: settings_data.email_for_user_settings(person),
-        can_edit_subscribers: page_params.is_admin,
+        can_remove_subscribers: user_can_remove_subscribers,
         show_email: settings_data.show_email(),
     });
 }
@@ -87,6 +87,7 @@ export function enable_subscriber_management({sub, $parent_container}) {
     });
 
     const user_ids = peer_data.get_subscribers(stream_id);
+    const user_can_remove_subscribers = stream_data.can_unsubscribe_others(sub);
 
     // We track a single subscribers_list_widget for this module, since we
     // only ever have one list of subscribers visible at a time.
@@ -94,10 +95,11 @@ export function enable_subscriber_management({sub, $parent_container}) {
         $parent_container,
         name: "stream_subscribers",
         user_ids,
+        user_can_remove_subscribers,
     });
 }
 
-function make_list_widget({$parent_container, name, user_ids}) {
+function make_list_widget({$parent_container, name, user_ids, user_can_remove_subscribers}) {
     const users = people.get_users_from_ids(user_ids);
     people.sort_but_pin_current_user_on_top(users);
 
@@ -109,7 +111,7 @@ function make_list_widget({$parent_container, name, user_ids}) {
     return ListWidget.create($list_container, users, {
         name,
         modifier(item) {
-            return format_member_list_elem(item);
+            return format_member_list_elem(item, user_can_remove_subscribers);
         },
         filter: {
             $element: $parent_container.find(".search"),

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -90,6 +90,9 @@ export function update_property(stream_id, property, value, other_values) {
         case "message_retention_days":
             stream_settings_ui.update_message_retention_setting(sub, value);
             break;
+        case "can_remove_subscribers_group_id":
+            stream_settings_ui.update_can_remove_subscribers_group_id(sub, value);
+            break;
         default:
             blueslip.warn("Unexpected subscription property type", {
                 property,

--- a/static/js/stream_settings_data.js
+++ b/static/js/stream_settings_data.js
@@ -46,6 +46,7 @@ export function add_settings_fields(sub) {
     sub.can_change_stream_permissions = stream_data.can_change_permissions(sub);
     sub.can_access_subscribers = stream_data.can_view_subscribers(sub);
     sub.can_add_subscribers = stream_data.can_subscribe_others(sub);
+    sub.can_remove_subscribers = stream_data.can_unsubscribe_others(sub);
 
     sub.preview_url = hash_util.by_stream_url(sub.stream_id);
     sub.is_old_stream = sub.stream_weekly_traffic !== null;

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -241,6 +241,12 @@ export function update_message_retention_setting(sub, new_value) {
     stream_ui_updates.update_setting_element(sub, "message_retention_days");
 }
 
+export function update_can_remove_subscribers_group_id(sub, new_value) {
+    stream_data.update_can_remove_subscribers_group_id(sub, new_value);
+    stream_ui_updates.update_setting_element(sub, "can_remove_subscribers_group_id");
+    stream_edit_subscribers.rerender_subscribers_list(sub);
+}
+
 export function set_color(stream_id, color) {
     const sub = sub_store.get(stream_id);
     stream_edit.set_stream_property(sub, "color", color);

--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -14,6 +14,7 @@ import * as channel from "./channel";
 import * as components from "./components";
 import * as compose_state from "./compose_state";
 import * as confirm_dialog from "./confirm_dialog";
+import {DropdownListWidget} from "./dropdown_list_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as keydown_util from "./keydown_util";
@@ -39,6 +40,7 @@ import * as stream_ui_updates from "./stream_ui_updates";
 import * as sub_store from "./sub_store";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
+import * as user_groups from "./user_groups";
 import * as util from "./util";
 
 export function set_right_panel_title(sub) {
@@ -549,6 +551,8 @@ export function switch_stream_sort(tab_name) {
     redraw_left_panel();
 }
 
+export let new_stream_can_remove_subscribers_group_widget = null;
+
 export function setup_page(callback) {
     // We should strongly consider only setting up the page once,
     // but I am writing these comments write before a big release,
@@ -623,6 +627,15 @@ export function setup_page(callback) {
 
     function populate_and_fill() {
         $("#manage_streams_container").empty();
+
+        const opts = {
+            widget_name: "new_stream_can_remove_subscribers_group_id",
+            data: user_groups.get_realm_user_groups_for_dropdown_list_widget(true, true),
+            default_text: $t({defaultMessage: "No user groups"}),
+            include_current_item: false,
+            value: user_groups.get_user_group_from_name("@role:administrators").id,
+        };
+        new_stream_can_remove_subscribers_group_widget = new DropdownListWidget(opts);
 
         // TODO: Ideally we'd indicate in some way what stream types
         // the user can create, by showing other options as disabled.

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -134,7 +134,7 @@ export function enable_or_disable_permission_settings_in_edit_panel(sub) {
 
     const $general_settings_container = $stream_settings.find($("#stream_permission_settings"));
     $general_settings_container
-        .find("input, select")
+        .find("input, select, button")
         .prop("disabled", !sub.can_change_stream_permissions);
 
     if (!sub.can_change_stream_permissions) {

--- a/static/js/user_profile.js
+++ b/static/js/user_profile.js
@@ -55,7 +55,7 @@ function initialize_bot_owner(element_id, bot_id) {
 
 function format_user_stream_list_item(stream, user) {
     const show_unsubscribe_button =
-        people.can_admin_user(user) || settings_data.user_can_unsubscribe_other_users();
+        people.can_admin_user(user) || stream_data.can_unsubscribe_others(stream);
     const show_private_stream_unsub_tooltip =
         people.is_my_user_id(user.user_id) && stream.invite_only;
     return render_user_stream_list_item({

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -514,6 +514,11 @@ ul {
         margin-bottom: 5px;
         -webkit-overflow-scrolling: touch;
 
+        .remove-subscription-button {
+            padding-top: 2px;
+            padding-bottom: 2px;
+        }
+
         .user-stream-list,
         .user-group-list {
             width: 100%;
@@ -522,6 +527,9 @@ ul {
 
             tr {
                 border-bottom: 1px solid hsl(0, 0%, 87%);
+                /* Ensure equal height for rows with a remove-subscription-button and
+                   those without one. */
+                height: 34px;
 
                 &:last-of-type {
                     border-bottom: none;

--- a/static/styles/subscriptions.css
+++ b/static/styles/subscriptions.css
@@ -994,6 +994,22 @@ div.settings-radio-input-parent {
     select.stream_post_policy_setting {
         margin-bottom: 10px;
     }
+
+    .dropdown-list-widget {
+        .dropdown-toggle {
+            margin-bottom: 10px;
+            width: 325px;
+        }
+
+        ul.dropdown-menu {
+            width: 325px;
+
+            input {
+                /* 325 - 2* (9px (margin) + 1px (border) + 6px (padding)) */
+                width: 293px;
+            }
+        }
+    }
 }
 
 #change_user_group_description,

--- a/static/templates/stream_settings/stream_creation_form.hbs
+++ b/static/templates/stream_settings/stream_creation_form.hbs
@@ -24,7 +24,8 @@
                 <div class="stream-types">
                     {{> stream_types
                       stream_post_policy=stream_post_policy_values.everyone.code
-                      is_stream_edit=false }}
+                      is_stream_edit=false
+                      can_remove_subscribers_setting_widget_name="new_stream_can_remove_subscribers_group_id" }}
                 </div>
             </section>
             <section class="block">

--- a/static/templates/stream_settings/stream_member_list_entry.hbs
+++ b/static/templates/stream_settings/stream_member_list_entry.hbs
@@ -9,7 +9,7 @@
     <td class="hidden-subscriber-email">{{t "(hidden)"}}</td>
     {{/if}}
     <td class="subscriber-user-id">{{user_id}}</td>
-    {{#if can_edit_subscribers}}
+    {{#if can_remove_subscribers}}
     <td class="unsubscribe">
         <div class="subscriber_list_remove">
             <form class="remove-subscriber-form">

--- a/static/templates/stream_settings/stream_members.hbs
+++ b/static/templates/stream_settings/stream_members.hbs
@@ -24,7 +24,7 @@
                     <th>{{t "Name" }}</th>
                     <th>{{t "Email" }}</th>
                     <th>{{t "User ID" }}</th>
-                    {{#if is_realm_admin}}
+                    {{#if can_remove_subscribers}}
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -60,7 +60,8 @@
                   upgrade_text_for_wide_organization_logo=../upgrade_text_for_wide_organization_logo
                   is_business_type_org=../is_business_type_org
                   org_level_message_retention_setting=../org_level_message_retention_setting
-                  is_stream_edit=true }}
+                  is_stream_edit=true
+                  can_remove_subscribers_setting_widget_name="can_remove_subscribers_group_id" }}
             </div>
             {{/with}}
             <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -40,6 +40,17 @@
     </select>
 </div>
 
+{{#if is_stream_edit}}
+<div class="input-group new-style">
+    <label class="dropdown-title">{{t 'Who can unsubscribe others from this stream?'}}
+    </label>
+    {{> ../settings/dropdown_list_widget
+      widget_name="can_remove_subscribers_group_id"
+      list_placeholder=(t 'Filter roles')
+      value_type="number" }}
+</div>
+{{/if}}
+
 {{#if (or is_owner is_stream_edit)}}
 <div>
     <div class="input-group inline-block message-retention-setting-group time-limit-setting">

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -40,16 +40,14 @@
     </select>
 </div>
 
-{{#if is_stream_edit}}
 <div class="input-group new-style">
     <label class="dropdown-title">{{t 'Who can unsubscribe others from this stream?'}}
     </label>
     {{> ../settings/dropdown_list_widget
-      widget_name="can_remove_subscribers_group_id"
+      widget_name=can_remove_subscribers_setting_widget_name
       list_placeholder=(t 'Filter roles')
       value_type="number" }}
 </div>
-{{/if}}
 
 {{#if (or is_owner is_stream_edit)}}
 <div>

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 159
+API_FEATURE_LEVEL = 161
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8027,14 +8027,23 @@ paths:
         Unsubscribe yourself or other users from one or more streams.
 
         In addition to managing the current user's subscriptions, this
-        endpoint can be used by organization administrators to remove
-        other users from streams, or to remove a bot that the current
-        user is the `bot_owner` for from any stream that the current
-        user can access.
+        endpoint can be used to remove other users from streams. This
+        is possible in 3 situations:
 
-        **Changes**: Before Zulip 6.0 (feature level 145), only
-        organization administrators could remove other users from
-        streams.
+        - Organization administrators can remove any user from any
+          stream.
+        - Users can remove a bot that they own from any stream that
+          the user can access.
+        - Users who can access a stream and are in the group with ID
+          `can_remove_subscribers_group_id` for that stream can
+          unsubscribe any user from that stream.
+
+        **Changes**: Before Zulip 7.0 (feature level 161),
+        `can_remove_subscribers_group_id` was always the system group
+        for organization administrators.
+
+        Before Zulip 6.0 (feature level 145), users had no special
+        privileges for managing bots that they own.
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -14536,6 +14545,7 @@ paths:
           required: false
         - $ref: "#/components/parameters/StreamPostPolicy"
         - $ref: "#/components/parameters/MessageRetentionDays"
+        - $ref: "#/components/parameters/CanRemoveSubscribersGroupId"
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
@@ -17561,6 +17571,22 @@ components:
           - type: string
           - type: integer
       example: "20"
+      required: false
+    CanRemoveSubscribersGroupId:
+      name: can_remove_subscribers_group_id
+      in: query
+      description: |
+        ID of the user group whose members are allowed to unsubscribe others
+        from the stream, if they have access to this stream, even if
+        they are not an organization administrator.
+
+        This setting can currently only be set to system user groups
+        except `@role:internet` and `@role:owners` group.
+
+        **Changes**: New in Zulip 7.0 (feature level 161).
+      schema:
+        type: integer
+      example: 20
       required: false
     LinkifierPattern:
       name: pattern

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7855,6 +7855,7 @@ paths:
         - $ref: "#/components/parameters/HistoryPublicToSubscribers"
         - $ref: "#/components/parameters/StreamPostPolicy"
         - $ref: "#/components/parameters/MessageRetentionDays"
+        - $ref: "#/components/parameters/CanRemoveSubscribersGroupId"
       responses:
         "200":
           description: Success.

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -99,6 +99,7 @@ from zerver.lib.validator import (
 from zerver.models import (
     Realm,
     Stream,
+    UserGroup,
     UserMessage,
     UserProfile,
     get_active_user,
@@ -555,6 +556,7 @@ def add_subscriptions_backend(
     message_retention_days: Union[str, int] = REQ(
         json_validator=check_string_or_int, default=RETENTION_DEFAULT
     ),
+    can_remove_subscribers_group_id: Optional[int] = REQ(json_validator=check_int, default=None),
     announce: bool = REQ(json_validator=check_bool, default=False),
     principals: Union[Sequence[str], Sequence[int]] = REQ(
         json_validator=check_principals,
@@ -565,6 +567,19 @@ def add_subscriptions_backend(
     realm = user_profile.realm
     stream_dicts = []
     color_map = {}
+
+    if can_remove_subscribers_group_id is not None:
+        can_remove_subscribers_group = access_user_group_for_setting(
+            can_remove_subscribers_group_id,
+            user_profile,
+            setting_name="can_remove_subscribers_group",
+            require_system_group=True,
+        )
+    else:
+        can_remove_subscribers_group = UserGroup.objects.get(
+            name="@role:administrators", realm=user_profile.realm, is_system_group=True
+        )
+
     for stream_dict in streams_raw:
         # 'color' field is optional
         # check for its presence in the streams_raw first
@@ -585,6 +600,7 @@ def add_subscriptions_backend(
         stream_dict_copy["message_retention_days"] = parse_message_retention_days(
             message_retention_days, Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP
         )
+        stream_dict_copy["can_remove_subscribers_group"] = can_remove_subscribers_group
 
         stream_dicts.append(stream_dict_copy)
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to allow changing `can_remove_subscribers_group` setting using API.
- Second commit is to set `can_remove_subscribers_group` setting when creating streams.
- Third commit is to update UI to use `can_remove_subscribers_group` setting.
- Fourth commit adds `dropdown_list_widget` element for `can_remove_subscribers_group` in stream settings UI.
- Fifth commit adds live update code.
- Sixth commit adds dropdown_list_widget` element for `can_remove_subscribers_group` in stream creation form.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2023-01-05 23-01-39](https://user-images.githubusercontent.com/35494118/210845211-9ee380e3-096b-48d2-b392-424fc4f79828.png)

![can-remove-sub-group](https://user-images.githubusercontent.com/35494118/210845246-b69066c2-f7d5-46d3-aa0f-f7a0388a0121.gif)








<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
