### PR TITLE
css: Fix edit icon bug in user profile modal.

### DIFF
--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -358,7 +358,7 @@ export function register_click_handlers() {
     /* These click handlers are implemented as just deep links to the
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */
-    $("body").on("click", "#user-profile-modal #name #edit-button", () => {
+    $("body").on("click", "#user-profile-modal #name .user_profile_edit_button", () => {
         hide_user_profile();
     });
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -420,7 +420,7 @@ ul {
         text-align: center;
     }
 
-    #edit-button {
+    #user_profile_edit_button_icon {
         font-size: 18px;
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -414,9 +414,14 @@ ul {
         }
     }
 
+    .user_profile_edit_button {
+        margin-left: 10px;
+        width: 25px;
+        text-align: center;
+    }
+
     #edit-button {
         font-size: 18px;
-        margin-left: 10px;
     }
 
     #default-section {

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -12,7 +12,7 @@
                     {{/if}}
                     {{#if is_me}}
                     <a href="/#settings/profile" class="user_profile_edit_button">
-                        <i class="fa fa-edit" id="edit-button" aria-hidden="true"></i>
+                        <i class="fa fa-edit" id="user_profile_edit_button_icon" aria-hidden="true"></i>
                     </a>
                     {{/if}}
                 </h1>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -11,7 +11,7 @@
                     <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                     {{/if}}
                     {{#if is_me}}
-                    <a href="/#settings/profile">
+                    <a href="/#settings/profile" class="user_profile_edit_button">
                         <i class="fa fa-edit" id="edit-button" aria-hidden="true"></i>
                     </a>
                     {{/if}}


### PR DESCRIPTION
[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/edit.20button.20in.20profile.20modal.20bug)

Close user profile modal on clicking the space around edit button, by calling hide_user_profile() on clicking the hover box around the edit button.

Also, modified the hover box to center around the edit button.

**Screenshots:**

Hover box before - 

![hover-box-before](https://user-images.githubusercontent.com/96468766/222355903-1ec3bc7f-55a2-49b0-b219-7f6f8216862a.png)

Hover box after - 

![hover-box-new](https://user-images.githubusercontent.com/96468766/222355981-fea27af6-b58b-4d81-94aa-08f461ec61e4.png)

**screen captures:**

Before - 

![edit-before-1](https://user-images.githubusercontent.com/96468766/218253852-14a8c28c-6784-40e8-847b-01165dfa2d6e.gif)

![edit-before-2](https://user-images.githubusercontent.com/96468766/218253856-20f4b60c-98fc-488a-8a14-c0bbb7ef2267.gif)

After - 

![edit-after-1](https://user-images.githubusercontent.com/96468766/222356182-fcef2343-11a5-49f3-a3f8-b239d55ab1c5.gif)

![edit-after-2](https://user-images.githubusercontent.com/96468766/222356199-985ae19c-f978-4c7f-b8ea-03c466dad72b.gif)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
