### PR TITLE
help: Update documentation on editing and moving messages

### DIFF
--- a/help/configure-message-editing-and-deletion.md
+++ b/help/configure-message-editing-and-deletion.md
@@ -1,83 +1,52 @@
-# Configure message editing and deletion
+# Restrict message editing and deletion
 
 {!admin-only.md!}
 
-There are several settings that control who can [edit and delete
-messages](/help/edit-or-delete-a-message) and topics. By default,
-users have 10 minutes after posting a message to edit it, they can
-edit any topic at any time, and they cannot delete their messages.
-
-Different organizations have different message editing needs, so this area
-is highly configurable. Two things are true under any configuration:
+Zulip lets you separately configure permissions for editing and deleting
+messages, and you can set time limits for both actions. Regardless of the
+configuration you select:
 
 * Message content can only ever be modified by the original author.
 * Any message can be deleted at any time by an organization administrator.
 
-<div class="centered_table"></div>
-|                                       | Admins   | Members |
-|---                                    |---       |---      |
-| Edit your message content             | [1]      | [1]     |
-| Edit others' message content          |          |         |
-| Edit your message topics              | [1]      | [1]     |
-| Add topic to messages without a topic | [1]      | [1]     |
-| Edit others' message topics           | [1]      | [2]     |
-| Move topics between streams           | [3]      | [3]     |
-| Delete your messages                  | &#10004; | [4]     |
-| Delete others' messages               | &#10004; |         |
+Note that if a user can edit a message, they can also "delete" it by removing
+all the message content. This is different from proper message deletion in two
+ways: the original content will still show up in [message edit
+history](/help/view-a-messages-edit-history), and will be included in
+[exports](/help/export-your-organization). Deletion permanently (and
+irretrievably) removes the message from Zulip.
 
-[1] Controlled by **Allow message editing**.
+## Configure message editing permissions
 
-[2] Controlled by **Who can edit topic of any message**.
+!!! tip ""
 
-[3] Controlled by **Who can move messages between streams**, in
-addition to other restrictions on editing topics.
-
-[4] Controlled by **Who can delete their own messages**
-and **Time limit for deleting messages**.
-
-There are a few useful things to understand about the message editing
-settings.
-
-* **Allow message editing** can be set to **Never**, **Any time** or
-  **Up to [a customizable time limit] after posting**. If set to **Never**,
-  users cannot edit message topics either. For any other value, users can
-  edit message topics at any time.
-
-* If a user can edit a message, they can also "delete" it by removing all
-  the message content. This is different from proper message deletion in two
-  ways: the original content will still show up in
-  [message edit history](view-a-messages-edit-history), and will be included
-  in [exports](/help/export-your-organization). Deletion
-  permanently (and irretrievably) removes the message from Zulip.
-
-## Configure message editing and deletion
+    Users can only edit their own messages.
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
-1. Under **Message and topic editing**, configure:
-
-    - **Allow message editing**
-    - **Who can edit topic of any message**
-    - **Who can delete their own messages**
-    - **Time limit for deleting messages**
+1. Under **Message editing**:
+    - Toggle **Allow message editing**.
+    - Configure **Time limit for editing messages**.
 
 {!save-changes.md!}
 
 {end_tabs}
 
-## Configure who can move topics between streams
+## Configure message deletion permissions
 
-You can configure which [roles](/help/roles-and-permissions)
-have permission to move topics between streams.
+!!! tip ""
+
+    Administrators can always delete any message.
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
-1. Under **Message and topic editing**, configure
-   **Who can move messages between streams**.
+1. Under **Message deletion**:
+    - Configure **Who can delete their own messages**.
+    - Configure **Time limit for deleting messages**.
 
 {!save-changes.md!}
 
@@ -85,8 +54,8 @@ have permission to move topics between streams.
 
 ## Related articles
 
+* [Edit or delete a message](/help/edit-or-delete-a-message)
+* [Delete a topic](/help/delete-a-topic)
 * [Disable message edit history](/help/disable-message-edit-history)
 * [Configure message retention policy](/help/message-retention-policy)
-* [Move content to another stream](/help/move-content-to-another-stream)
-* [Rename a topic](/help/rename-a-topic)
-* [Restrict topic editing](/help/configure-who-can-edit-topics)
+* [Restrict moving messages](/help/configure-who-can-edit-topics)

--- a/help/configure-who-can-edit-topics.md
+++ b/help/configure-who-can-edit-topics.md
@@ -1,27 +1,77 @@
-# Restrict topic editing
+# Restrict moving messages
 
 {!admin-only.md!}
 
-By default, anyone can edit any message topic. This is useful because it allows
-the community to keep conversations organized, even if some members are still
-learning how to use topics effectively. However, you can restrict the ability to
-edit the topic of any message to specific [roles](/help/roles-and-permissions).
+Zulip lets you configure which [roles](/help/roles-and-permissions) can edit
+message topics and move topics between streams. In general, allowing all
+organization members to edit message topics is highly recommended because:
 
-Note that users may still be able to edit the topic of messages with
-**(no topic)**; see the full article on [message and topic
-editing](/help/configure-message-editing-and-deletion) for details.
+- It allows the community to keep conversations organized, even if some members
+  are still learning how to use topics effectively.
+- It lets users [resolve topics](/help/resolve-a-topic).
+- It makes it possible to fix a typo in the topic of a message you just sent.
 
-Also, only administrators and moderators can edit the topics of
-messages that were sent more than 3 days ago, regardless of the value
-of this setting.
+You can let users edit topics without a time limit, or prohibit topic editing on
+older messages to avoid potential abuse. The time limit will never apply to
+administrators and moderators.
 
-### Change who can edit topics
+Permissions for moving messages between streams can be configured separately.
+
+## Configure who can edit topics
+
+!!! tip ""
+    Anyone can add a topic to messages sent without a topic.
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
-2. Under **Message and topic editing**, configure **Who can edit the topic of any message**.
+1. Under **Moving messages**, configure **Who can move messages to another
+   topic**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Set a time limit for editing topics
+
+!!! tip ""
+    The time limit you set will not apply to administrators and moderators.
+
+{start_tabs}
+
+{settings_tab|organization-permissions}
+
+1. Under **Moving messages**, configure **Time limit for editing topics**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Configure who can move messages to another stream
+
+{start_tabs}
+
+{settings_tab|organization-permissions}
+
+1. Under **Moving messages**, configure **Who can move messages to another
+   stream**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Set a time limit for moving messages between streams
+
+!!! tip ""
+    The time limit you set will not apply to administrators and moderators.
+
+{start_tabs}
+
+{settings_tab|organization-permissions}
+
+1. Under **Moving messages**, configure **Time limit for  moving messages
+   between streams**.
 
 {!save-changes.md!}
 
@@ -29,7 +79,10 @@ of this setting.
 
 ## Related articles
 
-* [Message and topic editing](/help/configure-message-editing-and-deletion)
 * [Rename a topic](/help/rename-a-topic)
+* [Resolve a topic](/help/resolve-a-topic)
 * [Move content to another topic](/help/move-content-to-another-topic)
+* [Move content to another stream](/help/move-content-to-another-stream)
+* [Restrict message editing and
+  deletion](/help/configure-message-editing-and-deletion)
 * [Roles and permissions](/help/roles-and-permissions)

--- a/help/disable-message-edit-history.md
+++ b/help/disable-message-edit-history.md
@@ -22,4 +22,4 @@ also disable viewing of message edit history more generally.
 
 ## Related articles
 
-* [Restrict message editing](/help/configure-message-editing-and-deletion)
+* [Restrict message editing and deletion](/help/configure-message-editing-and-deletion)

--- a/help/edit-or-delete-a-message.md
+++ b/help/edit-or-delete-a-message.md
@@ -97,4 +97,4 @@ permissions to delete that message.
 * [Delete a topic](/help/delete-a-topic)
 * [Archive a stream](/help/archive-a-stream)
 * [Message retention policy](/help/message-retention-policy)
-* [Configure editing and deletion policies](/help/configure-message-editing-and-deletion)
+* [Restrict message editing and deletion](/help/configure-message-editing-and-deletion)

--- a/help/import-from-gitter.md
+++ b/help/import-from-gitter.md
@@ -107,7 +107,7 @@ keep in mind about the import process:
   workspace settings, so you will need to [configure the settings for your Zulip
   organization](/help/customize-organization-settings). This includes settings
   like [email visibility](/help/restrict-visibility-of-email-addresses),
-  [message editing permissions](/help/configure-message-editing-and-deletion#configure-message-editing-and-deletion_1),
+  [message editing permissions](/help/configure-message-editing-and-deletion),
   and [how users can join your organization](/help/restrict-account-creation).
 
 - Gitter's export tool does not export user settings, so users in your organization
@@ -143,10 +143,10 @@ Once the import process is completed, you will need to:
 1. [Configure the settings for your organization](/help/customize-organization-settings),
    which are not exported. This includes settings like [email
    visibility](/help/restrict-visibility-of-email-addresses), [message editing
-   permissions](/help/configure-message-editing-and-deletion#configure-message-editing-and-deletion_1),
+   permissions](/help/configure-message-editing-and-deletion),
    and [how users can join your organization](/help/restrict-account-creation).
 
-1. [Configure user roles](/help/change-a-users-role). Only organization owners
+2. [Configure user roles](/help/change-a-users-role). Only organization owners
    and administrators can do this.
     * If you [import into Zulip Cloud](#import-your-data-into-zulip), you will
     specify the user whose account will have the owner role when you request the
@@ -155,15 +155,15 @@ Once the import process is completed, you will need to:
     organization owner from the terminal][grant-admin-access] to mark the appropriate
     users as organization owners.
 
-1. All users from your previous workspace will have accounts in your new Zulip
+3. All users from your previous workspace will have accounts in your new Zulip
    organization. However, you will need to let users know about their new
    accounts, and [how they will log in for the first time
    ](#how-users-will-log-in-for-the-first-time).
 
-1. Share the URL for your new Zulip organization, and (recommended) the [Getting
+4. Share the URL for your new Zulip organization, and (recommended) the [Getting
    started with Zulip guide](/help/getting-started-with-zulip).
 
-1. Migrate any [integrations](/integrations).
+5. Migrate any [integrations](/integrations).
 
 {end_tabs}
 

--- a/help/import-from-mattermost.md
+++ b/help/import-from-mattermost.md
@@ -255,7 +255,7 @@ keep in mind about the import process:
   the settings for your Zulip organization](/help/customize-organization-settings).
   This includes settings like [email
   visibility](/help/restrict-visibility-of-email-addresses),
-  [message editing permissions](/help/configure-message-editing-and-deletion#configure-message-editing-and-deletion_1),
+  [message editing permissions](/help/configure-message-editing-and-deletion),
   and [how users can join your organization](/help/restrict-account-creation).
 
 - Mattermost's user roles are mapped to Zulip's [user

--- a/help/import-from-rocketchat.md
+++ b/help/import-from-rocketchat.md
@@ -104,7 +104,7 @@ keep in mind about the import process:
   the settings for your Zulip organization](/help/customize-organization-settings).
   This includes settings like [email
   visibility](/help/restrict-visibility-of-email-addresses),
-  [message editing permissions](/help/configure-message-editing-and-deletion#configure-message-editing-and-deletion_1),
+  [message editing permissions](/help/configure-message-editing-and-deletion),
   and [how users can join your organization](/help/restrict-account-creation).
 
 - Rocket.Chat does not export user settings, so users in your organization may

--- a/help/import-from-slack.md
+++ b/help/import-from-slack.md
@@ -135,7 +135,7 @@ in mind about the import process:
   the settings for your Zulip organization](/help/customize-organization-settings).
   This includes settings like [email
   visibility](/help/restrict-visibility-of-email-addresses),
-  [message editing permissions](/help/configure-message-editing-and-deletion#configure-message-editing-and-deletion_1),
+  [message editing permissions](/help/configure-message-editing-and-deletion),
   and [how users can join your organization](/help/restrict-account-creation).
 
 - Slack does not export user settings, so users in your organization may want to

--- a/help/include/customize-organization-settings.md
+++ b/help/include/customize-organization-settings.md
@@ -17,12 +17,13 @@ A few settings to highlight:
 
 * [Add custom emoji](/help/custom-emoji), including your organization's logo.
 
-For many other settings, e.g. [message and topic editing
-permissions][topic-editing-permissions], you can experience how Zulip
-works for your organization before deciding what settings are best for
+For many other settings, e.g., [message][message-editing-permissions] and
+[topic][topic-editing-permissions] editing permissions, you can experience how
+Zulip works for your organization before deciding what settings are best for
 you.
 
-[topic-editing-permissions]: /help/configure-message-editing-and-deletion
+[message-editing-permissions]: /help/configure-message-editing-and-deletion
+[topic-editing-permissions]: /help/configure-who-can-edit-topics
 [default-code-block-language]: /help/code-blocks#default-code-block-language
 [code-playgrounds]: /help/code-blocks#code-playgrounds
 [email-address-visibility]: /help/restrict-visibility-of-email-addresses

--- a/help/include/import-get-your-organization-started.md
+++ b/help/include/import-get-your-organization-started.md
@@ -5,17 +5,17 @@ Once the import process is completed, you will need to:
 1. [Configure the settings for your organization](/help/customize-organization-settings),
     which are not exported. This includes settings like [email
     visibility](/help/restrict-visibility-of-email-addresses), [message editing
-    permissions](/help/configure-message-editing-and-deletion#configure-message-editing-and-deletion_1),
+    permissions](/help/configure-message-editing-and-deletion),
     and [how users can join your organization](/help/restrict-account-creation).
 
-1. All users from your previous workspace will have accounts in your new Zulip
+2. All users from your previous workspace will have accounts in your new Zulip
    organization. However, you will need to let users know about their new
    accounts, and [decide how they will log
    in](/help/import-from-slack#decide-how-users-will-log-in) for the first time.
 
-1. Share the URL for your new Zulip organization, and (recommended) the [Getting
+3. Share the URL for your new Zulip organization, and (recommended) the [Getting
    started with Zulip guide](/help/getting-started-with-zulip).
 
-1. Migrate any [integrations](/integrations).
+4. Migrate any [integrations](/integrations).
 
 {end_tabs}

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -189,7 +189,7 @@
 * [Require topics in stream messages](/help/require-topics)
 * [Restrict private messages](/help/restrict-private-messages)
 * [Restrict wildcard mentions](/help/restrict-wildcard-mentions)
-* [Restrict topic editing](/help/configure-who-can-edit-topics)
+* [Restrict moving messages](/help/configure-who-can-edit-topics)
 * [Restrict message editing](/help/configure-message-editing-and-deletion)
 * [Disable message edit history](/help/disable-message-edit-history)
 * [Block image and link previews](/help/allow-image-link-previews)

--- a/help/move-content-to-another-stream.md
+++ b/help/move-content-to-another-stream.md
@@ -1,9 +1,11 @@
 # Move content to another stream
 
-Zulip makes it possible to move messages, or an entire topic, to another
-stream. Organizations can [configure][move-permission-setting] which
-[roles](/help/roles-and-permissions) have permission to move messages
-between streams.
+Zulip makes it possible to move messages, or an entire topic, to another stream.
+Organizations can [configure][configure-moving-permissions] which
+[roles](/help/roles-and-permissions) have permission to move messages between
+streams.
+
+[configure-moving-permissions]: /help/configure-who-can-edit-topics#configure-who-can-move-messages-to-another-stream
 
 To help others find moved content, you can have the [notification
 bot][notification-bot] send automated notices to the source topic, the
@@ -104,7 +106,6 @@ that one does not have permission to access.
 
 * [Rename a topic](/help/rename-a-topic)
 * [Move content to another topic](/help/move-content-to-another-topic)
-* [Configure message editing and deletion](/help/configure-message-editing-and-deletion)
+* [Restrict moving messages](/help/configure-who-can-edit-topics)
 
-[move-permission-setting]: /help/configure-message-editing-and-deletion#configure-who-can-move-topics-between-streams
 [notification-bot]: /help/configure-notification-bot

--- a/help/move-content-to-another-topic.md
+++ b/help/move-content-to-another-topic.md
@@ -12,9 +12,7 @@ topics](/help/mute-a-topic) are automatically migrated when an entire
 topic is moved.
 
 Organizations can [configure](/help/configure-who-can-edit-topics) which
-[roles](/help/roles-and-permissions) have permission to modify topics. See the
-[guide to message and topic editing](/help/configure-message-editing-and-deletion)
-for the details on when topic editing is allowed.
+[roles](/help/roles-and-permissions) have permission to modify topics.
 
 ## Move messages to another topic
 
@@ -39,4 +37,4 @@ for the details on when topic editing is allowed.
 
 * [Rename a topic](/help/rename-a-topic)
 * [Move content to another stream](/help/move-content-to-another-stream)
-* [Configure message editing and deletion](/help/configure-message-editing-and-deletion)
+* [Restrict moving messages](/help/configure-who-can-edit-topics)

--- a/help/rename-a-topic.md
+++ b/help/rename-a-topic.md
@@ -11,9 +11,7 @@ will automatically redirect to the new location of the message. [Muted
 topics](/help/mute-a-topic) are automatically migrated when a topic is renamed.
 
 Organizations can [configure](/help/configure-who-can-edit-topics) which
-[roles](/help/roles-and-permissions) have permission to rename topics. See the
-[guide to message and topic editing](/help/configure-message-editing-and-deletion)
-for the details on when topic editing is allowed.
+[roles](/help/roles-and-permissions) have permission to rename topics.
 
 ## Rename a topic
 
@@ -48,10 +46,10 @@ for the details on when topic editing is allowed.
 
 {end_tabs}
 
-[move-permission-setting]: /help/configure-message-editing-and-deletion#configure-who-can-move-topics-between-streams
-
 ## Related articles
 
 * [Move content to another topic](/help/move-content-to-another-topic)
 * [Move content to another stream](/help/move-content-to-another-stream)
 * [Resolve a topic](/help/resolve-a-topic)
+* [Restrict moving messages](/help/configure-who-can-edit-topics)
+

--- a/help/require-topics.md
+++ b/help/require-topics.md
@@ -23,7 +23,6 @@ specified topic.
 If a user sends a message without a topic, the message's topic is
 displayed as **(no topic)**.
 
-When [message editing](/help/configure-message-editing-and-deletion)
-is enabled, any user can [add a topic](/help/rename-a-topic)
-to messages without a topic. They can do so regardless of whether
-they can [edit topics in general](/help/configure-who-can-edit-topics).
+Any user can [add a topic](/help/rename-a-topic) to messages without a topic.
+They can do so regardless of whether they can [edit topics in
+general](/help/configure-who-can-edit-topics).

--- a/help/resolve-a-topic.md
+++ b/help/resolve-a-topic.md
@@ -37,10 +37,7 @@ approaches for deciding when to mark a topic as resolved:
 
 Users can resolve and unresolve a topic if they have permission to edit
 topics. Organization administrators can [configure who can edit
-topics](/help/configure-who-can-edit-topics) or turn off message
-editing entirely. See the [guide to message and topic
-editing](/help/configure-message-editing-and-deletion) for details
-on when topic editing is allowed.
+topics](/help/configure-who-can-edit-topics).
 
 ## Mark a topic as resolved
 
@@ -111,5 +108,4 @@ on when topic editing is allowed.
 * [Rename a topic](/help/rename-a-topic)
 * [Move content to another topic](/help/move-content-to-another-topic)
 * [Restrict topic editing](/help/configure-who-can-edit-topics)
-* [Configure message editing and deletion](/help/configure-message-editing-and-deletion)
 * [API documentation for resolving topics](/api/update-message)

--- a/help/setting-up-zulip-for-a-class.md
+++ b/help/setting-up-zulip-for-a-class.md
@@ -167,7 +167,7 @@ how to assign roles and permissions for a class.
   (Recommended: Admins for public streams; Admins, moderators and members for private streams)
 - Set [who can add users to streams](/help/configure-who-can-invite-to-streams).
   (Recommended: Admins and moderators)
-- Set [who can edit the topic of any message](/help/configure-who-can-invite-to-streams).
+- Set [who can edit the topic of any message](/help/configure-who-can-edit-topics).
   (Recommended: (default) Members for small classes;
   Admins and moderators for large classes)
 - Set [who can move messages between streams][move-between-streams].
@@ -176,7 +176,7 @@ how to assign roles and permissions for a class.
   (Recommended: Admins and moderators)
 
 [user-group-permissions]: /help/user-groups#configure-who-can-create-and-manage-user-groups
-[move-between-streams]: /help/configure-message-editing-and-deletion#configure-who-can-move-topics-between-streams
+[move-between-streams]: /help/configure-who-can-edit-topics#configure-who-can-move-messages-to-another-stream
 
 #### Recommended roles and permissions for a department
 
@@ -198,7 +198,7 @@ how to assign roles and permissions for a class.
    Admins, moderators and members for private streams)
 - Set [who can add users to streams](/help/configure-who-can-invite-to-streams).
   (Recommended: Admins and moderators)
-- Set [who can edit the topic of any message](/help/configure-who-can-invite-to-streams).
+- Set [who can edit the topic of any message](/help/configure-who-can-edit-topics).
   (Recommended: Admins and moderators)
 - Set [who can move messages between streams][move-between-streams].
   (Recommended: Admins and moderators)

--- a/help/view-a-messages-edit-history.md
+++ b/help/view-a-messages-edit-history.md
@@ -38,5 +38,5 @@ Organization administrators can
 
 ## Related articles
 
-* [Restrict message editing](/help/configure-message-editing-and-deletion)
+* [Restrict message editing and deletion](/help/configure-message-editing-and-deletion)
 * [Disable message edit history](/help/disable-message-edit-history)


### PR DESCRIPTION
Links from other help center pages have been updated.

I haven't had a chance to:

- Do a careful read-through
- Test links
- Review links from files outside of the `/help` directory
- Move pages to updated URLs

Other notes:
- I debated between "Restrict" and "Configure" for the message editing article title, but I think "Restrict" works better (it's more specific), and is consistent with the pattern we have in the left sidebar.
- Annoyingly, "Restrict message editing and deletion" doesn't fit on one line in the sidebar.

![Screen Shot 2023-02-08 at 2 02 16 PM](https://user-images.githubusercontent.com/2090066/217662920-a9ce8a87-8ee5-4052-bd7b-24a3ddb5ac70.png)
![Screen Shot 2023-02-08 at 2 03 00 PM](https://user-images.githubusercontent.com/2090066/217662918-ae9c64e1-d0be-4825-b30f-8b548d87c759.png)
![Screen Shot 2023-02-08 at 2 00 43 PM](https://user-images.githubusercontent.com/2090066/217662922-ac5fdf83-9ce7-4d5d-b80d-d5e75c4264c6.png)


