### PR TITLE
templates: Set `robots noindex` for attribution corporate template.

### DIFF
--- a/templates/corporate/attribution.html
+++ b/templates/corporate/attribution.html
@@ -3,6 +3,7 @@
 
 {% set PAGE_TITLE = "Website attributions | Zulip" %}
 {% set PAGE_DESCRIPTION = "Attributions for the Zulip website." %}
+{% set allow_search_engine_indexing = False %} <!-- Page is not indexed by search engines. -->
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Overrides the default context `allow_search_engine_indexing` to always be `False` for `templates/corporate/attribution.html` so that it does not appear in Google / search engine indexes.

Updates test of documentation pages in `test_docs.py` to have an option for corporate pages to set this value in the template and verifies that the meta tag for `robots noindex, nofollow` is always in the response.

**Notes**:
- Generally `allow_search_engine_indexing` is `False`, so this is already the case/not an issue for self-hosted servers.
- This change can serve as a model if ever any other landing pages are added to the site that would preferably not be search engine results. Non-programmers would be able to add the template variable and add a line to the test in `test_docs.py` for the new landing page.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
