### PR TITLE
compose: Make `focus_in_empty_compose` check untrimmed compose content.

### DIFF
--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -22,7 +22,7 @@ export function composing() {
     return Boolean(message_type);
 }
 
-function get_or_set(fieldname, keep_leading_whitespace) {
+function get_or_set(fieldname, keep_leading_whitespace, no_trim) {
     // We can't hoist the assignment of '$elem' out of this lambda,
     // because the DOM element might not exist yet when get_or_set
     // is called.
@@ -32,7 +32,12 @@ function get_or_set(fieldname, keep_leading_whitespace) {
         if (newval !== undefined) {
             $elem.val(newval);
         }
-        return keep_leading_whitespace ? oldval.trimEnd() : oldval.trim();
+        if (no_trim) {
+            return oldval;
+        } else if (keep_leading_whitespace) {
+            return oldval.trimEnd();
+        }
+        return oldval.trim();
     };
 }
 
@@ -54,11 +59,18 @@ export const topic = get_or_set("stream_message_recipient_topic");
 // of the indented syntax for multi-line code blocks.
 export const message_content = get_or_set("compose-textarea", true);
 
+const untrimmed_message_content = get_or_set("compose-textarea", true, true);
+
+export function cursor_at_start_of_whitespace_in_compose() {
+    const cursor_position = $("#compose-textarea").caret();
+    return message_content() === "" && cursor_position === 0;
+}
+
 export function focus_in_empty_compose() {
     // A user trying to press arrow keys in an empty compose is mostly
     // likely trying to navigate messages. This helper function
-    // decides whether the compose box is "empty" for this purpose.
-    if (!composing() || message_content() !== "") {
+    // decides whether the compose box is empty for this purpose.
+    if (!composing() || untrimmed_message_content() !== "") {
         return false;
     }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -735,13 +735,11 @@ export function process_hotkey(e, hotkey) {
         }
 
         if (
-            (event_name === "up_arrow" ||
-                event_name === "down_arrow" ||
-                event_name === "page_up" ||
-                event_name === "page_down" ||
-                event_name === "home" ||
-                event_name === "end") &&
-            compose_state.focus_in_empty_compose()
+            ((event_name === "down_arrow" || event_name === "page_down" || event_name === "end") &&
+                compose_state.focus_in_empty_compose()) ||
+            ((event_name === "up_arrow" || event_name === "page_up" || event_name === "home") &&
+                (compose_state.focus_in_empty_compose() ||
+                    compose_state.cursor_at_start_of_whitespace_in_compose()))
         ) {
             compose_actions.cancel();
             // don't return, as we still want it to be picked up by the code below


### PR DESCRIPTION
The `focus_in_empty_compose` function used for hotkeys, now checks if the compose box is truly empty by considering it's untrimmed value. If there are just spaces in the focused compose box, `focus_in_empty_compose` returns false now.

This fixes the bug where using the left key among just spaces did not move back the cursor as expected, and may unexpectedly trigger edit state for the last sent message.

<!-- Describe your pull request here.-->

Fixes: [#issues>can't use left key for spaces in composebox](https://chat.zulip.org/#narrow/stream/9-issues/topic/can't.20use.20left.20key.20for.20spaces.20in.20composebox)

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
