### PR TITLE
message_edit: Improved save/cancel styling in message_edit_ui.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -266,7 +266,7 @@ export function stream_and_topic_exist_in_edit_history(message, stream_id, topic
 
 export function hide_message_edit_spinner($row) {
     $row.find(".loader").hide();
-    $row.find(".message_edit_save span").show();
+    $row.find(".message_edit_save span").css("display", "inline-flex").show();
     $row.find(".message_edit_save").removeClass("disable-btn");
     $row.find(".message_edit_cancel").removeClass("disable-btn");
 }
@@ -506,7 +506,7 @@ function edit_message($row, raw_content) {
 
     // Add tooltip and timer
     if (is_editable && page_params.realm_message_content_edit_limit_seconds > 0) {
-        $row.find(".message-edit-timer").show();
+        $row.find(".message-edit-timer").css("display", "inline-flex").show();
 
         // Give them at least 10 seconds.
         // If you change this number also change edit_limit_buffer in

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -30,7 +30,8 @@
     }
 
     /************************* MODAL DARK THEME *******************/
-    .dialog_cancel_button {
+    .dialog_cancel_button,
+    .message_edit_cancel {
         background-color: hsl(211deg 29% 14%);
         color: hsl(0deg 0% 100%);
         border: 1px solid hsl(0deg 0% 0% / 60%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1532,27 +1532,56 @@ div.focused_table {
     max-height: 24em;
 }
 
-.message_edit_countdown_timer {
-    text-align: right;
-    display: inline;
-    color: hsl(0deg 0% 63%);
-}
+.edit-controls {
+    display: flex;
+    flex-wrap: wrap;
 
-.message_edit_tooltip {
-    display: inline;
-    color: hsl(0deg 0% 63%);
-}
+    .btn-wrapper {
+        cursor: not-allowed;
+    }
 
-.message-edit-timer {
-    float: right;
-    display: none;
-    margin-top: 5px;
-}
+    .disable-btn {
+        pointer-events: none;
+    }
 
-.message-edit-feature-group {
-    display: inline-flex;
-    margin: 0 auto -5px 10px;
-    align-items: baseline;
+    .message_edit_countdown_timer {
+        text-align: right;
+        display: inline;
+        color: hsl(0deg 0% 63%);
+    }
+
+    .message_edit_tooltip {
+        display: inline;
+        color: hsl(0deg 0% 63%);
+    }
+
+    .message-edit-timer {
+        display: none;
+        margin-top: 5px;
+        white-space: nowrap;
+    }
+
+    .message-edit-feature-group {
+        display: inline-flex;
+        margin: 0 auto -5px 0;
+        align-items: baseline;
+    }
+
+    .message-edit-buttons {
+        display: inline-flex;
+        gap: 5px;
+        margin-left: 15px;
+
+        .message_edit_save {
+            background-color: hsl(240deg 96% 68%) !important;
+            color: hsl(0deg 0% 100%) !important;
+        }
+
+        .message_edit_cancel {
+            background: hsl(0deg 0% 100%);
+            border: 1px solid hsl(300deg 2% 11% / 30%) !important;
+        }
+    }
 }
 
 .message_edit_save .loader {
@@ -1563,16 +1592,6 @@ div.focused_table {
     margin-top: -10px;
     top: 6px;
     width: 30px;
-}
-
-.edit-controls {
-    .btn-wrapper {
-        cursor: not-allowed;
-    }
-
-    .disable-btn {
-        pointer-events: none;
-    }
 }
 
 .topic_edit {
@@ -2819,6 +2838,27 @@ select.invite-as {
         width: calc(90% - 30px);
         left: 5%;
         top: 5%;
+    }
+}
+
+@media (max-width: 847px) and (min-width: 768px), (max-width: 467px) {
+    .message-edit-buttons {
+        margin-top: 5px;
+        margin-right: 5px;
+        margin-left: 0 !important;
+    }
+
+    .message-edit-timer {
+        margin-top: 10px !important;
+    }
+}
+
+@media (max-width: 1302px) and (min-width: 1200px),
+    (max-width: 1059px) and (min-width: 992px),
+    (max-width: 958px) and (min-width: 768px),
+    (max-width: 685px) {
+    .message-edit-timer {
+        order: 1;
     }
 }
 

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -14,32 +14,32 @@
         <div class="message_edit_spinner"></div>
         <div class="controls edit-controls">
             {{#if is_editable}}
-                <div class="btn-wrapper inline-block">
-                    <button type="button" class="button small rounded sea-green message_edit_save">
-                        <img class="loader" alt="" src="" />
-                        <span>{{t "Save" }}</span>
-                    </button>
-                </div>
-                <div class="btn-wrapper inline-block">
-                    <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
-                </div>
                 {{#if is_editable}}
-                <div class="message-edit-feature-group">
-                    {{> compose_control_buttons }}
-                </div>
+                    <div class="message-edit-feature-group">
+                        {{> compose_control_buttons }}
+                    </div>
                 {{/if}}
+                <div class="message-edit-timer">
+                    <span class="message_edit_countdown_timer"></span>
+                    <span>
+                        <i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true"
+                          data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}">
+                        </i>
+                    </span>
+                </div>
+                <div class="message-edit-buttons">
+                    <div class="btn-wrapper inline-block">
+                        <button type="button" class="modal__btn message_edit_cancel">{{t "Cancel" }}</button>
+                    </div>
+                    <div class="btn-wrapper inline-block">
+                        <button type="button" class="modal__btn message_edit_save">
+                            <img class="loader" alt="" src="" />
+                            <span>{{t "Save" }}</span>
+                        </button>
+                    </div>
+                </div>
             {{else}}
                 <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
-            {{/if}}
-            {{#if is_editable}}
-            <div class="message-edit-timer">
-                <span class="message_edit_countdown_timer"></span>
-                <span>
-                    <i id="message_edit_tooltip" class="tippy-zulip-tooltip message_edit_tooltip fa fa-question-circle" aria-hidden="true"
-                      data-tippy-content="{{t 'This organization is configured to restrict editing of message content to {minutes_to_edit} minutes after it is sent.' }}">
-                    </i>
-                </span>
-            </div>
             {{/if}}
         </div>
     </div>


### PR DESCRIPTION
- [x]  In the message editing UI, move the Save / Cancel buttons from the bottom left to the bottom right, with the Cancel button on the left.
- [x]  Restyle the buttons to match the Cancel / Confirm button styling in modals.
- [x]   Wrap the `N minutes` notice to next line on narrow width.

Fixes: #23089 

**Screenshots and screen captures:**

![Screenshot from 2023-01-29 22-16-31](https://user-images.githubusercontent.com/66828942/215341313-38eb8e3d-475c-450a-bbda-40bd1a8fcb54.png)

![zulip_23089](https://user-images.githubusercontent.com/66828942/215341965-8904dbc0-ff52-43e5-b99b-0e638e5b56da.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
