### PR TITLE
keyboard_ui: Add a new keyboard shortcut '='

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -123,6 +123,7 @@ const keydown_either_mappings = {
 const keypress_mappings = {
     42: {name: "star_deprecated", message_view_only: true}, // '*'
     43: {name: "thumbs_up_emoji", message_view_only: true}, // '+'
+    61: {name: "upvote_first_emoji", message_view_only: true}, // '='
     45: {name: "toggle_message_collapse", message_view_only: true}, // '-'
     47: {name: "search", message_view_only: false}, // '/'
     58: {name: "toggle_reactions_popover", message_view_only: true}, // ':'
@@ -965,6 +966,23 @@ export function process_hotkey(e, hotkey) {
             const thumbs_up_emoji_code = "1f44d";
             const canonical_name = emoji.get_emoji_name(thumbs_up_emoji_code);
             reactions.toggle_emoji_reaction(msg.id, canonical_name);
+            return true;
+        }
+        case "upvote_first_emoji": {
+            // '=': If the current message has at least one emoji
+            // reaction, toggle out vote on the first one.
+            const message_reactions = reactions.get_message_reactions(msg);
+            if (message_reactions.length === 0) {
+                return true;
+            }
+
+            const first_reaction = message_reactions[0];
+            if (!first_reaction) {
+                // If the message has no emoji reactions, do nothing.
+                return true;
+            }
+
+            reactions.toggle_emoji_reaction(msg.id, first_reaction.emoji_name);
             return true;
         }
         case "toggle_topic_mute":

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -358,6 +358,9 @@ run_test("misc", ({override}) => {
 
     assert_mapping("@", compose_actions, "reply_with_mention");
     assert_mapping("+", reactions, "toggle_emoji_reaction");
+    // Without an existing emoji reaction, this next one will only
+    // call get_message_reactions, so we verify just that.
+    assert_mapping("=", reactions, "get_message_reactions");
     assert_mapping("-", condense, "toggle_collapse");
     assert_mapping("r", compose_actions, "respond_to_message");
     assert_mapping("R", compose_actions, "respond_to_message", true);


### PR DESCRIPTION
Fixes: #24256 ([CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/.2B.20keyboard.20shortcut.20for.20emoji/near/1500298)).

Added new keyboard shortcut '=' to toggle the first emoji on the selected message if it exists, else do nothing.

**Screen captures:**

Toggle reaction on the first emoji reaction - 

[keyboard-shortcut-1.webm](https://user-images.githubusercontent.com/96468766/216259107-033d3df7-d7d0-4fa8-a45f-63ad7953dc04.webm)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
