### PR TITLE
settings: Fix upgrade-banner for narrow width screens.

### DIFF
--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -523,10 +523,11 @@ div.overlay {
 
 .upgrade-tip,
 .upgrade-or-sponsorship-tip {
-    width: max-content;
+    width: fit-content;
 
     &::before {
         content: "\f135";
+        margin-right: 6px;
     }
 }
 
@@ -554,7 +555,6 @@ div.overlay {
 
     &::before {
         display: inline;
-        margin-right: 8px;
 
         font-family: FontAwesome;
         font-weight: 600;
@@ -563,6 +563,7 @@ div.overlay {
 
 .tip::before {
     content: "\f0a2";
+    margin-right: 8px;
 }
 
 /* We are mostly consistent in how we style


### PR DESCRIPTION
The upgrade banner was being clipped for narrow width screens and was only partially visible. This commit changes it to instead wrap the content such that complete content is visible on the screen.

We also decrease the right margin for icon in the banner such that the text of the banner fits in one line for at least normal screen size and zoom in stream settings overlay.

Reported here - https://chat.zulip.org/#narrow/stream/9-issues/topic/banner.20in.20create.20stream.20UI

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Org settings -
![org-settings-upgrade](https://user-images.githubusercontent.com/35494118/214787272-71ae9db2-59d7-47f0-9bd5-192803546111.gif)

Stream create UI -
![stream-create-upgrade](https://user-images.githubusercontent.com/35494118/214787203-917a129f-88ce-4707-be9a-4a39f1b929b9.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
