### PR TITLE
css: Fix long name overflow in user profile modal.

### DIFF
--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -50,10 +50,22 @@
     font-size: 1.375rem;
     font-weight: 600;
     line-height: 1.25;
+    display: flex;
 
     /* help_link_widget margin for the fa-circle-o. */
     .help_link_widget {
         margin-left: 5px;
+    }
+}
+
+.user_profile_name_heading {
+    padding-right: 1rem;
+    max-width: 80%;
+
+    .user_profile_name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }
 

--- a/static/templates/user_profile_modal.hbs
+++ b/static/templates/user_profile_modal.hbs
@@ -5,8 +5,8 @@
                 <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">
                     <span class="{{user_circle_class}} user_circle user_profile_presence"></span>
                 </div>
-                <h1 class="modal__title" id="name">
-                    {{full_name}}
+                <h1 class="modal__title user_profile_name_heading" id="name">
+                    <span class="user_profile_name">{{full_name}}</span>
                     {{#if is_bot}}
                     <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                     {{/if}}


### PR DESCRIPTION
Fixes: #23781.

Set width of the div tag displaying name of the user, which enables the ellipsis property on text overflow, without pushing the edit icon next to the name off the user profile modal.

The width is set on the basis of different breakpoints, which makes it responsive, for all screen sizes.

**Screenshots:**

![Long name](https://user-images.githubusercontent.com/96468766/215077451-dc05ae33-831c-4d04-a764-767b2edc466d.png)

**Different screen sizes -**

![device1](https://user-images.githubusercontent.com/96468766/215077485-25353271-c059-4438-9acb-cd9800a6dc3d.png)

![device2](https://user-images.githubusercontent.com/96468766/215077540-6b2f0695-27d2-4870-890f-1c027751516c.png)

![device3](https://user-images.githubusercontent.com/96468766/215077568-f113f9d6-bb5e-470c-b7da-ddb737d565b7.png)

![device4](https://user-images.githubusercontent.com/96468766/215077589-00f9085d-e9a0-4038-a7d4-a336959235a2.png)

![device5](https://user-images.githubusercontent.com/96468766/215077631-fe902ea9-10a6-492f-9141-1a7c803c3d70.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
