### PR TITLE
compose: show characters limit in message-edit UI

### DIFF
--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -571,6 +571,54 @@ test_ui("test_check_overflow_text", ({mock_template}) => {
     assert.ok(!banner_rendered);
 });
 
+test_ui("test_edit_check_overflow_text", ({mock_template}) => {
+    mock_banners();
+    page_params.max_message_length = 10000;
+
+    const $textarea = $("#message_edit_content");
+    const $indicator = $("#edit_compose_limit_indicator");
+    const $save_button = $("#edit-save-button");
+    let banner_rendered = false;
+    mock_template("compose_banner/compose_banner.hbs", false, (data) => {
+        assert.equal(data.classname, compose_banner.CLASSNAMES.message_too_long);
+        assert.equal(
+            data.banner_text,
+            $t({
+                defaultMessage: "Message length shouldn't be greater than 10000 characters.",
+            }),
+        );
+        banner_rendered = true;
+    });
+
+    // Indicator should show red colored text
+    $textarea.val("a".repeat(10000 + 1));
+    compose_validate.edit_check_overflow_text();
+    assert.ok($indicator.hasClass("over_limit"));
+    assert.equal($indicator.text(), "10001/10000");
+    assert.ok($textarea.hasClass("over_limit"));
+    assert.ok(banner_rendered);
+    assert.ok($save_button.prop("disabled"));
+
+    // Indicator should show orange colored text
+    banner_rendered = false;
+    $textarea.val("a".repeat(9000 + 1));
+    compose_validate.edit_check_overflow_text();
+    assert.ok(!$indicator.hasClass("over_limit"));
+    assert.equal($indicator.text(), "9001/10000");
+    assert.ok(!$textarea.hasClass("over_limit"));
+    assert.ok(!$save_button.prop("disabled"));
+    assert.ok(!banner_rendered);
+
+    // Indicator must be empty
+    banner_rendered = false;
+    $textarea.val("a".repeat(9000));
+    compose_validate.edit_check_overflow_text();
+    assert.ok(!$indicator.hasClass("over_limit"));
+    assert.equal($indicator.text(), "");
+    assert.ok(!$textarea.hasClass("over_limit"));
+    assert.ok(!banner_rendered);
+});
+
 test_ui("needs_subscribe_warning", () => {
     const invalid_user_id = 999;
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -553,6 +553,10 @@ export function initialize() {
         $("#compose .file_input").trigger("click");
     });
 
+    $("body").on("input propertychange", "#message_edit_content", () => {
+        compose_validate.edit_check_overflow_text();
+    });
+
     $("body").on("click", ".video_link", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -53,6 +53,7 @@ export const topic = get_or_set("stream_message_recipient_topic");
 // We can't trim leading whitespace in `compose_textarea` because
 // of the indented syntax for multi-line code blocks.
 export const message_content = get_or_set("compose-textarea", true);
+export const edit_message_content = get_or_set("message_edit_content", true);
 
 export function focus_in_empty_compose() {
     // A user trying to press arrow keys in an empty compose is mostly

--- a/static/js/compose_validate.js
+++ b/static/js/compose_validate.js
@@ -593,6 +593,46 @@ export function check_overflow_text() {
     return text.length;
 }
 
+export function edit_check_overflow_text() {
+    // This function is called when typing every character while
+    // editing box, so it's important that it not doing anything
+    // expensive.
+    const text = compose_state.edit_message_content();
+    const max_length = page_params.max_message_length;
+    const $indicator = $("#edit_compose_limit_indicator");
+    if (text.length > max_length) {
+        $indicator.addClass("over_limit");
+        $("#message_edit_content").addClass("over_limit");
+        $indicator.text(text.length + "/" + max_length);
+        compose_banner.show_error_message(
+            $t(
+                {
+                    defaultMessage:
+                        "Message length shouldn't be greater than {max_length} characters.",
+                },
+                {max_length},
+            ),
+            compose_banner.CLASSNAMES.message_too_long,
+        );
+        $("#edit-save-button").prop("disabled", true);
+    } else if (text.length > 0.9 * max_length) {
+        $indicator.removeClass("over_limit");
+        $("#message_edit_content").removeClass("over_limit");
+        $indicator.text(text.length + "/" + max_length);
+
+        $("#edit-save-button").prop("disabled", false);
+        $(`#compose_banners .${compose_banner.CLASSNAMES.message_too_long}`).remove();
+    } else {
+        $indicator.text("");
+        $("#message_edit_content").removeClass("over_limit");
+
+        $("#edit-save-button").prop("disabled", false);
+        $(`#compose_banners .${compose_banner.CLASSNAMES.message_too_long}`).remove();
+    }
+
+    return text.length;
+}
+
 export function warn_for_text_overflow_when_tries_to_send() {
     if (compose_state.message_content().length > page_params.max_message_length) {
         $("#compose-textarea").addClass("flash");

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -222,6 +222,18 @@
     }
 }
 
+#edit_compose_limit_indicator {
+    margin-right: 8px;
+    font-size: 12px;
+    color: hsl(39, 100%, 50%);
+    align-self: center;
+
+    &.over_limit {
+        color: hsl(0, 76%, 65%);
+        font-weight: bold;
+    }
+}
+
 #compose {
     position: fixed;
     bottom: 0;

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -7,7 +7,9 @@
     </div>
     <div class="edit-controls">
         {{> copy_message_button message_id=this.message_id}}
-        <textarea class="message_edit_content" maxlength="{{ max_message_length }}">{{content}}</textarea>
+        <div id="compose_banners"></div>
+        <span id="edit_compose_limit_indicator"></span>
+        <textarea class="message_edit_content" id="message_edit_content">{{content}}</textarea>
         <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
             <div class="markdown_preview_spinner"></div>
             <div class="preview_content rendered_markdown"></div>
@@ -18,7 +20,7 @@
         <div class="controls edit-controls">
             {{#if is_editable}}
                 <div class="btn-wrapper inline-block">
-                    <button type="button" class="button small rounded sea-green message_edit_save">
+                    <button type="button" id="edit-save-button" class="button small rounded sea-green message_edit_save">
                         <img class="loader" alt="" src="" />
                         <span>{{t "Save" }}</span>
                     </button>


### PR DESCRIPTION
Created a function to check and show overflow of text during message editing similar to what was used in compose box.

Fixes #22525

**Screenshots and screen captures:**
 
Previous Behavior:

![messageprev](https://user-images.githubusercontent.com/96344003/211199921-330579d3-98ee-41fa-9df7-7bf09b204d12.png)

New behavior:

![chars](https://user-images.githubusercontent.com/96344003/211199955-811db142-5273-483a-8914-3d0ca1b5ed38.png)

![charsabove](https://user-images.githubusercontent.com/96344003/211199956-9f9d45e3-dff4-471a-bd1f-bd63c4e205c6.png)

https://user-images.githubusercontent.com/96344003/211200190-10fe8644-b4da-496f-bc38-158db8e2cc88.mov

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
