### PR TITLE
help: Move "Admins only" banner in "Deactivate or reactivate a bot".

### DIFF
--- a/help/deactivate-or-reactivate-a-bot.md
+++ b/help/deactivate-or-reactivate-a-bot.md
@@ -1,7 +1,5 @@
 # Deactivate or reactivate a bot
 
-{!admin-only.md!}
-
 By default, users can deactivate and reactivate the bots that they
 add. Organization admins can prevent users from reactivating bots by
 [restricting bot creation](/help/restrict-bot-creation).
@@ -28,6 +26,8 @@ bot, regardless of who owns them.
     scroll down to the bottom, and click **Deactivate bot**.
 
 {tab|via-organization-settings}
+
+{!admin-only.md!}
 
 {settings_tab|bot-list-admin}
 
@@ -58,6 +58,8 @@ bot, regardless of who owns them.
 1. Approve by clicking **Confirm**.
 
 {tab|via-organization-settings}
+
+{!admin-only.md!}
 
 {settings_tab|bot-list-admin}
 


### PR DESCRIPTION
Moves the "Admins only" banner from the top of the page to the "Via organization settings" instruction tabs.

**Screenshots and screen captures:**

<img width="672" alt="image" src="https://user-images.githubusercontent.com/2343554/214465775-74ff8e85-7d8d-4585-8619-fa0164f8cbce.png">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>
