### PR TITLE
message_list_view: Use translated form of "at" in timestamp tooltip.

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -256,10 +256,12 @@ export class MessageListView {
         if (last_edit_timestamp !== undefined) {
             const last_edit_time = new Date(last_edit_timestamp * 1000);
             const today = new Date();
-            return (
-                timerender.render_date(last_edit_time, undefined, today)[0].textContent +
-                " at " +
-                timerender.stringify_time(last_edit_time)
+            return $t(
+                {defaultMessage: "{date} at {time}"},
+                {
+                    date: timerender.render_date(last_edit_time, undefined, today)[0].textContent,
+                    time: timerender.stringify_time(last_edit_time),
+                },
             );
         }
         return undefined;


### PR DESCRIPTION
The English word "at" was manually appended to the string output of datetime-related functions to generate the string shown in the tooltip when hovering over the timestamp of a message. Use the translated form "{date} at {time}" instead, as found elsewhere in the codebase.

<!-- Describe your pull request here.-->

Fixes: https://chat.zulip.org/#narrow/stream/9-issues/topic/date.2Ftime.20in.20tooltip.20not.20internationalized (at least in part) <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

These taken in the context of a local server with a user configured to use Czech and 12h clocks.

Before, current `main`: 
![screenshot-2023-01-11-05:26:51Z](https://user-images.githubusercontent.com/799439/211726112-2bb158db-e08d-406f-9481-d95b42f25789.png)

After: 
![screenshot-2023-01-11-05:33:47Z](https://user-images.githubusercontent.com/799439/211726197-75c95489-8944-4877-bbf5-3d6db454c4f0.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>