### PR TITLE
Bots permission

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -4,6 +4,7 @@ import $ from "jquery";
 import render_settings_deactivation_bot_modal from "../templates/confirm_dialog/confirm_deactivate_bot.hbs";
 import render_add_new_bot_form from "../templates/settings/add_new_bot_form.hbs";
 import render_bot_avatar_row from "../templates/settings/bot_avatar_row.hbs";
+import render_bot_settings_tip from "../templates/settings/bot_settings_tip.hbs";
 import render_edit_bot_form from "../templates/settings/edit_bot_form.hbs";
 import render_settings_edit_embedded_bot_service from "../templates/settings/edit_embedded_bot_service.hbs";
 import render_settings_edit_outgoing_webhook_service from "../templates/settings/edit_outgoing_webhook_service.hbs";
@@ -157,30 +158,23 @@ export function can_create_new_bots() {
 }
 
 export function update_bot_settings_tip() {
-    const permission_type = bot_creation_policy_values;
-    let tip_text;
+    const rendered_tip = render_bot_settings_tip({
+        realm_bot_creation_policy: page_params.realm_bot_creation_policy,
+        permission_type: bot_creation_policy_values,
+    });
 
-    if (!can_create_new_bots()) {
-        // This policy doesn't currently support restricting by role
-        // beyond just requiring an administrator.
-        tip_text = $t({
-            defaultMessage: "Only organization administrators can add bots to this organization.",
-        });
-    } else if (
-        page_params.realm_bot_creation_policy === permission_type.restricted.code &&
-        !page_params.is_admin
-    ) {
-        // We arguably need a tip for restrictions on bot type even if you can create bots.
-        // Probably it would be better to have two independent permission settings, but
-        // this is the model we have.
-        tip_text = $t({defaultMessage: "Only organization administrators can add generic bots."});
-    } else {
-        $(".bot-settings-tip").hide();
+    $(".bot-settings-tip").html(rendered_tip);
+    $("#personal-bot-settings-tip").hide();
+
+    if (page_params.is_admin) {
         return;
     }
 
+    if (page_params.realm_bot_creation_policy === bot_creation_policy_values.everyone.code) {
+        $("#admin-bot-settings-tip").hide();
+        return;
+    }
     $(".bot-settings-tip").show();
-    $(".bot-settings-tip").text(tip_text);
 }
 
 function update_add_bot_button() {

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -158,17 +158,28 @@ export function can_create_new_bots() {
 
 export function update_bot_settings_tip() {
     const permission_type = bot_creation_policy_values;
-    const current_permission = page_params.realm_bot_creation_policy;
     let tip_text;
-    if (current_permission === permission_type.admins_only.code) {
+
+    if (!can_create_new_bots()) {
+        // This policy doesn't currently support restricting by role
+        // beyond just requiring an administrator.
         tip_text = $t({
             defaultMessage: "Only organization administrators can add bots to this organization.",
         });
-    } else if (current_permission === permission_type.restricted.code) {
+    } else if (
+        page_params.realm_bot_creation_policy === permission_type.restricted.code &&
+        !page_params.is_admin
+    ) {
+        // We arguably need a tip for restrictions on bot type even if you can create bots.
+        // Probably it would be better to have two independent permission settings, but
+        // this is the model we have.
         tip_text = $t({defaultMessage: "Only organization administrators can add generic bots."});
     } else {
-        tip_text = $t({defaultMessage: "Anyone in this organization can add bots."});
+        $(".bot-settings-tip").hide();
+        return;
     }
+
+    $(".bot-settings-tip").show();
     $(".bot-settings-tip").text(tip_text);
 }
 

--- a/static/templates/settings/bot_list_admin.hbs
+++ b/static/templates/settings/bot_list_admin.hbs
@@ -1,5 +1,7 @@
 <div id="admin-bot-list" class="settings-section" data-name="bot-list-admin">
-    <div class="tip bot-settings-tip"></div>
+    <div class="bot-settings-tip" id="admin-bot-settings-tip">
+        {{> bot_settings_tip}}
+    </div>
     <div class="clear-float"></div>
     <div>
         <button class="button rounded sea-green add-a-new-bot {{#unless can_create_new_bots}}hide{{/unless}}">{{t "Add a new bot" }}</button>

--- a/static/templates/settings/bot_settings.hbs
+++ b/static/templates/settings/bot_settings.hbs
@@ -8,7 +8,9 @@
                 {{#*inline "z-api"}}<a href="/api" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </div>
-        <div class="tip bot-settings-tip"></div>
+        <div class="bot-settings-tip" id="personal-bot-settings-tip">
+            {{> bot_settings_tip}}
+        </div>
         <div>
             <button class="button rounded sea-green add-a-new-bot {{#unless can_create_new_bots}}hide{{/unless}}">{{t "Add a new bot" }}</button>
         </div>

--- a/static/templates/settings/bot_settings_tip.hbs
+++ b/static/templates/settings/bot_settings_tip.hbs
@@ -1,0 +1,7 @@
+{{#if (eq realm_bot_creation_policy permission_type.admins_only.code)}}
+    <div class='tip'>{{t "Only organization administrators can add bots to this organization." }}</div>
+{{else if (eq realm_bot_creation_policy permission_type.restricted.code) }}
+    <div class='tip'>{{t "Only organization administrators can add generic bots." }}</div>
+{{else}}
+    <div class='tip'>{{t "Anyone in this organization can bots." }}</div>
+{{/if}}


### PR DESCRIPTION
The PR improves the bot permission UI tip for both `Organisation -> Bots` and `Personal -> Bots`. As reported here https://github.com/zulip/zulip/issues/24259 for user groups. Now, for `Organisation -> Bots` the tip banner is always visible to admin and only to non-admin when they do not have the required permission.

Fixes: #24155

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

1. If Administrators/moderators have the permissions to add bots -
![image](https://user-images.githubusercontent.com/81819156/215100776-9d71c124-514d-4c29-9b48-3ee003c06512.png)

2. For normal users (if they don't have the permission) - 
![image](https://user-images.githubusercontent.com/81819156/215101186-7d71fdab-8310-4a25-8ffa-10da60f821bd.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
