### PR TITLE
popovers: Fix hide popovers when clicked.

### DIFF
--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -9,6 +9,7 @@ import * as peer_data from "./peer_data";
 import * as recent_topics_util from "./recent_topics_util";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
+import * as popovers from "./popovers";
 
 function get_formatted_sub_count(sub_count) {
     if (sub_count >= 1000) {
@@ -98,9 +99,13 @@ function bind_title_area_handlers() {
         search.initiate_search();
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
     });
 
     $("#message_view_header .navbar-click-opens-search").on("click", (e) => {
+        // Hide all popovers when the user clicks on the search bar.
+        popovers.hide_all();
+
         if (document.getSelection().type === "Range") {
             // Allow copy/paste to work normally without interference.
             return;
@@ -175,6 +180,7 @@ export function initialize() {
         exit_search();
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
     });
 }
 


### PR DESCRIPTION
Popovers hide while clicking on the search bar/icon now.

Fixes: #24318

**Screenshots and screen captures:**
![fix](https://user-images.githubusercontent.com/101464851/217641515-72cf7fb5-b196-4186-bcb1-ce0f3472a287.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
