### PR TITLE
recipient_bar: Add box shadow at top.

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1471,6 +1471,8 @@ export class MessageListView {
         const partially_hidden_header_position = visible_top - 1;
 
         function is_sticky(header) {
+            // header has a box-shodow of `1px` at top but since it doesn't impact
+            // `y` position of the header, we don't take it into account during calculations.
             const header_props = header.getBoundingClientRect();
             // This value is dependent upon margin-bottom applied to recipient row.
             const margin_between_recipient_rows = 10;

--- a/static/styles/dark_theme.css
+++ b/static/styles/dark_theme.css
@@ -364,6 +364,10 @@
         color: hsl(212, 28%, 18%);
     }
 
+    .message_header {
+        box-shadow: 0 -1px 0 0 hsl(212, 28%, 18%);
+    }
+
     /* these are converting grey things to "new grey" */
     :disabled,
     input:not([type="radio"]):read-only,

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1087,6 +1087,7 @@ td.pointer {
         position: sticky;
         top: $sidebar_top;
         z-index: 3;
+        box-shadow: 0 -1px 0 0 hsl(0, 0%, 100%);
 
         @media (width < $sm_min) {
             top: $sidebar_top_sm;


### PR DESCRIPTION
We add a box shadow at top of the recipient bar to hide message text that are partially visible above the recipient bar. At 100% zoom, this issue is not visible but it has been reported by a user at 150% zoom.

Following this change we don't need to do change any of our JS calculations since `y` position of header remains the same and when determining if a header `is_sticky` that is the only thing we verify.

There should not be any visual changes.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20header.20bar.20sometimes.20off.20aligned


before: 
![image](https://user-images.githubusercontent.com/25124304/217715146-af9c62fc-781c-425c-bb36-d7c154a58472.png)
after:
![image](https://user-images.githubusercontent.com/25124304/217715156-c39b96b6-7cd9-4c63-9f77-34c3d243d4ef.png)
