### PR TITLE
typeahead: Add message view context to PM recipient suggestions.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1705,3 +1705,29 @@ test("muted users excluded from results", () => {
     const mention_all = ct.broadcast_mentions()[0];
     assert.deepEqual(results, [mention_all, call_center]);
 });
+
+test("PM recipients sorted according to stream / topic being viewed", ({override_rewire}) => {
+    // This tests that PM recipient results are sorted with subscribers of
+    // the stream / topic being viewed being given priority. If no stream
+    // is being viewed, the sort is alphabetical (for testing, since we do not
+    // simulate PM history)
+    let results;
+
+    // Simulating just cordelia being subscribed to denmark.
+    override_rewire(
+        stream_data,
+        "is_user_subscribed",
+        (stream_id, user_id) =>
+            stream_id === denmark_stream.stream_id && user_id === cordelia.user_id,
+    );
+
+    // When viewing no stream, sorting is alphabetical
+    compose_state.set_stream_name("");
+    results = ct.get_pm_people("li");
+    assert.deepEqual(results, [alice, cordelia]);
+
+    // When viewing denmark stream, subscriber twin2 is placed higher
+    compose_state.set_stream_name("Denmark");
+    results = ct.get_pm_people("li");
+    assert.deepEqual(results, [cordelia, alice]);
+});

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -445,6 +445,8 @@ export function get_pm_people(query) {
     const opts = {
         want_broadcast: false,
         filter_pills: true,
+        stream: compose_state.stream_name(),
+        topic: compose_state.topic(),
     };
     return get_person_suggestions(query, opts);
 }

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -234,7 +234,7 @@ export function compare_people_for_relevance(
 }
 
 export function sort_people_for_relevance(objs, current_stream_name, current_topic) {
-    // If sorting for recipientbox typeahead or compose state is private, then current_stream = ""
+    // If sorting for recipientbox typeahead and not viewing a stream / topic, then current_stream = ""
     let current_stream = false;
     if (current_stream_name) {
         current_stream = stream_data.get_sub(current_stream_name);


### PR DESCRIPTION
Uptil now when composing PMs, only for @-mentions was the stream / topic being viewed taken into consideration. The PM recipient suggestions were unaffected by the current view.

Now this context has been added to the PM recipient suggestions as well, ensuring consistent sorting of options across both typeahead menus, with subscribers and recent posters to that stream / view getting priority.

When the view is not narrowed to a stream / topic, the PM suggestions are sorted the same as before.

This PR has the same code changes discussed and made in #22630, with an added test suite.

Fixes: #21645.

**Screenshots and screen captures:**

(For PM recipient field)
Before:
![image](https://user-images.githubusercontent.com/68962290/211805257-f0617756-fc4e-40de-9704-047c1f40e8d1.png)

After:
![image](https://user-images.githubusercontent.com/68962290/211804689-8d56f7ef-41ca-4a00-9a5f-4529ca41edec.png)

The after state is same as the @-mention suggestions:
![image](https://user-images.githubusercontent.com/68962290/211804758-19791679-5b37-472a-8ec2-29af4ed07924.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
