### PR TITLE
hotkey: Add `z` shortcut to zoom to message `near` view.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -89,6 +89,8 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Narrow to all private messages**: <kbd>Shift</kbd> + <kbd>P</kbd>
 
+* **Zoom to message in conversation context**: <kbd>Z</kbd> — This view does not mark messages as read.
+
 * **Cycle between stream narrows**: <kbd>Shift</kbd> + <kbd>A</kbd>
   (previous) and <kbd>Shift</kbd> + <kbd>D</kbd> (next)
 

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -162,6 +162,7 @@ const keypress_mappings = {
     118: {name: "show_lightbox", message_view_only: true}, // 'v'
     119: {name: "query_users", message_view_only: true}, // 'w'
     120: {name: "compose_private_message", message_view_only: true}, // 'x'
+    122: {name: "zoom_to_message_near", message_view_only: true}, // 'z'
 };
 
 export function get_keydown_hotkey(e) {
@@ -990,6 +991,32 @@ export function process_hotkey(e, hotkey) {
 
             stream_popover.build_move_topic_to_stream_popover(msg.stream_id, msg.topic, msg);
             return true;
+        }
+        case "zoom_to_message_near": {
+            // The following code is essentially equivalent to
+            // `window.location = hashutil.by_conversation_and_time_url(msg)`
+            // but we use `narrow.activate` to pass in the `trigger` parameter
+            switch (msg.type) {
+                case "private":
+                    narrow.activate(
+                        [
+                            {operator: "pm-with", operand: msg.reply_to},
+                            {operator: "near", operand: msg.id},
+                        ],
+                        {trigger: "hotkey"},
+                    );
+                    return true;
+                case "stream":
+                    narrow.activate(
+                        [
+                            {operator: "stream", operand: msg.stream},
+                            {operator: "topic", operand: msg.topic},
+                            {operator: "near", operand: msg.id},
+                        ],
+                        {trigger: "hotkey"},
+                    );
+                    return true;
+            }
         }
     }
 

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -176,6 +176,10 @@
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
+                    <td><span class="hotkey"><kbd>Z</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Narrow to next unread topic' }}</td>
                     <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>


### PR DESCRIPTION
A new hotkey, lowercase `z` (for `zoom`) has been implemented to allow the user to go to the near view of the selected message with 1 keypress.

The effect is identical to clicking on a message's timestamp, which links to that message's near view.

Fixes: #24227.

PS: This is actually my first time working so closely with narrows. Also, since the near view was so far only accessible via the timestamp link (which I have barely ever used too) and there is no function dedicated to handling near narrows, I feel extensive testing would be needed here (though all my manual testing seems to have been succesful so far). The code can probably be cleaned up too, but first I want to ensure the logic is correct.

**Screenshots and screen captures:**

Near view of a topic in a stream
![image](https://user-images.githubusercontent.com/68962290/216027295-3d496184-eefe-4c61-a11c-121a158c0ae5.png)

Near view of PM group retaining the unread status
![image](https://user-images.githubusercontent.com/68962290/216027443-69442364-1b09-4222-be2b-88cedaf77fc6.png)

![image](https://user-images.githubusercontent.com/68962290/216396199-c4bd4fd4-5db9-469b-9d45-eab0d5fc5be8.png)

![image](https://user-images.githubusercontent.com/68962290/216396323-da407566-1ffd-4c46-9e69-8c4219f4cbbd.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
