### PR TITLE
compose: Add x to topic input box in compose box

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -613,6 +613,11 @@ export function initialize() {
         browser_history.go_to_location(target);
     });
 
+    $("body").on("click", "#compose-clear-topic-button", () => {
+        compose_actions.clear_topic_box();
+        compose_actions.display_topic_clear_button();
+    });
+
     function handle_compose_click(e) {
         const $target = $(e.target);
         // Emoji clicks should be handled by their own click handler in emoji_picker.js

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -428,7 +428,10 @@ export function initialize() {
     $("#below-compose-content .video_link").toggle(compute_show_video_chat_button());
     $(
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient",
-    ).on("keyup", update_on_recipient_change);
+    ).on("keyup", () => {
+        update_on_recipient_change();
+        compose_actions.display_topic_clear_button();
+    });
     $(
         "#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient",
     ).on("change", () => {

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -103,6 +103,19 @@ export function clear_textarea() {
     $("#compose").find("input[type=text], textarea").val("");
 }
 
+export function clear_topic_box() {
+    $("#stream_message_recipient_topic").val("");
+    $("#stream_message_recipient_topic").trigger("focus");
+}
+
+export function display_topic_clear_button() {
+    if ($("#stream_message_recipient_topic").val()) {
+        $("#compose-clear-topic-button").show();
+    } else {
+        $("#compose-clear-topic-button").hide();
+    }
+}
+
 function clear_box() {
     compose.clear_invites();
 

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -127,5 +127,6 @@ export function initialize() {
 
     $("body").on("click", ".compose_reply_button", () => {
         compose_actions.respond_to_message({trigger: "reply button"});
+        compose_actions.display_topic_clear_button();
     });
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -537,6 +537,12 @@ input.recipient_box {
        the left sidebar with a single digit unread count without being
        cut off. */
     width: 175px;
+    padding-right: 19px;
+    text-overflow: ellipsis;
+}
+
+#compose-clear-topic-button {
+    padding: 4px;
 }
 
 #private_message_recipient.recipient_box {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -81,7 +81,8 @@
                                 </a>
                                 <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="{{ max_stream_name_length }}" value="" placeholder="{{t 'Stream' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Stream' }}" />
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
-                                <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                                <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}"/>
+                                <button type="button" class="btn clear_search_button" id="compose-clear-topic-button"><i class="fa fa-remove"></i></button>
                             </div>
                         </div>
                         <div id="private-message" class="order-1">

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -507,6 +507,7 @@ test_ui("update_fade", ({override}) => {
     let set_focused_recipient_checked = false;
     let update_all_called = false;
     let update_narrow_to_recipient_visibility_called = false;
+    let should_display_topic_clear_button = false;
 
     override(compose_fade, "set_focused_recipient", (msg_type) => {
         assert.equal(msg_type, "private");
@@ -521,19 +522,32 @@ test_ui("update_fade", ({override}) => {
         update_narrow_to_recipient_visibility_called = true;
     });
 
+    override(compose_actions, "display_topic_clear_button", () => {
+        if ($("#stream_message_recipient_topic").val()) {
+            should_display_topic_clear_button = true;
+        } else if ($("#stream_message_recipient_topic").val() === "") {
+            should_display_topic_clear_button = false;
+        }
+    });
+
     compose_state.set_message_type(false);
+    $("#stream_message_recipient_topic").val("Has topic input");
+
     keyup_handler_func();
     assert.ok(!set_focused_recipient_checked);
     assert.ok(!update_all_called);
     assert.ok(update_narrow_to_recipient_visibility_called);
+    assert.ok(should_display_topic_clear_button);
 
     update_narrow_to_recipient_visibility_called = false;
-
+    $("#stream_message_recipient_topic").val("");
     compose_state.set_message_type("private");
+
     keyup_handler_func();
     assert.ok(set_focused_recipient_checked);
     assert.ok(update_all_called);
     assert.ok(update_narrow_to_recipient_visibility_called);
+    assert.ok(!should_display_topic_clear_button);
 });
 
 test_ui("trigger_submit_compose_form", ({override, override_rewire}) => {


### PR DESCRIPTION
We should make clearing topics easier by introducing an x to 
clear the topic input box. This can possibly help improve 
workflow experience.

fixes #21464

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

When topic input box is populated:
![image](https://user-images.githubusercontent.com/62449508/213602484-3270ea4f-7cab-468b-9da0-6235d42da423.png)

When topic input box is empty:
![image](https://user-images.githubusercontent.com/62449508/213602532-cc9d26ef-fa61-4324-81d8-32bab87846fb.png)


Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
add a screen capture of the new functionality as well.

When topic input box is populated:
![image](https://user-images.githubusercontent.com/62449508/213602484-3270ea4f-7cab-468b-9da0-6235d42da423.png)

When topic input box is empty:
![image](https://user-images.githubusercontent.com/62449508/213602532-cc9d26ef-fa61-4324-81d8-32bab87846fb.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
