### PR TITLE
css:  Remove focus outline on simplebar wrapper elements.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -3147,3 +3147,9 @@ select.invite-as {
         }
     }
 }
+
+.simplebar-content-wrapper {
+    /* `simplebar-content-wrapper` has `tabindex=0` set, which makes it focusable
+        but we don't want it to have an outline when focused anywhere in the app. */
+    outline: none;
+}


### PR DESCRIPTION
This removes the focus outline on `simplebar-content-wrapper` in the left sidebar and other places in the app when focused since it doesn't look visually nice.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/extraneous.20box.20in.20left.20sidebar

Only way I could reproduce was just tabbing in a topic narrow to get to the left sidebar.
![image](https://user-images.githubusercontent.com/25124304/217260727-034da3f4-a314-4611-a874-6179887510f9.png)
