### PR TITLE
portico-signin: Clean up CSS for buttons on dev login page.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -809,15 +809,6 @@ input#terminal:checked ~ #tab-terminal {
     width: 100%;
 }
 
-.btn-direct {
-    margin-top: 0;
-    margin-bottom: 0;
-    padding: 8px;
-    font-size: 18px;
-    border-radius: 0;
-    min-width: 300px;
-}
-
 .login-page {
     text-align: center;
 

--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -163,17 +163,35 @@ html {
         display: inline-block;
     }
 
-    .btn-dev-login {
+    .dev-button {
         color: hsl(170, 41%, 52%);
         border: 1px solid hsl(170, 41%, 52%);
         border-radius: 4px;
         background-color: transparent;
+        font-family: inherit;
+        font-weight: normal;
+        line-height: 20px;
+        vertical-align: middle;
+        margin: 0;
+        width: auto;
 
         transition: color 0.3s ease, border 0.3s ease;
 
         &:hover {
             color: hsl(156, 62%, 61%);
             border-color: hsl(156, 62%, 61%);
+        }
+
+        &.dev-login-button {
+            padding: 8px;
+            font-size: 19px;
+            min-width: 300px;
+        }
+
+        &.dev-create-button {
+            padding: 6px 12px;
+            margin-bottom: 4px;
+            font-size: 15px;
         }
     }
 }

--- a/templates/zerver/development/dev_login.html
+++ b/templates/zerver/development/dev_login.html
@@ -26,7 +26,7 @@ page can be easily identified in it's respective JavaScript file -->
                     <h2>{{_('Anonymous user') }}</h2>
                     <p>
                         <input type="submit" formaction="{{ current_realm.uri }}{{ url('login-local') }}"
-                          name="prefers_web_public_view" class="btn-direct btn-dev-login" value="Anonymous login" />
+                          name="prefers_web_public_view" class="dev-button dev-login-button" value="Anonymous login" />
                     </p>
                     {% endif %}
                     <h2>{{_('Owners') }}</h2>
@@ -34,7 +34,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_owner in direct_owners %}
                         <p>
                             <button type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_owner.delivery_email }}">
+                              name="direct_email" class="dev-button dev-login-button" value="{{ direct_owner.delivery_email }}">
                                 {% if direct_owner.realm.demo_organization_scheduled_deletion_date %}
                                     {{ direct_owner.full_name }}
                                 {% else %}
@@ -51,7 +51,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_admin in direct_admins %}
                         <p>
                             <input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_admin.delivery_email }}" />
+                              name="direct_email" class="dev-button dev-login-button" value="{{ direct_admin.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -62,7 +62,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_moderator in direct_moderators %}
                         <p>
                             <input type="submit" formaction="{{ direct_moderator.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_moderator.delivery_email }}" />
+                              name="direct_email" class="dev-button dev-login-button" value="{{ direct_moderator.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -73,7 +73,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for guest_user in guest_users %}
                         <p>
                             <input type="submit" formaction="{{ guest_user.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-dev-login" value="{{ guest_user.delivery_email }}" />
+                              name="direct_email" class="dev-button dev-login-button" value="{{ guest_user.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -87,7 +87,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% for direct_user in direct_users %}
                         <p>
                             <input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('login-local') }}"
-                              name="direct_email" class="btn-direct btn-dev-login" value="{{ direct_user.delivery_email }}" />
+                              name="direct_email" class="dev-button dev-login-button" value="{{ direct_user.delivery_email }}" />
                         </p>
                         {% endfor %}
                     {% else %}
@@ -109,13 +109,13 @@ page can be easily identified in it's respective JavaScript file -->
         <div id="devtools-wrapper">
             <div id="devtools-registration">
                 <form name="register_dev_user" action="{{ url('register_dev_user') }}" method="POST">
-                    <input type="submit" class="btn btn-dev-login" value="Create new user" />
+                    <input type="submit" class="dev-button dev-create-button" value="Create new user" />
                 </form>
                 <form name="register_dev_realm" action="{{ url('register_dev_realm') }}" method="POST">
-                    <input type="submit" class="btn btn-dev-login" value="Create new realm" />
+                    <input type="submit" class="dev-button dev-create-button" value="Create new realm" />
                 </form>
                 <form name="register_demo_dev_realm" action="{{ url('register_demo_dev_realm') }}" method="POST">
-                    <input type="submit" class="btn btn-dev-login" value="Create demo organization" />
+                    <input type="submit" class="dev-button dev-create-button" value="Create demo organization" />
                 </form>
             </div>
             <a href="/devtools">Zulip developer tools</a>


### PR DESCRIPTION
**CSS class changes**:
- Removes the `btn-direct` class in `portico.css` that was only being used for dev login buttons.
- Adds `dev-button` class for general CSS rules for button/input elements on the dev login page to `portico_signin.css`.
- Adds `dev-login-button` and `dev-create-button` classes for CSS rules specific to the two types of button/input elements on the page, also to `portico_signin.css`.

Follow-up to #23910.

**Notes**:
- The button text on the dev login page is now inheriting the font family from `portico.css` (which is `"Source Sans 3", sans-serif`) instead of having the font family set by `bootstrap.css` to `"Helvetica Neue", Helvetica, Arial, sans-serif`.
- Some of the shared rules for `input` elements in set in `bootstrap.css`, I added to the `dev-button` class.
- The `btn` class from `boostrap-btn.css` is no longer being used on the dev login page.
- I added a small bottom margin to the buttons for creating users/realms/demo organizations, so that when the window is narrowed there is some space between the buttons when they wrap on the page, see screenshots below.

---

**Screenshots and screen captures:**

<details>
<summary>Normal screen width</summary>

### Current page
![Screenshot from 2023-01-17 16-01-49](https://user-images.githubusercontent.com/63245456/212933234-9eeb8a6c-5539-4681-8d61-ab1367fefe43.png)

### Updated page
![Screenshot from 2023-01-17 16-01-32](https://user-images.githubusercontent.com/63245456/212933286-c1422995-7904-4ce4-a9e0-1b7c94cd9a82.png)

</details>
<details>
<summary>Narrow screen width</summary>

### Current page
![Screenshot from 2023-01-17 16-03-05](https://user-images.githubusercontent.com/63245456/212933791-ab9d1fbb-0501-4e2e-bb43-71e4f1132dbd.png)

### Updated page
![Screenshot from 2023-01-17 16-03-21](https://user-images.githubusercontent.com/63245456/212933745-c504f7f5-2979-4a63-ac1f-488f1c77019b.png)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
