### PR TITLE
Minor prep changes for rechecking User notification settings again just before sending notifications

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -264,12 +264,11 @@ def get_recipient_info(
         }
 
         if possible_wildcard_mention:
-            # If there's a possible wildcard mention, we need to
-            # determine the set of users who have enabled the
-            # "wildcard_mentions_notify" setting (that is, the set of
-            # users for whom wildcard mentions should be treated like
-            # personal mentions for notifications). This setting
-            # applies to both email and push notifications.
+            # We calculate `wildcard_mention_user_ids` only if there's a possible
+            # wildcard mention in the message. This is important so as to avoid
+            # unnecessarily sending huge user ID lists with thousands of elements
+            # to the event queue (which can happen because this setting is `True`
+            # by default for new users.)
             wildcard_mention_user_ids = {
                 row["user_profile_id"]
                 for row in subscription_rows

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -174,6 +174,25 @@ class UserMessageNotificationsData:
             return None
 
 
+def user_allows_notifications_in_StreamTopic(
+    stream_is_muted: bool,
+    topic_is_muted: bool,
+    stream_specific_setting: Optional[bool],
+    global_setting: bool,
+) -> bool:
+    """
+    Captures the hierarchy of notification settings, where muting is considered first, followed
+    by stream-specific settings, and the global-setting in the UserProfile is the fallback.
+    """
+    if stream_is_muted or topic_is_muted:
+        return False
+
+    if stream_specific_setting is not None:
+        return stream_specific_setting
+
+    return global_setting
+
+
 def get_user_group_mentions_data(
     mentioned_user_ids: Set[int], mentioned_user_group_ids: List[int], mention_data: MentionData
 ) -> Dict[int, int]:


### PR DESCRIPTION
Part of #19451

These are small refactors for the main change, which is still draft and I have pushed to another branch on my fork: https://github.com/abhijeetbodas2001/zulip/commit/7276b8a14e1ae53cdfccfcf0fb51eaa81d9576a4
That will result in test failures, so I didn't push it here yet. But would be great to have a (atleast higher-level) review on that as well!