### PR TITLE
typeahead: Show the time typeahead irrespective of text before syntax.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1274,6 +1274,7 @@ test("begins_typeahead", ({override, override_rewire}) => {
     assert_typeahead_equals("@zulip :ta", emoji_list);
     assert_stream_list(":tada: #foo");
     assert_typeahead_equals("#foo\n~~~py", lang_list);
+    assert_typeahead_equals(":tada: <time:", ["translated: Mention a time-zone-aware time"]);
 
     assert_typeahead_equals("@", all_mentions);
     assert_typeahead_equals("@_", people_only);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -314,6 +314,11 @@ export function tokenize_compose_str(s) {
                     return s.slice(i);
                 }
                 break;
+            case "<":
+                if (s.indexOf("<time", i) === i) {
+                    return s.slice(i);
+                }
+                break;
             case ">":
                 // topic_jump
                 //
@@ -331,11 +336,6 @@ export function tokenize_compose_str(s) {
                 // maybe topic_list; let's let the stream_topic_regex decide later.
                 return ">topic_list";
         }
-    }
-
-    const timestamp_index = s.indexOf("<time");
-    if (timestamp_index >= 0) {
-        return s.slice(timestamp_index);
     }
 
     return "";


### PR DESCRIPTION
Uptil now, on typing "<time" after some other autocompleteable token like a mention or emoji, the timezone aware time typeahead would not get triggered since the time syntax was checked after the earlier syntax had been mistakenly used to (wrongly) tokenize the precursor text.

Now the code has been fixed to detect the time syntax the same way as the rest: checking each character in the precursor text from end to start, and tokenize it correctly.

Fixes: #23998.

**Screenshots and screen captures:**
Before:
![image](https://user-images.githubusercontent.com/68962290/212917198-7ee68ee6-13e6-44d8-874d-efed4b99397f.png)

After:
![image](https://user-images.githubusercontent.com/68962290/212916760-ac485642-c3dd-4eba-bff4-46a881a33d36.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
