### PR TITLE
update run-dev.py to ./tools/run-dev.py in documentation

### DIFF
--- a/docs/development/setup-recommended.md
+++ b/docs/development/setup-recommended.md
@@ -450,7 +450,7 @@ automatically whenever you commit).
 
 #### Understanding run-dev.py debugging output
 
-It's good to have the terminal running `run-dev.py` up as you work since error
+It's good to have the terminal running `./tools/run-dev.py` up as you work since error
 messages including tracebacks along with every backend request will be printed
 there.
 


### PR DESCRIPTION
Issue reference: https://chat.zulip.org/#narrow/stream/19-documentation/topic/run-dev.2Epy.20section.20in.20recommended.20set-up.20docs/near/1495833
<!-- Describe your pull request here.-->

Fixes: Updated documentation to consistently use ./tools/run-dev.py instead of run-dev.py
![image](https://user-images.githubusercontent.com/91288069/215283853-ca39e1cc-679c-4dca-bac6-347a71436a7c.png)