### PR TITLE
popovers: Fix hide all popovers when clicked on search or settings.

### DIFF
--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -6,6 +6,7 @@ import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
+import * as popovers from "./popovers";
 import * as recent_topics_util from "./recent_topics_util";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
@@ -95,12 +96,15 @@ function append_and_display_title_area(message_view_header_data) {
 
 function bind_title_area_handlers() {
     $(".search_closed").on("click", (e) => {
+        popovers.hide_all();
         search.initiate_search();
         e.preventDefault();
         e.stopPropagation();
     });
 
     $("#message_view_header .navbar-click-opens-search").on("click", (e) => {
+        popovers.hide_all();
+
         if (document.getSelection().type === "Range") {
             // Allow copy/paste to work normally without interference.
             return;
@@ -172,6 +176,7 @@ export function initialize() {
 
     // register searchbar click handler
     $("#search_exit").on("click", (e) => {
+        popovers.hide_all();
         exit_search();
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
Popovers hide while clicking on the search bar/icon and settings icon now.

Fixes: #24318

**Screenshots and screen captures:**
![217641515-72cf7fb5-b196-4186-bcb1-ce0f3472a287](https://user-images.githubusercontent.com/101464851/217779901-36e88aaf-95b4-4f9b-a0d2-892b0915ddfa.gif)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
