### PR TITLE
design: Loading Message Misaligned on Smaller Devices.

### DIFF
--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -18,7 +18,6 @@ $(() => {
     // get_events completes.
     if (!page_params.needs_tutorial) {
         loading.make_indicator($("#page_loading_indicator"), {
-            text: "Loading...",
             abs_positioned: true,
         });
     }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The loading message was not properly aligned on smaller screen devices.

Removed 'loading...' message to improve visual alignment on smaller screen devices. Considered options for keeping fixed height and avoiding content jump, but ultimately decided on eliminating the text and enhancing the visibility of the loading spinner for better user experience.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Previous behavior : 

<img src="https://user-images.githubusercontent.com/96344003/217647215-108e9de1-1da1-42b5-8145-336b78b8da61.png" width="620" height="340"/>

New behavior :

<img src="https://user-images.githubusercontent.com/96344003/217647425-7a3df5c5-054b-4905-bc68-6c8119c815c7.png" width="620" height="340"/>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
