### PR TITLE
missed_messages: Include messages from topic which differ by case.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3000,7 +3000,7 @@ class Message(AbstractMessage):
 def get_context_for_message(message: Message) -> QuerySet[Message]:
     return Message.objects.filter(
         recipient_id=message.recipient_id,
-        subject=message.subject,
+        subject__iexact=message.subject,
         id__lt=message.id,
         date_sent__gt=message.date_sent - timedelta(minutes=15),
     ).order_by("-id")[:10]

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -516,7 +516,12 @@ class TestMissedMessages(ZulipTestCase):
         self, send_as_user: bool, show_message_content: bool = True
     ) -> None:
         for i in range(0, 11):
-            self.send_stream_message(self.example_user("othello"), "Denmark", content=str(i))
+            self.send_stream_message(
+                self.example_user("othello"),
+                "Denmark",
+                content=str(i),
+                topic_name="test" if i % 2 == 0 else "TEST",
+            )
         self.send_stream_message(self.example_user("othello"), "Denmark", "11", topic_name="test2")
         msg_id = self.send_stream_message(
             self.example_user("othello"), "denmark", "@**King Hamlet**"


### PR DESCRIPTION
In Zulip, message topics are case-insensitive but case-preserving. The `get_context_for_message` function erroneously did a case-sensitive search, and thus only messages whose topic matched exactly were pulled in as context.

Make the missed-message pipeline aware that message topics are not case-sensitive.  This means that, when collapsing adjacent messages, we merge messages with topic headers which are "different"; create a separate explicit "grouping" to know which to collapse.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
