### PR TITLE
stripe: Change realm.plan_type when upgrading a realm to Plus plan.

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1187,6 +1187,10 @@ def switch_realm_from_standard_to_plus_plan(realm: Realm) -> None:
     standard_plan.next_invoice_date = plan_switch_time
     standard_plan.save(update_fields=["status", "next_invoice_date"])
 
+    from zerver.actions.realm_settings import do_change_realm_plan_type
+
+    do_change_realm_plan_type(realm, Realm.PLAN_TYPE_PLUS, acting_user=None)
+
     standard_plan_next_renewal_date = start_of_next_billing_cycle(standard_plan, plan_switch_time)
 
     standard_plan_last_renewal_ledger = (

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -3804,6 +3804,9 @@ class StripeTest(StripeTestCase):
         self.assertEqual(plus_plan.tier, CustomerPlan.PLUS)
         self.assertEqual(LicenseLedger.objects.filter(plan=plus_plan).count(), 1)
 
+        realm.refresh_from_db()
+        self.assertEqual(realm.plan_type, Realm.PLAN_TYPE_PLUS)
+
         # There are 9 licenses and the realm is on the Standard monthly plan.
         # Therefore, the customer has already paid 800 * 9 = 7200 = $72 for
         # the month. Once they upgrade to Plus, the new price for their 9


### PR DESCRIPTION
This should be updated and was missing (though doesn't have practical impact for organization, it's just a informative record)