### PR TITLE
Fix new Ruff SIM rules

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -653,20 +653,17 @@ class TestSupportEndpoint(ZulipTestCase):
 
         with mock.patch(
             "analytics.views.support.downgrade_now_without_creating_additional_invoices"
-        ) as m1:
-            with mock.patch("analytics.views.support.void_all_open_invoices", return_value=1) as m2:
-                result = self.client_post(
-                    "/activity/support",
-                    {
-                        "realm_id": f"{iago.realm_id}",
-                        "downgrade_method": "downgrade_now_void_open_invoices",
-                    },
-                )
-                m1.assert_called_once_with(get_realm("zulip"))
-                m2.assert_called_once_with(get_realm("zulip"))
-                self.assert_in_success_response(
-                    ["zulip downgraded and voided 1 open invoices"], result
-                )
+        ) as m1, mock.patch("analytics.views.support.void_all_open_invoices", return_value=1) as m2:
+            result = self.client_post(
+                "/activity/support",
+                {
+                    "realm_id": f"{iago.realm_id}",
+                    "downgrade_method": "downgrade_now_void_open_invoices",
+                },
+            )
+            m1.assert_called_once_with(get_realm("zulip"))
+            m2.assert_called_once_with(get_realm("zulip"))
+            self.assert_in_success_response(["zulip downgraded and voided 1 open invoices"], result)
 
     def test_scrub_realm(self) -> None:
         cordelia = self.example_user("cordelia")

--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -361,10 +361,7 @@ def get_chart_data(
         # Otherwise, we can use tables on the current server to
         # determine a nice range, and some additional validation.
         if start is None:
-            if for_installation:
-                start = installation_epoch()
-            else:
-                start = realm.date_created
+            start = installation_epoch() if for_installation else realm.date_created
         if end is None:
             end = max(
                 stat.last_successful_fill() or datetime.min.replace(tzinfo=timezone.utc)

--- a/manage.py
+++ b/manage.py
@@ -86,10 +86,7 @@ class FilteredManagementUtility(ManagementUtility):
             ]
             commands_dict = defaultdict(list)
             for name, app in get_filtered_commands().items():
-                if app == "django.core":
-                    app = "django"
-                else:
-                    app = app.rpartition(".")[-1]
+                app = "django" if app == "django.core" else app.rpartition(".")[-1]
                 commands_dict[app].append(name)
             style = color_style()
             for app in sorted(commands_dict):

--- a/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_zephyr_mirror
+++ b/puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_zephyr_mirror
@@ -35,10 +35,7 @@ def report(state: str, data: str, last_check: float) -> NoReturn:
 
 with open(RESULTS_FILE) as f:
     data = f.read().strip()
-if data.split("\n")[-1].strip() == "0":
-    state = "OK"
-else:
-    state = "CRITICAL"
+state = "OK" if data.split("\n")[-1].strip() == "0" else "CRITICAL"
 
 last_check = os.stat(RESULTS_FILE).st_mtime
 time_since_last_check = time.time() - last_check

--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -18,10 +18,7 @@ DEFAULT_PRODUCTION = False
 
 
 def get_yarn_args(production: bool) -> List[str]:
-    if production:
-        yarn_args = ["--prod"]
-    else:
-        yarn_args = []
+    yarn_args = ["--prod"] if production else []
     return yarn_args
 
 

--- a/scripts/lib/sharding.py
+++ b/scripts/lib/sharding.py
@@ -63,10 +63,7 @@ def write_updated_configs() -> None:
             else:
                 ports = [int(port) for port in key.split("_")]
                 for shard in shards.split():
-                    if "." in shard:
-                        host = shard
-                    else:
-                        host = f"{shard}.{external_host}"
+                    host = shard if "." in shard else f"{shard}.{external_host}"
                     assert host not in shard_map, f"host {host} duplicated"
                     shard_map[host] = ports[0] if len(ports) == 1 else ports
                     nginx_sharding_conf_f.write(

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -115,10 +115,7 @@ if args.skip_restart and args.skip_tornado:
     logging.warning("Ignored --skip-tornado; all upgrades with --skip-restart skip all restarts.")
     args.skip_tornado = False
 if minimal_change:
-    if args.skip_restart:
-        flagname = "--skip-restart"
-    else:
-        flagname = "--skip-tornado"
+    flagname = "--skip-restart" if args.skip_restart else "--skip-tornado"
     if args.less_graceful:
         logging.warning("Ignored --less-graceful; %s is always graceful.", flagname)
         args.less_graceful = False

--- a/scripts/log-search
+++ b/scripts/log-search
@@ -209,10 +209,7 @@ def main() -> None:
 
 
 def parse_logfile_names(args: argparse.Namespace) -> List[str]:
-    if args.nginx:
-        base_path = "/var/log/nginx/access.log"
-    else:
-        base_path = "/var/log/zulip/server.log"
+    base_path = "/var/log/nginx/access.log" if args.nginx else "/var/log/zulip/server.log"
 
     logfile_names = [base_path]
     if args.all_logs:

--- a/scripts/nagios/check-rabbitmq-consumers
+++ b/scripts/nagios/check-rabbitmq-consumers
@@ -61,10 +61,7 @@ for queue_name in consumers:
     if queue_name == "notify_tornado":
         target_count = TORNADO_PROCESSES
 
-    if consumers[queue_name] < target_count:
-        status = 2
-    else:
-        status = 0
+    status = 2 if consumers[queue_name] < target_count else 0
     with open(state_file_tmp, "w") as f:
         f.write(
             f"{now}|{status}|{states[status]}|queue {queue_name} has {consumers[queue_name]} consumers, needs {target_count}\n"

--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -149,10 +149,7 @@ def tokenize(text: str) -> List[Token]:
                 kind = "handlebars_partial_block"
             elif looking_at_html_start():
                 s = get_html_tag(text, state.i)
-                if s.endswith("/>"):
-                    end_offset = -2
-                else:
-                    end_offset = -1
+                end_offset = -2 if s.endswith("/>") else -1
                 tag_parts = s[1:end_offset].split()
 
                 if not tag_parts:
@@ -222,10 +219,7 @@ def tokenize(text: str) -> List[Token]:
             elif looking_at(" "):
                 s = get_spaces(text, state.i)
                 tag = ""
-                if not tokens or tokens[-1].kind == "newline":
-                    kind = "indent"
-                else:
-                    kind = "whitespace"
+                kind = "indent" if not tokens or tokens[-1].kind == "newline" else "whitespace"
             elif text[state.i] in "{<":
                 snippet = text[state.i :][:15]
                 raise AssertionError(f"tool cannot parse {snippet}")

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -34,18 +34,12 @@ parser.add_argument("--quiet", action="store_true", help="suppress mypy summary 
 args = parser.parse_args()
 assert_provisioning_status_ok(args.skip_provision_check)
 
-if args.use_daemon:
-    command_name = "dmypy"
-else:
-    command_name = "mypy"
+command_name = "dmypy" if args.use_daemon else "mypy"
 
 # Use zulip-py3-venv's mypy if it's available.
 VENV_DIR = "/srv/zulip-py3-venv"
 MYPY_VENV_PATH = os.path.join(VENV_DIR, "bin", command_name)
-if os.path.exists(MYPY_VENV_PATH):
-    mypy_command = MYPY_VENV_PATH
-else:
-    mypy_command = command_name
+mypy_command = MYPY_VENV_PATH if os.path.exists(MYPY_VENV_PATH) else command_name
 
 if args.version:
     print("mypy command:", mypy_command)

--- a/tools/tail-ses
+++ b/tools/tail-ses
@@ -64,9 +64,10 @@ def main() -> None:
     args = parser.parse_args()
 
     sns_topic_arn = get_ses_arn(session, args)
-    with our_sqs_queue(session, sns_topic_arn) as (queue_arn, queue_url):
-        with our_sns_subscription(session, sns_topic_arn, queue_arn):
-            print_messages(session, queue_url)
+    with our_sqs_queue(session, sns_topic_arn) as (queue_arn, queue_url), our_sns_subscription(
+        session, sns_topic_arn, queue_arn
+    ):
+        print_messages(session, queue_url)
 
 
 def get_ses_arn(session: boto3.session.Session, args: argparse.Namespace) -> str:

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -163,11 +163,12 @@ def get_failed_tests() -> List[str]:
 def block_internet() -> Iterator[None]:
     # Monkey-patching - responses library raises requests.ConnectionError when access to an unregistered URL
     # is attempted. We want to replace that with our own exception, so that it propagates all the way:
-    with mock.patch.object(responses, "ConnectionError", new=ZulipInternetBlockedError):
-        # We'll run all tests in this context manager. It'll cause an error to be raised (see above comment),
-        # if any code attempts to access the internet.
-        with responses.RequestsMock():
-            yield
+    # We'll run all tests in this context manager. It'll cause an error to be raised (see above comment),
+    # if any code attempts to access the internet.
+    with mock.patch.object(
+        responses, "ConnectionError", new=ZulipInternetBlockedError
+    ), responses.RequestsMock():
+        yield
 
 
 class ZulipInternetBlockedError(Exception):

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -348,14 +348,7 @@ def main() -> None:
 
     full_suite = len(args) == 0
 
-    if full_suite:
-        suites = [
-            "zerver.tests",
-            "analytics.tests",
-            "corporate.tests",
-        ]
-    else:
-        suites = args
+    suites = ["zerver.tests", "analytics.tests", "corporate.tests"] if full_suite else args
 
     if full_suite and include_webhooks:
         suites.append("zerver.webhooks")

--- a/tools/test-locked-requirements
+++ b/tools/test-locked-requirements
@@ -20,14 +20,13 @@ CACHE_FILE = os.path.join(CACHE_DIR, "requirements_hashes")
 
 
 def print_diff(path_file1: str, path_file2: str) -> None:
-    with open(path_file1) as file1:
-        with open(path_file2) as file2:
-            diff = difflib.unified_diff(
-                file1.readlines(),
-                file2.readlines(),
-                fromfile=path_file1,
-                tofile=path_file2,
-            )
+    with open(path_file1) as file1, open(path_file2) as file2:
+        diff = difflib.unified_diff(
+            file1.readlines(),
+            file2.readlines(),
+            fromfile=path_file1,
+            tofile=path_file2,
+        )
     sys.stdout.writelines(diff)
 
 

--- a/tools/total-contributions
+++ b/tools/total-contributions
@@ -106,10 +106,7 @@ if len(args.version) > 2:
     parser.error("Expects 0 to 2 version number(s)")
 
 lower_zulip_version = args.version[0]
-if len(args.version) == 1:
-    upper_zulip_version = "main"
-else:
-    upper_zulip_version = args.version[1]
+upper_zulip_version = "main" if len(args.version) == 1 else args.version[1]
 
 subprocess.check_call(["git", "fetch"], cwd=find_path("zulip"))
 

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -427,10 +427,7 @@ def do_update_message(
         )
 
         if target_message.is_stream_message():
-            if topic_name is not None:
-                new_topic_name = topic_name
-            else:
-                new_topic_name = target_message.topic_name()
+            new_topic_name = topic_name if topic_name is not None else target_message.topic_name()
 
             stream_topic: Optional[StreamTopicTarget] = StreamTopicTarget(
                 stream_id=stream_id,

--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -568,10 +568,7 @@ def process_posts(
             content = re.sub("[a-z]", "x", content)
             content = re.sub("[A-Z]", "X", content)
 
-        if "reactions" in post_dict:
-            reactions = post_dict["reactions"] or []
-        else:
-            reactions = []
+        reactions = post_dict["reactions"] or [] if "reactions" in post_dict else []
 
         message_dict = dict(
             sender_id=sender_id,

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -659,10 +659,7 @@ def process_messages(
                 message,
             )
 
-        if message.get("reactions"):
-            reactions = list_reactions(message["reactions"])
-        else:
-            reactions = []
+        reactions = list_reactions(message["reactions"]) if message.get("reactions") else []
 
         message_dict = dict(
             sender_id=sender_id,

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -279,10 +279,7 @@ def users_to_zerver_userprofile(
     for user in users:
         slack_user_id = user["id"]
 
-        if user.get("is_primary_owner", False):
-            user_id = primary_owner_id
-        else:
-            user_id = user_id_count
+        user_id = primary_owner_id if user.get("is_primary_owner", False) else user_id_count
 
         email = get_user_email(user, domain_name)
         # ref: https://zulip.com/help/change-your-profile-picture

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1292,10 +1292,11 @@ def fetch_team_icons(
     )
 
     resized_icon_output_path = os.path.join(output_dir, str(realm_id), "icon.png")
-    with open(resized_icon_output_path, "wb") as output_file:
-        with open(original_icon_output_path, "rb") as original_file:
-            resized_data = resize_logo(original_file.read())
-            output_file.write(resized_data)
+    with open(resized_icon_output_path, "wb") as output_file, open(
+        original_icon_output_path, "rb"
+    ) as original_file:
+        resized_data = resize_logo(original_file.read())
+        output_file.write(resized_data)
     records.append(
         {
             "realm_id": realm_id,

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -154,10 +154,7 @@ def cache_with_key(
             if cache_name == "database":
                 extra = ".dbcache"
 
-            if with_statsd_key is not None:
-                metric_key = with_statsd_key
-            else:
-                metric_key = statsd_key(key)
+            metric_key = with_statsd_key if with_statsd_key is not None else statsd_key(key)
 
             status = "hit" if val is not None else "miss"
             statsd.incr(f"cache{extra}.{metric_key}.{status}")
@@ -389,10 +386,7 @@ def generic_bulk_cached_fetch(
     ]
 
     # Only call query_function if there are some ids to fetch from the database:
-    if len(needed_ids) > 0:
-        db_objects = query_function(needed_ids)
-    else:
-        db_objects = []
+    db_objects = query_function(needed_ids) if len(needed_ids) > 0 else []
 
     items_for_remote_cache: Dict[str, Tuple[CompressedItemT]] = {}
     for obj in db_objects:

--- a/zerver/lib/context_managers.py
+++ b/zerver/lib/context_managers.py
@@ -26,6 +26,5 @@ def lockfile(filename: str, shared: bool = False) -> Iterator[None]:
     If shared is True, use a LOCK_SH lock, otherwise LOCK_EX.
 
     The file is given by name and will be created if it does not exist."""
-    with open(filename, "w") as lock:
-        with flock(lock, shared=shared):
-            yield
+    with open(filename, "w") as lock, flock(lock, shared=shared):
+        yield

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -92,10 +92,7 @@ def create_user_profile(
     force_id: Optional[int] = None,
     force_date_joined: Optional[datetime] = None,
 ) -> UserProfile:
-    if force_date_joined is None:
-        date_joined = timezone_now()
-    else:
-        date_joined = force_date_joined
+    date_joined = timezone_now() if force_date_joined is None else force_date_joined
 
     email = UserManager.normalize_email(email)
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -474,10 +474,7 @@ def process_message(message: EmailMessage, rcpt_to: Optional[str] = None) -> Non
     to: Optional[str] = None
 
     try:
-        if rcpt_to is not None:
-            to = rcpt_to
-        else:
-            to = find_emailgateway_recipient(message)
+        to = rcpt_to if rcpt_to is not None else find_emailgateway_recipient(message)
 
         if is_missed_message_address(to):
             process_missed_message(to, message)

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -68,10 +68,7 @@ def encode_email_address_helper(name: str, email_token: str, show_sender: bool =
     encoded_name = slug_name if len(slug_name) == len(name) else ""
 
     # If encoded_name ends up empty, we just skip this part of the address:
-    if encoded_name:
-        encoded_token = f"{encoded_name}.{email_token}"
-    else:
-        encoded_token = email_token
+    encoded_token = f"{encoded_name}.{email_token}" if encoded_name else email_token
 
     if show_sender:
         encoded_token += ".show-sender"
@@ -105,9 +102,6 @@ def decode_email_address(email: str) -> Tuple[str, Dict[str, bool]]:
 
     # There should be one or two parts left:
     # [stream_name, email_token] or just [email_token]
-    if len(remaining_parts) == 1:
-        token = remaining_parts[0]
-    else:
-        token = remaining_parts[1]
+    token = remaining_parts[0] if len(remaining_parts) == 1 else remaining_parts[1]
 
     return token, options

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -438,10 +438,7 @@ def do_send_missedmessage_events_reply_in_zulip(
     from zerver.lib.email_mirror import create_missed_message_address
 
     reply_to_address = create_missed_message_address(user_profile, missed_messages[0]["message"])
-    if reply_to_address == FromAddress.NOREPLY:
-        reply_to_name = ""
-    else:
-        reply_to_name = "Zulip"
+    reply_to_name = "" if reply_to_address == FromAddress.NOREPLY else "Zulip"
 
     narrow_url = get_narrow_url(user_profile, missed_messages[0]["message"])
     context.update(

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1130,10 +1130,7 @@ def apply_event(
         else:
             raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "presence":
-        if slim_presence:
-            user_key = str(event["user_id"])
-        else:
-            user_key = event["email"]
+        user_key = str(event["user_id"]) if slim_presence else event["email"]
         state["presences"][user_key] = get_presence_for_user(event["user_id"], slim_presence)[
             user_key
         ]
@@ -1155,10 +1152,7 @@ def apply_event(
                 if message_id in stream_dict:
                     stream_dict[message_id]["topic"] = topic
     elif event["type"] == "delete_message":
-        if "message_id" in event:
-            message_ids = [event["message_id"]]
-        else:
-            message_ids = event["message_ids"]  # nocoverage
+        message_ids = [event["message_id"]] if "message_id" in event else event["message_ids"]
         max_message = (
             Message.objects.filter(usermessage__user_profile=user_profile).order_by("-id").first()
         )

--- a/zerver/lib/generate_test_data.py
+++ b/zerver/lib/generate_test_data.py
@@ -41,10 +41,7 @@ def generate_topics(num_topics: int) -> List[str]:
     # many topics in a few streams. Note that these don't have the
     # "Marked as resolved" messages, so don't match the normal user
     # experience perfectly.
-    if random.random() < 0.15:
-        resolved_topic_probability = 0.5
-    else:
-        resolved_topic_probability = 0.05
+    resolved_topic_probability = 0.5 if random.random() < 0.15 else 0.05
 
     final_topics = []
     for topic in topics:

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -177,20 +177,14 @@ server via `ps -ef` or reading bash history. Prefer
         """
         Parses parameters for user creation defined in add_create_user_args.
         """
-        if options["email"] is None:
-            email = input("Email: ")
-        else:
-            email = options["email"]
+        email = input("Email: ") if options["email"] is None else options["email"]
 
         try:
             validators.validate_email(email)
         except ValidationError:
             raise CommandError("Invalid email address.")
 
-        if options["full_name"] is None:
-            full_name = input("Full name: ")
-        else:
-            full_name = options["full_name"]
+        full_name = input("Full name: ") if options["full_name"] is None else options["full_name"]
 
         if options["password_file"] is not None:
             with open(options["password_file"]) as f:

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2536,10 +2536,7 @@ def do_convert(
     # * message_realm is passed -> use that realm for Markdown purposes
     if message is not None and message_realm is None:
         message_realm = message.get_realm()
-    if message_realm is None:
-        linkifiers_key = DEFAULT_MARKDOWN_KEY
-    else:
-        linkifiers_key = message_realm.id
+    linkifiers_key = DEFAULT_MARKDOWN_KEY if message_realm is None else message_realm.id
 
     if message and hasattr(message, "id") and message.id:
         logging_message_id = "id# " + str(message.id)

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -441,10 +441,7 @@ class FencedBlockPreprocessor(Preprocessor):
         return output
 
     def format_code(self, lang: Optional[str], text: str) -> str:
-        if lang:
-            langclass = LANG_TAG.format(lang)
-        else:
-            langclass = ""
+        langclass = LANG_TAG.format(lang) if lang else ""
 
         # Check for code hilite extension
         if not self.checked_for_codehilite:

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1269,10 +1269,7 @@ def apply_unread_message_event(
         message_type = "stream"
     elif message["type"] == "private":
         others = [recip for recip in message["display_recipient"] if recip["id"] != user_profile.id]
-        if len(others) <= 1:
-            message_type = "private"
-        else:
-            message_type = "huddle"
+        message_type = "private" if len(others) <= 1 else "huddle"
     else:
         raise AssertionError("Invalid message type {}".format(message["type"]))
 
@@ -1292,10 +1289,7 @@ def apply_unread_message_event(
             state["unmuted_stream_msgs"].add(message_id)
 
     elif message_type == "private":
-        if len(others) == 1:
-            other_user_id = others[0]["id"]
-        else:
-            other_user_id = user_profile.id
+        other_user_id = others[0]["id"] if len(others) == 1 else user_profile.id
 
         state["pm_dict"][message_id] = RawUnreadPrivateMessageDict(
             other_user_id=other_user_id,
@@ -1335,10 +1329,7 @@ def format_unread_message_details(
 
     for message_id, private_message_details in raw_unread_data["pm_dict"].items():
         other_user_id = private_message_details["other_user_id"]
-        if other_user_id == my_user_id:
-            user_ids = []
-        else:
-            user_ids = [other_user_id]
+        user_ids = [] if other_user_id == my_user_id else [other_user_id]
 
         # Note that user_ids excludes ourself, even for the case we send messages
         # to ourself.

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -283,10 +283,7 @@ class NarrowBuilder:
         if method is None:
             raise BadNarrowOperatorError("unknown operator " + operator)
 
-        if negated:
-            maybe_negate = not_
-        else:
-            maybe_negate = lambda cond: cond
+        maybe_negate = not_ if negated else lambda cond: cond
 
         return method(query, operand, maybe_negate)
 

--- a/zerver/lib/realm_logo.py
+++ b/zerver/lib/realm_logo.py
@@ -18,10 +18,7 @@ def get_realm_logo_url(realm: Realm, night: bool) -> str:
     logo_source = get_realm_logo_source(realm, night)
 
     if logo_source == Realm.LOGO_UPLOADED:
-        if night:
-            logo_version = realm.night_logo_version
-        else:
-            logo_version = realm.logo_version
+        logo_version = realm.night_logo_version if night else realm.logo_version
         return upload_backend.get_realm_logo_url(realm.id, logo_version, night)
     return settings.DEFAULT_LOGO_URI + "?version=0"
 

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -532,12 +532,13 @@ def send_custom_email(
     rendered_input = render_markdown_path(plain_text_template_path.replace("templates/", ""))
 
     # And then extend it with our standard email headers.
-    with open(html_source_template_path, "w") as f:
-        with open(markdown_email_base_template_path) as base_template:
-            # Note that we're doing a hacky non-Jinja2 substitution here;
-            # we do this because the normal render_markdown_path ordering
-            # doesn't commute properly with inline_email_css.
-            f.write(base_template.read().replace("{{ rendered_input }}", rendered_input))
+    with open(html_source_template_path, "w") as f, open(
+        markdown_email_base_template_path
+    ) as base_template:
+        # Note that we're doing a hacky non-Jinja2 substitution here;
+        # we do this because the normal render_markdown_path ordering
+        # doesn't commute properly with inline_email_css.
+        f.write(base_template.read().replace("{{ rendered_input }}", rendered_input))
 
     with open(subject_path, "w") as f:
         f.write(get_header(options.get("subject"), parsed_email_template.get("subject"), "subject"))

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1660,14 +1660,13 @@ Output:
         # So explicitly change parameter name to 'notice' to work around this problem
         with mock.patch(
             "zerver.tornado.event_queue.process_notification", lambda notice: lst.append(notice)
-        ):
+        ), self.captureOnCommitCallbacks(execute=True):
             # Some `send_event` calls need to be executed only after the current transaction
             # commits (using `on_commit` hooks). Because the transaction in Django tests never
             # commits (rather, gets rolled back after the test completes), such events would
             # never be sent in tests, and we would be unable to verify them. Hence, we use
-            # this helper to make sure the `send_event` calls actually run.
-            with self.captureOnCommitCallbacks(execute=True):
-                yield
+            # captureOnCommitCallbacks to make sure the `send_event` calls actually run.
+            yield
 
         self.assert_length(lst, expected_num_events)
 

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -86,9 +86,10 @@ class MockLDAP(fakeldap.MockLDAP):
 def stub_event_queue_user_events(
     event_queue_return: Any, user_events_return: Any
 ) -> Iterator[None]:
-    with mock.patch("zerver.lib.events.request_event_queue", return_value=event_queue_return):
-        with mock.patch("zerver.lib.events.get_user_events", return_value=user_events_return):
-            yield
+    with mock.patch(
+        "zerver.lib.events.request_event_queue", return_value=event_queue_return
+    ), mock.patch("zerver.lib.events.get_user_events", return_value=user_events_return):
+        yield
 
 
 @contextmanager

--- a/zerver/lib/upload/local.py
+++ b/zerver/lib/upload/local.py
@@ -166,10 +166,7 @@ class LocalUploadBackend(ZulipUploadBackend):
         write_local_file("avatars", os.path.join(upload_path, resized_file), resized_data)
 
     def get_realm_logo_url(self, realm_id: int, version: int, night: bool) -> str:
-        if night:
-            file_name = "night_logo.png"
-        else:
-            file_name = "logo.png"
+        file_name = "night_logo.png" if night else "logo.png"
         return f"/user_avatars/{realm_id}/realm/{file_name}?version={version}"
 
     def ensure_avatar_image(self, user_profile: UserProfile, is_medium: bool = False) -> None:

--- a/zerver/lib/upload/s3.py
+++ b/zerver/lib/upload/s3.py
@@ -341,10 +341,7 @@ class S3UploadBackend(ZulipUploadBackend):
         self, logo_file: IO[bytes], user_profile: UserProfile, night: bool
     ) -> None:
         content_type = guess_type(logo_file.name)[0]
-        if night:
-            basename = "night_logo"
-        else:
-            basename = "logo"
+        basename = "night_logo" if night else "logo"
         s3_file_name = os.path.join(self.realm_avatar_and_logo_path(user_profile.realm), basename)
 
         image_data = logo_file.read()
@@ -368,10 +365,7 @@ class S3UploadBackend(ZulipUploadBackend):
         # that users use gravatar.)
 
     def get_realm_logo_url(self, realm_id: int, version: int, night: bool) -> str:
-        if not night:
-            file_name = "logo.png"
-        else:
-            file_name = "night_logo.png"
+        file_name = "logo.png" if not night else "night_logo.png"
         public_url = self.get_public_upload_url(f"{realm_id}/realm/{file_name}")
         return public_url + f"?version={version}"
 

--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -29,10 +29,7 @@ class StatsDWrapper:
         """Set a gauge value."""
         from django_statsd.clients import statsd
 
-        if delta:
-            value_str = f"{value:+g}|g"
-        else:
-            value_str = f"{value:g}|g"
+        value_str = f"{value:+g}|g" if delta else f"{value:g}|g"
         statsd._send(stat, value_str, rate)
 
     def __getattr__(self, name: str) -> Any:

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -209,10 +209,7 @@ def get_http_headers_from_filename(http_header_key: str) -> Callable[[str], Dict
     method in the headers.py file for the integration."""
 
     def fixture_to_headers(filename: str) -> Dict[str, str]:
-        if "__" in filename:
-            event_type = filename.split("__")[0]
-        else:
-            event_type = filename
+        event_type = filename.split("__")[0] if "__" in filename else filename
         return {http_header_key: event_type}
 
     return fixture_to_headers

--- a/zerver/management/commands/send_to_email_mirror.py
+++ b/zerver/management/commands/send_to_email_mirror.py
@@ -59,10 +59,7 @@ Example:
             self.print_help("./manage.py", "send_to_email_mirror")
             raise CommandError
 
-        if options["stream"] is None:
-            stream = "Denmark"
-        else:
-            stream = options["stream"]
+        stream = "Denmark" if options["stream"] is None else options["stream"]
 
         realm = self.get_realm(options)
         if realm is None:

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -257,10 +257,7 @@ def write_log_line(
             statsd.incr(f"{statsd_path}.dbq", len(queries))
             statsd.timing(f"{statsd_path}.total", timedelta_ms(time_delta))
 
-    if "extra" in log_data:
-        extra_request_data = " {}".format(log_data["extra"])
-    else:
-        extra_request_data = ""
+    extra_request_data = " {}".format(log_data["extra"]) if "extra" in log_data else ""
     if client_version is None:
         logger_client = f"({requestor_for_logs} via {client_name})"
     else:

--- a/zerver/migrations/0182_set_initial_value_is_private_flag.py
+++ b/zerver/migrations/0182_set_initial_value_is_private_flag.py
@@ -34,10 +34,7 @@ def set_initial_value_of_is_private_flag(
 
         i = range_end
         processed += len(message_ids)
-        if total != 0:
-            percent = round((processed / total) * 100, 2)
-        else:
-            percent = 100.00
+        percent = round(processed / total * 100, 2) if total != 0 else 100.0
         print(f"Processed {processed}/{total} {percent}%", flush=True)
 
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1943,12 +1943,9 @@ class UserProfile(AbstractBaseUser, PermissionsMixin, UserBaseSettings):  # type
 
     def can_admin_user(self, target_user: "UserProfile") -> bool:
         """Returns whether this user has permission to modify target_user"""
-        if target_user.bot_owner == self:
-            return True
-        elif self.is_realm_admin and self.realm == target_user.realm:
-            return True
-        else:
-            return False
+        return target_user.bot_owner == self or (
+            self.is_realm_admin and self.realm == target_user.realm
+        )
 
     def __str__(self) -> str:
         return f"<UserProfile: {self.email} {self.realm}>"

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -133,10 +133,7 @@ def render_python_code_example(
     method = zerver.openapi.python_examples.TEST_FUNCTIONS[function]
     function_source_lines = inspect.getsourcelines(method)[0]
 
-    if admin_config:
-        config_string = PYTHON_CLIENT_ADMIN_CONFIG
-    else:
-        config_string = PYTHON_CLIENT_CONFIG
+    config_string = PYTHON_CLIENT_ADMIN_CONFIG if admin_config else PYTHON_CLIENT_CONFIG
 
     endpoint, endpoint_method = function.split(":")
     extra_imports = check_additional_imports(endpoint, endpoint_method)
@@ -177,10 +174,7 @@ def render_javascript_code_example(
 
     snippets = extract_code_example(function_source_lines, [], JS_EXAMPLE_REGEX)
 
-    if admin_config:
-        config = JS_CLIENT_ADMIN_CONFIG.splitlines()
-    else:
-        config = JS_CLIENT_CONFIG.splitlines()
+    config = JS_CLIENT_ADMIN_CONFIG.splitlines() if admin_config else JS_CLIENT_CONFIG.splitlines()
 
     code_example = [
         "{tab|js}\n",

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -331,11 +331,10 @@ class DecoratorTestCase(ZulipTestCase):
         # Start a valid request here
         request = HostRequestMock()
         request.POST["api_key"] = webhook_bot_api_key
-        with self.assertLogs(level="WARNING") as m:
-            with self.assertRaisesRegex(
-                JsonableError, "Account is not associated with this subdomain"
-            ):
-                api_result = my_webhook(request)
+        with self.assertLogs(level="WARNING") as m, self.assertRaisesRegex(
+            JsonableError, "Account is not associated with this subdomain"
+        ):
+            api_result = my_webhook(request)
         self.assertEqual(
             m.output,
             [
@@ -347,12 +346,11 @@ class DecoratorTestCase(ZulipTestCase):
 
         request = HostRequestMock()
         request.POST["api_key"] = webhook_bot_api_key
-        with self.assertLogs(level="WARNING") as m:
-            with self.assertRaisesRegex(
-                JsonableError, "Account is not associated with this subdomain"
-            ):
-                request.host = "acme." + settings.EXTERNAL_HOST
-                api_result = my_webhook(request)
+        with self.assertLogs(level="WARNING") as m, self.assertRaisesRegex(
+            JsonableError, "Account is not associated with this subdomain"
+        ):
+            request.host = "acme." + settings.EXTERNAL_HOST
+            api_result = my_webhook(request)
         self.assertEqual(
             m.output,
             [
@@ -369,11 +367,12 @@ class DecoratorTestCase(ZulipTestCase):
         request = HostRequestMock()
         request.host = "zulip.testserver"
         request.POST["api_key"] = webhook_bot_api_key
-        with self.assertLogs("zulip.zerver.webhooks", level="INFO") as log:
-            with self.assertRaisesRegex(Exception, "raised by webhook function"):
-                request.body = b"{}"
-                request.content_type = "application/json"
-                my_webhook_raises_exception(request)
+        with self.assertLogs("zulip.zerver.webhooks", level="INFO") as log, self.assertRaisesRegex(
+            Exception, "raised by webhook function"
+        ):
+            request.body = b"{}"
+            request.content_type = "application/json"
+            my_webhook_raises_exception(request)
 
         # Test when content_type is not application/json; exception raised
         # in the webhook function should be re-raised
@@ -381,11 +380,12 @@ class DecoratorTestCase(ZulipTestCase):
         request = HostRequestMock()
         request.host = "zulip.testserver"
         request.POST["api_key"] = webhook_bot_api_key
-        with self.assertLogs("zulip.zerver.webhooks", level="INFO") as log:
-            with self.assertRaisesRegex(Exception, "raised by webhook function"):
-                request.body = b"notjson"
-                request.content_type = "text/plain"
-                my_webhook_raises_exception(request)
+        with self.assertLogs("zulip.zerver.webhooks", level="INFO") as log, self.assertRaisesRegex(
+            Exception, "raised by webhook function"
+        ):
+            request.body = b"notjson"
+            request.content_type = "text/plain"
+            my_webhook_raises_exception(request)
 
         # Test when content_type is application/json but request.body
         # is not valid JSON; invalid JSON should be logged and the
@@ -393,12 +393,13 @@ class DecoratorTestCase(ZulipTestCase):
         request = HostRequestMock()
         request.host = "zulip.testserver"
         request.POST["api_key"] = webhook_bot_api_key
-        with self.assertLogs("zulip.zerver.webhooks", level="ERROR") as log:
-            with self.assertRaisesRegex(Exception, "raised by webhook function"):
-                request.body = b"invalidjson"
-                request.content_type = "application/json"
-                request.META["HTTP_X_CUSTOM_HEADER"] = "custom_value"
-                my_webhook_raises_exception(request)
+        with self.assertLogs("zulip.zerver.webhooks", level="ERROR") as log, self.assertRaisesRegex(
+            Exception, "raised by webhook function"
+        ):
+            request.body = b"invalidjson"
+            request.content_type = "application/json"
+            request.META["HTTP_X_CUSTOM_HEADER"] = "custom_value"
+            my_webhook_raises_exception(request)
 
         self.assertIn(
             self.logger_output("raised by webhook function\n", "error", "webhooks"), log.output[0]
@@ -409,12 +410,13 @@ class DecoratorTestCase(ZulipTestCase):
         request.host = "zulip.testserver"
         request.POST["api_key"] = webhook_bot_api_key
         exception_msg = "The 'test_event' event isn't currently supported by the ClientName webhook"
-        with self.assertLogs("zulip.zerver.webhooks.unsupported", level="ERROR") as log:
-            with self.assertRaisesRegex(UnsupportedWebhookEventTypeError, exception_msg):
-                request.body = b"invalidjson"
-                request.content_type = "application/json"
-                request.META["HTTP_X_CUSTOM_HEADER"] = "custom_value"
-                my_webhook_raises_exception_unsupported_event(request)
+        with self.assertLogs(
+            "zulip.zerver.webhooks.unsupported", level="ERROR"
+        ) as log, self.assertRaisesRegex(UnsupportedWebhookEventTypeError, exception_msg):
+            request.body = b"invalidjson"
+            request.content_type = "application/json"
+            request.META["HTTP_X_CUSTOM_HEADER"] = "custom_value"
+            my_webhook_raises_exception_unsupported_event(request)
 
         self.assertIn(
             self.logger_output(exception_msg, "error", "webhooks.unsupported"), log.output[0]
@@ -423,9 +425,10 @@ class DecoratorTestCase(ZulipTestCase):
         request = HostRequestMock()
         request.host = "zulip.testserver"
         request.POST["api_key"] = webhook_bot_api_key
-        with self.settings(RATE_LIMITING=True):
-            with mock.patch("zerver.decorator.rate_limit_user") as rate_limit_mock:
-                api_result = orjson.loads(my_webhook(request).content).get("msg")
+        with self.settings(RATE_LIMITING=True), mock.patch(
+            "zerver.decorator.rate_limit_user"
+        ) as rate_limit_mock:
+            api_result = orjson.loads(my_webhook(request).content).get("msg")
 
         # Verify rate limiting was attempted.
         self.assertTrue(rate_limit_mock.called)
@@ -553,9 +556,10 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.body = b"{}"
         request.content_type = "text/plain"
 
-        with self.assertLogs("zulip.zerver.webhooks") as logger:
-            with self.assertRaisesRegex(Exception, "raised by webhook function"):
-                my_webhook_raises_exception(request)
+        with self.assertLogs("zulip.zerver.webhooks") as logger, self.assertRaisesRegex(
+            Exception, "raised by webhook function"
+        ):
+            my_webhook_raises_exception(request)
 
         self.assertIn("raised by webhook function", logger.output[0])
 
@@ -602,9 +606,10 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.body = b"{}"
         request.content_type = "application/json"
 
-        with mock.patch("zerver.decorator.webhook_logger.exception") as mock_exception:
-            with self.assertRaisesRegex(Exception, "raised by a non-webhook view"):
-                non_webhook_view_raises_exception(request)
+        with mock.patch(
+            "zerver.decorator.webhook_logger.exception"
+        ) as mock_exception, self.assertRaisesRegex(Exception, "raised by a non-webhook view"):
+            non_webhook_view_raises_exception(request)
 
         self.assertFalse(mock_exception.called)
 
@@ -1486,15 +1491,14 @@ class TestValidateApiKey(ZulipTestCase):
     def test_valid_api_key_if_user_is_on_wrong_subdomain(self) -> None:
         with self.settings(RUNNING_INSIDE_TORNADO=False):
             api_key = get_api_key(self.default_bot)
-            with self.assertLogs(level="WARNING") as m:
-                with self.assertRaisesRegex(
-                    JsonableError, "Account is not associated with this subdomain"
-                ):
-                    validate_api_key(
-                        HostRequestMock(host=settings.EXTERNAL_HOST),
-                        self.default_bot.email,
-                        api_key,
-                    )
+            with self.assertLogs(level="WARNING") as m, self.assertRaisesRegex(
+                JsonableError, "Account is not associated with this subdomain"
+            ):
+                validate_api_key(
+                    HostRequestMock(host=settings.EXTERNAL_HOST),
+                    self.default_bot.email,
+                    api_key,
+                )
             self.assertEqual(
                 m.output,
                 [
@@ -1504,15 +1508,14 @@ class TestValidateApiKey(ZulipTestCase):
                 ],
             )
 
-            with self.assertLogs(level="WARNING") as m:
-                with self.assertRaisesRegex(
-                    JsonableError, "Account is not associated with this subdomain"
-                ):
-                    validate_api_key(
-                        HostRequestMock(host="acme." + settings.EXTERNAL_HOST),
-                        self.default_bot.email,
-                        api_key,
-                    )
+            with self.assertLogs(level="WARNING") as m, self.assertRaisesRegex(
+                JsonableError, "Account is not associated with this subdomain"
+            ):
+                validate_api_key(
+                    HostRequestMock(host="acme." + settings.EXTERNAL_HOST),
+                    self.default_bot.email,
+                    api_key,
+                )
             self.assertEqual(
                 m.output,
                 [

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -209,9 +209,8 @@ class TestDigestEmailMessages(ZulipTestCase):
         with mock.patch("zerver.lib.digest.send_future_email") as mock_send_future_email:
             digest_user_ids = [user.id for user in digest_users]
 
-            with self.assert_database_query_count(12):
-                with cache_tries_captured() as cache_tries:
-                    bulk_handle_digest_email(digest_user_ids, cutoff)
+            with self.assert_database_query_count(12), cache_tries_captured() as cache_tries:
+                bulk_handle_digest_email(digest_user_ids, cutoff)
 
             self.assert_length(cache_tries, 0)
 
@@ -403,9 +402,10 @@ class TestDigestEmailMessages(ZulipTestCase):
         tuesday = self.tuesday()
         cutoff = tuesday - datetime.timedelta(days=5)
 
-        with mock.patch("zerver.lib.digest.timezone_now", return_value=tuesday):
-            with mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock:
-                enqueue_emails(cutoff)
+        with mock.patch("zerver.lib.digest.timezone_now", return_value=tuesday), mock.patch(
+            "zerver.lib.digest.queue_digest_user_ids"
+        ) as queue_mock:
+            enqueue_emails(cutoff)
         queue_mock.assert_not_called()
 
     @override_settings(SEND_DIGEST_EMAILS=True)
@@ -415,9 +415,10 @@ class TestDigestEmailMessages(ZulipTestCase):
         not_tuesday = datetime.datetime(year=2016, month=1, day=6, tzinfo=datetime.timezone.utc)
         cutoff = not_tuesday - datetime.timedelta(days=5)
 
-        with mock.patch("zerver.lib.digest.timezone_now", return_value=not_tuesday):
-            with mock.patch("zerver.lib.digest.queue_digest_user_ids") as queue_mock:
-                enqueue_emails(cutoff)
+        with mock.patch("zerver.lib.digest.timezone_now", return_value=not_tuesday), mock.patch(
+            "zerver.lib.digest.queue_digest_user_ids"
+        ) as queue_mock:
+            enqueue_emails(cutoff)
         queue_mock.assert_not_called()
 
     @override_settings(SEND_DIGEST_EMAILS=True)

--- a/zerver/tests/test_embedded_bot_system.py
+++ b/zerver/tests/test_embedded_bot_system.py
@@ -76,15 +76,14 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
         with patch(
             "zulip_bots.bots.helloworld.helloworld.HelloWorldHandler.handle_message",
             side_effect=EmbeddedBotQuitError("I'm quitting!"),
-        ):
-            with self.assertLogs(level="WARNING") as m:
-                self.send_stream_message(
-                    self.user_profile,
-                    "Denmark",
-                    content=f"@**{self.bot_profile.full_name}** foo",
-                    topic_name="bar",
-                )
-                self.assertEqual(m.output, ["WARNING:root:I'm quitting!"])
+        ), self.assertLogs(level="WARNING") as m:
+            self.send_stream_message(
+                self.user_profile,
+                "Denmark",
+                content=f"@**{self.bot_profile.full_name}** foo",
+                topic_name="bar",
+            )
+            self.assertEqual(m.output, ["WARNING:root:I'm quitting!"])
 
 
 class TestEmbeddedBotFailures(ZulipTestCase):

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -77,12 +77,13 @@ class EventsEndpointTest(ZulipTestCase):
         test_event = dict(id=6, type=event_type, realm_emoji=[])
 
         # Test that call is made to deal with a returning soft deactivated user.
-        with mock.patch("zerver.lib.events.reactivate_user_if_soft_deactivated") as fa:
-            with stub_event_queue_user_events(return_event_queue, return_user_events):
-                result = self.api_post(
-                    user, "/api/v1/register", dict(event_types=orjson.dumps([event_type]).decode())
-                )
-                self.assertEqual(fa.call_count, 1)
+        with mock.patch(
+            "zerver.lib.events.reactivate_user_if_soft_deactivated"
+        ) as fa, stub_event_queue_user_events(return_event_queue, return_user_events):
+            result = self.api_post(
+                user, "/api/v1/register", dict(event_types=orjson.dumps([event_type]).decode())
+            )
+            self.assertEqual(fa.call_count, 1)
 
         with stub_event_queue_user_events(return_event_queue, return_user_events):
             result = self.api_post(
@@ -1204,9 +1205,10 @@ class FetchQueriesTest(ZulipTestCase):
         self.login_user(user)
 
         flush_per_request_caches()
-        with self.assert_database_query_count(37):
-            with mock.patch("zerver.lib.events.always_want") as want_mock:
-                fetch_initial_state_data(user)
+        with self.assert_database_query_count(37), mock.patch(
+            "zerver.lib.events.always_want"
+        ) as want_mock:
+            fetch_initial_state_data(user)
 
         expected_counts = dict(
             alert_words=1,

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -172,10 +172,7 @@ class RateLimitTests(ZulipTestCase):
             self.assertNotEqual(result.headers["Content-Type"], "application/json")
             self.assert_in_response("Rate limit exceeded.", result)
 
-        if is_json:
-            assert_func = api_assert_func
-        else:
-            assert_func = user_facing_assert_func
+        assert_func = api_assert_func if is_json else user_facing_assert_func
 
         start_time = time.time()
         for i in range(6):

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -300,12 +300,13 @@ class RateLimitTests(ZulipTestCase):
         # We need to reset the circuitbreaker before starting.  We
         # patch the .opened property to be false, then call the
         # function, so it resets to closed.
-        with mock.patch("builtins.open", mock.mock_open(read_data=orjson.dumps(["1.2.3.4"]))):
-            with mock.patch(
-                "circuitbreaker.CircuitBreaker.opened", new_callable=mock.PropertyMock
-            ) as mock_opened:
-                mock_opened.return_value = False
-                get_tor_ips()
+        with mock.patch(
+            "builtins.open", mock.mock_open(read_data=orjson.dumps(["1.2.3.4"]))
+        ), mock.patch(
+            "circuitbreaker.CircuitBreaker.opened", new_callable=mock.PropertyMock
+        ) as mock_opened:
+            mock_opened.return_value = False
+            get_tor_ips()
 
         # Having closed it, it's now cached.  Clear the cache.
         assert CircuitBreakerMonitor.get("get_tor_ips").closed
@@ -356,13 +357,14 @@ class RateLimitTests(ZulipTestCase):
         # An empty list of IPs is treated as some error in parsing the
         # input, and as such should not be cached; rate-limiting
         # should work as normal, per-IP
-        with self.tor_mock(read_data=[]) as tor_open:
-            with self.assertLogs("zerver.lib.rate_limiter", level="WARNING"):
-                self.do_test_hit_ratelimits(
-                    lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
-                )
-                resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
-                self.assertNotEqual(resp.status_code, 429)
+        with self.tor_mock(read_data=[]) as tor_open, self.assertLogs(
+            "zerver.lib.rate_limiter", level="WARNING"
+        ):
+            self.do_test_hit_ratelimits(
+                lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
+            )
+            resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
+            self.assertNotEqual(resp.status_code, 429)
 
         # Was not cached, so tried to read twice before hitting the
         # circuit-breaker, and stopping trying
@@ -374,15 +376,16 @@ class RateLimitTests(ZulipTestCase):
         for ip in ["1.2.3.4", "5.6.7.8", "tor-exit-node"]:
             RateLimitedIPAddr(ip, domain="api_by_ip").clear_history()
 
-        with self.tor_mock(side_effect=FileNotFoundError("File not found")) as tor_open:
-            # If we cannot get a list of TOR exit nodes, then
-            # rate-limiting works as normal, per-IP
-            with self.assertLogs("zerver.lib.rate_limiter", level="WARNING") as log_mock:
-                self.do_test_hit_ratelimits(
-                    lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
-                )
-                resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
-                self.assertNotEqual(resp.status_code, 429)
+        # If we cannot get a list of TOR exit nodes, then
+        # rate-limiting works as normal, per-IP
+        with self.tor_mock(
+            side_effect=FileNotFoundError("File not found")
+        ) as tor_open, self.assertLogs("zerver.lib.rate_limiter", level="WARNING") as log_mock:
+            self.do_test_hit_ratelimits(
+                lambda: self.send_unauthed_api_request(REMOTE_ADDR="1.2.3.4")
+            )
+            resp = self.send_unauthed_api_request(REMOTE_ADDR="5.6.7.8")
+            self.assertNotEqual(resp.status_code, 429)
 
         # Tries twice before hitting the circuit-breaker, and stopping trying
         tor_open.assert_has_calls(

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -245,10 +245,11 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         flush_per_request_caches()
-        with self.assert_database_query_count(47):
-            with patch("zerver.lib.cache.cache_set") as cache_mock:
-                result = self._get_home_page(stream="Denmark")
-                self.check_rendered_logged_in_app(result)
+        with self.assert_database_query_count(47), patch(
+            "zerver.lib.cache.cache_set"
+        ) as cache_mock:
+            result = self._get_home_page(stream="Denmark")
+            self.check_rendered_logged_in_app(result)
         self.assertEqual(
             set(result["Cache-Control"].split(", ")), {"must-revalidate", "no-store", "no-cache"}
         )
@@ -301,10 +302,9 @@ class HomeTest(ZulipTestCase):
 
         # Verify succeeds once logged-in
         flush_per_request_caches()
-        with queries_captured():
-            with patch("zerver.lib.cache.cache_set"):
-                result = self._get_home_page(stream="Denmark")
-                self.check_rendered_logged_in_app(result)
+        with queries_captured(), patch("zerver.lib.cache.cache_set"):
+            result = self._get_home_page(stream="Denmark")
+            self.check_rendered_logged_in_app(result)
 
         page_params = self._get_page_params(result)
         actual_keys = sorted(str(k) for k in page_params)
@@ -391,11 +391,12 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         flush_per_request_caches()
-        with self.assert_database_query_count(44):
-            with patch("zerver.lib.cache.cache_set") as cache_mock:
-                result = self._get_home_page()
-                self.check_rendered_logged_in_app(result)
-                self.assert_length(cache_mock.call_args_list, 6)
+        with self.assert_database_query_count(44), patch(
+            "zerver.lib.cache.cache_set"
+        ) as cache_mock:
+            result = self._get_home_page()
+            self.check_rendered_logged_in_app(result)
+            self.assert_length(cache_mock.call_args_list, 6)
 
     def test_num_queries_with_streams(self) -> None:
         main_user = self.example_user("hamlet")

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -33,11 +33,10 @@ from zerver.models import (
 class TestCheckConfig(ZulipTestCase):
     def test_check_config(self) -> None:
         check_config()
-        with self.settings(REQUIRED_SETTINGS=[("asdf", "not asdf")]):
-            with self.assertRaisesRegex(
-                CommandError, "Error: You must set asdf in /etc/zulip/settings.py."
-            ):
-                check_config()
+        with self.settings(REQUIRED_SETTINGS=[("asdf", "not asdf")]), self.assertRaisesRegex(
+            CommandError, "Error: You must set asdf in /etc/zulip/settings.py."
+        ):
+            check_config()
 
     @override_settings(WARN_NO_EMAIL=True)
     def test_check_send_email(self) -> None:
@@ -212,9 +211,8 @@ class TestCommandsCanStart(ZulipTestCase):
     def test_management_commands_show_help(self) -> None:
         with stdout_suppressed():
             for command in self.commands:
-                with self.subTest(management_command=command):
-                    with self.assertRaises(SystemExit):
-                        call_command(command, "--help")
+                with self.subTest(management_command=command), self.assertRaises(SystemExit):
+                    call_command(command, "--help")
         # zerver/management/commands/runtornado.py sets this to True;
         # we need to reset it here.  See #3685 for details.
         settings.RUNNING_INSIDE_TORNADO = False

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -3102,18 +3102,16 @@ class MarkdownApiTests(ZulipTestCase):
 
 class MarkdownErrorTests(ZulipTestCase):
     def test_markdown_error_handling(self) -> None:
-        with self.simulated_markdown_failure():
-            with self.assertRaises(MarkdownRenderingError):
-                markdown_convert_wrapper("")
+        with self.simulated_markdown_failure(), self.assertRaises(MarkdownRenderingError):
+            markdown_convert_wrapper("")
 
     def test_send_message_errors(self) -> None:
 
         message = "whatever"
-        with self.simulated_markdown_failure():
-            # We don't use assertRaisesRegex because it seems to not
-            # handle i18n properly here on some systems.
-            with self.assertRaises(JsonableError):
-                self.send_stream_message(self.example_user("othello"), "Denmark", message)
+        # We don't use assertRaisesRegex because it seems to not
+        # handle i18n properly here on some systems.
+        with self.simulated_markdown_failure(), self.assertRaises(JsonableError):
+            self.send_stream_message(self.example_user("othello"), "Denmark", message)
 
     @override_settings(MAX_MESSAGE_LENGTH=10)
     def test_ultra_long_rendering(self) -> None:
@@ -3123,9 +3121,8 @@ class MarkdownErrorTests(ZulipTestCase):
 
         with mock.patch("zerver.lib.markdown.timeout", return_value=msg), mock.patch(
             "zerver.lib.markdown.markdown_logger"
-        ):
-            with self.assertRaises(MarkdownRenderingError):
-                markdown_convert_wrapper(msg)
+        ), self.assertRaises(MarkdownRenderingError):
+            markdown_convert_wrapper(msg)
 
     def test_curl_code_block_validation(self) -> None:
         processor = SimulatedFencedBlockPreprocessor(Markdown())

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -3365,9 +3365,10 @@ class DeleteMessageTest(ZulipTestCase):
         self.send_stream_message(hamlet, "Denmark")
         message = self.get_last_message()
 
-        with self.tornado_redirected_to_list([], expected_num_events=1):
-            with mock.patch("zerver.actions.message_edit.send_event") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits."
-                )
-                do_delete_messages(hamlet.realm, [message])
+        with self.tornado_redirected_to_list([], expected_num_events=1), mock.patch(
+            "zerver.actions.message_edit.send_event"
+        ) as m:
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits."
+            )
+            do_delete_messages(hamlet.realm, [message])

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -3313,9 +3313,8 @@ class GetOldMessagesTest(ZulipTestCase):
         request = HostRequestMock(query_params, user_profile)
 
         first_visible_message_id = first_unread_message_id + 2
-        with first_visible_id_as(first_visible_message_id):
-            with queries_captured() as all_queries:
-                get_messages_backend(request, user_profile)
+        with first_visible_id_as(first_visible_message_id), queries_captured() as all_queries:
+            get_messages_backend(request, user_profile)
 
         queries = [q for q in all_queries if "/* get_messages */" in str(q["sql"])]
         self.assert_length(queries, 1)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1877,9 +1877,10 @@ class StreamMessagesTest(ZulipTestCase):
         self.subscribe(cordelia, "test_stream")
         do_set_realm_property(cordelia.realm, "wildcard_mention_policy", 10, acting_user=None)
         content = "@**all** test wildcard mention"
-        with mock.patch("zerver.lib.message.num_subscribers_for_stream_id", return_value=16):
-            with self.assertRaisesRegex(AssertionError, "Invalid wildcard mention policy"):
-                self.send_stream_message(cordelia, "test_stream", content)
+        with mock.patch(
+            "zerver.lib.message.num_subscribers_for_stream_id", return_value=16
+        ), self.assertRaisesRegex(AssertionError, "Invalid wildcard mention policy"):
+            self.send_stream_message(cordelia, "test_stream", content)
 
     def test_stream_message_mirroring(self) -> None:
         user = self.mit_user("starnine")

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -627,11 +627,10 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
         )
         with mock.patch(
             "zerver.lib.outgoing_webhook.fail_with_message", side_effect=wrapped
-        ) as fail:
-            with self.assertLogs(level="INFO") as logs:
-                self.send_stream_message(
-                    bot_owner, "Denmark", content=f"@**{bot.full_name}** foo", topic_name="bar"
-                )
+        ) as fail, self.assertLogs(level="INFO") as logs:
+            self.send_stream_message(
+                bot_owner, "Denmark", content=f"@**{bot.full_name}** foo", topic_name="bar"
+            )
 
         self.assert_length(logs.output, 5)
         fail.assert_called_once()

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -1063,12 +1063,13 @@ class ReactionAPIEventTest(EmojiReactionBase):
             "reaction_type": "unicode_emoji",
         }
         events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
-            with mock.patch("zerver.actions.reactions.send_event") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits!"
-                )
-                self.api_post(reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info)
+        with self.tornado_redirected_to_list(events, expected_num_events=1), mock.patch(
+            "zerver.actions.reactions.send_event"
+        ) as m:
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits!"
+            )
+            self.api_post(reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info)
 
         event = events[0]["event"]
         event_user_ids = set(events[0]["users"])
@@ -1147,9 +1148,10 @@ class ReactionAPIEventTest(EmojiReactionBase):
             reaction_type="whatever",
         )
 
-        with self.tornado_redirected_to_list([], expected_num_events=1):
-            with mock.patch("zerver.actions.reactions.send_event") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits."
-                )
-                notify_reaction_update(hamlet, message, reaction, "stuff")
+        with self.tornado_redirected_to_list([], expected_num_events=1), mock.patch(
+            "zerver.actions.reactions.send_event"
+        ) as m:
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits."
+            )
+            notify_reaction_update(hamlet, message, reaction, "stuff")

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -65,9 +65,8 @@ class RealmTest(ZulipTestCase):
             )
 
     def test_realm_creation_on_social_auth_subdomain_disallowed(self) -> None:
-        with self.settings(SOCIAL_AUTH_SUBDOMAIN="zulipauth"):
-            with self.assertRaises(AssertionError):
-                do_create_realm("zulipauth", "Test Realm")
+        with self.settings(SOCIAL_AUTH_SUBDOMAIN="zulipauth"), self.assertRaises(AssertionError):
+            do_create_realm("zulipauth", "Test Realm")
 
     def test_permission_for_education_non_profit_organization(self) -> None:
         realm = do_create_realm(

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -304,9 +304,8 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_emoji_upload_file_size_error(self) -> None:
         self.login("iago")
-        with get_test_image_file("img.png") as fp:
-            with self.settings(MAX_EMOJI_FILE_SIZE_MIB=0):
-                result = self.client_post("/json/realm/emoji/my_emoji", {"file": fp})
+        with get_test_image_file("img.png") as fp, self.settings(MAX_EMOJI_FILE_SIZE_MIB=0):
+            result = self.client_post("/json/realm/emoji/my_emoji", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 
     def test_upload_already_existed_emoji(self) -> None:
@@ -340,10 +339,9 @@ class RealmEmojiTest(ZulipTestCase):
         self.login("iago")
         with mock.patch(
             "zerver.lib.upload.local.write_local_file", side_effect=BadImageError(msg="Broken")
-        ):
-            with get_test_image_file("img.png") as fp1:
-                emoji_data = {"f1": fp1}
-                result = self.client_post("/json/realm/emoji/my_emoji", info=emoji_data)
+        ), get_test_image_file("img.png") as fp1:
+            emoji_data = {"f1": fp1}
+            result = self.client_post("/json/realm/emoji/my_emoji", info=emoji_data)
         self.assert_json_error(result, "Broken")
 
     def test_check_admin_realm_emoji(self) -> None:

--- a/zerver/tests/test_send_email.py
+++ b/zerver/tests/test_send_email.py
@@ -132,15 +132,16 @@ class TestSendEmail(ZulipTestCase):
 
         for message, side_effect in errors.items():
             with mock.patch.object(EmailBackend, "send_messages", side_effect=side_effect):
-                with self.assertLogs(logger=logger) as info_log:
-                    with self.assertRaises(EmailNotDeliveredError):
-                        send_email(
-                            "zerver/emails/password_reset",
-                            to_emails=[hamlet.email],
-                            from_name=from_name,
-                            from_address=FromAddress.NOREPLY,
-                            language="en",
-                        )
+                with self.assertLogs(logger=logger) as info_log, self.assertRaises(
+                    EmailNotDeliveredError
+                ):
+                    send_email(
+                        "zerver/emails/password_reset",
+                        to_emails=[hamlet.email],
+                        from_name=from_name,
+                        from_address=FromAddress.NOREPLY,
+                        language="en",
+                    )
                 self.assert_length(info_log.records, 2)
                 self.assertEqual(
                     info_log.output[0],
@@ -151,15 +152,16 @@ class TestSendEmail(ZulipTestCase):
     def test_send_email_config_error_logging(self) -> None:
         hamlet = self.example_user("hamlet")
 
-        with self.settings(EMAIL_HOST_USER="test", EMAIL_HOST_PASSWORD=None):
-            with self.assertLogs(logger=logger, level="ERROR") as error_log:
-                send_email(
-                    "zerver/emails/password_reset",
-                    to_emails=[hamlet.email],
-                    from_name="From Name",
-                    from_address=FromAddress.NOREPLY,
-                    language="en",
-                )
+        with self.settings(EMAIL_HOST_USER="test", EMAIL_HOST_PASSWORD=None), self.assertLogs(
+            logger=logger, level="ERROR"
+        ) as error_log:
+            send_email(
+                "zerver/emails/password_reset",
+                to_emails=[hamlet.email],
+                from_name="From Name",
+                from_address=FromAddress.NOREPLY,
+                language="en",
+            )
 
         self.assertEqual(
             error_log.output,

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -286,9 +286,10 @@ class UserSoftDeactivationTests(ZulipTestCase):
         ).count()
         self.assertEqual(0, received_count)
 
-        with self.settings(AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS=False):
-            with self.assertLogs(logger_string, level="INFO") as m:
-                users_deactivated = do_auto_soft_deactivate_users(-1, realm)
+        with self.settings(AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS=False), self.assertLogs(
+            logger_string, level="INFO"
+        ) as m:
+            users_deactivated = do_auto_soft_deactivate_users(-1, realm)
         self.assertEqual(
             m.output,
             [

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -195,9 +195,10 @@ class TestBasics(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         message_id = self.send_stream_message(hamlet, "Denmark")
 
-        with self.tornado_redirected_to_list([], expected_num_events=1):
-            with mock.patch("zerver.actions.submessage.send_event") as m:
-                m.side_effect = AssertionError(
-                    "Events should be sent only after the transaction commits."
-                )
-                do_add_submessage(hamlet.realm, hamlet.id, message_id, "whatever", "whatever")
+        with self.tornado_redirected_to_list([], expected_num_events=1), mock.patch(
+            "zerver.actions.submessage.send_event"
+        ) as m:
+            m.side_effect = AssertionError(
+                "Events should be sent only after the transaction commits."
+            )
+            do_add_submessage(hamlet.realm, hamlet.id, message_id, "whatever", "whatever")

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2187,10 +2187,7 @@ class StreamAdminTest(ZulipTestCase):
     ) -> "TestHttpResponse":
 
         # Set up the main user, who is in most cases an admin.
-        if is_realm_admin:
-            user_profile = self.example_user("iago")
-        else:
-            user_profile = self.example_user("hamlet")
+        user_profile = self.example_user("iago") if is_realm_admin else self.example_user("hamlet")
 
         self.login_user(user_profile)
 

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -147,9 +147,10 @@ class TypingHappyPathTestPMs(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with self.assert_database_query_count(4):
-            with self.tornado_redirected_to_list(events, expected_num_events=1):
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with self.assert_database_query_count(4), self.tornado_redirected_to_list(
+            events, expected_num_events=1
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
 
         self.assert_json_success(result)
         self.assert_length(events, 1)
@@ -183,9 +184,10 @@ class TypingHappyPathTestPMs(ZulipTestCase):
             op="start",
         )
 
-        with self.assert_database_query_count(5):
-            with self.tornado_redirected_to_list(events, expected_num_events=1):
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with self.assert_database_query_count(5), self.tornado_redirected_to_list(
+            events, expected_num_events=1
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
 
@@ -363,9 +365,10 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with self.assert_database_query_count(5):
-            with self.tornado_redirected_to_list(events, expected_num_events=1):
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with self.assert_database_query_count(5), self.tornado_redirected_to_list(
+            events, expected_num_events=1
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
 
@@ -398,9 +401,10 @@ class TypingHappyPathTestStreams(ZulipTestCase):
         )
 
         events: List[Mapping[str, Any]] = []
-        with self.assert_database_query_count(5):
-            with self.tornado_redirected_to_list(events, expected_num_events=1):
-                result = self.api_post(sender, "/api/v1/typing", params)
+        with self.assert_database_query_count(5), self.tornado_redirected_to_list(
+            events, expected_num_events=1
+        ):
+            result = self.api_post(sender, "/api/v1/typing", params)
         self.assert_json_success(result)
         self.assert_length(events, 1)
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1694,10 +1694,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
 
         is_night_str = str(self.night).lower()
 
-        if self.night:
-            file_name = "night_logo.png"
-        else:
-            file_name = "logo.png"
+        file_name = "night_logo.png" if self.night else "logo.png"
         self.assertEqual(
             redirect_url,
             f"/user_avatars/{realm.id}/realm/{file_name}?version=2&night={is_night_str}",
@@ -1775,10 +1772,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
     def test_logo_version(self) -> None:
         self.login("iago")
         realm = get_realm("zulip")
-        if self.night:
-            version = realm.night_logo_version
-        else:
-            version = realm.logo_version
+        version = realm.night_logo_version if self.night else realm.logo_version
         self.assertEqual(version, 1)
         with get_test_image_file(self.correct_files[0][0]) as fp:
             self.client_post(

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1403,9 +1403,10 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_avatar_upload_file_size_error(self) -> None:
         self.login("hamlet")
-        with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_AVATAR_FILE_SIZE_MIB=0):
-                result = self.client_post("/json/users/me/avatar", {"file": fp})
+        with get_test_image_file(self.correct_files[0][0]) as fp, self.settings(
+            MAX_AVATAR_FILE_SIZE_MIB=0
+        ):
+            result = self.client_post("/json/users/me/avatar", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 
     def tearDown(self) -> None:
@@ -1605,9 +1606,10 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_realm_icon_upload_file_size_error(self) -> None:
         self.login("iago")
-        with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_ICON_FILE_SIZE_MIB=0):
-                result = self.client_post("/json/realm/icon", {"file": fp})
+        with get_test_image_file(self.correct_files[0][0]) as fp, self.settings(
+            MAX_ICON_FILE_SIZE_MIB=0
+        ):
+            result = self.client_post("/json/realm/icon", {"file": fp})
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 
     def tearDown(self) -> None:
@@ -1786,11 +1788,12 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_logo_upload_file_size_error(self) -> None:
         self.login("iago")
-        with get_test_image_file(self.correct_files[0][0]) as fp:
-            with self.settings(MAX_LOGO_FILE_SIZE_MIB=0):
-                result = self.client_post(
-                    "/json/realm/logo", {"file": fp, "night": orjson.dumps(self.night).decode()}
-                )
+        with get_test_image_file(self.correct_files[0][0]) as fp, self.settings(
+            MAX_LOGO_FILE_SIZE_MIB=0
+        ):
+            result = self.client_post(
+                "/json/realm/logo", {"file": fp, "night": orjson.dumps(self.night).decode()}
+            )
         self.assert_json_error(result, "Uploaded file is larger than the allowed limit of 0 MiB")
 
     def tearDown(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -804,17 +804,19 @@ class QueryCountTest(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
 
-        with self.assert_database_query_count(91):
-            with cache_tries_captured() as cache_tries:
-                with self.tornado_redirected_to_list(events, expected_num_events=11):
-                    fred = do_create_user(
-                        email="fred@zulip.com",
-                        password="password",
-                        realm=realm,
-                        full_name="Fred Flintstone",
-                        prereg_user=prereg_user,
-                        acting_user=None,
-                    )
+        with self.assert_database_query_count(
+            91
+        ), cache_tries_captured() as cache_tries, self.tornado_redirected_to_list(
+            events, expected_num_events=11
+        ):
+            fred = do_create_user(
+                email="fred@zulip.com",
+                password="password",
+                realm=realm,
+                full_name="Fred Flintstone",
+                prereg_user=prereg_user,
+                acting_user=None,
+            )
 
         self.assert_length(cache_tries, 28)
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]
@@ -2027,9 +2029,8 @@ class GetProfileTest(ZulipTestCase):
         """
         realm = get_realm("zulip")
         email = self.example_user("hamlet").email
-        with self.assert_database_query_count(1):
-            with simulated_empty_cache() as cache_queries:
-                user_profile = get_user(email, realm)
+        with self.assert_database_query_count(1), simulated_empty_cache() as cache_queries:
+            user_profile = get_user(email, realm)
 
         self.assert_length(cache_queries, 1)
         self.assertEqual(user_profile.email, email)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1148,10 +1148,7 @@ def process_message_update_event(
     # on the `user_id` key not being present in legacy events that
     # would have had rendering_only set. Remove this check when one
     # can no longer directly update from 4.x to main.
-    if "rendering_only" in event_template:
-        rendering_only_update = event_template["rendering_only"]
-    else:
-        rendering_only_update = "user_id" not in event_template
+    rendering_only_update = event_template.get("rendering_only", "user_id" not in event_template)
 
     for user_data in users:
         user_profile_id = user_data["id"]

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -451,10 +451,7 @@ def remote_user_sso(
     # login_or_register_remote_user if appropriate.
     validate_otp_params(mobile_flow_otp, desktop_flow_otp)
 
-    if realm is None:
-        user_profile = None
-    else:
-        user_profile = authenticate(remote_user=remote_user, realm=realm)
+    user_profile = None if realm is None else authenticate(remote_user=remote_user, realm=realm)
     if user_profile is not None:
         assert isinstance(user_profile, UserProfile)
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -204,10 +204,7 @@ def json_fetch_raw_message(
     if not maybe_user_profile.is_authenticated:
         allow_edit_history = realm.allow_edit_history
     else:
-        if user_message:
-            flags = user_message.flags_list()
-        else:
-            flags = ["read", "historical"]
+        flags = user_message.flags_list() if user_message else ["read", "historical"]
         allow_edit_history = maybe_user_profile.realm.allow_edit_history
 
     # Security note: It's important that we call this only with a

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -272,15 +272,9 @@ def update_stream_backend(
     (stream, sub) = access_stream_for_delete_or_update(user_profile, stream_id)
 
     # Validate that the proposed state for permissions settings is permitted.
-    if is_private is not None:
-        proposed_is_private = is_private
-    else:
-        proposed_is_private = stream.invite_only
+    proposed_is_private = is_private if is_private is not None else stream.invite_only
 
-    if is_web_public is not None:
-        proposed_is_web_public = is_web_public
-    else:
-        proposed_is_web_public = stream.is_web_public
+    proposed_is_web_public = is_web_public if is_web_public is not None else stream.is_web_public
 
     if stream.realm.is_zephyr_mirror_realm:
         # In the Zephyr mirroring model, history is unconditionally

--- a/zerver/webhooks/ansibletower/view.py
+++ b/zerver/webhooks/ansibletower/view.py
@@ -52,10 +52,7 @@ def get_body(payload: WildValue) -> str:
     if friendly_name == "Job":
         hosts_data = []
         for host, host_data in payload["hosts"].items():
-            if host_data["failed"].tame(check_bool):
-                hoststatus = "Failed"
-            else:
-                hoststatus = "Success"
+            hoststatus = "Failed" if host_data["failed"].tame(check_bool) else "Success"
             hosts_data.append(
                 {
                     "hostname": host,
@@ -63,10 +60,7 @@ def get_body(payload: WildValue) -> str:
                 }
             )
 
-        if payload["status"] == "successful":
-            status = "was successful"
-        else:
-            status = "failed"
+        status = "was successful" if payload["status"] == "successful" else "failed"
 
         return ANSIBLETOWER_JOB_MESSAGE_TEMPLATE.format(
             name=payload["name"].tame(check_string),

--- a/zerver/webhooks/beeminder/view.py
+++ b/zerver/webhooks/beeminder/view.py
@@ -43,10 +43,7 @@ def api_beeminder_webhook(
     pledge = payload["goal"]["pledge"].tame(check_union([check_int, check_float]))
     time_remain = get_time(payload)  # time in hours
     # To show user's probable reaction by looking at pledge amount
-    if pledge > 0:
-        expression = ":worried:"
-    else:
-        expression = ":relieved:"
+    expression = ":worried:" if pledge > 0 else ":relieved:"
 
     topic = "beekeeper"
     body = MESSAGE_TEMPLATE.format(

--- a/zerver/webhooks/bitbucket3/view.py
+++ b/zerver/webhooks/bitbucket3/view.py
@@ -75,10 +75,7 @@ def ping_handler(
     branches: Optional[str],
     include_title: Optional[str],
 ) -> List[Dict[str, str]]:
-    if include_title:
-        subject = include_title
-    else:
-        subject = "Bitbucket Server Ping"
+    subject = include_title if include_title else "Bitbucket Server Ping"
     body = "Congratulations! The Bitbucket Server webhook was configured successfully!"
     return [{"subject": subject, "body": body}]
 

--- a/zerver/webhooks/clubhouse/view.py
+++ b/zerver/webhooks/clubhouse/view.py
@@ -267,10 +267,7 @@ def get_update_name_body(payload: WildValue, action: WildValue, entity: str) -> 
 
 def get_update_archived_body(payload: WildValue, action: WildValue, entity: str) -> str:
     archived = action["changes"]["archived"]
-    if archived["new"]:
-        operation = "archived"
-    else:
-        operation = "unarchived"
+    operation = "archived" if archived["new"] else "unarchived"
 
     kwargs = {
         "entity": entity,

--- a/zerver/webhooks/flock/view.py
+++ b/zerver/webhooks/flock/view.py
@@ -17,10 +17,7 @@ def api_flock_webhook(
     payload: WildValue = REQ(argument_type="body", converter=to_wild_value),
 ) -> HttpResponse:
     text = payload["text"].tame(check_string)
-    if len(text) != 0:
-        message_body = text
-    else:
-        message_body = payload["notification"].tame(check_string)
+    message_body = text if len(text) != 0 else payload["notification"].tame(check_string)
 
     topic = "Flock notifications"
     body = f"{message_body}"

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -173,10 +173,7 @@ def get_issue_comment_body(helper: Helper) -> str:
     comment = payload["comment"]
     issue = payload["issue"]
 
-    if action == "created":
-        action = "[commented]"
-    else:
-        action = f"{action} a [comment]"
+    action = "[commented]" if action == "created" else f"{action} a [comment]"
     action += "({}) on".format(comment["html_url"].tame(check_string))
 
     return get_issue_event_message(

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -116,10 +116,7 @@ def format_issue_comment_event(payload: WildValue, include_title: bool = False) 
     comment = payload["comment"]
     issue = payload["issue"]
 
-    if action == "created":
-        action = "[commented]"
-    else:
-        action = f"{action} a [comment]"
+    action = "[commented]" if action == "created" else f"{action} a [comment]"
     action += "({}) on".format(comment["html_url"].tame(check_string))
 
     return get_issue_event_message(

--- a/zerver/webhooks/hellosign/view.py
+++ b/zerver/webhooks/hellosign/view.py
@@ -35,10 +35,7 @@ def get_message_body(payload: WildValue) -> str:
             signed_recipients=get_recipients_text(recipients["signed"]),
         )
 
-        if recipients_text:
-            recipients_text = f"{recipients_text}, and {text}"
-        else:
-            recipients_text = text
+        recipients_text = f"{recipients_text}, and {text}" if recipients_text else text
 
     return BODY.format(contract_title=contract_title, actions=recipients_text).strip()
 

--- a/zerver/webhooks/homeassistant/view.py
+++ b/zerver/webhooks/homeassistant/view.py
@@ -20,10 +20,7 @@ def api_homeassistant_webhook(
     body = payload["message"].tame(check_string)
 
     # set the topic to the topic parameter, if given
-    if "topic" in payload:
-        topic = payload["topic"].tame(check_string)
-    else:
-        topic = "homeassistant"
+    topic = payload["topic"].tame(check_string) if "topic" in payload else "homeassistant"
 
     # send the message
     check_send_webhook_message(request, user_profile, topic, body)

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -84,10 +84,7 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
     for username in mention_re.findall(content):
         # Try to look up username
         user_profile = guess_zulip_user_from_jira(username, realm)
-        if user_profile:
-            replacement = f"**{user_profile.full_name}**"
-        else:
-            replacement = f"**{username}**"
+        replacement = f"**{user_profile.full_name}**" if user_profile else f"**{username}**"
 
         content = content.replace(f"[~{username}]", replacement)
 
@@ -112,10 +109,7 @@ def get_issue_string(
     if issue_id is None:
         issue_id = get_issue_id(payload)
 
-    if with_title:
-        text = f"{issue_id}: {get_issue_title(payload)}"
-    else:
-        text = issue_id
+    text = f"{issue_id}: {get_issue_title(payload)}" if with_title else issue_id
 
     base_url = re.match(
         r"(.*)\/rest\/api/.*", get_in(payload, ["issue", "self"]).tame(check_string)
@@ -210,10 +204,7 @@ def handle_updated_issue_event(payload: WildValue, user_profile: UserProfile) ->
     )
     assignee_mention = get_assignee_mention(assignee_email, user_profile.realm)
 
-    if assignee_mention != "":
-        assignee_blurb = f" (assigned to {assignee_mention})"
-    else:
-        assignee_blurb = ""
+    assignee_blurb = f" (assigned to {assignee_mention})" if assignee_mention != "" else ""
 
     sub_event = get_sub_event_for_update_issue(payload)
     if "comment" in sub_event:

--- a/zerver/webhooks/newrelic/view.py
+++ b/zerver/webhooks/newrelic/view.py
@@ -155,10 +155,7 @@ def api_newrelic_webhook(
             )
 
         policy_names_list = payload.get("alertPolicyNames", []).tame(check_list(check_string))
-        if policy_names_list:
-            policy_names_str = ",".join(policy_names_list)
-        else:
-            policy_names_str = "Unknown Policy"
+        policy_names_str = ",".join(policy_names_list) if policy_names_list else "Unknown Policy"
         topic_info = {
             "policy_name": policy_names_str,
             "incident_id": payload.get("id", "Unknown ID").tame(

--- a/zerver/webhooks/pivotal/tests.py
+++ b/zerver/webhooks/pivotal/tests.py
@@ -202,11 +202,10 @@ Try again next time
 
     def test_bad_payload(self) -> None:
         bad = ("foo", None, "bar")
-        with self.assertRaisesRegex(AssertionError, "Unable to handle Pivotal payload"):
-            with mock.patch(
-                "zerver.webhooks.pivotal.view.api_pivotal_webhook_v3", return_value=bad
-            ):
-                self.check_webhook("accepted", expect_topic="foo")
+        with self.assertRaisesRegex(AssertionError, "Unable to handle Pivotal payload"), mock.patch(
+            "zerver.webhooks.pivotal.view.api_pivotal_webhook_v3", return_value=bad
+        ):
+            self.check_webhook("accepted", expect_topic="foo")
 
     def test_bad_request(self) -> None:
         request = mock.MagicMock()
@@ -218,9 +217,10 @@ Try again next time
             self.assertEqual(result[0], "#0: ")
 
         bad = orjson.loads(self.get_body("bad_kind"))
-        with self.assertRaisesRegex(UnsupportedWebhookEventTypeError, "'unknown_kind'.* supported"):
-            with mock.patch("zerver.webhooks.pivotal.view.orjson.loads", return_value=bad):
-                api_pivotal_webhook_v5(request, hamlet)
+        with self.assertRaisesRegex(
+            UnsupportedWebhookEventTypeError, "'unknown_kind'.* supported"
+        ), mock.patch("zerver.webhooks.pivotal.view.orjson.loads", return_value=bad):
+            api_pivotal_webhook_v5(request, hamlet)
 
     def get_body(self, fixture_name: str) -> str:
         return self.webhook_fixture_data("pivotal", f"v5_{fixture_name}", file_type="json")

--- a/zerver/webhooks/pivotal/view.py
+++ b/zerver/webhooks/pivotal/view.py
@@ -39,10 +39,11 @@ def api_pivotal_webhook_v3(request: HttpRequest, user_profile: UserProfile) -> T
     # description in quotes as the first quoted string
     name_re = re.compile(r'[^"]+"([^"]+)".*')
     match = name_re.match(description)
-    if match and len(match.groups()):
-        name = match.group(1)
-    else:
-        name = "Story changed"  # Failed for an unknown reason, show something
+    name = (
+        match.group(1)
+        if match and len(match.groups())
+        else "Story changed"  # Failed for an unknown reason, show something
+    )
     more_info = f" [(view)]({url})."
 
     if event_type == "story_update":
@@ -127,10 +128,7 @@ def api_pivotal_webhook_v5(request: HttpRequest, user_profile: UserProfile) -> T
                 )
             if "estimate" in old_values and "estimate" in new_values:
                 old_estimate = old_values.get("estimate", None)
-                if old_estimate is None:
-                    estimate = "is now"
-                else:
-                    estimate = f"changed from {old_estimate} to"
+                estimate = "is now" if old_estimate is None else f"changed from {old_estimate} to"
                 new_estimate = new_values["estimate"] if new_values["estimate"] is not None else "0"
                 content += f"* estimate {estimate} **{new_estimate} points**\n"
             if "story_type" in old_values and "story_type" in new_values:

--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -232,10 +232,7 @@ Value without title
         )
 
     def get_body(self, fixture_name: str) -> str:
-        if "urlencoded" in fixture_name:
-            file_type = "txt"
-        else:
-            file_type = "json"
+        file_type = "txt" if "urlencoded" in fixture_name else "json"
         return self.webhook_fixture_data("slack_incoming", fixture_name, file_type=file_type)
 
     def test_attachment_pieces_title_null(self) -> None:

--- a/zerver/webhooks/sonarqube/view.py
+++ b/zerver/webhooks/sonarqube/view.py
@@ -66,10 +66,7 @@ def render_body_with_branch(payload: WildValue) -> str:
     project_name = payload["project"]["name"].tame(check_string)
     project_url = payload["project"]["url"].tame(check_string)
     quality_gate_status = payload["qualityGate"]["status"].tame(check_string).lower()
-    if quality_gate_status == "ok":
-        quality_gate_status = "success"
-    else:
-        quality_gate_status = "error"
+    quality_gate_status = "success" if quality_gate_status == "ok" else "error"
     branch = payload["branch"]["name"].tame(check_string)
 
     conditions = parse_conditions(payload["qualityGate"]["conditions"])
@@ -90,10 +87,7 @@ def render_body_without_branch(payload: WildValue) -> str:
     project_name = payload["project"]["name"].tame(check_string)
     project_url = payload["project"]["url"].tame(check_string)
     quality_gate_status = payload["qualityGate"]["status"].tame(check_string).lower()
-    if quality_gate_status == "ok":
-        quality_gate_status = "success"
-    else:
-        quality_gate_status = "error"
+    quality_gate_status = "success" if quality_gate_status == "ok" else "error"
     conditions = parse_conditions(payload["qualityGate"]["conditions"])
 
     if not conditions:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -451,10 +451,7 @@ class ConfirmationEmailWorker(QueueProcessingWorker):
         logger.info(
             "Sending invitation for realm %s to %s", referrer.realm.string_id, invitee.email
         )
-        if "email_language" in data:
-            email_language = data["email_language"]
-        else:
-            email_language = referrer.realm.default_language
+        email_language = data.get("email_language", referrer.realm.default_language)
 
         activate_url = do_send_confirmation_email(
             invitee, referrer, email_language, invite_expires_in_minutes

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -387,9 +387,8 @@ class QueueProcessingWorker(ABC):
         fn = os.path.join(settings.QUEUE_ERROR_DIR, fname)
         line = f"{time.asctime()}\t{orjson.dumps(events).decode()}\n"
         lock_fn = fn + ".lock"
-        with lockfile(lock_fn):
-            with open(fn, "a") as f:
-                f.write(line)
+        with lockfile(lock_fn), open(fn, "a") as f:
+            f.write(line)
         check_and_send_restart_signal()
 
     def setup(self) -> None:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -245,10 +245,7 @@ class QueueProcessingWorker(ABC):
     def update_statistics(self) -> None:
         total_seconds = sum(seconds for _, seconds in self.recent_consume_times)
         total_events = sum(events_number for events_number, _ in self.recent_consume_times)
-        if total_events == 0:
-            recent_average_consume_time = None
-        else:
-            recent_average_consume_time = total_seconds / total_events
+        recent_average_consume_time = None if total_events == 0 else total_seconds / total_events
         stats_dict = dict(
             update_time=time.time(),
             recent_average_consume_time=recent_average_consume_time,

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -536,10 +536,7 @@ def email_belongs_to_ldap(realm: Realm, email: str) -> bool:
         return Address(addr_spec=email).domain.lower() == settings.LDAP_APPEND_DOMAIN
 
     # If we don't have an LDAP domain, we have to do a lookup for the email.
-    if find_ldap_users_by_email(email):
-        return True
-    else:
-        return False
+    return bool(find_ldap_users_by_email(email))
 
 
 ldap_logger = logging.getLogger("zulip.ldap")

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -697,10 +697,7 @@ SCIM_LOG_PATH = zulip_path("/var/log/zulip/scim.log")
 ZULIP_WORKER_TEST_FILE = "/tmp/zulip-worker-test-file"
 
 
-if IS_WORKER:
-    FILE_LOG_PATH = WORKER_LOG_PATH
-else:
-    FILE_LOG_PATH = SERVER_LOG_PATH
+FILE_LOG_PATH = WORKER_LOG_PATH if IS_WORKER else SERVER_LOG_PATH
 
 # This is disabled in a few tests.
 LOGGING_ENABLED = True

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1133,10 +1133,7 @@ for idp_name, idp_dict in SOCIAL_AUTH_SAML_ENABLED_IDPS.items():
     if "x509cert" in idp_dict:
         continue
 
-    if "x509cert_path" in idp_dict:
-        path = idp_dict["x509cert_path"]
-    else:
-        path = f"/etc/zulip/saml/idps/{idp_name}.crt"
+    path = idp_dict.get("x509cert_path", f"/etc/zulip/saml/idps/{idp_name}.crt")
     idp_dict["x509cert"] = get_from_file_if_exists(path)
 
 SOCIAL_AUTH_PIPELINE = [


### PR DESCRIPTION
Ruff has added almost all of the rules from `flake8-simplify`, many with automatic fixes (including a few I contributed).

This doesn’t yet upgrade Ruff to enforce these rules, it’s just preparing for when we do.