### PR TITLE
left-sidebar: Increase max conversations/topics shown to 8 (no unreads) and 12 (unreads).

### DIFF
--- a/web/src/pm_list_data.js
+++ b/web/src/pm_list_data.js
@@ -7,10 +7,10 @@ import * as unread from "./unread";
 import * as user_status from "./user_status";
 
 // Maximum number of conversation threads to show in default view.
-const max_conversations_to_show = 5;
+const max_conversations_to_show = 8;
 
 // Maximum number of conversation threads to show in default view with unreads.
-const max_conversations_to_show_with_unreads = 8;
+const max_conversations_to_show_with_unreads = 15;
 
 export function get_active_user_ids_string() {
     const filter = narrow_state.filter();

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -44,6 +44,11 @@ const cardelio = {
     user_id: 105,
     full_name: "Cardelio",
 };
+const iago = {
+    email: "iago@zulip.com",
+    user_id: 106,
+    full_name: "Iago",
+};
 const bot_test = {
     email: "outgoingwebhook@zulip.com",
     user_id: 314,
@@ -56,6 +61,7 @@ people.add_active_user(bob);
 people.add_active_user(me);
 people.add_active_user(zoe);
 people.add_active_user(cardelio);
+people.add_active_user(iago);
 people.add_active_user(bot_test);
 people.initialize_current_user(me.user_id);
 
@@ -211,9 +217,23 @@ test("get_list_info_unread_messages", ({override}) => {
     pm_conversations.recent.insert([zoe.user_id, bob.user_id, alice.user_id], 8);
     pm_conversations.recent.insert([cardelio.user_id, zoe.user_id], 9);
     pm_conversations.recent.insert([cardelio.user_id, bob.user_id], 10);
+    pm_conversations.recent.insert([cardelio.user_id, alice.user_id], 11);
+    pm_conversations.recent.insert([cardelio.user_id, zoe.user_id, bob.user_id], 12);
+    pm_conversations.recent.insert([cardelio.user_id, zoe.user_id, alice.user_id], 13);
+    pm_conversations.recent.insert([cardelio.user_id, bob.user_id, alice.user_id], 14);
+    pm_conversations.recent.insert([cardelio.user_id, bob.user_id, alice.user_id, zoe.user_id], 15);
+    pm_conversations.recent.insert([cardelio.user_id], 16);
+    pm_conversations.recent.insert([iago.user_id], 17);
 
     list_info = pm_list_data.get_list_info(false);
-    check_list_info(list_info, 8, 2, [
+    check_list_info(list_info, 15, 2, [
+        "Iago",
+        "Cardelio",
+        "Alice, Bob, Cardelio, Zoe",
+        "Alice, Bob, Cardelio",
+        "Alice, Cardelio, Zoe",
+        "Bob, Cardelio, Zoe",
+        "Alice, Cardelio",
         "Bob, Cardelio",
         "Cardelio, Zoe",
         "Alice, Bob, Zoe",
@@ -229,7 +249,14 @@ test("get_list_info_unread_messages", ({override}) => {
     // unread is removed from more_conversations_unread_count.
     set_pm_with_filter("alice@zulip.com");
     list_info = pm_list_data.get_list_info(false);
-    check_list_info(list_info, 9, 1, [
+    check_list_info(list_info, 16, 1, [
+        "Iago",
+        "Cardelio",
+        "Alice, Bob, Cardelio, Zoe",
+        "Alice, Bob, Cardelio",
+        "Alice, Cardelio, Zoe",
+        "Bob, Cardelio, Zoe",
+        "Alice, Cardelio",
         "Bob, Cardelio",
         "Cardelio, Zoe",
         "Alice, Bob, Zoe",
@@ -244,7 +271,14 @@ test("get_list_info_unread_messages", ({override}) => {
     // Zooming will show all conversations and there will
     // be no unreads in more_conversations_unread_count.
     list_info = pm_list_data.get_list_info(true);
-    check_list_info(list_info, 10, 0, [
+    check_list_info(list_info, 17, 0, [
+        "Iago",
+        "Cardelio",
+        "Alice, Bob, Cardelio, Zoe",
+        "Alice, Bob, Cardelio",
+        "Alice, Cardelio, Zoe",
+        "Bob, Cardelio, Zoe",
+        "Alice, Cardelio",
         "Bob, Cardelio",
         "Cardelio, Zoe",
         "Alice, Bob, Zoe",
@@ -269,17 +303,32 @@ test("get_list_info_no_unread_messages", ({override}) => {
     pm_conversations.recent.insert([cardelio.user_id], 5);
     pm_conversations.recent.insert([zoe.user_id, cardelio.user_id], 6);
     pm_conversations.recent.insert([alice.user_id, bob.user_id], 7);
+    pm_conversations.recent.insert([zoe.user_id, bob.user_id], 8);
+    pm_conversations.recent.insert([alice.user_id, cardelio.user_id], 9);
+    pm_conversations.recent.insert([bob.user_id, cardelio.user_id], 10);
 
     // Visible conversations are limited to value of
     // `max_conversations_to_show`.
     list_info = pm_list_data.get_list_info(false);
-    check_list_info(list_info, 5, 0, ["Alice, Bob", "Cardelio, Zoe", "Cardelio", "Zoe", "Bob"]);
+    check_list_info(list_info, 8, 0, [
+        "Bob, Cardelio",
+        "Alice, Cardelio",
+        "Bob, Zoe",
+        "Alice, Bob",
+        "Cardelio, Zoe",
+        "Cardelio",
+        "Zoe",
+        "Bob",
+    ]);
 
     // Narrowing to private messages with Alice adds older
     // one-on-one conversation with her to the list.
     set_pm_with_filter("alice@zulip.com");
     list_info = pm_list_data.get_list_info(false);
-    check_list_info(list_info, 6, 0, [
+    check_list_info(list_info, 9, 0, [
+        "Bob, Cardelio",
+        "Alice, Cardelio",
+        "Bob, Zoe",
         "Alice, Bob",
         "Cardelio, Zoe",
         "Cardelio",
@@ -290,7 +339,10 @@ test("get_list_info_no_unread_messages", ({override}) => {
 
     // Zooming will show all conversations.
     list_info = pm_list_data.get_list_info(true);
-    check_list_info(list_info, 7, 0, [
+    check_list_info(list_info, 10, 0, [
+        "Bob, Cardelio",
+        "Alice, Cardelio",
+        "Bob, Zoe",
         "Alice, Bob",
         "Cardelio, Zoe",
         "Cardelio",


### PR DESCRIPTION
Increases the max numbers of private/direct conversations and stream topics displayed in the left sidebar to be:
- 8 max conversations/topics with all messages read
- 12 max conversations/topics when there are some/all with unread messages

See [this CZO conversation for more context](https://chat.zulip.org/#narrow/stream/137-feedback/topic/customize.20number.20of.20private.20messages/near/1504593).

**Notes**:
- There is a prep commit that cleans up the node test for `pm_list_data.js` to make increasing these max numbers easier in that test.

---

**Screenshots**

<details>
<summary>Some unreads in direct/private messages</summary>

![Screenshot from 2023-02-10 21-21-07](https://user-images.githubusercontent.com/63245456/218190356-d1909bdb-2afa-4a90-ad8e-6317d931ce4b.png)
</details>
<details>
<summary>All read in direct/private messages</summary>

![Screenshot from 2023-02-10 21-21-47](https://user-images.githubusercontent.com/63245456/218190367-d38601ad-ae60-44d1-888c-d41f0ac487e2.png)
</details><details>
<summary>All unread in direct/private messages</summary>

![Screenshot from 2023-02-10 21-22-16](https://user-images.githubusercontent.com/63245456/218190368-5a7f8944-fa56-4973-a381-e42ab1c51d52.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
