### PR TITLE
Add stream icon to bookend

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -306,7 +306,8 @@ export class MessageList {
             just_unsubscribed = true;
         }
 
-        // Adding a stream icon to bookend inline message rendered
+        // Adding a stream icon to bookend inline
+        // message subscribed/unsubscribed rendered
         // after subscribe/unsubscribe
         let stream_icon = sub !== undefined && "hashtag";
         if (sub !== undefined) {

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -305,6 +305,17 @@ export class MessageList {
         } else if (!subscribed && !this.last_message_historical) {
             just_unsubscribed = true;
         }
+
+        // Adding a stream icon to bookend inline message rendered
+        // after subscribe/unsubscribe
+        let stream_icon = sub !== undefined && "hashtag";
+        if (sub !== undefined) {
+            if (sub.invite_only) {
+                stream_icon = "fa fa-lock";
+            } else if (sub.is_web_public) {
+                stream_icon = "zulip-icon zulip-icon-globe";
+            }
+        }
         this.view.render_trailing_bookend(
             stream_name,
             subscribed,
@@ -312,6 +323,7 @@ export class MessageList {
             just_unsubscribed,
             can_toggle_subscription,
             page_params.is_spectator,
+            stream_icon,
         );
     }
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1388,6 +1388,7 @@ export class MessageListView {
         just_unsubscribed,
         can_toggle_subscription,
         is_spectator,
+        stream_icon,
     ) {
         // This is not the only place we render bookends; see also the
         // partial in message_group.hbs, which do not set is_trailing_bookend.
@@ -1400,6 +1401,7 @@ export class MessageListView {
                 just_unsubscribed,
                 is_spectator,
                 is_trailing_bookend: true,
+                stream_icon,
             }),
         );
         rows.get_table(this.table_name).append($rendered_trailing_bookend);

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -2558,6 +2558,26 @@ select.invite-as {
     opacity: 0.5;
 }
 
+.zulip-icon.zulip-icon-globe {
+    font-size: 12px;
+    position: relative;
+    top: 1px;
+}
+
+.fa-lock {
+    font-size: 15px;
+    position: relative;
+    top: 1px;
+}
+
+.stream-icon {
+    font-size: 15px;
+    font-weight: 800;
+    position: relative;
+    top: 1px;
+    margin-left: 2px;
+}
+
 .sub-unsub-message span {
     font-size: 1em;
     text-transform: none;

--- a/static/templates/bookend.hbs
+++ b/static/templates/bookend.hbs
@@ -9,11 +9,22 @@
             {{#if deactivated}}
                 {{t "This stream has been deactivated" }}
             {{else if subscribed }}
-                {{#tr}}You subscribed to stream {stream_name}{{/tr}}
-            {{else if just_unsubscribed }}
-                {{#tr}}You unsubscribed from stream {stream_name}{{/tr}}
+              {{#tr}}You subscribed to stream <z-stream-icon></z-stream-icon>
+               {{#*inline "z-stream-icon"}}<i class="{{stream_icon}} stream-icon"  aria-hidden="true"></i>
+               {{/inline}}
+                   {{stream_name}}
+                   {{/tr}}
+
+                   {{else if just_unsubscribed}}
+                   {{#tr}} You unsubscribed from stream <z-stream-icon></z-stream-icon>
+                    {{#*inline "z-stream-icon"}}<i class="{{stream_icon}} stream-icon" aria-hidden="true"></i>
+                    {{/inline}} {{stream_name}}
+                     {{/tr}}
             {{else}}
-                {{#tr}}You are not subscribed to stream {stream_name}{{/tr}}
+                {{#tr}} You are not subscribed to stream <z-stream-icon></z-stream-icon>
+                {{#*inline "z-stream-icon"}}<i class="{{stream_icon}} stream-icon" aria-hidden="true"></i>{{/inline}}
+                {{stream_name}}
+                {{/tr}}
             {{/if}}
         </span>
     {{/if}}


### PR DESCRIPTION
Add a stream icon to the Subscribe/unsubscribe divider line

Fixes:23709
![Screenshot from 2023-02-08 11-49-03](https://user-images.githubusercontent.com/76694292/217511229-e75f96a9-c3cd-49be-9ba6-5436b77483cc.png)

![Screenshot from 2023-02-08 11-49-35](https://user-images.githubusercontent.com/76694292/217511249-e960debc-c254-4ee3-8186-3b1cca6dc671.png)


Self-review checklist

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

-  [ ] Visual appearance of the changes.

- [ ]  Responsiveness and internationalization.

- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
