### PR TITLE
help center: Consistently use bold formatting for icon names.

### DIFF
--- a/docs/documentation/helpcenter.md
+++ b/docs/documentation/helpcenter.md
@@ -311,40 +311,40 @@ base class `icon-vector` and have dropped support for it. We now only support
 icons from [FontAwesome](https://fontawesome.com/v4.7.0/) (version 4.7.0) which
 make use of `fa` as a base class.
 
-- cog (<i class="fa fa-cog"></i>) icon —
-  `cog (<i class="fa fa-cog"></i>) icon`
-- down chevron (<i class="fa fa-chevron-down"></i>) icon —
-  `down chevron (<i class="fa fa-chevron-down"></i>) icon`
-- eye (<i class="fa fa-eye"></i>) icon —
-  `eye (<i class="fa fa-eye"></i>) icon`
-- file (<i class="fa fa-file-code-o"></i>) icon —
-  `file (<i class="fa fa-file-code-o"></i>) icon`
-- filled star (<i class="fa fa-star"></i>) icon —
-  `filled star (<i class="fa fa-star"></i>) icon`
-- formatting (<i class="fa fa-font"></i>) icon —
-  `formatting (<i class="fa fa-font"></i>) icon`
-- menu (<i class="fa fa-bars"></i>) icon —
-  `menu (<i class="fa fa-bars"></i>) icon`
-- overflow ( <i class="fa fa-ellipsis-v"></i> ) icon —
-  `overflow ( <i class="fa fa-ellipsis-v"></i> ) icon`
-- paperclip (<i class="fa fa-paperclip"></i>) icon —
-  `paperclip (<i class="fa fa-paperclip"></i>) icon`
-- pencil (<i class="fa fa-pencil"></i>) icon —
-  `pencil (<i class="fa fa-pencil"></i>) icon`
-- pencil and paper (<i class="fa fa-pencil-square-o"></i>) icon —
-  `pencil and paper (<i class="fa fa-pencil-square-o"></i>) icon`
-- plus (<i class="fa fa-plus"></i>) icon —
-  `plus (<i class="fa fa-plus"></i>) icon`
-- smiley face (<i class="fa fa-smile-o"></i>) icon —
-  `smiley face (<i class="fa fa-smile-o"></i>) icon`
-- star (<i class="fa fa-star-o"></i>) icon —
-  `star (<i class="fa fa-star-o"></i>) icon`
-- trash (<i class="fa fa-trash-o"></i>) icon —
-  `trash (<i class="fa fa-trash-o"></i>) icon`
-- video-camera (<i class="fa fa-video-camera"></i>) icon —
-  `video-camera (<i class="fa fa-video-camera"></i>) icon`
-- x (<i class="fa fa-times"></i>) icon —
-  `x (<i class="fa fa-times"></i>) icon`
+- **cog** (<i class="fa fa-cog"></i>) icon:
+  `**cog** (<i class="fa fa-cog"></i>) icon`
+- **down chevron** (<i class="fa fa-chevron-down"></i>) icon:
+  `**down chevron** (<i class="fa fa-chevron-down"></i>) icon`
+- **eye** (<i class="fa fa-eye"></i>) icon:
+  `**eye** (<i class="fa fa-eye"></i>) icon`
+- **file** (<i class="fa fa-file-code-o"></i>) icon:
+  `**file** (<i class="fa fa-file-code-o"></i>) icon`
+- **filled star** (<i class="fa fa-star"></i>) icon:
+  `**filled star** (<i class="fa fa-star"></i>) icon`
+- **formatting** (<i class="fa fa-font"></i>) icon:
+  `**formatting** (<i class="fa fa-font"></i>) icon`
+- **menu** (<i class="fa fa-bars"></i>) icon:
+  `**menu** (<i class="fa fa-bars"></i>) icon`
+- **verflow** ( <i class="fa fa-ellipsis-v"></i> ) icon:
+  `**overflow** ( <i class="fa fa-ellipsis-v"></i> ) icon`
+- **paperclip** (<i class="fa fa-paperclip"></i>) icon:
+  `**paperclip** (<i class="fa fa-paperclip"></i>) icon`
+- **pencil** (<i class="fa fa-pencil"></i>) icon:
+  `**pencil** (<i class="fa fa-pencil"></i>) icon`
+- **pencil and paper** (<i class="fa fa-pencil-square-o"></i>) icon:
+  `**pencil and paper** (<i class="fa fa-pencil-square-o"></i>) icon`
+- **plus** (<i class="fa fa-plus"></i>) icon:
+  `**plus** (<i class="fa fa-plus"></i>) icon`
+- **smiley face** (<i class="fa fa-smile-o"></i>) icon:
+  `**smiley face** (<i class="fa fa-smile-o"></i>) icon`
+- **star** (<i class="fa fa-star-o"></i>) icon:
+  `**star** (<i class="fa fa-star-o"></i>) icon`
+- **trash** (<i class="fa fa-trash-o"></i>) icon:
+  `**trash** (<i class="fa fa-trash-o"></i>) icon`
+- **video-camera** (<i class="fa fa-video-camera"></i>) icon:
+  `**video-camera** (<i class="fa fa-video-camera"></i>) icon`
+- **x** (<i class="fa fa-times"></i>) icon:
+  `**x** (<i class="fa fa-times"></i>) icon`
 
 ### Macros
 

--- a/templates/zerver/help/emoji-and-emoticons.md
+++ b/templates/zerver/help/emoji-and-emoticons.md
@@ -27,7 +27,7 @@ emoji picker, or hover over the emoji in a message.
 
 {!start-composing.md!}
 
-1. Click the smiley face (<i class="fa fa-smile-o"></i>) icon at the
+1. Click the **smiley face** (<i class="fa fa-smile-o"></i>) icon at the
    bottom of the compose box.
 
 1. Select an emoji. You can type to search, use the arrow keys, or click on

--- a/templates/zerver/help/include/desktop-sidebar-settings-menu.md
+++ b/templates/zerver/help/include/desktop-sidebar-settings-menu.md
@@ -1,1 +1,1 @@
-1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the bottom left corner of the app.
+1. Click the **gear** (<i class="fa fa-cog"></i>) icon in the bottom left corner of the app.

--- a/templates/zerver/help/logging-in.md
+++ b/templates/zerver/help/logging-in.md
@@ -55,7 +55,7 @@ Here are some ways to find the URL for your Zulip organization.
 * On [Zulip Cloud](https://zulip.com/plans/) and other Zulip servers updated to
   [Zulip 6.0 or
   higher](https://zulip.readthedocs.io/en/latest/overview/changelog.html#zulip-6-x-series),
-  click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper right
+  click the **gear** (<i class="fa fa-cog"></i>) icon in the upper right
   corner of the web or desktop app. Your organization's log in URL is shown in the top
   section of the menu.
 

--- a/templates/zerver/help/logging-out.md
+++ b/templates/zerver/help/logging-out.md
@@ -3,7 +3,7 @@
 {start_tabs}
 {tab|desktop-web}
 
-1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the top
+1. Click the **gear** (<i class="fa fa-cog"></i>) icon in the top
 right corner of the app.
 
 1. Click **Log out**.

--- a/templates/zerver/help/organize-the-streams-sidebar.md
+++ b/templates/zerver/help/organize-the-streams-sidebar.md
@@ -39,7 +39,7 @@ To learn more about pinning a stream, see [here](/help/pin-a-stream).
  If you don't have a stream pinned, you can search for it instead of scrolling
  through the alphabetically ordered list.
 
-1. On the left sidebar in the **Streams** section, click on the search
+1. On the left sidebar in the **Streams** section, click the **search**
  (<i class="fa fa-search" aria-hidden="true"></i>) icon in the top
  right-hand corner.
 

--- a/templates/zerver/help/public-access-option.md
+++ b/templates/zerver/help/public-access-option.md
@@ -2,7 +2,7 @@
 
 {!web-public-streams-intro.md!}
 
-Web-public streams are indicated with a globe (<i class="zulip-icon zulip-icon-globe"></i>) icon.
+Web-public streams are indicated with a **globe** (<i class="zulip-icon zulip-icon-globe"></i>) icon.
 
 ## Enabling web-public streams in your organization
 

--- a/templates/zerver/help/share-and-upload-files.md
+++ b/templates/zerver/help/share-and-upload-files.md
@@ -6,7 +6,7 @@ First, [open the compose box](/help/open-the-compose-box). Then
 
 * **Drag and drop** files into the compose box.
 * **Copy and paste** files into the compose box.
-* **Click the paperclip** (<i class="fa fa-paperclip"></i>) icon at
+* Click the **paperclip** (<i class="fa fa-paperclip"></i>) icon at
   the bottom of the compose box to find files on your computer.
 
 Zulip will insert a link to the file, in Markdown format:

--- a/templates/zerver/help/start-a-call.md
+++ b/templates/zerver/help/start-a-call.md
@@ -4,7 +4,7 @@
 
 {!start-composing.md!}
 
-1. Click the video-camera (<i class="fa fa-video-camera"></i>) icon in the
+1. Click the **video-camera** (<i class="fa fa-video-camera"></i>) icon in the
 bottom left corner of the compose box. This will insert a link like
 **[Click to join video call]\(https://meet.jit.si/123456789)** into the
 compose box.

--- a/templates/zerver/help/user-groups.md
+++ b/templates/zerver/help/user-groups.md
@@ -41,7 +41,7 @@ trying to send a message to a group of people, you'll want to either
 
 1. Find the group.
 
-1. Click on the trash (<i class="fa fa-trash-o"></i>) icon in the top
+1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon in the top
    right corner of the user group.
 
 1. Approve by clicking **Confirm**.


### PR DESCRIPTION
- Fixes formatting of icon names to follow current help center documentation patterns.
- Updates [contributor documentation for writing help center articles](https://zulip.readthedocs.io/en/stable/documentation/helpcenter.html#icons).

**Screenshots and screen captures:**

*The `**` bold formatting markup increased the length of each line in the list so I replaced the em dashes " —" with colons ":" to prevent line wrapping.

<img width="754" alt="image" src="https://user-images.githubusercontent.com/2343554/213589739-cd1100a8-85ee-41d7-a866-8fb72269adb7.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>