### PR TITLE
Include Code Playground pygment_languages in composebox typeahead

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
 
-import pygments_data from "../generated/pygments_data.json";
 import * as typeahead from "../shared/src/typeahead";
 
 import * as compose from "./compose";
@@ -17,6 +16,7 @@ import * as message_store from "./message_store";
 import * as muted_users from "./muted_users";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as realm_playground from "./realm_playground";
 import * as rows from "./rows";
 import * as stream_data from "./stream_data";
 import * as stream_topic_history from "./stream_topic_history";
@@ -631,7 +631,7 @@ export function get_candidates(query) {
         }
         this.completing = "syntax";
         this.token = current_token;
-        return Object.keys(pygments_data.langs);
+        return realm_playground.get_pygments_typeahead_list_for_composebox();
     }
 
     // Only start the emoji autocompleter if : is directly after one

--- a/web/src/realm_playground.js
+++ b/web/src/realm_playground.js
@@ -29,7 +29,7 @@ export function get_playground_info_for_languages(lang) {
 
 export function sort_pygments_pretty_names_by_priority(generated_pygments_data) {
     const priority_sorted_pygments_data = Object.keys(generated_pygments_data.langs).sort(
-        typeahead_helper.compare_by_popularity,
+        typeahead_helper.compare_language,
     );
     for (const alias of priority_sorted_pygments_data) {
         const pretty_name = generated_pygments_data.langs[alias].pretty_name;

--- a/web/src/realm_playground.js
+++ b/web/src/realm_playground.js
@@ -42,7 +42,7 @@ export function sort_pygments_pretty_names_by_priority(generated_pygments_data) 
     }
 }
 
-export function get_pygments_typeahead_list(query) {
+export function get_pygments_typeahead_list_for_settings(query) {
     const language_labels = new Map();
 
     // Adds a typeahead that allows selecting a custom language, by adding a

--- a/web/src/realm_playground.js
+++ b/web/src/realm_playground.js
@@ -58,8 +58,7 @@ export function get_pygments_typeahead_list_for_composebox() {
 }
 
 // This gets the candidate list for showing autocomplete in settings when
-// adding a new Code Playground. This will not include existing Code
-// Playgrounds in the candidate list.
+// adding a new Code Playground.
 export function get_pygments_typeahead_list_for_settings(query) {
     const language_labels = new Map();
 
@@ -71,6 +70,11 @@ export function get_pygments_typeahead_list_for_settings(query) {
             clean_query,
             $t({defaultMessage: "Custom language: {query}"}, {query: clean_query}),
         );
+    }
+
+    const playground_pygment_langs = [...map_language_to_playground_info.keys()];
+    for (const lang of playground_pygment_langs) {
+        language_labels.set(lang, $t({defaultMessage: "Custom language: {query}"}, {query: lang}));
     }
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {

--- a/web/src/realm_playground.js
+++ b/web/src/realm_playground.js
@@ -1,3 +1,4 @@
+import generated_pygments_data from "../generated/pygments_data.json";
 import * as typeahead from "../shared/src/typeahead";
 
 import {$t} from "./i18n";
@@ -42,6 +43,23 @@ export function sort_pygments_pretty_names_by_priority(generated_pygments_data) 
     }
 }
 
+// This gets the candidate list for showing autocomplete for a code block in
+// the composebox. The candidate list will include pygments data as well as any
+// Code Playgrounds.
+//
+// May return duplicates, since it's common for playground languages
+// to also be pygments languages! retain_unique_language_aliases will
+// deduplicate them.
+export function get_pygments_typeahead_list_for_composebox() {
+    const playground_pygment_langs = [...map_language_to_playground_info.keys()];
+    const generated_pygment_langs = Object.keys(generated_pygments_data.langs);
+
+    return playground_pygment_langs.concat(generated_pygment_langs);
+}
+
+// This gets the candidate list for showing autocomplete in settings when
+// adding a new Code Playground. This will not include existing Code
+// Playgrounds in the candidate list.
 export function get_pygments_typeahead_list_for_settings(query) {
     const language_labels = new Map();
 

--- a/web/src/settings_playgrounds.js
+++ b/web/src/settings_playgrounds.js
@@ -165,7 +165,7 @@ function build_page() {
 
     $search_pygments_box.typeahead({
         source(query) {
-            language_labels = realm_playground.get_pygments_typeahead_list(query);
+            language_labels = realm_playground.get_pygments_typeahead_list_for_settings(query);
             return Array.from(language_labels.keys());
         },
         items: 5,

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -259,14 +259,22 @@ export function sort_people_for_relevance(objs, current_stream_name, current_top
     return objs;
 }
 
+function compare_language_by_popularity(lang_a, lang_b) {
+    return pygments_data.langs[lang_b].priority - pygments_data.langs[lang_a].priority;
+}
+
 // This function compares two languages first by their popularity, then if
 // there is a tie on popularity, then compare alphabetically to break the tie.
 export function compare_language(lang_a, lang_b) {
-    const diff = pygments_data.langs[lang_b].priority - pygments_data.langs[lang_a].priority;
-    if (diff !== 0) {
-        return diff;
+    let diff = compare_language_by_popularity(lang_a, lang_b);
+
+    // Check to see if there is a tie. If there is, then use alphabetical order
+    // to break the tie.
+    if (diff === 0) {
+        diff = util.strcmp(lang_a, lang_b);
     }
-    return util.strcmp(lang_a, lang_b);
+
+    return diff;
 }
 
 function retain_unique_language_aliases(matches) {

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -259,7 +259,9 @@ export function sort_people_for_relevance(objs, current_stream_name, current_top
     return objs;
 }
 
-export function compare_by_popularity(lang_a, lang_b) {
+// This function compares two languages first by their popularity, then if
+// there is a tie on popularity, then compare alphabetically to break the tie.
+export function compare_language(lang_a, lang_b) {
     const diff = pygments_data.langs[lang_b].priority - pygments_data.langs[lang_a].priority;
     if (diff !== 0) {
         return diff;
@@ -289,7 +291,7 @@ export function sort_languages(matches, query) {
     const results = typeahead.triage(query, matches, (x) => x);
 
     // Languages that start with the query
-    results.matches = results.matches.sort(compare_by_popularity);
+    results.matches = results.matches.sort(compare_language);
 
     // Push exact matches to top.
     const match_index = results.matches.indexOf(query);
@@ -299,7 +301,7 @@ export function sort_languages(matches, query) {
     }
 
     // Languages that have the query somewhere in their name
-    results.rest = results.rest.sort(compare_by_popularity);
+    results.rest = results.rest.sort(compare_language);
     return retain_unique_language_aliases(results.matches.concat(results.rest));
 }
 

--- a/web/tests/realm_playground.test.js
+++ b/web/tests/realm_playground.test.js
@@ -7,6 +7,7 @@ const {run_test} = require("./lib/test");
 
 const pygments_data = zrequire("../generated/pygments_data.json");
 
+const {$t} = zrequire("i18n");
 const realm_playground = zrequire("realm_playground");
 
 run_test("get_pygments_typeahead_list_for_composebox", () => {
@@ -37,5 +38,69 @@ run_test("get_pygments_typeahead_list_for_composebox", () => {
     assert.equal(
         candidates.length,
         Object.keys(pygments_data.langs).length + playground_data.length,
+    );
+});
+
+run_test("get_pygments_typeahead_list_for_settings", () => {
+    const custom_pygment_language = "custom_lang";
+    const playground_data = [
+        {
+            id: 1,
+            name: "Custom Lang #1",
+            pygments_language: custom_pygment_language,
+            url_prefix: "https://example.com/?q=",
+        },
+        {
+            id: 2,
+            name: "Custom Lang #2",
+            pygments_language: custom_pygment_language,
+            url_prefix: "https://example.com/?q=",
+        },
+        {
+            id: 3,
+            name: "Invent a Language",
+            pygments_language: "invent_a_lang",
+            url_prefix: "https://example.com/?q=",
+        },
+    ];
+    realm_playground.initialize(playground_data, pygments_data);
+
+    let candidates = realm_playground.get_pygments_typeahead_list_for_settings("");
+    let iterator = candidates.entries();
+    assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
+    assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
+    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(
+        iterator.next().value[1],
+        "Python (python, py, py3, python3, sage, python, py, py3, python3, sage)",
+    );
+    assert.equal(iterator.next().value[1], "Java (java, java)");
+    assert.equal(iterator.next().value[1], "Go (go, golang, go, golang)");
+    assert.equal(iterator.next().value[1], "Rust (rust, rs, rust, rs)");
+
+    // Test typing "cu". Previously added custom languages should show up too.
+    candidates = realm_playground.get_pygments_typeahead_list_for_settings("cu");
+    iterator = candidates.entries();
+    assert.equal(
+        iterator.next().value[1],
+        $t({defaultMessage: "Custom language: {query}"}, {query: "cu"}),
+    );
+    assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
+    assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
+    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(
+        iterator.next().value[1],
+        "Python (python, py, py3, python3, sage, python, py, py3, python3, sage)",
+    );
+
+    // Test typing "invent_a_lang". Make sure there is no duplicate entries.
+    candidates = realm_playground.get_pygments_typeahead_list_for_settings("invent_a_lang");
+    iterator = candidates.entries();
+    assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: invent_a_lang"}));
+    assert.equal(iterator.next().value[1], $t({defaultMessage: "Custom language: custom_lang"}));
+    assert.equal(iterator.next().value[1], "JavaScript (javascript, js, javascript, js)");
+    assert.equal(
+        iterator.next().value[1],
+        "Python (python, py, py3, python3, sage, python, py, py3, python3, sage)",
     );
 });

--- a/web/tests/realm_playground.test.js
+++ b/web/tests/realm_playground.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("./lib/namespace");
+const {run_test} = require("./lib/test");
+
+const pygments_data = zrequire("../generated/pygments_data.json");
+
+const realm_playground = zrequire("realm_playground");
+
+run_test("get_pygments_typeahead_list_for_composebox", () => {
+    // When no Code Playground is configured, the list of candidates should
+    // include everything in pygments_data, but nothing more. Order doesn't
+    // matter.
+    let candidates = realm_playground.get_pygments_typeahead_list_for_composebox();
+    assert.ok(Object.keys(pygments_data.langs).every((value) => candidates.includes(value)));
+    assert.equal(candidates.length, Object.keys(pygments_data.langs).length);
+
+    const custom_pygment_language = "Custom_lang";
+    const playground_data = [
+        {
+            id: 2,
+            name: "Custom Lang",
+            pygments_language: custom_pygment_language,
+            url_prefix: "https://example.com/?q=",
+        },
+    ];
+    realm_playground.initialize(playground_data, pygments_data);
+
+    // Verify that Code Playground's pygments_language shows up in the result.
+    // As well as all of pygments_data. Order doesn't matter and the result
+    // shouldn't include anything else.
+    candidates = realm_playground.get_pygments_typeahead_list_for_composebox();
+    assert.ok(Object.keys(pygments_data.langs).every((value) => candidates.includes(value)));
+    assert.ok(candidates.includes(custom_pygment_language));
+    assert.equal(
+        candidates.length,
+        Object.keys(pygments_data.langs).length + playground_data.length,
+    );
+});

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -18,6 +18,7 @@ const stream_data = zrequire("stream_data");
 const compose_state = zrequire("compose_state");
 const emoji = zrequire("emoji");
 const pygments_data = zrequire("../generated/pygments_data.json");
+const util = zrequire("util");
 const actual_pygments_data = {...pygments_data};
 const ct = zrequire("composebox_typeahead");
 const th = zrequire("typeahead_helper");
@@ -815,4 +816,13 @@ test("sort_slash_commands", () => {
         {name: "poll"},
         {name: "test"},
     ]);
+});
+
+test("compare_language", () => {
+    assert.ok(th.compare_language("javascript", "haskell") < 0);
+    assert.ok(th.compare_language("haskell", "javascript") > 0);
+
+    // "abap" and "amdgpu" both have priority = 0 at this time, so there is a tie.
+    // Alphabetical order should be used to break that tie.
+    assert.equal(th.compare_language("abap", "amdgpu"), util.strcmp("abap", "amdgpu"));
 });

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -825,4 +825,14 @@ test("compare_language", () => {
     // "abap" and "amdgpu" both have priority = 0 at this time, so there is a tie.
     // Alphabetical order should be used to break that tie.
     assert.equal(th.compare_language("abap", "amdgpu"), util.strcmp("abap", "amdgpu"));
+
+    // Test with languages that aren't in the generated pygments data.
+    assert.equal(actual_pygments_data.langs.custom_a, undefined);
+    assert.equal(actual_pygments_data.langs.custom_b, undefined);
+    // Since custom_a has no popularity score, it gets sorted behind python.
+    assert.equal(th.compare_language("custom_a", "python"), 1);
+    assert.equal(th.compare_language("python", "custom_a"), -1);
+    // Whenever there is a tie, even in the case neither have a popularity
+    // score, then alphabetical order is used to break the tie.
+    assert.equal(th.compare_language("custom_a", "custom_b"), util.strcmp("custom_a", "custom_b"));
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #23935

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/122081200/211171287-a2801ab2-5739-46bc-8c0e-e68125498e69.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
