### PR TITLE
help: Document "Mute/Unmute stream" mobile app feature.

### DIFF
--- a/help/include/mobile-stream-settings-menu-tip.md
+++ b/help/include/mobile-stream-settings-menu-tip.md
@@ -1,6 +1,6 @@
 !!! tip ""
 
-    If you are viewing a single stream or topic, you can access the
+    If you are in a stream view, you can access the
     stream settings menu from the information
     (<img src="/static/images/help/mobile-info-circle-icon.svg" alt="information" class="mobile-icon"/>)
     button in the top right corner of the app.

--- a/help/include/stream-long-press-menu-tip.md
+++ b/help/include/stream-long-press-menu-tip.md
@@ -1,4 +1,4 @@
 !!! tip ""
 
-    If you are viewing a single stream, you can access the long-press
+    If you are in a stream view, you can access the long-press
     menu from the bar at the top of the app.

--- a/help/mute-a-stream.md
+++ b/help/mute-a-stream.md
@@ -23,6 +23,14 @@ sorted to the bottom of their section.
 
 1. Click **Mute stream**.
 
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Mute stream**.
+
+{!stream-long-press-menu-tip.md!}
+
 {end_tabs}
 
 
@@ -35,6 +43,14 @@ sorted to the bottom of their section.
 {!stream-actions.md!}
 
 1. Click **Unmute stream**.
+
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Unmute stream**.
+
+{!stream-long-press-menu-tip.md!}
 
 {end_tabs}
 
@@ -51,6 +67,16 @@ sorted to the bottom of their section.
 {!select-stream-view-personal.md!}
 
 1. Under **Personal settings**, toggle **Mute stream**.
+
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Stream settings**.
+
+1. Toggle **Muted**.
+
+{!mobile-stream-settings-menu-tip.md!}
 
 {end_tabs}
 

--- a/help/mute-a-stream.md
+++ b/help/mute-a-stream.md
@@ -17,9 +17,11 @@ sorted to the bottom of their section.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!stream-actions.md!}
 
-3. Select **Mute stream**.
+1. Click **Mute stream**.
 
 {end_tabs}
 
@@ -28,9 +30,27 @@ sorted to the bottom of their section.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!stream-actions.md!}
 
-3. Select **Unmute stream**.
+1. Click **Unmute stream**.
+
+{end_tabs}
+
+## Alternate method to mute or unmute a stream
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|stream|subscribed}
+
+1. Select a stream.
+
+{!select-stream-view-personal.md!}
+
+1. Under **Personal settings**, toggle **Mute stream**.
 
 {end_tabs}
 

--- a/help/pin-a-stream.md
+++ b/help/pin-a-stream.md
@@ -44,7 +44,7 @@ which is especially handy if you are subscribed to a large number of streams.
 
 {end_tabs}
 
-### Alternate method
+## Alternate method to pin or unpin a stream
 
 {start_tabs}
 
@@ -69,3 +69,8 @@ which is especially handy if you are subscribed to a large number of streams.
 {!mobile-stream-settings-menu-tip.md!}
 
 {end_tabs}
+
+## Related articles
+
+* [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams)
+* [Mute a stream](/help/mute-a-stream)


### PR DESCRIPTION
This PR replaces #22272.

Fixes #22196.

**Screenshots and screen captures:**

- Updates [Mute a stream](https://zulip.com/help/mute-a-stream) and [Pin a stream](https://zulip.com/help/pin-a-stream) to follow our current help center documentation patterns.
<img width="487" alt="image" src="https://user-images.githubusercontent.com/2343554/213302471-af0b635f-a3f0-4d75-acd3-16c074cb70e8.png">

<img width="476" alt="image" src="https://user-images.githubusercontent.com/2343554/213302562-62442cad-5d56-499e-b406-eb0d4fc3058e.png">

- Adds step-by-step instructions for mobile app users.
<img width="496" alt="image" src="https://user-images.githubusercontent.com/2343554/213301611-8299fdeb-f8e6-49bb-afe1-a4710da99972.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>