### PR TITLE
compose: Clean code to fix `up` hotkey to edit previous message.

### DIFF
--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -70,24 +70,26 @@ export const message_content = get_or_set("compose-textarea", true);
 
 const untrimmed_message_content = get_or_set("compose-textarea", true, true);
 
-export function cursor_at_start_of_whitespace_in_compose() {
-    // First check if the compose box is focused.  TODO: Maybe we
-    // should make `consider_start_of_whitespace_message_empty` a
-    // parameter to `focus_in_empty_compose` instead.
-    const focused_element_id = document.activeElement.id;
-    if (focused_element_id !== "compose-textarea") {
-        return false;
-    }
-
+function cursor_at_start_of_whitespace_in_compose() {
     const cursor_position = $("#compose-textarea").caret();
     return message_content() === "" && cursor_position === 0;
 }
 
-export function focus_in_empty_compose() {
+export function focus_in_empty_compose(consider_start_of_whitespace_message_empty = false) {
     // A user trying to press arrow keys in an empty compose is mostly
     // likely trying to navigate messages. This helper function
     // decides whether the compose box is empty for this purpose.
-    if (!composing() || untrimmed_message_content() !== "") {
+    if (!composing()) {
+        return false;
+    }
+
+    // We treat the compose box as empty if it's completely empty, or
+    // if the caller requested, if it contains only whitespace and we're
+    // at the start of te compose box.
+    const treat_compose_as_empty =
+        untrimmed_message_content() === "" ||
+        (consider_start_of_whitespace_message_empty && cursor_at_start_of_whitespace_in_compose());
+    if (!treat_compose_as_empty) {
         return false;
     }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -738,8 +738,7 @@ export function process_hotkey(e, hotkey) {
             ((event_name === "down_arrow" || event_name === "page_down" || event_name === "end") &&
                 compose_state.focus_in_empty_compose()) ||
             ((event_name === "up_arrow" || event_name === "page_up" || event_name === "home") &&
-                (compose_state.focus_in_empty_compose() ||
-                    compose_state.cursor_at_start_of_whitespace_in_compose()))
+                compose_state.focus_in_empty_compose(true))
         ) {
             compose_actions.cancel();
             // don't return, as we still want it to be picked up by the code below


### PR DESCRIPTION
This is a follow up to [875ad8e](https://github.com/zulip/zulip/commit/875ad8ed5be2bb86f447e92f97578d4b771f77af) implementing a better approach (though the `if` check's logic is hard to read).

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
