### PR TITLE
personal_settings: Add deactivate organization button for organization with only one user.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -107,6 +107,7 @@ export function build_page() {
             defaultMessage: "Read receipts are currently disabled in this organization.",
         }),
         user_is_only_organization_owner: people.is_current_user_only_owner(),
+        owner_is_only_user_organization: people.get_active_human_count() === 1,
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import render_change_email_modal from "../templates/change_email_modal.hbs";
 import render_confirm_deactivate_own_user from "../templates/confirm_dialog/confirm_deactivate_own_user.hbs";
+import render_settings_deactivate_realm_modal from "../templates/confirm_dialog/confirm_deactivate_realm.hbs";
 import render_dialog_change_password from "../templates/dialog_change_password.hbs";
 import render_settings_api_key_modal from "../templates/settings/api_key_modal.hbs";
 import render_settings_custom_user_profile_field from "../templates/settings/custom_user_profile_field.hbs";
@@ -870,5 +871,32 @@ export function set_up() {
             data,
             $("#account-settings .privacy-setting-status").expectOne(),
         );
+    });
+
+    $("#deactivate_realm_personal_button").on("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        function do_deactivate_realm() {
+            channel.post({
+                url: "/json/realm/deactivate",
+                error(xhr) {
+                    ui_report.error(
+                        $t_html({defaultMessage: "Failed"}),
+                        xhr,
+                        $("#admin-realm-deactivation-status").expectOne(),
+                    );
+                },
+            });
+        }
+
+        const html_body = render_settings_deactivate_realm_modal();
+
+        confirm_dialog.launch({
+            html_heading: $t_html({defaultMessage: "Deactivate organization"}),
+            help_link: "/help/deactivate-your-organization",
+            html_body,
+            on_click: do_deactivate_realm,
+        });
     });
 }

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -167,6 +167,20 @@ h3,
     cursor: not-allowed;
 }
 
+#deactivate_realm_personal_setting_container {
+    display: inline-block;
+    @media (max-width: 380px) {
+        margin-top: 18px;
+    }
+}
+
+#deactivate_account_container {
+    &.only_organization_owner_tooltip {
+        cursor: not-allowed;
+    }
+    margin-right: 18px;
+}
+
 #change_email_button,
 #user_deactivate_account_button,
 #deactivate_realm_button {

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -42,6 +42,13 @@
                             {{t 'Deactivate account' }}
                         </button>
                     </div>
+                    {{#if owner_is_only_user_organization}}
+                        <div id="deactivate_realm_personal_setting_container">
+                            <button type="submit" class="button rounded btn-danger" id="deactivate_realm_personal_button">
+                                {{t 'Deactivate organization' }}
+                            </button>
+                        </div>
+                    {{/if}}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Added a button `Deactivate organization` in personal_settings > Account & privacy.
- It appears only when owner is the only user in the organization.

Fixes: #24105 

**Screenshots and screen captures:**

**Screenshot:**
![Screenshot from 2023-01-30 22-16-04](https://user-images.githubusercontent.com/66828942/215541900-f3107295-4756-41da-a132-1b0882e7f90a.png)


**View Port:**
![zulip_24105_](https://user-images.githubusercontent.com/66828942/215541795-58558f6a-0da0-4394-b6c5-5b5ce579cedd.gif)


**Demo Video:**
![zulip_24105](https://user-images.githubusercontent.com/66828942/215541711-a1fd74da-4302-45e0-b2c1-125d398c64a7.gif)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
