### PR TITLE
navbar_alert: Change banner text and delay display for new organizati…

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 200**
+
+* [`POST /register`](/api/register-queue): Added
+  `realm_date_created` field to realm data.
+
 **Feature level 199**
 
 * [`POST /register`](/api/register-queue), [`GET /events`][/api/get-events],

--- a/web/src/navbar_alerts.js
+++ b/web/src/navbar_alerts.js
@@ -92,11 +92,23 @@ export function dismiss_upgrade_nag(ls) {
     }
 }
 
-export function check_profile_incomplete() {
+export function should_display_profile_incomplete_alert() {
+    const now = new Date(Date.now());
+    const realm_date_created = new Date(page_params.realm_date_created * 1000);
+    const day = 24 * 60 * 60 * 1000; // hours * minutes * seconds * milliseconds
+    const delay = Math.round(Math.abs(realm_date_created - now) / day);
+
     if (!page_params.is_admin) {
         return false;
     }
 
+    if (check_profile_incomplete() && delay >= 15) {
+        return true;
+    }
+    return false;
+}
+
+export function check_profile_incomplete() {
     // Eventually, we might also check page_params.realm_icon_source,
     // but it feels too aggressive to ask users to do change that
     // since their organization might not have a logo yet.
@@ -174,7 +186,7 @@ export function initialize() {
             custom_class: "bankruptcy",
             rendered_alert_content_html: render_bankruptcy_alert_content({unread_msgs_count}),
         });
-    } else if (check_profile_incomplete()) {
+    } else if (should_display_profile_incomplete_alert()) {
         open({
             data_process: "profile-incomplete",
             rendered_alert_content_html: render_profile_incomplete_alert_content(),

--- a/web/templates/navbar_alerts/profile_incomplete.hbs
+++ b/web/templates/navbar_alerts/profile_incomplete.hbs
@@ -1,7 +1,7 @@
 <div data-step="1">
     {{#tr}}
-        Complete the <z-link>organization profile</z-link>
-        to brand and explain the purpose of this Zulip organization.
+        Complete your <z-link>organization profile</z-link>,
+        which is displayed on your organization's registration and login pages.
         {{#*inline "z-link"}}<a class="alert-link" href="#organization/organization-profile">{{> @partial-block}}</a>{{/inline}}
     {{/tr}}
 </div>

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -62,21 +62,27 @@ test("allow_notification_alert", ({disallow, override}) => {
     assert.equal(navbar_alerts.should_show_notifications(ls), false);
 });
 
-test("profile_incomplete_alert", () => {
+test("profile_incomplete_alert", ({override}) => {
     // Show alert.
     page_params.is_admin = true;
     page_params.realm_description = "Organization imported from Slack!";
-    assert.equal(navbar_alerts.check_profile_incomplete(), true);
+
+    const start_time = new Date(1620327447050); // Thursday 06/5/2021 07:02:27 AM (UTC+0)
+
+    const delay = addDays(start_time, 15);
+    page_params.realm_date_created = Math.trunc(delay / 1000);
+    override(Date, "now", () => start_time);
+    assert.equal(navbar_alerts.should_display_profile_incomplete_alert(), true);
 
     // Avoid showing if the user is not admin.
     page_params.is_admin = false;
-    assert.equal(navbar_alerts.check_profile_incomplete(), false);
+    assert.equal(navbar_alerts.should_display_profile_incomplete_alert(), false);
 
     // Avoid showing if the realm description is already updated.
     page_params.is_admin = true;
-    assert.equal(navbar_alerts.check_profile_incomplete(), true);
+    assert.equal(navbar_alerts.should_display_profile_incomplete_alert(), true);
     page_params.realm_description = "Organization description already set!";
-    assert.equal(navbar_alerts.check_profile_incomplete(), false);
+    assert.equal(navbar_alerts.should_display_profile_incomplete_alert(), false);
 });
 
 test("server_upgrade_alert hide_duration_expired", ({override}) => {

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -359,6 +359,7 @@ def fetch_initial_state_data(
             state["demo_organization_scheduled_deletion_date"] = datetime_to_timestamp(
                 realm.demo_organization_scheduled_deletion_date
             )
+        state["realm_date_created"] = datetime_to_timestamp(realm.date_created)
 
         # Presence system parameters for client behavior.
         state["server_presence_ping_interval_seconds"] = settings.PRESENCE_PING_INTERVAL_SECS

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11093,6 +11093,11 @@ paths:
                           field values on individual user objects to display users' profiles.
                         items:
                           $ref: "#/components/schemas/CustomProfileField"
+                      realm_date_created:
+                        type: integer
+                        description: |
+                          The UNIX timestamp (UTC) when the organization was
+                          created.
                       custom_profile_field_types:
                         type: object
                         description: |

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -119,6 +119,7 @@ class HomeTest(ZulipTestCase):
         "realm_create_private_stream_policy",
         "realm_create_public_stream_policy",
         "realm_create_web_public_stream_policy",
+        "realm_date_created",
         "realm_default_code_block_language",
         "realm_default_external_accounts",
         "realm_default_language",


### PR DESCRIPTION
Fixes: #24122

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="1470" alt="Screenshot 2023-01-20 at 8 07 40 PM" src="https://user-images.githubusercontent.com/72064462/213736140-86bdd08a-b496-4727-bda3-4e93a0e07bf5.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
