### PR TITLE
help center:  Document sizing for organization logo and profile picture.

### DIFF
--- a/templates/zerver/help/include/add-a-wide-logo.md
+++ b/templates/zerver/help/include/add-a-wide-logo.md
@@ -1,8 +1,15 @@
 {!cloud-standard-only.md!}
 
 You can customize the logo users see in the top left corner
-of the Zulip app. For best results make sure your logo has a
-transparent background, and trim any bordering whitespace. To upload a logo:
+of the Zulip app. For best results:
+
+- The logo should be a wide rectangle image with an 8:1 width to height ratio.
+  It will be displayed at 200×25 pixels, or more on high-resolution displays.
+
+- Make sure your logo has a transparent background, and trim any bordering
+  whitespace.
+
+To upload a logo:
 
 {start_tabs}
 

--- a/templates/zerver/help/include/edit-organization-profile.md
+++ b/templates/zerver/help/include/edit-organization-profile.md
@@ -1,7 +1,11 @@
 !!! tip ""
 
-    The organization description supports [full Markdown syntax][markdown-syntax],
+    The **organization description** supports [full Markdown syntax][markdown-syntax],
     including **bold**/*italic*, links, lists, and more.
+
+!!! tip ""
+    Your **organization profile picture** should be a square image. It will be displayed at
+    100×100 pixels, or more on high-resolution displays.
 
 {start_tabs}
 


### PR DESCRIPTION
Fixes part of #22121; alternative to #24033

Current: https://zulip.com/help/create-your-organization-profile
Updated:

<img width="750" alt="Screen Shot 2023-01-12 at 5 45 17 PM" src="https://user-images.githubusercontent.com/2090066/212197316-293a8de2-22df-4a9a-bd81-2efcc7d43ca9.png">
