### PR TITLE
image_upload_widget: Refactor style of upload_widget's preview_image.

### DIFF
--- a/web/src/upload_widget.ts
+++ b/web/src/upload_widget.ts
@@ -35,6 +35,7 @@ export function build_widget(
         if ($preview_text !== undefined && $preview_image !== undefined) {
             const image_blob = URL.createObjectURL(file);
             $preview_image.attr("src", image_blob);
+            $preview_image.addClass("upload_widget_image_preview");
             $preview_text.show();
         }
     }

--- a/web/styles/image_upload_widget.css
+++ b/web/styles/image_upload_widget.css
@@ -206,3 +206,8 @@
     justify-content: space-around;
     flex-wrap: wrap;
 }
+
+/* CSS  related to upload widget's preview image */
+.upload_widget_image_preview {
+    object-fit: cover;
+}

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -669,10 +669,6 @@ input[type="checkbox"] {
     #emoji_preview_text {
         margin-top: 6px;
     }
-
-    #emoji_preview_image {
-        object-fit: cover;
-    }
 }
 
 #emoji_file_input_error {
@@ -887,7 +883,6 @@ input[type="checkbox"] {
 .edit_bot_avatar_preview_image,
 #add_bot_preview_image {
     height: 100px;
-    object-fit: cover;
     width: 100px;
     margin: 2px 0 8px;
 }


### PR DESCRIPTION
As suggested by @timabbott [here](https://github.com/zulip/zulip/pull/23965#discussion_r1096180748), the same style was used for both the bot and emoji forms for image preview.

Fix this by adding CSS specific to the preview image in the image upload widget.

Follow up to #23965

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Preview image(Edit bot form)-

![refactor1](https://user-images.githubusercontent.com/96344003/217235378-17039a4b-bd32-4ff0-99e4-4760932ced42.png)

After saving- 

![refactor2](https://user-images.githubusercontent.com/96344003/217235400-fceb2429-6c31-4cd0-aff6-327065eb39bf.png)

Preview image in add bot form: 

![refactor3](https://user-images.githubusercontent.com/96344003/217235403-4573c55a-fb1e-4a0a-9690-01c41003e5a8.png)

Preview image in custom emoji : 

![refactor4](https://user-images.githubusercontent.com/96344003/217235411-14b98aca-e1a2-4fdb-866b-d90856da19df.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
