### PR TITLE
markdown-extensions: Update API argument and return value preprocessors.

### DIFF
--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -16,9 +16,6 @@ REGEXP = re.compile(r"\{generate_return_values_table\|\s*(.+?)\s*\|\s*(.+)\s*\}"
 
 
 class MarkdownReturnValuesTableGenerator(Extension):
-    def __init__(self, configs: Mapping[str, Any] = {}) -> None:
-        self.config: Dict[str, Any] = {}
-
     def extendMarkdown(self, md: markdown.Markdown) -> None:
         md.preprocessors.register(
             APIReturnValuesTablePreprocessor(md, self.getConfigs()),
@@ -225,4 +222,4 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
 
 
 def makeExtension(*args: Any, **kwargs: str) -> MarkdownReturnValuesTableGenerator:
-    return MarkdownReturnValuesTableGenerator(kwargs)
+    return MarkdownReturnValuesTableGenerator(*args, **kwargs)

--- a/zerver/lib/templates.py
+++ b/zerver/lib/templates.py
@@ -122,9 +122,7 @@ def render_markdown_path(
             zerver.lib.markdown.api_arguments_table_generator.makeExtension(
                 base_path="templates/zerver/api/"
             ),
-            zerver.lib.markdown.api_return_values_table_generator.makeExtension(
-                base_path="templates/zerver/api/"
-            ),
+            zerver.lib.markdown.api_return_values_table_generator.makeExtension(),
             zerver.lib.markdown.nested_code_blocks.makeExtension(),
             zerver.lib.markdown.tabbed_sections.makeExtension(),
             zerver.lib.markdown.help_settings_links.makeExtension(),

--- a/zerver/lib/templates.py
+++ b/zerver/lib/templates.py
@@ -119,9 +119,7 @@ def render_markdown_path(
             zerver.lib.markdown.fenced_code.makeExtension(
                 run_content_validators=context.get("run_content_validators", False),
             ),
-            zerver.lib.markdown.api_arguments_table_generator.makeExtension(
-                base_path="templates/zerver/api/"
-            ),
+            zerver.lib.markdown.api_arguments_table_generator.makeExtension(),
             zerver.lib.markdown.api_return_values_table_generator.makeExtension(),
             zerver.lib.markdown.nested_code_blocks.makeExtension(),
             zerver.lib.markdown.tabbed_sections.makeExtension(),


### PR DESCRIPTION
In `zerver/lib/templates.py`, we've been passing a `base_path` argument for the markdown extensions for generating parameters and return values for API endpoint documentation.

**Notes**:
- This argument is no longer needed for API parameters because all endpoints are in the OpenAPI documentation (`zerver/openapi/zulip.yaml`). Previously it was used for API parameters documented in JSON files.
- It seems like the `base_path` argument was never used for API return values, see [commit d2ee99a](https://github.com/zulip/zulip/commit/d2ee99a2fdbc1a703af19c43f00f793227894950).
- Removes the unnecessary `init` function definition from both the `MarkdownArgumentsTableGenerator` and `MarkdownReturnValuesTableGenerator` classes.

This is related to #24241 since the `base_path` string for both markdown extensions is set to `"templates/zerver/api/"`, which will no longer be an existing directory when the API documentation is moved.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
