### PR TITLE
personal_settings: Add deactivate organization button for organization with only one user.

### DIFF
--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -108,6 +108,7 @@ export function build_page() {
         }),
         user_is_only_organization_owner: people.is_current_user_only_owner(),
         email_address_visibility_values: settings_config.email_address_visibility_values,
+        owner_is_only_user_in_organization: people.get_active_human_count() === 1,
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -22,6 +22,7 @@ import * as people from "./people";
 import * as pill_typeahead from "./pill_typeahead";
 import * as settings_bots from "./settings_bots";
 import * as settings_data from "./settings_data";
+import * as settings_org from "./settings_org";
 import * as settings_ui from "./settings_ui";
 import * as typeahead_helper from "./typeahead_helper";
 import * as ui_report from "./ui_report";
@@ -764,6 +765,10 @@ export function set_up() {
         }
     });
 
+    $("#account-settings .deactivate_realm_button").on(
+        "click",
+        settings_org.deactivate_organization,
+    );
     $("#user_deactivate_account_button").on("click", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -167,9 +167,13 @@ h3,
     cursor: not-allowed;
 }
 
+#account-settings .deactivate_realm_button {
+    margin-left: 10px;
+}
+
 #change_email_button,
 #user_deactivate_account_button,
-#deactivate_realm_button {
+.deactivate_realm_button {
     &:disabled {
         pointer-events: none;
     }
@@ -1860,6 +1864,12 @@ $option_title_width: 180px;
         .custom_user_field textarea {
             width: calc(100% - 25px);
         }
+    }
+}
+
+@media (width < $mm_min) {
+    .deactivate_realm_button {
+        margin-top: 20px;
     }
 }
 

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -42,6 +42,11 @@
                             {{t 'Deactivate account' }}
                         </button>
                     </div>
+                    {{#if owner_is_only_user_in_organization}}
+                        <button type="submit" class="button rounded btn-danger deactivate_realm_button">
+                            {{t 'Deactivate organization' }}
+                        </button>
+                    {{/if}}
                 </div>
             </div>
         </div>

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -89,7 +89,7 @@
         <div class="deactivate-realm-section">
             <div class="input-group">
                 <div id="deactivate_realm_button_container" class="inline-block {{#unless is_owner}}disabled_setting_tooltip{{/unless}}">
-                    <button class="button rounded btn-danger" id="deactivate_realm_button">
+                    <button class="button rounded btn-danger deactivate_realm_button">
                         {{t 'Deactivate organization' }}
                     </button>
                 </div>


### PR DESCRIPTION
- Added a button `Deactivate organization` in personal_settings > Account & privacy.
- It appears only when owner is the only user in the organization.

Fixes: #24105 

**Screenshot:**

![Screenshot from 2023-02-08 06-29-32](https://user-images.githubusercontent.com/66828942/217401896-77738cd3-93a7-4725-bc1c-c2edfa3f2f31.png)



**View Port:**

![view-port](https://user-images.githubusercontent.com/66828942/217401925-5cc06482-fdaf-4f0a-88ca-60d14ee08d18.gif)

**Demo Video:**
![zulip_24105](https://user-images.githubusercontent.com/66828942/215541711-a1fd74da-4302-45e0-b2c1-125d398c64a7.gif)

**Error on modal:**
![Screenshot from 2023-02-08 06-26-10](https://user-images.githubusercontent.com/66828942/217401451-8471ec9c-82d3-4e08-a446-fa83e6924c6e.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
