### PR TITLE
compose: Remove remaining instances of compose-send-status.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -114,7 +114,6 @@ test_ui("send_message_success", ({override_rewire}) => {
     mock_banners();
     $("#compose-textarea").val("foobarfoobar");
     $("#compose-textarea").trigger("blur");
-    $("#compose-send-status").show();
     $("#compose-send-button .loader").show();
 
     let reify_message_id_checked;
@@ -128,7 +127,6 @@ test_ui("send_message_success", ({override_rewire}) => {
 
     assert.equal($("#compose-textarea").val(), "");
     assert.ok($("#compose-textarea").is_focused());
-    assert.ok(!$("#compose-send-status").visible());
     assert.ok(!$("#compose-send-button .loader").visible());
 
     assert.ok(reify_message_id_checked);
@@ -210,7 +208,6 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
         $("#compose-textarea").val("[foobar](/user_uploads/123456)");
         $("#compose-textarea").trigger("blur");
-        $("#compose-send-status").show();
         $("#compose-send-button .loader").show();
 
         compose.send_message();
@@ -223,7 +220,6 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.deepEqual(stub_state, state);
         assert.equal($("#compose-textarea").val(), "");
         assert.ok($("#compose-textarea").is_focused());
-        assert.ok(!$("#compose-send-status").visible());
         assert.ok(!$("#compose-send-button .loader").visible());
     })();
 
@@ -266,7 +262,6 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         stub_state = initialize_state_stub_dict();
         $("#compose-textarea").val("foobarfoobar");
         $("#compose-textarea").trigger("blur");
-        $("#compose-send-status").show();
         $("#compose-send-button .loader").show();
         $("#compose-textarea").off("select");
         echo_error_msg_checked = false;
@@ -286,7 +281,6 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         assert.ok(banner_rendered);
         assert.equal($("#compose-textarea").val(), "foobarfoobar");
         assert.ok($("#compose-textarea").is_focused());
-        assert.ok($("#compose-send-status").visible());
         assert.ok(!$("#compose-send-button .loader").visible());
     })();
 });
@@ -337,7 +331,6 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     user_settings.enter_sends = true;
 
     compose.enter_with_preview_open();
-    assert.equal($("#compose-error-msg").html(), "never-been-set");
 });
 
 test_ui("finish", ({override, override_rewire, mock_template}) => {

--- a/frontend_tests/node_tests/compose_validate.js
+++ b/frontend_tests/node_tests/compose_validate.js
@@ -375,7 +375,6 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
     compose_state.set_stream_name("social");
     assert.ok(compose_validate.validate());
     assert.ok(!$("#compose-all-everyone").visible());
-    assert.ok(!$("#compose-send-status").visible());
 
     peer_data.get_subscriber_count = (stream_id) => {
         assert.equal(stream_id, 101);
@@ -392,7 +391,6 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
     compose_state.message_content("Hey @**all**");
     assert.ok(!compose_validate.validate());
     assert.equal($("#compose-send-button").prop("disabled"), false);
-    assert.ok(!$("#compose-send-status").visible());
     assert.ok(wildcard_warning_rendered);
 
     let wildcards_not_allowed_rendered = false;

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -717,10 +717,6 @@ export function initialize() {
 
     // COMPOSE
 
-    $("body").on("click", "#compose-send-status .compose-send-status-close", () => {
-        $("#compose-send-status").stop(true).fadeOut(500);
-    });
-
     $("body").on("click", ".empty_feed_compose_stream", (e) => {
         compose_actions.start("stream", {trigger: "empty feed message"});
         e.preventDefault();

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -194,7 +194,6 @@ export function clear_compose_box() {
     compose_validate.clear_topic_resolved_warning();
     $("#compose-textarea").removeData("draft-id");
     compose_ui.autosize_textarea($("#compose-textarea"));
-    $("#compose-send-status").hide(0);
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
     compose_ui.hide_compose_spinner();

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -5,7 +5,6 @@ import _ from "lodash";
 import * as fenced_code from "../shared/js/fenced_code";
 
 import * as channel from "./channel";
-import * as common from "./common";
 import * as compose from "./compose";
 import * as compose_banner from "./compose_banner";
 import * as compose_fade from "./compose_fade";
@@ -91,7 +90,6 @@ function show_compose_box(msg_type, opts) {
         $("#stream_toggle").removeClass("active");
         $("#private_message_toggle").addClass("active");
     }
-    $("#compose-send-status").removeClass(common.status_classes).hide();
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
     $("#compose").css({visibility: "visible"});
@@ -120,7 +118,6 @@ function clear_box() {
     compose_validate.check_overflow_text();
     $("#compose-textarea").removeData("draft-id");
     compose_ui.autosize_textarea($("#compose-textarea"));
-    $("#compose-send-status").hide(0);
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
 }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -305,12 +305,6 @@ export function process_escape_key(e) {
             }
 
             // Check for errors in compose box; close errors if they exist
-            if ($("#compose-send-status").css("display") !== "none") {
-                $("#compose-send-status").hide();
-                return true;
-            }
-
-            // Clear open compose banners, if present.
             if ($(".compose_banner").length) {
                 compose_banner.clear_errors();
                 compose_banner.clear_warnings();

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -445,36 +445,6 @@
     }
 }
 
-/* Like .nav-tabs > li > a */
-#compose-send-status {
-    padding: 8px 14px;
-    margin-bottom: 8px;
-    line-height: 20px;
-    display: none;
-}
-
-#compose-send-status .progress {
-    height: 10px;
-    margin-bottom: 10px;
-}
-
-/* Like .alert .close */
-.send-status-close,
-.compose-send-status-close {
-    font-size: 17px;
-    font-weight: bold;
-    color: hsl(0, 0%, 0%);
-    text-shadow: 0 1px 0 hsl(0, 0%, 100%);
-    opacity: 0.2;
-    float: right;
-}
-
-.send-status-close:hover,
-.compose-send-status-close:hover {
-    cursor: pointer;
-    opacity: 0.4;
-}
-
 .composition-area {
     position: relative;
     flex: 1;

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -162,15 +162,6 @@
         }
     }
 
-    .compose-send-status-close {
-        color: hsl(0, 0%, 100%);
-        opacity: 1;
-    }
-
-    .compose-send-status-close:hover {
-        opacity: 0.4;
-    }
-
     .compose_banner {
         &.success {
             background-color: hsl(147, 100%, 8%);

--- a/static/templates/compose.hbs
+++ b/static/templates/compose.hbs
@@ -47,10 +47,6 @@
     </div>
     <div class="message_comp">
         <div id="compose_banners"></div>
-        <div class="alert" id="compose-send-status">
-            <span class="compose-send-status-close">&times;</span>
-            <span id="compose-error-msg"></span>
-        </div>
         <div class="composition-area">
             <form id="send_message_form" action="/json/messages" method="post">
                 {{ csrf_input }}


### PR DESCRIPTION
All banners that used to be rendered here are now in #compose_banners.

No visual or functional changes.