### PR TITLE
typeahead : Change playground language names in typeahead to lowercase.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -784,9 +784,14 @@ export function register_click_handlers() {
             const $view_in_playground_button = $(this);
             const $codehilite_div = $(this).closest(".codehilite");
             e.stopPropagation();
-            const playground_info = realm_playground.get_playground_info_for_languages(
+            let playground_info = realm_playground.get_playground_info_for_languages(
                 $codehilite_div.data("code-language"),
             );
+            if (playground_info === undefined) {
+                playground_info = realm_playground.get_playground_info_for_languages(
+                    $codehilite_div.data("code-language").toLowerCase(),
+                );
+            }
             // We do the code extraction here and set the target href combining the url_prefix
             // and the extracted code. Depending on whether the language has multiple playground
             // links configured, a popover is show.

--- a/static/js/realm_playground.js
+++ b/static/js/realm_playground.js
@@ -56,7 +56,10 @@ export function get_pygments_typeahead_list(query) {
     }
 
     for (const [key, values] of map_pygments_pretty_name_to_aliases) {
-        language_labels.set(key, key + " (" + Array.from(values).join(", ") + ")");
+        language_labels.set(
+            key.toLowerCase(),
+            key.toLowerCase() + " (" + Array.from(values).join(", ") + ")",
+        );
     }
 
     return language_labels;

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -203,8 +203,13 @@ export const update_elements = ($content) => {
         const $pre = $codehilite.find("pre");
         const fenced_code_lang = $codehilite.data("code-language");
         if (fenced_code_lang !== undefined) {
-            const playground_info =
+            let playground_info =
                 realm_playground.get_playground_info_for_languages(fenced_code_lang);
+            if (playground_info === undefined) {
+                playground_info = realm_playground.get_playground_info_for_languages(
+                    fenced_code_lang.toLowerCase(),
+                );
+            }
             if (playground_info !== undefined) {
                 // If a playground is configured for this language,
                 // offer to view the code in that playground.  When

--- a/static/templates/settings/playground_settings_admin.hbs
+++ b/static/templates/settings/playground_settings_admin.hbs
@@ -32,7 +32,7 @@
                     <div class="alert" id="admin-playground-status"></div>
                     <div class="input-group">
                         <label for="playground_pygments_language"> {{t "Language" }}</label>
-                        <input type="text" id="playground_pygments_language" name="pygments_language" autocomplete="off" placeholder="Python" />
+                        <input type="text" id="playground_pygments_language" name="pygments_language" autocomplete="off" placeholder="python" />
                     </div>
                     <div class="input-group">
                         <label for="playground_name"> {{t "Name" }}</label>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Initially, when we create playground the typeahead shows languages in both uppercase and lowercase. This PR changes the languages shown in typeahead to all lowercase.
Fixes: #24021 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before : 
![Screenshot from 2023-01-13 19-02-31](https://user-images.githubusercontent.com/101850957/212331985-68545396-09c5-47a0-87ce-ccf60e7ca8ba.png)

After : 
![Screenshot from 2023-01-13 19-03-03](https://user-images.githubusercontent.com/101850957/212332034-1c7597d4-a936-4411-b4b6-6104048b1a7f.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
