### PR TITLE
Fix bug where timezone-aware times are not pickable after emoji etc.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1332,7 +1332,10 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("hi emoji :da ", emoji_list);
     assert_typeahead_equals("hi emoji\n:da", emoji_list);
     assert_typeahead_equals("hi emoji\n :ra", emoji_list);
+    assert_typeahead_equals("<time:2023-01-05T20:06:00-05:00> :+", emoji_list);
     assert_typeahead_equals(":+", emoji_list);
+    // CURRENTLY FAILING
+    // assert_typeahead_equals(":+1: ", false); // Already completed the emoji
     assert_typeahead_equals(":la", emoji_list);
     assert_typeahead_equals(" :lee", emoji_list);
     assert_typeahead_equals("hi :see no", emoji_list);
@@ -1406,16 +1409,28 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("#**Sweden>totally new topic", sweden_topics_to_show);
 
     // time_jump
+    assert_typeahead_equals("@**a person** <tim", false);
     assert_typeahead_equals("<tim", false);
     assert_typeahead_equals("<timerandom", false);
     assert_typeahead_equals("<time", ["translated: Mention a time-zone-aware time"]);
     assert_typeahead_equals("<time:", ["translated: Mention a time-zone-aware time"]);
+    // CURRENTLY FAILING, same bug as above with emoji mentions
+    // assert_typeahead_equals(":octopus: <tim", false);
+    assert_typeahead_equals(":octopus: <timerandom", false);
+    assert_typeahead_equals(":octopus: <time", ["translated: Mention a time-zone-aware time"]);
+    assert_typeahead_equals(":octopus: <time:", ["translated: Mention a time-zone-aware time"]);
+    assert_typeahead_equals(":octopus: <time:something", [
+        "translated: Mention a time-zone-aware time",
+    ]);
     assert_typeahead_equals("<time:something", ["translated: Mention a time-zone-aware time"]);
     assert_typeahead_equals("<time:something", "> ", [
         "translated: Mention a time-zone-aware time",
     ]);
     assert_typeahead_equals("<time:something>", ["translated: Mention a time-zone-aware time"]);
     assert_typeahead_equals("<time:something> ", false); // Already completed the mention
+    assert_typeahead_equals("<time:something> <time", [
+        "translated: Mention a time-zone-aware time",
+    ]);
 
     // Following tests place the cursor before the second string
     assert_typeahead_equals("#test", "ing", false);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -287,6 +287,8 @@ export function tokenize_compose_str(s) {
         min_i = 0;
     }
 
+    const timestamp_index = s.indexOf("<time");
+
     while (i > min_i) {
         i -= 1;
         switch (s[i]) {
@@ -331,11 +333,10 @@ export function tokenize_compose_str(s) {
                 // maybe topic_list; let's let the stream_topic_regex decide later.
                 return ">topic_list";
         }
-    }
 
-    const timestamp_index = s.indexOf("<time");
-    if (timestamp_index >= 0) {
-        return s.slice(timestamp_index);
+        if (timestamp_index >= i) {
+            return s.slice(timestamp_index);
+        }
     }
 
     return "";


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/23998


**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
