### PR TITLE
bootstrap: Remove `form-horizontal` class.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -1095,7 +1095,7 @@ button#register_auth_button_gitlab {
         padding: 0;
         margin: 0;
 
-        &.form-horizontal:hover {
+        &.select-email-form:hover {
             background-color: hsl(202, 56%, 91%);
             cursor: pointer;
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -213,6 +213,11 @@ h3,
     text-transform: capitalize;
 }
 
+select.setting_email_notifications_batching_period_seconds {
+    /* Override undesired Bootstrap default. */
+    margin-bottom: 0;
+}
+
 .table {
     tbody {
         border-bottom: 1px solid hsl(0, 0%, 87%);

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -868,11 +868,19 @@ input[type="checkbox"] {
     #bot-role-select:disabled {
         opacity: 1;
     }
+
+    select {
+        margin-bottom: 0;
+    }
 }
 
 #add-alert-word {
     form {
         margin-bottom: 4px;
+    }
+
+    input {
+        margin-bottom: 0;
     }
 }
 
@@ -1851,6 +1859,17 @@ $option_title_width: 180px;
     #edit-linkifier-format-status {
         margin-top: 10px;
     }
+
+    input {
+        margin-bottom: 0;
+    }
+}
+
+#edit-user-form,
+#create-bot-form {
+    select {
+        margin-bottom: 0;
+    }
 }
 
 .settings_panel_list_header {
@@ -1873,5 +1892,9 @@ $option_title_width: 180px;
     .disabled_label {
         cursor: default;
         opacity: 0.7;
+    }
+
+    select {
+        margin-bottom: 0;
     }
 }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -456,6 +456,17 @@ input[type="checkbox"] {
     margin-top: 10px;
 }
 
+#organization-profile,
+#organization-settings,
+#organization-permissions,
+#profile-settings {
+    select,
+    input {
+        /* Override undesired Bootstrap default. */
+        margin-bottom: 0;
+    }
+}
+
 #id_org_profile_preview {
     margin-bottom: 20px;
     display: inline-flex;

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2480,6 +2480,12 @@ textarea.invitee_emails {
     .invite-stream-controls {
         margin-top: 5px;
     }
+
+    /* Override undesired Bootstrap defaults. */
+    select,
+    input {
+        margin-bottom: 0;
+    }
 }
 
 #invite_status {

--- a/static/templates/invite_user.hbs
+++ b/static/templates/invite_user.hbs
@@ -5,7 +5,7 @@
             <button type="button" class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
             <h3 id="invite-user-label">{{t "Invite users to Zulip" }}</h3>
         </div>
-        <form id="invite_user_form" class="form-horizontal">{{ csrf_input }}
+        <form id="invite_user_form">{{ csrf_input }}
             <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
                 <div class="alert" id="invite_status"></div>
                 {{#if development_environment}}

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -46,7 +46,7 @@
             </div>
         </div>
 
-        <div class="form-horizontal" id="privacy_settings_box">
+        <div id="privacy_settings_box">
             <h3 class="inline-block">{{t "Privacy" }}</h3>
             <div class="alert-notification privacy-setting-status"></div>
             <div class="input-group">

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -82,7 +82,7 @@
 
         <hr class="settings_separator" />
 
-        <div class="form-horizontal" id="api_key_button_box">
+        <div id="api_key_button_box">
             <h3>{{t "API key" }}</h3>
 
             <div class="input-group">

--- a/static/templates/settings/add_alert_word.hbs
+++ b/static/templates/settings/add_alert_word.hbs
@@ -1,4 +1,4 @@
-<form id="add-alert-word-form" class="form-horizontal">
+<form id="add-alert-word-form">
     <label for="add-alert-word-name">{{t "Alert word" }}</label>
     <input type="text" name="alert-word-name" id="add-alert-word-name" class="required" maxlength=100 placeholder="{{t 'Alert word' }}" value="" />
 </form>

--- a/static/templates/settings/add_new_bot_form.hbs
+++ b/static/templates/settings/add_new_bot_form.hbs
@@ -1,4 +1,4 @@
-<form id="create_bot_form" class="form-horizontal new-style">
+<form id="create_bot_form" class="new-style">
     <div class="new-bot-form">
         <div class="input-group">
             <label for="bot_type">

--- a/static/templates/settings/add_new_custom_profile_field_form.hbs
+++ b/static/templates/settings/add_new_custom_profile_field_form.hbs
@@ -1,4 +1,4 @@
-<form class="form-horizontal admin-profile-field-form new-style" id="add-new-custom-profile-field-form">
+<form class="admin-profile-field-form new-style" id="add-new-custom-profile-field-form">
     <div class="new-profile-field-form wrapper">
         <div class="input-group">
             <label for="profile_field_type" >{{t "Type" }}</label>

--- a/static/templates/settings/admin_human_form.hbs
+++ b/static/templates/settings/admin_human_form.hbs
@@ -1,5 +1,5 @@
 <div id="edit-user-form" data-user-id="{{user_id}}">
-    <form class="form-horizontal name-setting">
+    <form class="name-setting">
         <input type="hidden" name="is_full_name" value="true" />
         <div class="input-group name_change_container">
             <label for="edit_user_full_name">{{t "Full name" }}</label>

--- a/static/templates/settings/admin_linkifier_edit_form.hbs
+++ b/static/templates/settings/admin_linkifier_edit_form.hbs
@@ -1,5 +1,5 @@
 <div id="edit-linkifier-form">
-    <form class="form-horizontal linkifier-edit-form">
+    <form class="linkifier-edit-form">
         <div class="input-group name_change_container">
             <label for="edit-linkifier-pattern" >{{t "Pattern" }}</label>
             <input type="text" autocomplete="off" id="edit-linkifier-pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" value="{{ pattern }}" />

--- a/static/templates/settings/alert_word_settings.hbs
+++ b/static/templates/settings/alert_word_settings.hbs
@@ -1,5 +1,5 @@
 <div id="alert-word-settings" class="settings-section" data-name="alert-words">
-    <form class="form-horizontal" id="alert_word_info_box">
+    <form id="alert_word_info_box">
         <p class="alert-word-settings-note">
             {{t "Alert words allow you to be notified as if you were @-mentioned when certain words or phrases are used in Zulip. Alert words are not case sensitive."}}
         </p>

--- a/static/templates/settings/auth_methods_settings_admin.hbs
+++ b/static/templates/settings/auth_methods_settings_admin.hbs
@@ -2,7 +2,7 @@
     {{#unless is_owner}}
     <div class='tip'>{{t "Only organization owners can edit these settings."}}</div>
     {{/unless}}
-    <form class="form-horizontal admin-realm-form org-authentications-form">
+    <form class="admin-realm-form org-authentications-form">
         <div id="org-auth_settings" class="admin-table-wrapper settings-subsection-parent">
             <div class ="subsection-header">
                 <h3>{{t "Authentication methods" }}</h3>

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -19,7 +19,7 @@
     <div class="alert" id="export_status" role="alert">
         <span class="export_status_text"></span>
     </div>
-    <form class="form-horizontal">
+    <form>
         <div class="add-new-export-box grey-box">
             <div class="wrapper">
                 <button type="submit" class="button rounded sea-green" id="export-data">

--- a/static/templates/settings/default_streams_list_admin.hbs
+++ b/static/templates/settings/default_streams_list_admin.hbs
@@ -4,7 +4,7 @@
     </div>
 
     {{#if is_admin}}
-    <form class="form-horizontal default-stream-form">
+    <form class="default-stream-form">
         <div class="add-new-default-stream-box grey-box">
             <div class="wrapper">
                 <div class="alert" id="admin-default-stream-status"></div>

--- a/static/templates/settings/edit_bot_form.hbs
+++ b/static/templates/settings/edit_bot_form.hbs
@@ -1,5 +1,5 @@
 <div id="bot-edit-form" data-user-id="{{user_id}}" data-email="{{email}}">
-    <form class="new-style edit_bot_form form-horizontal name-setting">
+    <form class="new-style edit_bot_form name-setting">
         <div class="input-group name_change_container">
             <label for="edit_bot_full_name">{{t "Full name" }}</label>
             <input type="text" autocomplete="off" name="full_name" id="edit_bot_full_name" value="{{ full_name }}" />

--- a/static/templates/settings/edit_custom_profile_field_form.hbs
+++ b/static/templates/settings/edit_custom_profile_field_form.hbs
@@ -1,5 +1,5 @@
 {{#with profile_field_info}}
-<form class="form-horizontal name-setting profile-field-form new-style" id="edit-custom-profile-field-form-{{id}}">
+<form class="name-setting profile-field-form new-style" id="edit-custom-profile-field-form-{{id}}">
     <div class="input-group">
         <label for="name">{{t "Label" }}</label>
         <input type="text" name="name" value="{{ name }}" maxlength="40" />

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -5,7 +5,7 @@
     <p class="add-emoji-text {{#unless can_add_emojis}}hide{{/unless}}">
         {{#tr}}Add extra emoji for members of the {realm_name} organization.{{/tr}}
     </p>
-    <form class="form-horizontal admin-emoji-form {{#unless can_add_emojis}}hide{{/unless}}">
+    <form class="admin-emoji-form {{#unless can_add_emojis}}hide{{/unless}}">
         <div class="add-new-emoji-box grey-box">
             <div class="new-emoji-form">
                 <div class="settings-section-title new-emoji-section-title no-padding">{{t "Add a new emoji" }}</div>

--- a/static/templates/settings/linkifier_settings_admin.hbs
+++ b/static/templates/settings/linkifier_settings_admin.hbs
@@ -42,7 +42,7 @@
         </p>
 
         {{#if is_admin}}
-        <form class="form-horizontal admin-linkifier-form">
+        <form class="admin-linkifier-form">
             <div class="add-new-linkifier-box grey-box">
                 <div class="new-linkifier-form wrapper">
                     <div class="settings-section-title new-linkifier-section-title">{{t "Add a new linkifier" }}</div>

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -124,7 +124,7 @@
             {{> settings_save_discard_widget section_name="email-message-settings" show_only_indicator=(not for_realm_settings) }}
         </div>
 
-        <div class="input-group form-horizontal time-limit-setting">
+        <div class="input-group time-limit-setting">
 
             <label for="email_notifications_batching_period">
                 {{t "Delay before sending message notification emails" }}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -1,5 +1,5 @@
 <div id="organization-permissions" data-name="organization-permissions" class="settings-section">
-    <form class="form-horizontal admin-realm-form org-permissions-form">
+    <form class="admin-realm-form org-permissions-form">
 
         <div id="org-join-settings" class="settings-subsection-parent">
             <div class="subsection-header">

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -1,5 +1,5 @@
 <div id="organization-profile" data-name="organization-profile" class="settings-section">
-    <form class="form-horizontal admin-realm-form org-profile-form">
+    <form class="admin-realm-form org-profile-form">
         <div class="alert" id="admin-realm-deactivation-status"></div>
 
         <div id="org-org-profile" class="settings-subsection-parent">

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -1,5 +1,5 @@
 <div id="organization-settings" data-name="organization-settings" class="settings-section">
-    <form class="form-horizontal admin-realm-form org-settings-form">
+    <form class="admin-realm-form org-settings-form">
 
         <div id="org-notifications" class="settings-subsection-parent">
             <div class="subsection-header">

--- a/static/templates/settings/organization_user_settings_defaults.hbs
+++ b/static/templates/settings/organization_user_settings_defaults.hbs
@@ -10,7 +10,7 @@
 
     {{> notification_settings prefix="realm_" for_realm_settings=true}}
 
-    <div class="form-horizontal privacy_settings settings-subsection-parent">
+    <div class="privacy_settings settings-subsection-parent">
         <div class="subsection-header inline-block">
             <h3 class="inline-block">{{t "Privacy settings" }}</h3>
             {{> settings_save_discard_widget section_name="privacy-setting" show_only_indicator=false }}
@@ -30,7 +30,7 @@
           help_link="/help/read-receipts"}}
     </div>
 
-    <div class="form-horizontal other_settings settings-subsection-parent">
+    <div class="other_settings settings-subsection-parent">
         <div class="subsection-header inline-block">
             <h3 class="inline-block">{{t "Other settings" }}</h3>
             {{> settings_save_discard_widget section_name="other-setting" show_only_indicator=false }}

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -22,7 +22,7 @@
         </ul>
 
         {{#if is_admin}}
-        <form class="form-horizontal admin-playground-form">
+        <form class="admin-playground-form">
             <div class="add-new-playground-box grey-box">
                 <div class="new-playground-form wrapper">
                     <div class="settings-section-title">

--- a/static/templates/settings/profile_settings.hbs
+++ b/static/templates/settings/profile_settings.hbs
@@ -15,7 +15,7 @@
                     </div>
                 </div>
 
-                <form class="form-horizontal timezone-setting-form">
+                <form class="timezone-setting-form">
                     <div class="input-group grid">
                         <label for="timezone" class="dropdown-title inline-block">{{t "Time zone" }}</label>
                         <div class="alert-notification timezone-setting-status"></div>
@@ -33,7 +33,7 @@
                     </div>
                 </form>
 
-                <form class="form-horizontal custom-profile-fields-form grid"></form>
+                <form class="custom-profile-fields-form grid"></form>
             </div>
         </div>
 

--- a/static/templates/topic_edit_form.hbs
+++ b/static/templates/topic_edit_form.hbs
@@ -1,6 +1,6 @@
 {{! Client-side Mustache template for rendering the topic edit form. }}
 
-<form id="topic_edit_form" class="form-horizontal">
+<form id="topic_edit_form">
     <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
       autocomplete="off" maxlength="{{ max_topic_length }}" />
     <button type="button" class="topic_edit_save small_square_button animated-purple-button"><i class="fa fa-check" aria-hidden="true"></i></button>

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -756,13 +756,9 @@ input.search-query {
   border-radius: 15px;
 }
 .form-inline input,
-.form-horizontal input,
 .form-inline select,
-.form-horizontal select,
 .form-inline .help-inline,
-.form-horizontal .help-inline,
-.form-inline .input-append,
-.form-horizontal .input-append {
+.form-inline .input-append {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
@@ -771,8 +767,7 @@ input.search-query {
   margin-bottom: 0;
   vertical-align: middle;
 }
-.form-inline .hide,
-.form-horizontal .hide {
+.form-inline .hide {
   display: none;
 }
 .form-inline label,

--- a/templates/corporate/support_request.html
+++ b/templates/corporate/support_request.html
@@ -7,7 +7,7 @@
             <h1>{{ _('Contact support') }}</h1>
         </div>
 
-        <form method="post" class="form-horizontal white-box" id="registration">
+        <form method="post" class="white-box" id="registration">
             {{ csrf_input }}
 
             <fieldset class="support-request">

--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -18,8 +18,8 @@ the registration flow has its own (nearly identical) copy of the fields below in
             <h1 class="get-started">{{ _("Accept the Terms of Service") }}</h1>
         </div>
 
-        <div class="form-horizontal white-box">
-            <form method="post" class="form-horizontal" id="registration" action="{{ url('accept_terms') }}">
+        <div class="white-box">
+            <form method="post" id="registration" action="{{ url('accept_terms') }}">
                 {{ csrf_input }}
                 <div id="registration-email">
                     <label for="id_email">{{ _("Email") }}</label>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -28,7 +28,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
             {% endtrans %}
         </div>
 
-        <form method="post" class="form-horizontal white-box" id="registration" action="{{ url('accounts_register') }}">
+        <form method="post" class="white-box" id="registration" action="{{ url('accounts_register') }}">
             {{ csrf_input }}
 
             <fieldset class="org-registration">

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -16,7 +16,7 @@
 
             <p>Forgot your password? No problem, we'll send a link to reset your password to the email you signed up with.</p>
 
-            <form method="post" class="form-horizontal" action="{{ url('password_reset') }}">
+            <form method="post" action="{{ url('password_reset') }}">
                 {{ csrf_input }}
                 <div class="new-style">
                     <div class="input-box horizontal">

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -18,7 +18,7 @@
             <!-- TODO: Ask about meta viewport 1:1 scaling -->
 
             {% if validlink %}
-            <form method="post" id="password_reset" class="form-horizontal" autocomplete="off">
+            <form method="post" id="password_reset" autocomplete="off">
                 {{ csrf_input }}
                 <div class="input-box" id="email-section">
                     <label for="id_email">{{ _("Email") }}</label>

--- a/templates/zerver/social_auth_select_email.html
+++ b/templates/zerver/social_auth_select_email.html
@@ -13,7 +13,7 @@
     </div>
 
     <div class="white-box">
-        <form method="post" class="form-horizontal" action="/complete/{{ backend }}/">
+        <form method="post" class="select-email-form" action="/complete/{{ backend }}/">
             <div class="choose-email-box">
                 <input type="hidden" name="email" value="{{ primary_email }}" />
                 {% if avatar_urls[primary_email] %}
@@ -37,7 +37,7 @@
             </div>
         </form>
         {% for email in verified_non_primary_emails %}
-        <form method="post" class="form-horizontal" action="/complete/{{ backend }}/">
+        <form method="post" class="select-email-form" action="/complete/{{ backend }}/">
             <div class="choose-email-box">
                 <input type="hidden" name="email" value="{{ email }}" />
                 {% if avatar_urls[email] %}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First four commits are to remove the class from portico pages (including support page, register page, password reset page, etc.)
- Next two commits are to remove the class from invite and inline topic edit form respectively.
- Next four commits are to remove the class from settings templates.
- Next commit is to remove the class from moda templates.
- Last commit is to use the CSS for this class from `boostrap.css`.

Completing the work started by @isabellalcarmo in #23651. Did not include the commit of that PR since I split the commits as per what CSS we wanted to add and if not how the existing CSS works for maintaining the current UI and have explained these in commit messages.
<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
