### PR TITLE
stream_settings: Add an option to make a stream default for new users in stream creation and editing UIs.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 200**
+
+* [`PATCH /streams/{stream_id}`](/api/update-stream): Added
+  `is_default_stream` parameter to add or remove the stream as a default
+  stream for new users.
+
 **Feature level 199**
 
 * [`POST /register`](/api/register-queue), [`GET /events`][/api/get-events],

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -23,8 +23,11 @@ format used by the Zulip server that they are interacting with.
 **Feature level 200**
 
 * [`PATCH /streams/{stream_id}`](/api/update-stream): Added
-  `is_default_stream` parameter to add or remove the stream as a default
-  stream for new users.
+  `is_default_stream` parameter to change whether the stream is a
+  default stream for new users in the organization.
+* [`POST /users/me/subscriptions`](/api/subscribe): Added
+  `is_default_stream` parameter which determines whether any streams
+  created by this request will be default streams for new users.
 
 **Feature level 199**
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 199
+API_FEATURE_LEVEL = 200
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -102,6 +102,7 @@ export function dispatch_normal_event(event) {
         case "default_streams":
             stream_data.set_realm_default_streams(event.default_streams);
             settings_streams.update_default_streams_table();
+            stream_settings_ui.update_is_default_stream();
             break;
 
         case "delete_message": {

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -168,6 +168,9 @@ function get_property_value(property_name, for_realm_default_settings, sub) {
         if (property_name === "stream_privacy") {
             return stream_data.get_stream_privacy_policy(sub.stream_id);
         }
+        if (property_name === "is_default_stream") {
+            return stream_data.is_default_stream_id(sub.stream_id);
+        }
 
         return sub[property_name];
     }

--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -217,6 +217,9 @@ function create_stream() {
     data.invite_only = JSON.stringify(invite_only);
     data.history_public_to_subscribers = JSON.stringify(history_public_to_subscribers);
 
+    const default_stream = $("#stream_creation_form .is_default_stream").prop("checked");
+    data.is_default_stream = JSON.stringify(default_stream);
+
     const stream_post_policy = Number.parseInt(
         $("#stream_creation_form select[name=stream-post-policy]").val(),
         10,
@@ -370,8 +373,10 @@ export function show_new_stream_modal() {
         true,
     );
 
-    // set default state for "announce stream" option.
+    // set default state for "announce stream" and "default stream" option.
+    $("#stream_creation_form .default-stream input").prop("checked", false);
     update_announce_stream_state();
+    stream_ui_updates.update_default_stream_and_stream_privacy_state($("#stream-creation"));
     clear_error_display();
 }
 
@@ -381,7 +386,14 @@ export function set_up_handlers() {
 
     const $container = $("#stream-creation").expectOne();
 
-    $container.on("change", ".stream-privacy-values input", update_announce_stream_state);
+    $container.on("change", ".stream-privacy-values input", () => {
+        update_announce_stream_state();
+        stream_ui_updates.update_default_stream_and_stream_privacy_state($container);
+    });
+
+    $container.on("change", ".default-stream input", () => {
+        stream_ui_updates.update_default_stream_and_stream_privacy_state($container);
+    });
 
     $container.on("click", ".finalize_create_stream", (e) => {
         e.preventDefault();

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -247,6 +247,7 @@ export function show_settings_for(node) {
         stream_post_policy_values: stream_data.stream_post_policy_values,
         stream_privacy_policy_values: stream_data.stream_privacy_policy_values,
         stream_privacy_policy: stream_data.get_stream_privacy_policy(stream_id),
+        check_default_stream: stream_data.is_default_stream_id(stream_id),
         zulip_plan_is_not_limited: page_params.zulip_plan_is_not_limited,
         upgrade_text_for_wide_organization_logo:
             page_params.upgrade_text_for_wide_organization_logo,
@@ -679,6 +680,9 @@ export function initialize() {
         const sub = sub_store.get(stream_id);
         const $subsection = $(e.target).closest(".settings-subsection-parent");
         settings_org.save_discard_widget_status_handler($subsection, false, sub);
+        if (sub) {
+            stream_ui_updates.update_default_stream_and_stream_privacy_state($subsection);
+        }
         return true;
     });
 
@@ -714,6 +718,7 @@ export function initialize() {
             for (const elem of settings_org.get_subsection_property_elements($subsection)) {
                 settings_org.discard_property_element_changes(elem, false, sub);
             }
+            stream_ui_updates.update_default_stream_and_stream_privacy_state($subsection);
             const $save_btn_controls = $(e.target).closest(".save-button-controls");
             settings_org.change_save_button_state($save_btn_controls, "discarded");
         },

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -717,6 +717,7 @@ export function setup_page(callback) {
             stream_privacy_policy_values: stream_data.stream_privacy_policy_values,
             stream_privacy_policy,
             stream_post_policy_values: stream_data.stream_post_policy_values,
+            check_default_stream: false,
             zulip_plan_is_not_limited: page_params.zulip_plan_is_not_limited,
             org_level_message_retention_setting:
                 stream_edit.get_display_text_for_realm_message_retention_setting(),

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -250,6 +250,14 @@ export function update_can_remove_subscribers_group_id(sub, new_value) {
     stream_edit_subscribers.rerender_subscribers_list(sub);
 }
 
+export function update_is_default_stream() {
+    const active_stream_id = get_active_data().id;
+    if (active_stream_id) {
+        const sub = sub_store.get(active_stream_id);
+        stream_ui_updates.update_setting_element(sub, "is_default_stream");
+    }
+}
+
 export function set_color(stream_id, color) {
     const sub = sub_store.get(stream_id);
     stream_edit.set_stream_property(sub, "color", color);
@@ -1156,7 +1164,7 @@ export function update_public_stream_privacy_option_state($container) {
     $public_stream_elem.prop("disabled", !settings_data.user_can_create_public_streams());
 }
 
-export function update_private_stream_privacy_option_state($container) {
+export function update_private_stream_privacy_option_state($container, is_default_stream = false) {
     // Disable both "Private, shared history" and "Private, protected history" options.
     const $private_stream_elem = $container.find(
         `input[value='${CSS.escape(stream_data.stream_privacy_policy_values.private.code)}']`,
@@ -1167,11 +1175,18 @@ export function update_private_stream_privacy_option_state($container) {
         )}']`,
     );
 
-    $private_stream_elem.prop("disabled", !settings_data.user_can_create_private_streams());
-    $private_with_public_history_elem.prop(
-        "disabled",
-        !settings_data.user_can_create_private_streams(),
-    );
+    const disable_private_stream_options =
+        is_default_stream || !settings_data.user_can_create_private_streams();
+
+    $private_stream_elem.prop("disabled", disable_private_stream_options);
+    $private_with_public_history_elem.prop("disabled", disable_private_stream_options);
+
+    $private_stream_elem
+        .closest("div")
+        .toggleClass("default_stream_private_tooltip", is_default_stream);
+    $private_with_public_history_elem
+        .closest("div")
+        .toggleClass("default_stream_private_tooltip", is_default_stream);
 }
 
 export function hide_or_disable_stream_privacy_options_if_required($container) {

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -115,6 +115,15 @@ export function update_regular_sub_settings(sub) {
 
 export function update_default_stream_and_stream_privacy_state($container) {
     const $default_stream = $container.find(".default-stream");
+    const is_stream_creation = $container.attr("id") === "stream-creation";
+
+    // In the stream creation UI, if the user is a non-admin hide the
+    // "Default stream for new users" widget
+    if (is_stream_creation && !page_params.is_admin) {
+        $default_stream.hide();
+        return;
+    }
+
     const privacy_type = $container.find("input[type=radio][name=privacy]:checked").val();
     const is_invite_only =
         privacy_type === "invite-only" || privacy_type === "invite-only-public-history";

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -113,6 +113,24 @@ export function update_regular_sub_settings(sub) {
     }
 }
 
+export function update_default_stream_and_stream_privacy_state($container) {
+    const $default_stream = $container.find(".default-stream");
+    const privacy_type = $container.find("input[type=radio][name=privacy]:checked").val();
+    const is_invite_only =
+        privacy_type === "invite-only" || privacy_type === "invite-only-public-history";
+
+    // If a private stream option is selected, the default stream option is disabled.
+    $default_stream.find("input").prop("disabled", is_invite_only);
+    $default_stream.toggleClass(
+        "control-label-disabled default_stream_private_tooltip",
+        is_invite_only,
+    );
+
+    // If the default stream option is checked, the private stream options are disabled.
+    const is_default_stream = $default_stream.find("input").prop("checked");
+    stream_settings_ui.update_private_stream_privacy_option_state($container, is_default_stream);
+}
+
 export function enable_or_disable_permission_settings_in_edit_panel(sub) {
     if (!hash_util.is_editing_stream(sub.stream_id)) {
         return;
@@ -128,6 +146,8 @@ export function enable_or_disable_permission_settings_in_edit_panel(sub) {
     if (!sub.can_change_stream_permissions) {
         return;
     }
+
+    update_default_stream_and_stream_privacy_state($stream_settings);
 
     const disable_message_retention_setting =
         !page_params.zulip_plan_is_not_limited || !page_params.is_owner;

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -293,6 +293,28 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: [".settings-radio-input-parent.default_stream_private_tooltip"],
+        content: $t({
+            defaultMessage: "Default streams for new users cannot be made private.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
+        target: [".default-stream.default_stream_private_tooltip"],
+        content: $t({
+            defaultMessage: "Private streams cannot be default streams for new users.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
         target: ["#generate_multiuse_invite_radio_container.disabled_setting_tooltip"],
         content: $t({
             defaultMessage:

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1006,6 +1006,14 @@ div.settings-radio-input-parent {
             cursor: not-allowed;
         }
     }
+
+    &.default_stream_private_tooltip {
+        cursor: not-allowed;
+
+        & label {
+            pointer-events: none;
+        }
+    }
 }
 
 .stream-permissions,
@@ -1038,6 +1046,15 @@ div.settings-radio-input-parent {
         min-width: 325px;
         max-width: 100%;
         height: 30px;
+    }
+
+    .default-stream {
+        margin: 25px 0;
+        width: fit-content;
+
+        .inline {
+            display: inline;
+        }
     }
 }
 

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -56,6 +56,7 @@
                   stream_post_policy_values=../stream_post_policy_values
                   stream_privacy_policy_values=../stream_privacy_policy_values
                   stream_privacy_policy=../stream_privacy_policy
+                  check_default_stream=../check_default_stream
                   zulip_plan_is_not_limited=../zulip_plan_is_not_limited
                   upgrade_text_for_wide_organization_logo=../upgrade_text_for_wide_organization_logo
                   is_business_type_org=../is_business_type_org

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -16,17 +16,15 @@
     </div>
 </div>
 
-{{#if is_stream_edit}}
-    <div class="default-stream">
-        {{> ../settings/settings_checkbox
-          prefix="id_"
-          setting_name="is_default_stream"
-          is_checked=check_default_stream
-          label="Default stream for new users"
-          help_link="/help/set-default-streams-for-new-users"
-          }}
-    </div>
-{{/if}}
+<div class="default-stream">
+    {{> ../settings/settings_checkbox
+      prefix="id_"
+      setting_name="is_default_stream"
+      is_checked=check_default_stream
+      label="Default stream for new users"
+      help_link="/help/set-default-streams-for-new-users"
+      }}
+</div>
 
 <div class="input-group">
     <label class="dropdown-title">{{t 'Who can post to the stream?'}}

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -16,6 +16,18 @@
     </div>
 </div>
 
+{{#if is_stream_edit}}
+    <div class="default-stream">
+        {{> ../settings/settings_checkbox
+          prefix="id_"
+          setting_name="is_default_stream"
+          is_checked=check_default_stream
+          label="Default stream for new users"
+          help_link="/help/set-default-streams-for-new-users"
+          }}
+    </div>
+{{/if}}
+
 <div class="input-group">
     <label class="dropdown-title">{{t 'Who can post to the stream?'}}
         {{> ../help_link_widget link="/help/stream-sending-policy" }}

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -293,6 +293,7 @@ run_test("custom profile fields", ({override}) => {
 run_test("default_streams", ({override}) => {
     const event = event_fixtures.default_streams;
     override(settings_streams, "update_default_streams_table", noop);
+    override(stream_settings_ui, "update_is_default_stream", noop);
     const stub = make_stub();
     override(stream_data, "set_realm_default_streams", stub.f);
     dispatch(event);

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -670,6 +670,7 @@ def list_to_streams(
     user_profile: UserProfile,
     autocreate: bool = False,
     unsubscribing_others: bool = False,
+    is_default_stream: bool = False,
 ) -> Tuple[List[Stream], List[Stream]]:
     """Converts list of dicts to a list of Streams, validating input in the process
 
@@ -736,6 +737,10 @@ def list_to_streams(
                 raise JsonableError(_("Insufficient permission"))
             if not invite_only and not user_profile.can_create_public_streams():
                 raise JsonableError(_("Insufficient permission"))
+            if is_default_stream and not user_profile.is_realm_admin:
+                raise JsonableError(_("Insufficient permission"))
+            if invite_only and is_default_stream:
+                raise JsonableError(_("A default stream cannot be private."))
 
         if not autocreate:
             raise JsonableError(

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15978,6 +15978,20 @@ paths:
             type: boolean
           example: false
           required: false
+        - name: is_default_stream
+          in: query
+          description: |
+            Add or remove the stream as a [default stream][default-stream]
+            for new users joining the organization.
+
+            [default-stream]: /help/set-default-streams-for-new-users
+
+            **Changes**: New in Zulip 8.0 (feature level 200). Previously, default stream status
+            could only be changed using the [dedicated API endpoint](/api/add-default-stream).
+          schema:
+            type: boolean
+          example: false
+          required: false
         - $ref: "#/components/parameters/StreamPostPolicy"
         - $ref: "#/components/parameters/MessageRetentionDays"
         - $ref: "#/components/parameters/CanRemoveSubscribersGroupId"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8657,6 +8657,21 @@ paths:
             type: boolean
             default: false
           example: true
+        - name: is_default_stream
+          in: query
+          description: |
+            This parameter determines whether any newly created streams will be
+            added as [default streams][default-streams] for new users joining
+            the organization.
+
+            [default-streams]: /help/set-default-streams-for-new-users
+
+            **Changes**: New in Zulip 8.0 (feature level 200). Previously, default stream status
+            could only be changed using the [dedicated API endpoint](/api/add-default-stream).
+          schema:
+            type: boolean
+            default: false
+          example: true
         - $ref: "#/components/parameters/HistoryPublicToSubscribers"
         - $ref: "#/components/parameters/StreamPostPolicy"
         - $ref: "#/components/parameters/MessageRetentionDays"

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -714,7 +714,7 @@ class StreamAdminTest(ZulipTestCase):
             "is_private": orjson.dumps(True).decode(),
         }
         result = self.client_patch(f"/json/streams/{default_stream.id}", params)
-        self.assert_json_error(result, "Default streams cannot be made private.")
+        self.assert_json_error(result, "A default stream cannot be private.")
         self.assertFalse(default_stream.invite_only)
 
         do_change_user_role(user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
@@ -1050,6 +1050,76 @@ class StreamAdminTest(ZulipTestCase):
             }
         ).decode()
         self.assertEqual(realm_audit_log.extra_data, expected_extra_data)
+
+    def test_add_and_remove_stream_as_default(self) -> None:
+        user_profile = self.example_user("hamlet")
+        self.login_user(user_profile)
+        realm = user_profile.realm
+        stream = self.make_stream("stream", realm=realm)
+        stream_id = self.subscribe(user_profile, "stream").id
+
+        params = {
+            "is_default_stream": orjson.dumps(True).decode(),
+        }
+        result = self.client_patch(f"/json/streams/{stream_id}", params)
+        self.assert_json_error(result, "Must be an organization administrator")
+        self.assertFalse(stream_id in get_default_stream_ids_for_realm(realm.id))
+
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR, acting_user=None)
+        result = self.client_patch(f"/json/streams/{stream_id}", params)
+        self.assert_json_success(result)
+        self.assertTrue(stream_id in get_default_stream_ids_for_realm(realm.id))
+
+        params = {
+            "is_private": orjson.dumps(True).decode(),
+        }
+        result = self.client_patch(f"/json/streams/{stream_id}", params)
+        self.assert_json_error(result, "A default stream cannot be private.")
+        stream.refresh_from_db()
+        self.assertFalse(stream.invite_only)
+
+        params = {
+            "is_private": orjson.dumps(True).decode(),
+            "is_default_stream": orjson.dumps(False).decode(),
+        }
+        result = self.client_patch(f"/json/streams/{stream_id}", params)
+        self.assert_json_success(result)
+        stream.refresh_from_db()
+        self.assertTrue(stream.invite_only)
+        self.assertFalse(stream_id in get_default_stream_ids_for_realm(realm.id))
+
+        stream_2 = self.make_stream("stream_2", realm=realm)
+        stream_2_id = self.subscribe(user_profile, "stream_2").id
+
+        bad_params = {
+            "is_default_stream": orjson.dumps(True).decode(),
+            "is_private": orjson.dumps(True).decode(),
+        }
+        result = self.client_patch(f"/json/streams/{stream_2_id}", bad_params)
+        self.assert_json_error(result, "A default stream cannot be private.")
+        stream.refresh_from_db()
+        self.assertFalse(stream_2.invite_only)
+        self.assertFalse(stream_2_id in get_default_stream_ids_for_realm(realm.id))
+
+        private_stream = self.make_stream("private_stream", realm=realm, invite_only=True)
+        private_stream_id = self.subscribe(user_profile, "private_stream").id
+
+        params = {
+            "is_default_stream": orjson.dumps(True).decode(),
+        }
+        result = self.client_patch(f"/json/streams/{private_stream_id}", params)
+        self.assert_json_error(result, "A default stream cannot be private.")
+        self.assertFalse(private_stream_id in get_default_stream_ids_for_realm(realm.id))
+
+        params = {
+            "is_private": orjson.dumps(False).decode(),
+            "is_default_stream": orjson.dumps(True).decode(),
+        }
+        result = self.client_patch(f"/json/streams/{private_stream_id}", params)
+        self.assert_json_success(result)
+        private_stream.refresh_from_db()
+        self.assertFalse(private_stream.invite_only)
+        self.assertTrue(private_stream_id in get_default_stream_ids_for_realm(realm.id))
 
     def test_stream_permission_changes_updates_updates_attachments(self) -> None:
         self.login("desdemona")


### PR DESCRIPTION
<!-- Describe your pull request here.-->
To add or remove a stream as default for new users the admin has to navigate to a separate menu. To address this, added a [checkbox] Default stream for new users in the stream creation and editing UIs.

We prevent users from creating an incompatible configuration in both the stream creation and stream edition UIs.

For the front-end (stream_ui_updates.js > `update_default_stream_and_stream_privacy_state`):

- If the private stream option is selected, the default stream option is disabled with a tooltip that states, 'Private streams cannot be default streams for new users.'

- If the default stream option is checked, the private stream options are disabled with a tooltip that states, 'Default streams for new users cannot be made private.'

For the back-end (streams.py > `update_stream_backend`):

| Stream | Parameters | Result / Error message |
| ------------- | ------------- | ------------- |
| default | `is_private:True` | Error / 'Default streams cannot be made private.' |
| private | `is_default_stream:True` | Error / 'Private streams cannot be made default.' |
| any | `is_private:True`, `is_default_stream:True` | Error / 'A stream cannot be both a default stream for new users and private.' |
| any | `is_private:True`, `is_default_stream:False` | Success |
| any | `is_private:False`, `is_default_stream:True` | Success |

**Fixes:** #24048<!-- Issue link, or clear description.-->

**Screenshots:**

<details>
<summary>Tooltip: Private stream options are disabled</summary>

![image](https://github.com/zulip/zulip/assets/87542880/9d1e8d23-89ec-4615-9324-c05b48f9cbf6)

</details>

<details>
<summary>Tooltip: Default stream checkbox is disabled</summary>

![image](https://github.com/zulip/zulip/assets/87542880/0623f8d2-83d3-436b-a879-78c758d2e1bf)

</details>

<details>
<summary>Stream editing UI</summary>

![image](https://github.com/zulip/zulip/assets/87542880/ba1b4de2-8340-4117-89c1-1a625c380c79)

</details>

<details>
<summary>Stream creation UI</summary>

![image](https://github.com/zulip/zulip/assets/87542880/edd21601-dedb-49dc-b465-94b28a6c2900)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
