### PR TITLE
subscribers: Add warning when administrator unsubscribes last user fr…

### DIFF
--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -263,15 +263,13 @@ function remove_subscriber({stream_id, target_user_id, $list_entry}) {
         });
 
         const html_body = render_unsubscribe_private_stream_modal({
-            message: $t({
-                defaultMessage: "Once you leave this stream, you will not be able to rejoin.",
-            }),
+            unsubscribing_other_user: false,
             display_stream_archive_warning: sub_count === 1,
         });
 
         confirm_dialog.launch({
             html_heading: $t_html(
-                {defaultMessage: "Unsubscribe from <z-link></z-link>"},
+                {defaultMessage: "Unsubscribe from <z-link></z-link>?"},
                 {"z-link": () => stream_name_with_privacy_symbol_html},
             ),
             html_body,

--- a/web/src/stream_edit_subscribers.js
+++ b/web/src/stream_edit_subscribers.js
@@ -256,22 +256,45 @@ function remove_subscriber({stream_id, target_user_id, $list_entry}) {
         );
     }
 
-    if (sub.invite_only && people.is_my_user_id(target_user_id)) {
+    if (sub.invite_only) {
         const sub_count = peer_data.get_subscriber_count(stream_id);
+        const unsubscribing_other_user = !people.is_my_user_id(target_user_id);
+
+        if (!people.is_my_user_id(target_user_id) && sub_count !== 1) {
+            // We do not show any confirmation modal if any other user is
+            // being unsubscribed and that user is not the last subscriber
+            // of that stream.
+            remove_user_from_private_stream();
+            return;
+        }
+
         const stream_name_with_privacy_symbol_html = render_inline_decorated_stream_name({
             stream: sub,
         });
 
         const html_body = render_unsubscribe_private_stream_modal({
-            unsubscribing_other_user: false,
+            unsubscribing_other_user,
             display_stream_archive_warning: sub_count === 1,
         });
 
-        confirm_dialog.launch({
-            html_heading: $t_html(
+        let html_heading;
+        if (unsubscribing_other_user) {
+            html_heading = $t_html(
+                {defaultMessage: "Unsubscribe {full_name} from <z-link></z-link>?"},
+                {
+                    full_name: people.get_full_name(target_user_id),
+                    "z-link": () => stream_name_with_privacy_symbol_html,
+                },
+            );
+        } else {
+            html_heading = $t_html(
                 {defaultMessage: "Unsubscribe from <z-link></z-link>?"},
                 {"z-link": () => stream_name_with_privacy_symbol_html},
-            ),
+            );
+        }
+
+        confirm_dialog.launch({
+            html_heading,
             html_body,
             on_click: remove_user_from_private_stream,
         });

--- a/web/src/stream_settings_components.js
+++ b/web/src/stream_settings_components.js
@@ -196,9 +196,7 @@ export function unsubscribe_from_private_stream(sub) {
     const stream_name_with_privacy_symbol_html = render_inline_decorated_stream_name({stream: sub});
 
     const html_body = render_unsubscribe_private_stream_modal({
-        message: $t({
-            defaultMessage: "Once you leave this stream, you will not be able to rejoin.",
-        }),
+        unsubscribing_other_user: false,
         display_stream_archive_warning: sub_count === 1 && invite_only,
     });
 
@@ -215,7 +213,7 @@ export function unsubscribe_from_private_stream(sub) {
 
     confirm_dialog.launch({
         html_heading: $t_html(
-            {defaultMessage: "Unsubscribe from <z-link></z-link>"},
+            {defaultMessage: "Unsubscribe from <z-link></z-link>?"},
             {"z-link": () => stream_name_with_privacy_symbol_html},
         ),
         html_body,

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -26,6 +26,7 @@ import * as ListWidget from "./list_widget";
 import * as loading from "./loading";
 import * as modals from "./modals";
 import {page_params} from "./page_params";
+import * as peer_data from "./peer_data";
 import * as people from "./people";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
@@ -873,7 +874,11 @@ export function initialize() {
             ui_report.client_error(error_message, $alert_box, 1200);
         }
 
-        if (sub.invite_only && people.is_my_user_id(target_user_id)) {
+        if (
+            sub.invite_only &&
+            (people.is_my_user_id(target_user_id) ||
+                peer_data.get_subscriber_count(stream_id) === 1)
+        ) {
             const new_hash = hash_util.stream_edit_url(sub);
             hide_user_profile();
             browser_history.go_to_location(new_hash);

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -173,6 +173,8 @@ function format_user_stream_list_item_html(stream, user) {
         people.can_admin_user(user) || stream_data.can_unsubscribe_others(stream);
     const show_private_stream_unsub_tooltip =
         people.is_my_user_id(user.user_id) && stream.invite_only;
+    const show_last_user_in_private_stream_unsub_tooltip =
+        stream.invite_only && peer_data.get_subscriber_count(stream.stream_id) === 1;
     return render_user_stream_list_item({
         name: stream.name,
         stream_id: stream.stream_id,
@@ -181,6 +183,7 @@ function format_user_stream_list_item_html(stream, user) {
         is_web_public: stream.is_web_public,
         show_unsubscribe_button,
         show_private_stream_unsub_tooltip,
+        show_last_user_in_private_stream_unsub_tooltip,
         stream_edit_url: hash_util.stream_edit_url(stream),
     });
 }

--- a/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
@@ -3,9 +3,16 @@
 {{/unless}}
 {{#if display_stream_archive_warning}}
     <p>
-        {{#tr}}
-        Because you are the only subscriber, this stream will be automatically <z-link>archived</z-link>.
-        {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-stream">{{> @partial-block}}</a>{{/inline}}
-        {{/tr}}
+        {{#if unsubscribing_other_user}}
+            {{#tr}}
+            Because you are removing the last subscriber from a private stream, it will be automatically <z-link>archived</z-link>.
+            {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-stream">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        {{else}}
+            {{#tr}}
+            Because you are the only subscriber, this stream will be automatically <z-link>archived</z-link>.
+            {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-stream">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        {{/if}}
     </p>
 {{/if}}

--- a/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_unsubscribe_private_stream.hbs
@@ -1,4 +1,11 @@
-<p>{{message}}</p>
+{{#unless unsubscribing_other_user}}
+    <p>{{t "Once you leave this stream, you will not be able to rejoin."}}</p>
+{{/unless}}
 {{#if display_stream_archive_warning}}
-    <p>{{t "Because you are the only subscriber, this stream will be automatically archived." }}</p>
+    <p>
+        {{#tr}}
+        Because you are the only subscriber, this stream will be automatically <z-link>archived</z-link>.
+        {{#*inline "z-link"}}<a target="_blank" rel="noopener noreferrer" href="/help/archive-a-stream">{{> @partial-block}}</a>{{/inline}}
+        {{/tr}}
+    </p>
 {{/if}}

--- a/web/templates/user_stream_list_item.hbs
+++ b/web/templates/user_stream_list_item.hbs
@@ -8,7 +8,7 @@
     {{#if show_unsubscribe_button}}
     <td class="remove_subscription">
         <div class="subscription_list_remove">
-            <button type="button" name="unsubscribe" class="remove-subscription-button button small rounded btn-danger {{#if show_private_stream_unsub_tooltip}}tippy-zulip-tooltip{{/if}}" data-tippy-content='{{t "Use stream settings to unsubscribe from private streams."}}'>
+            <button type="button" name="unsubscribe" class="remove-subscription-button button small rounded btn-danger {{#if (or show_private_stream_unsub_tooltip show_last_user_in_private_stream_unsub_tooltip)}}tippy-zulip-tooltip{{/if}}" data-tippy-content='{{#if show_private_stream_unsub_tooltip}}{{t "Use stream settings to unsubscribe from private streams."}}{{else}}{{t "Use stream settings to unsubscribe the last user from a private stream."}}{{/if}}'>
                 {{t 'Unsubscribe' }}
             </button>
         </div>


### PR DESCRIPTION
Fixes: #24025

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="542" alt="Screenshot 2023-04-20 at 12 57 57 PM" src="https://user-images.githubusercontent.com/72064462/233292141-5c14a52e-cf20-4224-add4-81de6df55674.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
