### PR TITLE
message: Keep user card tooltip limited to user name and avatar.

### DIFF
--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -467,13 +467,9 @@ export function initialize() {
     delegate("body", {
         target: "#show_all_private_messages",
         placement: "bottom",
-        onShow(instance) {
-            instance.setContent(
-                $t({
-                    defaultMessage: "All private messages (P)",
-                }),
-            );
-        },
+        content: $t({
+            defaultMessage: "All private messages (P)",
+        }),
         appendTo: () => document.body,
     });
 }

--- a/static/js/tippyjs.js
+++ b/static/js/tippyjs.js
@@ -472,4 +472,13 @@ export function initialize() {
         }),
         appendTo: () => document.body,
     });
+
+    delegate("body", {
+        target: ".view_user_card_tooltip",
+        content: $t({
+            defaultMessage: "View user card (u)",
+        }),
+        delay: [500, 20],
+        appendTo: () => document.body,
+    });
 }

--- a/static/styles/message_row.css
+++ b/static/styles/message_row.css
@@ -2,12 +2,11 @@ $avatar_column_width: 46px;
 $distance_of_text_elements_from_message_box_top: 8.5px;
 $distance_of_non_text_elements_from_message_box_top: 6px;
 $sender_name_distance_below_flex_center: 3px;
-$time_column_min_width: 50px; /* + padding */
 
 .message_row {
     .messagebox .messagebox-content {
         /* Total 868px
-        1    56px   2                                        697px                                                      3     55px     4  60px(min)  5
+        1    56px   2                                        697px                                                      3     55px     4     60px    5
       1 |‾‾‾‾‾‾‾‾‾‾‾:‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾:‾‾‾‾‾‾‾‾‾‾‾‾‾‾:‾‾‾‾‾‾‾‾‾‾‾‾|
         |           :   TEXT                                                                                             :   +  ⋮  ☆    :  10:00 AM  |
         |           :   TEXT                                                                                             :              :            |
@@ -27,10 +26,10 @@ $time_column_min_width: 50px; /* + padding */
         padding-left: 10px;
         grid-template-rows: repeat(4, auto);
 
-        grid-template-columns: $avatar_column_width auto 55px auto;
+        grid-template-columns: $avatar_column_width auto 55px 60px;
 
         @media (width < $sm_min) {
-            grid-template-columns: $avatar_column_width auto max-content auto;
+            grid-template-columns: $avatar_column_width auto max-content 60px;
         }
 
         .message_controls {
@@ -65,8 +64,6 @@ $time_column_min_width: 50px; /* + padding */
             line-height: 1;
             justify-self: end;
             padding-right: 10px;
-            min-width: $time_column_min_width;
-            text-align: end;
             grid-row-start: 1;
             grid-column-start: 4;
             position: relative;

--- a/static/styles/message_row.css
+++ b/static/styles/message_row.css
@@ -222,10 +222,13 @@ $time_column_min_width: 50px; /* + padding */
                        be in any language and `line-height: 1` doesn't work to accommodate text
                        from start and end vertically in all languages. */
                     line-height: normal;
-                    /* Add padding to align user name with the content */
-                    padding-left: $avatar_column_width;
                     outline: none;
                     margin-top: $sender_name_distance_below_flex_center;
+
+                    .sender_name_padding {
+                        /* Add padding to align user name with the content */
+                        padding-left: $avatar_column_width;
+                    }
                 }
             }
 

--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -7,7 +7,7 @@
 
     <span class="sender-status">
         <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">
-            <span title="{{t 'View user card' }} (u)" >
+            <span class="view_user_card_tooltip">
                 {{msg/sender_full_name}}
             </span>
         </span>

--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,6 +1,6 @@
 <span class="message_sender no-select is_me_message">
     <span class="sender_info_hover">
-        <span title="{{t 'View user card' }} (u)">
+        <span>
             {{> message_avatar}}
         </span>
     </span>

--- a/static/templates/message_avatar.hbs
+++ b/static/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}" aria-hidden="true" title="{{t 'View user card' }} (u)">
+<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip" aria-hidden="true">
     <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
 </div>
 {{~! remove whitespace ~}}

--- a/static/templates/message_avatar.hbs
+++ b/static/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}" aria-hidden="true">
+<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}" aria-hidden="true" title="{{t 'View user card' }} (u)">
     <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
 </div>
 {{~! remove whitespace ~}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -3,7 +3,10 @@
     {{#if include_sender}}
     <span>
         {{> message_avatar ~}}
-        <span class="sender_name auto-select view_user_card_tooltip" role="button" tabindex="0">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
+        <span class="sender_name auto-select" role="button" tabindex="0">
+            <span class="sender_name_padding view_user_card_tooltip"></span>
+            <span class="view_user_card_tooltip">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
+        </span>
         {{#if sender_is_bot}}
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -1,9 +1,9 @@
 {{#unless status_message}}
 <span class="message_sender sender_info_hover no-select">
     {{#if include_sender}}
-    <span title="{{t 'View user card' }} (u)">
+    <span>
         {{> message_avatar ~}}
-        <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
+        <span class="sender_name auto-select" role="button" tabindex="0" title="{{t 'View user card' }} (u)">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
         {{#if sender_is_bot}}
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -3,7 +3,7 @@
     {{#if include_sender}}
     <span>
         {{> message_avatar ~}}
-        <span class="sender_name auto-select" role="button" tabindex="0" title="{{t 'View user card' }} (u)">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
+        <span class="sender_name auto-select view_user_card_tooltip" role="button" tabindex="0">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
         {{#if sender_is_bot}}
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}


### PR DESCRIPTION
We accidentally added tooltip to open user card to a much larger area than intended as a regression from moving the message to use grid.

In this, we keep it limited to user name and avatar by adding the tooltip directly to them.

This image depicts the previous incorrect area of the tooltip.
<img width="920" alt="Screenshot 2023-01-20 at 4 21 18 PM" src="https://user-images.githubusercontent.com/25124304/213677980-355fb0c1-2ec8-476b-9214-9b2d5e32bfa4.png">
