### PR TITLE
Puppet abort

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -416,6 +416,9 @@ if not args.skip_puppet and IS_SERVER_UP:
             logging.info("No puppet changes found, skipping!")
         args.skip_puppet = True
         has_puppet_changes = False
+    elif try_puppet.returncode == 2:
+        logging.error("Puppet error -- aborting!")
+        sys.exit(1)
     elif minimal_change:
         logging.error("Would need to apply puppet changes -- aborting!")
         sys.exit(1)

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -83,6 +83,8 @@ def noop_would_change(puppet_cmd: List[str]) -> bool:
         with open(lastrun_file.name) as lastrun:
             lastrun_data = yaml.safe_load(lastrun)
             return lastrun_data.get("resources", {}).get("out_of_sync", 0) != 0
+    except subprocess.CalledProcessError:
+        sys.exit(2)
     finally:
         lastrun_file.close()
 
@@ -111,4 +113,4 @@ ret = subprocess.call([*puppet_cmd, "--detailed-exitcodes"], env=puppet_env)
 # ret = 4 => no changes, yes errors
 # ret = 6 => changes, yes errors
 if ret != 0 and ret != 2:
-    sys.exit(1)
+    sys.exit(2)


### PR DESCRIPTION
Noticed when testing a puppet application which broke, and the early check of it errored out but upgrade-zulip kept trying to power through.

It's possible we want to emulate the exit codes of `puppet --detailed-exitcodes` (detailed at the end of `zulip-puppet-apply`) but I don't think anything expects `zulip-puppet-apply` to be a drop-in replacement for `puppet`, and those exitcodes don't seem to be particularly sensible (I'd expect bitfields, and thus 0/1/2/3, not 0/2/4/6).

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
