### PR TITLE
Disable the message-retention setting for limited plan in stream creation form and refactor some code.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -317,17 +317,24 @@ export function show_new_stream_modal() {
     // Select the first visible and enabled choice for stream privacy.
     $("#make-invite-only input:visible:not([disabled])").first().prop("checked", true);
     // Make the options default to the same each time
-    $("#stream_creation_form .stream-message-retention-days-input").hide();
-    $("#stream_creation_form select[name=stream_message_retention_setting]").val("realm_default");
 
-    // Add listener to .show stream-message-retention-days-input that we've hidden above
-    $("#stream_creation_form .stream_message_retention_setting").on("change", (e) => {
-        if (e.target.value === "custom_period") {
-            $("#stream_creation_form .stream-message-retention-days-input").show();
-        } else {
-            $("#stream_creation_form .stream-message-retention-days-input").hide();
-        }
-    });
+    // The message retention setting is visible to owners only. The below block
+    // sets the default state of setting if it is visible.
+    if (page_params.is_owner) {
+        $("#stream_creation_form .stream-message-retention-days-input").hide();
+        $("#stream_creation_form select[name=stream_message_retention_setting]").val(
+            "realm_default",
+        );
+
+        // Add listener to .show stream-message-retention-days-input that we've hidden above
+        $("#stream_creation_form .stream_message_retention_setting").on("change", (e) => {
+            if (e.target.value === "custom_period") {
+                $("#stream_creation_form .stream-message-retention-days-input").show();
+            } else {
+                $("#stream_creation_form .stream-message-retention-days-input").hide();
+            }
+        });
+    }
 
     // set default state for "announce stream" option.
     update_announce_stream_state();

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -316,8 +316,7 @@ export function show_new_stream_modal() {
 
     // Select the first visible and enabled choice for stream privacy.
     $("#make-invite-only input:visible:not([disabled])").first().prop("checked", true);
-    // Make the options default to the same each time:
-    // "announce stream" on.
+    // Make the options default to the same each time
     $("#stream_creation_form .stream-message-retention-days-input").hide();
     $("#stream_creation_form select[name=stream_message_retention_setting]").val("realm_default");
 
@@ -330,6 +329,7 @@ export function show_new_stream_modal() {
         }
     });
 
+    // set default state for "announce stream" option.
     update_announce_stream_state();
     clear_error_display();
 }

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -326,14 +326,24 @@ export function show_new_stream_modal() {
             "realm_default",
         );
 
-        // Add listener to .show stream-message-retention-days-input that we've hidden above
-        $("#stream_creation_form .stream_message_retention_setting").on("change", (e) => {
-            if (e.target.value === "custom_period") {
-                $("#stream_creation_form .stream-message-retention-days-input").show();
-            } else {
-                $("#stream_creation_form .stream-message-retention-days-input").hide();
-            }
-        });
+        // The user is not allowed to set the setting to amy value other than
+        // "realm_default" for realms on limited plans, so we disable the setting.
+        $("#stream_creation_form select[name=stream_message_retention_setting]").prop(
+            "disabled",
+            !page_params.zulip_plan_is_not_limited,
+        );
+
+        // This listener is only needed if the dropdown setting is enabled.
+        if (page_params.zulip_plan_is_not_limited) {
+            // Add listener to .show stream-message-retention-days-input that we've hidden above
+            $("#stream_creation_form .stream_message_retention_setting").on("change", (e) => {
+                if (e.target.value === "custom_period") {
+                    $("#stream_creation_form .stream-message-retention-days-input").show();
+                } else {
+                    $("#stream_creation_form .stream-message-retention-days-input").hide();
+                }
+            });
+        }
     }
 
     // set default state for "announce stream" option.

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -211,6 +211,8 @@ export function show_settings_for(node) {
         zulip_plan_is_not_limited: page_params.zulip_plan_is_not_limited,
         upgrade_text_for_wide_organization_logo:
             page_params.upgrade_text_for_wide_organization_logo,
+        is_business_type_org:
+            page_params.realm_org_type === settings_config.all_org_type_values.business.code,
         is_admin: page_params.is_admin,
         org_level_message_retention_setting: get_display_text_for_realm_message_retention_setting(),
     });

--- a/static/templates/stream_settings/stream_settings.hbs
+++ b/static/templates/stream_settings/stream_settings.hbs
@@ -58,6 +58,7 @@
                   stream_privacy_policy=../stream_privacy_policy
                   zulip_plan_is_not_limited=../zulip_plan_is_not_limited
                   upgrade_text_for_wide_organization_logo=../upgrade_text_for_wide_organization_logo
+                  is_business_type_org=../is_business_type_org
                   org_level_message_retention_setting=../org_level_message_retention_setting
                   is_stream_edit=true }}
             </div>

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -42,12 +42,13 @@
 
 {{#if (or is_owner is_stream_edit)}}
 <div>
-    {{> ../settings/upgrade_tip_widget}}
-
     <div class="input-group inline-block message-retention-setting-group">
         <label class="dropdown-title">{{t "Message retention period" }}
             {{> ../help_link_widget link="/help/message-retention-policy" }}
         </label>
+
+        {{> ../settings/upgrade_tip_widget}}
+
         <select name="stream_message_retention_setting"
           class="stream_message_retention_setting prop-element"
           id="id_message_retention_days"


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit just fixes a comment.
- Second commit is to refactor the code to call setting related jquery code only is setting is visible.
- Third commit is to disable the setting for limited plan realms in stream creation form.
- Fourth commit fixes the uograde text in stream edit panel to not mention about sponsorship for business type orgs.
- Fifth commit is to change the position of upgrade text.

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/stream/9-issues/topic/stream.20retention.20period

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Stream creation form -
![stream-create](https://user-images.githubusercontent.com/35494118/210977689-7e430286-076f-4824-9cf0-efa4459b9470.png)

Stream edit panel -
![stream-edit](https://user-images.githubusercontent.com/35494118/210977748-473e1936-b695-469d-b0dd-1e8e4789d49b.png)





<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
