### PR TITLE
migrations: Fix ‘continue’ logic error in 0037

### DIFF
--- a/zerver/migrations/0037_disallow_null_string_id.py
+++ b/zerver/migrations/0037_disallow_null_string_id.py
@@ -19,10 +19,11 @@ def set_string_id_using_domain(apps: StateApps, schema_editor: BaseDatabaseSchem
                 try:
                     realm.string_id = prefix + str(i)
                     realm.save(update_fields=["string_id"])
-                    continue
+                    break
                 except IntegrityError:
                     pass
-            raise RuntimeError(f"Unable to find a good string_id for realm {realm}")
+            else:
+                raise RuntimeError(f"Unable to find a good string_id for realm {realm}")
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
The intention was to continue the outer `for` loop, not the inner one (but Python doesn’t have labelled `continue`).