### PR TITLE
unread: Show unread count for only non bot messages for user list icon.

### DIFF
--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -154,14 +154,22 @@ class UnreadPMCounter {
     get_counts() {
         const pm_dict = new Map(); // Hash by user_ids_string -> count
         let total_count = 0;
+        let right_sidebar_count = 0;
         for (const [user_ids_string, id_set] of this.bucketer) {
             const count = id_set.size;
             pm_dict.set(user_ids_string, count);
+            const user_ids = people.user_ids_string_to_ids_array(user_ids_string);
+            const is_with_one_human =
+                user_ids.length === 1 && !people.get_by_user_id(user_ids[0]).is_bot;
+            if (is_with_one_human) {
+                right_sidebar_count += count;
+            }
             total_count += count;
         }
         return {
             total_count,
             pm_dict,
+            right_sidebar_count,
         };
     }
 
@@ -704,6 +712,7 @@ export function get_counts() {
     const pm_res = unread_pm_counter.get_counts();
     res.pm_count = pm_res.pm_dict;
     res.private_message_count = pm_res.total_count;
+    res.right_sidebar_private_message_count = pm_res.right_sidebar_count;
     res.home_unread_messages += pm_res.total_count;
 
     return res;

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -84,7 +84,12 @@ export function update_unread_counts() {
     // Set the unread counts that we show in the buttons that
     // toggle open the sidebar menus when we have a thin window.
     set_count_toggle_button($("#streamlist-toggle-unreadcount"), res.home_unread_messages);
-    set_count_toggle_button($("#userlist-toggle-unreadcount"), res.private_message_count);
+    // Bots and group PMs do not appear in the right sidebar user list, so
+    // we show unread count for only non bot 1:1 private messages there.
+    set_count_toggle_button(
+        $("#userlist-toggle-unreadcount"),
+        res.right_sidebar_private_message_count,
+    );
 }
 
 export function should_display_bankruptcy_banner() {


### PR DESCRIPTION
Uptil now, the user list unread count included bot PMs which sometimes resulted in the confusing state of the user list icon indicating unread messages but on expanding the user list, no username had a counter beside it, since the list excludes bots, while unread count did not.

Now this unread count too excludes bots, so the unread count and the user list are consistent, without any ghost counts.

Fixes: [issue described here](https://chat.zulip.org/#narrow/stream/9-issues/topic/User.20list.20shows.20unread.20count.20for.20bot.20message)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before: Notice the unread count on top left with no username with unread messages in the user list
![image](https://user-images.githubusercontent.com/68962290/212748944-a67620f6-ced0-4f0e-95de-931a73ce6ba1.png)

After: The unread count is not shown as the message is from a bot
![image](https://user-images.githubusercontent.com/68962290/212748838-5b156237-c70d-48e4-abaa-8eaa07dc55dd.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
