### PR TITLE
index: Remove `Loading...` text from the app loading overlay.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -79,9 +79,6 @@
     border-top-color: hsl(0,0%,52%);
     animation: zspinner 1s linear infinite;
     }
-    .app-loading-text {
-    font-weight: normal;
-    }
 </style>
 {% endblock %}
 
@@ -95,7 +92,6 @@
             <div class="app-loading-spinner"></div>
             <img class="app-loading-logo" src="/static/images/logo/zulip-icon-circle.svg"/>
         </div>
-        <h3 class="app-loading-text">{{ _('Loading...') }}</h3>
     </div>
     <div id="app-loading-bottom-content">
         <p>{% trans %}If this message does not go away, try <a id="reload-lnk">reloading</a> the page.{% endtrans %}</p>

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -228,7 +228,7 @@ class HomeTest(ZulipTestCase):
         # Keep this list sorted!!!
         html_bits = [
             "message_feed_errors_container",
-            "Loading...",
+            "app-loading-logo",
             # Verify that the app styles get included
             "app-stubentry.js",
             "data-params",


### PR DESCRIPTION
The new loading spinner animation conveys the message well that the app is loading and this text is no longer required.
<img width="1097" alt="Screenshot 2023-02-03 at 12 39 12 AM" src="https://user-images.githubusercontent.com/25124304/216426569-7b17863e-43f7-4269-ba1a-a28de81a6243.png">

<img width="1097" alt="Screenshot 2023-02-03 at 12 38 53 AM" src="https://user-images.githubusercontent.com/25124304/216426423-258d0925-ceb9-4a22-8a63-e83ebd59421e.png">
