### PR TITLE
documentation: Clean up MarkdownDirectoryView `get_context` function.

### DIFF
--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -154,14 +154,14 @@ class MarkdownDirectoryView(ApiURLView):
             documentation_article.article_path
         ):
             # Absolute path case
-            article_path = documentation_article.article_path
+            article_absolute_path = documentation_article.article_path
         elif documentation_article.article_path.startswith("/"):
             # Hack: `context["article"] has a leading `/`, so we use + to add directories.
-            article_path = (
+            article_absolute_path = (
                 os.path.join(settings.DEPLOY_ROOT, "templates") + documentation_article.article_path
             )
         else:
-            article_path = os.path.join(
+            article_absolute_path = os.path.join(
                 settings.DEPLOY_ROOT, "templates", documentation_article.article_path
             )
 
@@ -190,8 +190,8 @@ class MarkdownDirectoryView(ApiURLView):
         # The following is a somewhat hacky approach to extract titles from articles.
         endpoint_name = None
         endpoint_method = None
-        if os.path.exists(article_path):
-            with open(article_path) as article_file:
+        if os.path.exists(article_absolute_path):
+            with open(article_absolute_path) as article_file:
                 first_line = article_file.readlines()[0]
             # Strip the header and then use the first line to get the article title
             if context["article"] == "/zerver/api/api-doc-template.md":

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -172,7 +172,7 @@ class MarkdownDirectoryView(ApiURLView):
             sidebar_article = self.get_path("include/sidebar_index")
             sidebar_index = sidebar_article.article_path
             title_base = "Zulip help center"
-        elif self.path_template == f"{settings.POLICIES_DIRECTORY}/%s.md":
+        elif self.policies_view:
             context["page_is_policy_center"] = True
             context["doc_root"] = "/policies/"
             context["doc_root_title"] = "Terms and policies"
@@ -193,7 +193,6 @@ class MarkdownDirectoryView(ApiURLView):
         if os.path.exists(article_absolute_path):
             with open(article_absolute_path) as article_file:
                 first_line = article_file.readlines()[0]
-            # Strip the header and then use the first line to get the article title
             if context["article"] == "/zerver/api/api-doc-template.md":
                 endpoint_name, endpoint_method = (
                     documentation_article.endpoint_path,
@@ -209,6 +208,7 @@ class MarkdownDirectoryView(ApiURLView):
                 endpoint_name, endpoint_method = get_endpoint_from_operationid(api_operation)
                 article_title = get_openapi_summary(endpoint_name, endpoint_method)
             else:
+                # Strip the header and then use the first line to get the article title
                 article_title = first_line.lstrip("#").strip()
                 endpoint_name = endpoint_method = None
             if not_index_page:

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -148,6 +148,8 @@ class MarkdownDirectoryView(ApiURLView):
 
         documentation_article = self.get_path(article)
         context["article"] = documentation_article.article_path
+        not_index_page = not context["article"].endswith("/index.md")
+
         if documentation_article.article_path.startswith("/") and os.path.exists(
             documentation_article.article_path
         ):
@@ -163,8 +165,6 @@ class MarkdownDirectoryView(ApiURLView):
                 settings.DEPLOY_ROOT, "templates", documentation_article.article_path
             )
 
-        # For disabling the "Back to home" on the homepage
-        context["not_index_page"] = not context["article"].endswith("/index.md")
         if self.path_template == "/zerver/help/%s.md":
             context["page_is_help_center"] = True
             context["doc_root"] = "/help/"
@@ -211,7 +211,7 @@ class MarkdownDirectoryView(ApiURLView):
             else:
                 article_title = first_line.lstrip("#").strip()
                 endpoint_name = endpoint_method = None
-            if context["not_index_page"]:
+            if not_index_page:
                 context["PAGE_TITLE"] = f"{article_title} | {title_base}"
             else:
                 context["PAGE_TITLE"] = title_base


### PR DESCRIPTION
Updates `get_context` function in `MarkdownDirectoryView` class:
- `not_index_page` is no longer added to the context dict because it hasn't been used in any documentation template/page for a while.
- Renames `article_path` to be `article_absolute_path` so that it no longer overlaps with the `DocumentationAritcle` dataclass `article_path` field.
- Uses `self.policies_view` boolean to check/set policy page context instead of the `self.template_path` value.
- Moves/removes comments that were no longer accurate/applicable.

Prep commit for #24038.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
