### PR TITLE
[WIP] help: Document new user setting for configuring email visibility.

### DIFF
--- a/help/configure-email-visibility.md
+++ b/help/configure-email-visibility.md
@@ -9,6 +9,14 @@ for new users in the organization.
 
 {start_tabs}
 
+{tab|on-sign-up}
+
+1. After confirming your email, click **Change** below your email address.
+
+1. Configure **Who can access your email address**, and click **Confirm**.
+
+{tab|desktop-web}
+
 {settings_tab|account-and-privacy}
 
 1. Under **Privacy**, configure **Who can access your email address**.

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -92,6 +92,7 @@ TAB_SECTION_LABELS = {
     "logged-out": "If you are logged out",
     "user": "User",
     "bot": "Bot",
+    "on-sign-up": "On sign-up",
 }
 
 


### PR DESCRIPTION
This PR documents the changes in #22994.

The new page is closely modeled after parts of https://zulip.com/help/read-receipts.

The PR is not complete, as links to `/help/restrict-visibility-of-email-addresses` need to be changed to point to the new page.

Testing:
- Manually tested links'


![Screen Shot 2023-02-06 at 6 41 07 PM](https://user-images.githubusercontent.com/2090066/217135318-3687fb20-75ec-40cf-852e-1fbba99c3758.png)


