### PR TITLE
private-messages: Change user-facing strings to use "direct message".

### DIFF
--- a/analytics/tests/test_stats_views.py
+++ b/analytics/tests/test_stats_views.py
@@ -179,20 +179,20 @@ class TestGetChartData(ZulipTestCase):
                 "everyone": {
                     "Public streams": self.data(100),
                     "Private streams": self.data(0),
-                    "Private messages": self.data(101),
-                    "Group private messages": self.data(0),
+                    "Direct messages": self.data(101),
+                    "Group direct messages": self.data(0),
                 },
                 "user": {
                     "Public streams": self.data(200),
                     "Private streams": self.data(201),
-                    "Private messages": self.data(0),
-                    "Group private messages": self.data(0),
+                    "Direct messages": self.data(0),
+                    "Group direct messages": self.data(0),
                 },
                 "display_order": [
-                    "Private messages",
+                    "Direct messages",
                     "Public streams",
                     "Private streams",
-                    "Group private messages",
+                    "Group direct messages",
                 ],
                 "result": "success",
             },
@@ -287,8 +287,8 @@ class TestGetChartData(ZulipTestCase):
             {
                 "Public streams": [0],
                 "Private streams": [0],
-                "Private messages": [0],
-                "Group private messages": [0],
+                "Direct messages": [0],
+                "Group direct messages": [0],
             },
         )
         self.assertEqual(
@@ -296,8 +296,8 @@ class TestGetChartData(ZulipTestCase):
             {
                 "Public streams": [0],
                 "Private streams": [0],
-                "Private messages": [0],
-                "Group private messages": [0],
+                "Direct messages": [0],
+                "Group direct messages": [0],
             },
         )
 

--- a/analytics/views/stats.py
+++ b/analytics/views/stats.py
@@ -293,8 +293,8 @@ def get_chart_data(
             stats[0]: {
                 "public_stream": _("Public streams"),
                 "private_stream": _("Private streams"),
-                "private_message": _("Private messages"),
-                "huddle_message": _("Group private messages"),
+                "private_message": _("Direct messages"),
+                "huddle_message": _("Group direct messages"),
             }
         }
         labels_sort_function = lambda data: sort_by_totals(data["everyone"])

--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -1,6 +1,6 @@
 {% if show_message_content %}
-    {% if group_pm %} {% trans %}Group PMs with {{ huddle_display_name }}{% endtrans %}
-    {% elif private_message %} {% trans %}PMs with {{ sender_str }}{% endtrans %}
+    {% if group_pm %} {% trans %}Group DMs with {{ huddle_display_name }}{% endtrans %}
+    {% elif private_message %} {% trans %}DMs with {{ sender_str }}{% endtrans %}
     {% elif stream_email_notify or mention %}
         {#
         Some email clients, like Gmail Web (as of 2022), will auto-thread

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -31,6 +31,8 @@ IGNORED_PHRASES = [
     r"Pivotal",
     r"PM",
     r"PMs",
+    r"DM",
+    r"DMs",
     r"Slack",
     r"Google",
     r"Terms of Service",

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -29,8 +29,6 @@ IGNORED_PHRASES = [
     r"Markdown",
     r"OTP",
     r"Pivotal",
-    r"PM",
-    r"PMs",
     r"DM",
     r"DMs",
     r"Slack",
@@ -98,9 +96,9 @@ IGNORED_PHRASES = [
     r"\bN\b",
     # Capital c feels obtrusive in clear status option
     r"clear",
-    r"group private messages with \{recipient\}",
-    r"private messages with \{recipient\}",
-    r"private messages with yourself",
+    r"group direct messages with \{recipient\}",
+    r"direct messages with \{recipient\}",
+    r"direct messages with yourself",
     r"GIF",
     # Emoji name placeholder
     r"leafy green vegetable",

--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -106,7 +106,7 @@ async function test_open_close_compose_box(page: Page): Promise<void> {
 
 async function test_narrow_to_private_messages_with_cordelia(page: Page): Promise<void> {
     const you_and_cordelia_selector =
-        '*[title="Narrow to your private messages with Cordelia, Lear\'s daughter"]';
+        '*[title="Narrow to your direct messages with Cordelia, Lear\'s daughter"]';
     // For some unknown reason page.click() isn't working here.
     await page.evaluate(
         (selector: string) => document.querySelector<HTMLElement>(selector)!.click(),

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -118,7 +118,7 @@ async function test_navigations_from_home(page: Page): Promise<void> {
     return; // TODO: rest of this test seems nondeterministically broken
     console.log("Narrowing by clicking group personal header");
     await page.click(
-        `#zhome [title="Narrow to your private messages with Cordelia, Lear's daughter, King Hamlet"]`,
+        `#zhome [title="Narrow to your direct messages with Cordelia, Lear's daughter, King Hamlet"]`,
     );
     await expect_huddle(page);
 
@@ -126,7 +126,7 @@ async function test_navigations_from_home(page: Page): Promise<void> {
     await expect_home(page);
 
     await page.click(
-        `#zhome [title="Narrow to your private messages with Cordelia, Lear's daughter, King Hamlet"]`,
+        `#zhome [title="Narrow to your direct messages with Cordelia, Lear's daughter, King Hamlet"]`,
     );
     await un_narrow_by_clicking_org_icon(page);
     await expect_recent_topics(page);
@@ -199,7 +199,7 @@ async function search_tests(page: Page): Promise<void> {
     await search_and_check(
         page,
         "Cordelia",
-        "Private",
+        "Direct",
         expect_cordelia_private_narrow,
         "Cordelia, Lear's daughter - Zulip Dev - Zulip",
     );
@@ -269,7 +269,7 @@ async function expect_all_pm(page: Page): Promise<void> {
         await common.get_text_from_selector(page, "#left_bar_compose_stream_button_big"),
         "New stream message",
     );
-    assert.strictEqual(await page.title(), "Private messages - Zulip Dev - Zulip");
+    assert.strictEqual(await page.title(), "Direct messages - Zulip Dev - Zulip");
 }
 
 async function test_narrow_by_clicking_the_left_sidebar(page: Page): Promise<void> {

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -65,7 +65,7 @@ function update_conversation_button(btn_text, title) {
 
 function update_buttons(text_stream) {
     const title_stream = text_stream + " (c)";
-    const text_conversation = $t({defaultMessage: "New private message"});
+    const text_conversation = $t({defaultMessage: "New direct message"});
     const title_conversation = text_conversation + " (x)";
     update_stream_button(text_stream, title_stream);
     update_conversation_button(text_conversation, title_conversation);

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -501,7 +501,7 @@ function validate_private_message() {
     ) {
         // Unless we're composing to a bot
         compose_banner.show_error_message(
-            $t({defaultMessage: "Private messages are disabled in this organization."}),
+            $t({defaultMessage: "Direct messages are disabled in this organization."}),
             compose_banner.CLASSNAMES.private_messages_disabled,
             $("#private_message_recipient"),
         );

--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -703,7 +703,7 @@ export class Filter {
                 case "is-mentioned":
                     return $t({defaultMessage: "Mentions"});
                 case "is-private":
-                    return $t({defaultMessage: "Private messages"});
+                    return $t({defaultMessage: "Direct messages"});
                 case "is-resolved":
                     return $t({defaultMessage: "Topics marked as resolved"});
                 // These cases return false for is_common_narrow, and therefore are not
@@ -981,7 +981,7 @@ export class Filter {
                 return verb + "sent by";
 
             case "pm-with":
-                return verb + "private messages with";
+                return verb + "direct messages with";
 
             case "in":
                 return verb + "messages in";
@@ -991,7 +991,7 @@ export class Filter {
                 return verb + "messages that are";
 
             case "group-pm-with":
-                return verb + "group private messages including";
+                return verb + "group direct messages including";
         }
         return "";
     }
@@ -999,11 +999,13 @@ export class Filter {
     static describe_is_operator(operator) {
         const verb = operator.negated ? "exclude " : "";
         const operand = operator.operand;
-        const operand_list = ["private", "starred", "alerted", "unread"];
+        const operand_list = ["starred", "alerted", "unread"];
         if (operand_list.includes(operand)) {
             return verb + operand + " messages";
         } else if (operand === "mentioned") {
             return verb + "@-mentions";
+        } else if (operand === "private") {
+            return verb + "direct messages";
         }
         return "invalid " + operand + " operand for is operator";
     }

--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -194,12 +194,12 @@ function pick_empty_narrow_banner() {
                         return {
                             title: $t({
                                 defaultMessage:
-                                    "You are not allowed to send private messages in this organization.",
+                                    "You are not allowed to send direct messages in this organization.",
                             }),
                         };
                     }
                     return {
-                        title: $t({defaultMessage: "You have no private messages yet!"}),
+                        title: $t({defaultMessage: "You have no direct messages yet!"}),
                         html: $t_html(
                             {
                                 defaultMessage: "Why not <z-link>start the conversation</z-link>?",
@@ -301,7 +301,7 @@ function pick_empty_narrow_banner() {
                 return {
                     title: $t({
                         defaultMessage:
-                            "You are not allowed to send private messages in this organization.",
+                            "You are not allowed to send direct messages in this organization.",
                     }),
                 };
             }
@@ -311,7 +311,7 @@ function pick_empty_narrow_banner() {
                     return {
                         title: $t({
                             defaultMessage:
-                                "You have not sent any private messages to yourself yet!",
+                                "You have not sent any direct messages to yourself yet!",
                         }),
                         html: $t_html(
                             {
@@ -330,7 +330,7 @@ function pick_empty_narrow_banner() {
                 return {
                     title: $t(
                         {
-                            defaultMessage: "You have no private messages with {person} yet.",
+                            defaultMessage: "You have no direct messages with {person} yet.",
                         },
                         {person: people.get_by_user_id(user_ids[0]).full_name},
                     ),
@@ -348,7 +348,7 @@ function pick_empty_narrow_banner() {
                 };
             }
             return {
-                title: $t({defaultMessage: "You have no private messages with these users yet."}),
+                title: $t({defaultMessage: "You have no direct messages with these users yet."}),
                 html: $t_html(
                     {
                         defaultMessage: "Why not <z-link>start the conversation</z-link>?",
@@ -393,14 +393,14 @@ function pick_empty_narrow_banner() {
                 return {
                     title: $t({
                         defaultMessage:
-                            "You are not allowed to send group private messages in this organization.",
+                            "You are not allowed to send group direct messages in this organization.",
                     }),
                 };
             }
             return {
                 title: $t(
                     {
-                        defaultMessage: "You have no group private messages with {person} yet.",
+                        defaultMessage: "You have no group direct messages with {person} yet.",
                     },
                     {person: person_in_group_pm.full_name},
                 ),

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -253,7 +253,7 @@ export function process_notification(notification) {
             user_settings.pm_content_in_desktop_notifications !== undefined &&
             !user_settings.pm_content_in_desktop_notifications
         ) {
-            content = "New private message from " + message.sender_full_name;
+            content = "New direct message from " + message.sender_full_name;
         }
         key = message.display_reply_to;
         // Remove the sender from the list of other recipients
@@ -535,15 +535,15 @@ function get_message_header(message) {
     }
     if (message.display_recipient.length > 2) {
         return $t(
-            {defaultMessage: "group private messages with {recipient}"},
+            {defaultMessage: "group direct messages with {recipient}"},
             {recipient: message.display_reply_to},
         );
     }
     if (people.is_current_user(message.reply_to)) {
-        return $t({defaultMessage: "private messages with yourself"});
+        return $t({defaultMessage: "direct messages with yourself"});
     }
     return $t(
-        {defaultMessage: "private messages with {recipient}"},
+        {defaultMessage: "direct messages with {recipient}"},
         {recipient: message.display_reply_to},
     );
 }

--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -506,7 +506,7 @@ function get_is_filter_suggestions(last, operators) {
     const suggestions = [
         {
             search_string: "is:private",
-            description_html: "private messages",
+            description_html: "direct messages",
             invalid: [
                 {operator: "is", operand: "private"},
                 {operator: "stream"},

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -52,7 +52,7 @@ function setup_settings_label() {
             defaultMessage: "Let subscribers see when I'm typing messages in streams",
         }),
         send_private_typing_notifications: $t({
-            defaultMessage: "Let recipients see when I'm typing private messages",
+            defaultMessage: "Let recipients see when I'm typing direct messages",
         }),
         send_read_receipts: $t({
             defaultMessage: "Let others see when I've read messages",

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -201,7 +201,7 @@ export const private_message_policy_values = {
     disabled: {
         order: 2,
         code: 2,
-        description: $t({defaultMessage: "Private messages disabled"}),
+        description: $t({defaultMessage: "Direct messages disabled"}),
     },
 };
 
@@ -526,7 +526,7 @@ export const notification_settings_labels = {
         defaultMessage: "Send mobile notifications even if I'm online",
     }),
     pm_content_in_desktop_notifications: $t({
-        defaultMessage: "Include content of private messages in desktop notifications",
+        defaultMessage: "Include content of direct messages in desktop notifications",
     }),
     desktop_icon_count_display: $t({
         defaultMessage: "Unread count badge (appears in desktop sidebar and browser tab)",
@@ -768,7 +768,7 @@ export const all_notifications = (settings_object: Settings): AllNotifications =
             ),
         },
         {
-            label: $t({defaultMessage: "PMs, mentions, and alerts"}),
+            label: $t({defaultMessage: "DMs, mentions, and alerts"}),
             notification_settings: get_notifications_table_row_data(
                 pm_mention_notification_settings,
                 settings_object,
@@ -794,7 +794,7 @@ export const desktop_icon_count_display_values = {
     },
     notifiable: {
         code: 2,
-        description: $t({defaultMessage: "Private messages and mentions"}),
+        description: $t({defaultMessage: "Direct messages and mentions"}),
     },
     none: {
         code: 3,

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -266,7 +266,7 @@ export function initialize() {
                     compose_state.get_message_type() === "private"
                 ) {
                     display_current_view = $t({
-                        defaultMessage: "Currently viewing all private messages.",
+                        defaultMessage: "Currently viewing all direct messages.",
                     });
                 }
             }
@@ -435,11 +435,11 @@ export function initialize() {
             if ($("#toggle_private_messages_section_icon").hasClass("fa-caret-down")) {
                 instance.setContent(
                     $t({
-                        defaultMessage: "Collapse private messages",
+                        defaultMessage: "Collapse direct messages",
                     }),
                 );
             } else {
-                instance.setContent($t({defaultMessage: "Expand private messages"}));
+                instance.setContent($t({defaultMessage: "Expand direct messages"}));
             }
             return true;
         },
@@ -451,7 +451,7 @@ export function initialize() {
         target: "#show_all_private_messages",
         placement: "bottom",
         content: $t({
-            defaultMessage: "All private messages (P)",
+            defaultMessage: "All direct messages (P)",
         }),
         appendTo: () => document.body,
     });

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -41,8 +41,8 @@
             <span class="new_message_button private_button_container">
                 <button type="button" class="button small rounded compose_private_button"
                   id="left_bar_compose_private_button_big"
-                  title="{{t 'New private message' }} (x)">
-                    <span class="compose_private_button_label">{{t 'New private message' }}</span>
+                  title="{{t 'New direct message' }} (x)">
+                    <span class="compose_private_button_label">{{t 'New direct message' }}</span>
                 </button>
             </span>
             {{/unless}}

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -17,7 +17,7 @@
                     <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New private message' }}</td>
+                    <td class="definition">{{t 'New direct message' }}</td>
                     <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
@@ -41,7 +41,7 @@
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Next unread private message' }}</td>
+                    <td class="definition">{{t 'Next unread direct message' }}</td>
                     <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
@@ -135,7 +135,7 @@
                     <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'New private message' }}</td>
+                    <td class="definition">{{t 'New direct message' }}</td>
                     <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
@@ -168,11 +168,11 @@
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to topic or PM conversation' }}</td>
+                    <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to all private messages' }}</td>
+                    <td class="definition">{{t 'Narrow to all direct messages' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
                 </tr>
                 <tr>
@@ -184,7 +184,7 @@
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to next unread private message' }}</td>
+                    <td class="definition">{{t 'Narrow to next unread direct message' }}</td>
                     <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -62,11 +62,11 @@
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
                 <span id="pm_tooltip_container">
                     <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down toggle_private_messages_section zoom-in-hide" aria-hidden="true"></i>
-                    <h4 class="sidebar-title toggle_private_messages_section">{{t 'PRIVATE MESSAGES' }}</h4>
+                    <h4 class="sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
                 </span>
                 <span class="unread_count"></span>
                 <a id="show_all_private_messages" href="#narrow/is/private">
-                    <i class="fa fa-align-right" aria-label="{{t 'All private messages' }}"></i>
+                    <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
                 </a>
             </div>
         </div>

--- a/web/templates/mobile_message_buttons_popover_content.hbs
+++ b/web/templates/mobile_message_buttons_popover_content.hbs
@@ -13,9 +13,9 @@
         <a class="compose_mobile_private_button">
             <i class="fa fa-envelope" aria-hidden="true"></i>
             {{#if is_in_private_narrow }}
-            {{t "New private message" }}
+            {{t "New direct message" }}
             {{else}}
-            {{t "New private message" }}
+            {{t "New direct message" }}
             {{/if}}
         </a>
     </li>

--- a/web/templates/recent_topic_row.hbs
+++ b/web/templates/recent_topic_row.hbs
@@ -4,7 +4,7 @@
             <div class="left_part recent_topics_focusable">
                 {{#if is_private}}
                 <span class="fa fa-envelope"></span>
-                <a href="{{pm_url}}">Private messages</a>
+                <a href="{{pm_url}}">Direct messages</a>
                 {{else}}
                 <span id="stream_sidebar_privacy_swatch_{{stream_id}}" class="stream-privacy filter-icon" style="color: {{stream_color}}">
                     {{> stream_privacy }}

--- a/web/templates/recent_topics_filters.hbs
+++ b/web/templates/recent_topics_filters.hbs
@@ -5,7 +5,7 @@
     {{else}}
     <i class="fa fa-square-o"></i>
     {{/if}}
-    {{t 'Include PMs' }}
+    {{t 'Include DMs' }}
 </button>
 <button data-filter="include_muted" type="button" class="btn btn-default btn-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="false">
     {{#if filter_muted }}

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -87,7 +87,7 @@
         <div class="message-header-contents">
             <a class="message_label_clickable narrows_by_recipient stream_label"
               href="{{pm_with_url}}"
-              title="{{#tr}}Narrow to your private messages with {display_reply_to}{{/tr}}">
+              title="{{#tr}}Narrow to your direct messages with {display_reply_to}{{/tr}}">
                 {{#tr}}You and {display_reply_to}{{/tr}}
             </a>
 

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -39,14 +39,14 @@
                     <tr>
                         <td class="operator">is:private</td>
                         <td class="definition">
-                            {{t 'Narrow to private messages.'}}
+                            {{t 'Narrow to direct messages.'}}
                         </td>
                     </tr>
                     <tr>
                         <td class="operator">pm-with:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
-                                Narrow to private messages with <z-value></z-value>.
+                                Narrow to direct messages with <z-value></z-value>.
                                 {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
                             {{/tr}}
                         </td>
@@ -55,7 +55,7 @@
                         <td class="operator">group-pm-with:<span class="operator_value">user</span></td>
                         <td class="definition">
                             {{#tr}}
-                                Narrow to group private messages with <z-value></z-value>.
+                                Narrow to group direct messages with <z-value></z-value>.
                                 {{#*inline "z-value"}}<span class="operator_value">user</span>{{/inline}}
                             {{/tr}}
                         </td>

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -304,7 +304,7 @@
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_private_message_policy">{{t "Who can use private messages" }} ({{t "beta" }})
+                    <label for="realm_private_message_policy">{{t "Who can use direct messages" }} ({{t "beta" }})
                         {{> ../help_link_widget link="/help/restrict-private-messages" }}
                     </label>
                     <select name="realm_private_message_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_private_message_policy" data-setting-widget-type="number">

--- a/web/templates/user_info_popover_content.hbs
+++ b/web/templates/user_info_popover_content.hbs
@@ -124,7 +124,7 @@
         {{#if can_send_private_message}}
             <li>
                 <a tabindex="0" class="{{ private_message_class }}">
-                    <i class="fa fa-comment" aria-hidden="true"></i> {{#tr}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
+                    <i class="fa fa-comment" aria-hidden="true"></i> {{#tr}}Send direct message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
                 </a>
             </li>
         {{/if}}
@@ -159,7 +159,7 @@
                 {{#if is_me}}
                     {{#tr}}View messages with yourself{{/tr}}
                 {{else}}
-                    {{#tr}}View private messages{{/tr}}
+                    {{#tr}}View direct messages{{/tr}}
                 {{/if}}
             </a>
         </li>

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -771,7 +771,7 @@ test_ui("narrow_button_titles", () => {
     );
     assert.equal(
         $("#left_bar_compose_private_button_big").text(),
-        $t({defaultMessage: "New private message"}),
+        $t({defaultMessage: "New direct message"}),
     );
 
     compose_closed_ui.update_buttons_for_stream();
@@ -781,7 +781,7 @@ test_ui("narrow_button_titles", () => {
     );
     assert.equal(
         $("#left_bar_compose_private_button_big").text(),
-        $t({defaultMessage: "New private message"}),
+        $t({defaultMessage: "New direct message"}),
     );
 });
 

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1138,7 +1138,7 @@ test("describe", () => {
         {operator: "is", operand: "private"},
         {operator: "search", operand: "lunch"},
     ];
-    string = "private messages, search for lunch";
+    string = "direct messages, search for lunch";
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [{operator: "id", operand: 99}];
@@ -1177,7 +1177,7 @@ test("describe", () => {
         {operator: "is", operand: "private"},
         {operator: "search", operand: "lunch", negated: true},
     ];
-    string = "private messages, exclude lunch";
+    string = "direct messages, exclude lunch";
     assert.equal(Filter.describe(narrow), string);
 
     narrow = [
@@ -1517,7 +1517,7 @@ test("navbar_helpers", () => {
             operator: is_private,
             is_common_narrow: true,
             icon: "envelope",
-            title: "translated: Private messages",
+            title: "translated: Direct messages",
             redirect_url_with_search: "/#narrow/is/private",
         },
         {

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -317,7 +317,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You are not allowed to send private messages in this organization.",
+            "translated: You are not allowed to send direct messages in this organization.",
         ),
     );
 
@@ -330,7 +330,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no private messages yet!",
+            "translated: You have no direct messages yet!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -379,7 +379,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You are not allowed to send private messages in this organization.",
+            "translated: You are not allowed to send direct messages in this organization.",
         ),
     );
 
@@ -392,7 +392,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no private messages with Example Bot yet.",
+            "translated: You have no direct messages with Example Bot yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -405,7 +405,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You are not allowed to send private messages in this organization.",
+            "translated: You are not allowed to send direct messages in this organization.",
         ),
     );
 
@@ -418,7 +418,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no private messages with Alice Smith yet.",
+            "translated: You have no direct messages with Alice Smith yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -431,7 +431,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have not sent any private messages to yourself yet!",
+            "translated: You have not sent any direct messages to yourself yet!",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start a conversation with yourself</a>?',
         ),
     );
@@ -442,7 +442,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no private messages with these users yet.",
+            "translated: You have no direct messages with these users yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );
@@ -466,7 +466,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You are not allowed to send group private messages in this organization.",
+            "translated: You are not allowed to send group direct messages in this organization.",
         ),
     );
 
@@ -478,7 +478,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You are not allowed to send group private messages in this organization.",
+            "translated: You are not allowed to send group direct messages in this organization.",
         ),
     );
 
@@ -491,7 +491,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: You have no group private messages with Alice Smith yet.",
+            "translated: You have no group direct messages with Alice Smith yet.",
             'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
         ),
     );

--- a/web/tests/search_future.test.js
+++ b/web/tests/search_future.test.js
@@ -154,7 +154,7 @@ test("initialize", ({mock_template}) => {
                     [
                         "group-pm-with:zo",
                         {
-                            description_html: "group private messages including",
+                            description_html: "group direct messages including",
                             is_person: true,
                             search_string: "group-pm-with:user7@zulipdev.com",
                             user_pill_context: {
@@ -169,7 +169,7 @@ test("initialize", ({mock_template}) => {
                     [
                         "pm-with:zo",
                         {
-                            description_html: "private messages with",
+                            description_html: "direct messages with",
                             is_person: true,
                             search_string: "pm-with:user7@zulipdev.com",
                             user_pill_context: {
@@ -220,10 +220,10 @@ test("initialize", ({mock_template}) => {
             expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
             assert.equal(opts.highlighter(source[1]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>private messages with</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
             assert.equal(opts.highlighter(source[2]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>group private messages including</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
             assert.equal(opts.highlighter(source[3]), expected_value);
 
             /* Test sorter */

--- a/web/tests/search_now.test.js
+++ b/web/tests/search_now.test.js
@@ -136,7 +136,7 @@ run_test("initialize", ({mock_template}) => {
                     [
                         "group-pm-with:zo",
                         {
-                            description_html: "group private messages including",
+                            description_html: "group direct messages including",
                             is_person: true,
                             search_string: "group-pm-with:user7@zulipdev.com",
                             user_pill_context: {
@@ -151,7 +151,7 @@ run_test("initialize", ({mock_template}) => {
                     [
                         "pm-with:zo",
                         {
-                            description_html: "private messages with",
+                            description_html: "direct messages with",
                             is_person: true,
                             search_string: "pm-with:user7@zulipdev.com",
                             user_pill_context: {
@@ -202,10 +202,10 @@ run_test("initialize", ({mock_template}) => {
             expected_value = `<div class="search_list_item">\n    <span>sent by</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
             assert.equal(opts.highlighter(source[1]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>private messages with</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>direct messages with</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
             assert.equal(opts.highlighter(source[2]), expected_value);
 
-            expected_value = `<div class="search_list_item">\n    <span>group private messages including</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
+            expected_value = `<div class="search_list_item">\n    <span>group direct messages including</span>\n    <span class="pill-container pill-container-btn">\n        <div class='pill ' tabindex=0>\n    <img class="pill-image" src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d&#x3D;identicon&amp;version&#x3D;1&amp;s&#x3D;50" />\n    <span class="pill-value">&lt;strong&gt;Zo&lt;/strong&gt;e</span>\n    <div class="exit">\n        <span aria-hidden="true">&times;</span>\n    </div>\n</div>\n    </span>\n</div>\n`;
             assert.equal(opts.highlighter(source[3]), expected_value);
 
             /* Test sorter */

--- a/web/tests/search_pill.test.js
+++ b/web/tests/search_pill.test.js
@@ -16,7 +16,7 @@ const is_starred_item = {
 
 const is_private_item = {
     display_value: "is:private",
-    description_html: "private messages",
+    description_html: "direct messages",
 };
 
 run_test("create_item", () => {

--- a/web/tests/search_suggestion_future.test.js
+++ b/web/tests/search_suggestion_future.test.js
@@ -388,7 +388,7 @@ test("empty_query_suggestions", () => {
     function describe(q) {
         return suggestions.lookup_table.get(q).description_html;
     }
-    assert.equal(describe("is:private"), "Private messages");
+    assert.equal(describe("is:private"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
@@ -483,7 +483,7 @@ test("check_is_suggestions", ({override}) => {
         return suggestions.lookup_table.get(q).description_html;
     }
 
-    assert.equal(describe("is:private"), "Private messages");
+    assert.equal(describe("is:private"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
@@ -503,7 +503,7 @@ test("check_is_suggestions", ({override}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    assert.equal(describe("-is:private"), "Exclude private messages");
+    assert.equal(describe("-is:private"), "Exclude direct messages");
     assert.equal(describe("-is:starred"), "Exclude starred messages");
     assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
@@ -870,9 +870,9 @@ test("people_suggestions", ({override}) => {
     assert.equal(has_image("group-pm-with:bob@zulip.com"), true);
 
     const describe = (q) => suggestions.lookup_table.get(q).description_html;
-    assert.equal(describe("pm-with:ted@zulip.com"), "Private messages with");
+    assert.equal(describe("pm-with:ted@zulip.com"), "Direct messages with");
     assert.equal(describe("sender:ted@zulip.com"), "Sent by");
-    assert.equal(describe("group-pm-with:ted@zulip.com"), "Group private messages including");
+    assert.equal(describe("group-pm-with:ted@zulip.com"), "Group direct messages including");
 
     let expectedString = "<strong>Te</strong>d Smith";
 

--- a/web/tests/search_suggestion_now.test.js
+++ b/web/tests/search_suggestion_now.test.js
@@ -393,7 +393,7 @@ test("empty_query_suggestions", () => {
     function describe(q) {
         return suggestions.lookup_table.get(q).description_html;
     }
-    assert.equal(describe("is:private"), "Private messages");
+    assert.equal(describe("is:private"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
@@ -491,7 +491,7 @@ test("check_is_suggestions", ({override}) => {
         return suggestions.lookup_table.get(q).description_html;
     }
 
-    assert.equal(describe("is:private"), "Private messages");
+    assert.equal(describe("is:private"), "Direct messages");
     assert.equal(describe("is:starred"), "Starred messages");
     assert.equal(describe("is:mentioned"), "@-mentions");
     assert.equal(describe("is:alerted"), "Alerted messages");
@@ -511,7 +511,7 @@ test("check_is_suggestions", ({override}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    assert.equal(describe("-is:private"), "Exclude private messages");
+    assert.equal(describe("-is:private"), "Exclude direct messages");
     assert.equal(describe("-is:starred"), "Exclude starred messages");
     assert.equal(describe("-is:mentioned"), "Exclude @-mentions");
     assert.equal(describe("-is:alerted"), "Exclude alerted messages");
@@ -847,9 +847,9 @@ test("people_suggestions", ({override}) => {
     function describe(q) {
         return suggestions.lookup_table.get(q).description_html;
     }
-    assert.equal(describe("pm-with:ted@zulip.com"), "Private messages with");
+    assert.equal(describe("pm-with:ted@zulip.com"), "Direct messages with");
     assert.equal(describe("sender:ted@zulip.com"), "Sent by");
-    assert.equal(describe("group-pm-with:ted@zulip.com"), "Group private messages including");
+    assert.equal(describe("group-pm-with:ted@zulip.com"), "Group direct messages including");
 
     let expectedString = "<strong>Te</strong>d Smith";
 

--- a/web/tests/settings_config.test.js
+++ b/web/tests/settings_config.test.js
@@ -68,7 +68,7 @@ run_test("all_notifications", () => {
             ],
         },
         {
-            label: "translated: PMs, mentions, and alerts",
+            label: "translated: DMs, mentions, and alerts",
             notification_settings: [
                 {
                     is_checked: false,

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -85,9 +85,9 @@ def validate_message_edit_payload(
 
     if not message.is_stream_message():
         if stream_id is not None:
-            raise JsonableError(_("Private messages cannot be moved to streams."))
+            raise JsonableError(_("Direct messages cannot be moved to streams."))
         if topic_name is not None:
-            raise JsonableError(_("Private messages cannot have topics."))
+            raise JsonableError(_("Direct messages cannot have topics."))
 
     if propagate_mode != "change_one" and topic_name is None and stream_id is None:
         raise JsonableError(_("Invalid propagate_mode without topic edit"))

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1322,7 +1322,7 @@ def check_private_message_policy(
             # notifications from system bots to users.
             return
 
-        raise JsonableError(_("Private messages are disabled in this organization."))
+        raise JsonableError(_("Direct messages are disabled in this organization."))
 
 
 # check_message:

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -70,7 +70,7 @@ def send_initial_pms(user: UserProfile) -> None:
         content = "".join(
             [
                 welcome_msg + " ",
-                _("This is a private message from me, Welcome Bot.") + "\n\n",
+                _("This is a direct message from me, Welcome Bot.") + "\n\n",
                 _(
                     "If you are new to Zulip, check out our [Getting started guide]({getting_started_url})!"
                 ),
@@ -160,7 +160,7 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
                 + "\n\n",
                 _(
                     "Check out [Recent conversations](#recent) to see what's happening! "
-                    'You can return to this conversation by clicking "Private messages" in the upper left.'
+                    'You can return to this conversation by clicking "Direct messages" in the upper left.'
                 ),
             ]
         )

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -107,7 +107,7 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
         self, base_url: str, event: Dict[str, Any], realm: Realm
     ) -> Optional[Response]:
         if event["message"]["type"] == "private":
-            failure_message = "Slack outgoing webhooks don't support private messages."
+            failure_message = "Slack outgoing webhooks don't support direct messages."
             fail_with_message(event, failure_message)
             return None
 

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -661,12 +661,12 @@ def get_gcm_alert(
         message.recipient.type == Recipient.HUDDLE
         and trigger == NotificationTriggers.PRIVATE_MESSAGE
     ):
-        return f"New private group message from {sender_str}"
+        return f"New direct group message from {sender_str}"
     elif (
         message.recipient.type == Recipient.PERSONAL
         and trigger == NotificationTriggers.PRIVATE_MESSAGE
     ):
-        return f"New private message from {sender_str}"
+        return f"New direct message from {sender_str}"
     elif message.is_stream_message() and trigger == NotificationTriggers.MENTION:
         if mentioned_user_group_name is None:
             return f"{sender_str} mentioned you in #{display_recipient}"

--- a/zerver/lib/recipient_users.py
+++ b/zerver/lib/recipient_users.py
@@ -74,7 +74,7 @@ def validate_recipient_user_profiles(
             realms.add(user_profile.realm_id)
 
     if len(realms) > 1:
-        raise ValidationError(_("You can't send private messages outside of your organization."))
+        raise ValidationError(_("You can't send direct messages outside of your organization."))
 
     return list(recipient_profiles_map.values())
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -506,10 +506,10 @@ class TestMissedMessages(ZulipTestCase):
             "Extremely personal message!",
         )
         verify_body_include = ["Extremely personal message!"]
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
 
         if realm_name_in_notifications:
-            email_subject = "PMs with Othello, the Moor of Venice [Zulip Dev]"
+            email_subject = "DMs with Othello, the Moor of Venice [Zulip Dev]"
         self._test_cases(msg_id, verify_body_include, email_subject, False)
 
     def _extra_context_in_missed_stream_messages_mention(
@@ -676,7 +676,7 @@ class TestMissedMessages(ZulipTestCase):
 
         if show_message_content:
             verify_body_include = ["> Extremely personal message!"]
-            email_subject = "PMs with Othello, the Moor of Venice"
+            email_subject = "DMs with Othello, the Moor of Venice"
             verify_body_does_not_include: List[str] = []
         else:
             if message_content_disabled_by_realm:
@@ -717,7 +717,7 @@ class TestMissedMessages(ZulipTestCase):
             "Extremely personal message!",
         )
         verify_body_include = ["Reply to this email directly, or view it in Zulip Dev Zulip"]
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(msg_id, verify_body_include, email_subject, send_as_user)
 
     def _reply_warning_in_missed_personal_messages(self, send_as_user: bool) -> None:
@@ -727,7 +727,7 @@ class TestMissedMessages(ZulipTestCase):
             "Extremely personal message!",
         )
         verify_body_include = ["Do not reply to this email."]
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(msg_id, verify_body_include, email_subject, send_as_user)
 
     def _extra_context_in_missed_huddle_messages_two_others(
@@ -746,7 +746,7 @@ class TestMissedMessages(ZulipTestCase):
             verify_body_include = [
                 "Othello, the Moor of Venice: > Group personal message! -- Reply"
             ]
-            email_subject = "Group PMs with Iago and Othello, the Moor of Venice"
+            email_subject = "Group DMs with Iago and Othello, the Moor of Venice"
             verify_body_does_not_include: List[str] = []
         else:
             verify_body_include = [
@@ -785,7 +785,7 @@ class TestMissedMessages(ZulipTestCase):
 
         verify_body_include = ["Othello, the Moor of Venice: > Group personal message! -- Reply"]
         email_subject = (
-            "Group PMs with Cordelia, Lear's daughter, Iago, and Othello, the Moor of Venice"
+            "Group DMs with Cordelia, Lear's daughter, Iago, and Othello, the Moor of Venice"
         )
         self._test_cases(msg_id, verify_body_include, email_subject, send_as_user)
 
@@ -802,7 +802,7 @@ class TestMissedMessages(ZulipTestCase):
         )
 
         verify_body_include = ["Othello, the Moor of Venice: > Group personal message! -- Reply"]
-        email_subject = "Group PMs with Cordelia, Lear's daughter, Iago, and 2 others"
+        email_subject = "Group DMs with Cordelia, Lear's daughter, Iago, and 2 others"
         self._test_cases(msg_id, verify_body_include, email_subject, send_as_user)
 
     def _deleted_message_in_missed_stream_messages(self, send_as_user: bool) -> None:
@@ -1189,7 +1189,7 @@ class TestMissedMessages(ZulipTestCase):
         verify_body_include = [
             f'<img alt=":green_tick:" src="{realm_emoji_url}" title="green tick" style="height: 20px;">'
         ]
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(
             msg_id, verify_body_include, email_subject, send_as_user=False, verify_html_body=True
         )
@@ -1206,7 +1206,7 @@ class TestMissedMessages(ZulipTestCase):
         verify_body_include = [
             '<img alt=":hamburger:" src="http://testserver/static/generated/emoji/images-twitter-64/1f354.png" title="hamburger" style="height: 20px;">'
         ]
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(
             msg_id, verify_body_include, email_subject, send_as_user=False, verify_html_body=True
         )
@@ -1222,7 +1222,7 @@ class TestMissedMessages(ZulipTestCase):
         verify_body_include = [
             f'<a class="stream" data-stream-id="{stream_id}" href="{href}">#Verona</a'
         ]
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(
             msg_id, verify_body_include, email_subject, send_as_user=False, verify_html_body=True
         )
@@ -1239,7 +1239,7 @@ class TestMissedMessages(ZulipTestCase):
         verify_body_include = [
             f"view it in Zulip Dev Zulip: http://zulip.testserver/#narrow/pm-with/{cordelia.id}-{encoded_name}"
         ]
-        email_subject = "PMs with Cordelia, Lear's daughter"
+        email_subject = "DMs with Cordelia, Lear's daughter"
         self._test_cases(msg_id, verify_body_include, email_subject, send_as_user=False)
 
     def test_sender_name_in_missed_message(self) -> None:
@@ -1302,9 +1302,9 @@ class TestMissedMessages(ZulipTestCase):
             ],
         )
         self.assert_length(mail.outbox, 2)
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
         self.assertEqual(mail.outbox[0].subject, email_subject)
-        email_subject = "PMs with Iago"
+        email_subject = "DMs with Iago"
         self.assertEqual(mail.outbox[1].subject, email_subject)
 
     def test_multiple_stream_messages(self) -> None:
@@ -1586,7 +1586,7 @@ class TestMissedMessages(ZulipTestCase):
             "```\n```",
         )
         verify_body_include = ["view it in Zulip Dev Zulip"]
-        email_subject = "PMs with Othello, the Moor of Venice"
+        email_subject = "DMs with Othello, the Moor of Venice"
         self._test_cases(
             msg_id, verify_body_include, email_subject, send_as_user=False, verify_html_body=True
         )

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -152,7 +152,7 @@ class EditMessagePayloadTest(EditMessageTestCase):
             },
         )
 
-        self.assert_json_error(result, "Private messages cannot be moved to streams.")
+        self.assert_json_error(result, "Direct messages cannot be moved to streams.")
 
     def test_private_message_edit_topic(self) -> None:
         hamlet = self.example_user("hamlet")
@@ -167,7 +167,7 @@ class EditMessagePayloadTest(EditMessageTestCase):
             },
         )
 
-        self.assert_json_error(result, "Private messages cannot have topics.")
+        self.assert_json_error(result, "Direct messages cannot have topics.")
 
     def test_propagate_invalid(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2351,7 +2351,7 @@ class InternalPrepTest(ZulipTestCase):
             m.output[0].split("\n")[0],
             "ERROR:root:Error queueing internal message by {}: {}".format(
                 "cordelia@zulip.com",
-                "You can't send private messages outside of your organization.",
+                "You can't send direct messages outside of your organization.",
             ),
         )
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2070,7 +2070,7 @@ class TestGetGCMPayload(PushNotificationTest):
             {
                 "user_id": hamlet.id,
                 "event": "message",
-                "alert": "New private message from King Hamlet",
+                "alert": "New direct message from King Hamlet",
                 "zulip_message_id": message.id,
                 "time": datetime_to_timestamp(message.date_sent),
                 "content": message.content,

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -107,7 +107,7 @@ class TutorialTests(ZulipTestCase):
                 "In Zulip, topics [tell you what a message is about](/help/streams-and-topics). "
                 "They are light-weight subjects, very similar to the subject line of an email.\n\n"
                 "Check out [Recent conversations](#recent) to see what's happening! "
-                'You can return to this conversation by clicking "Private messages" in the upper left.'
+                'You can return to this conversation by clicking "Direct messages" in the upper left.'
             )
             self.assertEqual(most_recent_message(user).content, expected_response)
 

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -448,9 +448,7 @@ class TestSendTypingNotificationsSettings(ZulipTestCase):
         with self.tornado_redirected_to_list(events, expected_num_events=0):
             result = self.api_post(sender, "/api/v1/typing", params)
 
-        self.assert_json_error(
-            result, "User has disabled typing notifications for private messages"
-        )
+        self.assert_json_error(result, "User has disabled typing notifications for direct messages")
         self.assertEqual(events, [])
 
     def test_send_stream_typing_notifications_setting(self) -> None:

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -49,7 +49,7 @@ def send_notification_backend(
         do_send_stream_typing_notification(user_profile, operator, stream, topic)
     else:
         if not user_profile.send_private_typing_notifications:
-            raise JsonableError(_("User has disabled typing notifications for private messages"))
+            raise JsonableError(_("User has disabled typing notifications for direct messages"))
 
         user_ids = notification_to
         check_send_typing_notification(user_profile, user_ids, operator)


### PR DESCRIPTION
First step in rebranding from "private messages" to "direct messages": change all the translateable strings.

See relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/.22Private.22.20vs.20.22Direct.22/near/1486225) for more context about these updates.

---

**Searches used to identify translated strings with "private message"**:
<details>
<summary>git grep -i "private message" locale/ru/LC_MESSAGES/</summary>

```console
locale/ru/LC_MESSAGES/django.po:msgid "Private messages"
locale/ru/LC_MESSAGES/django.po:msgid "Group private messages"
locale/ru/LC_MESSAGES/django.po:msgid "Private messages cannot be moved to streams."
locale/ru/LC_MESSAGES/django.po:msgid "Private messages cannot have topics."
locale/ru/LC_MESSAGES/django.po:msgid "Private messages are disabled in this organization."
locale/ru/LC_MESSAGES/django.po:msgid "This is a private message from me, Welcome Bot."
locale/ru/LC_MESSAGES/django.po:"return to this conversation by clicking \"Private messages\" in the upper "
locale/ru/LC_MESSAGES/django.po:msgid "You can't send private messages outside of your organization."
locale/ru/LC_MESSAGES/django.po:msgid "User has disabled typing notifications for private messages"
```

</details>
<details>
<summary>git grep -i "private message" locale/ru/translations.json</summary>

```console
locale/ru/translations.json:  "All private messages": "Все личные сообщения",
locale/ru/translations.json:  "All private messages (P)": "Все личные сообщения (P)",
locale/ru/translations.json:  "Collapse private messages": "Свернуть личные сообщения",
locale/ru/translations.json:  "Currently viewing all private messages.": "В данный момент отображаются все личные сообщения.",
locale/ru/translations.json:  "Expand private messages": "Развернуть личные сообщения",
locale/ru/translations.json:  "Include content of private messages in desktop notifications": "Получать содержимое личных сообщений во всплывающих оповещениях",
locale/ru/translations.json:  "Let recipients see when I'm typing private messages": "Показывать участникам, когда я печатаю личные сообщения",
locale/ru/translations.json:  "Narrow to all private messages": "Показать только личные сообщения",
locale/ru/translations.json:  "Narrow to group private messages with <z-value></z-value>.": "Показать только групповые личные сообщения с <z-value></z-value>.",
locale/ru/translations.json:  "Narrow to next unread private message": "Показать только непрочитанные личные сообщения",
locale/ru/translations.json:  "Narrow to private messages with <z-value></z-value>.": "Показать только личные сообщения с <z-value></z-value>.",
locale/ru/translations.json:  "Narrow to private messages.": "Показать только личные сообщения.",
locale/ru/translations.json:  "Narrow to your private messages with {display_reply_to}": "Показать только ваши личные сообщения с {display_reply_to}",
locale/ru/translations.json:  "New private message": "Новое личное сообщение",
locale/ru/translations.json:  "Next unread private message": "Следующее непрочитанное личное сообщение",
locale/ru/translations.json:  "PRIVATE MESSAGES": "ЛИЧНЫЕ СООБЩЕНИЯ",
locale/ru/translations.json:  "Private messages": "Личные сообщения",
locale/ru/translations.json:  "Private messages and mentions": "Личные сообщения и упоминания",
locale/ru/translations.json:  "Private messages are disabled in this organization.": "Личные сообщения в этой организации отключены.",
locale/ru/translations.json:  "Private messages disabled": "Личные сообщения отключены",
locale/ru/translations.json:  "Send private message": "Отправить личное сообщение",
locale/ru/translations.json:  "View private messages": "Показать личные сообщения",
locale/ru/translations.json:  "Who can use private messages": "Кто имеет право использовать личные сообщения?",
locale/ru/translations.json:  "You are not allowed to send group private messages in this organization.": "Вам не разрешена отправка групповых личных сообщений в данной организации.",
locale/ru/translations.json:  "You are not allowed to send private messages in this organization.": "Вам не разрешена отправка личных сообщений в данной организации.",
locale/ru/translations.json:  "You have no group private messages with {person} yet.": "У вас пока нет групповых личных сообщений с {person}.",
locale/ru/translations.json:  "You have no private messages with these users yet.": "У вас пока нет личных сообщений с этими пользователями.",
locale/ru/translations.json:  "You have no private messages with {person} yet.": "У вас пока нет личных сообщений с {person}!",
locale/ru/translations.json:  "You have no private messages yet!": "У вас пока нет ни одного личного сообщения!",
locale/ru/translations.json:  "You have not sent any private messages to yourself yet!": "У вас пока нет ни одного личного сообщения самому себе!",
locale/ru/translations.json:  "group private messages with {recipient}": "групповых личных сообщений с {recipient}",
locale/ru/translations.json:  "private messages with yourself": "личные сообщения с собой",
locale/ru/translations.json:  "private messages with {recipient}": "личные сообщения с {recipient}",

```

</details>

---

**Directories reviewed for additional strings to update at this stage**:
- `analytics/...`
- `frontend_tests/...`
- `static/...`
- `zerver/...`
  - Note here that I ignored all strings in `zerver/openapi/zulip.yaml` as those would be part of the documentation updates

---

**Notes**:
- Frontend and backend changes are in separate commits; see two lists of translated strings above.
- Also separated out some backend updates to push notifications, email notifications and outgoing webhooks because I wasn't sure if we wanted to include those in this first stage of changes.

---

**Screenshots and screen captures:**

<details>
<summary>Direct message view with user card open</summary>

![Screenshot from 2023-01-30 20-58-43](https://user-images.githubusercontent.com/63245456/215582346-07e5d2fd-8086-45b4-9ccc-1c7dfb3fc076.png)

</details>
<details>
<summary>Search suggestions for "pm-with"</summary>

![Screenshot from 2023-01-30 21-00-14](https://user-images.githubusercontent.com/63245456/215582734-e99cd9d3-d8d5-4380-a0f5-50e61aa5077c.png)
</details>
<details>
<summary>help menus</summary>

#### Keyboard shortcuts
![Screenshot from 2023-01-30 21-02-20](https://user-images.githubusercontent.com/63245456/215583204-29a57dcc-bf3c-461e-9db1-0ff1cc716855.png)

#### Search filters
![Screenshot from 2023-01-30 21-02-35](https://user-images.githubusercontent.com/63245456/215583207-46fe0a07-6317-4422-9eab-a28d626533b4.png)
</details>
<details>
<summary>Recent conversations view</summary>

![Screenshot from 2023-01-30 21-06-50](https://user-images.githubusercontent.com/63245456/215583949-74e772eb-d93c-4143-9356-6bbf1eba0b33.png)

</details>
---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
