### PR TITLE
email_log: Resolve AssertionErrors by handling all sub-requests as properly internal.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -229,6 +229,10 @@ def process_client(
         client_name = "website"
 
     request_notes.client = get_client(client_name)
+
+    # Clear request_notes.client_name to avoid code using it;
+    # request_notes.client is preferred once populated.
+    request_notes.client_name = None
     if user is not None and user.is_authenticated:
         update_user_activity(request, user, query)
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -28,7 +28,7 @@ from zerver.lib.email_validation import (
 )
 from zerver.lib.exceptions import JsonableError, RateLimitedError
 from zerver.lib.name_restrictions import is_disposable_domain, is_reserved_subdomain
-from zerver.lib.rate_limiter import RateLimitedObject, rate_limit_request_by_ip
+from zerver.lib.rate_limiter import RateLimitedObject, rate_limit_request_by_ip, should_rate_limit
 from zerver.lib.send_email import FromAddress, send_email
 from zerver.lib.soft_deactivation import queue_soft_reactivation
 from zerver.lib.subdomains import get_subdomain, is_root_domain_available
@@ -369,7 +369,7 @@ class ZulipPasswordResetForm(PasswordResetForm):
             logging.info("Realm is deactivated")
             return
 
-        if settings.RATE_LIMITING:
+        if should_rate_limit(request):
             try:
                 rate_limit_password_reset_form_by_email(email)
                 rate_limit_request_by_ip(request, domain="sends_email_by_ip")

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -52,6 +52,12 @@ class RequestNotes(BaseNotes[HttpRequest, "RequestNotes"]):
     of `assert request_notes.foo is not None` when accessing them.
     """
 
+    # The client* fields are a bit messy. The main `client` field is a
+    # Client object representing the type of client being used; it is
+    # set inside `process_client`.
+    #
+    # client_name is initially set earlier, by parsing the User-Agent
+    # in middleware,
     client: Optional[Client] = None
     client_name: Optional[str] = None
     client_version: Optional[str] = None

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -323,18 +323,18 @@ def parse_client(
     if req_client is not None:
         return req_client, None
     if "User-Agent" in request.headers:
-        user_agent: Optional[Dict[str, str]] = parse_user_agent(request.headers["User-Agent"])
+        user_agent_dict: Optional[Dict[str, str]] = parse_user_agent(request.headers["User-Agent"])
     else:
-        user_agent = None
-    if user_agent is None:
+        user_agent_dict = None
+    if user_agent_dict is None:
         # In the future, we will require setting USER_AGENT, but for
         # now we just want to tag these requests so we can review them
         # in logs and figure out the extent of the problem
         return "Unspecified", None
 
-    client_name = user_agent["name"]
+    client_name = user_agent_dict["name"]
     if client_name.startswith("Zulip"):
-        return client_name, user_agent.get("version")
+        return client_name, user_agent_dict.get("version")
 
     # We could show browser versions in logs, and it'd probably be a
     # good idea, but the current parsing will just get you Mozilla/5.0.

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -57,7 +57,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
 
     from django.test import Client
 
-    client = Client()
+    client = Client(REMOTE_ADDR="127.0.0.1")
 
     # write fake data for all variables
     registered_email = "hamlet@zulip.com"
@@ -71,34 +71,48 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Password reset emails
     # active account in realm
     result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=realm.host
+        "/accounts/password/reset/",
+        {"client": "internal", "email": registered_email},
+        HTTP_HOST=realm.host,
     )
     assert result.status_code == 302
     # deactivated user
     change_user_is_active(user, False)
     result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=realm.host
+        "/accounts/password/reset/",
+        {"client": "internal", "email": registered_email},
+        HTTP_HOST=realm.host,
     )
     assert result.status_code == 302
     change_user_is_active(user, True)
     # account on different realm
     assert other_realm is not None
     result = client.post(
-        "/accounts/password/reset/", {"email": registered_email}, HTTP_HOST=other_realm.host
+        "/accounts/password/reset/",
+        {"client": "internal", "email": registered_email},
+        HTTP_HOST=other_realm.host,
     )
     assert result.status_code == 302
     # no account anywhere
     result = client.post(
-        "/accounts/password/reset/", {"email": unregistered_email_1}, HTTP_HOST=realm.host
+        "/accounts/password/reset/",
+        {"client": "internal", "email": unregistered_email_1},
+        HTTP_HOST=realm.host,
     )
     assert result.status_code == 302
 
     # Confirm account email
-    result = client.post("/accounts/home/", {"email": unregistered_email_1}, HTTP_HOST=realm.host)
+    result = client.post(
+        "/accounts/home/",
+        {"client": "internal", "email": unregistered_email_1},
+        HTTP_HOST=realm.host,
+    )
     assert result.status_code == 302
 
     # Find account email
-    result = client.post("/accounts/find/", {"emails": registered_email}, HTTP_HOST=realm.host)
+    result = client.post(
+        "/accounts/find/", {"client": "internal", "emails": registered_email}, HTTP_HOST=realm.host
+    )
     assert result.status_code == 302
 
     # New login email
@@ -110,6 +124,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     result = client.post(
         "/json/invites",
         {
+            "client": "internal",
             "invitee_emails": unregistered_email_2,
             "invite_expires_in_minutes": invite_expires_in_minutes,
             "stream_ids": orjson.dumps([stream.id]).decode(),
@@ -121,7 +136,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Verification for new email
     result = client.patch(
         "/json/settings",
-        urllib.parse.urlencode({"email": "hamlets-new@zulip.com"}),
+        urllib.parse.urlencode({"client": "internal", "email": "hamlets-new@zulip.com"}),
         content_type="application/x-www-form-urlencoded",
         HTTP_HOST=realm.host,
     )

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -36,7 +36,7 @@ from zerver.lib.email_validation import (
 )
 from zerver.lib.exceptions import JsonableError, RateLimitedError, UserDeactivatedError
 from zerver.lib.i18n import get_available_language_codes
-from zerver.lib.rate_limiter import RateLimitedUser
+from zerver.lib.rate_limiter import RateLimitedUser, should_rate_limit
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email
@@ -304,11 +304,12 @@ def json_change_settings(
             except ValidationError as e:
                 raise JsonableError(e.message)
 
-            ratelimited, time_until_free = RateLimitedUser(
-                user_profile, domain="email_change_by_user"
-            ).rate_limit()
-            if ratelimited:
-                raise RateLimitedError(time_until_free)
+            if should_rate_limit(request):
+                ratelimited, time_until_free = RateLimitedUser(
+                    user_profile, domain="email_change_by_user"
+                ).rate_limit()
+                if ratelimited:
+                    raise RateLimitedError(time_until_free)
 
             do_start_email_change_process(user_profile, new_email)
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -45,7 +45,10 @@ from zerver.lib.exceptions import (
     OrganizationOwnerRequiredError,
 )
 from zerver.lib.integrations import EMBEDDED_BOTS
-from zerver.lib.rate_limiter import rate_limit_spectator_attachment_access_by_file
+from zerver.lib.rate_limiter import (
+    rate_limit_spectator_attachment_access_by_file,
+    should_rate_limit,
+)
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.lib.send_email import FromAddress, send_email
@@ -293,7 +296,7 @@ def avatar(
         if is_email:
             raise MissingAuthenticationError
 
-        if settings.RATE_LIMITING:
+        if should_rate_limit(request):
             unique_avatar_key = f"{realm.id}/{email_or_id}/{medium}"
             rate_limit_spectator_attachment_access_by_file(unique_avatar_key)
     else:


### PR DESCRIPTION
This is a second take on fixing the concerns that led to #24176. Fixes a regression introduced in 0cfb156545 and [reported by Alya recently](https://chat.zulip.org/#narrow/stream/49-development-help/topic/error.20generating.20emails/near/1496308) where `/emails/generate` throws an `AssertionError` in Vagrant environments due to the Django test client being rate limited on three domains. Dev environments are meant to be exempt from rate limiting, but this applied only to the outer-most request handlers, where `/emails/generate` instantiates a Django test `Client` to call internal endpoints.

> Aside: a third option for fixing this issue, albeit more invasive, would be to entirely refactor this endpoint to call the inner behaviors of the endpoints directly, without making partially-fake HTTP requests and going through all the middlewares and auth stack and etc., however I suspect that's a fairly non-trivial option due to how much code is involved.

Where #24176 changed the global rate limiting rules for this endpoint similarly to how our unit tests do to force success, this PR fixes the "am I a dev environment?" detection in several pieces, described below:

- eb9d70f498: This is a quick fix to a case that comes up once the later commits are applied: that POSTing an endpoint with `client=internal` in the body will result in a populated `RequestNotes.client_name`, but not always a populated `RequestNotes.client`. Further, in certain cases, we can end up with a `RequestNotes.client` and a **differing** `RequestNotes.client_name`, where the latter is pulled from the PATCH/POST body and should be preferred (since, as we'll see later, we're explicitly opting in to being `internal`).

- eed5c0b9d6: This fixes bugs where rate limiting was applied without regard to exemptions, providing no break-glass for cases such as this `/emails/generate` endpoint.

- 5086d84b8b: A commit that's definitely up for some debate and discussion, but I think should have predictable-if-any footguns, allowing PATCH bodies to populate `@has_request_variables` kwargs much as query params and POST bodies can. Required for `/json/settings` PATCH call in `/emails/generate` to work reliably.

- e8ea701308: A fix to ensure rate limiting in `/json/settings` is only applied if the request warrants it.

- 3c0d82b246: This is just a bunch of plumbing `client=internal` all over the place to glue the above bits together and restore `/emails/generate` functionality.