### PR TITLE
emails: Improve followup_day1 (registration confirmation) email.

### DIFF
--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -5,51 +5,55 @@
 {% endblock %}
 
 {% block content %}
-<p>{{ _('Welcome to Zulip!') }}</p>
-
+{% if realm_creation %}
+{% if is_demo_org %}
 <p>
-    {% if realm_creation %}
-        {% if is_demo_org %}
-            {% trans %}You've created a demo Zulip organization. Note that this organization will be automatically deleted in 30 days. Learn more about demo organizations <a href="https://zulip.com/help/demo-organizations">here</a>!{% endtrans %}
-        {% else %}
-            {% trans %}You've created the new Zulip organization <b>{{ realm_name }}</b>.{% endtrans %}
-        {% endif %}
-    {% else %}
-        {% trans %}You've joined the Zulip organization <b>{{ realm_name }}</b>.{% endtrans %}
-    {% endif %}
+    {% trans %}Congratulations, you have created a new Zulip organization. Note
+    that this organization will be automatically deleted in 30 days. Learn more
+    about demo organizations <a
+    href="https://zulip.com/help/demo-organizations">here</a>!
+    {% endtrans %}
 </p>
+{% else %}
+<p>
+    {% trans %}Congratulations, you have created a new Zulip
+    organization: <b>{{ realm_name }}</b>.{% endtrans %}
+</p>
+{% endif %}
+{% else %}
+<p>{{ _('Welcome to Zulip!') }}</p>
+<p>
+    {% trans %}You've joined the Zulip organization <b>{{ realm_name }}</b>.
+    {% endtrans %}
+</p>
+{% endif %}
 
 <p>
-    {{ _('Your account details:') }}
+    {% trans apps_page_link="https://zulip.com/apps" %}You will use the following info to log into the Zulip web, <a href="{{ apps_page_link }}">mobile and desktop</a> apps:{% endtrans %}
     <ul>
         <li>{% trans organization_url=macros.link_tag(realm_uri) %}Organization URL: {{ organization_url }}{% endtrans %}<br /></li>
         {% if ldap %}
             {% if ldap_username %}
-            <li>{% trans %}Username: {{ ldap_username }}{% endtrans %}<br /></li>
+            <li>{% trans %}Your username: {{ ldap_username }}{% endtrans %}<br /></li>
             {% else %}
             <li>{{ _('Use your LDAP account to log in') }}<br /></li>
             {% endif %}
         {% else %}
-            <li>{% trans email=macros.email_tag(email) %}Email: {{ email }}{% endtrans %}<br /></li>
+            <li>{% trans email=macros.email_tag(email) %}Your account email: {{ email }}{% endtrans %}<br /></li>
         {% endif %}
     </ul>
-    {% trans apps_page_link="https://zulip.com/apps" %}(you'll need these to sign in to the <a href="{{ apps_page_link }}">mobile and desktop</a> apps){% endtrans %}
+    <a class="button" href="{{ realm_uri }}">{{ _('Go to organization') }}</a>
 </p>
 
 <p>
+    {% trans %}If you are new to Zulip, check out our <a href="{{ getting_user_started_link }}">Getting started guide</a>!{% endtrans %}
     {% if is_realm_admin %}
-        {% trans %}Check out our <a href="{{ getting_started_link }}">guide for admins</a>, become a Zulip pro with a few <a href="{{ keyboard_shortcuts_link }}">keyboard shortcuts</a>, or <a href="{{ realm_uri }}">dive right in</a>!{% endtrans %}
-    {% else %}
-        {% trans %}<a href="{{ getting_started_link }}">Learn more</a> about Zulip, become a pro with a few <a href="{{ keyboard_shortcuts_link }}">keyboard shortcuts</a>, or <a href="{{ realm_uri }}">dive right in</a>!{% endtrans %}
+    {% trans %}We also have a guide for <a href="{{ getting_organization_started_link }}">Setting up your organization</a>.{% endtrans %}
     {% endif %}
 </p>
 
 <p>
-    {{ _("Cheers,") }}<br />
-    {{ _("Team Zulip") }}
-</p>
-
-<p>
-    {% trans %}PS: Follow us on <a href="https://twitter.com/zulip">Twitter</a>, star us on <a href="https://github.com/zulip/zulip">GitHub</a>, or chat with us live on the <a href="https://zulip.com/development-community/">Zulip community server</a>!{% endtrans %}
+    {% trans support_email=macros.email_tag(support_email) %}Questions? Contact
+us any time at {{ support_email }}.{% endtrans %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -8,10 +8,10 @@
 {% if realm_creation %}
 {% if is_demo_org %}
 <p>
-    {% trans %}Congratulations, you have created a new Zulip organization. Note
+    {% trans demo_organizations_help_link="https://zulip.com/help/demo-organizations" %}Congratulations, you have created a new Zulip demo organization. Note
     that this organization will be automatically deleted in 30 days. Learn more
     about demo organizations <a
-    href="https://zulip.com/help/demo-organizations">here</a>!
+    href="{{ demo_organizations_help_link }}">here</a>!
     {% endtrans %}
 </p>
 {% else %}

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -2,7 +2,7 @@
 
 {% if realm_creation %}
     {% if is_demo_org %}
-        {% trans %}Congratulations, you have created a new Zulip organization. Note that this organization will be automatically deleted in 30 days. Learn more about demo organizations here: https://zulip.com/help/demo-organizations{% endtrans %}
+        {% trans demo_organizations_help_link="https://zulip.com/help/demo-organizations" %} Congratulations, you have created a new demo Zulip organization. Note that this organization will be automatically deleted in 30 days. Learn more about demo organizations here: {{ demo_organizations_help_link }}!{% endtrans %}
     {% else %}
         {% trans %}Congratulations, you have created a new Zulip organization: {{ realm_name }}.{% endtrans %}
     {% endif %}

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -2,38 +2,31 @@
 
 {% if realm_creation %}
     {% if is_demo_org %}
-        {% trans %}You've created a demo Zulip organization. Note that this organization will be automatically deleted in 30 days. Learn more about demo organizations here: https://zulip.com/help/demo-organizations{% endtrans %}
+        {% trans %}Congratulations, you have created a new Zulip organization. Note that this organization will be automatically deleted in 30 days. Learn more about demo organizations here: https://zulip.com/help/demo-organizations{% endtrans %}
     {% else %}
-        {% trans %}You've created the new Zulip organization {{ realm_name }}.{% endtrans %}
+        {% trans %}Congratulations, you have created a new Zulip organization: {{ realm_name }}.{% endtrans %}
     {% endif %}
-{% trans %}You've created the new Zulip organization {{ realm_name }}.{% endtrans %}
 {% else %}
 {% trans %}You've joined the Zulip organization {{ realm_name }}.{% endtrans %}
 {% endif %}
 
 
-{{ _('Your account details:') }}
+{% trans apps_page_link="https://zulip.com/apps" %}You will use the following info to log into the Zulip web, mobile and desktop apps ({{ apps_page_link}}):{% endtrans %}
+
 * {% trans organization_url=realm_uri %}Organization URL: {{ organization_url }}{% endtrans %}
+
 {% if ldap %}
 {% if ldap_username %}
-* {% trans %}Username: {{ ldap_username }}{% endtrans %}
+* {% trans %}Your username: {{ ldap_username }}{% endtrans %}
 {% else %}
 * {{ _('Use your LDAP account to log in') }}
 {% endif %}
 {% else %}
-* {% trans %}Email: {{ email }}{% endtrans %}
+* {% trans %}Your account email: {{ email }}{% endtrans %}
 {% endif %}
-{% trans apps_page_link="https://zulip.com/apps" %}(you'll need these to sign in to the mobile and desktop apps ({{ apps_page_link }})){% endtrans %}
 
 
+{% trans %}If you are new to Zulip, check out our Getting started guide ({{ getting_user_started_link }})!{% endtrans %}
 {% if is_realm_admin %}
-{% trans %}Check out our guide ({{ getting_started_link }}) for admins, become a Zulip pro with a few keyboard shortcuts ({{ keyboard_shortcuts_link }}), or dive right in to {{ realm_uri }}!{% endtrans %}
-{% else %}
-{% trans %}Learn more ({{ getting_started_link }}) about Zulip, become a pro with a few keyboard shortcuts ({{ keyboard_shortcuts_link }}), or dive right in to {{ realm_uri }}!{% endtrans %}
+{% trans %} We also have a guide for Setting up your organization ({{ getting_organization_started_link }}).{% endtrans %}
 {% endif %}
-
-
-{{ _("Cheers,") }}
-{{ _("Team Zulip") }}
-
-{% trans %}PS: Check us out on Twitter (@zulip), star us on GitHub (https://github.com/zulip/zulip), or chat with us live on the Zulip community server (https://zulip.com/development-community/)!{% endtrans %}

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -687,12 +687,11 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> N
         is_realm_admin=user.is_realm_admin,
         is_demo_org=user.realm.demo_organization_scheduled_deletion_date is not None,
     )
-    if user.is_realm_admin:
-        context["getting_started_link"] = (
-            user.realm.uri + "/help/getting-your-organization-started-with-zulip"
-        )
-    else:
-        context["getting_started_link"] = "https://zulip.com"
+
+    context["getting_organization_started_link"] = (
+        user.realm.uri + "/help/getting-your-organization-started-with-zulip"
+    )
+    context["getting_user_started_link"] = user.realm.uri + "/help/getting-started-with-zulip"
 
     # Imported here to avoid import cycles.
     from zproject.backends import ZulipLDAPAuthBackend, email_belongs_to_ldap

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -214,7 +214,10 @@ class TestFollowupEmails(ZulipTestCase):
         email_data = orjson.loads(scheduled_emails[0].data)
         self.assertEqual(email_data["context"]["email"], self.example_email("hamlet"))
         self.assertEqual(email_data["context"]["is_realm_admin"], False)
-        self.assertEqual(email_data["context"]["getting_started_link"], "https://zulip.com")
+        self.assertEqual(
+            email_data["context"]["getting_user_started_link"],
+            "http://zulip.testserver/help/getting-started-with-zulip",
+        )
         self.assertNotIn("ldap_username", email_data["context"])
 
         ScheduledEmail.objects.all().delete()
@@ -226,8 +229,12 @@ class TestFollowupEmails(ZulipTestCase):
         self.assertEqual(email_data["context"]["email"], self.example_email("iago"))
         self.assertEqual(email_data["context"]["is_realm_admin"], True)
         self.assertEqual(
-            email_data["context"]["getting_started_link"],
+            email_data["context"]["getting_organization_started_link"],
             "http://zulip.testserver/help/getting-your-organization-started-with-zulip",
+        )
+        self.assertEqual(
+            email_data["context"]["getting_user_started_link"],
+            "http://zulip.testserver/help/getting-started-with-zulip",
         )
         self.assertNotIn("ldap_username", email_data["context"])
 
@@ -350,7 +357,7 @@ class TestFollowupEmails(ZulipTestCase):
         self.assert_length(outbox, 1)
 
         message = outbox[0]
-        self.assertIn("You've created the new Zulip organization", message.body)
+        self.assertIn("you have created a new Zulip organization", message.body)
         self.assertNotIn("demo org", message.body)
 
     def test_followup_emails_for_demo_realms(self) -> None:
@@ -372,7 +379,7 @@ class TestFollowupEmails(ZulipTestCase):
         self.assert_length(outbox, 1)
 
         message = outbox[0]
-        self.assertIn("You've created a demo Zulip organization", message.body)
+        self.assertIn("you have created a new demo Zulip organization", message.body)
 
 
 class TestMissedMessages(ZulipTestCase):

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -69,7 +69,9 @@ class EmailTranslationTestCase(ZulipTestCase):
 
         with self.settings(DEVELOPMENT_LOG_EMAILS=True):
             enqueue_welcome_emails(hamlet)
-        check_translation("Viele Grüße", "")
+        # TODO: Uncomment and replace with translation once we have German translations for the strings
+        # in followup_day1 emails.
+        # check_translation("Viele Grüße", "")
 
 
 class TranslationTestCase(ZulipTestCase):


### PR DESCRIPTION
- Clean up the language.
- Add a prominent "Go to organization" button.
- Link to guides for new users and admins.
- Fix duplication bug in text email version.

Testing:
- Preview and manual link testing
- Not tested for demo orgs
- Not tested for login with LDAP


## Screenshots: After changes


<details>
<summary>New org admin</summary>

![Screen Shot 2023-02-02 at 1 45 24 PM](https://user-images.githubusercontent.com/2090066/216462330-ec76f175-2e3c-4117-85c1-20d9e053eb6a.png)

</details>

<details>
<summary>Existing org admin</summary>

![Screen Shot 2023-02-02 at 1 48 11 PM](https://user-images.githubusercontent.com/2090066/216461985-44cb1fe3-a161-4c43-acad-d70f15fea855.png)

</details>

<details>
<summary>Existing org member</summary>

![Screen Shot 2023-02-02 at 1 46 43 PM](https://user-images.githubusercontent.com/2090066/216461988-c69ad080-9096-4d82-9820-60d3db6efe07.png)

</details>

<details>
<summary>New org admin</summary>

![Screen Shot 2023-02-02 at 1 54 35 PM](https://user-images.githubusercontent.com/2090066/216462440-3fe8f7a1-d55c-45e2-875a-5393bb303b59.png)

</details>
<details>
<summary>Existing org admin</summary>

![Screen Shot 2023-02-02 at 1 53 40 PM](https://user-images.githubusercontent.com/2090066/216462455-0bff2b53-0ef6-4086-8832-59233117c67a.png)

</details>

## Screenshots: Before changes

<details>
<summary>New org admin</summary>

![Screen Shot 2023-02-02 at 12 42 07 PM](https://user-images.githubusercontent.com/2090066/216462588-2b7769a9-31ac-4ce6-a3f7-d78483604692.png)

</details>
<details>
<summary>Existing org member</summary>

![Screen Shot 2023-02-02 at 9 24 36 AM](https://user-images.githubusercontent.com/2090066/216462615-d146c29a-c97f-48c8-9662-2404dde2ae2f.png)

</details>
