### PR TITLE
Deploy hooks, with Sentry deploy hook.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -85,6 +85,12 @@ running on the server; though installing alongside other applications
 is not recommended, we do have [some notes on the
 process](install-existing-server.md).
 
+## Deployment hooks
+
+Zulip's upgrades have a hook system which allows for arbitrary
+user-configured actions to run before and after an upgrade; see the
+[upgrading documentation](upgrade.md#deployment-hooks) for details.
+
 ## Running Zulip's service dependencies on different machines
 
 Zulip has full support for each top-level service living on its own

--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -89,7 +89,58 @@ process](install-existing-server.md).
 
 Zulip's upgrades have a hook system which allows for arbitrary
 user-configured actions to run before and after an upgrade; see the
-[upgrading documentation](upgrade.md#deployment-hooks) for details.
+[upgrading documentation](upgrade.md#deployment-hooks) for details on
+how to write your own.
+
+Zulip also provides and optional deploy hook for Sentry.
+
+### Sentry deploy hook
+
+Zulip can use its deploy hooks to create [Sentry
+releases][sentry-release], which can help associate Sentry [error
+logging][sentry-error] with specific releases. If you are deploying
+Zulip from Git, it can be aware of which Zulip commits are associated
+with the release, and help identify which commits might be relevant to
+an error.
+
+To do so:
+
+1. Enable [Sentry error logging][sentry-error].
+2. Add a new [internal Sentry integration][sentry-internal] named
+   "Release annotator".
+3. Grant the internal integration the [permissions][sentry-perms] of
+   "Admin" on "Release".
+4. Add `, zulip::hooks::sentry` to the `puppet_classes` line in `/etc/zulip/zulip.conf`
+5. Add a `[sentry]` section to `/etc/zulip/zulip.conf`:
+   ```ini
+   [sentry]
+   organization = your-organization-name
+   project = your-project-name
+   ```
+6. Add the [authentication token] for your internal Sentry integration
+   to your `/etc/zulip/zulip-secrets.conf`:
+   ```ini
+   # Replace with your own token, found in Sentry
+   sentry_release_auth_token = 6c12f890c1c864666e64ee9c959c4552b3de473a076815e7669f53793fa16afc
+   ```
+7. As root, run `/home/zulip/deployments/current/scripts/zulip-puppet-apply`.
+
+If you are deploying Zulip from Git, you will also need to:
+
+1. In your Zulip project, add the [GitHub integration][sentry-github].
+2. Configure the `zulip/zulip` GitHub project for your Sentry project.
+   You should do this even if you are deploying a private fork of
+   Zulip.
+3. Additionally grant the internal integration "Read & Write" on
+   "Organization"; this is necessary to associate the commits with the
+   release.
+
+[sentry-release]: https://docs.sentry.io/product/releases/
+[sentry-error]: ../subsystems/logging.md#sentry-error-logging
+[sentry-github]: https://docs.sentry.io/product/integrations/source-code-mgmt/github/
+[sentry-internal]: https://docs.sentry.io/product/integrations/integration-platform/internal-integration/
+[sentry-perms]: https://docs.sentry.io/product/integrations/integration-platform/#permissions
+[sentry-tokens]: https://docs.sentry.io/product/integrations/integration-platform/internal-integration#auth-tokens
 
 ## Running Zulip's service dependencies on different machines
 
@@ -844,3 +895,13 @@ Because Camo includes logic to deny access to private subnets, routing
 its requests through Smokescreen is generally not necessary. Set to
 true or false to override the default, which uses the proxy only if
 it is not the default of Smokescreen on a local host.
+
+### `[sentry]`
+
+#### `organization`
+
+The Sentry organization used for the [Sentry deploy hook](#sentry-deploy-hook).
+
+#### `project`
+
+The Sentry project used for the [Sentry deploy hook](#sentry-deploy-hook).

--- a/docs/production/upgrade.md
+++ b/docs/production/upgrade.md
@@ -211,6 +211,18 @@ earlier previous version by running
 `restart-server` script stops any running Zulip server, and starts
 the version corresponding to the `restart-server` path you call.
 
+## Deployment hooks
+
+Zulip's upgrades have a hook system which allows for arbitrary
+user-configured actions to run before and after an upgrade.
+
+Files in the `/etc/zulip/pre-deploy.d` and `/etc/zulip/post-deploy.d`
+directories are inspected for files ending with `.hook`, just before
+and after the critical period when the server is restarted. Each file
+is called, sorted in alphabetical order, from the working directory of
+the new version, with arguments of the old and new Zulip versions. If
+they exit with non-0 exit code, the upgrade will abort.
+
 ## Preserving local changes to service configuration files
 
 :::{warning}

--- a/docs/production/upgrade.md
+++ b/docs/production/upgrade.md
@@ -223,6 +223,9 @@ is called, sorted in alphabetical order, from the working directory of
 the new version, with arguments of the old and new Zulip versions. If
 they exit with non-0 exit code, the upgrade will abort.
 
+See the [deploy documentation](deployment.md#deployment-hooks) for
+hooks included with Zulip.
+
 ## Preserving local changes to service configuration files
 
 :::{warning}

--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -39,10 +39,30 @@ Since 500 errors in any Zulip server are usually a problem the server
 administrator should investigate and/or report upstream, we have this
 email reporting system configured to report errors by default.
 
-Zulip's optional [Sentry][sentry] integration will aggregate errors to
-show which users and realms are affected, any logging which happened
-prior to the exception, local variables in each frame of the
+### Sentry error logging
+
+Zulip's optional backend [Sentry][sentry] integration will aggregate
+errors to show which users and realms are affected, any logging which
+happened prior to the exception, local variables in each frame of the
 exception, and the full request headers which triggered it.
+
+You can enable it by:
+
+1.  Create a [project][sentry-project] in your Sentry organization
+    with a platform of "Django."
+2.  Copy your [Sentry DSN][sentry-dsn] into `/etc/zulip/settings.py`
+    as `SENTRY_DSN`:
+    ```python3
+    ## Controls the DSN used to report errors to Sentry.io
+    SENTRY_DSN = "https://bbb@bbb.ingest.sentry.io/1234"
+    ```
+3.  As the `zulip` user, restart Zulip by running:
+    ```shell
+    /home/zulip/deployments/current/scripts/restart-server
+    ```
+
+[sentry-project]: https://docs.sentry.io/product/projects/
+[sentry-dsn]: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
 
 ### Backend logging
 

--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -61,8 +61,12 @@ You can enable it by:
     /home/zulip/deployments/current/scripts/restart-server
     ```
 
+You may also want to enable Zulip's [Sentry deploy
+hook][sentry-deploy-hook].
+
 [sentry-project]: https://docs.sentry.io/product/projects/
 [sentry-dsn]: https://docs.sentry.io/product/sentry-basics/dsn-explainer/
+[sentry-relase-hook]: ../production/deployment.md#sentry-deploy-hook
 
 ### Backend logging
 

--- a/puppet/zulip/files/hooks/post-deploy.d/sentry.hook
+++ b/puppet/zulip/files/hooks/post-deploy.d/sentry.hook
@@ -1,0 +1,50 @@
+#!/usr/bin/bash
+# Arguments: OLD_COMMIT NEW_COMMIT ...where both are `git describe`
+# output or tag names.  The CWD will be the new deploy directory.
+
+set -e
+set -u
+
+if ! grep -q 'SENTRY_DSN' /etc/zulip/settings.py; then
+    echo "sentry: No DSN configured!  Set SENTRY_DSN in /etc/zulip/settings.py"
+    exit 0
+fi
+
+if ! SENTRY_AUTH_TOKEN=$(crudini --get /etc/zulip/zulip-secrets.conf secrets sentry_release_auth_token); then
+    echo "sentry: No release auth token set!  Set sentry_release_auth_token in /etc/zulip/zulip-secrets.conf"
+    exit 0
+fi
+
+if ! SENTRY_ORG=$(crudini --get /etc/zulip/zulip.conf sentry organization); then
+    echo "sentry: No organization set!  Set sentry.organization in /etc/zulip/zulip.conf"
+    exit 0
+fi
+
+if ! SENTRY_PROJECT=$(crudini --get /etc/zulip/zulip.conf sentry project); then
+    echo "sentry: No project set!  Set setry.project in /etc/zulip/zulip.conf"
+    exit 0
+fi
+
+if ! which sentry-cli >/dev/null; then
+    echo "sentry: No sentry-cli installed!"
+    exit 0
+fi
+
+if ! [ -f ./sentry-release ]; then
+    echo "sentry: No Sentry sentry-release file found!"
+    exit 0
+fi
+
+SENTRY_RELEASE=$(cat ./sentry-release)
+
+ENVIRONMENT=$(crudini --get /etc/zulip/zulip.conf machine deploy_type || echo "development")
+
+echo "sentry: Adding deploy of '$ENVIRONMENT' and finalizing release"
+
+export SENTRY_AUTH_TOKEN
+sentry-cli releases --org="$SENTRY_ORG" --project="$SENTRY_PROJECT" deploys "$SENTRY_RELEASE" new \
+    --env "$ENVIRONMENT" \
+    --started "$(stat -c %Y ./sentry-release)" \
+    --finished "$(date +%s)" \
+    --name "$(hostname --fqdn)"
+sentry-cli releases --org="$SENTRY_ORG" --project="$SENTRY_PROJECT" finalize "$SENTRY_RELEASE"

--- a/puppet/zulip/files/hooks/pre-deploy.d/sentry.hook
+++ b/puppet/zulip/files/hooks/pre-deploy.d/sentry.hook
@@ -1,0 +1,59 @@
+#!/usr/bin/bash
+# Arguments: OLD_COMMIT NEW_COMMIT ...where both are `git describe`
+# output or tag names.  The CWD will be the new deploy directory.
+
+set -e
+set -u
+
+if ! grep -q 'SENTRY_DSN' /etc/zulip/settings.py; then
+    echo "sentry: No DSN configured!  Set SENTRY_DSN in /etc/zulip/settings.py"
+    exit 0
+fi
+
+if ! SENTRY_AUTH_TOKEN=$(crudini --get /etc/zulip/zulip-secrets.conf secrets sentry_release_auth_token); then
+    echo "sentry: No release auth token set!  Set sentry_release_auth_token in /etc/zulip/zulip-secrets.conf"
+    exit 0
+fi
+
+if ! SENTRY_ORG=$(crudini --get /etc/zulip/zulip.conf sentry organization); then
+    echo "sentry: No organization set!  Set sentry.organization in /etc/zulip/zulip.conf"
+    exit 0
+fi
+
+if ! SENTRY_PROJECT=$(crudini --get /etc/zulip/zulip.conf sentry project); then
+    echo "sentry: No project set!  Set setry.project in /etc/zulip/zulip.conf"
+    exit 0
+fi
+
+if ! which sentry-cli >/dev/null; then
+    echo "sentry: No sentry-cli installed!"
+    exit 0
+fi
+
+NEW_VERSION="$2"
+
+MERGE_BASE=""
+if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null || true)" = "true" ]; then
+    # Extract the merge-base that tools/cache-zulip-git-version
+    # encoded into ./zulip-git-version, and turn it from a `git
+    # describe` into a commit hash
+    MERGE_BASE_DESCRIBED=$(head -n2 ./zulip-git-version | tail -1)
+    if [[ "$MERGE_BASE_DESCRIBED" =~ ^.*-g([0-9a-f]{7,})$ ]]; then
+        MERGE_BASE=$(git rev-parse "${BASH_REMATCH[1]}")
+    else
+        MERGE_BASE=$(git rev-parse "$MERGE_BASE_DESCRIBED")
+    fi
+fi
+
+SENTRY_RELEASE="zulip-server@$NEW_VERSION"
+echo "$SENTRY_RELEASE" >./sentry-release
+
+echo "sentry: Creating release $SENTRY_RELEASE"
+
+export SENTRY_AUTH_TOKEN
+sentry-cli releases --org="$SENTRY_ORG" --project="$SENTRY_PROJECT" new "$SENTRY_RELEASE"
+
+if [ -n "$MERGE_BASE" ]; then
+    echo "sentry: Setting commit range based on merge-base to upstream of $MERGE_BASE"
+    sudo -u zulip --preserve-env=SENTRY_AUTH_TOKEN sentry-cli releases --org="$SENTRY_ORG" --project="$SENTRY_PROJECT" set-commits "$SENTRY_RELEASE" --commit="zulip/zulip@$MERGE_BASE"
+fi

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -5,6 +5,7 @@ class zulip::app_frontend_base {
   include zulip::sasl_modules
   include zulip::supervisor
   include zulip::tornado_sharding
+  include zulip::hooks::base
 
   if $::os['family'] == 'Debian' {
     # Upgrade and other tooling wants to be able to get a database

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -85,6 +85,15 @@ class zulip::common {
 
     ### zulip_ops packages
 
+    # https://release-registry.services.sentry.io/apps/sentry-cli/latest
+    'sentry-cli' => {
+      'version' => '2.11.0',
+      'sha256'  => {
+        'amd64'   => 'bc8f5f223fa688b3ad963c60a729f02aa8f5b17525de66fb3abf86800977ff6e',
+        'aarch64' => 'c62c5c1259307611e78af4f24a4c30162cff8adb0f021d363b307c42cded5c70',
+      },
+    },
+
     # https://grafana.com/grafana/download?edition=oss
     'grafana' => {
       'version' => '9.3.4',

--- a/puppet/zulip/manifests/external_dep.pp
+++ b/puppet/zulip/manifests/external_dep.pp
@@ -22,11 +22,10 @@ define zulip::external_dep(
   $dir = "/srv/zulip-${title}-${version}"
 
   zulip::sha256_tarball_to { $title:
-    url     => $url,
-    sha256  => $sha256_filled,
-    install => {
-      $tarball_prefix => $dir,
-    },
+    url          => $url,
+    sha256       => $sha256_filled,
+    install_from => $tarball_prefix,
+    install_to   => $dir,
   }
 
   file { $dir:

--- a/puppet/zulip/manifests/external_dep.pp
+++ b/puppet/zulip/manifests/external_dep.pp
@@ -1,8 +1,9 @@
 define zulip::external_dep(
   String $version,
   String $url,
-  String $tarball_prefix,
+  String $tarball_prefix = '',
   String $sha256 = '',
+  String $mode = '0755',
 ) {
   if $sha256 == '' {
     if $zulip::common::versions[$title]['sha256'] =~ Hash {
@@ -19,25 +20,38 @@ define zulip::external_dep(
     $sha256_filled = $sha256
   }
 
-  $dir = "/srv/zulip-${title}-${version}"
+  $path = "/srv/zulip-${title}-${version}"
 
-  zulip::sha256_tarball_to { $title:
-    url          => $url,
-    sha256       => $sha256_filled,
-    install_from => $tarball_prefix,
-    install_to   => $dir,
+  if $tarball_prefix == '' {
+    zulip::sha256_file_to { $title:
+      url        => $url,
+      sha256     => $sha256_filled,
+      install_to => $path,
+      before     => File[$path],
+    }
+    file { $path:
+      ensure => file,
+      mode   => $mode,
+    }
+  } else {
+    zulip::sha256_tarball_to { $title:
+      url          => $url,
+      sha256       => $sha256_filled,
+      install_from => $tarball_prefix,
+      install_to   => $path,
+      before       => File[$path],
+    }
+    file { $path:
+      ensure => directory,
+    }
   }
 
-  file { $dir:
-    ensure  => present,
-    require => Zulip::Sha256_Tarball_To[$title],
-  }
 
   tidy { "/srv/zulip-${title}-*":
     path    => '/srv/',
     recurse => 1,
     rmdirs  => true,
     matches => "zulip-${title}-*",
-    require => File[$dir],
+    require => File[$path],
   }
 }

--- a/puppet/zulip/manifests/hooks/base.pp
+++ b/puppet/zulip/manifests/hooks/base.pp
@@ -1,0 +1,15 @@
+# @summary Install sentry-cli binary and pre/post deploy hooks
+#
+class zulip::hooks::base {
+  file { [
+    '/etc/zulip/hooks',
+    '/etc/zulip/hooks/pre-deploy.d',
+    '/etc/zulip/hooks/post-deploy.d',
+  ]:
+    ensure => directory,
+    owner  => 'zulip',
+    group  => 'zulip',
+    mode   => '0755',
+    tag    => ['hooks'],
+  }
+}

--- a/puppet/zulip/manifests/hooks/sentry.pp
+++ b/puppet/zulip/manifests/hooks/sentry.pp
@@ -1,0 +1,39 @@
+# @summary Install sentry-cli binary and pre/post deploy hooks
+#
+class zulip::hooks::sentry {
+  include zulip::hooks::base
+  $version = $zulip::common::versions['sentry-cli']['version']
+  $bin = "/srv/zulip-sentry-cli-${version}"
+
+  $arch = $::os['architecture'] ? {
+    'amd64'   => 'x86_64',
+    'aarch64' => 'aarch64',
+  }
+
+  zulip::external_dep { 'sentry-cli':
+    version => $version,
+    url     => "https://downloads.sentry-cdn.com/sentry-cli/${version}/sentry-cli-Linux-${arch}",
+  }
+
+  file { '/usr/local/bin/sentry-cli':
+    ensure => link,
+    target => $bin,
+  }
+
+  file { '/etc/zulip/hooks/pre-deploy.d/sentry.hook':
+    ensure => file,
+    mode   => '0755',
+    owner  => 'zulip',
+    group  => 'zulip',
+    source => 'puppet:///modules/zulip/hooks/pre-deploy.d/sentry.hook',
+    tag    => ['hooks'],
+  }
+  file { '/etc/zulip/hooks/post-deploy.d/sentry.hook':
+    ensure => file,
+    mode   => '0755',
+    owner  => 'zulip',
+    group  => 'zulip',
+    source => 'puppet:///modules/zulip/hooks/post-deploy.d/sentry.hook',
+    tag    => ['hooks'],
+  }
+}

--- a/puppet/zulip/manifests/sha256_file_to.pp
+++ b/puppet/zulip/manifests/sha256_file_to.pp
@@ -1,0 +1,13 @@
+# @summary Downloads, verifies hash, and copies the one file out.
+#
+define zulip::sha256_file_to(
+  String $sha256,
+  String $url,
+  String $install_to,
+) {
+  exec { $url:
+    command => "${::zulip_scripts_path}/setup/sha256-file-to ${sha256} ${url} ${install_to}",
+    creates => $install_to,
+    timeout => 600,
+  }
+}

--- a/puppet/zulip/manifests/sha256_tarball_to.pp
+++ b/puppet/zulip/manifests/sha256_tarball_to.pp
@@ -3,14 +3,12 @@
 define zulip::sha256_tarball_to(
   String $sha256,
   String $url,
-  Hash[String, String] $install,
+  String $install_from,
+  String $install_to,
 ) {
-  $install_expanded = $install.convert_to(Array).join(' ')
-  # Puppet does not support `creates => [...]`, so we have to pick one
-  $a_file = $install[keys($install)[0]]
   exec { $url:
-    command => "${::zulip_scripts_path}/setup/sha256-tarball-to ${sha256} ${url} ${install_expanded}",
-    creates => $a_file,
+    command => "${::zulip_scripts_path}/setup/sha256-tarball-to ${sha256} ${url} ${install_from} ${install_to}",
+    creates => $install_to,
     timeout => 600,
   }
 }

--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -168,7 +168,6 @@ try:
                 stderr=subprocess.DEVNULL,
             ).strip()
     refname = fullref
-    logging.info("Upgrading to %s, in %s", commit_hash, deploy_path)
     subprocess.check_call(
         ["git", "worktree", "add", "--detach", deploy_path, refname],
         stdout=subprocess.DEVNULL,

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import NoReturn, Optional
+from typing import Literal, NoReturn, Optional
 
 os.environ["PYTHONUNBUFFERED"] = "y"
 
@@ -407,6 +407,13 @@ if not migrations_needed:
         ["./manage.py", "fill_memcached_caches", "--skip-checks"], preexec_fn=su_to_zulip
     )
 
+# Install hooks before we check for puppet changes, so we skip an
+# unnecessary stop/start cycle if hook changes are the only ones.
+logging.info("Installing hooks")
+subprocess.check_call(
+    ["./scripts/zulip-puppet-apply", "--tags", "hooks", "--force"],
+)
+
 # If we are planning on running puppet, we can pre-run it in --noop
 # mode and see if it will actually make any changes; if not, we can
 # skip it during the upgrade.  We omit this check if the server is
@@ -432,6 +439,19 @@ if not args.skip_puppet and IS_SERVER_UP:
         sys.exit(1)
 
 
+def run_hooks(kind: Literal["pre-deploy", "post-deploy"]) -> None:
+    # Updates to the above literal to add a new hook type should
+    # adjust puppet's `app_frontend_base.pp` as well.
+    path = f"/etc/zulip/hooks/{kind}.d"
+    if not os.path.exists(path):
+        return
+    for script_name in sorted(f for f in os.listdir(path) if f.endswith(".hook")):
+        subprocess.check_call(
+            [os.path.join(path, script_name), old_version, NEW_ZULIP_VERSION],
+            cwd=deploy_path,
+        )
+
+
 if args.skip_restart:
     logging.info("Successfully configured in %s!", deploy_path)
 else:
@@ -439,6 +459,8 @@ else:
     # shutting down the server; we should strive to minimize the number of
     # steps that happen between here and the "Restarting Zulip" line
     # below.
+
+    run_hooks("pre-deploy")
 
     if rabbitmq_dist_listen:
         shutdown_server()
@@ -490,6 +512,8 @@ else:
         subprocess.check_call(["./scripts/start-server", *start_args], preexec_fn=su_to_zulip)
 
     logging.info("Upgrade complete!")
+
+    run_hooks("post-deploy")
 
 if args.audit_fts_indexes:
     logging.info("Correcting full-text search indexes for updated dictionary files")

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -25,11 +25,13 @@ os.environ["LANGUAGE"] = "C.UTF-8"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from scripts.lib.zulip_tools import (
+    DEPLOYMENTS_DIR,
     assert_running_as_root,
     get_config,
     get_config_file,
     listening_publicly,
     parse_os_release,
+    parse_version_from,
     run_psql_as_postgres,
     start_arg_parser,
     su_to_zulip,
@@ -142,6 +144,15 @@ os.chdir(deploy_path)
 config_file = get_config_file()
 
 IS_SERVER_UP = True
+
+if args.from_git:
+    logging.info("Caching Zulip Git version...")
+    subprocess.check_call(["./tools/cache-zulip-git-version"], preexec_fn=su_to_zulip)
+
+from version import ZULIP_VERSION as NEW_ZULIP_VERSION
+
+old_version = parse_version_from(DEPLOYMENTS_DIR + "/current")
+logging.info("Upgrading from %s to %s, in %s", old_version, NEW_ZULIP_VERSION, deploy_path)
 
 
 # Check if rabbitmq port 25672 is listening on anything except 127.0.0.1
@@ -349,8 +360,6 @@ elif args.from_git:
             logging.error("Try stopping the Zulip server (scripts/stop-server) and trying again.")
         sys.exit(1)
 
-    logging.info("Caching Zulip Git version...")
-    subprocess.check_call(["./tools/cache-zulip-git-version"], preexec_fn=su_to_zulip)
 else:
     # Since this doesn't do any actual work, it's likely safe to have
     # this run before we apply Puppet changes (saving a bit of downtime).

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -108,11 +108,14 @@ def get_deploy_root() -> str:
 
 
 def parse_version_from(deploy_path: str) -> str:
-    with open(os.path.join(deploy_path, "version.py")) as f:
-        result = re.search('ZULIP_VERSION = "(.*)"', f.read())
-        if result:
-            return result.groups()[0]
-    return "0.0.0"
+    try:
+        return subprocess.check_output(
+            [sys.executable, "-c", "from version import ZULIP_VERSION; print(ZULIP_VERSION)"],
+            cwd=deploy_path,
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return "0.0.0"
 
 
 def get_deployment_version(extract_path: str) -> str:

--- a/scripts/setup/sha256-file-to
+++ b/scripts/setup/sha256-file-to
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage:"
+    echo "  sha256-file-to SHA256 http://FETCH/FROM DST"
+    echo
+    echo "SHA256 is the sha256sum of the file fetched; the file is"
+    echo "placed in DST."
+    exit 1
+fi
+
+set -e
+set -x
+
+SHA256="$1"
+URL="$2"
+DST="$3"
+
+# Work in a tmpdir which we clean up at the end
+tmpdir="$(mktemp -d)"
+trap 'rm -r "$tmpdir"' EXIT
+cd "$tmpdir"
+
+# Fetch to a predictable name, not whatever curl guesses from the URL
+LOCALFILE="output"
+curl -fL --retry 3 -o "$LOCALFILE" "$URL"
+
+# Check the hash against what was passed in
+echo "$SHA256  $LOCALFILE" >"$LOCALFILE.sha256"
+sha256sum -c "$LOCALFILE.sha256"
+
+mv "$LOCALFILE" "$DST"

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -1,3 +1,4 @@
+import os
 from typing import TYPE_CHECKING, Optional
 
 import sentry_sdk
@@ -9,6 +10,7 @@ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.utils import capture_internal_exceptions
 
 from version import ZULIP_VERSION
+from zproject.config import DEPLOY_ROOT
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint
@@ -58,10 +60,15 @@ def add_context(event: "Event", hint: "Hint") -> Optional["Event"]:
 def setup_sentry(dsn: Optional[str], environment: str) -> None:
     if not dsn:
         return
+
+    sentry_release = ZULIP_VERSION
+    if os.path.exists(os.path.join(DEPLOY_ROOT, "sentry-release")):
+        with open(os.path.join(DEPLOY_ROOT, "sentry-release")) as sentry_release_file:
+            sentry_release = sentry_release_file.readline().strip()
     sentry_sdk.init(
         dsn=dsn,
         environment=environment,
-        release=ZULIP_VERSION,
+        release=sentry_release,
         integrations=[
             DjangoIntegration(),
             RedisIntegration(),


### PR DESCRIPTION
These hooks are run immediately around the critical section of the
upgrade.  If the upgrade fails for preparatory reasons, the pre-deploy
hook may not be run; if it fails during the upgrade, the post-deploy
hook will not be run.  Hooks are called from the CWD of the new
deploy, with arguments of the old version and the new version.  If
they exit with non-0 exit code, the deploy aborts.

Fixes: #23620
(in passing)

----

Tested using the Sentry hook.  This needs documentation for the Sentry hook.  I'm not entirely convinced at the old-version/new-version arguments -- but, well, we have them, so why not.

We may also want another hook earlier in the process, but around the critical portion seems the most useful and clearest boundary to have one.

**Screenshots and screen captures:**
```
2023-01-30 21:16:13,680 upgrade-zulip-from-git: Fetching the latest commits
Updating files: 100% (5909/5909), done.
2023-01-30 21:16:16,609 upgrade-zulip-stage-2: Caching Zulip Git version...
2023-01-30 21:16:16,804 upgrade-zulip-stage-2: Upgrading from 6.0-548-g8f81c8063e to 6.0-552-g9887b9a3b1, in /home/zulip/deployments/2023-01-30-21-16-13
2023-01-30 21:16:16,825 upgrade-zulip-stage-2: Upgrading system packages...
[...]
2023-01-30 21:18:41,891 upgrade-zulip-stage-2: Pre-checking for puppet changes...
sentry: Creating release zulip-server@6.0-552-g9887b9a3b1
Created release zulip-server@6.0-552-g9887b9a3b1
sentry: Setting commit range based on merge-base to upstream of e2e39acbc441a1b5429b691592ad09c2d747a8d2
+-------------+--------------+
| Repository  | Revision     |
+-------------+--------------+
| zulip/zulip | e2e39acbc441 |
+-------------+--------------+
2023-01-30 21:18:52,777 upgrade-zulip-stage-2: Stopping Zulip...
[...]
2023-01-30 21:19:41,799 restart-server: Done!
Zulip started successfully!
2023-01-30 21:19:41,825 upgrade-zulip-stage-2: Upgrade complete!
sentry: Adding deploy of 'production' and finalizing release
Created new deploy unnamed for 'production'
Finalized release zulip-server@6.0-552-g9887b9a3b1
2023-01-30 21:19:42,926 upgrade-zulip-stage-2: Purging old deployments...
Deployments cleaned successfully...
Cleaning orphaned/unused caches...
Cleaning unused venv caches...
Cleaning unused node modules caches...
Cleaning unused emoji caches...
Done!
```
<img width="1432" alt="Screenshot 2023-01-30 at 4 50 55 PM" src="https://user-images.githubusercontent.com/28347/215604402-a77b0099-0e2a-4228-a0ca-d42ac037344e.png">
<img width="372" alt="Screenshot 2023-01-30 at 5 00 46 PM" src="https://user-images.githubusercontent.com/28347/215605188-51c964fe-8b9e-4323-8a62-5552433d009a.png">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
