### PR TITLE
pm-list-data: Remove unused `is_all_privates` function.

### DIFF
--- a/frontend_tests/node_tests/pm_list_data.js
+++ b/frontend_tests/node_tests/pm_list_data.js
@@ -214,23 +214,6 @@ test("get_active_user_ids_string", () => {
     assert.equal(pm_list_data.get_active_user_ids_string(), "101,102");
 });
 
-function private_filter() {
-    return {
-        operands(operand) {
-            assert.equal(operand, "is");
-            return ["private", "starred"];
-        },
-    };
-}
-
-test("is_all_privates", () => {
-    assert.equal(narrow_state.filter(), undefined);
-    assert.equal(pm_list_data.is_all_privates(), false);
-
-    narrow_state.set_current_filter(private_filter());
-    assert.equal(pm_list_data.is_all_privates(), true);
-});
-
 test("get_list_info", ({override}) => {
     let list_info;
     assert.equal(narrow_state.filter(), undefined);

--- a/static/js/pm_list_data.js
+++ b/static/js/pm_list_data.js
@@ -79,16 +79,6 @@ export function get_conversations() {
     return display_objects;
 }
 
-export function is_all_privates() {
-    const filter = narrow_state.filter();
-
-    if (!filter) {
-        return false;
-    }
-
-    return filter.operands("is").includes("private");
-}
-
 // Designed to closely match topic_list_data.get_list_info().
 export function get_list_info(zoomed) {
     const conversations = get_conversations();


### PR DESCRIPTION
In commit 6f9e97921, the last use of `pm_list_data.is_all_privates` was removed when we restructured how private messages are shown in the left sidebar. Removes the function (and related tests) since it is now no longer relevant.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
