### PR TITLE
compose: delete drafts with attachments

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -203,6 +203,9 @@ export function clear_compose_box() {
 
 export function send_message_success(local_id, message_id, locally_echoed) {
     if (!locally_echoed) {
+        if ($("#compose-textarea").data("draft-id")) {
+            drafts.draft_model.deleteDraft($("#compose-textarea").data("draft-id"));
+        }
         clear_compose_box();
     }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Draft messages containing attachments, polls, or to-dos were not being deleted after they were sent. This was occurring because only locally echoed draft messages were being deleted. 
To resolve this issue, I implemented additional code in the send_message_success function to delete draft messages that were not locally echoed after they were successfully sent.
Fixes: #24063

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/96344003/214677960-ae78e76b-219f-4ab4-b2b5-1b6f9ba61b15.mov


Initial image of draft (Before sending the draft with attachment)

![draft](https://user-images.githubusercontent.com/96344003/213112585-c1d3e71f-3ed7-44b1-a6a0-2a93a24214f3.png)

Sending draft message with attachment

![draft2](https://user-images.githubusercontent.com/96344003/213112594-d74be58e-a2cd-4f0b-b868-d52d76633f60.png)

Later image of draft (After sending the draft message)

![draft3](https://user-images.githubusercontent.com/96344003/213112600-845a8ac8-eea8-410d-9315-807f79947b9c.png)

<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x]  Corner cases, error conditions, and easily imagined bugs.
</details>
