### PR TITLE
me_message: Fix user unable to select a /me message.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -212,6 +212,10 @@ $time_column_max_width: 150px;
                         margin: 0;
                         margin-top: 13px;
 
+                        .sender_info_hover {
+                            outline: none;
+                        }
+
                         .message_edit_notice {
                             position: relative;
                             top: -1px;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1174,6 +1174,7 @@ td.pointer {
     line-height: 17px; /* identical to box height, or 131% */
     letter-spacing: 0.04em;
     text-transform: uppercase;
+    cursor: default;
 
     /* Display the date when unchanged only for sticky headers. */
     &.recipient_row_date_unchanged {
@@ -1481,6 +1482,7 @@ div.message_table {
     .date_row {
         /* We only want padding for the date rows between recipient blocks */
         padding-bottom: 0;
+        cursor: default;
 
         & span {
             font-size: calc(12em / 14);

--- a/web/templates/me_message.hbs
+++ b/web/templates/me_message.hbs
@@ -1,4 +1,4 @@
-<span class="message_sender no-select is_me_message">
+<span class="message_sender is_me_message">
     <span class="sender_info_hover">
         <span>
             {{> message_avatar}}

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip" aria-hidden="true">
+<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip no-select" aria-hidden="true">
     <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
 </div>
 {{~! remove whitespace ~}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -1,5 +1,5 @@
 {{#unless status_message}}
-<span class="message_sender sender_info_hover no-select">
+<span class="message_sender sender_info_hover">
     {{#if include_sender}}
     <span>
         {{> message_avatar ~}}

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -3,7 +3,7 @@
   role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     {{#if want_date_divider}}
-    <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 3px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
+    <div class="date_row" {{#if msg/is_stream}}style="box-shadow: inset 3px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
     {{/if}}
     <div class="messagebox"
       {{#if msg/is_stream}}style="box-shadow: inset 3px 0px 0px -1px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>


### PR DESCRIPTION
This happens due to `no-select` class being applied on the entire message, similar to how `display:none` gets applied on the entire element.

Since, sender name is indeed a part of the message content here, someone copying the message should also be able to copy the sender name and hence the whole of `message_sender` should be selectable in this case alone.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/selection.20issue.20in.20.2Fme.20messages