### PR TITLE
email_log: Override rate limit rules to resolve AssertionErrors.

### DIFF
--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -18,9 +18,8 @@ from zerver.lib.rate_limiter import (
     RateLimitedIPAddr,
     RateLimitedUser,
     RateLimiterLockingError,
-    add_ratelimit_rule,
     get_tor_ips,
-    remove_ratelimit_rule,
+    rate_limit_rule,
 )
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.zephyr import compute_mit_user_fullname
@@ -74,18 +73,6 @@ class MITNameTest(ZulipTestCase):
     def test_notmailinglist(self) -> None:
         with mock.patch("DNS.dnslookup", return_value=[["POP IMAP.EXCHANGE.MIT.EDU starnine"]]):
             email_is_not_mit_mailing_list("sipbexch@mit.edu")
-
-
-@contextmanager
-def rate_limit_rule(range_seconds: int, num_requests: int, domain: str) -> Iterator[None]:
-    RateLimitedIPAddr("127.0.0.1", domain=domain).clear_history()
-    add_ratelimit_rule(range_seconds, num_requests, domain=domain)
-    try:
-        yield
-    finally:
-        # We need this in a finally block to ensure the test cleans up after itself
-        # even in case of failure, to avoid polluting the rules state.
-        remove_ratelimit_rule(range_seconds, num_requests, domain=domain)
 
 
 class RateLimitTests(ZulipTestCase):

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -263,6 +263,16 @@ class RateLimitedObjectsTest(ZulipTestCase):
         # Reverts back to the empty rules edge case
         self.assertEqual(obj.get_rules(), [(1, 9999)])
 
+    def test_rate_limit_rule_exclusive(self) -> None:
+        user_profile = self.example_user("hamlet")
+        obj = RateLimitedUser(user_profile, domain="test_decorator_exclusive")
+
+        add_ratelimit_rule(4, 5, domain="test_decorator_exclusive")
+        with rate_limit_rule(3, 3, domain="test_decorator_exclusive", exclusive=True):
+            self.assertEqual(obj.get_rules(), [(3, 3)])
+
+        self.assertEqual(obj.get_rules(), [(4, 5)])
+
 
 # Don't load the base class as a test: https://bugs.python.org/issue17519.
 del RateLimiterBackendBase

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -12,6 +12,7 @@ from zerver.lib.rate_limiter import (
     RedisRateLimiterBackend,
     TornadoInMemoryRateLimiterBackend,
     add_ratelimit_rule,
+    rate_limit_rule,
     remove_ratelimit_rule,
 )
 from zerver.lib.test_classes import ZulipTestCase
@@ -250,6 +251,16 @@ class RateLimitedObjectsTest(ZulipTestCase):
 
     def test_empty_rules_edge_case(self) -> None:
         obj = RateLimitedTestObject("test", rules=[], backend=RedisRateLimiterBackend)
+        self.assertEqual(obj.get_rules(), [(1, 9999)])
+
+    def test_rate_limit_rule(self) -> None:
+        user_profile = self.example_user("hamlet")
+        obj = RateLimitedUser(user_profile, domain="test_decorator")
+
+        with rate_limit_rule(3, 3, domain="test_decorator"):
+            self.assertEqual(obj.get_rules(), [(3, 3)])
+
+        # Reverts back to the empty rules edge case
         self.assertEqual(obj.get_rules(), [(1, 9999)])
 
 

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -273,6 +273,21 @@ class RateLimitedObjectsTest(ZulipTestCase):
 
         self.assertEqual(obj.get_rules(), [(4, 5)])
 
+    def test_rate_limit_rule_preserves_redundancies(self) -> None:
+        user_profile = self.example_user("hamlet")
+        obj = RateLimitedUser(user_profile, domain="test_decorator_redundancies")
+
+        add_ratelimit_rule(4, 5, domain="test_decorator_redundancies")
+        with rate_limit_rule(4, 5, domain="test_decorator_redundancies", exclusive=False):
+            self.assertEqual(obj.get_rules(), [(4, 5)])
+
+        self.assertEqual(obj.get_rules(), [(4, 5)])
+
+        with rate_limit_rule(4, 5, domain="test_decorator_redundancies", exclusive=True):
+            self.assertEqual(obj.get_rules(), [(4, 5)])
+
+        self.assertEqual(obj.get_rules(), [(4, 5)])
+
 
 # Don't load the base class as a test: https://bugs.python.org/issue17519.
 del RateLimiterBackendBase


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes a regression introduced in 0cfb156545 and [reported by @alya today](https://chat.zulip.org/#narrow/stream/49-development-help/topic/error.20generating.20emails/near/1496308) where `/emails/generate` throws an `AssertionError` in Vagrant environments due to the Django test client being rate limited on three domains. Dev environments are meant to be exempt from such rate limiting, but due to REMOTE_ADDR being something other than 127.0.0.1 or ::1 in these environments, they are not. This endpoint is a bit special in how many rules it needs to break, and so rather than casting a wide net trying to hack 172.17.0.0 address spaces (and who knows how many others) into being considered local, with likely unwanted side effects, just edge case this particular endpoint.

In support of this, one feature addition and one bug fix were done to `@rate_limit_rule`, formerly a test-only decorator now repurposed, and tests for that decorator were written. See commit messages and code docstrings for details.

I'd have liked to write a unit test verifying that this won't regress again in the future, but the test I wrote does not fail against current `main`, so it's been excluded. I assume there's some bits of plumbing I'm missing to actually repro the `AssertionError` in a test environment: I tried overriding with `with self.settings(DEBUG_RATE_LIMITING=False): ...` as well as by passing `REMOTE_ADDR="172.17.0.2"` as a kwarg to `self.client_get()` in `test_email_log.py`, neither worked and I gave up for now.

Also interesting, passing `REMOTE_ADDR="127.0.0.1"` to the Django test client instantiated in the endpoint does not resolve the issue despite the localhost checks I found in the rate limiter file (though didn't examine deeply): the logs correctly change IPs from my Docker/Vagrant IP to `127.0.0.1`, but the requests are still rate limited, thus the more complex solution with `@rate_limit_rule` here.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
