### PR TITLE
puppet: Do not start the "puppet" service.

### DIFF
--- a/puppet/zulip/manifests/profile/base.pp
+++ b/puppet/zulip/manifests/profile/base.pp
@@ -107,6 +107,12 @@ class zulip::profile::base {
     source => 'puppet:///modules/zulip/limits.conf',
   }
 
+  service { 'puppet':
+    ensure  => 'stopped',
+    enable  => 'false',
+    require => Package['puppet'],
+  }
+
   # This directory is written to by cron jobs for reading by Nagios
   file { '/var/lib/nagios_state/':
     ensure => directory,


### PR DESCRIPTION
Zulip runs puppet manually, using the command-line tool; it does not make use of the `puppet` service which, by default, attempts to contact a host named `puppet` every two minutes to get a manifest to apply.  These attempts can generate log spam and user confusion.

Disable and stop the `puppet` service via puppet.

----

Tested via applying in a test production host.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
