### PR TITLE
emoji: Fix regex expression for valid emoji names

### DIFF
--- a/zerver/lib/emoji.py
+++ b/zerver/lib/emoji.py
@@ -111,13 +111,13 @@ def check_remove_custom_emoji(user_profile: UserProfile, emoji_name: str) -> Non
 
 def check_valid_emoji_name(emoji_name: str) -> None:
     if emoji_name:
-        if re.match(r"^[0-9a-z.\-_]+(?<![.\-_])$", emoji_name):
+        if re.match(r"^[0-9a-z\-_]+(?<![\-_])$", emoji_name):
             return
-        if re.match(r"^[0-9a-z.\-_]+$", emoji_name):
-            raise JsonableError(_("Emoji names must end with either a letter or number."))
+        if re.match(r"^[0-9a-z\-_]+$", emoji_name):
+            raise JsonableError(_("Emoji names must end with either a letter or digit."))
         raise JsonableError(
             _(
-                "Emoji names must contain only numbers, lowercase English letters, spaces, dashes, underscores, and periods.",
+                "Emoji names must contain only lowercase English letters, digits, spaces, dashes, and underscores.",
             )
         )
     raise JsonableError(_("Emoji name is missing"))

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -120,7 +120,7 @@ class RealmEmojiTest(ZulipTestCase):
             result = self.client_post("/json/realm/emoji/my_em*oji", info=emoji_data)
         self.assert_json_error(
             result,
-            "Emoji names must contain only numbers, lowercase English letters, spaces, dashes, underscores, and periods.",
+            "Emoji names must contain only lowercase English letters, digits, spaces, dashes, and underscores.",
         )
 
     def test_forward_slash_exception(self) -> None:
@@ -132,7 +132,7 @@ class RealmEmojiTest(ZulipTestCase):
             )
         self.assert_json_error(
             result,
-            "Emoji names must contain only numbers, lowercase English letters, spaces, dashes, underscores, and periods.",
+            "Emoji names must contain only lowercase English letters, digits, spaces, dashes, and underscores.",
         )
 
     def test_upload_uppercase_exception(self) -> None:
@@ -142,7 +142,7 @@ class RealmEmojiTest(ZulipTestCase):
             result = self.client_post("/json/realm/emoji/my_EMoji", info=emoji_data)
         self.assert_json_error(
             result,
-            "Emoji names must contain only numbers, lowercase English letters, spaces, dashes, underscores, and periods.",
+            "Emoji names must contain only lowercase English letters, digits, spaces, dashes, and underscores.",
         )
 
     def test_upload_end_character_exception(self) -> None:
@@ -150,7 +150,7 @@ class RealmEmojiTest(ZulipTestCase):
         with get_test_image_file("img.png") as fp1:
             emoji_data = {"f1": fp1}
             result = self.client_post("/json/realm/emoji/my_emoji_", info=emoji_data)
-        self.assert_json_error(result, "Emoji names must end with either a letter or number.")
+        self.assert_json_error(result, "Emoji names must end with either a letter or digit.")
 
     def test_missing_name_exception(self) -> None:
         self.login("iago")


### PR DESCRIPTION
- Modified Regex Expression responsible for validating emoji names.
- Disallowed "periods" in the emoji name.

<!-- Describe your pull request here.-->

Fixes: #24066 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
