### PR TITLE
Fix alignment of loading message and add translation tags.

### DIFF
--- a/web/src/attachments_ui.js
+++ b/web/src/attachments_ui.js
@@ -6,7 +6,7 @@ import render_uploaded_files_list from "../templates/settings/uploaded_files_lis
 
 import * as channel from "./channel";
 import * as dialog_widget from "./dialog_widget";
-import {$t_html} from "./i18n";
+import {$t, $t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import * as loading from "./loading";
 import {page_params} from "./page_params";
@@ -148,7 +148,9 @@ export function set_up_attachments() {
     // The settings page must be rendered before this function gets called.
 
     const $status = $("#delete-upload-status");
-    loading.make_indicator($("#attachments_loading_indicator"), {text: "Loading..."});
+    loading.make_indicator($("#attachments_loading_indicator"), {
+        text: $t({defaultMessage: "Loading…"}),
+    });
 
     $("#uploaded_files_table").on("click", ".remove-attachment", (e) => {
         const file_name = $(e.target).closest(".uploaded_file_row").attr("id");

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -274,7 +274,9 @@ function human_info(person) {
 let bot_list_widget;
 
 section.bots.create_table = () => {
-    loading.make_indicator($("#admin_page_bots_loading_indicator"), {text: "Loading..."});
+    loading.make_indicator($("#admin_page_bots_loading_indicator"), {
+        text: $t({defaultMessage: "Loading…"}),
+    });
     const $bots_table = $("#admin_bots_table");
     $bots_table.hide();
     const bot_user_ids = people.get_bot_ids();
@@ -407,9 +409,11 @@ export function redraw_bots_list() {
 }
 
 function start_data_load() {
-    loading.make_indicator($("#admin_page_users_loading_indicator"), {text: "Loading..."});
+    loading.make_indicator($("#admin_page_users_loading_indicator"), {
+        text: $t({defaultMessage: "Loading…"}),
+    });
     loading.make_indicator($("#admin_page_deactivated_users_loading_indicator"), {
-        text: "Loading...",
+        text: $t({defaultMessage: "Loading…"}),
     });
     $("#admin_deactivated_users_table").hide();
     $("#admin_users_table").hide();

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -329,7 +329,7 @@ td .button {
 
     .loading_indicator_spinner {
         width: 30%;
-        height: 30px;
+        height: 20px;
         margin-top: 7px;
         vertical-align: middle;
         display: inline-block;


### PR DESCRIPTION
The loading message that appears at the top of the page when loading the Bots/Uploaded Files/Users/Deactivated Users page under Settings appears to be misaligned.
Fixed this by changing the top margin of the 'Loading...' message.

Also, added the translation tags for 'Loading...' message.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<b> Alignment: </b> 
Previous behavior:

![load1](https://user-images.githubusercontent.com/96344003/218270229-e0785a59-8c13-4456-8933-fd7ac9a966b0.png)

New behavior(After code changes):

![load1](https://user-images.githubusercontent.com/96344003/224825094-6db7e28d-c9ce-4455-9ceb-fcba841d10c3.png)

![load2](https://user-images.githubusercontent.com/96344003/224825104-52d9f365-3992-4587-8de5-7c3b0ea66a89.png)

I added the translation for 'Loading...' in Hindi language to check whether translation tags are working or not and it works perfectly.
Here are the screenshots that show that translation tags been successfully implemented:

![load3](https://user-images.githubusercontent.com/96344003/224825148-9384891d-7421-42e6-b814-821e073c5e8f.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
