### PR TITLE
typeahead: Make menu scrollable with upto 50 items.

### DIFF
--- a/web/src/bootstrap_typeahead.ts
+++ b/web/src/bootstrap_typeahead.ts
@@ -164,6 +164,7 @@ import assert from "minimalistic-assert";
 import {insertTextIntoField} from "text-field-edit";
 import * as tippy from "tippy.js";
 
+import * as scroll_util from "./scroll_util";
 import {get_string_diff} from "./util";
 
 function get_pseudo_keycode(
@@ -196,13 +197,15 @@ export function defaultSorter(items: string[], query: string): string[] {
     return [...beginswith, ...caseSensitive, ...caseInsensitive];
 }
 
+export const MAX_ITEMS = 50;
+
 /* TYPEAHEAD PUBLIC CLASS DEFINITION
  * ================================= */
 
 const HEADER_ELEMENT_HTML =
     '<p class="typeahead-header"><span id="typeahead-header-text"></span></p>';
 const CONTAINER_HTML = '<div class="typeahead dropdown-menu"></div>';
-const MENU_HTML = '<ul class="typeahead-menu"></ul>';
+const MENU_HTML = '<ul class="typeahead-menu" data-simplebar></ul>';
 const ITEM_HTML = "<li><a></a></li>";
 const MIN_LENGTH = 1;
 
@@ -274,7 +277,7 @@ export class Typeahead<ItemType extends string | object> {
         } else {
             assert(!this.input_element.$element.is("[contenteditable]"));
         }
-        this.items = options.items ?? 8;
+        this.items = options.items ?? MAX_ITEMS;
         this.matcher = options.matcher ?? ((item, query) => this.defaultMatcher(item, query));
         this.sorter = options.sorter;
         this.highlighter_html = options.highlighter_html;
@@ -511,7 +514,10 @@ export class Typeahead<ItemType extends string | object> {
         if (this.requireHighlight || this.shouldHighlightFirstResult()) {
             $items[0]!.addClass("active");
         }
-        this.$menu.empty().append($items);
+        // Getting scroll element ensures simplebar has processed the element
+        // before we render it.
+        scroll_util.get_scroll_element(this.$menu);
+        scroll_util.get_content_element(this.$menu).empty().append($items);
         return this;
     }
 
@@ -531,6 +537,7 @@ export class Typeahead<ItemType extends string | object> {
         }
 
         $next.addClass("active");
+        scroll_util.scroll_element_into_container($next, this.$menu);
     }
 
     prev(): void {
@@ -549,6 +556,7 @@ export class Typeahead<ItemType extends string | object> {
         }
 
         $prev.addClass("active");
+        scroll_util.scroll_element_into_container($prev, this.$menu);
     }
 
     listen(): void {
@@ -804,7 +812,7 @@ export class Typeahead<ItemType extends string | object> {
 
 type TypeaheadOptions<ItemType> = {
     highlighter_html: (item: ItemType, query: string) => string | undefined;
-    items: number;
+    items?: number;
     source: (query: string, input_element: TypeaheadInputElement) => ItemType[];
     // optional options
     advanceKeyCodes?: number[];

--- a/web/src/composebox_typeahead.ts
+++ b/web/src/composebox_typeahead.ts
@@ -6,7 +6,7 @@ import * as typeahead from "../shared/src/typeahead";
 import type {Emoji, EmojiSuggestion} from "../shared/src/typeahead";
 import render_topic_typeahead_hint from "../templates/topic_typeahead_hint.hbs";
 
-import {Typeahead} from "./bootstrap_typeahead";
+import {MAX_ITEMS, Typeahead} from "./bootstrap_typeahead";
 import type {TypeaheadInputElement} from "./bootstrap_typeahead";
 import * as bulleted_numbered_list_util from "./bulleted_numbered_list_util";
 import * as compose_pm_pill from "./compose_pm_pill";
@@ -103,9 +103,8 @@ export type TypeaheadSuggestion =
     | EmojiSuggestion
     | SlashCommandSuggestion;
 
-// This is what we use for direct message/compose typeaheads.
 // We export it to allow tests to mock it.
-export const max_num_items = 8;
+export const max_num_items = MAX_ITEMS;
 
 export let emoji_collection: Emoji[] = [];
 
@@ -1239,7 +1238,7 @@ export function initialize_topic_edit_typeahead(
             const stream_id = stream_data.get_stream_id(stream_name);
             return topics_seen_for(stream_id);
         },
-        items: 5,
+        items: max_num_items,
     });
 }
 
@@ -1317,7 +1316,7 @@ export function initialize({
         source(): string[] {
             return topics_seen_for(compose_state.stream_id());
         },
-        items: 3,
+        items: max_num_items,
         highlighter_html(item: string): string {
             return typeahead_helper.render_typeahead_item({primary: item});
         },

--- a/web/src/custom_profile_fields_ui.ts
+++ b/web/src/custom_profile_fields_ui.ts
@@ -202,7 +202,6 @@ export function initialize_custom_pronouns_type_fields(element_id: string): void
                 type: "input" as const,
             };
             new Typeahead(bootstrap_typeahead_input, {
-                items: 3,
                 helpOnEmptyStrings: true,
                 source() {
                     return commonly_used_pronouns;

--- a/web/src/pill_typeahead.ts
+++ b/web/src/pill_typeahead.ts
@@ -41,7 +41,6 @@ export function set_up_user(
         type: "contenteditable",
     };
     new Typeahead(bootstrap_typeahead_input, {
-        items: 5,
         dropup: true,
         source(_query: string): UserPillData[] {
             return user_pill.typeahead_source(pills, exclude_bots);
@@ -87,7 +86,6 @@ export function set_up_stream(
     };
     opts.help_on_empty_strings ||= false;
     new Typeahead(bootstrap_typeahead_input, {
-        items: 12,
         dropup: true,
         helpOnEmptyStrings: true,
         source(_query: string): StreamPillData[] {
@@ -153,7 +151,6 @@ export function set_up_combined(
         type: "contenteditable",
     };
     new Typeahead(bootstrap_typeahead_input, {
-        items: 5,
         dropup: true,
         source(query: string): TypeaheadItem[] {
             let source: TypeaheadItem[] = [];

--- a/web/src/search_suggestion.ts
+++ b/web/src/search_suggestion.ts
@@ -3,6 +3,7 @@ import assert from "minimalistic-assert";
 
 import render_user_pill from "../templates/user_pill.hbs";
 
+import {MAX_ITEMS} from "./bootstrap_typeahead";
 import * as common from "./common";
 import * as direct_message_group_data from "./direct_message_group_data";
 import {Filter, create_user_pill_context} from "./filter";
@@ -41,7 +42,7 @@ export type Suggestion = {
       }
 );
 
-export const max_num_of_search_results = 12;
+export const max_num_of_search_results = MAX_ITEMS;
 
 function channel_matches_query(channel_name: string, q: string): boolean {
     return common.phrase_match(q, channel_name);

--- a/web/src/settings_playgrounds.ts
+++ b/web/src/settings_playgrounds.ts
@@ -169,7 +169,6 @@ function build_page(): void {
             language_labels = realm_playground.get_pygments_typeahead_list_for_settings(query);
             return [...language_labels.keys()];
         },
-        items: 5,
         helpOnEmptyStrings: true,
         highlighter_html: (item: string): string =>
             render_typeahead_item({primary: language_labels.get(item)}),

--- a/web/src/typeahead_helper.ts
+++ b/web/src/typeahead_helper.ts
@@ -6,6 +6,7 @@ import * as typeahead from "../shared/src/typeahead";
 import type {EmojiSuggestion} from "../shared/src/typeahead";
 import render_typeahead_list_item from "../templates/typeahead_list_item.hbs";
 
+import {MAX_ITEMS} from "./bootstrap_typeahead";
 import * as buddy_data from "./buddy_data";
 import * as compose_state from "./compose_state";
 import type {LanguageSuggestion, SlashCommandSuggestion} from "./composebox_typeahead";
@@ -416,7 +417,7 @@ export function sort_recipients<UserType extends UserOrMentionPillData | UserPil
     current_stream_id,
     current_topic,
     groups = [],
-    max_num_items = 20,
+    max_num_items = MAX_ITEMS,
 }: {
     users: UserType[];
     query: string;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -1404,6 +1404,12 @@ textarea.new_message_textarea {
     .typeahead-menu {
         list-style: none;
         margin: 4px 0;
+        max-height: min(248px, 95vh);
+        overflow-y: auto;
+
+        .simplebar-content {
+            min-width: max-content;
+        }
     }
 
     .typeahead-header {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -166,7 +166,7 @@
             color: var(--color-text-search-hover);
         }
 
-        .typeahead-menu > li > a {
+        .typeahead-menu .simplebar-content > li > a {
             max-width: none;
         }
     }
@@ -331,7 +331,7 @@
         }
     }
 
-    .typeahead-menu > li > a {
+    .typeahead-menu .simplebar-content > li > a {
         padding: 3px 30px;
         /* Override white-space: nowrap from zulip.css */
         white-space: normal;

--- a/web/styles/typeahead.css
+++ b/web/styles/typeahead.css
@@ -14,7 +14,7 @@
     z-index: 1051;
 }
 
-.typeahead.dropdown-menu .typeahead-menu {
+.typeahead.dropdown-menu .typeahead-menu .simplebar-content {
     & > li {
         word-break: break-word;
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -59,11 +59,6 @@ const settings_config = zrequire("settings_config");
 
 const ct = composebox_typeahead;
 
-// Use a slightly larger value than what's user-facing
-// to facilitate testing different combinations of
-// broadcast-mentions/persons/groups.
-ct.__Rewire__("max_num_items", 15);
-
 function user_item(user) {
     return {type: "user", user};
 }

--- a/web/tests/pill_typeahead.test.js
+++ b/web/tests/pill_typeahead.test.js
@@ -162,7 +162,6 @@ run_test("set_up_user", ({mock_template, override, override_rewire}) => {
 
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
         assert.equal(input_element.$element, $fake_input);
-        assert.equal(config.items, 5);
         assert.ok(config.dropup);
         assert.ok(config.stopAdvance);
 
@@ -255,7 +254,6 @@ run_test("set_up_stream", ({mock_template, override, override_rewire}) => {
 
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
         assert.equal(input_element.$element, $fake_input);
-        assert.equal(config.items, 12);
         assert.ok(config.dropup);
         assert.ok(config.stopAdvance);
 
@@ -345,7 +343,6 @@ run_test("set_up_combined", ({mock_template, override, override_rewire}) => {
     let opts = {};
     override(bootstrap_typeahead, "Typeahead", (input_element, config) => {
         assert.equal(input_element.$element, $fake_input);
-        assert.equal(config.items, 5);
         assert.ok(config.dropup);
         assert.ok(config.stopAdvance);
 

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -16,8 +16,6 @@ const stream_topic_history = zrequire("stream_topic_history");
 const people = zrequire("people");
 const search = zrequire("search_suggestion");
 
-search.__Rewire__("max_num_of_search_results", 15);
-
 const me = {
     email: "myself@zulip.com",
     full_name: "Me Myself",


### PR DESCRIPTION
To increase the number of options available for the user to pick from, we increase the limit of options shown to 50 for all typeaheads, and make the menu scrollable. The max height is set to original height of the composebox typeahead menu, which fit 8 options.

A thorough audit of the effect of this change on the performance of the typeaheads will probably be needed, followed by reduction of the maximum number of options shown if and where necessary.

Fixes: #20620.

**Screenshots and screen captures:**
Composebox:
![image](https://github.com/zulip/zulip/assets/68962290/9a0a48f2-c6c2-44ac-b995-3d10573c9f49)
Search:
![image](https://github.com/zulip/zulip/assets/68962290/64b3b09c-879f-4283-8009-29a0fbed9ceb)
Move message modal:
![image](https://github.com/zulip/zulip/assets/68962290/7d37d48b-feea-4680-a029-1451c6f546b7)
Code playground settings:
![image](https://github.com/zulip/zulip/assets/68962290/d8f3bc75-a585-4657-b18a-c3f8cafff097)
Adding channel's members to user group:
![image](https://github.com/zulip/zulip/assets/68962290/b97c5928-fd93-4b02-abde-06c0a9a3e127)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
