### PR TITLE
hotkey: Repurpose `s` to toggle conversation view and remove `shift+S`.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -83,9 +83,9 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Narrow to next unread direct message**: <kbd>P</kbd>
 
-* **Narrow to stream**: <kbd>S</kbd>
+* **Narrow to topic or DM conversation**: <kbd>S</kbd>
 
-* **Narrow to topic or DM conversation**: <kbd>Shift</kbd> + <kbd>S</kbd>
+* **Narrow to stream from topic view**: <kbd>S</kbd>
 
 * **Narrow to all direct messages**: <kbd>Shift</kbd> + <kbd>P</kbd>
 

--- a/web/src/deprecated_feature_notice.js
+++ b/web/src/deprecated_feature_notice.js
@@ -19,13 +19,19 @@ let shown_deprecation_notices = [];
 export function maybe_show_deprecation_notice(key) {
     let message;
     const isCmdOrCtrl = common.has_mac_keyboard() ? "Cmd" : "Ctrl";
-    if (key === "C") {
-        message = get_hotkey_deprecation_notice("C", "x");
-    } else if (key === "*") {
-        message = get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
-    } else {
-        blueslip.error("Unexpected deprecation notice for hotkey:", {key});
-        return;
+    switch (key) {
+        case "C":
+            message = get_hotkey_deprecation_notice("C", "x");
+            break;
+        case "*":
+            message = get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
+            break;
+        case "Shift + S":
+            message = get_hotkey_deprecation_notice("Shift + S", "S");
+            break;
+        default:
+            blueslip.error("Unexpected deprecation notice for hotkey:", {key});
+            return;
     }
 
     // Here we handle the tracking for showing deprecation notices,

--- a/web/src/deprecated_feature_notice.js
+++ b/web/src/deprecated_feature_notice.js
@@ -20,11 +20,11 @@ export function maybe_show_deprecation_notice(key) {
     let message;
     const isCmdOrCtrl = common.has_mac_keyboard() ? "Cmd" : "Ctrl";
     switch (key) {
-        case "C":
-            message = get_hotkey_deprecation_notice("C", "x");
+        case "Shift + C":
+            message = get_hotkey_deprecation_notice("Shift + C", "X");
             break;
         case "*":
-            message = get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
+            message = get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + S");
             break;
         case "Shift + S":
             message = get_hotkey_deprecation_notice("Shift + S", "S");

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -868,7 +868,7 @@ export function process_hotkey(e, hotkey) {
             browser_history.go_to_location("drafts");
             return true;
         case "C_deprecated":
-            deprecated_feature_notice.maybe_show_deprecation_notice("C");
+            deprecated_feature_notice.maybe_show_deprecation_notice("Shift + C");
             return true;
         case "star_deprecated":
             deprecated_feature_notice.maybe_show_deprecation_notice("*");

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -139,7 +139,7 @@ const keypress_mappings = {
     77: {name: "toggle_topic_mute", message_view_only: true}, // 'M'
     80: {name: "narrow_private", message_view_only: true}, // 'P'
     82: {name: "respond_to_author", message_view_only: true}, // 'R'
-    83: {name: "narrow_by_topic", message_view_only: true}, // 'S'
+    83: {name: "toggle_stream_subscription", message_view_only: true}, // 'S'
     85: {name: "mark_unread", message_view_only: true}, // 'U'
     86: {name: "view_selected_stream", message_view_only: false}, // 'V'
     97: {name: "all_messages", message_view_only: true}, // 'a'
@@ -157,7 +157,7 @@ const keypress_mappings = {
     112: {name: "p_key", message_view_only: false}, // 'p'
     113: {name: "query_streams", message_view_only: true}, // 'q'
     114: {name: "reply_message", message_view_only: true}, // 'r'
-    115: {name: "narrow_by_recipient", message_view_only: true}, // 's'
+    115: {name: "toggle_conversation_view", message_view_only: true}, // 's'
     116: {name: "open_recent_topics", message_view_only: true}, // 't'
     117: {name: "show_sender_info", message_view_only: true}, // 'u'
     118: {name: "show_lightbox", message_view_only: true}, // 'v'
@@ -646,7 +646,7 @@ export function process_hotkey(e, hotkey) {
         if (processing_text()) {
             return false;
         }
-        if (event_name === "narrow_by_topic" && overlays.streams_open()) {
+        if (event_name === "toggle_stream_subscription" && overlays.streams_open()) {
             stream_settings_ui.keyboard_sub();
             return true;
         }
@@ -923,9 +923,7 @@ export function process_hotkey(e, hotkey) {
     if (
         // Allow UI only features for spectators which they can perform.
         page_params.is_spectator &&
-        !["narrow_by_topic", "narrow_by_recipient", "show_lightbox", "show_sender_info"].includes(
-            event_name,
-        )
+        !["toggle_conversation_view", "show_lightbox", "show_sender_info"].includes(event_name)
     ) {
         spectators.login_to_access();
         return true;
@@ -939,10 +937,19 @@ export function process_hotkey(e, hotkey) {
         case "star_message":
             message_flags.toggle_starred_and_update_server(msg);
             return true;
-        case "narrow_by_recipient":
-            return do_narrow_action(narrow.by_recipient);
-        case "narrow_by_topic":
+        case "toggle_conversation_view":
+            if (narrow_state.narrowed_by_topic_reply()) {
+                // narrow to stream if user is in topic view
+                return do_narrow_action(narrow.by_recipient);
+            } else if (narrow_state.narrowed_by_pm_reply()) {
+                // do nothing if user is in DM view
+                return false;
+            }
+            // else narrow to conversation view (topic / DM)
             return do_narrow_action(narrow.by_topic);
+        case "toggle_stream_subscription":
+            deprecated_feature_notice.maybe_show_deprecation_notice("Shift + S");
+            return true;
         case "respond_to_author": // 'R': respond to author
             compose_actions.respond_to_message({reply_type: "personal", trigger: "hotkey pm"});
             return true;

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -164,12 +164,12 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Narrow to stream' }}</td>
+                    <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
                     <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
+                    <td class="definition">{{t 'Narrow to stream from topic view' }}</td>
+                    <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{{t 'Narrow to all direct messages' }}</td>

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -47,6 +47,9 @@ const message_edit = mock_esm("../src/message_edit");
 const message_lists = mock_esm("../src/message_lists");
 const muted_topics_ui = mock_esm("../src/muted_topics_ui");
 const narrow = mock_esm("../src/narrow");
+const narrow_state = mock_esm("../src/narrow_state", {
+    is_message_feed_visible: () => true,
+});
 const navigate = mock_esm("../src/navigate");
 const overlays = mock_esm("../src/overlays", {
     is_active: () => false,
@@ -78,7 +81,6 @@ mock_esm("../src/hotspots", {
 });
 
 mock_esm("../src/recent_topics_util", {
-    is_visible: () => false,
     is_in_focus: () => false,
 });
 
@@ -337,7 +339,7 @@ run_test("modal open", ({override}) => {
 
 run_test("misc", ({override}) => {
     // Next, test keys that only work on a selected message.
-    const message_view_only_keys = "@+>RjJkKsSuvi:GM";
+    const message_view_only_keys = "@+>RjJkKsuvi:GM";
 
     // Check that they do nothing without a selected message
     with_overrides(({override}) => {
@@ -365,13 +367,22 @@ run_test("misc", ({override}) => {
     assert_mapping("J", navigate, "page_down");
     assert_mapping("k", navigate, "up");
     assert_mapping("K", navigate, "page_up");
-    assert_mapping("s", narrow, "by_recipient");
-    assert_mapping("S", narrow, "by_topic");
     assert_mapping("u", popovers, "show_sender_info");
     assert_mapping("i", popover_menus, "toggle_message_actions_menu");
     assert_mapping(":", reactions, "open_reactions_popover", true);
     assert_mapping(">", compose_actions, "quote_and_reply");
     assert_mapping("e", message_edit, "start");
+
+    override(narrow_state, "narrowed_by_topic_reply", () => true);
+    assert_mapping("s", narrow, "by_recipient");
+
+    override(narrow_state, "narrowed_by_topic_reply", () => false);
+    override(narrow_state, "narrowed_by_pm_reply", () => true);
+    assert_unmapped("s");
+
+    override(narrow_state, "narrowed_by_topic_reply", () => false);
+    override(narrow_state, "narrowed_by_pm_reply", () => false);
+    assert_mapping("s", narrow, "by_topic");
 
     override(message_edit, "can_move_message", () => true);
     assert_mapping("m", stream_popover, "build_move_topic_to_stream_popover");


### PR DESCRIPTION
Earlier, the `s` hotkey just narrowed to the stream of the selected message (to a topic), while `shift+s` narrowed to the conversation view (topic / pm) of the selected message.

Now, the `shift+s` hotkey has been removed (but retained for toggling subscription to a stream when the stream overlay is active), and the `s` hotkey takes on double duty: if the current view is not topic / pm, it narrows to that, else when in topic view, it switches to stream view. It has no effect when in pm view. Documentation has been updated for this both in the help center, and the in-app `Keyboard shortcuts` menu.

Fixes: #24226.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/68962290/217284844-932397cd-6b72-4955-b3ed-463694fd7c51.png)

![image](https://user-images.githubusercontent.com/68962290/217285005-2af4febb-68ab-45ed-adac-bdacc620adca.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
