### PR TITLE
emojis: Filter out unicode emojis with same codes from typeahead menu.

### DIFF
--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -210,3 +210,13 @@ run_test("sort_emojis: prefix before midphrase, with space (traffic li)", () => 
         "horizontal_traffic_light",
     ]);
 });
+
+run_test("sort_emojis: remove duplicates", () => {
+    // notice the last 2 are aliases of the same emoji (same emoji code)
+    const emoji_list = [
+        {emoji_name: "laughter_tears", emoji_code: "1f602", reaction_type: "unicode_emoji"},
+        {emoji_name: "tear", emoji_code: "1f972", reaction_type: "unicode_emoji"},
+        {emoji_name: "smile_with_tear", emoji_code: "1f972", reaction_type: "unicode_emoji"},
+    ];
+    assert.deepEqual(typeahead.sort_emojis(emoji_list, "tear"), [emoji_list[1], emoji_list[0]]);
+});

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -220,3 +220,14 @@ run_test("sort_emojis: remove duplicates", () => {
     ];
     assert.deepEqual(typeahead.sort_emojis(emoji_list, "tear"), [emoji_list[1], emoji_list[0]]);
 });
+
+run_test("sort_emojis: prioritise realm emojis", () => {
+    const emoji_list = [
+        {emoji_name: "thank_you", emoji_code: "1f64f", reaction_type: "unicode_emoji"},
+        {emoji_name: "thank_you_custom", url: "something", is_realm_emoji: true},
+    ];
+    assert.deepEqual(typeahead.sort_emojis(emoji_list, "thank you"), [
+        emoji_list[1],
+        emoji_list[0],
+    ]);
+});

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -153,5 +153,22 @@ export function sort_emojis(objs, query) {
 
     const triage_results = triage(query, others, (x) => x.emoji_name);
 
-    return [...popular_emoji_matches, ...triage_results.matches, ...triage_results.rest];
+    const sorted_results_with_possible_duplicates = [
+        ...popular_emoji_matches,
+        ...triage_results.matches,
+        ...triage_results.rest,
+    ];
+    // remove unicode emojis with same code but different names
+    const unicode_emoji_codes = new Set();
+    const sorted_unique_results = [];
+    for (const emoji of sorted_results_with_possible_duplicates) {
+        if (!is_unicode_emoji(emoji)) {
+            sorted_unique_results.push(emoji);
+        } else if (!unicode_emoji_codes.has(emoji.emoji_code)) {
+            unicode_emoji_codes.add(emoji.emoji_code);
+            sorted_unique_results.push(emoji);
+        }
+    }
+
+    return sorted_unique_results;
 }

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -153,10 +153,17 @@ export function sort_emojis(objs, query) {
 
     const triage_results = triage(query, others, (x) => x.emoji_name);
 
+    function prioritise_realm_emojis(emojis) {
+        return [
+            ...emojis.filter((emoji) => emoji.is_realm_emoji),
+            ...emojis.filter((emoji) => !emoji.is_realm_emoji),
+        ];
+    }
+
     const sorted_results_with_possible_duplicates = [
         ...popular_emoji_matches,
-        ...triage_results.matches,
-        ...triage_results.rest,
+        ...prioritise_realm_emojis(triage_results.matches),
+        ...prioritise_realm_emojis(triage_results.rest),
     ];
     // remove unicode emojis with same code but different names
     const unicode_emoji_codes = new Set();

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -15,9 +15,7 @@
     the emoji code matches.  For example, we'll show the
     emoji with code 1f44d at the top of your suggestions
     whether you type "+" as a prefix for "+1"
-    or "th" as a prefix for "thumbs up".  The caveat is
-    that other factors still may matter more, such as
-    prefix matches trumping "popularity".
+    or "th" as a prefix for "thumbs up".
 */
 export const popular_emojis = [
     "1f44d", // +1


### PR DESCRIPTION
The 1st commit fixes the issue described [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/too.20many.20emojis.20with.20same.20code.20suggested) while the 2nd fixes the core issue described in #18135

Fixes: #18135 

**Screenshots and screen captures:**
1st commit:
Before (duplicates):
![image](https://user-images.githubusercontent.com/68962290/212376595-4e5d3a81-3244-45d4-a9cc-d53483140796.png)

After:
![image](https://user-images.githubusercontent.com/68962290/212376720-9c7ca4bb-8225-469a-bb4e-96c5c839aaeb.png)

2nd commit:
Before (custom emoji at the bottom):
![image](https://user-images.githubusercontent.com/68962290/212377094-e979bf83-7639-4f2f-a720-39b9097d9b29.png)

After (realm emoji gets priority):
![image](https://user-images.githubusercontent.com/68962290/212377020-7163afd5-730d-46e5-9c29-ed3f2103a1b2.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
