### PR TITLE
compose: Retain compose state across narrows if recipient was edited.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -210,6 +210,7 @@ export function send_message_success(local_id, message_id, locally_echoed) {
 }
 
 export function send_message(request = create_message_object()) {
+    compose_state.set_recipient_edited_manually(false);
     if (request.type === "private") {
         request.to = JSON.stringify(request.to);
     } else {
@@ -424,7 +425,10 @@ export function initialize() {
     ).on("keyup", update_on_recipient_change);
     $(
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient",
-    ).on("change", update_on_recipient_change);
+    ).on("change", () => {
+        update_on_recipient_change();
+        compose_state.set_recipient_edited_manually(true);
+    });
     $("#compose-textarea").on("keydown", (event) => {
         compose_ui.handle_keydown(event, $("#compose-textarea").expectOne());
     });

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -115,6 +115,7 @@ function clear_box() {
     compose.clear_private_stream_alert();
     compose_validate.set_user_acknowledged_wildcard_flag(undefined);
 
+    compose_state.set_recipient_edited_manually(false);
     compose.clear_preview_area();
     clear_textarea();
     compose_validate.check_overflow_text();
@@ -495,8 +496,8 @@ export function on_topic_narrow() {
 
     if (compose_state.stream_name() !== narrow_state.stream()) {
         // If we changed streams, then we only leave the
-        // compose box open if there is content.
-        if (compose_state.has_message_content()) {
+        // compose box open if there is content or if the recipient was edited.
+        if (compose_state.has_message_content() || compose_state.is_recipient_edited_manually()) {
             compose_fade.update_message_list();
             return;
         }
@@ -506,14 +507,17 @@ export function on_topic_narrow() {
         return;
     }
 
-    if (compose_state.topic() && compose_state.has_message_content()) {
-        // If the user has written something to a different topic,
+    if (
+        (compose_state.topic() && compose_state.has_message_content()) ||
+        compose_state.is_recipient_edited_manually()
+    ) {
+        // If the user has written something to a different topic or edited it,
         // they probably want that content, so leave compose open.
         //
         // This effectively uses the heuristic of whether there is
-        // content in compose to determine whether the user had firmly
-        // decided to compose to the old topic or is just looking to
-        // reply to what they see.
+        // content in compose or the topic was edited to determine whether
+        // the user had firmly decided to compose to the old topic or is
+        // just looking to reply to what they see.
         compose_fade.update_message_list();
         return;
     }
@@ -612,7 +616,7 @@ export function on_narrow(opts) {
         return;
     }
 
-    if (compose_state.has_message_content()) {
+    if (compose_state.has_message_content() || compose_state.is_recipient_edited_manually()) {
         compose_fade.update_message_list();
         return;
     }

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -3,6 +3,15 @@ import $ from "jquery";
 import * as compose_pm_pill from "./compose_pm_pill";
 
 let message_type = false; // 'stream', 'private', or false-y
+let recipient_edited_manually = false;
+
+export function set_recipient_edited_manually(flag) {
+    recipient_edited_manually = flag;
+}
+
+export function is_recipient_edited_manually() {
+    return recipient_edited_manually;
+}
 
 export function set_message_type(msg_type) {
     message_type = msg_type;

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -1048,7 +1048,7 @@ export function deactivate(coming_from_recent_topics = false) {
         return;
     }
 
-    if (!compose_state.has_message_content()) {
+    if (!compose_state.has_message_content() && !compose_state.is_recipient_edited_manually()) {
         compose_actions.cancel();
     }
 


### PR DESCRIPTION
Uptil now, the compose box's state was retained across narrows only if the compose box had any content in it. Else it was reset to match the current narrow.

To not lose any changes made to the recipient fields only, the compose box will now retain its state also if the recipient (stream, topic or PMs) has been manually edited.

This is achieved by having a variable in `compose_state` track if the recipient fields were changed, and checking it before resetting the compose box on narrowing. This variable is reset when the compose box is manually closed, or a message is sent.

Fixes: #23064.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
