### PR TITLE
Refactor code for waiting period and message retention settings.

### DIFF
--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -597,8 +597,8 @@ manually handle such situations in a couple key functions:
 
 - `settings_org.update_dependent_subsettings`: This handles settings
   whose value and state depend on other elements. For example,
-  `realm_waiting_period_threshold` is only shown for with the right
-  state of `realm_waiting_period_setting`.
+  `realm_waiting_period_threshold_custom_input` is only shown for with
+  the right state of `realm_waiting_period_threshold`.
 
 Finally, update `server_events_dispatch.js` to handle related events coming from
 the server. There is an object, `realm_settings`, in the function
@@ -646,9 +646,9 @@ Here are few important cases you should consider when testing your changes:
 
 - If your setting is dependent on another setting, carefully check
   that both are properly synchronized. For example, the input element
-  for `realm_waiting_period_threshold` is shown only when we have
-  selected the custom time limit option in the
-  `realm_waiting_period_setting` dropdown.
+  for `realm_waiting_period_threshold_custom_input` is shown only when
+  we have selected the custom time limit option in the
+  `realm_waiting_period_threshold` dropdown.
 
 - Do some manual testing for the real-time synchronization of input
   elements across the browsers and just like "Discard changes" button,

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -551,14 +551,14 @@ test("set_up", ({override, override_rewire}) => {
 
     const $custom_edit_limit_input = $("#id_realm_message_content_edit_limit_minutes");
     $stub_message_content_edit_limit_parent.set_find_results(
-        ".admin-realm-time-limit-input",
+        ".time-limit-custom-input",
         $custom_edit_limit_input,
     );
     $custom_edit_limit_input.attr("id", "id_realm_message_content_edit_limit_minutes");
 
     const $custom_delete_limit_input = $("#id_realm_message_content_delete_limit_minutes");
     $stub_message_content_delete_limit_parent.set_find_results(
-        ".admin-realm-time-limit-input",
+        ".time-limit-custom-input",
         $custom_delete_limit_input,
     );
     $custom_delete_limit_input.attr("id", "id_realm_message_content_delete_limit_minutes");
@@ -586,7 +586,7 @@ test("set_up", ({override, override_rewire}) => {
         $stub_realm_waiting_period_threshold_parent,
     );
     $stub_realm_waiting_period_threshold_parent.set_find_results(
-        ".admin-realm-time-limit-input",
+        ".time-limit-custom-input",
         $realm_waiting_period_threshold_custom_input,
     );
     $realm_waiting_period_threshold_custom_input.attr(

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -575,6 +575,25 @@ test("set_up", ({override, override_rewire}) => {
     );
     $realm_message_retention_custom_input.attr("id", "id_realm_message_retention_custom_input");
 
+    const $stub_realm_waiting_period_threshold_parent = $.create(
+        "<stub waiting period threshold setting parent>",
+    );
+    const $realm_waiting_period_threshold_custom_input = $(
+        "#id_realm_waiting_period_threshold_custom_input",
+    );
+    $("#id_realm_waiting_period_threshold").set_parent($stub_realm_waiting_period_threshold_parent);
+    $realm_waiting_period_threshold_custom_input.set_parent(
+        $stub_realm_waiting_period_threshold_parent,
+    );
+    $stub_realm_waiting_period_threshold_parent.set_find_results(
+        ".admin-realm-time-limit-input",
+        $realm_waiting_period_threshold_custom_input,
+    );
+    $realm_waiting_period_threshold_custom_input.attr(
+        "id",
+        "id_realm_waiting_period_threshold_custom_input",
+    );
+
     $("#message_content_in_email_notifications_label").set_parent(
         $.create("<stub in-content setting checkbox>"),
     );

--- a/frontend_tests/puppeteer_tests/admin.ts
+++ b/frontend_tests/puppeteer_tests/admin.ts
@@ -154,18 +154,18 @@ async function submit_joining_organization_change(page: Page): Promise<void> {
 
 async function test_set_new_user_threshold_to_three_days(page: Page): Promise<void> {
     console.log("Test setting new user threshold to three days.");
-    await page.waitForSelector("#id_realm_waiting_period_setting", {visible: true});
-    await page.select("#id_realm_waiting_period_setting", "three_days");
+    await page.waitForSelector("#id_realm_waiting_period_threshold", {visible: true});
+    await page.select("#id_realm_waiting_period_threshold", "three_days");
     await submit_joining_organization_change(page);
 }
 
 async function test_set_new_user_threshold_to_N_days(page: Page): Promise<void> {
     console.log("Test setting new user threshold to three days.");
-    await page.waitForSelector("#id_realm_waiting_period_setting", {visible: true});
-    await page.select("#id_realm_waiting_period_setting", "custom_period");
+    await page.waitForSelector("#id_realm_waiting_period_threshold", {visible: true});
+    await page.select("#id_realm_waiting_period_threshold", "custom_period");
 
     const N = "10";
-    await common.clear_and_type(page, "#id_realm_waiting_period_threshold", N);
+    await common.clear_and_type(page, "#id_realm_waiting_period_threshold_custom_input", N);
     await submit_joining_organization_change(page);
 }
 

--- a/frontend_tests/puppeteer_tests/admin.ts
+++ b/frontend_tests/puppeteer_tests/admin.ts
@@ -155,7 +155,7 @@ async function submit_joining_organization_change(page: Page): Promise<void> {
 async function test_set_new_user_threshold_to_three_days(page: Page): Promise<void> {
     console.log("Test setting new user threshold to three days.");
     await page.waitForSelector("#id_realm_waiting_period_threshold", {visible: true});
-    await page.select("#id_realm_waiting_period_threshold", "three_days");
+    await page.select("#id_realm_waiting_period_threshold", "3");
     await submit_joining_organization_change(page);
 }
 

--- a/frontend_tests/puppeteer_tests/admin.ts
+++ b/frontend_tests/puppeteer_tests/admin.ts
@@ -162,7 +162,7 @@ async function test_set_new_user_threshold_to_three_days(page: Page): Promise<vo
 async function test_set_new_user_threshold_to_N_days(page: Page): Promise<void> {
     console.log("Test setting new user threshold to three days.");
     await page.waitForSelector("#id_realm_waiting_period_setting", {visible: true});
-    await page.select("#id_realm_waiting_period_setting", "custom_days");
+    await page.select("#id_realm_waiting_period_setting", "custom_period");
 
     const N = "10";
     await common.clear_and_type(page, "#id_realm_waiting_period_threshold", N);

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -155,6 +155,8 @@ export function build_page() {
         msg_delete_limit_dropdown_values: settings_config.msg_delete_limit_dropdown_values,
         bot_creation_policy_values: settings_bots.bot_creation_policy_values,
         email_address_visibility_values: settings_config.email_address_visibility_values,
+        waiting_period_threshold_dropdown_values:
+            settings_config.waiting_period_threshold_dropdown_values,
         can_invite_others_to_realm: settings_data.user_can_invite_others_to_realm(),
         realm_invite_required: page_params.realm_invite_required,
         can_edit_user_groups: settings_data.user_can_edit_user_groups(),

--- a/static/js/settings_config.ts
+++ b/static/js/settings_config.ts
@@ -349,6 +349,21 @@ export const time_limit_dropdown_values = [
 export const msg_edit_limit_dropdown_values = time_limit_dropdown_values;
 export const msg_delete_limit_dropdown_values = time_limit_dropdown_values;
 
+export const waiting_period_threshold_dropdown_values = [
+    {
+        description: $t({defaultMessage: "None"}),
+        code: 0,
+    },
+    {
+        description: $t({defaultMessage: "3 days"}),
+        code: 3,
+    },
+    {
+        description: $t({defaultMessage: "Custom"}),
+        code: "custom_period",
+    },
+];
+
 export const retain_message_forever = -1;
 
 export const user_role_values = {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -281,7 +281,7 @@ function update_custom_value_input(property_name) {
     const $dropdown_elem = $(`#id_${CSS.escape(property_name)}`);
     const custom_input_elem_id = $dropdown_elem
         .parent()
-        .find(".admin-realm-time-limit-input")
+        .find(".time-limit-custom-input")
         .attr("id");
 
     const show_custom_limit_input = $dropdown_elem.val() === "custom_period";
@@ -312,7 +312,7 @@ function set_time_limit_setting(property_name) {
 
     const $custom_input = $(`#id_${CSS.escape(property_name)}`)
         .parent()
-        .find(".admin-realm-time-limit-input");
+        .find(".time-limit-custom-input");
     $custom_input.val(get_realm_time_limits_in_minutes(property_name));
 
     change_element_block_display_property(
@@ -838,7 +838,7 @@ function get_time_limit_setting_value($input_elem, for_api_data = true) {
         return Number.parseInt(select_elem_val, 10);
     }
 
-    const $custom_input_elem = $input_elem.parent().find(".admin-realm-time-limit-input");
+    const $custom_input_elem = $input_elem.parent().find(".time-limit-custom-input");
     if ($custom_input_elem.val().length === 0) {
         // This handles the case where the initial setting value is "Any time" and then
         // dropdown is changed to "Custom" where the input box is empty initially and
@@ -965,7 +965,7 @@ function enable_or_disable_save_button($subsection_elem) {
     let disable_save_btn = false;
     for (const setting_elem of time_limit_settings) {
         const dropdown_elem_val = $(setting_elem).find("select").val();
-        const $custom_input_elem = $(setting_elem).find(".admin-realm-time-limit-input");
+        const $custom_input_elem = $(setting_elem).find(".time-limit-custom-input");
         const custom_input_elem_val = Number.parseInt(Number($custom_input_elem.val()), 10);
 
         disable_save_btn =

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -168,7 +168,7 @@ function get_property_value(property_name, for_realm_default_settings, sub) {
         return sub[property_name];
     }
 
-    if (property_name === "realm_waiting_period_setting") {
+    if (property_name === "realm_waiting_period_threshold") {
         if (page_params.realm_waiting_period_threshold === 0) {
             return "none";
         }
@@ -246,10 +246,10 @@ export function change_element_block_display_property(elem_id, show_element) {
 }
 
 function set_realm_waiting_period_dropdown() {
-    const value = get_property_value("realm_waiting_period_setting");
-    $("#id_realm_waiting_period_setting").val(value);
+    const value = get_property_value("realm_waiting_period_threshold");
+    $("#id_realm_waiting_period_threshold").val(value);
     change_element_block_display_property(
-        "id_realm_waiting_period_threshold",
+        "id_realm_waiting_period_threshold_custom_input",
         value === "custom_period",
     );
 }
@@ -1084,7 +1084,7 @@ export function register_save_discard_widget_handlers(
                         break;
                 }
 
-                const waiting_period_threshold = $("#id_realm_waiting_period_setting").val();
+                const waiting_period_threshold = $("#id_realm_waiting_period_threshold").val();
                 switch (waiting_period_threshold) {
                     case "none":
                         data.waiting_period_threshold = 0;
@@ -1094,7 +1094,7 @@ export function register_save_discard_widget_handlers(
                         break;
                     case "custom_period":
                         data.waiting_period_threshold = $(
-                            "#id_realm_waiting_period_threshold",
+                            "#id_realm_waiting_period_threshold_custom_input",
                         ).val();
                         break;
                 }
@@ -1190,7 +1190,7 @@ export function build_page() {
         );
     });
 
-    $("#id_realm_waiting_period_setting").on("change", function () {
+    $("#id_realm_waiting_period_threshold").on("change", function () {
         const waiting_period_threshold = this.value;
         change_element_block_display_property(
             "id_realm_waiting_period_threshold",

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -379,7 +379,7 @@ function get_message_retention_setting_value($input_elem, for_api_data = true) {
     if ($custom_input.val().length === 0) {
         return settings_config.retain_message_forever;
     }
-    return Number.parseInt($custom_input.val(), 10);
+    return Number.parseInt(Number($custom_input.val()), 10);
 }
 
 function get_dropdown_value_for_message_retention_setting(setting_value) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -175,7 +175,7 @@ function get_property_value(property_name, for_realm_default_settings, sub) {
         if (page_params.realm_waiting_period_threshold === 3) {
             return "three_days";
         }
-        return "custom_days";
+        return "custom_period";
     }
 
     if (property_name === "realm_org_join_restrictions") {
@@ -250,7 +250,7 @@ function set_realm_waiting_period_dropdown() {
     $("#id_realm_waiting_period_setting").val(value);
     change_element_block_display_property(
         "id_realm_waiting_period_threshold",
-        value === "custom_days",
+        value === "custom_period",
     );
 }
 
@@ -1092,7 +1092,7 @@ export function register_save_discard_widget_handlers(
                     case "three_days":
                         data.waiting_period_threshold = 3;
                         break;
-                    case "custom_days":
+                    case "custom_period":
                         data.waiting_period_threshold = $(
                             "#id_realm_waiting_period_threshold",
                         ).val();
@@ -1194,7 +1194,7 @@ export function build_page() {
         const waiting_period_threshold = this.value;
         change_element_block_display_property(
             "id_realm_waiting_period_threshold",
-            waiting_period_threshold === "custom_days",
+            waiting_period_threshold === "custom_period",
         );
     });
 

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1445,7 +1445,7 @@ $option_title_width: 180px;
 
 /* These have enough space for all the options in German. */
 .setting_desktop_icon_count_display,
-#id_realm_waiting_period_setting,
+#id_realm_waiting_period_threshold,
 #id_realm_create_public_stream_policy,
 #id_realm_create_private_stream_policy,
 #id_realm_invite_to_stream_policy,

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -1178,7 +1178,7 @@ $option_title_width: 180px;
     overflow: hidden;
     border-radius: 4px;
 
-    .admin-realm-time-limit-input {
+    .time-limit-custom-input {
         width: 5ch;
         text-align: right;
     }

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -140,7 +140,7 @@
                 </label>
                 <input type="text"
                   name="email_notification_batching_period_edit_minutes"
-                  class="email_notification_batching_period_edit_minutes admin-realm-time-limit-input"
+                  class="email_notification_batching_period_edit_minutes time-limit-custom-input"
                   data-setting-widget-type="time-limit"
                   autocomplete="off"
                   id="{{prefix}}email_notification_batching_period_edit_minutes"/>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -48,7 +48,7 @@
                         <label for="id_realm_waiting_period_threshold_custom_input" class="inline-block">{{t "Waiting period (days)" }}:</label>
                         <input type="text" id="id_realm_waiting_period_threshold_custom_input"
                           name="realm_waiting_period_threshold_custom_input"
-                          class="admin-realm-time-limit-input"
+                          class="time-limit-custom-input"
                           value="{{ realm_waiting_period_threshold }}"/>
                     </div>
                 </div>
@@ -171,7 +171,7 @@
                         </label>
                         <input type="text" id="id_realm_message_content_edit_limit_minutes"
                           name="realm_message_content_edit_limit_minutes"
-                          class="admin-realm-time-limit-input"
+                          class="time-limit-custom-input"
                           autocomplete="off"
                           value="{{ realm_message_content_edit_limit_minutes }}"
                           {{#unless realm_allow_message_editing}}disabled{{/unless}}/>
@@ -238,7 +238,7 @@
                         </label>
                         <input type="text" id="id_realm_message_content_delete_limit_minutes"
                           name="realm_message_content_delete_limit_minutes"
-                          class="admin-realm-time-limit-input"
+                          class="time-limit-custom-input"
                           autocomplete="off"
                           value="{{ realm_message_content_delete_limit_minutes }}"/>
                     </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -35,22 +35,20 @@
                         {{/if}}
                     </div>
                 </div>
-                <div class="input-group">
+                <div class="input-group time-limit-setting">
                     <label for="realm_waiting_period_threshold" class="dropdown-title">
                         {{t "Waiting period before new members turn into full members" }}
                         {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
-                    <select name="realm_waiting_period_threshold" id="id_realm_waiting_period_threshold" class="prop-element">
-                        <option value="none">{{t "None" }}</option>
-                        <option value="three_days">{{t "3 days" }}</option>
-                        <option value="custom_period">{{t "Custom" }}</option>
+                    <select name="realm_waiting_period_threshold" id="id_realm_waiting_period_threshold" class="prop-element" data-setting-widget-type="time-limit">
+                        {{> dropdown_options_widget option_values=waiting_period_threshold_dropdown_values}}
                     </select>
                     {{!-- This setting is hidden unless `custom_period` --}}
                     <div class="dependent-settings-block">
                         <label for="id_realm_waiting_period_threshold_custom_input" class="inline-block">{{t "Waiting period (days)" }}:</label>
                         <input type="text" id="id_realm_waiting_period_threshold_custom_input"
                           name="realm_waiting_period_threshold_custom_input"
-                          class="admin-realm-time-limit-input prop-element"
+                          class="admin-realm-time-limit-input"
                           value="{{ realm_waiting_period_threshold }}"/>
                     </div>
                 </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -43,9 +43,9 @@
                     <select name="realm_waiting_period_setting" id="id_realm_waiting_period_setting" class="prop-element">
                         <option value="none">{{t "None" }}</option>
                         <option value="three_days">{{t "3 days" }}</option>
-                        <option value="custom_days">{{t "Custom" }}</option>
+                        <option value="custom_period">{{t "Custom" }}</option>
                     </select>
-                    {{!-- This setting is hidden unless `custom_days` --}}
+                    {{!-- This setting is hidden unless `custom_period` --}}
                     <div class="dependent-settings-block">
                         <label for="id_realm_waiting_period_threshold" class="inline-block">{{t "Waiting period (days)" }}:</label>
                         <input type="text" id="id_realm_waiting_period_threshold"

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -36,20 +36,20 @@
                     </div>
                 </div>
                 <div class="input-group">
-                    <label for="realm_waiting_period_setting" class="dropdown-title">
+                    <label for="realm_waiting_period_threshold" class="dropdown-title">
                         {{t "Waiting period before new members turn into full members" }}
                         {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
-                    <select name="realm_waiting_period_setting" id="id_realm_waiting_period_setting" class="prop-element">
+                    <select name="realm_waiting_period_threshold" id="id_realm_waiting_period_threshold" class="prop-element">
                         <option value="none">{{t "None" }}</option>
                         <option value="three_days">{{t "3 days" }}</option>
                         <option value="custom_period">{{t "Custom" }}</option>
                     </select>
                     {{!-- This setting is hidden unless `custom_period` --}}
                     <div class="dependent-settings-block">
-                        <label for="id_realm_waiting_period_threshold" class="inline-block">{{t "Waiting period (days)" }}:</label>
-                        <input type="text" id="id_realm_waiting_period_threshold"
-                          name="realm_waiting_period_threshold"
+                        <label for="id_realm_waiting_period_threshold_custom_input" class="inline-block">{{t "Waiting period (days)" }}:</label>
+                        <input type="text" id="id_realm_waiting_period_threshold_custom_input"
+                          name="realm_waiting_period_threshold_custom_input"
                           class="admin-realm-time-limit-input prop-element"
                           value="{{ realm_waiting_period_threshold }}"/>
                     </div>

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -70,7 +70,7 @@
             {{> upgrade_tip_widget }}
 
             <div class="inline-block organization-settings-parent">
-                <div class="input-group">
+                <div class="input-group time-limit-setting">
                     <label for="id_realm_message_retention_days" class="dropdown-title">{{t "Message retention period" }}
                     </label>
                     <select name="realm_message_retention_days"
@@ -87,7 +87,7 @@
                         </label>
                         <input type="text" id="id_realm_message_retention_custom_input" autocomplete="off"
                           name="realm_message_retention_custom_input"
-                          class="admin-realm-message-retention-days message-retention-setting-custom-input"
+                          class="admin-realm-message-retention-days message-retention-setting-custom-input time-limit-custom-input"
                           data-setting-widget-type="number"
                           {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}/>
                     </div>

--- a/static/templates/stream_settings/stream_types.hbs
+++ b/static/templates/stream_settings/stream_types.hbs
@@ -42,7 +42,7 @@
 
 {{#if (or is_owner is_stream_edit)}}
 <div>
-    <div class="input-group inline-block message-retention-setting-group">
+    <div class="input-group inline-block message-retention-setting-group time-limit-setting">
         <label class="dropdown-title">{{t "Message retention period" }}
             {{> ../help_link_widget link="/help/message-retention-policy" }}
         </label>
@@ -64,7 +64,7 @@
             </label>
             <input type="text" autocomplete="off"
               name="stream-message-retention-days"
-              class="stream-message-retention-days message-retention-setting-custom-input"
+              class="stream-message-retention-days message-retention-setting-custom-input time-limit-custom-input"
               id="stream_message_retention_custom_input"
               value="{{ stream_message_retention_days }}"/>
         </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to rename `custom_days` option to `custom_period`.
- Second commit adds `waiting_period_threshold_values` object.
- Third commit renames IDs of waiting-period setting elements.
- Fourth commit refactors the code for waiting period setting and also adds code to disable the save button for invalid values in custom input.
- Fifth commit is a prep commit to rename class.
- Sixth commit is to disable the save button for invalid values in message retention custom input.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Waiting period setting 
![waiting-period-setting](https://user-images.githubusercontent.com/35494118/212703187-c39c49f4-a0d9-48c0-bf00-3c4902f77404.gif)


Realm message retention setting
![realm-retention](https://user-images.githubusercontent.com/35494118/212703207-e68c7fb2-cbb0-47f9-8173-70b92c630aef.gif)


Stream message retention setting
![stream-retention](https://user-images.githubusercontent.com/35494118/212703261-12b8f092-1fe8-48d7-90e1-e72aef12415a.gif)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
