### PR TITLE
help center: Document supporting Zulip and linking to the Zulip website.

### DIFF
--- a/help/communities-directory.md
+++ b/help/communities-directory.md
@@ -51,6 +51,8 @@ service.
 
 * [Create your organization profile](/help/create-your-organization-profile)
 * [Public access option](/help/public-access-option)
+* [Linking to the Zulip website](/help/linking-to-zulip-website)
+* [Support the Zulip project](/help/support-zulip-project)
 * [Restrict account creation](/help/restrict-account-creation)
 * [Moderating open organizations](/help/moderating-open-organizations)
 * [Organization type](/help/organization-type)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -211,4 +211,6 @@
 ## Support
 * [View Zulip version](/help/view-zulip-version)
 * [Zulip Cloud billing](/help/zulip-cloud-billing)
+* [Support the Zulip project](/help/support-zulip-project)
+* [Linking to the Zulip website](/help/linking-to-zulip-website)
 * [Contact support](/help/contact-support)

--- a/help/include/supporting-zulip-motivation.md
+++ b/help/include/supporting-zulip-motivation.md
@@ -1,0 +1,4 @@
+Zulip sponsors free [Zulip Cloud Standard](https://zulip.com/plans/) hosting for
+hundreds of worthy organizations. Zulip has also invested into making it as easy
+as possible to [self-host](https://zulip.com/self-hosting/) its [100%
+open-source](https://github.com/zulip/zulip#readme) software.

--- a/help/linking-to-zulip-website.md
+++ b/help/linking-to-zulip-website.md
@@ -1,0 +1,31 @@
+# Linking to the Zulip website
+
+{!supporting-zulip-motivation.md!}
+
+If your organization is sponsored by Zulip, or wishes to express appreciation
+for the Zulip project, please help others find out about Zulip. To do so, follow the
+guidelines below to list Zulip in the appropriate section of your organization's
+website (e.g., **Sponsors** or **Acknowledgements**).
+
+## Link to the Zulip website
+
+{start_tabs}
+
+1. Select a [Zulip
+   logo](https://github.com/zulip/zulip/tree/main/static/images/logo),
+   preferably a **round Zulip icon** (available in `.png` and `.svg` formats).
+
+1. Link to <https://zulip.com/>.
+
+2. If appropriate, add a brief description:
+
+   > Zulip is an open-source modern team chat app designed to keep both live and
+     asynchronous conversations organized.
+
+{end_tabs}
+
+## Related articles
+
+* [Support the Zulip project](/help/support-zulip-project)
+* [Linking to your Zulip organization](/help/linking-to-zulip)
+* [Zulip communities directory](/help/communities-directory)

--- a/help/linking-to-zulip.md
+++ b/help/linking-to-zulip.md
@@ -24,3 +24,4 @@ HTML
 ## Related articles
 
 * [Link to a message or conversation](/help/link-to-a-message-or-conversation)
+* [Linking to the Zulip website](/help/linking-to-zulip-website)

--- a/help/support-zulip-project.md
+++ b/help/support-zulip-project.md
@@ -1,0 +1,55 @@
+# Support the Zulip project
+
+{!supporting-zulip-motivation.md!}
+
+If you appreciate Zulip, here are some ways you can help support the Zulip
+project.
+
+## Support Zulip financially
+
+You can sponsor Zulip through the [GitHub sponsors
+program](https://github.com/sponsors/zulip) (preferred), on
+[Patreon](https://patreon.com/zulip), or on [Open
+Collective](https://opencollective.com/zulip).
+
+## Help others find Zulip
+
+* [Link to Zulip](/help/linking-to-zulip-website) from your organization's website.
+
+* [List your organization](/help/communities-directory) in the [Zulip communities
+  directory](https://zulip.com/communities/).
+
+* Star Zulip on GitHub. There are four main repositories:
+  [server/web](https://github.com/zulip/zulip),
+  [mobile](https://github.com/zulip/zulip-mobile),
+  [desktop](https://github.com/zulip/zulip-desktop), and
+  [Python API](https://github.com/zulip/python-zulip-api).
+
+* Review Zulip on product comparison websites, such as
+  [Capterra](https://reviews.capterra.com/new/197945)
+  and [G2](https://www.g2.com/products/zulip/take_survey).
+
+* Mention Zulip on social media, or like and retweet [Zulip's tweets](https://twitter.com/zulip).
+
+## Help improve Zulip
+
+* [Report
+  issues](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#reporting-issues),
+  including both feature requests and bug reports.
+
+* [Give
+  feedback](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#user-feedback)
+  if you are evaluating or using Zulip.
+
+* [Translate](https://zulip.readthedocs.io/en/latest/translating/translating.html)
+  Zulip into your language.
+
+* [Contribute
+  code](https://zulip.readthedocs.io/en/latest/contributing/contributing.html)
+  to the Zulip open-source project.
+
+## Related articles
+
+* [Linking to Zulip](/help/linking-to-zulip-website)
+* [Zulip communities directory](/help/communities-directory)
+* [Contact Zulip](/help/contact-support)


### PR DESCRIPTION
Notes:
- I debated between "Linking to" and "Link to", and decided that the former sounded better. It's also what we picked for linking to a Zulip organization.

Testing:
- Links were manually tested


<img width="819" alt="Screen Shot 2023-01-25 at 11 16 25 PM" src="https://user-images.githubusercontent.com/2090066/214778256-92aefd44-9af8-42e8-8c47-1add0c710c1d.png">
<img width="1160" alt="Screen Shot 2023-01-25 at 11 16 15 PM" src="https://user-images.githubusercontent.com/2090066/214778260-3ea77d08-977b-4d4d-b647-0e5ac3a68fb3.png">
