### PR TITLE
settings: Drop less important columns from settings on narrow screen.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1829,6 +1829,14 @@ $option_title_width: 180px;
 }
 
 @media (width < $sm_min) {
+    .user_row,
+    .settings-section {
+        .bot_type,
+        .last_active {
+            display: none;
+        }
+    }
+
     #pw_strength {
         margin: auto;
     }
@@ -1864,6 +1872,10 @@ $option_title_width: 180px;
         .custom_user_field textarea {
             width: calc(100% - 25px);
         }
+    }
+
+    .topic_date_muted {
+        display: none;
     }
 }
 

--- a/web/templates/muted_topic_ui_row.hbs
+++ b/web/templates/muted_topic_ui_row.hbs
@@ -2,7 +2,7 @@
 <tr data-stream-id="{{stream_id}}" data-stream="{{stream}}" data-topic="{{topic}}" data-date-muted="{{date_muted_str}}">
     <td>{{stream}}</td>
     <td>{{topic}}</td>
-    <td>{{date_muted_str}}</td>
+    <td class="topic_date_muted">{{date_muted_str}}</td>
     <td class="actions">
         <span><a class="settings-unmute-topic">{{t "Unmute" }}</a></span>
     </td>

--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -32,7 +32,7 @@
             {{/if}}
         </span>
     </td>
-    <td>
+    <td class="bot_type">
         <span class="bot type">{{bot_type}}</span>
     </td>
     {{else if is_active}}

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -17,7 +17,7 @@
                 <th data-sort="email">{{t "Email" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th data-sort="bot_owner">{{t "Owner" }}</th>
-                <th data-sort="alphabetic" data-sort-prop="bot_type">{{t "Bot type" }}</th>
+                <th data-sort="alphabetic" data-sort-prop="bot_type" class="bot_type">{{t "Bot type" }}</th>
                 {{#if is_admin}}
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}

--- a/web/templates/settings/muted_topics_settings.hbs
+++ b/web/templates/settings/muted_topics_settings.hbs
@@ -8,7 +8,7 @@
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="stream">{{t "Stream" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="topic">{{t "Topic" }}</th>
-                <th data-sort="numeric" data-sort-prop="date_muted">{{t "Date muted" }}</th>
+                <th data-sort="numeric" data-sort-prop="date_muted" class="topic_date_muted">{{t "Date muted" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
             <tbody id="muted_topics_table" class="required-text" data-empty="{{t 'You have not muted any topics yet.'}}"></tbody>


### PR DESCRIPTION
### Drop:

- **last_active** (organization_settings > Users) on sm_min (576px)
- **Bot_type** (organization_settings > Bots) on sm_min (576px)
- **Date_muted** (personal_settings > muted stream) on ml_min (425px)

**Fixes**: #24320
**CZO:** [Thread](https://chat.zulip.org/#narrow/stream/101-design/topic/drop.20columns.20in.20settings.20panel)

### Demo:

- **last_active:**

![last_active](https://user-images.githubusercontent.com/66828942/217658426-01ed9a43-87a7-4167-afeb-fcc0ddaae844.gif)

- **Bot_type:**

![bot_type](https://user-images.githubusercontent.com/66828942/217658473-9a568eed-ba66-4df6-8f5a-eebd07d12bba.gif)

- **Date_muted:**
![date_muted](https://user-images.githubusercontent.com/66828942/217658518-72308b8e-8c60-402c-8a1b-1f7c640809d7.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
