### PR TITLE
portico-css: Remove unused `find_account` CSS rules.

### DIFF
--- a/static/styles/portico/portico.css
+++ b/static/styles/portico/portico.css
@@ -1317,15 +1317,6 @@ label.label-title {
     float: right;
 }
 
-#find_account .form-control {
-    height: 30px;
-}
-
-#find_account .btn {
-    height: 40px;
-    border-radius: 5px;
-}
-
 .documentation-footer {
     font-size: 0.85rem;
     opacity: 0.8;


### PR DESCRIPTION
Removes `#find_account .btn` and `#find_account .form-control` rules in `static/styles/portico/portico.css`.

The last use of these rules was removed in commit 7afbc9ddd6e when the login and registration pages were redesigned; specifically note changes to `find_my_team.html` in that commit, which was renamed to `find_account.html` in commit ac0d90e53342a4.

Noted when working on #24093.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
