### PR TITLE
help: Improve relative settings links for documentation on bots.

### DIFF
--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -115,6 +115,15 @@ settings_markdown = """
 """
 
 
+def getMarkdown(setting_type_name: str, setting_name: str, setting_link: str) -> str:
+    if relative_settings_links:
+        return f"1. Go to [{setting_name}]({setting_link})."
+    return settings_markdown.format(
+        setting_type_name=setting_type_name,
+        setting_reference=f"**{setting_name}**",
+    )
+
+
 class SettingHelpExtension(Extension):
     def extendMarkdown(self, md: Markdown) -> None:
         """Add SettingHelpExtension to the Markdown instance."""
@@ -156,15 +165,7 @@ class Setting(Preprocessor):
 
     def handleMatch(self, match: Match[str]) -> str:
         setting_identifier = match.group("setting_identifier")
-        setting_type_name = link_mapping[setting_identifier][0]
-        setting_name = link_mapping[setting_identifier][1]
-        setting_link = link_mapping[setting_identifier][2]
-        if relative_settings_links:
-            return f"1. Go to [{setting_name}]({setting_link})."
-        return settings_markdown.format(
-            setting_type_name=setting_type_name,
-            setting_reference=f"**{setting_name}**",
-        )
+        return getMarkdown(*link_mapping[setting_identifier])
 
 
 def makeExtension(*args: Any, **kwargs: Any) -> SettingHelpExtension:

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -26,7 +26,7 @@ link_mapping = {
     ],
     "display-settings": ["Personal settings", "Display settings", "/#settings/display-settings"],
     "notifications": ["Personal settings", "Notifications", "/#settings/notifications"],
-    "your-bots": ["Personal settings", "your Bots", "/#settings/your-bots"],
+    "your-bots": ["Personal settings", "Bots", "/#settings/your-bots"],
     "alert-words": ["Personal settings", "Alert words", "/#settings/alert-words"],
     "uploaded-files": ["Personal settings", "Uploaded files", "/#settings/uploaded-files"],
     "muted-topics": ["Personal settings", "Muted topics", "/#settings/muted-topics"],
@@ -70,7 +70,7 @@ link_mapping = {
     ],
     "bot-list-admin": [
         "Organization settings",
-        "your organization's Bots",
+        "Bots",
         "/#organization/bot-list-admin",
     ],
     "default-streams-list": [
@@ -117,7 +117,13 @@ settings_markdown = """
 
 def getMarkdown(setting_type_name: str, setting_name: str, setting_link: str) -> str:
     if relative_settings_links:
-        return f"1. Go to [{setting_name}]({setting_link})."
+        relative_link = f"[{setting_name}]({setting_link})"
+        # The "Bots" label appears in both Personal and Organization settings
+        # in the user interface so we need special text for this setting.
+        if setting_name == "Bots":
+            return f"1. Navigate to the {relative_link} \
+                    tab of the **{setting_type_name}** menu."
+        return f"1. Go to {relative_link}."
     return settings_markdown.format(
         setting_type_name=setting_type_name,
         setting_reference=f"**{setting_name}**",


### PR DESCRIPTION
I noticed that some of the documentation on bots is not accurate, e.g. https://zulip.com/help/edit-a-bot:  
<img width="274" alt="image" src="https://user-images.githubusercontent.com/2343554/213845138-4f8f0be2-7021-47e4-ab2f-6709b4f5f3da.png">
<img width="302" alt="image" src="https://user-images.githubusercontent.com/2343554/213845144-ce590187-8776-4295-85ba-bde2a13f1b00.png">

due to the relative links to the **Bots** tab, e.g. https://chat.zulip.org/help/edit-a-bot:
<img width="232" alt="image" src="https://user-images.githubusercontent.com/2343554/214078671-dc9e4062-4cea-4ba6-b60d-f78c6dcdc4f1.png">
<img width="234" alt="image" src="https://user-images.githubusercontent.com/2343554/214078787-f04a444b-10ae-474f-8e81-75f10dd2fbee.png">

This PR fixes the documentation generated from the Markdown macros `{settings_tab|your-bots}` and `{settings_tab|bot-list-admin}` to match the text labels in the Zulip UI and improves the text of relative links to explicitly say if we are referring to the **Bots** tab of the **Personal** or **Organization** settings menu.

This PR does some refactoring in help_settings_links.py, making it easier to document special cases of Zulip menu settings, like tabs with the same name in both Personal and Organization settings.

 Follow-up to #23256.

**Screenshots and screen captures:**

<img width="493" alt="image" src="https://user-images.githubusercontent.com/2343554/213845001-e484ec5c-a8f7-4623-a986-5588b12481d1.png">

<img width="472" alt="image" src="https://user-images.githubusercontent.com/2343554/213845062-3aa39653-70ab-4b66-8397-544ded2694d0.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans.
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>