### PR TITLE
message_body: Structure hidden message similar to a normal message.

### DIFF
--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -40,7 +40,9 @@
         {{/if}}
     </div>
     {{else}}
-    {{> message_hidden_dialog}}
+    <div class="message_content rendered_markdown">
+        {{> message_hidden_dialog}}
+    </div>
     {{/unless}}
 {{/unless}}
 

--- a/static/templates/message_hidden_dialog.hbs
+++ b/static/templates/message_hidden_dialog.hbs
@@ -1,4 +1,6 @@
-<em>
-    {{#tr}}This message was hidden because you have muted the sender. {{/tr}}
-    <a class="reveal_hidden_message">{{#tr}}Click here to reveal.{{/tr}}</a>
-</em>
+<p>
+    <em>
+        {{#tr}}This message was hidden because you have muted the sender. {{/tr}}
+        <a class="reveal_hidden_message">{{#tr}}Click here to reveal.{{/tr}}</a>
+    </em>
+</p>


### PR DESCRIPTION
Messages sent by muted users are hidden. To make sure they are displayed properly, we provide them a HTML structure similar to that of a normal message so that any CSS applied to a normal message also applied to it.

This fixes message controls being misaligned in hidden message.

<img width="920" alt="image" src="https://user-images.githubusercontent.com/25124304/213400875-e60935b7-581c-494d-b7cf-35ef6befe108.png">

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/misaligned.20buttons.20in.20muted.20message