### PR TITLE
settings:  `change email and password` dialog responsive on narrow screens

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1831,6 +1831,11 @@ $option_title_width: 180px;
         margin: auto;
         float: none;
     }
+
+    #change_password_modal,
+    #change_email_modal {
+        width: 400px;
+    }
 }
 
 @media (width < $ml_min) {
@@ -1849,6 +1854,11 @@ $option_title_width: 180px;
 
     .topic_date_muted {
         display: none;
+    }
+
+    #change_password_modal,
+    #change_email_modal {
+        width: 300px;
     }
 }
 

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -4,7 +4,7 @@
         <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
         <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
         <div class="settings-forgot-password">
-            <a href="/accounts/password/reset/" class="sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgotten it?" }}</a>
+            <a href="/accounts/password/reset/" class="sea-green" target="_blank" rel="noopener noreferrer">{{t "Forgot it?" }}</a>
         </div>
     </div>
     <div class="field password-div">


### PR DESCRIPTION
- **Added a width for the `Change Email and Password` dialog at `sm_min (576px)` and `ml_min (425px)` to make it more responsive on narrow screens.**

 Fixes: #24339
 CZO: [Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Change.20Password.20modal.20not.20responsive)

### Screenshots and screen captures:

**Change Email:**

- **Before**:
![Screenshot from 2023-02-10 00-57-58](https://user-images.githubusercontent.com/66828942/217917413-5fed59ac-97d9-4d81-bbb4-b31ec9278d33.png)

- **New Change**:

![change_email](https://user-images.githubusercontent.com/66828942/217917505-c6ffddea-b1fd-49e7-ad6b-f3ec9321530b.gif)

**Change Password:**

- **Before**:
![Screenshot from 2023-02-10 00-57-50](https://user-images.githubusercontent.com/66828942/217917616-a1ebebd2-eb7b-42c4-8468-1c2fe4a8c6d4.png)

- **New Change**:

![change_password](https://user-images.githubusercontent.com/66828942/217918245-33225837-90c9-4340-863a-8a9cb6c9cc80.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
