### PR TITLE
upload: Replace deprecated PIL.PngImagePlugin.APNG_DISPOSE_OP_NONE

### DIFF
--- a/zerver/lib/upload/base.py
+++ b/zerver/lib/upload/base.py
@@ -111,7 +111,12 @@ def resize_animated(im: Image.Image, size: int = DEFAULT_EMOJI_SIZE) -> bytes:
                 im.disposal_method  # type: ignore[attr-defined]  # private member missing from stubs
             )
         elif isinstance(im, PngImagePlugin.PngImageFile):
-            disposals.append(im.info.get("disposal", PngImagePlugin.APNG_DISPOSE_OP_NONE))
+            disposals.append(
+                im.info.get(
+                    "disposal",
+                    PngImagePlugin.Disposal.OP_NONE,  # type: ignore[attr-defined] # https://github.com/python/typeshed/pull/9698
+                )
+            )
         else:  # nocoverage
             raise BadImageError(_("Unknown animated image format."))
     out = io.BytesIO()


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/deprecations.html#constants

I also submitted python/typeshed#9698 for the missing stubs.