### PR TITLE
stream_muting: Fix message reselect bug.

### DIFF
--- a/web/src/stream_muting.js
+++ b/web/src/stream_muting.js
@@ -3,6 +3,7 @@ import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as message_util from "./message_util";
 import * as message_viewport from "./message_viewport";
+import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import * as settings_notifications from "./settings_notifications";
@@ -20,7 +21,8 @@ export function update_is_muted(sub, value) {
         if (overlays.is_active() || overlays.is_modal_open()) {
             saved_ypos = message_viewport.scrollTop();
         } else if (
-            message_lists.home === message_lists.current &&
+            narrow_state.is_message_feed_visible() &&
+            message_lists.current === message_lists.home &&
             message_lists.current.selected_row().offset() !== null
         ) {
             msg_offset = message_lists.current.selected_row().offset().top;
@@ -34,7 +36,10 @@ export function update_is_muted(sub, value) {
         // Ensure we're still at the same scroll position
         if (overlays.is_overlay_or_modal_open()) {
             message_viewport.scrollTop(saved_ypos);
-        } else if (message_lists.home === message_lists.current) {
+        } else if (
+            narrow_state.is_message_feed_visible() &&
+            message_lists.current === message_lists.home
+        ) {
             // We pass use_closest to handle the case where the
             // currently selected message is being hidden from the
             // home view

--- a/web/src/stream_muting.js
+++ b/web/src/stream_muting.js
@@ -46,6 +46,7 @@ export function update_is_muted(sub, value) {
             message_lists.home.select_id(message_lists.home.selected_id(), {
                 use_closest: true,
                 empty_ok: true,
+                mark_read: false,
             });
             if (message_lists.current.selected_id() !== -1) {
                 message_lists.current.view.set_message_offset(msg_offset);


### PR DESCRIPTION
Extended else if statement responsible for reselecting messages to include check `!recent_topic_util.is_visible()`.

Before without this check, this code was consuming 1 unread message on muting/unmuting a stream even when we were in the "Recent Conversations" view.

Also added `mark_read: false` as it doesn't make sense to read/undread a message when just muting or unmuting a stream.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
