### PR TITLE
settings-modal: Only update display if overlay loaded in DOM.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -720,6 +720,8 @@ test("test get_sorted_options_list", () => {
 
 test("misc", ({override_rewire}) => {
     page_params.is_admin = false;
+    $("#user-avatar-upload-widget").length = 1;
+    $("#user_details_section").length = 1;
 
     const $stub_notification_disable_parent = $.create("<stub notification_disable parent");
     $stub_notification_disable_parent.set_find_results(

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -51,6 +51,10 @@ export function update_full_name(new_full_name) {
 }
 
 export function update_name_change_display() {
+    if ($("#user_details_section").length === 0) {
+        return;
+    }
+
     if (!settings_data.user_can_change_name()) {
         $("#full_name").prop("disabled", true);
         $(".change_name_tooltip").show();
@@ -61,6 +65,10 @@ export function update_name_change_display() {
 }
 
 export function update_email_change_display() {
+    if ($("#user_details_section").length === 0) {
+        return;
+    }
+
     if (!settings_data.user_can_change_email()) {
         $("#change_email_button").prop("disabled", true);
         $("#change_email_button_container").addClass("email_changes_disabled_tooltip");
@@ -116,6 +124,10 @@ function upload_avatar($file_input) {
 }
 
 export function update_avatar_change_display() {
+    if ($("#user-avatar-upload-widget").length === 0) {
+        return;
+    }
+
     if (!settings_data.user_can_change_avatar()) {
         $("#user-avatar-upload-widget .image_upload_button").addClass("hide");
         $("#user-avatar-upload-widget .image-disabled").removeClass("hide");
@@ -130,6 +142,10 @@ export function update_avatar_change_display() {
 }
 
 export function update_account_settings_display() {
+    if ($("#user_details_section").length === 0) {
+        return;
+    }
+
     update_name_change_display();
     update_email_change_display();
     update_avatar_change_display();


### PR DESCRIPTION
If the personal / organization settings overlay has not been loaded to the DOM in the user's session, then there's no need to update the overlay display for changes to the user's permissions to update their name, email or avatar.

So we add a checks for the relevant element ids before updating the overlay display when the user's role or these organization settings change.

Follow-up to #23964.

**Notes**:
- The call to `avatar.build_user_avatar_widget` has an `expectOne` assertion, so the avatar widget update (`update_avatar_change_display`) is the only one that's causing a blueslip error.
- It seemed like a good pattern to check/assert for these elements in the DOM in general though, since there's no guarantee that the user has opened their settings overlay during their session.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
