### PR TITLE
settings: Fix text overflow while hovering over reactions/Users hover/viewing profile card.

### DIFF
--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -29,7 +29,7 @@ export const intl = createIntl(
 export const $t = intl.formatMessage.bind(intl);
 
 export const default_html_elements = Object.fromEntries(
-    ["b", "code", "em", "i", "kbd", "p", "strong"].map((tag) => [
+    ["b", "code", "div", "em", "i", "kbd", "p", "span", "strong"].map((tag) => [
         tag,
         (content_html: string[]) => `<${tag}>${content_html.join("")}</${tag}>`,
     ]),

--- a/web/src/reactions.js
+++ b/web/src/reactions.js
@@ -6,7 +6,7 @@ import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as emoji from "./emoji";
 import * as emoji_picker from "./emoji_picker";
-import {$t} from "./i18n";
+import {$t, $t_html} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import {page_params} from "./page_params";
@@ -164,18 +164,24 @@ function generate_title(emoji_name, user_ids) {
 
     if (user_ids.length === 1) {
         if (current_user_reacted) {
-            return $t({defaultMessage: "You (click to remove) reacted with {emoji_name}"}, context);
+            return $t_html(
+                {defaultMessage: "You (click to remove) reacted with {emoji_name}"},
+                context,
+            );
         }
         context.username = usernames[0];
-        return $t({defaultMessage: "{username} reacted with {emoji_name}"}, context);
+        return $t_html(
+            {defaultMessage: "<div><span>{username}</span> reacted with {emoji_name}</div>"},
+            context,
+        );
     }
 
     if (user_ids.length === 2 && current_user_reacted) {
         context.other_username = usernames[0];
-        return $t(
+        return $t_html(
             {
                 defaultMessage:
-                    "You (click to remove) and {other_username} reacted with {emoji_name}",
+                    "<div><span>You (click to remove) and {other_username}</span> reacted with {emoji_name}</div>",
             },
             context,
         );
@@ -184,18 +190,18 @@ function generate_title(emoji_name, user_ids) {
     context.comma_separated_usernames = usernames.slice(0, -1).join(", ");
     context.last_username = usernames.at(-1);
     if (current_user_reacted) {
-        return $t(
+        return $t_html(
             {
                 defaultMessage:
-                    "You (click to remove), {comma_separated_usernames} and {last_username} reacted with {emoji_name}",
+                    "<div><span>You (click to remove), {comma_separated_usernames}</span> and <span>{last_username}</span> reacted with {emoji_name}</div>",
             },
             context,
         );
     }
-    return $t(
+    return $t_html(
         {
             defaultMessage:
-                "{comma_separated_usernames} and {last_username} reacted with {emoji_name}",
+                "<div><span>{comma_separated_usernames}</span> and <span>{last_username}</span> reacted with {emoji_name}</div>",
         },
         context,
     );

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -130,7 +130,10 @@ export function initialize() {
                 const local_id = $elem.attr("data-reaction-id");
                 const message_id = rows.get_message_id(instance.reference);
                 const title = reactions.get_reaction_title_data(message_id, local_id);
-                instance.setContent(title);
+                instance.setContent(parse_html(title));
+                instance.popper
+                    .querySelector(".tippy-content > div > span")
+                    .classList.add("break_all_words");
             }
 
             const config = {attributes: false, childList: true, subtree: true};

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1007,3 +1007,7 @@ div.overlay {
         }
     }
 }
+
+.break_all_words {
+    word-break: break-all;
+}

--- a/web/templates/buddy_list_tooltip_content.hbs
+++ b/web/templates/buddy_list_tooltip_content.hbs
@@ -1,5 +1,5 @@
 <div class="buddy_list_tooltip_content">
-    <span>
+    <span class="break_all_words">
         {{first_line}}
         {{#if show_you}}
         <span class="my_user_status">{{t "(you)" }}</span>

--- a/web/templates/user_info_popover_content.hbs
+++ b/web/templates/user_info_popover_content.hbs
@@ -1,7 +1,10 @@
 {{! Contents of the "message info" popup }}
 <ul class="nav nav-list info_popover_actions" id="user_info_popover" data-user-id="{{user_id}}">
     <li class="popover_user_name_row">
-        <b class="user_full_name" data-tippy-content="{{user_full_name}}">{{user_full_name}}</b>
+        <b class="user_full_name" data-tooltip-template-id="user_full_name_tooltip">{{user_full_name}}</b>
+        <template id="user_full_name_tooltip">
+            <span class="break_all_words">{{user_full_name}}</span>
+        </template>
         {{#if is_active }}
             {{#if is_bot}}
             <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>

--- a/web/tests/lib/i18n.js
+++ b/web/tests/lib/i18n.js
@@ -10,7 +10,7 @@ exports.intl = createIntl(
         locale: "en",
         defaultLocale: "en",
         defaultRichTextElements: Object.fromEntries(
-            ["b", "code", "em", "i", "kbd", "p", "strong"].map((tag) => [
+            ["b", "code", "div", "em", "i", "kbd", "p", "span", "strong"].map((tag) => [
                 tag,
                 /* istanbul ignore next */
                 (content_html) => `<${tag}>${content_html.join("")}</${tag}>`,

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -164,7 +164,7 @@ test("basics", () => {
             count: 1,
             vote_text: "1",
             user_ids: [7],
-            label: "translated: Cali reacted with :frown:",
+            label: "translated HTML: <div><span>Cali</span> reacted with :frown:</div>",
             emoji_alt_code: false,
             class: "message_reaction",
             is_realm_emoji: false,
@@ -177,7 +177,7 @@ test("basics", () => {
             count: 1,
             vote_text: "1",
             user_ids: [5],
-            label: "translated: You (click to remove) reacted with :inactive_realm_emoji:",
+            label: "translated HTML: You (click to remove) reacted with :inactive_realm_emoji:",
             emoji_alt_code: false,
             is_realm_emoji: true,
             url: "/url/for/992",
@@ -192,7 +192,7 @@ test("basics", () => {
             count: 2,
             vote_text: "2",
             user_ids: [5, 6],
-            label: "translated: You (click to remove) and Bob van Roberts reacted with :smile:",
+            label: "translated HTML: <div><span>You (click to remove) and Bob van Roberts</span> reacted with :smile:</div>",
             emoji_alt_code: false,
             class: "message_reaction reacted",
             is_realm_emoji: false,
@@ -205,7 +205,7 @@ test("basics", () => {
             count: 2,
             vote_text: "2",
             user_ids: [7, 8],
-            label: "translated: Cali and Alexus reacted with :tada:",
+            label: "translated HTML: <div><span>Cali</span> and <span>Alexus</span> reacted with :tada:</div>",
             emoji_alt_code: false,
             class: "message_reaction",
             is_realm_emoji: false,
@@ -218,7 +218,7 @@ test("basics", () => {
             count: 3,
             vote_text: "3",
             user_ids: [5, 6, 7],
-            label: "translated: You (click to remove), Bob van Roberts and Cali reacted with :rocket:",
+            label: "translated HTML: <div><span>You (click to remove), Bob van Roberts</span> and <span>Cali</span> reacted with :rocket:</div>",
             emoji_alt_code: false,
             class: "message_reaction reacted",
             is_realm_emoji: false,
@@ -231,7 +231,7 @@ test("basics", () => {
             count: 3,
             vote_text: "3",
             user_ids: [6, 7, 8],
-            label: "translated: Bob van Roberts, Cali and Alexus reacted with :wave:",
+            label: "translated HTML: <div><span>Bob van Roberts, Cali</span> and <span>Alexus</span> reacted with :wave:</div>",
             emoji_alt_code: false,
             class: "message_reaction",
             is_realm_emoji: false,
@@ -479,7 +479,7 @@ test("update_vote_text_on_message", ({override_rewire}) => {
                     emoji_code: "992",
                     emoji_name: "inactive_realm_emoji",
                     is_realm_emoji: true,
-                    label: "translated: You (click to remove) reacted with :inactive_realm_emoji:",
+                    label: "translated HTML: You (click to remove) reacted with :inactive_realm_emoji:",
                     local_id: "realm_emoji,992",
                     reaction_type: "realm_emoji",
                     still_url: "/still/url/for/992",
@@ -494,7 +494,7 @@ test("update_vote_text_on_message", ({override_rewire}) => {
                     emoji_code: "1f44b",
                     emoji_name: "wave",
                     is_realm_emoji: false,
-                    label: "translated: You (click to remove) and Bob van Roberts reacted with :wave:",
+                    label: "translated HTML: <div><span>You (click to remove) and Bob van Roberts</span> reacted with :wave:</div>",
                     local_id: "unicode_emoji,1f44b",
                     reaction_type: "unicode_emoji",
                     user_ids: [5, 6],
@@ -531,7 +531,7 @@ test("emoji_reaction_title", ({override}) => {
 
     assert.equal(
         reactions.get_reaction_title_data(message.id, local_id),
-        "translated: You (click to remove) and Bob van Roberts reacted with :smile:",
+        "translated HTML: <div><span>You (click to remove) and Bob van Roberts</span> reacted with :smile:</div>",
     );
 });
 
@@ -617,7 +617,7 @@ test("add_reaction/remove_reaction", ({override}) => {
         emoji_code: alice_8ball_event.emoji_code,
         emoji_name: alice_8ball_event.emoji_name,
         is_realm_emoji: false,
-        label: "translated: You (click to remove) reacted with :8ball:",
+        label: "translated HTML: You (click to remove) reacted with :8ball:",
         local_id: "unicode_emoji,1f3b1",
         reaction_type: alice_8ball_event.reaction_type,
         user_ids: [alice.user_id],
@@ -661,7 +661,7 @@ test("add_reaction/remove_reaction", ({override}) => {
         emoji_code: bob_8ball_event.emoji_code,
         emoji_name: bob_8ball_event.emoji_name,
         is_realm_emoji: false,
-        label: "translated: You (click to remove) and Bob van Roberts reacted with :8ball:",
+        label: "translated HTML: <div><span>You (click to remove) and Bob van Roberts</span> reacted with :8ball:</div>",
         local_id: "unicode_emoji,1f3b1",
         reaction_type: bob_8ball_event.reaction_type,
         user_ids: [alice.user_id, bob.user_id],
@@ -696,7 +696,7 @@ test("add_reaction/remove_reaction", ({override}) => {
         emoji_code: cali_airplane_event.emoji_code,
         emoji_name: cali_airplane_event.emoji_name,
         is_realm_emoji: false,
-        label: "translated: Cali reacted with :airplane:",
+        label: "translated HTML: <div><span>Cali</span> reacted with :airplane:</div>",
         local_id: "unicode_emoji,2708",
         reaction_type: cali_airplane_event.reaction_type,
         user_ids: [cali.user_id],
@@ -762,7 +762,7 @@ test("add_reaction/remove_reaction", ({override}) => {
                     emoji_code: alice_8ball_event.emoji_code,
                     emoji_name: alice_8ball_event.emoji_name,
                     is_realm_emoji: false,
-                    label: "translated:  and  reacted with :8ball:",
+                    label: "translated HTML: <div><span></span> and <span></span> reacted with :8ball:</div>",
                     local_id: "unicode_emoji,1f3b1",
                     reaction_type: alice_8ball_event.reaction_type,
                     user_ids: [],
@@ -800,7 +800,7 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({mock_template}) => {
         emoji_code: "1f3b1",
         emoji_name: "8ball",
         is_realm_emoji: false,
-        label: "translated: You (click to remove) reacted with :8ball:",
+        label: "translated HTML: You (click to remove) reacted with :8ball:",
         local_id: "unicode_emoji,1f3b1",
         reaction_type: "unicode_emoji",
         user_ids: [alice.user_id],
@@ -824,7 +824,7 @@ test("view.insert_new_reaction (me w/unicode emoji)", ({mock_template}) => {
             local_id: "unicode_emoji,1f3b1",
             class: "message_reaction reacted",
             message_id,
-            label: "translated: You (click to remove) reacted with :8ball:",
+            label: "translated HTML: You (click to remove) reacted with :8ball:",
             reaction_type: clean_reaction_object.reaction_type,
             is_realm_emoji: false,
             vote_text: "",
@@ -864,7 +864,7 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({mock_template}) => {
         emoji_code: "zulip",
         emoji_name: "zulip",
         is_realm_emoji: false,
-        label: "translated: Bob van Roberts reacted with :zulip:",
+        label: "translated HTML: <div><span>Bob van Roberts</span> reacted with :zulip:</div>",
         local_id: "realm_emoji,zulip",
         reaction_type: "realm_emoji",
         user_ids: [bob.user_id],
@@ -890,7 +890,7 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({mock_template}) => {
             local_id: "realm_emoji,zulip",
             class: "message_reaction",
             message_id,
-            label: "translated: Bob van Roberts reacted with :zulip:",
+            label: "translated HTML: <div><span>Bob van Roberts</span> reacted with :zulip:</div>",
             still_url: null,
             reaction_type: clean_reaction_object.reaction_type,
             vote_text: "",
@@ -965,7 +965,7 @@ test("view.update_existing_reaction (me)", () => {
     assert.ok($our_reaction.hasClass("reacted"));
     assert.equal(
         $our_reaction.attr("aria-label"),
-        "translated: You (click to remove) and Bob van Roberts reacted with :8ball:",
+        "translated HTML: <div><span>You (click to remove) and Bob van Roberts</span> reacted with :8ball:</div>",
     );
 });
 
@@ -1024,7 +1024,7 @@ test("view.update_existing_reaction (them)", () => {
     assert.ok(!$our_reaction.hasClass("reacted"));
     assert.equal(
         $our_reaction.attr("aria-label"),
-        "translated: You (click to remove), Bob van Roberts, Cali and Alexus reacted with :8ball:",
+        "translated HTML: <div><span>You (click to remove), Bob van Roberts, Cali</span> and <span>Alexus</span> reacted with :8ball:</div>",
     );
 });
 
@@ -1072,7 +1072,7 @@ test("view.remove_reaction (me)", () => {
     assert.ok(!$message_reactions.hasClass("reacted"));
     assert.equal(
         $message_reactions.attr("aria-label"),
-        "translated: Bob van Roberts and Cali reacted with :8ball:",
+        "translated HTML: <div><span>Bob van Roberts</span> and <span>Cali</span> reacted with :8ball:</div>",
     );
 });
 
@@ -1114,7 +1114,7 @@ test("view.remove_reaction (them)", () => {
     assert.ok($message_reactions.hasClass("reacted"));
     assert.equal(
         $message_reactions.attr("aria-label"),
-        "translated: You (click to remove) reacted with :8ball:",
+        "translated HTML: You (click to remove) reacted with :8ball:",
     );
 });
 


### PR DESCRIPTION
Currently, if a reaction has been made by a user with a long name, the text overflows when hovering over the reaction.

The same bug appears while hovering over long usernames in user's profile card or in the Users section.

To fix this, we add a span tag to the usernames and assign it a class 'break_all_words' and apply 'word-break:break-all' property to the class to prevent overflow.

To handle overflow in case of user's profile or in the users section, we add a template that handles the username tooltip for the user's profile card add class 'break_all_words' to the span element that contains the username.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Previous behavior: 

![reaction_bug](https://user-images.githubusercontent.com/96344003/218385667-3ac09538-b130-47ad-9840-9d5c8020b2e3.png)

<img src="https://user-images.githubusercontent.com/96344003/225551519-fbf78efd-483a-403e-8869-7cd0d020f062.png" width="600" height="300"/>

<img src="https://user-images.githubusercontent.com/96344003/225553033-b8fea879-42cc-49cc-b718-83bb56f81983.png" width="600" height="400"/>

New behavior:

![reaction_hover_fix](https://user-images.githubusercontent.com/96344003/224756165-fb1ba8d9-8cfa-428a-91f8-0483446b90fc.png)

<img src="https://user-images.githubusercontent.com/96344003/225552047-d5bcb20f-e972-44ec-a5cf-230d439acc85.png" width="600" height="400"/>

<img src="https://user-images.githubusercontent.com/96344003/225552055-66f556e8-694a-4e58-985c-87cf599b95c8.png" width="500" height="300"/>

<img src="https://user-images.githubusercontent.com/96344003/225552840-88d97243-145d-4e74-af93-92d41c661d5f.png" width="600" height="300"/>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
