### PR TITLE
bug: correctly use configured postfix mailname

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -721,7 +721,8 @@ more than 3.5GiB of RAM, 4 on hosts with less.
 #### `mailname`
 
 The hostname that [Postfix should be configured to receive mail
-at](email-gateway.md#local-delivery-setup).
+at](email-gateway.md#local-delivery-setup), as well as identify itself as for
+outgoing email.
 
 ### `[postgresql]`
 

--- a/docs/production/email-gateway.md
+++ b/docs/production/email-gateway.md
@@ -80,9 +80,10 @@ using an [HTTP reverse proxy][reverse-proxy]).
    mailname = emaildomain.example.com
    ```
 
-   This tells postfix to expect to receive emails at addresses ending
-   with `@emaildomain.example.com`, overriding the default of
-   `@hostname.example.com`.
+   This tells postfix to expect to receive emails at addresses ending with
+   `@emaildomain.example.com`, overriding the default of
+   `@hostname.example.com`. It will also identify itself as
+   `emaildomain.example.com` on any outgoing emails it sends.
 
 1. Run `/home/zulip/deployments/current/scripts/zulip-puppet-apply`
    (and answer `y`) to apply your new `/etc/zulip/zulip.conf`

--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -21,7 +21,7 @@ class zulip::postfix_localmail {
     mode    => '0644',
     owner   => root,
     group   => root,
-    content => $fqdn,
+    content => $postfix_mailname,
   }
 
   file {'/etc/postfix/main.cf':


### PR DESCRIPTION
Correctly use configured postfix mailname

Fixes:

- Scenario: `mailname` is configured in `[postfix]` section in `zulip.conf`

- Current behavior: the option is ignored. `/etc/mailname` is always equal to machine's `hostname`.

- Expected behavior: the option `mailname` option should be respect.

In fact, I haven't check the code much because the bug seems to be obvious.
I am using zulip-docker. Currently, instead of rebuilding the image, I monkey patch `/etc/mailname` for a temporary solution.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
