### PR TITLE
stream_settings: Warn when archiving a notification stream.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -578,8 +578,24 @@ export function initialize() {
             is_web_public: stream.is_web_public,
         });
         const stream_name = stream_data.maybe_get_stream_name(stream_id);
+
+        const is_new_stream_notification_stream =
+            stream_id === page_params.realm_notifications_stream_id;
+        const is_signup_notification_stream =
+            stream_id === page_params.realm_signup_notifications_stream_id;
+        const is_report_notification_stream =
+            stream_id === page_params.realm_report_message_stream_id;
+        const is_notification_stream =
+            is_new_stream_notification_stream ||
+            is_signup_notification_stream ||
+            is_report_notification_stream;
+
         const html_body = render_settings_deactivation_stream_modal({
             stream_name,
+            is_new_stream_notification_stream,
+            is_signup_notification_stream,
+            is_report_notification_stream,
+            is_notification_stream,
             stream_privacy_symbol_html,
         });
 

--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -127,6 +127,15 @@
     margin-bottom: 10px;
 }
 
+.notification_stream_archive_warning {
+    margin-bottom: 0;
+    margin-top: 10px;
+}
+
+.notification_stream_archive_warning_list {
+    margin-bottom: 0;
+}
+
 #read_receipts_modal {
     .modal__container {
         width: 360px;

--- a/static/templates/confirm_dialog/confirm_deactivate_stream.hbs
+++ b/static/templates/confirm_dialog/confirm_deactivate_stream.hbs
@@ -2,3 +2,18 @@
     Archiving stream <z-stream></z-stream> will immediately unsubscribe everyone. This action cannot be undone.
     {{#*inline "z-stream"}}<strong>{{{stream_privacy_symbol_html}}}{{stream_name}}</strong>{{/inline}}
 {{/tr}}
+
+{{#if is_notification_stream}}
+<p class="notification_stream_archive_warning">{{#tr}}Archiving this stream will also disable:{{/tr}}</p>
+<ul class="notification_stream_archive_warning_list">
+    {{#if is_new_stream_notification_stream}}
+        <li>{{#tr}}New stream notifications{{/tr}}</li>
+    {{/if}}
+    {{#if is_signup_notification_stream}}
+        <li>{{#tr}}New user notifications{{/tr}}</li>
+    {{/if}}
+    {{#if is_report_notification_stream}}
+        <li>{{#tr}}Message reporting{{/tr}}</li>
+    {{/if}}
+</ul>
+{{/if}}


### PR DESCRIPTION
We warn the user in order to avoid silently disabling notifications.

Fixes #22110

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
