### PR TITLE
todo_widget: Improve its functionality and customizability (revision)

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -489,6 +489,7 @@ export const slash_commands = [
         text: $t({defaultMessage: "/todo (Create a collaborative to-do list)"}),
         name: "todo",
         aliases: "",
+        placeholder: $t({defaultMessage: "Task list"}),
     },
 ];
 

--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -32,6 +32,7 @@ const poll_widget_extra_data_schema = z
 export const todo_widget_extra_data_schema = z
     .object({
         task_list_title: z.string().optional(),
+        tasks: z.array(z.object({task: z.string(), desc: z.string()})).optional(),
     })
     .nullable();
 

--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -29,12 +29,21 @@ const poll_widget_extra_data_schema = z
     })
     .nullable();
 
+export const todo_widget_extra_data_schema = z
+    .object({
+        task_list_title: z.string().optional(),
+    })
+    .nullable();
+
 const widget_data_event_schema = z.object({
     sender_id: z.number(),
     data: z.discriminatedUnion("widget_type", [
         z.object({widget_type: z.literal("poll"), extra_data: poll_widget_extra_data_schema}),
         z.object({widget_type: z.literal("zform"), extra_data: zform_widget_extra_data_schema}),
-        z.object({widget_type: z.literal("todo"), extra_data: z.null()}),
+        z.object({
+            widget_type: z.literal("todo"),
+            extra_data: todo_widget_extra_data_schema,
+        }),
     ]),
 });
 

--- a/web/src/submessage.ts
+++ b/web/src/submessage.ts
@@ -7,32 +7,35 @@ import type {Message} from "./message_store";
 import type {Submessage} from "./types";
 import * as widgetize from "./widgetize";
 
-export const zform_widget_extra_data_schema = z.object({
-    choices: z.array(
-        z.object({
-            type: z.string(),
-            long_name: z.string(),
-            reply: z.string(),
-            short_name: z.string(),
-        }),
-    ),
-    heading: z.string(),
-    type: z.literal("choices"),
-});
+export const zform_widget_extra_data_schema = z
+    .object({
+        choices: z.array(
+            z.object({
+                type: z.string(),
+                long_name: z.string(),
+                reply: z.string(),
+                short_name: z.string(),
+            }),
+        ),
+        heading: z.string(),
+        type: z.literal("choices"),
+    })
+    .nullable();
 
-const poll_widget_extra_data_schema = z.object({
-    question: z.string().optional(),
-    options: z.array(z.string()).optional(),
-});
+const poll_widget_extra_data_schema = z
+    .object({
+        question: z.string().optional(),
+        options: z.array(z.string()).optional(),
+    })
+    .nullable();
 
 const widget_data_event_schema = z.object({
     sender_id: z.number(),
-    data: z.object({
-        widget_type: z.string().optional(),
-        extra_data: z
-            .union([zform_widget_extra_data_schema, poll_widget_extra_data_schema])
-            .nullable(),
-    }),
+    data: z.discriminatedUnion("widget_type", [
+        z.object({widget_type: z.literal("poll"), extra_data: poll_widget_extra_data_schema}),
+        z.object({widget_type: z.literal("zform"), extra_data: zform_widget_extra_data_schema}),
+        z.object({widget_type: z.literal("todo"), extra_data: z.null()}),
+    ]),
 });
 
 const inbound_data_event_schema = z.object({

--- a/web/src/todo_widget.js
+++ b/web/src/todo_widget.js
@@ -22,6 +22,7 @@ export class TaskData {
         current_user_id,
         is_my_task_list,
         task_list_title,
+        tasks,
         report_error_function,
     }) {
         this.message_sender_id = message_sender_id;
@@ -35,6 +36,14 @@ export class TaskData {
             this.set_task_list_title(task_list_title);
         } else {
             this.set_task_list_title($t({defaultMessage: "Task list"}));
+        }
+
+        for (const [i, data] of tasks.entries()) {
+            this.handle.new_task.inbound("canned", {
+                key: i,
+                task: data.task,
+                desc: data.desc,
+            });
         }
     }
 
@@ -219,13 +228,14 @@ export function activate({$elem, callback, extra_data, message}) {
         return;
     }
     const {data} = parse_result;
-    const {task_list_title = ""} = data || {};
+    const {task_list_title = "", tasks = []} = data || {};
     const is_my_task_list = people.is_my_user_id(message.sender_id);
     const task_data = new TaskData({
         message_sender_id: message.sender_id,
         current_user_id: people.my_current_user_id(),
         is_my_task_list,
         task_list_title,
+        tasks,
         report_error_function: blueslip.warn,
     });
 

--- a/web/src/todo_widget.js
+++ b/web/src/todo_widget.js
@@ -7,6 +7,7 @@ import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import {todo_widget_extra_data_schema} from "./submessage";
 
 // Any single user should send add a finite number of tasks
 // to a todo list. We arbitrarily pick this value.
@@ -16,8 +17,46 @@ export class TaskData {
     task_map = new Map();
     my_idx = 1;
 
-    constructor({current_user_id}) {
+    constructor({
+        message_sender_id,
+        current_user_id,
+        is_my_task_list,
+        task_list_title,
+        report_error_function,
+    }) {
+        this.message_sender_id = message_sender_id;
         this.me = current_user_id;
+        this.is_my_task_list = is_my_task_list;
+        // input_mode indicates if the task list title is being input currently
+        this.input_mode = is_my_task_list; // for now
+        this.report_error_function = report_error_function;
+
+        if (task_list_title) {
+            this.set_task_list_title(task_list_title);
+        } else {
+            this.set_task_list_title($t({defaultMessage: "Task list"}));
+        }
+    }
+
+    set_task_list_title(new_title) {
+        this.input_mode = false;
+        this.task_list_title = new_title;
+    }
+
+    get_task_list_title() {
+        return this.task_list_title;
+    }
+
+    set_input_mode() {
+        this.input_mode = true;
+    }
+
+    clear_input_mode() {
+        this.input_mode = false;
+    }
+
+    get_input_mode() {
+        return this.input_mode;
     }
 
     get_widget_data() {
@@ -41,6 +80,36 @@ export class TaskData {
     }
 
     handle = {
+        new_task_list_title: {
+            outbound: (title) => {
+                const event = {
+                    type: "new_task_list_title",
+                    title,
+                };
+                if (this.is_my_task_list) {
+                    return event;
+                }
+                return undefined;
+            },
+
+            inbound: (sender_id, data) => {
+                // Only the message author can edit questions.
+                if (sender_id !== this.message_sender_id) {
+                    this.report_error_function(
+                        `user ${sender_id} is not allowed to edit the task list title`,
+                    );
+                    return;
+                }
+
+                if (typeof data.title !== "string") {
+                    this.report_error_function("todo widget: bad type for inbound task list title");
+                    return;
+                }
+
+                this.set_task_list_title(data.title);
+            },
+        },
+
         new_task: {
             outbound: (task, desc) => {
                 this.my_idx += 1;
@@ -143,17 +212,117 @@ export class TaskData {
     }
 }
 
-export function activate(opts) {
-    const $elem = opts.$elem;
-    const callback = opts.callback;
-
+export function activate({$elem, callback, extra_data, message}) {
+    const parse_result = todo_widget_extra_data_schema.safeParse(extra_data);
+    if (!parse_result.success) {
+        blueslip.warn("invalid todo extra data", parse_result.error.issues);
+        return;
+    }
+    const {data} = parse_result;
+    const {task_list_title = ""} = data || {};
+    const is_my_task_list = people.is_my_user_id(message.sender_id);
     const task_data = new TaskData({
+        message_sender_id: message.sender_id,
         current_user_id: people.my_current_user_id(),
+        is_my_task_list,
+        task_list_title,
+        report_error_function: blueslip.warn,
     });
 
-    function render() {
+    function update_edit_controls() {
+        const has_title = $elem.find("input.todo-task-list-title").val().trim() !== "";
+        $elem.find("button.todo-task-list-title-check").toggle(has_title);
+    }
+
+    function render_task_list_title() {
+        const task_list_title = task_data.get_task_list_title();
+        const input_mode = task_data.get_input_mode();
+        const can_edit = is_my_task_list && !input_mode;
+
+        $elem.find(".todo-task-list-title-header").toggle(!input_mode);
+        $elem.find(".todo-task-list-title-header").text(task_list_title);
+        $elem.find(".todo-edit-task-list-title").toggle(can_edit);
+        update_edit_controls();
+
+        $elem.find(".todo-task-list-title-bar").toggle(input_mode);
+    }
+
+    function start_editing() {
+        task_data.set_input_mode();
+
+        const task_list_title = task_data.get_task_list_title();
+        $elem.find("input.todo-task-list-title").val(task_list_title);
+        render_task_list_title();
+        $elem.find("input.todo-task-list-title").trigger("focus");
+    }
+
+    function abort_edit() {
+        task_data.clear_input_mode();
+        render_task_list_title();
+    }
+
+    function submit_task_list_title() {
+        const $task_list_title_input = $elem.find("input.todo-task-list-title");
+        let new_task_list_title = $task_list_title_input.val().trim();
+        const old_task_list_title = task_data.get_task_list_title();
+
+        // We should disable the button for blank task list title,
+        // so this is just defensive code.
+        if (new_task_list_title.trim() === "") {
+            new_task_list_title = old_task_list_title;
+        }
+
+        // Optimistically set the task list title locally.
+        task_data.set_task_list_title(new_task_list_title);
+        render_task_list_title();
+
+        // If there were no actual edits, we can exit now.
+        if (new_task_list_title === old_task_list_title) {
+            return;
+        }
+
+        // Broadcast the new task list title to our peers.
+        const data = task_data.handle.new_task_list_title.outbound(new_task_list_title);
+        callback(data);
+    }
+
+    function build_widget() {
         const html = render_widgets_todo_widget();
         $elem.html(html);
+
+        $elem.find("input.todo-task-list-title").on("keyup", (e) => {
+            e.stopPropagation();
+            update_edit_controls();
+        });
+
+        $elem.find("input.todo-task-list-title").on("keydown", (e) => {
+            e.stopPropagation();
+
+            if (e.key === "Enter") {
+                submit_task_list_title();
+                return;
+            }
+
+            if (e.key === "Escape") {
+                abort_edit();
+                return;
+            }
+        });
+
+        $elem.find(".todo-edit-task-list-title").on("click", (e) => {
+            e.stopPropagation();
+            start_editing();
+        });
+
+        $elem.find("button.todo-task-list-title-check").on("click", (e) => {
+            e.stopPropagation();
+            submit_task_list_title();
+        });
+
+        $elem.find("button.todo-task-list-title-remove").on("click", (e) => {
+            e.stopPropagation();
+            abort_edit();
+        });
 
         $elem.find("button.add-task").on("click", (e) => {
             e.stopPropagation();
@@ -210,9 +379,11 @@ export function activate(opts) {
             task_data.handle_event(event.sender_id, event.data);
         }
 
+        render_task_list_title();
         render_results();
     };
 
-    render();
+    build_widget();
+    render_task_list_title();
     render_results();
 }

--- a/web/src/widgetize.ts
+++ b/web/src/widgetize.ts
@@ -15,6 +15,7 @@ type ZFormExtraData = {
 // TODO: This TodoWidgetExtraData type should be moved to web/src/todo_widget.js when it will be migrated
 type TodoWidgetExtraData = {
     task_list_title?: string;
+    tasks?: {task: string; desc: string}[];
 };
 
 type WidgetExtraData = PollWidgetExtraData | TodoWidgetExtraData | ZFormExtraData | null;

--- a/web/src/widgetize.ts
+++ b/web/src/widgetize.ts
@@ -12,7 +12,12 @@ type ZFormExtraData = {
     choices: {type: string; reply: string; long_name: string; short_name: string}[];
 };
 
-type WidgetExtraData = PollWidgetExtraData | ZFormExtraData | null;
+// TODO: This TodoWidgetExtraData type should be moved to web/src/todo_widget.js when it will be migrated
+type TodoWidgetExtraData = {
+    task_list_title?: string;
+};
+
+type WidgetExtraData = PollWidgetExtraData | TodoWidgetExtraData | ZFormExtraData | null;
 
 type WidgetOptions = {
     widget_type: string;

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -216,7 +216,8 @@ button {
     &.add-task,
     &.add-desc,
     &.poll-option,
-    &.poll-question {
+    &.poll-question,
+    &.todo-task-list-title {
         padding: 4px 6px;
         margin: 2px 0;
     }
@@ -228,7 +229,9 @@ button {
 }
 
 .poll-question-check,
-.poll-question-remove {
+.poll-question-remove,
+.todo-task-list-title-check,
+.todo-task-list-title-remove {
     width: 28px !important;
     height: 28px;
     border-radius: 3px;
@@ -240,7 +243,8 @@ button {
     }
 }
 
-.poll-edit-question {
+.poll-edit-question,
+.todo-edit-task-list-title {
     opacity: 0.4;
     display: inline-block;
     margin-left: 5px;
@@ -250,7 +254,8 @@ button {
     }
 }
 
-.poll-question-header {
+.poll-question-header,
+.todo-task-list-title-header {
     display: inline;
 }
 

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -67,6 +67,10 @@
             }
         }
     }
+
+    .add-task-bar {
+        margin-bottom: 5px;
+    }
 }
 
 .todo-widget,
@@ -87,7 +91,7 @@
     }
 
     & ul {
-        margin: 0 0 5px;
+        margin: 5px 0;
         padding: 0;
     }
 

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -1,5 +1,11 @@
 <div class="todo-widget">
-    <h4>{{t "Task list" }}</h4>
+    <h4 class="todo-task-list-title-header">{{t "Task list" }}</h4>
+    <i class="fa fa-pencil todo-edit-task-list-title"></i>
+    <div class="todo-task-list-title-bar">
+        <input type="text" class="todo-task-list-title" placeholder="{{t 'Add todo task list title'}}" />
+        <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
+        <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
+    </div>
     <div class="add-task-bar">
         <input type="text" class="add-task" placeholder="{{t 'New task'}}" />
         <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />

--- a/web/templates/widgets/todo_widget.hbs
+++ b/web/templates/widgets/todo_widget.hbs
@@ -6,12 +6,12 @@
         <button class="todo-task-list-title-remove"><i class="fa fa-remove"></i></button>
         <button class="todo-task-list-title-check"><i class="fa fa-check"></i></button>
     </div>
+    <ul class="todo-widget new-style">
+    </ul>
     <div class="add-task-bar">
         <input type="text" class="add-task" placeholder="{{t 'New task'}}" />
         <input type="text" class="add-desc" placeholder="{{t 'Description'}}" />
         <button class="add-task">{{t "Add task" }}</button>
         <div class="widget-error"></div>
     </div>
-    <ul class="todo-widget new-style">
-    </ul>
 </div>

--- a/web/templates/widgets/todo_widget_tasks.hbs
+++ b/web/templates/widgets/todo_widget_tasks.hbs
@@ -1,4 +1,3 @@
-<br />
 {{#each all_tasks}}
     <li>
         <label class="checkbox">

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -547,7 +547,7 @@ def validate_poll_data(poll_data: object, is_widget_author: bool) -> None:
     raise ValidationError(f"Unknown type for poll data: {poll_data['type']}")
 
 
-def validate_todo_data(todo_data: object) -> None:
+def validate_todo_data(todo_data: object, is_widget_author: bool) -> None:
     check_dict([("type", check_string)])("todo data", todo_data)
 
     assert isinstance(todo_data, dict)
@@ -570,6 +570,19 @@ def validate_todo_data(todo_data: object) -> None:
             [
                 ("type", check_string),
                 ("key", check_string),
+            ]
+        )
+        checker("todo data", todo_data)
+        return
+
+    if todo_data["type"] == "new_task_list_title":
+        if not is_widget_author:
+            raise ValidationError("You can't edit the task list title unless you are the author.")
+
+        checker = check_dict_only(
+            [
+                ("type", check_string),
+                ("title", check_string),
             ]
         )
         checker("todo data", todo_data)

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -21,6 +21,56 @@ def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
     return None, None
 
 
+def parse_poll_extra_data(content: str) -> Any:
+    # This is used to extract the question from the poll command.
+    # The command '/poll question' will pre-set the question in the poll
+    lines = content.splitlines()
+    question = ""
+    options = []
+    if lines and lines[0]:
+        question = lines.pop(0).strip()
+    for line in lines:
+        # If someone is using the list syntax, we remove it
+        # before adding an option.
+        option = re.sub(r"(\s*[-*]?\s*)", "", line.strip(), count=1)
+        if len(option) > 0:
+            options.append(option)
+    extra_data = {
+        "question": question,
+        "options": options,
+    }
+    return extra_data
+
+
+def parse_todo_extra_data(content: str) -> Any:
+    # This is used to extract the task list title from the todo command.
+    # The command '/todo Title' will pre-set the task list title
+    lines = content.splitlines()
+    task_list_title = ""
+    if lines and lines[0]:
+        task_list_title = lines.pop(0).strip()
+    tasks = []
+    for line in lines:
+        # If someone is using the list syntax, we remove it
+        # before adding a task.
+        task_data = re.sub(r"(\s*[-*]?\s*)", "", line.strip(), count=1)
+        if len(task_data) > 0:
+            # a task and its description (optional) are separated
+            # by the (first) `:` character
+            task_data_array = task_data.split(":", 1)
+            tasks.append(
+                {
+                    "task": task_data_array[0].strip(),
+                    "desc": task_data_array[1].strip() if len(task_data_array) > 1 else "",
+                }
+            )
+    extra_data = {
+        "task_list_title": task_list_title,
+        "tasks": tasks,
+    }
+    return extra_data
+
+
 def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) -> Any:
     if widget_type == "poll":
         # This is used to extract the question from the poll command.
@@ -41,7 +91,15 @@ def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) ->
             "options": options,
         }
         return extra_data
-    return None
+    else:
+        # This is used to extract the task list title from the todo command.
+        # The command '/todo Title' will pre-set the task list title
+        lines = content.splitlines()
+        task_list_title = ""
+        if lines and lines[0]:
+            task_list_title = lines.pop(0).strip()
+        extra_data = {"task_list_title": task_list_title}
+        return extra_data
 
 
 def do_widget_post_save_actions(send_request: SendMessageRequest) -> None:

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -6,7 +6,7 @@ from zerver.lib.message import SendMessageRequest
 from zerver.models import Message, SubMessage
 
 
-def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
+def get_widget_data(content: str) -> Tuple[Optional[str], Any]:
     valid_widget_types = ["poll", "todo"]
     tokens = re.split(r"\s+|\n+", content)
 
@@ -73,33 +73,9 @@ def parse_todo_extra_data(content: str) -> Any:
 
 def get_extra_data_from_widget_type(content: str, widget_type: Optional[str]) -> Any:
     if widget_type == "poll":
-        # This is used to extract the question from the poll command.
-        # The command '/poll question' will pre-set the question in the poll
-        lines = content.splitlines()
-        question = ""
-        options = []
-        if lines and lines[0]:
-            question = lines.pop(0).strip()
-        for line in lines:
-            # If someone is using the list syntax, we remove it
-            # before adding an option.
-            option = re.sub(r"(\s*[-*]?\s*)", "", line.strip(), count=1)
-            if len(option) > 0:
-                options.append(option)
-        extra_data = {
-            "question": question,
-            "options": options,
-        }
-        return extra_data
+        return parse_poll_extra_data(content)
     else:
-        # This is used to extract the task list title from the todo command.
-        # The command '/todo Title' will pre-set the task list title
-        lines = content.splitlines()
-        task_list_title = ""
-        if lines and lines[0]:
-            task_list_title = lines.pop(0).strip()
-        extra_data = {"task_list_title": task_list_title}
-        return extra_data
+        return parse_todo_extra_data(content)
 
 
 def do_widget_post_save_actions(send_request: SendMessageRequest) -> None:

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -14,7 +14,7 @@ def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
     if tokens[0].startswith("/"):
         widget_type = tokens[0][1:]
         if widget_type in valid_widget_types:
-            remaining_content = content.replace(tokens[0], "", 1).strip()
+            remaining_content = content.replace(tokens[0], "", 1)
             extra_data = get_extra_data_from_widget_type(remaining_content, widget_type)
             return widget_type, extra_data
 

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -49,7 +49,7 @@ def process_submessage(
 
     if widget_type == "todo":
         try:
-            validate_todo_data(todo_data=widget_data)
+            validate_todo_data(todo_data=widget_data, is_widget_author=is_widget_author)
         except ValidationError as error:
             raise JsonableError(error.message)
 


### PR DESCRIPTION
Near identical to #22551, except this excludes 1 buggy commit for reordering tasks. Everything else works the same as in #22551.

Earlier the tasks in a list were sorted alphabetically and on marking one complete, it was pushed under any incomplete tasks. This behaviour can be unexpected and confusing, so now each task is appended to the bottom of the list on being added, and no shifting takes place on marking it completed.

Users can now name task lists by providing the task list title in the `/todo` command on the same line. Example: `/todo School Work`. If no title is provided by the user, "Task list" (which is also the placeholder) is used as default. The author of a task list can later edit / update the task list title in the todo widget, just like the question in the poll widget.

Up until now, users could add tasks to a todo widget only after creating it through the `/todo` command in the compose box. Users can now add an initial list of tasks using the `/todo` command, with each task on a new line in the compose box, where the 1st `:` would separate a task from its (optional) description. 
Example: `/todo\nTask1:description1\nTask2 without description`.

Until now, if the user did not specify a poll question, but included options when using the `/poll` command, the 1st option wrongly became the poll question. Using `/todo` without task list title but with tasks resulted in a similar bug. Now on leaving the poll question / todo title space blank, the next line will not be confused for it. For todo widget the default title will be shown, while the poll widget will have an input for adding a question.

Up until now, a dash `-` was used to separate the task from its (optional) description. But a colon `:` was used in the `/todo` command syntax to indicate where the task ends and it's description starts. To make the separator symbol consistent for both the syntax and widget, `:` is used for both. It was chosen over `-` as `:` is encountered less often in normal language, and so accidental usage of it when using the `/todo` command syntax is less likely. It is also is impossible to confuse with the bullet list syntax which is allowed for tasks.

When users needed to add a new task in the todo widget, they would type it in the field at the top, but the task would be appended to the list, showing up at the very bottom, which can seem unintuitive. Now the `add-task-bar` is at the bottom of the list, so that when a new task is added, it'll appear right where it was typed. The task field would then shift lower.

Fixes part of #20213.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/de60bca8-0b04-436c-9de2-e5905f736e58)
![image](https://github.com/zulip/zulip/assets/68962290/f63681e4-d9d1-429e-979f-5e25bb7c8154)
![image](https://github.com/zulip/zulip/assets/68962290/05109637-c4d8-4b78-8637-90fdc65a7512)
![image](https://github.com/zulip/zulip/assets/68962290/b2641a56-67f6-45d5-a160-3a171466a307)
![image](https://github.com/zulip/zulip/assets/68962290/3ca4838d-26d6-42ce-8bf9-c0b860ab96c8)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
