### PR TITLE
Consistently use static-host abstraction

### DIFF
--- a/static/js/assets.d.ts
+++ b/static/js/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+    const url: string;
+    export default url;
+}

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -72,6 +72,9 @@ function build_emoticon_translations({emoticon_conversions}) {
 const zulip_emoji = {
     id: "zulip",
     emoji_name: "zulip",
+    // We don't use a webpack'd URL here, for consistency with the
+    // server-side markdown, which doesn't want to render it into the
+    // message content.
     emoji_url: "/static/generated/emoji/images/emoji/unicode/zulip.png",
     is_realm_emoji: true,
     deactivated: false,

--- a/static/js/favicon.js
+++ b/static/js/favicon.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import static_favicon_image from "../images/favicon.svg";
 import render_favicon_svg from "../templates/favicon.svg.hbs";
 
 import * as blueslip from "./blueslip";
@@ -39,7 +40,7 @@ export function update_favicon(new_message_count, pm_count) {
         }
 
         if (new_message_count === 0 && pm_count === 0) {
-            $("#favicon").attr("href", "/static/images/favicon.svg?v=4");
+            $("#favicon").attr("href", static_favicon_image);
             return;
         }
 

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import _ from "lodash";
 
+import whale_image from "../images/hotspots/whale.svg";
 import render_hotspot_icon from "../templates/hotspot_icon.hbs";
 import render_hotspot_overlay from "../templates/hotspot_overlay.hbs";
 
@@ -54,9 +55,6 @@ const HOTSPOT_LOCATIONS = new Map([
         },
     ],
 ]);
-
-// popover illustration url(s)
-const WHALE = "/static/images/hotspots/whale.svg";
 
 export function post_hotspot_as_read(hotspot_name) {
     channel.post({
@@ -207,7 +205,7 @@ function insert_hotspot_into_DOM(hotspot) {
         name: hotspot.name,
         title: hotspot.title,
         description: hotspot.description,
-        img: WHALE,
+        img: whale_image,
     });
 
     const hotspot_icon_HTML = render_hotspot_icon({

--- a/static/js/loading.ts
+++ b/static/js/loading.ts
@@ -1,5 +1,7 @@
 import $ from "jquery";
 
+import loading_black_image from "../images/loading/loader-black.svg";
+import loading_white_image from "../images/loading/loader-white.svg";
 import render_loader from "../templates/loader.hbs";
 
 export function make_indicator(
@@ -84,9 +86,9 @@ export function destroy_indicator($container: JQuery): void {
 
 export function show_button_spinner($elt: JQuery, using_dark_theme: boolean): void {
     if (!using_dark_theme) {
-        $elt.attr("src", "/static/images/loading/loader-black.svg");
+        $elt.attr("src", loading_black_image);
     } else {
-        $elt.attr("src", "/static/images/loading/loader-white.svg");
+        $elt.attr("src", loading_white_image);
     }
     $elt.css("display", "inline-block");
 }

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -1,5 +1,11 @@
 import $ from "jquery";
 
+import macbook_image from "../../images/app-screenshots/macbook.png";
+import microsoft_image from "../../images/app-screenshots/microsoft.png";
+import ubuntu_image from "../../images/app-screenshots/ubuntu.png";
+import android_image from "../../images/app-screenshots/zulip-android.png";
+import iphone_image from "../../images/app-screenshots/zulip-iphone-rough.png";
+
 import {detect_user_os} from "./tabbed-instructions";
 import render_tabs from "./team";
 
@@ -14,7 +20,7 @@ const hello_events = function () {
 const apps_events = function () {
     const info = {
         windows: {
-            image: "/static/images/app-screenshots/microsoft.png",
+            image: microsoft_image,
             alt: "Windows",
             description:
                 "Zulip for Windows is even better than Zulip on the web, with a cleaner look, tray integration, native notifications, and support for multiple Zulip accounts.",
@@ -24,7 +30,7 @@ const apps_events = function () {
             app_type: "desktop",
         },
         mac: {
-            image: "/static/images/app-screenshots/macbook.png",
+            image: macbook_image,
             alt: "macOS",
             description:
                 "Zulip on macOS is even better than Zulip on the web, with a cleaner look, tray integration, native notifications, and support for multiple Zulip accounts.",
@@ -35,7 +41,7 @@ const apps_events = function () {
             app_type: "desktop",
         },
         android: {
-            image: "/static/images/app-screenshots/zulip-android.png",
+            image: android_image,
             alt: "Android",
             description: "Zulip's native Android app makes it easy to keep up while on the go.",
             show_instructions: false,
@@ -44,7 +50,7 @@ const apps_events = function () {
             app_type: "mobile",
         },
         ios: {
-            image: "/static/images/app-screenshots/zulip-iphone-rough.png",
+            image: iphone_image,
             alt: "iOS",
             description: "Zulip's native iOS app makes it easy to keep up while on the go.",
             show_instructions: false,
@@ -52,7 +58,7 @@ const apps_events = function () {
             app_type: "mobile",
         },
         linux: {
-            image: "/static/images/app-screenshots/ubuntu.png",
+            image: ubuntu_image,
             alt: "Linux",
             description:
                 "Zulip on the Linux desktop is even better than Zulip on the web, with a cleaner look, tray integration, native notifications, and support for multiple Zulip accounts.",

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -96,6 +96,7 @@ const apps_events = function () {
         $download_from_apple_app_store.attr("href", version_info.app_store_link);
         $download_android_apk.attr("href", version_info.download_link);
         $download_mac_arm64.attr("href", version_info.mac_arm64_link);
+        $(".image img").addClass(`app-screenshot-${version_info.app_type}`);
         $(".image img").attr("src", version_info.image);
         $download_instructions.find("a").attr("href", version_info.install_guide);
 

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -188,7 +188,6 @@ export function add_custom_emoji_post_render() {
         $preview_image.hide();
         $placeholder_icon.show();
         $preview_text.show();
-        $preview_image.attr("src", "/static/images/default-avatar.png");
     });
 }
 

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -1,12 +1,14 @@
 import $ from "jquery";
 
+import checkbox_image from "../images/checkbox-green.svg";
+
 import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as ui_report from "./ui_report";
 
 export function display_checkmark($elem) {
     const check_mark = document.createElement("img");
-    check_mark.src = "/static/images/checkbox-green.svg";
+    check_mark.src = checkbox_image;
     $elem.prepend(check_mark);
     $(check_mark).css("width", "13px");
 }

--- a/static/styles/app_components.css
+++ b/static/styles/app_components.css
@@ -614,7 +614,7 @@ div.overlay {
 
 .white_zulip_icon_without_text {
     display: inline-block;
-    background-image: url("../../static/images/logo/white-zulip-logo-without-text.svg");
+    background-image: url("../images/logo/white-zulip-logo-without-text.svg");
     background-size: cover;
 }
 

--- a/static/styles/portico/landing_page.css
+++ b/static/styles/portico/landing_page.css
@@ -2025,14 +2025,7 @@ nav {
     max-width: 600px;
 }
 
-.portico-landing.apps
-    .hero
-    .image
-    img[src="/static/images/app-screenshots/zulip-android.png"],
-.portico-landing.apps
-    .hero
-    .image
-    img[src="/static/images/app-screenshots/zulip-iphone-rough.png"] {
+.portico-landing.apps .hero .image img.app-screenshot-mobile {
     height: 85%;
 }
 

--- a/static/templates/about_zulip.hbs
+++ b/static/templates/about_zulip.hbs
@@ -3,7 +3,7 @@
         <button type="button" class="exit" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <div class="modal-body">
             <div class="about-zulip-logo">
-                <a target="_blank" rel="noopener noreferrer" href="https://zulip.com"><img src="/static/images/logo/zulip-org-logo.svg" alt="{{t 'Zulip' }}" /></a>
+                <a target="_blank" rel="noopener noreferrer" href="https://zulip.com"><img src="../images/logo/zulip-org-logo.svg" alt="{{t 'Zulip' }}" /></a>
             </div>
             <p>
                 <strong>Zulip Server</strong>

--- a/static/templates/giphy_picker.hbs
+++ b/static/templates/giphy_picker.hbs
@@ -15,7 +15,7 @@
             <div class="giphy-content"></div>
         </div>
         <div class="popover-footer">
-            <img src="/static/images/giphy/GIPHY_attribution.png" alt="{{t 'GIPHY attribution' }}" />
+            <img src="../images/giphy/GIPHY_attribution.png" alt="{{t 'GIPHY attribution' }}" />
         </div>
     </div>
 </div>

--- a/static/templates/keyboard_shortcuts.hbs
+++ b/static/templates/keyboard_shortcuts.hbs
@@ -233,7 +233,7 @@
                         {{t 'React to selected message with' }}
                         <img alt=":thumbs_up:"
                           class="emoji"
-                          src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
+                          src="../generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>
                     <td><span class="hotkey"><kbd>+</kbd></span></td>

--- a/static/templates/more_topics_spinner.hbs
+++ b/static/templates/more_topics_spinner.hbs
@@ -1,3 +1,3 @@
 <li class="searching-for-more-topics">
-    <img src="/static/images/loading/loading-ellipsis.svg" alt="" />
+    <img src="../images/loading/loading-ellipsis.svg" alt="" />
 </li>

--- a/static/templates/settings/admin_user_group_list.hbs
+++ b/static/templates/settings/admin_user_group_list.hbs
@@ -6,7 +6,7 @@
         <span class="spacer">—</span>
         <span class="description" data-placeholder="{{t 'Description' }}" contenteditable="true">{{description}}</span>
         <button class="button save-status sea-green small">
-            <img class="checkmark" src="/static/images/checkbox-green.svg" />
+            <img class="checkmark" src="../../images/checkbox-green.svg" />
             {{t 'Saved' }}
         </button>
         <button class="button save-status btn-danger small">

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -19,7 +19,7 @@
             {{ upload_text }}
         </span>
         <span class="upload-spinner-background">
-            <img class="image_upload_spinner" src="/static/images/loading/tail-spin.svg" alt="" />
+            <img class="image_upload_spinner" src="../../images/loading/tail-spin.svg" alt="" />
         </span>
     </div>
     <img class="image-block" src="{{ image }}"/>

--- a/templates/404.html
+++ b/templates/404.html
@@ -10,7 +10,7 @@
 <div class="error_page">
     <div class="container">
         <div class="row-fluid">
-            <img src="/static/images/errors/400art.svg" alt=""/>
+            <img src="{{ static('images/errors/400art.svg') }}" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
                     {% if status_code == 405 %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -15,7 +15,7 @@
 <div class="error_page">
     <div class="container">
         <div class="row-fluid">
-            <img src="/static/images/errors/500art.svg" alt=""/>
+            <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _("Internal server error") }}</h1>

--- a/templates/confirmation/link_does_not_exist.html
+++ b/templates/confirmation/link_does_not_exist.html
@@ -7,7 +7,7 @@
 {% block portico_content %}
 <div class="error_page">
     <div class="container row-fluid">
-        <img src="/static/images/errors/400art.svg" alt=""/>
+        <img src="{{ static('images/errors/400art.svg') }}" alt=""/>
         <div class="errorbox">
             <div class="errorcontent">
                 <h1 class="lead">{{ _("Whoops. We couldn't find your confirmation link in the system.") }}</h1>

--- a/templates/confirmation/link_expired.html
+++ b/templates/confirmation/link_expired.html
@@ -8,7 +8,7 @@
 <div class="error_page">
     <div class="container">
         <div class="row-fluid">
-            <img class="hourglass-img" src="/static/images/errors/timeout_hourglass.png" alt=""/>
+            <img class="hourglass-img" src="{{ static('images/errors/timeout_hourglass.png') }}" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _("Whoops. The confirmation link has expired or been deactivated.") }}</h1>

--- a/templates/confirmation/link_malformed.html
+++ b/templates/confirmation/link_malformed.html
@@ -7,7 +7,7 @@
 {% block portico_content %}
 <div class="error_page">
     <div class="container row-fluid">
-        <img src="/static/images/errors/500art.svg" alt=""/>
+        <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
         <div class="errorbox">
             <div class="errorcontent">
                 <h1 class="lead">{{ _("Whoops. The confirmation link is malformed.") }}</h1>

--- a/templates/corporate/apps.html
+++ b/templates/corporate/apps.html
@@ -28,8 +28,8 @@
                         <p class="description"></p>
                         <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank" rel="noopener noreferrer">desktop app install guide</a>.</p>
                         <a class="desktop-download-link no-action" hidden href=""><span class="button green">Download Zulip for <span class="platform"></span></span></a>
-                        <a class="download-from-google-play-store" hidden href=""><img src='/static/images/store-badges/google-play-badge.png' alt=""/></a>
-                        <a class="download-from-apple-app-store" hidden href=""><img src='/static/images/store-badges/app-store-badge.svg' alt=""/></a>
+                        <a class="download-from-google-play-store" hidden href=""><img src="{{ static('images/store-badges/google-play-badge.png') }}" alt=""/></a>
+                        <a class="download-from-apple-app-store" hidden href=""><img src="{{ static('images/store-badges/app-store-badge.svg') }}" alt=""/></a>
                         <span><a id="download-android-apk" hidden href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
                         <span><a id="download-mac-arm64" hidden href="">or download Apple silicon native build</a></span>
                     </div>
@@ -37,7 +37,7 @@
             </div>
             <div class="image">
                 <div class="flex">
-                    <img src="/static/images/loading/loader-white.svg" alt="" />
+                    <img src="{{ static('images/loading/loader-white.svg') }}" alt="" />
                 </div>
             </div>
         </div>

--- a/templates/corporate/attribution.html
+++ b/templates/corporate/attribution.html
@@ -21,7 +21,7 @@
             <ul>
                 <li>
                     <b>On <a href="/for/business">/for/business</a> page:</b>
-                    <img alt="" src="/static/images/landing-page/companies/software-engineer.svg" />
+                    <img alt="" src="{{ static('images/landing-page/companies/software-engineer.svg') }}" />
                     <p>"<a href="https://iconscout.com/illustration/software-engineer-2043023">Software engineer Illustration</a>" By <a href="https://iconscout.com/contributors/delesign/illustrations">Delesign Graphic</a> is licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
                 </li>
             </ul>

--- a/templates/corporate/features.html
+++ b/templates/corporate/features.html
@@ -69,7 +69,7 @@
                 </p>
             </div>
         </div>
-        <img class="image" src="/static/images/landing-page/features/message-formatting.png" alt="" />
+        <img class="image" src="{{ static('images/landing-page/features/message-formatting.png') }}" alt="" />
     </section>
 
     <section class="notifications">
@@ -93,7 +93,7 @@
     </section>
 
     <section class="keyboard-shortcuts">
-        <img class="overflow-wave" src="/static/images/landing-page/features/wave.png" alt="" />
+        <img class="overflow-wave" src="{{ static('images/landing-page/features/wave.png') }}" alt="" />
         <div class="feature-block">
             <h3>Keyboard shortcuts.</h3>
             <p>Communicate as efficiently as you use your favorite
@@ -103,7 +103,7 @@
                     Learn more about keyboard shortcuts.</a>
             </p>
         </div>
-        <img class="image" src="/static/images/landing-page/features/love-keyboard-shortcuts.svg" alt="" />
+        <img class="image" src="{{ static('images/landing-page/features/love-keyboard-shortcuts.svg') }}" alt="" />
     </section>
 
     <section>

--- a/templates/corporate/for/business.html
+++ b/templates/corporate/for/business.html
@@ -112,7 +112,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image topics-image">
-                <img alt="" src="/static/images/story-tutorial/zulip-streams-unreads-arrows.png" />
+                <img alt="" src="{{ static('images/story-tutorial/zulip-streams-unreads-arrows.png') }}" />
             </div>
         </div>
     </div>
@@ -121,7 +121,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/software-engineer.svg" />
+                <img alt="" src="{{ static('images/landing-page/companies/software-engineer.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -172,7 +172,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/software-engineer.svg" />
+                <img alt="" src="{{ static('images/landing-page/companies/software-engineer.svg') }}" />
             </div>
         </div>
     </div>
@@ -219,7 +219,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/knowledge-repository.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/knowledge-repository.svg') }}" />
             </div>
         </div>
     </div>
@@ -227,7 +227,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/integrations_with_border.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/integrations_with_border.png') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -300,7 +300,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/integrations_with_border.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/integrations_with_border.png') }}" />
             </div>
         </div>
     </div>
@@ -340,7 +340,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/message-formatting-top.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/message-formatting-top.png') }}" />
             </div>
         </div>
     </div>
@@ -348,7 +348,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/message-formatting-bottom.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/message-formatting-bottom.png') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -384,7 +384,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/message-formatting-bottom.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/message-formatting-bottom.png') }}" />
             </div>
         </div>
     </div>
@@ -421,7 +421,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
             </div>
         </div>
     </div>
@@ -430,7 +430,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img class="mirror-image" alt="" src="/static/images/landing-page/education/privacy.svg" />
+                <img class="mirror-image" alt="" src="{{ static('images/landing-page/education/privacy.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -474,7 +474,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img class="mirror-image" alt="" src="/static/images/landing-page/education/privacy.svg" />
+                <img class="mirror-image" alt="" src="{{ static('images/landing-page/education/privacy.svg') }}" />
             </div>
         </div>
     </div>
@@ -510,7 +510,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img class="mirror-image" alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img class="mirror-image" alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
     </div>

--- a/templates/corporate/for/education.html
+++ b/templates/corporate/for/education.html
@@ -78,7 +78,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image topics-image">
-                <img alt="" src="/static/images/landing-page/education/streams_and_topics_day.png" />
+                <img alt="" src="{{ static('images/landing-page/education/streams_and_topics_day.png') }}" />
             </div>
         </div>
     </div>
@@ -86,7 +86,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/message_formatting_day.png" />
+                <img alt="" src="{{ static('images/landing-page/education/message_formatting_day.png') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -104,7 +104,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/message_formatting_day.png" />
+                <img alt="" src="{{ static('images/landing-page/education/message_formatting_day.png') }}" />
             </div>
         </div>
     </div>
@@ -142,7 +142,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/interactive_messaging_day.png" />
+                <img alt="" src="{{ static('images/landing-page/education/interactive_messaging_day.png') }}" />
             </div>
         </div>
     </div>
@@ -150,7 +150,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -168,7 +168,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
             </div>
         </div>
     </div>
@@ -194,7 +194,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/privacy.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/privacy.svg') }}" />
             </div>
         </div>
     </div>
@@ -203,7 +203,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -237,7 +237,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
     </div>

--- a/templates/corporate/for/events.html
+++ b/templates/corporate/for/events.html
@@ -98,7 +98,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image topics-image">
-                <img alt="" src="/static/images/landing-page/events/streams_and_topics_day.png" />
+                <img alt="" src="{{ static('images/landing-page/events/streams_and_topics_day.png') }}" />
             </div>
         </div>
     </div>
@@ -106,7 +106,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/events/your_communication_hub_day.png" />
+                <img alt="" src="{{ static('images/landing-page/events/your_communication_hub_day.png') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -149,7 +149,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/events/your_communication_hub_day.png" />
+                <img alt="" src="{{ static('images/landing-page/events/your_communication_hub_day.png') }}" />
             </div>
         </div>
     </div>
@@ -183,7 +183,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/knowledge-repository.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/knowledge-repository.svg') }}" />
             </div>
         </div>
     </div>
@@ -191,7 +191,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/events/message_formatting_day.png" />
+                <img alt="" src="{{ static('images/landing-page/events/message_formatting_day.png') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -209,7 +209,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/events/message_formatting_day.png" />
+                <img alt="" src="{{ static('images/landing-page/events/message_formatting_day.png') }}" />
             </div>
         </div>
     </div>
@@ -234,7 +234,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
             </div>
         </div>
     </div>
@@ -242,7 +242,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -272,7 +272,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
     </div>

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -103,7 +103,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image topics-image">
-                <img alt="" src="/static/images/landing-page/open_source/streams_and_topics_day.png" />
+                <img alt="" src="{{ static('images/landing-page/open_source/streams_and_topics_day.png') }}" />
             </div>
         </div>
     </div>
@@ -111,7 +111,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/knowledge-repository.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/knowledge-repository.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -173,7 +173,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/knowledge-repository.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/knowledge-repository.svg') }}" />
             </div>
         </div>
     </div>
@@ -237,7 +237,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/open_source/build_inclusive_communities.svg" />
+                <img alt="" src="{{ static('images/landing-page/open_source/build_inclusive_communities.svg') }}" />
             </div>
         </div>
     </div>
@@ -246,7 +246,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/software-engineer.svg" />
+                <img alt="" src="{{ static('images/landing-page/companies/software-engineer.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -318,7 +318,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/software-engineer.svg" />
+                <img alt="" src="{{ static('images/landing-page/companies/software-engineer.svg') }}" />
             </div>
         </div>
     </div>
@@ -375,7 +375,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/message-formatting-top.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/message-formatting-top.png') }}" />
             </div>
         </div>
     </div>
@@ -384,7 +384,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/message-formatting-bottom.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/message-formatting-bottom.png') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -443,7 +443,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/message-formatting-bottom.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/message-formatting-bottom.png') }}" />
             </div>
         </div>
     </div>
@@ -513,7 +513,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/companies/integrations_with_border.png" />
+                <img alt="" src="{{ static('images/landing-page/companies/integrations_with_border.png') }}" />
             </div>
         </div>
     </div>
@@ -521,7 +521,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -566,7 +566,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
             </div>
         </div>
     </div>
@@ -614,7 +614,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img class="mirror-image" alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img class="mirror-image" alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
     </div>

--- a/templates/corporate/for/research.html
+++ b/templates/corporate/for/research.html
@@ -108,7 +108,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image topics-image">
-                <img alt="" src="/static/images/landing-page/research/streams_and_topics_day.png" />
+                <img alt="" src="{{ static('images/landing-page/research/streams_and_topics_day.png') }}" />
             </div>
         </div>
     </div>
@@ -116,7 +116,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/knowledge-repository.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/knowledge-repository.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -168,7 +168,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/knowledge-repository.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/knowledge-repository.svg') }}" />
             </div>
         </div>
     </div>
@@ -209,7 +209,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/events/message_formatting_day.png" />
+                <img alt="" src="{{ static('images/landing-page/events/message_formatting_day.png') }}" />
             </div>
         </div>
     </div>
@@ -217,7 +217,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/research/interactive_messaging_day.png" />
+                <img alt="" src="{{ static('images/landing-page/research/interactive_messaging_day.png') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -274,7 +274,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/research/interactive_messaging_day.png" />
+                <img alt="" src="{{ static('images/landing-page/research/interactive_messaging_day.png') }}" />
             </div>
         </div>
     </div>
@@ -309,7 +309,7 @@
         </div>
         <div class="feature-half">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
             </div>
         </div>
     </div>
@@ -317,7 +317,7 @@
     <div class="feature-container alternate-grid">
         <div class="feature-half md-hide">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
         <div class="feature-half">
@@ -349,7 +349,7 @@
         </div>
         <div class="feature-half md-display">
             <div class="feature-image">
-                <img alt="" src="/static/images/landing-page/education/mobile.svg" />
+                <img alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
             </div>
         </div>
     </div>

--- a/templates/corporate/hello.html
+++ b/templates/corporate/hello.html
@@ -50,7 +50,7 @@
                                 <div class="item-inner">
 
                                     <button data-target="#tour-carousel" data-slide="next" type="button" name="button" class="start-button">Take the tour</button>
-                                    <img src="/static/images/story-tutorial/zulip-topic-blurred.png" alt="" class="start-image" />
+                                    <img src="{{ static('images/story-tutorial/zulip-topic-blurred.png') }}" alt="" class="start-image" />
                                 </div>
                             </div>
                             <div class="item">
@@ -59,11 +59,11 @@
                                     <div class="zulip-slack-comparison">
                                         <div class="comparison-zulip">
                                             <div class="caption">Zulip</div>
-                                            <img src="/static/images/story-tutorial/zulip-streams.png" class="zulip-streams" alt="{{ _('Streams in Zulip') }}" />
+                                            <img src="{{ static('images/story-tutorial/zulip-streams.png') }}" class="zulip-streams" alt="{{ _('Streams in Zulip') }}" />
                                         </div>
                                         <div class="comparison-slack">
                                             <div class="caption">Other team chat</div>
-                                            <img src="/static/images/story-tutorial/slack-streams.png" class="slack-streams" alt="{{ _('Streams in Slack') }}" />
+                                            <img src="{{ static('images/story-tutorial/slack-streams.png') }}" class="slack-streams" alt="{{ _('Streams in Slack') }}" />
                                         </div>
                                     </div>
                                 </div>
@@ -74,11 +74,11 @@
                                     <div class="zulip-slack-comparison">
                                         <div class="comparison-zulip">
                                             <div class="caption">Zulip</div>
-                                            <img src="/static/images/story-tutorial/zulip-streams-selected.png" class="zulip-streams-selected" alt="{{ _('Topics in Zulip') }}" />
+                                            <img src="{{ static('images/story-tutorial/zulip-streams-selected.png') }}" class="zulip-streams-selected" alt="{{ _('Topics in Zulip') }}" />
                                         </div>
                                         <div class="comparison-slack">
                                             <div class="caption">Other team chat</div>
-                                            <img src="/static/images/story-tutorial/slack-streams-selected.png" class="slack-streams-selected" alt="{{ _('Streams in Slack') }}" />
+                                            <img src="{{ static('images/story-tutorial/slack-streams-selected.png') }}" class="slack-streams-selected" alt="{{ _('Streams in Slack') }}" />
                                         </div>
                                     </div>
                                 </div>
@@ -89,11 +89,11 @@
                                     <div class="zulip-slack-comparison">
                                         <div class="comparison-zulip">
                                             <div class="caption comparison-2-caption-zulip">Zulip</div>
-                                            <img src="/static/images/story-tutorial/zulip-streams-unreads-arrows.png" alt="{{ _('Stream topics in Zulip') }}" class="zulip-unreads-arrows" />
+                                            <img src="{{ static('images/story-tutorial/zulip-streams-unreads-arrows.png') }}" alt="{{ _('Stream topics in Zulip') }}" class="zulip-unreads-arrows" />
                                         </div>
                                         <div class="comparison-slack">
                                             <div class="caption comparison-2-caption-slack">Other team chat</div>
-                                            <img src="/static/images/story-tutorial/slack-streams-unreads.png" class="slack-stream-unreads" alt="{{ _('Streams in Slack') }}" />
+                                            <img src="{{ static('images/story-tutorial/slack-streams-unreads.png') }}" class="slack-stream-unreads" alt="{{ _('Streams in Slack') }}" />
                                         </div>
                                     </div>
                                 </div>
@@ -101,27 +101,27 @@
                             <div class="item">
                                 <div class="item-inner">
                                     <p class="tour-item-header">Let&rsquo;s click on &ldquo;Tuesday night catering.&rdquo;</p>
-                                    <img src="/static/images/story-tutorial/zulip-topic.png" alt="{{ _('The Tuesday night catering topic in Zulip') }}" class="zulip-topic mobile-hide" />
-                                    <img src="/static/images/story-tutorial/zulip-topic-crop.png" alt="{{ _('The Tuesday night catering topic in Zulip') }}" class="centered-image zulip-topic mobile-show" />
+                                    <img src="{{ static('images/story-tutorial/zulip-topic.png') }}" alt="{{ _('The Tuesday night catering topic in Zulip') }}" class="zulip-topic mobile-hide" />
+                                    <img src="{{ static('images/story-tutorial/zulip-topic-crop.png') }}" alt="{{ _('The Tuesday night catering topic in Zulip') }}" class="centered-image zulip-topic mobile-show" />
                                 </div>
                             </div>
                             <div class="item">
                                 <div class="item-inner">
                                     <p class="tour-item-header">Messages in Zulip retain their context even if they&rsquo;re sent hours after the conversation started:</p>
-                                    <img src="/static/images/story-tutorial/zulip-streams-easy.png" alt="{{ _('The Tuesday night catering topic in Zulip') }}" class="zulip-easy mobile-hide" />
+                                    <img src="{{ static('images/story-tutorial/zulip-streams-easy.png') }}" alt="{{ _('The Tuesday night catering topic in Zulip') }}" class="zulip-easy mobile-hide" />
                                     <div class="mobile-show">
-                                        <img src="/static/images/story-tutorial/zulip-streams-easy-mobile-top.png" class="centered-image" alt="{{ _('The Tuesday night catering topic in Zulip') }}" />
+                                        <img src="{{ static('images/story-tutorial/zulip-streams-easy-mobile-top.png') }}" class="centered-image" alt="{{ _('The Tuesday night catering topic in Zulip') }}" />
                                         <p class="tour-explanation">Messages sent hours apart are linked in the same topic.</p>
-                                        <img src="/static/images/story-tutorial/zulip-streams-easy-mobile-bottom.png" class="centered-image" alt="{{ _('The Tuesday night catering topic in Zulip - compose box') }}" />
+                                        <img src="{{ static('images/story-tutorial/zulip-streams-easy-mobile-bottom.png') }}" class="centered-image" alt="{{ _('The Tuesday night catering topic in Zulip - compose box') }}" />
                                     </div>
                                 </div>
                             </div>
                             <div class="item">
                                 <div class="item-inner">
                                     <p class="tour-item-header">Without topics, it&rsquo;s hard to catch up efficiently, and hard to participate in conversations that started while you were away.</p>
-                                    <img src="/static/images/story-tutorial/slack-overwhelming.png" alt="{{ _('The Tuesday night catering topic in Slack') }}" class="slack-overwhelming mobile-hide" />
+                                    <img src="{{ static('images/story-tutorial/slack-overwhelming.png') }}" alt="{{ _('The Tuesday night catering topic in Slack') }}" class="slack-overwhelming mobile-hide" />
                                     <div class="mobile-show">
-                                        <img src="/static/images/story-tutorial/slack-overwhelming-mobile.png" class="centered-image" alt="{{ _('The Tuesday night catering topic in Slack') }}" />
+                                        <img src="{{ static('images/story-tutorial/slack-overwhelming-mobile.png') }}" class="centered-image" alt="{{ _('The Tuesday night catering topic in Slack') }}" />
                                         <p class="tour-explanation">The last message about Tuesday night catering is hidden 56 messages ago. Meanwhile, you just see a mix of unrelated messages.</p>
                                     </div>
                                 </div>
@@ -134,11 +134,11 @@
                                     </a>
                                     <div class="other-resources">
                                         <div class="other-resources-section">
-                                            <a href="/why-zulip"><img src="/static/images/landing-page/hello/organised.svg" alt="" /></a>
+                                            <a href="/why-zulip"><img src="{{ static('images/landing-page/hello/organised.svg') }}" alt="" /></a>
                                             <p><a href="/why-zulip">Zulip vs Slack &rarr;</a></p>
                                         </div>
                                         <div class="other-resources-section">
-                                            <a href="/features"><img src="/static/images/landing-page/hello/featured.svg" alt="" /></a>
+                                            <a href="/features"><img src="{{ static('images/landing-page/hello/featured.svg') }}" alt="" /></a>
                                             <p><a href="/features">See all features &rarr;</a></p>
                                         </div>
                                     </div>
@@ -355,7 +355,7 @@
 
     <div class="open-source">
         <div class="flex">
-            <img src="/static/images/landing-page/hello/opensource.svg" alt=""/>
+            <img src="{{ static('images/landing-page/hello/opensource.svg') }}" alt=""/>
             <div class="il-block">
                 <h1>Open source.</h1>
                 <p>
@@ -402,49 +402,49 @@
         <div class="integration-icons">
             <a href="/integrations/doc/travis">
                 <div class="group">
-                    <img class="integration-logo" src="/static/images/integrations/logos/travis.svg" alt="{{ _('Travis logo') }}" />
+                    <img class="integration-logo" src="{{ static('images/integrations/logos/travis.svg') }}" alt="{{ _('Travis logo') }}" />
                     <h3 class="integration-name">Travis CI</h3>
                     <p class="integration-description">See build results immediately</p>
                 </div>
             </a>
             <a href="/integrations/doc/github">
                 <div class="group">
-                    <img class="integration-logo" src="/static/images/integrations/logos/github.svg" alt="{{ _('GitHub logo') }}" />
+                    <img class="integration-logo" src="{{ static('images/integrations/logos/github.svg') }}" alt="{{ _('GitHub logo') }}" />
                     <h3 class="integration-name">GitHub</h3>
                     <p class="integration-description">Track issues and pull requests</p>
                 </div>
             </a>
             <a href="/integrations/doc/heroku">
                 <div class="group">
-                    <img class="integration-logo" src="/static/images/integrations/logos/heroku.svg" alt="{{ _('Heroku logo') }}" />
+                    <img class="integration-logo" src="{{ static('images/integrations/logos/heroku.svg') }}" alt="{{ _('Heroku logo') }}" />
                     <h3 class="integration-name">Heroku</h3>
                     <p class="integration-description">Keep up with deployments</p>
                 </div>
             </a>
             <a href="/integrations/doc/zendesk">
                 <div class="group">
-                    <img class="integration-logo" src="/static/images/integrations/logos/zendesk.svg" alt="{{ _('Zendesk logo') }}" />
+                    <img class="integration-logo" src="{{ static('images/integrations/logos/zendesk.svg') }}" alt="{{ _('Zendesk logo') }}" />
                     <h3 class="integration-name">Zendesk</h3>
                     <p class="integration-description">Receive support tickets and updates</p>
                 </div>
             </a>
             <a href="/integrations/doc/jira">
                 <div class="group">
-                    <img class="integration-logo" src="/static/images/integrations/logos/jira.svg" alt="{{ _('Jira logo') }}" />
+                    <img class="integration-logo" src="{{ static('images/integrations/logos/jira.svg') }}" alt="{{ _('Jira logo') }}" />
                     <h3 class="integration-name">Jira</h3>
                     <p class="integration-description">Monitor project bugs and issues</p>
                 </div>
             </a>
             <a href="/integrations/doc/sentry">
                 <div class="group">
-                    <img class="integration-logo" src="/static/images/integrations/logos/sentry.svg" alt="{{ _('Sentry logo') }}" />
+                    <img class="integration-logo" src="{{ static('images/integrations/logos/sentry.svg') }}" alt="{{ _('Sentry logo') }}" />
                     <h3 class="integration-name">Sentry</h3>
                     <p class="integration-description">See real-time error tracking</p>
                 </div>
             </a>
             <a href="/integrations/doc/pagerduty" class="hide-1">
                 <div class="group">
-                    <img class="integration-logo" src="/static/images/integrations/logos/pagerduty.svg" alt="{{ _('Pagerduty logo') }}" />
+                    <img class="integration-logo" src="{{ static('images/integrations/logos/pagerduty.svg') }}" alt="{{ _('Pagerduty logo') }}" />
                     <h3 class="integration-name">Pagerduty</h3>
                     <p class="integration-description">Connect to your monitoring systems</p>
                 </div>

--- a/templates/corporate/history.html
+++ b/templates/corporate/history.html
@@ -38,12 +38,12 @@
                 <div class="sponsors">
                     <div class="sponsor-picture">
                         <a href="https://seedfund.nsf.gov/">
-                            <img src="/static/images/landing-page/history/nsf-logo.png" alt="" />
+                            <img src="{{ static('images/landing-page/history/nsf-logo.png') }}" alt="" />
                         </a>
                     </div>
                     <div class="sponsor-picture">
                         <a href="https://summerofcode.withgoogle.com/">
-                            <img src="/static/images/landing-page/history/gsoc-logo.png" alt="" />
+                            <img src="{{ static('images/landing-page/history/gsoc-logo.png') }}" alt="" />
                         </a>
                     </div>
                 </div>

--- a/templates/corporate/self-hosting.html
+++ b/templates/corporate/self-hosting.html
@@ -56,7 +56,7 @@
             </div>
             <div class="feature-half">
                 <div class="feature-icon">
-                    <img alt="" src="/static/images/landing-page/open_source/build_inclusive_communities.svg" />
+                    <img alt="" src="{{ static('images/landing-page/open_source/build_inclusive_communities.svg') }}" />
                 </div>
             </div>
         </div>
@@ -64,7 +64,7 @@
         <div class="feature-container alternate-grid">
             <div class="feature-half md-hide">
                 <div class="feature-icon">
-                    <img class="mirror-image" alt="" src="/static/images/landing-page/education/privacy.svg" />
+                    <img class="mirror-image" alt="" src="{{ static('images/landing-page/education/privacy.svg') }}" />
                 </div>
             </div>
             <div class="feature-half">
@@ -90,7 +90,7 @@
             </div>
             <div class="feature-half md-display">
                 <div class="feature-icon">
-                    <img class="mirror-image" alt="" src="/static/images/landing-page/education/privacy.svg" />
+                    <img class="mirror-image" alt="" src="{{ static('images/landing-page/education/privacy.svg') }}" />
                 </div>
             </div>
         </div>
@@ -124,7 +124,7 @@
             </div>
             <div class="feature-half">
                 <div class="feature-icon">
-                    <img class="mirror-image" alt="" src="/static/images/landing-page/education/mobile.svg" />
+                    <img class="mirror-image" alt="" src="{{ static('images/landing-page/education/mobile.svg') }}" />
                 </div>
             </div>
         </div>
@@ -132,7 +132,7 @@
         <div class="feature-container alternate-grid">
             <div class="feature-half md-hide">
                 <div class="feature-icon">
-                    <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                    <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
                 </div>
             </div>
             <div class="feature-half">
@@ -160,7 +160,7 @@
             </div>
             <div class="feature-half md-display">
                 <div class="feature-icon">
-                    <img alt="" src="/static/images/landing-page/education/flexible-administration.svg" />
+                    <img alt="" src="{{ static('images/landing-page/education/flexible-administration.svg') }}" />
                 </div>
             </div>
         </div>
@@ -180,7 +180,7 @@
         <div class="feature-row">
             <div class="feature-box">
                 <div class="feature-icon">
-                    <img alt="" src="/static/images/landing-page/self-hosting/growth.png" />
+                    <img alt="" src="{{ static('images/landing-page/self-hosting/growth.png') }}" />
                 </div>
                 <div class="feature-text">
                     <h1>
@@ -204,7 +204,7 @@
             </div>
             <div class="feature-box">
                 <div class="feature-icon">
-                    <img alt="" src="/static/images/landing-page/self-hosting/database.png" />
+                    <img alt="" src="{{ static('images/landing-page/self-hosting/database.png') }}" />
                 </div>
                 <div class="feature-text">
                     <h1>
@@ -230,7 +230,7 @@
         <div class="feature-row">
             <div class="feature-box">
                 <div class="feature-icon">
-                    <img alt="" src="/static/images/landing-page/self-hosting/fork.png" />
+                    <img alt="" src="{{ static('images/landing-page/self-hosting/fork.png') }}" />
                 </div>
                 <div class="feature-text">
                     <h1>
@@ -250,7 +250,7 @@
             </div>
             <div class="feature-box">
                 <div class="feature-icon">
-                    <img alt="" src="/static/images/landing-page/self-hosting/help.png" />
+                    <img alt="" src="{{ static('images/landing-page/self-hosting/help.png') }}" />
                 </div>
                 <div class="feature-text">
                     <h1>

--- a/templates/corporate/support_request.html
+++ b/templates/corporate/support_request.html
@@ -31,7 +31,7 @@
                 <div class="register-button-box">
                     <button class="register-button support-submit-button" type="submit">
                         <span>{{ _('Submit') }}</span>
-                        <object class="loader" type="image/svg+xml" data="/static/images/loading/loader-white.svg"></object>
+                        <object class="loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                     </button>
                 </div>
             </fieldset>

--- a/templates/corporate/team.html
+++ b/templates/corporate/team.html
@@ -36,7 +36,7 @@ contributors, and more than 75 with 100+ commits." %}
                     <!-- Tim -->
                     <div class="profile bdfl">
                         <div class="profile-picture">
-                            <img src="/static/images/landing-page/team/tim.png" alt="" />
+                            <img src="{{ static('images/landing-page/team/tim.png') }}" alt="" />
                         </div>
                         <div class="profile-information">
                             <div class="profile-name">Tim Abbott</div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -9,7 +9,7 @@
 
 {% block customhead %}
 <meta name="apple-mobile-web-app-capable" content="yes" />
-<link href="/static/images/logo/apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" />
+<link href="{{ static('images/logo/apple-touch-icon-precomposed.png') }}" rel="apple-touch-icon-precomposed" />
 <style>
     #app-loading {
     font-size: 16px;

--- a/templates/zerver/auth_subdomain.html
+++ b/templates/zerver/auth_subdomain.html
@@ -9,7 +9,7 @@
 <div class="error_page">
     <div class="container">
         <div class="row-fluid">
-            <img src="/static/images/errors/500art.svg" alt=""/>
+            <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _("Authentication subdomain") }}</h1>

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -14,8 +14,8 @@
                 {% endif %}
             {% endif %}
         {% endblock %}
-        <link id="favicon" rel="icon" href="/static/images/favicon.svg?v=4" />
-        <link rel="alternate icon" href="/static/images/favicon.png?v=4" />
+        <link id="favicon" rel="icon" href="{{ static('images/favicon.svg') }}?v=4" />
+        <link rel="alternate icon" href="{{ static('images/favicon.png') }}?v=4" />
         {% block meta_viewport %}
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         {% endblock %}

--- a/templates/zerver/config_error.html
+++ b/templates/zerver/config_error.html
@@ -9,7 +9,7 @@
 <div class="error_page" style="padding-bottom: 60px;">
     <div class="container">
         <div class="row-fluid">
-            <img src="/static/images/errors/500art.svg" alt=""/>
+            <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
             <div class="errorbox config-error">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _("Configuration error") }}</h1>

--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -17,7 +17,7 @@
             </div>
             <div class="digest-email-html">
                 {% include 'zerver/emails/compiled/digest.html' %}
-                <img id="digest-footer" src="/static/images/emails/footer.png"/>
+                <img id="digest-footer" src="{{ static('images/emails/footer.png') }}"/>
             </div>
             <br />
             <br />

--- a/templates/zerver/insecure_desktop_app.html
+++ b/templates/zerver/insecure_desktop_app.html
@@ -9,7 +9,7 @@
 <div class="error_page">
     <div class="container">
         <div class="row-fluid">
-            <img src="/static/images/errors/400art.svg" alt=""/>
+            <img src="{{ static('images/errors/400art.svg') }}" alt=""/>
             <div class="errorbox config-error">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _('Update required') }}</h1>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -124,7 +124,7 @@ page can be easily identified in it's respective JavaScript file. -->
                             {% endif %}
 
                             <button type="submit" name="button" class="full-width">
-                                <img class="loader" src="/static/images/loading/loader-white.svg" alt="" />
+                                <img class="loader" src="{{ static('images/loading/loader-white.svg') }}" alt="" />
                                 <span class="text">{{ _("Log in") }}</span>
                             </button>
                         </form>

--- a/templates/zerver/meta_tags.html
+++ b/templates/zerver/meta_tags.html
@@ -20,6 +20,6 @@
 {% if PAGE_METADATA_IMAGE %}
 <meta property="og:image" content="{{ PAGE_METADATA_IMAGE }}" />
 {% else %}
-<meta property="og:image" content="{{ realm_uri }}/static/images/logo/zulip-icon-128x128.png" />
+<meta property="og:image" content="{{ static('images/logo/zulip-icon-128x128.png') }}" />
 {% endif %}
 <meta name="twitter:card" content="summary" />

--- a/templates/zerver/rate_limit_exceeded.html
+++ b/templates/zerver/rate_limit_exceeded.html
@@ -9,7 +9,7 @@
 <div class="error_page">
     <div class="container">
         <div class="row-fluid">
-            <img src="/static/images/errors/500art.svg" alt=""/>
+            <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _("Rate limit exceeded.") }}</h1>

--- a/templates/zerver/realm_creation_disabled.html
+++ b/templates/zerver/realm_creation_disabled.html
@@ -7,7 +7,7 @@
 {% block portico_content %}
 <div class="error_page">
     <div class="container row-fluid">
-        <img src="/static/images/errors/500art.svg" alt=""/>
+        <img src="{{ static('images/errors/500art.svg') }}" alt=""/>
         <div class="errorbox">
             <div class="errorcontent">
                 <h1 class="lead">{{ _("Organization creation link required") }}</h1>

--- a/templates/zerver/realm_creation_link_invalid.html
+++ b/templates/zerver/realm_creation_link_invalid.html
@@ -8,7 +8,7 @@
 <div class="error_page">
     <div class="container">
         <div class="row-fluid">
-            <img class="hourglass-img" src="/static/images/errors/timeout_hourglass.png" alt=""/>
+            <img class="hourglass-img" src="{{ static('images/errors/timeout_hourglass.png') }}" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _("Organization creation link expired or invalid") }}</h1>

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -267,7 +267,7 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 <div class="register-button-box">
                     <button class="register-button" type="submit">
                         <span>{{ _('Sign up') }}</span>
-                        <object class="loader" type="image/svg+xml" data="/static/images/loading/loader-white.svg"></object>
+                        <object class="loader" type="image/svg+xml" data="{{ static('images/loading/loader-white.svg') }}"></object>
                     </button>
                     <input type="hidden" name="next" value="{{ next }}" />
                 </div>

--- a/templates/zerver/unsupported_browser.html
+++ b/templates/zerver/unsupported_browser.html
@@ -9,7 +9,7 @@
 <div class="error_page unsupported_browser_page">
     <div class="container">
         <div class="row-fluid">
-            <img src="/static/images/errors/400art.svg" alt=""/>
+            <img src="{{ static('images/errors/400art.svg') }}" alt=""/>
             <div class="errorbox config-error">
                 <div class="errorcontent">
                     <h1 class="lead">{{ _('Unsupported browser') }}</h1>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -52,6 +52,7 @@ EXEMPT_FILES = make_set(
         "static/js/alert_popup.ts",
         "static/js/alert_words_ui.js",
         "static/js/archive.js",
+        "static/js/assets.d.ts",
         "static/js/attachments_ui.js",
         "static/js/avatar.js",
         "static/js/billing/event_status.js",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -146,6 +146,10 @@ export default (env: {minimize?: boolean} = {}, argv: {mode?: string}): webpack.
                             "tooltip_hotkey_hints",
                         ],
                         preventIndent: true,
+                        // This replaces relative image resources with
+                        // a computed require() path to them, so their
+                        // webpack-hashed URLs are used.
+                        inlineRequires: /^(\.\.\/)+(images|generated\/emoji\/images)\//,
                     },
                 },
                 // load fonts and files

--- a/zerver/lib/avatar.py
+++ b/zerver/lib/avatar.py
@@ -2,6 +2,7 @@ import urllib
 from typing import Any, Dict, Optional
 
 from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 from zerver.lib.avatar_hash import (
     gravatar_hash,
@@ -106,7 +107,10 @@ def _get_unversioned_gravatar_url(email: str, medium: bool) -> str:
         gravitar_query_suffix = f"&s={MEDIUM_AVATAR_SIZE}" if medium else ""
         hash_key = gravatar_hash(email)
         return f"https://secure.gravatar.com/avatar/{hash_key}?d=identicon{gravitar_query_suffix}"
-    return settings.DEFAULT_AVATAR_URI
+    elif settings.DEFAULT_AVATAR_URI is not None:
+        return settings.DEFAULT_AVATAR_URI
+    else:
+        return staticfiles_storage.url("images/default-avatar.png")
 
 
 def _get_unversioned_avatar_url(

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1505,6 +1505,8 @@ class Emoji(markdown.inlinepatterns.Pattern):
         if name in active_realm_emoji:
             return make_realm_emoji(active_realm_emoji[name]["source_url"], orig_syntax)
         elif name == "zulip":
+            # We explicitly do not use staticfiles to generate the URL
+            # for this, so that it is portable if exported.
             return make_realm_emoji(
                 "/static/generated/emoji/images/emoji/unicode/zulip.png", orig_syntax
             )

--- a/zerver/lib/markdown/priorities.py
+++ b/zerver/lib/markdown/priorities.py
@@ -17,6 +17,7 @@ PREPROCESSOR_PRIORITES = {
     "tabbed_sections": -500,
     "nested_code_blocks": -500,
     "emoticon_translations": -505,
+    "static_images": -510,
 }
 
 BLOCK_PROCESSOR_PRIORITIES = {

--- a/zerver/lib/markdown/static.py
+++ b/zerver/lib/markdown/static.py
@@ -1,0 +1,33 @@
+from typing import Any
+from xml.etree.ElementTree import Element
+
+import markdown
+from django.contrib.staticfiles.storage import staticfiles_storage
+from markdown.extensions import Extension
+
+from zerver.lib.markdown.priorities import PREPROCESSOR_PRIORITES
+
+
+class MarkdownStaticImagesGenerator(Extension):
+    def extendMarkdown(self, md: markdown.Markdown) -> None:
+        md.treeprocessors.register(
+            StaticImageProcessor(md),
+            "static_images",
+            PREPROCESSOR_PRIORITES["static_images"],
+        )
+
+
+class StaticImageProcessor(markdown.treeprocessors.Treeprocessor):
+    """
+    Rewrite img tags which refer to /static/ to use staticfiles
+    """
+
+    def run(self, root: Element) -> None:
+        for img in root.iter("img"):
+            url = img.get("src")
+            if url is not None and url.startswith("/static/"):
+                img.set("src", staticfiles_storage.url(url[len("/static/") :]))
+
+
+def makeExtension(*args: Any, **kwargs: str) -> MarkdownStaticImagesGenerator:
+    return MarkdownStaticImagesGenerator(*args, **kwargs)

--- a/zerver/lib/realm_icon.py
+++ b/zerver/lib/realm_icon.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 from zerver.lib.avatar_hash import gravatar_hash
 from zerver.lib.upload import upload_backend
@@ -15,5 +16,7 @@ def get_realm_icon_url(realm: Realm) -> str:
     elif settings.ENABLE_GRAVATAR:
         hash_key = gravatar_hash(realm.string_id)
         return f"https://secure.gravatar.com/avatar/{hash_key}?d=identicon"
+    elif settings.DEFAULT_AVATAR_URI is not None:
+        return settings.DEFAULT_AVATAR_URI
     else:
-        return settings.DEFAULT_AVATAR_URI + "?version=0"
+        return staticfiles_storage.url("images/default-avatar.png") + "?version=0"

--- a/zerver/lib/realm_logo.py
+++ b/zerver/lib/realm_logo.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
 from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 from zerver.lib.upload import upload_backend
 from zerver.models import Realm
@@ -23,7 +24,9 @@ def get_realm_logo_url(realm: Realm, night: bool) -> str:
         else:
             logo_version = realm.logo_version
         return upload_backend.get_realm_logo_url(realm.id, logo_version, night)
-    return settings.DEFAULT_LOGO_URI + "?version=0"
+    if settings.DEFAULT_LOGO_URI is not None:
+        return settings.DEFAULT_LOGO_URI
+    return staticfiles_storage.url("images/logo/zulip-org-logo.svg") + "?version=0"
 
 
 def get_realm_logo_data(realm: Realm, night: bool) -> Dict[str, Any]:

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -113,10 +113,14 @@ def build_email(
         # except having just a domain instead of an email address.
         extra_headers["List-Id"] = formataddr((realm.name, realm.host))
 
+    assert settings.STATIC_URL is not None
     context = {
         **context,
         "support_email": FromAddress.SUPPORT,
-        "email_images_base_uri": settings.ROOT_DOMAIN_URI + "/static/images/emails",
+        # Emails use unhashed image URLs so that those continue to
+        # work over time, even if the prod-static directory is cleaned
+        # out; as such, they just use a STATIC_URL prefix.
+        "email_images_base_uri": settings.STATIC_URL + "images/emails",
         "physical_address": settings.PHYSICAL_ADDRESS,
     }
 

--- a/zerver/lib/storage.py
+++ b/zerver/lib/storage.py
@@ -36,6 +36,11 @@ class IgnoreBundlesManifestStaticFilesStorage(ManifestStaticFilesStorage):
             # use a no-op hash function for these already-hashed
             # assets.
             return name
+        if name == "generated/emoji/emoji_api.json":
+            # Unlike most .json files, we do want to hash this file;
+            # its hashed URL is returned as part of the API.  See
+            # data_url() in zerver/lib/emoji.py.
+            return super().hashed_name(name, content, filename)
         if ext in [".png", ".gif", ".jpg", ".svg"]:
             # Similarly, don't hash-rename image files; we only serve
             # the original file paths (not the hashed file paths), and
@@ -46,7 +51,7 @@ class IgnoreBundlesManifestStaticFilesStorage(ManifestStaticFilesStorage):
             # used the hashed paths for these; in that case, though,
             # we should instead be removing the non-hashed paths.
             return name
-        if ext in ["json", "po", "mo", "mp3", "ogg", "html"]:
+        if ext in [".json", ".po", ".mo", ".mp3", ".ogg", ".html"]:
             # And same story for translation files, sound files, etc.
             return name
         return super().hashed_name(name, content, filename)

--- a/zerver/lib/storage.py
+++ b/zerver/lib/storage.py
@@ -51,7 +51,7 @@ class IgnoreBundlesManifestStaticFilesStorage(ManifestStaticFilesStorage):
             # used the hashed paths for these; in that case, though,
             # we should instead be removing the non-hashed paths.
             return name
-        if ext in [".json", ".po", ".mo", ".mp3", ".ogg", ".html"]:
+        if ext in [".json", ".po", ".mo", ".mp3", ".ogg", ".html", ".md"]:
             # And same story for translation files, sound files, etc.
             return name
         return super().hashed_name(name, content, filename)

--- a/zerver/lib/subdomains.py
+++ b/zerver/lib/subdomains.py
@@ -56,6 +56,7 @@ def is_root_domain_available() -> bool:
 
 
 def is_static_or_current_realm_url(url: str, realm: Optional[Realm]) -> bool:
+    assert settings.STATIC_URL is not None
     split_url = urllib.parse.urlsplit(url)
     split_static_url = urllib.parse.urlsplit(settings.STATIC_URL)
 

--- a/zerver/lib/templates.py
+++ b/zerver/lib/templates.py
@@ -22,6 +22,7 @@ import zerver.lib.markdown.help_relative_links
 import zerver.lib.markdown.help_settings_links
 import zerver.lib.markdown.include
 import zerver.lib.markdown.nested_code_blocks
+import zerver.lib.markdown.static
 import zerver.lib.markdown.tabbed_sections
 import zerver.openapi.markdown_extension
 from zerver.lib.cache import dict_to_items_tuple, ignore_unhashable_lru_cache, items_tuple_to_dict
@@ -127,6 +128,7 @@ def render_markdown_path(
             zerver.lib.markdown.help_settings_links.makeExtension(),
             zerver.lib.markdown.help_relative_links.makeExtension(),
             zerver.lib.markdown.help_emoticon_translations_table.makeExtension(),
+            zerver.lib.markdown.static.makeExtension(),
         ]
     if "api_url" in context:
         # We need to generate the API code examples extension each

--- a/zerver/lib/unminify.py
+++ b/zerver/lib/unminify.py
@@ -45,7 +45,7 @@ class SourceMap:
         out: str = ""
         for ln in stacktrace.splitlines():
             out += ln + "\n"
-            match = re.search(r"/static/webpack-bundles/([^:]+):(\d+):(\d+)", ln)
+            match = re.search(r"/webpack-bundles/([^:]+):(\d+):(\d+)", ln)
             if match:
                 # Get the appropriate source map for the minified file.
                 minified_src = match.groups()[0]

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -1204,7 +1204,7 @@ class TestMissedMessages(ZulipTestCase):
             "Extremely personal message with a hamburger :hamburger:!",
         )
         verify_body_include = [
-            '<img alt=":hamburger:" src="http://zulip.testserver/static/generated/emoji/images-twitter-64/1f354.png" title="hamburger" style="height: 20px;">'
+            '<img alt=":hamburger:" src="http://testserver/static/generated/emoji/images-twitter-64/1f354.png" title="hamburger" style="height: 20px;">'
         ]
         email_subject = "PMs with Othello, the Moor of Venice"
         self._test_cases(
@@ -1570,11 +1570,11 @@ class TestMissedMessages(ZulipTestCase):
             ' rain">:cloud_with_lightning_and_rain:</span>.</p>'
         )
         fragment = lxml.html.fromstring(test_data)
-        fix_emojis(fragment, "http://example.com", "google")
+        fix_emojis(fragment, "google")
         actual_output = lxml.html.tostring(fragment, encoding="unicode")
         expected_output = (
             '<p>See <img alt=":cloud_with_lightning_and_rain:"'
-            ' src="http://example.com/static/generated/emoji/images-google-64/26c8.png"'
+            ' src="http://testserver/static/generated/emoji/images-google-64/26c8.png"'
             ' title="cloud with lightning and rain" style="height: 20px;">.</p>'
         )
         self.assertEqual(actual_output, expected_output)

--- a/zerver/tests/test_subdomains.py
+++ b/zerver/tests/test_subdomains.py
@@ -84,6 +84,9 @@ class SubdomainsTest(ZulipTestCase):
             self.assertTrue(test(f"{settings.STATIC_URL}/x"))
             self.assertFalse(test(evil_url))
             self.assertFalse(test(f"{evil_url}/x"))
+            self.assertTrue(test(f"{realm.uri}"))
+            self.assertTrue(test("/static/images/logo/zulip-org-logo.svg"))
+            self.assertTrue(test("/anything"))
 
     @use_s3_backend
     def test_is_static_or_current_realm_url_with_s3(self) -> None:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -39,6 +39,7 @@ from decorator import decorator
 from django.conf import settings
 from django.contrib.auth import authenticate, get_backends
 from django.contrib.auth.backends import RemoteUserBackend
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.dispatch import Signal, receiver
@@ -1851,7 +1852,7 @@ class GitHubAuthBackend(SocialAuthMixin, GithubOAuth2):
     name = "github"
     auth_backend_name = "GitHub"
     sort_order = 100
-    display_icon = "/static/images/authentication_backends/github-icon.png"
+    display_icon = staticfiles_storage.url("images/authentication_backends/github-icon.png")
 
     def get_all_associated_email_objects(self, *args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
         access_token = kwargs["response"]["access_token"]
@@ -1946,7 +1947,7 @@ class AzureADAuthBackend(SocialAuthMixin, AzureADOAuth2):
     sort_order = 50
     name = "azuread-oauth2"
     auth_backend_name = "AzureAD"
-    display_icon = "/static/images/authentication_backends/azuread-icon.png"
+    display_icon = staticfiles_storage.url("images/authentication_backends/azuread-icon.png")
 
 
 @external_auth_method
@@ -1954,7 +1955,7 @@ class GitLabAuthBackend(SocialAuthMixin, GitLabOAuth2):
     sort_order = 75
     name = "gitlab"
     auth_backend_name = "GitLab"
-    display_icon = "/static/images/authentication_backends/gitlab-icon.png"
+    display_icon = staticfiles_storage.url("images/authentication_backends/gitlab-icon.png")
 
     # Note: GitLab as of early 2020 supports having multiple email
     # addresses connected with a GitLab account, and we could access
@@ -1970,7 +1971,7 @@ class GoogleAuthBackend(SocialAuthMixin, GoogleOAuth2):
     sort_order = 150
     auth_backend_name = "Google"
     name = "google"
-    display_icon = "/static/images/authentication_backends/googl_e-icon.png"
+    display_icon = staticfiles_storage.url("images/authentication_backends/googl_e-icon.png")
 
     def get_verified_emails(self, *args: Any, **kwargs: Any) -> List[str]:
         verified_emails: List[str] = []
@@ -2001,7 +2002,7 @@ class AppleAuthBackend(SocialAuthMixin, AppleIdAuth):
     sort_order = 10
     name = "apple"
     auth_backend_name = "Apple"
-    display_icon = "/static/images/authentication_backends/apple-icon.png"
+    display_icon = staticfiles_storage.url("images/authentication_backends/apple-icon.png")
 
     # Apple only sends `name` in its response the first time a user
     # tries to sign up, so we won't have it in consecutive attempts.

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -60,6 +60,7 @@ from .configured_settings import (
     SOCIAL_AUTH_SAML_ENABLED_IDPS,
     SOCIAL_AUTH_SAML_SECURITY_CONFIG,
     SOCIAL_AUTH_SUBDOMAIN,
+    STATIC_URL,
     STATSD_HOST,
     TORNADO_PORTS,
     USING_PGROONGA,
@@ -537,10 +538,11 @@ CAMO_KEY = get_secret("camo_key") if CAMO_URI != "" else None
 # STATIC CONTENT AND MINIFICATION SETTINGS
 ########################################################################
 
-if PRODUCTION or IS_DEV_DROPLET or os.getenv("EXTERNAL_HOST") is not None:
-    STATIC_URL = urljoin(ROOT_DOMAIN_URI, "/static/")
-else:
-    STATIC_URL = "http://localhost:9991/static/"
+if STATIC_URL is None:
+    if PRODUCTION or IS_DEV_DROPLET or os.getenv("EXTERNAL_HOST") is not None:
+        STATIC_URL = urljoin(ROOT_DOMAIN_URI, "/static/")
+    else:
+        STATIC_URL = "http://localhost:9991/static/"
 
 LOCAL_AVATARS_DIR = os.path.join(LOCAL_UPLOADS_DIR, "avatars") if LOCAL_UPLOADS_DIR else None
 LOCAL_FILES_DIR = os.path.join(LOCAL_UPLOADS_DIR, "files") if LOCAL_UPLOADS_DIR else None

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -133,8 +133,8 @@ SENTRY_DSN: Optional[str] = None
 
 # File uploads and avatars
 # TODO: Rename MAX_FILE_UPLOAD_SIZE to have unit in name.
-DEFAULT_AVATAR_URI = "/static/images/default-avatar.png"
-DEFAULT_LOGO_URI = "/static/images/logo/zulip-org-logo.svg"
+DEFAULT_AVATAR_URI: Optional[str] = None
+DEFAULT_LOGO_URI: Optional[str] = None
 S3_AVATAR_BUCKET = ""
 S3_AUTH_UPLOADS_BUCKET = ""
 S3_REGION: Optional[str] = None

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -19,6 +19,8 @@ DEBUG = DEVELOPMENT
 
 EXTERNAL_HOST_WITHOUT_PORT = deport(EXTERNAL_HOST)
 
+STATIC_URL: Optional[str] = None
+
 # These settings are intended for the server admin to set.  We document them in
 # prod_settings_template.py, and in the initial /etc/zulip/settings.py on a new
 # install of the Zulip server.

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -116,6 +116,7 @@ else:
         response["Access-Control-Allow-Origin"] = "*"
         return response
 
+    assert settings.STATIC_URL is not None
     urls += static(urlsplit(settings.STATIC_URL).path, view=serve_static)
 
 i18n_urls = [


### PR DESCRIPTION
This moves as many resource fetches as is feasible to use STATIC_URL and the abstractions that are built on it.  The goal is to collapse fetches for shared static resources onto one hostname as much as possible.

The zjsunit change and the typescript `declare module "*.svg"` are the parts I'm least certain of.

I'm unclear how to manage the import of the audio sounds in `static/js/notifications.js` and the emoji in `static/templates/settings/display_settings.hbs`.

See #18667 for a previous effort.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
