### PR TITLE
left_sidebar: Space topic / stream names from any icons on right by 3px.

### DIFF
--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -11,6 +11,9 @@ $topic_resolve_width: 13px;
 /* Space between section in the left sidebar. */
 $sections_vertical_gutter: 8px;
 $bottom_scrolling_buffer: 25px;
+/* space PM / stream / topic names from unread counters / @ mention
+indicators by 3px on the right */
+$before_unread_count_padding: 3px;
 
 .hashtag {
     &:empty {
@@ -106,12 +109,8 @@ li.show-more-topics {
     }
 
     li {
-        a {
-            padding: 1px 0;
-
-            &:hover {
-                text-decoration: none;
-            }
+        a:hover {
+            text-decoration: none;
         }
 
         ul {
@@ -141,15 +140,6 @@ li.show-more-topics {
         display: flex;
         align-items: center;
         white-space: nowrap;
-
-        .stream-name {
-            flex: auto;
-            overflow-x: hidden;
-            overflow-x: clip;
-            text-overflow: ellipsis;
-            min-width: 0;
-            padding-right: 2px;
-        }
 
         &.stream-with-count {
             margin-right: 15px;
@@ -447,14 +437,15 @@ li.top_left_recent_topics {
 }
 
 .conversation-partners,
-.topic-name {
+.topic-name,
+.stream-name {
     flex: auto;
     min-width: 0;
     white-space: nowrap;
     overflow-x: hidden;
     overflow-x: clip;
     text-overflow: ellipsis;
-    padding-right: 2px;
+    padding: 1px $before_unread_count_padding 1px 0;
 }
 
 .topic-name {


### PR DESCRIPTION
Due to some quirks of CSS specificity, a rule for 0 `right-padding` was overriding a rule for 2px `right-padding` for topic names.

This is now corrected, and the padding increased to 3px for a less cramped look, for both topics and streams.

Fixes: issue described [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/left.20sidebar.20unread.20count.20space)

**Screenshots and screen captures:**
Before:
![image](https://user-images.githubusercontent.com/68962290/215329675-bc00b33f-1940-4a87-bd43-51824796c8a5.png)

After:
![image](https://user-images.githubusercontent.com/68962290/215329874-4f8e23d8-97d3-40eb-a1e2-52794a9606e2.png)


<details>
<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
