### PR TITLE
popover: Adding top margin to fix avatar visibility in user profile

### DIFF
--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -404,7 +404,7 @@ ul {
         background-position: center;
         border-radius: 5px;
         box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.2);
-        margin-top: 5px;
+        margin-top: 1px;
 
         &.guest-avatar::after {
             outline: 9px solid hsl(0, 0%, 100%);

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -404,6 +404,7 @@ ul {
         background-position: center;
         border-radius: 5px;
         box-shadow: 0 0 0 1px hsla(0, 0%, 0%, 0.2);
+        margin-top: 5px;
 
         &.guest-avatar::after {
             outline: 9px solid hsl(0, 0%, 100%);


### PR DESCRIPTION
Fixes: #24210 Fixed the Avatar by adding a top margin in the CSS.



Before :
 
<img width="258" alt="215230140-9f51110c-f46c-4c3b-bf46-9dbf45fb820a" src="https://user-images.githubusercontent.com/84705984/215280636-fa128fda-03ee-4449-8dc3-e80ad299dbb4.png">



After : 
<img width="219" alt="Screenshot 2023-01-28 at 10 54 03 PM" src="https://user-images.githubusercontent.com/84705984/215280365-b01adcd3-a407-463a-a759-0cd91e6ce3fa.png">
