### PR TITLE
settings: Improve organization settings for bots

### DIFF
--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import render_admin_tab from "../templates/settings/admin_tab.hbs";
 import render_settings_organization_settings_tip from "../templates/settings/organization_settings_tip.hbs";
 
+import * as bot_data from "./bot_data";
 import {$t, get_language_name, language_list} from "./i18n";
 import {page_params} from "./page_params";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
@@ -201,6 +202,7 @@ export function build_page() {
         realm_enable_read_receipts: page_params.realm_enable_read_receipts,
         allow_sorting_deactivated_users_list_by_email:
             settings_users.allow_sorting_deactivated_users_list_by_email(),
+        has_bots: bot_data.get_all_bots_for_current_user().length > 0,
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -175,6 +175,7 @@ export function initialize() {
         show_uploaded_files_section: page_params.max_file_upload_size_mib > 0,
         show_emoji_settings_lock:
             !page_params.is_admin && page_params.realm_add_emoji_by_admins_only,
+        can_create_new_bots: settings_bots.can_create_new_bots(),
     });
     $("#settings_overlay_container").append(rendered_settings_overlay);
 }

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -3,7 +3,19 @@
     </div>
     <div class="clear-float"></div>
     <div>
-        <button class="button rounded sea-green add-a-new-bot {{#unless can_create_new_bots}}hide{{/unless}}">{{t "Add a new bot" }}</button>
+        {{t "You are viewing all the bots in this organization." }}
+        {{#if can_create_new_bots}}
+            {{#tr}}
+                You can <z-link-new-bot>add a new bot</z-link-new-bot> or <z-link-manage-bot>manage</z-link-manage-bot> your own bots.
+                {{#*inline "z-link-new-bot"}}<a class="add-a-new-bot">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link-manage-bot"}}<a href="/#settings/your-bots">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        {{else if has_bots}}
+            {{#tr}}
+                You can <z-link>manage</z-link> your own bots.
+                {{#*inline "z-link"}}<a href="/#settings/your-bots">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        {{/if}}
     </div>
     <div class="settings_panel_list_header">
         <h3>{{t "Bots"}}</h3>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -127,7 +127,7 @@
                     <li tabindex="0" data-section="bot-list-admin">
                         <i class="icon zulip-icon zulip-icon-smart-toy" aria-hidden="true"></i>
                         <div class="text">{{t "Bots" }}</div>
-                        {{#unless is_admin}}
+                        {{#unless can_create_new_bots}}
                         <i class="locked fa fa-lock" title="{{t 'Only organization administrators can edit these settings.' }}"></i>
                         {{/unless}}
                     </li>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This avoids some confusion around how users might feel about the permission they have for bots when viewing the org settings for bots.

Fixes: #24154<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

## Admin

![583e646271330982a822027b2818fd9](https://user-images.githubusercontent.com/39874143/214427964-09a1f100-824d-47d2-a343-d3a5c482e61d.png)
![584188c3ab09db296712bea4645d45a](https://user-images.githubusercontent.com/39874143/214427975-b8c0d49e-3834-467b-9254-8842e2ee724d.png)

## Non-admin (can add bots)

![image](https://user-images.githubusercontent.com/39874143/214429317-9bba7bb1-f5fa-436d-9e59-25efe141d8d0.png)

## Non-admin (cannot add bots)

![image](https://user-images.githubusercontent.com/39874143/214429187-095018c4-702e-4b74-b5cb-f779ebe5cb51.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
