### PR TITLE
settings: Convert names to pills in organization settings.

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -217,6 +217,7 @@ function bot_info(bot_user_id) {
     info.full_name = bot_user.full_name;
     info.bot_owner_id = owner_id;
     info.user_role_text = people.get_user_type(bot_user_id);
+    info.img_src = people.small_avatar_url_for_person(bot_user);
 
     // Convert bot type id to string for viewing to the users.
     info.bot_type = settings_bots.type_id_to_string(bot_user.bot_type);
@@ -235,6 +236,10 @@ function bot_info(bot_user_id) {
 
     // It's always safe to show the real email addresses for bot users
     info.display_email = bot_user.email;
+
+    if (owner_id) {
+        info.owner_img_src = people.small_avatar_url_for_person(people.get_by_user_id(owner_id));
+    }
 
     return info;
 }
@@ -262,6 +267,7 @@ function human_info(person) {
     info.is_current_user = people.is_my_user_id(person.user_id);
     info.cannot_deactivate = info.is_current_user || (person.is_owner && !page_params.is_owner);
     info.display_email = person.delivery_email;
+    info.img_src = people.small_avatar_url_for_person(person);
 
     if (info.is_active) {
         // TODO: We might just want to show this

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -382,6 +382,19 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ".view_user_profile .pill-value",
+        appendTo: () => document.body,
+        delay: LONG_HOVER_DELAY,
+        onShow(instance) {
+            const $elem = $(instance.reference)[0].textContent;
+            instance.setContent($elem);
+        },
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
         target: "#send_later",
         delay: LONG_HOVER_DELAY,
         placement: "top",

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -754,6 +754,10 @@ div.overlay {
         background-color: hsl(0deg 0% 98%);
     }
 
+    tbody > tr:nth-child(even) > td {
+        background-color: hsl(0deg 0% 95%);
+    }
+
     /* Force the actions column to use the minimum space necessary */
     .actions {
         width: 1%;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -896,12 +896,16 @@
     #settings_page .settings-header,
     #settings_page .sidebar li.active,
     #settings_page .sidebar-wrapper .tab-container,
-    .table-striped tbody tr:nth-child(even) td,
     .table-striped tbody tr:nth-child(odd) th,
     .modal-footer,
     .modal-bg .modal-header {
         border-color: hsl(0deg 0% 0% / 20%);
         background-color: hsl(0deg 0% 0% / 20%);
+    }
+
+    .table-striped tbody tr:nth-child(even) td {
+        border-color: hsl(0deg 0% 0% / 20%);
+        background-color: hsl(212deg 28% 14%);
     }
 
     .table-striped tbody tr:nth-child(odd) td {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1469,6 +1469,19 @@
         }
     }
 
+    .pill_container {
+        background-color: hsl(0deg 0% 0% / 30%);
+
+        &:hover {
+            color: hsl(0deg 0% 100%);
+            border: 1px solid hsl(176deg 78% 28%);
+        }
+
+        .pill-value {
+            color: hsl(0deg 0% 100%);
+        }
+    }
+
     /* Widgets: Todo */
     .todo-widget {
         & label.checkbox {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1868,6 +1868,13 @@ $option_title_width: 180px;
     #change_email_modal {
         width: 300px;
     }
+
+    #user_column_header,
+    .user_name_column {
+        position: sticky;
+        z-index: 2;
+        left: 0;
+    }
 }
 
 @media (width < $mm_min) {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -377,8 +377,8 @@ td .button {
     }
 }
 
-.user_role {
-    min-width: 95px;
+.user_name_column {
+    min-width: 30%;
 }
 
 .button,
@@ -1595,10 +1595,6 @@ $option_title_width: 180px;
     }
 }
 
-#admin-user-list .last_active {
-    width: 100px;
-}
-
 .required-text {
     &:empty::after {
         content: attr(data-empty);
@@ -1844,6 +1840,10 @@ $option_title_width: 180px;
     #change_password_modal,
     #change_email_modal {
         width: 400px;
+    }
+
+    .user_name_column {
+        min-width: 40%;
     }
 }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1730,6 +1730,10 @@ $option_title_width: 180px;
 }
 
 @media (width < $lg_min) {
+    .settings-email-column {
+        display: none;
+    }
+
     .upload-size {
         display: none;
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1949,3 +1949,39 @@ $option_title_width: 180px;
             0 0 8px hsl(206deg 80% 62% / 60%);
     }
 }
+
+.pill_container {
+    display: flex;
+    flex-direction: row;
+    width: fit-content;
+    border: 1px solid hsl(0deg 0% 0% / 15%);
+    background-color: hsl(0deg 0% 0% / 7%);
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 2px;
+
+    &:hover {
+        border: 1px solid hsl(0deg 0% 20%);
+    }
+
+    .pill-image {
+        height: 20px;
+        width: 20px;
+        border-radius: 4px 0 0 4px;
+    }
+
+    .pill-value {
+        margin: 0 5px;
+        color: hsl(0deg 0% 15%);
+        text-decoration: none;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .deactivated-user-icon {
+        display: flex;
+        align-items: center;
+        margin-left: -5px;
+    }
+}

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -9,11 +9,11 @@
         </span>
     </td>
     {{#if display_email}}
-    <td>
+    <td class="settings-email-column">
         <span class="email">{{display_email}}</span>
     </td>
     {{else}}
-    <td>
+    <td class="settings-email-column">
         <span class="hidden-email">{{t "(hidden)"}}</span>
     </td>
     {{/if}}

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -1,9 +1,12 @@
 <tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
     <td>
-        <span class="user_name" >
-            <a data-user-id="{{user_id}}" class="view_user_profile" tabindex="0">{{full_name}}</a>
-            {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
-        <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
+        <span class="user_name pill_container">
+            <a data-user-id="{{user_id}}" class="view_user_profile pill-value" tabindex="0">
+            <img class="pill-image" src="{{img_src}}" />
+            <span class="pill-value">{{full_name}}</span>
+            {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</a>
+            <i class="fa fa-ban deactivated-user-icon tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
+        </span>
     </td>
     {{#if display_email}}
     <td>
@@ -19,13 +22,18 @@
     </td>
     {{#if is_bot}}
     <td class="user_role">
-        <span class="owner">
-            {{#if no_owner }}
-            {{bot_owner_full_name}}
-            {{else}}
-            <a data-user-id="{{bot_owner_id}}" class="view_user_profile" tabindex="0">{{bot_owner_full_name}}</a>
-            {{/if}}
-        </span>
+        {{#if no_owner }}
+            <span class="owner">
+                {{bot_owner_full_name}}
+            </span>
+        {{else}}
+            <span class="owner pill_container">
+                <a data-user-id="{{bot_owner_id}}" class="view_user_profile pill-value" tabindex="0">
+                <img class="pill-image" src="{{owner_img_src}}" />
+                <span class="pill-value" >{{bot_owner_full_name}}</span>
+                </a>
+            </span>
+        {{/if}}
     </td>
     <td class="bot_type">
         <span class="bot type">{{bot_type}}</span>

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -1,5 +1,5 @@
 <tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
-    <td>
+    <td class="user_name_column">
         <span class="user_name pill_container">
             <a data-user-id="{{user_id}}" class="view_user_profile pill-value" tabindex="0">
             <img class="pill-image" src="{{img_src}}" />

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -14,8 +14,8 @@
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
-                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-                <th data-sort="email">{{t "Email" }}</th>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "User" }}</th>
+                <th data-sort="email" class="settings-email-column">{{t "Email" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th data-sort="bot_owner">{{t "Owner" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="bot_type" class="bot_type">{{t "Bot type" }}</th>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -12,8 +12,8 @@
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
-                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-                <th {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}}>{{t "Email" }}</th>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "User" }}</th>
+                <th {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}} class="settings-email-column">{{t "Email" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 {{#if is_admin}}
                 <th class="actions">{{t "Actions" }}</th>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -12,7 +12,7 @@
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
-                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "User" }}</th>
+                <th id="user_column_header" class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "User" }}</th>
                 <th {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}} class="settings-email-column">{{t "Email" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 {{#if is_admin}}

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -11,7 +11,7 @@
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
-                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "User" }}</th>
+                <th id="user_column_header" class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "User" }}</th>
                 <th data-sort="email" class="settings-email-column">{{t "Email" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -11,8 +11,8 @@
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-striped wrapped-table">
             <thead class="table-sticky-headers">
-                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-                <th data-sort="email">{{t "Email" }}</th>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "User" }}</th>
+                <th data-sort="email" class="settings-email-column">{{t "Email" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>
                 {{#if is_admin}}


### PR DESCRIPTION
- [x] Convert the plan anchor tags to pills displaying the user's avatar with the proper user name.
- [x] Users, Bots, Bot owners, Deactivated users all are migrated to pills.
- [x] If the name is too long or the viewport becomes smaller, the user's name is trimmed and abbreviated with ellipsis `...`
- [x]  When the viewport goes below 'lg_min' (992px), the email column is dropped from all three tables: users, deactivated     
          users, and bots.
- [x] Show `no owner` as a plain text inside bots table.
- [x] Rename name column to `User`.
- [x] Adjust the column widths to improve the visibility of tables.
- [x] Change the color of the pills for the dark theme.
- [x] Change the default width of the user column from 100px to occupy 30% of the  space.
- [x] Add a tippy tooltip for name pills.

-------------

Fixes: #24229
CZO: [Thread](https://chat.zulip.org/#narrow/stream/101-design/topic/Convert.20name.20to.20avatar.20pills.20in.20settings.20.2324308)
for Rows issue: [Thread](https://chat.zulip.org/#narrow/stream/49-development-help/topic/Settings.20Table.20Rows.20CSS.20Transparency)

------------------

### Screenshots and screen captures:

<details>
<summary>Overall Changes:</summary>

![overall](https://user-images.githubusercontent.com/66828942/223624376-3a691ab7-e68e-45db-83aa-c4fa4f2131ea.gif)


</details>

<details>
<summary>User Pill:</summary>

| Light | Dark |
|---------|---------|
| ![Screenshot from 2023-03-08 10-30-39](https://user-images.githubusercontent.com/66828942/223624465-017f4579-5c50-47c6-ba2a-08315a5bb086.png) | ![Screenshot from 2023-03-08 10-30-26](https://user-images.githubusercontent.com/66828942/223624484-7b892bb7-f99b-4afb-968a-cc04bae79837.png) |



</details>

<details>
<summary>Ellipses Change:</summary>

<br>

![ellipsis_change](https://user-images.githubusercontent.com/66828942/223624607-19e7bc38-3713-4f71-8ca9-42387d61df5f.gif)


</details>

<details>
<summary>Users UI:</summary>

**Light:**

![Screenshot from 2023-03-08 10-32-45](https://user-images.githubusercontent.com/66828942/223624694-001e9f3c-ac6e-4454-987c-2de12eb03207.png)

<br/>

**Dark:**

![Screenshot from 2023-03-08 10-32-34](https://user-images.githubusercontent.com/66828942/223624711-48a7e22f-f157-4edf-b7ee-554aa77a915a.png)


</details>

<details>
<summary>Bots list:</summary>

**Light:**

 ![Screenshot from 2023-03-08 10-32-58](https://user-images.githubusercontent.com/66828942/223624813-062cbfe3-105d-4e35-88ee-604b70fbffc1.png)

<br/>

**Dark:**

![Screenshot from 2023-03-08 10-33-06](https://user-images.githubusercontent.com/66828942/223624841-8b44d4c9-522e-4869-974a-61ec08878be8.png)



</details>

<details>
<summary>View port changes:</summary>
<details>
<summary>Bots list:</summary>

![bots_change](https://user-images.githubusercontent.com/66828942/223625523-f5c2bdb7-9340-4fa2-98ff-a7cb52ce8b8f.gif)

</details>
<details>
<summary>Users list:</summary>

![users_change](https://user-images.githubusercontent.com/66828942/223625583-be251dbe-83ca-4eb2-bea9-13a68ec5d082.gif)


</details>
</details>

<details>
<summary>Tippy tooltip:</summary>
<br>

<img width="214" alt="tooltip_name_pills" src="https://github.com/zulip/zulip/assets/66828942/d62dfdd1-b617-4555-aab1-9b74b2f2bd87">

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
