### PR TITLE
css: Fix positioning of text elements in message row without sender.

### DIFF
--- a/static/styles/message_row.css
+++ b/static/styles/message_row.css
@@ -1,5 +1,5 @@
 $avatar_column_width: 46px;
-$distance_of_text_elements_from_message_box_top: 10px;
+$distance_of_text_elements_from_message_box_top: 8.5px;
 $distance_of_non_text_elements_from_message_box_top: 6px;
 $sender_name_distance_below_flex_center: 3px;
 


### PR DESCRIPTION
When I changed the padding for message content in the PR which converted the message row to a grid, I forgot to adjust the position of edited and time elements.

<img width="1163" alt="Screenshot 2023-01-23 at 12 52 31 PM" src="https://user-images.githubusercontent.com/25124304/213985599-e1e17d37-83c3-455e-9d8c-879cd656e561.png">

after rebasing on #23696
<img width="1163" alt="Screenshot 2023-01-23 at 1 14 19 PM" src="https://user-images.githubusercontent.com/25124304/213988489-8326aa30-906c-42da-a659-d11a6af52b24.png">

