### PR TITLE
settings: Override bottom margin for inputs.

### DIFF
--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -470,11 +470,6 @@ input[type="checkbox"] {
     margin-top: 10px;
 }
 
-#organization-profile input {
-    /* Override undesired Bootstrap default. */
-    margin-bottom: 0;
-}
-
 #id_org_profile_preview {
     margin-bottom: 20px;
     display: inline-flex;
@@ -1444,6 +1439,12 @@ $option_title_width: 180px;
     #show_my_user_profile_modal i {
         padding-left: 2px;
         vertical-align: middle;
+    }
+
+    input,
+    input[type="url"] {
+        /* Override undesired Bootstrap default. */
+        margin-bottom: 0;
     }
 }
 


### PR DESCRIPTION
We override the bottom margin added by bootstrap for url type custom profile input in user profile page
and all the inputs in edit-user form. Previously, this was handled by form-horizontal class which was
removed in #24057.

For most of the other text-type inputs, it is overridden in app_components.css and for checkbox-type inputs,
it is overridden by other bootstrap CSS itself. But that only handles text-type and checkbox-type inputs inside
".new-style" element and not url type inputs.
Some other inputs already have specific CSS to override the bootstrap CSS.

For the same reason, there is no need to override bottom margin for inputs in organization profile as there is no
url type inputs in that page and this commit removes the CSS for it.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
