### PR TITLE
intercom: Return success on HEAD requests.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -55,7 +55,7 @@ from zerver.lib.exceptions import (
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.rate_limiter import is_local_addr, rate_limit_request_by_ip, rate_limit_user
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
-from zerver.lib.response import json_method_not_allowed, json_success
+from zerver.lib.response import json_method_not_allowed
 from zerver.lib.subdomains import get_subdomain, user_matches_subdomain
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 from zerver.lib.users import is_2fa_verified
@@ -962,7 +962,7 @@ def return_success_on_head_request(
         request: HttpRequest, /, *args: ParamT.args, **kwargs: ParamT.kwargs
     ) -> HttpResponse:
         if request.method == "HEAD":
-            return json_success(request)
+            return HttpResponse()
         return view_func(request, *args, **kwargs)
 
     return _wrapped_view_func

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1971,8 +1971,8 @@ class ReturnSuccessOnHeadRequestDecorator(ZulipTestCase):
             return json_response(msg="from_test_function")  # nocoverage. isn't meant to be called
 
         response = test_function(request)
-        self.assert_json_success(response)
-        self.assertNotEqual(orjson.loads(response.content).get("msg"), "from_test_function")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"")
 
     def test_returns_normal_response_if_request_method_is_not_head(self) -> None:
         class HeadRequest(HostRequestMock):

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -265,3 +265,7 @@ New user created:
             "Contact: Eeshan Garg",
             "User unsubscribed from emails.",
         )
+
+    def test_success_on_http_head(self) -> None:
+        result = self.client_head(self.url)
+        self.assertEqual(result.status_code, 200)

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, List, Tuple
 
 from django.http import HttpRequest, HttpResponse
 
-from zerver.decorator import webhook_view
+from zerver.decorator import return_success_on_head_request, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
@@ -325,6 +325,8 @@ ALL_EVENT_TYPES = list(EVENT_TO_FUNCTION_MAPPER.keys())
 
 
 @webhook_view("Intercom", all_event_types=ALL_EVENT_TYPES)
+# Intercom sends a HEAD request to validate the webhook URL. In this case, we just assume success.
+@return_success_on_head_request
 @has_request_variables
 def api_intercom_webhook(
     request: HttpRequest,


### PR DESCRIPTION
Intercom sends a HEAD request to validate the webhook URL on their side, which was not expected in the previous implementation. This fixes the problem that we send out a confusing error message for it.

Fixes #23912.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
