### PR TITLE
message_send: Use stream object for name in "no subscribers" message.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1240,22 +1240,28 @@ def send_pm_if_empty_stream(
     if not sender.is_bot or sender.bot_owner is None:
         return
 
-    arg_dict = {
-        "bot_identity": f"`{sender.delivery_email}`",
-        "stream_id": stream_id,
-        "stream_name": f"#**{stream_name}**",
-        "new_stream_link": "#streams/new",
-    }
     if sender.bot_owner is not None:
         with override_language(sender.bot_owner.default_language):
+            arg_dict: Dict[str, Any] = {
+                "bot_identity": f"`{sender.delivery_email}`",
+            }
             if stream is None:
                 if stream_id is not None:
+                    arg_dict = {
+                        **arg_dict,
+                        "stream_id": stream_id,
+                    }
                     content = _(
                         "Your bot {bot_identity} tried to send a message to stream ID "
                         "{stream_id}, but there is no stream with that ID."
                     ).format(**arg_dict)
                 else:
                     assert stream_name is not None
+                    arg_dict = {
+                        **arg_dict,
+                        "stream_name": f"#**{stream_name}**",
+                        "new_stream_link": "#streams/new",
+                    }
                     content = _(
                         "Your bot {bot_identity} tried to send a message to stream "
                         "{stream_name}, but that stream does not exist. "
@@ -1264,6 +1270,10 @@ def send_pm_if_empty_stream(
             else:
                 if num_subscribers_for_stream_id(stream.id) > 0:
                     return
+                arg_dict = {
+                    **arg_dict,
+                    "stream_name": f"#**{stream.name}**",
+                }
                 content = _(
                     "Your bot {bot_identity} tried to send a message to "
                     "stream {stream_name}. The stream exists but "


### PR DESCRIPTION
In the case where a stream existed but had no subscribers, the error message used to send to the owner always used `stream_name`, which may have been None.

Switch to using `stream.name` rather than `stream_name` for this case.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
