### PR TITLE
recent_conversations: Keep filters in sync with local storage.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -104,15 +104,6 @@ export function save_filters() {
     ls.set(ls_key, Array.from(filters));
 }
 
-export function load_filters() {
-    if (!page_params.is_spectator) {
-        // A user may have a stored filter and can log out
-        // to see web public view. This ensures no filters are
-        // selected for spectators.
-        filters = new Set(ls.get(ls_key));
-    }
-}
-
 export function set_default_focus() {
     // If at any point we are confused about the currently
     // focused element, we switch focus to search.
@@ -792,8 +783,6 @@ export function complete_rerender() {
         return;
     }
 
-    // Update header
-    load_filters();
     show_selected_filters();
 
     // Show topics list
@@ -1224,4 +1213,14 @@ export function change_focused_element($elt, input_key) {
     }
 
     return false;
+}
+
+export function initialize() {
+    // load filters from local storage.
+    if (!page_params.is_spectator) {
+        // A user may have a stored filter and can log out
+        // to see web public view. This ensures no filters are
+        // selected for spectators.
+        filters = new Set(ls.get(ls_key));
+    }
 }

--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -783,8 +783,6 @@ export function complete_rerender() {
         return;
     }
 
-    show_selected_filters();
-
     // Show topics list
     const mapped_topic_values = Array.from(get().values()).map((value) => value);
 
@@ -802,6 +800,13 @@ export function complete_rerender() {
         is_spectator: page_params.is_spectator,
     });
     $("#recent_topics_table").html(rendered_body);
+
+    // `show_selected_filters` needs to be called after the Recent
+    // Conversations view has been added to the DOM, to ensure that filters
+    // have the correct classes (checked or not) if Recent Conversations
+    // was not the first view loaded in the app.
+    show_selected_filters();
+
     const $container = $("#recent_topics_table table tbody");
     $container.empty();
     topics_widget = ListWidget.create($container, mapped_topic_values, {

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -65,6 +65,7 @@ import * as presence from "./presence";
 import * as realm_logo from "./realm_logo";
 import * as realm_playground from "./realm_playground";
 import * as realm_user_settings_defaults from "./realm_user_settings_defaults";
+import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload from "./reload";
 import * as rendered_markdown from "./rendered_markdown";
@@ -613,6 +614,7 @@ export function initialize_everything() {
 
     realm_logo.initialize();
     message_lists.initialize();
+    recent_topics_ui.initialize();
     alert_words.initialize(alert_words_params);
     emojisets.initialize();
     scroll_bar.initialize();


### PR DESCRIPTION
It is possible to get filter in a weird state if the user has multiple chrome tabs with Zulip open and the user changes filters for recent conversations in any one of them.

Quoting the bug reported by Lauryn Menard:
The key is having two tabs open in the same browser, which I do on occasion when I'm looking through discussions I've pulled up in a filtered/search view. And in doing so, I'll occasionally navigate back to Recent Conversations and filter the view in my non-pinned tab. When I close that extra tab and go back to using Zulip in my pinned tab, I will get into a state where Recent Conversations doesn't show the checked filters and I'm left wondering why there are no messages shown when no filters are shown as checked.

Steps to reproduce:
1. Open two tabs for the same user in a browser (I can reproduce in Chrome and Firefox) and have both in Recent Conversations
2. Filter one tab (A) for "Unread"
3. Go to the other tab (B), switch to a narrowed view (Starred messages or Private messages) and then back to Recent Conversations
4. The Recent Conversations view in tab B will be filtered for what you set in tab A, but the filter checkbox won't be checked. It will be the slightly gray color that indicates it's selected.
5. If you now filter tab B, for "Participated", then the filters will update to show both "Unread" and "Participated" as checked.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/recent.20conversations.20filter.20checkboxes