### PR TITLE
pm: Add compose and view pm links in user profile modal.

### DIFF
--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -810,6 +810,9 @@ export function register_click_handlers() {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const email = people.get_by_user_id(user_id).email;
         hide_all();
+        if (overlays.is_modal_open()) {
+            overlays.close_active_modal();
+        }
         if (overlays.is_active()) {
             overlays.close_active();
         }
@@ -999,6 +1002,9 @@ export function register_click_handlers() {
             private_message_recipient: email,
         });
         hide_all();
+        if (overlays.is_modal_open()) {
+            overlays.close_active_modal();
+        }
         if (overlays.is_active()) {
             overlays.close_active();
         }

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -18,6 +18,7 @@ import * as people from "./people";
 import * as popovers from "./popovers";
 import * as settings_account from "./settings_account";
 import * as settings_bots from "./settings_bots";
+import * as settings_config from "./settings_config";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
@@ -189,6 +190,9 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         .filter((f) => f.name !== undefined);
     const user_streams = stream_data.get_subscribed_streams_for_user(user.user_id);
     const groups_of_user = user_groups.get_user_groups_of_user(user.user_id);
+    const spectator_view = page_params.is_spectator;
+    const is_active = people.is_active_user_for_popover(user.user_id);
+    const is_me = people.is_my_user_id(user.user_id);
     const args = {
         user_id: user.user_id,
         full_name: user.full_name,
@@ -203,6 +207,13 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         ),
         user_circle_class: buddy_data.get_user_circle_class(user.user_id),
         last_seen: buddy_data.user_last_seen_time_status(user.user_id),
+        spectator_view,
+        can_send_private_message:
+            is_active &&
+            !is_me &&
+            page_params.realm_private_message_policy !==
+                settings_config.private_message_policy_values.disabled.code,
+        pm_with_url: hash_util.pm_with_url(user.email),
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),
         user_is_guest: user.is_guest,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -432,6 +432,17 @@ ul {
         }
     }
 
+    .compose_private_message,
+    .narrow_to_private_messages {
+        padding: 3px 0;
+        width: 180px;
+
+        &:hover {
+            text-decoration: underline;
+            background: none;
+        }
+    }
+
     .user_profile_edit_button {
         width: 25px;
         text-align: center;

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -60,31 +60,29 @@
                                     </div>
                                     {{/if}}
                                 </div>
+                                <div id="content">
+                                    {{#if is_bot}}
+                                        <div class="field-section">
+                                            <div class="name">{{t "Bot type" }}</div>
+                                            <div class="bot_info_value">{{bot_type}}</div>
+                                        </div>
+                                        {{#if bot_owner}}
+                                        <div class="field-section bot_owner_user_field" data-field-id="{{bot_owner.user_id}}">
+                                            <div class="name">{{t "Owner" }}</div>
+                                            <div class="pill-container not-editable">
+                                                <div class="input" contenteditable="false" style="display: none;"></div>
+                                            </div>
+                                        </div>
+                                        {{/if}}
+                                    {{else}}
+                                        {{> user_custom_profile_fields profile_fields=profile_data}}
+                                    {{/if}}
+                                </div>
                             </div>
                             <div class="col-wrap col-right">
                                 <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
                                   style="background-image: url('{{user_avatar}}');">
                                 </div>
-                            </div>
-                        </div>
-                        <div class="bottom">
-                            <div id="content">
-                                {{#if is_bot}}
-                                    <div class="field-section">
-                                        <div class="name">{{t "Bot type" }}</div>
-                                        <div class="bot_info_value">{{bot_type}}</div>
-                                    </div>
-                                    {{#if bot_owner}}
-                                    <div class="field-section bot_owner_user_field" data-field-id="{{bot_owner.user_id}}">
-                                        <div class="name">{{t "Owner" }}</div>
-                                        <div class="pill-container not-editable">
-                                            <div class="input" contenteditable="false" style="display: none;"></div>
-                                        </div>
-                                    </div>
-                                    {{/if}}
-                                {{else}}
-                                    {{> user_custom_profile_fields profile_fields=profile_data}}
-                                {{/if}}
                             </div>
                         </div>
                     </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -83,6 +83,27 @@
                                 <div id="avatar" {{#if user_is_guest}} class="guest-avatar" {{/if}}
                                   style="background-image: url('{{user_avatar}}');">
                                 </div>
+                                <ul class="nav info_popover_actions" id="user_info_popover" data-user-id="{{user_id}}">
+                                    {{#unless spectator_view}}
+                                        {{#if can_send_private_message}}
+                                            <li>
+                                                <a tabindex="0" class="compose_private_message">
+                                                    <i class="fa fa-comment" aria-hidden="true"></i> {{t "Send direct message" }}
+                                                </a>
+                                            </li>
+                                        {{/if}}
+                                        <li>
+                                            <a href="{{ pm_with_url }}" class="narrow_to_private_messages">
+                                                <i class="fa fa-envelope" aria-hidden="true"></i>
+                                                {{#if is_me}}
+                                                {{t "View messages with yourself" }}
+                                                {{else}}
+                                                {{t "View direct messages" }}
+                                                {{/if}}
+                                            </a>
+                                        </li>
+                                    {{/unless}}
+                                </ul>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Fixes: #18881.

To access a user's private messages, this PR adds links along with text labels to compose and view private messages for that user via their full profile modal.

No text label to compose private messages is displayed if the user doesn't have permission to send private messages to a user.

<details>

<summary>Screenshots</summary>

**Large screen size -**

![Screenshot_20230415_152316](https://user-images.githubusercontent.com/96468766/232206811-a98d5a20-cf45-473b-9f58-5e52ed38e529.png)

Self profile modal - 

![Screenshot_20230428_155942](https://user-images.githubusercontent.com/96468766/235124500-229c43a5-ddbd-4669-92ac-61017608d00c.png)

----

**Small screen size -**

![Screenshot_20230415_152336](https://user-images.githubusercontent.com/96468766/232206813-1dd01f5c-0b54-469d-b267-b1890f960cd3.png)

Self profile modal - 

![Screenshot_20230428_160003](https://user-images.githubusercontent.com/96468766/235124535-ba521879-d060-43ad-899a-b80843da484e.png)

</details>

<details>

<summary>Screen captures</summary>

![pm 1](https://user-images.githubusercontent.com/96468766/232206902-49bed0b9-04ad-41dd-8da6-8e74c8f70dae.gif)

![pm 2](https://user-images.githubusercontent.com/96468766/232206905-e3cd7416-d37a-46e5-a778-606f6b1a4423.gif)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
