### PR TITLE
navbar: Remove stale #top_navbar:not(.rightside-userlist) CSS.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2879,7 +2879,7 @@ textarea.invitee_emails {
         width: 30px;
     }
 
-    #top_navbar.rightside-userlist #navbar-buttons {
+    #top_navbar #navbar-buttons {
         margin-right: 41px;
     }
 
@@ -2904,18 +2904,6 @@ textarea.invitee_emails {
 
     .search_closed .fa-search {
         right: 115px;
-    }
-
-    #top_navbar:not(.rightside-userlist) {
-        .search_closed .fa-search {
-            right: 72px;
-        }
-
-        .top-navbar-border,
-        #searchbox_legacy .navbar-search.expanded,
-        #searchbox .navbar-search.expanded {
-            width: calc(100% - 50px);
-        }
     }
 }
 
@@ -2995,17 +2983,6 @@ textarea.invitee_emails {
 
     .search_closed .fa-search {
         right: 115px;
-    }
-
-    #top_navbar:not(.rightside-userlist) {
-        .top-navbar-border {
-            width: calc(100% - 75px);
-        }
-
-        #searchbox_legacy .navbar-search.expanded,
-        #searchbox .navbar-search.expanded {
-            width: calc(100% - 90px);
-        }
     }
 }
 

--- a/static/templates/navbar.hbs
+++ b/static/templates/navbar.hbs
@@ -1,5 +1,5 @@
 <div class="header">
-    <nav class="header-main rightside-userlist" id="top_navbar">
+    <nav class="header-main" id="top_navbar">
         <div class="column-left">
             <a class="brand no-style" href="#">
                 <img id="realm-logo" src="" alt="" class="nav-logo no-drag"/>


### PR DESCRIPTION
It looks like top_navbar always has rightside_userlist in the template, and I couldn't find code that makes it such that it doesn't. @amanagr also took a look and came to the same conclusion.

@YashRE42  confirmed that this is no longer used, since fbe9a9e539cf7fe042352eb968843341a1034f96
