### PR TITLE
css: Don't render message failed  buttons.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -89,7 +89,7 @@ export function show_message_failed(message_id, failed_msg) {
     // Failed to send message, so display inline retry/cancel
     update_message_in_all_views(message_id, ($row) => {
         const $failed_div = $row.find(".message_failed");
-        $failed_div.toggleClass("notvisible", false);
+        $failed_div.toggleClass("hide", false);
         $failed_div.find(".failed_text").attr("title", failed_msg);
     });
 }
@@ -97,7 +97,7 @@ export function show_message_failed(message_id, failed_msg) {
 export function show_failed_message_success(message_id) {
     // Previously failed message succeeded
     update_message_in_all_views(message_id, ($row) => {
-        $row.find(".message_failed").toggleClass("notvisible", true);
+        $row.find(".message_failed").toggleClass("hide", true);
     });
 }
 

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1068,13 +1068,16 @@ td.pointer {
     }
 
     .message_failed {
-        opacity: 1 !important;
         display: inline-flex;
         justify-content: space-between;
         cursor: pointer;
         position: relative;
         vertical-align: middle;
         padding-left: 2px;
+
+        &.hide {
+            display: none;
+        }
 
         .rotating {
             display: inline-block;

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -15,7 +15,7 @@
     </div>
     {{/unless}}
 
-    <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
+    <div class="message_failed {{#unless msg.failed_request}}hide{{/unless}}">
         <div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
             <i class="fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
         </div>


### PR DESCRIPTION
We used to make message failed button (retry / cancel) invisible when the message is successfully send instead of not rendering them. This resulted in them being accessible via keyboard when they are not visible. I couldn't find a reason for retry and cancel buttons to use `visibility` to be hidden instead of just being not rendered via
`display: none`.


discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/extraneous.20.22Retry.22.20and.20.22Cancel.22.20tooltips

No UI changes.