### PR TITLE
settings: Indicate character limit on restoring long draft messages.

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -15,6 +15,7 @@ import * as compose_actions from "./compose_actions";
 import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
+import * as compose_validate from "./compose_validate";
 import * as confirm_dialog from "./confirm_dialog";
 import {$t, $t_html} from "./i18n";
 import {localstorage} from "./localstorage";
@@ -319,6 +320,7 @@ export function restore_draft(draft_id) {
     compose_actions.start(compose_args.type, compose_args);
     compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-textarea").data("draft-id", draft_id);
+    compose_validate.check_overflow_text();
 }
 
 const DRAFT_LIFETIME = 30;


### PR DESCRIPTION
Currently, there is no display of character limit or a "Message length shouldn't be greater than 10,000 characters" message displaying compose banner when restoring long draft messages. 
Additionally, the "send" button remains active for long messages.

Fixed this by adding ```compose_validate.check_overflow_text()``` in ```restore_drafts()``` function inside ```drafts.js```.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Previous behavior:

https://user-images.githubusercontent.com/96344003/218307202-4ed7ec46-bf08-42f1-b338-80694eb68b3b.mov

New behavior:

![draft_overflow_fix](https://user-images.githubusercontent.com/96344003/218307220-b375e7da-3f86-4ad8-a78e-1c12f3392648.png)

https://user-images.githubusercontent.com/96344003/218307236-d8f09e31-4423-4f7f-979f-cecb4d3b8a6c.mov

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
