### PR TITLE
organization-profile: Update deactivate organization section.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -47,6 +47,7 @@ export function maybe_disable_widgets() {
 
     if (page_params.is_admin) {
         $("#deactivate_realm_button").prop("disabled", true);
+        $("#deactivate_realm_button_container").addClass("realm_deactivation_tooltip");
         $("#org-message-retention").find("input, select").prop("disabled", true);
         $("#org-join-settings").find("input, select").prop("disabled", true);
         $("#id_realm_invite_required_label").parent().addClass("control-label-disabled");

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -432,6 +432,17 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ["#deactivate_realm_button_container.realm_deactivation_tooltip"],
+        content: $t({
+            defaultMessage: "Only organization owners may deactivate an organization.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
         target: "#pm_tooltip_container",
         onShow(instance) {
             if ($(".private_messages_container").hasClass("zoom-in")) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -175,13 +175,20 @@ h3,
     }
 }
 
+#deactivate_realm_button_container {
+    &.realm_deactivation_tooltip {
+        cursor: not-allowed;
+    }
+}
+
 #deactivate_account_container {
     &.only_organization_owner_tooltip {
         cursor: not-allowed;
     }
 }
 
-#user_deactivate_account_button {
+#user_deactivate_account_button,
+#deactivate_realm_button {
     &:disabled {
         pointer-events: none;
     }

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -84,13 +84,15 @@
         </div>
         <h3 class="light">
             {{t "Deactivate organization" }}
-            <i class="fa fa-info-circle settings-info-icon realm_deactivation_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content="{{t 'Only owners can deactivate the organization.' }}"></i>
+            {{> ../help_link_widget link="/help/deactivate-your-organization" }}
         </h3>
         <div class="deactivate-realm-section">
             <div class="input-group">
-                <button class="button rounded btn-danger" id="deactivate_realm_button">
-                    {{t 'Deactivate organization' }}
-                </button>
+                <div id="deactivate_realm_button_container" class="inline-block {{#unless is_owner}}realm_deactivation_tooltip{{/unless}}">
+                    <button class="button rounded btn-danger" id="deactivate_realm_button">
+                        {{t 'Deactivate organization' }}
+                    </button>
+                </div>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Removes the info icon with the tooltip information and replaces it with a question help link icon to the help center article on deactivating an organization.

Also, when the button is disabled, adds a tooltip on hover that explains only organization owners can deactivate an organization.

If the current user's owner role is changed, then the button and tooltip are live updated. This overlay is not live updated when a user's role is changed to have higher permissions (e.g. moderator to admin), so that behavior is maintained with these changes.

Part of #22892.

---

**Screenshots and screen captures:**

<details>
<summary>Owner role</summary>

![Screenshot from 2023-01-19 17-21-02](https://user-images.githubusercontent.com/63245456/213502657-7937e794-5fd9-43a4-9bcb-6299245492f5.png)
</details>
<details>
<summary>Not-owner hovering</summary>

![Screenshot from 2023-01-19 17-19-55](https://user-images.githubusercontent.com/63245456/213502722-39d5ac44-993d-476d-8d19-437403211d91.png)
</details>
<details>
<summary>Not-owner not hovering</summary>

![Screenshot from 2023-01-19 17-19-50](https://user-images.githubusercontent.com/63245456/213502795-ab483597-0fef-476d-8f43-dd227760228c.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
