### PR TITLE
portico_signin: Wrap long email names to next line.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -1283,3 +1283,17 @@ button#register_auth_button_gitlab {
         min-height: calc(100vh - 560px);
     }
 }
+
+.account-creation .white-box .user_email {
+    word-break: break-all;
+}
+
+@media (width >= 600px) {
+    .account-creation .white-box {
+        max-width: min-content;
+
+        .alert-info {
+            min-width: max-content;
+        }
+    }
+}

--- a/templates/zerver/accounts_send_confirm.html
+++ b/templates/zerver/accounts_send_confirm.html
@@ -18,7 +18,7 @@ page can be easily identified in it's respective JavaScript file -->
             </div>
 
             <div class="white-box">
-                <p>{% trans %}Check your email (<span class="semi-bold">{{ email }}</span>) so we can get started.{% endtrans %}</p>
+                <p>{% trans %}Check your email (<span class="user_email semi-bold">{{ email }}</span>) so we can get started.{% endtrans %}</p>
 
                 {% include 'zerver/dev_env_email_access_details.html' %}
 


### PR DESCRIPTION
Along with wrapping long emails to next line, set the max-width of the email confirmation box to the alert box.

<img width="806" alt="Screenshot 2023-01-31 at 1 29 43 PM" src="https://user-images.githubusercontent.com/25124304/215700716-af8f9eda-b970-4142-b466-eb16b0b4ed13.png">
<img width="492" alt="Screenshot 2023-01-31 at 1 29 52 PM" src="https://user-images.githubusercontent.com/25124304/215700724-c74ed2a8-9fae-49fc-879f-1fbbd9c27436.png">

Followup on https://github.com/zulip/zulip/pull/24117#issuecomment-1402480368