### PR TITLE
recent topics: Fix exception displaying PMs with 5+ senders.

### DIFF
--- a/static/js/recent_topics_ui.js
+++ b/static/js/recent_topics_ui.js
@@ -445,9 +445,7 @@ function format_conversation(conversation_data) {
         senders = all_senders.slice(-MAX_AVATAR);
         // Collect extra senders fullname for tooltip.
         extra_sender_ids = all_senders.slice(0, -MAX_AVATAR);
-        displayed_other_senders = extra_sender_ids
-            .slice(-MAX_EXTRA_SENDERS)
-            .map((sender) => sender.id);
+        displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);
     }
 
     context.senders = people.sender_info_for_recent_topics_row(senders);


### PR DESCRIPTION
The previous logic incorrectly tried to map elements of the list of user IDs beyond 4 senders to their `.id` fields, which were undefined; the correct thing to do is just use the list of user IDs that we already have.
