### PR TITLE
portico_signin: Fix content wrapping too much.

### DIFF
--- a/static/styles/portico/portico_signin.css
+++ b/static/styles/portico/portico_signin.css
@@ -1288,12 +1288,8 @@ button#register_auth_button_gitlab {
     word-break: break-all;
 }
 
-@media (width >= 600px) {
+@media (width >= 800px) {
     .account-creation .white-box {
-        max-width: min-content;
-
-        .alert-info {
-            min-width: max-content;
-        }
+        max-width: 800px;
     }
 }


### PR DESCRIPTION
Due to `max-width: min-content` being used and `min-width: max-content` not being applied since it is not present outside of development environment, the text wrapped after every word.

The intention of this CSS was to restrict the max-width of the `white-box` and I think 800px is a good max-width after which content should wrap.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/password.20reset.20page.20width

broken images:
![image](https://user-images.githubusercontent.com/25124304/217994731-caffd226-88bd-4e65-b7e7-b133d6db608b.png)
![image](https://user-images.githubusercontent.com/25124304/217994752-4c128a97-f8b9-49f0-a013-69b37dc7bf61.png)



fixed images:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/25124304/217994666-2d97903d-64a6-4827-b701-7b72229f29cb.png">
<img width="781" alt="image" src="https://user-images.githubusercontent.com/25124304/217994678-388a2b81-e0fa-4e38-8538-28883db78cb3.png">
<img width="647" alt="image" src="https://user-images.githubusercontent.com/25124304/217994837-f2b59fa0-8cde-43e6-a808-f6545cda7a96.png">