### PR TITLE
help center: Document bot name in org settings link to bot's user card.

### DIFF
--- a/templates/zerver/help/user-cards.md
+++ b/templates/zerver/help/user-cards.md
@@ -9,6 +9,8 @@ sent](/help/view-messages-sent-by-a-user).
 
 {start_tabs}
 
+{tab|user}
+
 - Their avatar.
 - Their name.
 - Their email address, if you [have
@@ -20,11 +22,21 @@ sent](/help/view-messages-sent-by-a-user).
 - Their current [local time](/help/change-your-timezone).
 - Their [status and availability](/help/status-and-availability).
 
+{tab|bot}
+
+- Its avatar.
+- Its name.
+- Its owner's name.
+- Its email address, if you [have
+permission](/help/restrict-visibility-of-email-addresses) to view it.
+
 {end_tabs}
 
 ## View someone's user card
 
 {start_tabs}
+
+{tab|user}
 
 {!right-sidebar-user-card.md!}
 
@@ -36,6 +48,12 @@ sent](/help/view-messages-sent-by-a-user).
 
     Alternatively, open someone's **user card** by selecting a message they sent, and
     using the <kbd>U</kbd> shortcut.
+
+{tab|bot}
+
+{settings_tab|bot-list-admin}
+
+1. Click on the name of a bot in the **Name** column to open its **user card**.
 
 {end_tabs}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -90,6 +90,8 @@ TAB_SECTION_LABELS = {
     "keycloak": "Keycloak",
     "logged-in": "If you are logged in",
     "logged-out": "If you are logged out",
+    "user": "User",
+    "bot": "Bot",
 }
 
 


### PR DESCRIPTION
Documents link to the bot's user card from the bot's name in Organization settings > Bots, and information in the bot's user card.

Fixes part of #23970.

**Screenshots and screen captures:**
- https://zulip.com/help/user-cards
<img width="663" alt="image" src="https://user-images.githubusercontent.com/2343554/212447242-4ba9d240-b133-40f6-bd69-54ecdade393e.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>
