### PR TITLE
hotspots: Track open state within the module.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -18,7 +18,6 @@ import {media_breakpoints_num} from "./css_variables";
 import * as dark_theme from "./dark_theme";
 import * as emoji_picker from "./emoji_picker";
 import * as hash_util from "./hash_util";
-import * as hotspots from "./hotspots";
 import * as message_edit from "./message_edit";
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
@@ -27,7 +26,6 @@ import * as muted_topics_ui from "./muted_topics_ui";
 import * as narrow from "./narrow";
 import * as navigate from "./navigate";
 import * as notifications from "./notifications";
-import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as pm_list from "./pm_list";
 import * as popovers from "./popovers";
@@ -761,59 +759,6 @@ export function initialize() {
 
     // Don't focus links on context menu.
     $("body").on("contextmenu", "a", (e) => e.target.blur());
-
-    // HOTSPOTS
-
-    // open
-    $("body").on("click", ".hotspot-icon", function (e) {
-        // hide icon
-        hotspots.close_hotspot_icon(this);
-
-        // show popover
-        const [, hotspot_name] = /^hotspot_(.*)_icon$/.exec(
-            $(e.target).closest(".hotspot-icon").attr("id"),
-        );
-        const overlay_name = "hotspot_" + hotspot_name + "_overlay";
-
-        overlays.open_overlay({
-            name: overlay_name,
-            $overlay: $(`#${CSS.escape(overlay_name)}`),
-            on_close: function () {
-                // close popover
-                $(this).css({display: "block"});
-                $(this).animate(
-                    {opacity: 1},
-                    {
-                        duration: 300,
-                    },
-                );
-            }.bind(this),
-        });
-
-        e.preventDefault();
-        e.stopPropagation();
-    });
-
-    // confirm
-    $("body").on("click", ".hotspot.overlay .hotspot-confirm", function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-
-        const overlay_name = $(this).closest(".hotspot.overlay").attr("id");
-
-        const [, hotspot_name] = /^hotspot_(.*)_overlay$/.exec(overlay_name);
-
-        // Comment below to disable marking hotspots as read in production
-        hotspots.post_hotspot_as_read(hotspot_name);
-
-        overlays.close_overlay(overlay_name);
-        $(`#hotspot_${CSS.escape(hotspot_name)}_icon`).remove();
-    });
-
-    // stop propagation
-    $("body").on("click", ".hotspot.overlay .hotspot-popover", (e) => {
-        e.stopPropagation();
-    });
 
     // GEAR MENU
 

--- a/web/src/hotspots.js
+++ b/web/src/hotspots.js
@@ -57,6 +57,10 @@ const HOTSPOT_LOCATIONS = new Map([
     ],
 ]);
 
+const meta = {
+    opened_hotspot_name: null,
+};
+
 export function post_hotspot_as_read(hotspot_name) {
     channel.post({
         url: "/json/users/me/hotspots",
@@ -236,7 +240,7 @@ function insert_hotspot_into_DOM(hotspot) {
 }
 
 export function is_open() {
-    return $(".hotspot.overlay").hasClass("show");
+    return meta.opened_hotspot_name !== null;
 }
 
 export function close_hotspot_icon(elem) {
@@ -296,9 +300,12 @@ export function initialize() {
                         duration: 300,
                     },
                 );
+
+                meta.opened_hotspot_name = null;
             }.bind(this),
         });
 
+        meta.opened_hotspot_name = hotspot_name;
         e.preventDefault();
         e.stopPropagation();
     });


### PR DESCRIPTION
Previously, `hotspot.is_open` would check the DOM to see if there is a hotspot overlay currently active. This worked, but had performance implications that spilled over into `hotkey.process_hotkey`. `process_hotkey` is called on *every* keystroke, including those inside of the compose window (which is a particuarly performance-sensitive component).

This commit refactors the way hotspots' open state is tracked, moving it from the DOM to a `meta` variable inside of the hotspots module (emulating the way [`feedback_window.js`](https://github.com/zulip/zulip/blob/main/static/js/feedback_widget.js#L25-L30) handles managing this kind of state). The change allows `is_open` to perform a much simpler check, dramatically reducing the overhead when it is called in places like `process_hotkey`, as shown in the flamegraph below.

Note that I've assumed the mention of re-implementing the `process_text` function in the original issue is out of scope for this fix, as that sounds like a much larger refactor that should be taken care of in a separate PR.

Fixes: #24261

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![flamegraph](https://user-images.githubusercontent.com/141635/216326365-fa11b0b3-15f6-4d72-88a0-b3453a848c21.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
