### PR TITLE
stream_settings: Fix Announce stream disables unexpectedly.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -133,7 +133,7 @@ function update_announce_stream_state() {
     const $announce_stream_checkbox = $("#announce-new-stream input");
     const $announce_stream_label = $("#announce-new-stream");
     let disable_it = false;
-    const privacy_type = $("input:radio[name=privacy]:checked").val();
+    const privacy_type = $("#stream_creation_form input:radio[name=privacy]:checked").val();
     const is_invite_only =
         privacy_type === "invite-only" || privacy_type === "invite-only-public-history";
     $announce_stream_label.removeClass("control-label-disabled");


### PR DESCRIPTION
While switching from a private stream in the stream editing UI to the stream creation UI, Announce stream becomes disabled. The state of Announce stream option should not be affected by where the create stream UI is opened.

Made the privacy_type selector more specific since it was also selecting the last opened stream privacy type.

Fixes: #24238.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


https://user-images.githubusercontent.com/87542880/216095022-4a6b156e-95e2-46d6-88a3-751622f366e4.mp4




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
