### PR TITLE
api-docs: Clarify only API doc paths check for endpoint info.

### DIFF
--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -111,20 +111,20 @@ class MarkdownDirectoryView(ApiURLView):
                 endpoint_method=None,
             )
 
-        # The following is a somewhat hacky approach to extract titles from articles.
-        # Hack: `context["article"] has a leading `/`, so we use + to add directories.
-        article_path = os.path.join(settings.DEPLOY_ROOT, "templates") + path
-        if (not os.path.exists(article_path)) and self.path_template == "/zerver/api/%s.md":
-            try:
-                endpoint_name, endpoint_method = get_endpoint_from_operationid(article)
-                path = "/zerver/api/api-doc-template.md"
-            except AssertionError:
-                return DocumentationArticle(
-                    article_path=self.path_template % ("missing",),
-                    article_http_status=404,
-                    endpoint_path=None,
-                    endpoint_method=None,
-                )
+        if self.path_template == "/zerver/api/%s.md":
+            # Hack: `self.path_template` has a leading `/`, so we use + to add directories.
+            api_documentation_path = os.path.join(settings.DEPLOY_ROOT, "templates") + path
+            if not os.path.exists(api_documentation_path):
+                try:
+                    endpoint_name, endpoint_method = get_endpoint_from_operationid(article)
+                    path = "/zerver/api/api-doc-template.md"
+                except AssertionError:
+                    return DocumentationArticle(
+                        article_path=self.path_template % ("missing",),
+                        article_http_status=404,
+                        endpoint_path=None,
+                        endpoint_method=None,
+                    )
 
         try:
             loader.get_template(path)


### PR DESCRIPTION
Previously, we got the directory path for all documentation pages before checking for API method and path information in the OpenAPI documentation. Instead, we now check the `path_template` is the API documentation view template before getting the directory path.

Also, changes the confusingly named `article_path` variable, which overlapped with the `DocumentationArticle` dataclass `article_path` field, to now be `api_documentation_path`.

Prep commit for moving the help center documentation to a top level directory, see [this CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/help.20center.20directory.20structure/near/1481333) for more context..

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
