### PR TITLE
Enable sponsorship form on the billing page

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2293,6 +2293,20 @@ class StripeTest(StripeTestCase):
         self.assert_in_success_response(
             ["Your organization has requested sponsored or discounted hosting."], response
         )
+        self.assert_in_success_response(
+            [
+                'Please <a href="mailto:support@zulip.com">contact Zulip support</a> if you have any questions or concerns.'
+            ],
+            response,
+        )
+        # Ensure that the other "contact support" footer is not displayed, since that would be
+        # duplicate.
+        self.assert_not_in_success_response(
+            [
+                'Contact <a href="mailto:support@zulip.com">support@zulip.com</a> for billing history.'
+            ],
+            response,
+        )
 
         self.login_user(self.example_user("othello"))
         response = self.client_get("/billing/")
@@ -2307,6 +2321,12 @@ class StripeTest(StripeTestCase):
         response = self.client_get("/billing/")
         self.assert_in_success_response(
             ["Your organization is fully sponsored and is on the <b>Zulip Cloud Standard</b>"],
+            response,
+        )
+        self.assert_in_success_response(
+            [
+                'Contact <a href="mailto:support@zulip.com">support@zulip.com</a> for billing history.'
+            ],
             response,
         )
 

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2302,9 +2302,7 @@ class StripeTest(StripeTestCase):
         # Ensure that the other "contact support" footer is not displayed, since that would be
         # duplicate.
         self.assert_not_in_success_response(
-            [
-                'Contact <a href="mailto:support@zulip.com">support@zulip.com</a> for billing history.'
-            ],
+            ['<a href="mailto:support@zulip.com">Contact Zulip support</a> for billing history.'],
             response,
         )
 
@@ -2324,9 +2322,7 @@ class StripeTest(StripeTestCase):
             response,
         )
         self.assert_in_success_response(
-            [
-                'Contact <a href="mailto:support@zulip.com">support@zulip.com</a> for billing history.'
-            ],
+            ['<a href="mailto:support@zulip.com">Contact Zulip support</a> for billing history.'],
             response,
         )
 

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -194,6 +194,8 @@
                 <div class="tab-content">
                     {% if sponsorship_pending %}
                     <h3>Your organization has requested sponsored or discounted hosting.</h3>
+                    <br />
+                    Please <a href="mailto:support@zulip.com">contact Zulip support</a> if you have any questions or concerns.
                     {% elif is_sponsored %}
                     <center>
                         <p>
@@ -214,11 +216,14 @@
                     </center>
                     {% endif %}
                 </div>
+                {% if not sponsorship_pending %}
+                {# In the other case, we're displaying a different message about contacting support. #}
                 <div class="support-link">
                     <p>
                         Contact <a href="mailto:support@zulip.com">support@zulip.com</a> for billing history.
                     </p>
                 </div>
+                {% endif %}
                 {% else %}
                 <p>
                     You must be an organization owner or a billing administrator to view this page.

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -27,6 +27,7 @@
                     <li class="active"><a data-toggle="tab" href="#overview">Overview</a></li>
                     <li><a data-toggle="tab" href="#payment-method">Payment method</a></li>
                     <li><a data-toggle="tab" href="#settings">Settings</a></li>
+                    <li><a data-toggle="tab" href="#sponsorship">💚 Request sponsorship</a></li>
                 </ul>
 
                 <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
@@ -170,6 +171,8 @@
                         <div class="tab-pane" id="loading">
                         </div>
                     </div>
+
+                    {% include "corporate/sponsorship.html" %}
                 </div>
 
                 <div id="goto-zulip-organization-link">

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -186,7 +186,7 @@
                 <hr />
                 <div class="support-link">
                     <p>
-                        Contact <a href="mailto:support@zulip.com">support@zulip.com</a>
+                        <a href="mailto:support@zulip.com">Contact Zulip support</a>
                         for billing history or to make changes to your subscription or billing email.
                     </p>
                 </div>
@@ -220,7 +220,7 @@
                 {# In the other case, we're displaying a different message about contacting support. #}
                 <div class="support-link">
                     <p>
-                        Contact <a href="mailto:support@zulip.com">support@zulip.com</a> for billing history.
+                        <a href="mailto:support@zulip.com">Contact Zulip support</a> for billing history.
                     </p>
                 </div>
                 {% endif %}

--- a/templates/corporate/sponsorship.html
+++ b/templates/corporate/sponsorship.html
@@ -1,0 +1,51 @@
+<div class="tab-pane" id="sponsorship">
+    <div id="sponsorship-error" class="alert alert-danger"></div>
+    <div id="sponsorship-input-section">
+        <form id="sponsorship-form" method="post">
+            <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" />
+            <label>
+                <h4>Organization type</h4>
+            </label>
+            <select name="organization-type" class="bootstrap-focus-style">
+                {% for org_type in sorted_org_types %}
+                    {% if not org_type[1].hidden %}
+                    <option data-string-value="{{ org_type[0] }}"
+                      {% if org_type[1].id == realm_org_type %}selected{% endif %}
+                      value="{{ org_type[1].id }}">
+                        {{ _(org_type[1].name) }}
+                    </option>
+                    {% endif %}
+                {% endfor %}
+            </select>
+            <br />
+            <label>
+                <h4>Organization website</h4>
+            </label>
+            <input name="website" type="text" class="input-large" placeholder="{{ _('Leave blank if your organization does not have a website.') }}"/>
+            <label>
+                <h4>Describe your organization briefly</h4>
+            </label>
+            <textarea name="description" cols="100" rows="5" required></textarea>
+            <br />
+            <p id="sponsorship-discount-details"></p>
+            <!-- Disabled buttons do not fire any events, so we need a container div that isn't disabled for tippyjs to work -->
+            <div class="upgrade-button-container" {% if is_demo_organization %}data-tippy-content="{% trans %}Convert demo organization before upgrading.{% endtrans %}"{% endif %}>
+                <button type="submit" id="sponsorship-button" class="stripe-button-el invoice-button" {% if is_demo_organization %}disabled{% endif %}>
+                    Submit
+                </button>
+            </div>
+        </form>
+    </div>
+    <div id="sponsorship-loading">
+        <div class="zulip-loading-logo">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
+                <circle cx="386.56" cy="386.56" r="386.56"/>
+                <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"/>
+            </svg>
+        </div>
+        <div id="sponsorship_loading_indicator"></div>
+    </div>
+    <div id="sponsorship-success" class="alert alert-info">
+        Request received! The page will now reload.
+    </div>
+</div>

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -241,56 +241,7 @@
                         </div>
                     </div>
 
-                    <div class="tab-pane" id="sponsorship">
-                        <div id="sponsorship-error" class="alert alert-danger"></div>
-                        <div id="sponsorship-input-section">
-                            <form id="sponsorship-form" method="post">
-                                <label>
-                                    <h4>Organization type</h4>
-                                </label>
-                                <select name="organization-type" class="bootstrap-focus-style">
-                                    {% for org_type in sorted_org_types %}
-                                        {% if not org_type[1].hidden %}
-                                        <option data-string-value="{{ org_type[0] }}"
-                                          {% if org_type[1].id == realm_org_type %}selected{% endif %}
-                                          value="{{ org_type[1].id }}">
-                                            {{ _(org_type[1].name) }}
-                                        </option>
-                                        {% endif %}
-                                    {% endfor %}
-                                </select>
-                                <br />
-                                <label>
-                                    <h4>Organization website</h4>
-                                </label>
-                                <input name="website" type="text" class="input-large" placeholder="{{ _('Leave blank if your organization does not have a website.') }}"/>
-                                <label>
-                                    <h4>Describe your organization briefly</h4>
-                                </label>
-                                <textarea name="description" cols="100" rows="5" required></textarea>
-                                <br />
-                                <p id="sponsorship-discount-details"></p>
-                                <!-- Disabled buttons do not fire any events, so we need a container div that isn't disabled for tippyjs to work -->
-                                <div class="upgrade-button-container" {% if is_demo_organization %}data-tippy-content="{% trans %}Convert demo organization before upgrading.{% endtrans %}"{% endif %}>
-                                    <button type="submit" id="sponsorship-button" class="stripe-button-el invoice-button" {% if is_demo_organization %}disabled{% endif %}>
-                                        Submit
-                                    </button>
-                                </div>
-                            </form>
-                        </div>
-                        <div id="sponsorship-loading">
-                            <div class="zulip-loading-logo">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
-                                    <circle cx="386.56" cy="386.56" r="386.56"/>
-                                    <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"/>
-                                </svg>
-                            </div>
-                            <div id="sponsorship_loading_indicator"></div>
-                        </div>
-                        <div id="sponsorship-success" class="alert alert-info">
-                            Request received! The page will now reload.
-                        </div>
-                    </div>
+                    {% include "corporate/sponsorship.html" %}
 
                 </div>
                 <div class="support-link">

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -263,11 +263,11 @@
                                 <label>
                                     <h4>Organization website</h4>
                                 </label>
-                                <input name="website" style="width: 100%;" type="text" class="input-large" placeholder="{{ _('Leave blank if your organization does not have a website.') }}"/>
+                                <input name="website" type="text" class="input-large" placeholder="{{ _('Leave blank if your organization does not have a website.') }}"/>
                                 <label>
                                     <h4>Describe your organization briefly</h4>
                                 </label>
-                                <textarea name="description" style="width: 100%;" cols="100" rows="5" required></textarea>
+                                <textarea name="description" cols="100" rows="5" required></textarea>
                                 <br />
                                 <p id="sponsorship-discount-details"></p>
                                 <!-- Disabled buttons do not fire any events, so we need a container div that isn't disabled for tippyjs to work -->

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -14,6 +14,7 @@ export function create_update_license_request() {
 
 export function initialize() {
     helpers.set_tab("billing");
+    helpers.set_sponsorship_form();
 
     $("#update-card-button").on("click", (e) => {
         const success_callback = (response) => {

--- a/web/src/billing/helpers.js
+++ b/web/src/billing/helpers.js
@@ -136,6 +136,18 @@ export function set_tab(page) {
     window.addEventListener("hashchange", handle_hashchange);
 }
 
+export function set_sponsorship_form() {
+    $("#sponsorship-button").on("click", (e) => {
+        if (!is_valid_input($("#sponsorship-form"))) {
+            return;
+        }
+        e.preventDefault();
+        create_ajax_request("/json/billing/sponsorship", "sponsorship", [], "POST", () =>
+            window.location.replace("/"),
+        );
+    });
+}
+
 export function is_valid_input(elem) {
     return elem[0].checkValidity();
 }

--- a/web/src/billing/upgrade.js
+++ b/web/src/billing/upgrade.js
@@ -6,6 +6,7 @@ import * as helpers from "./helpers";
 
 export const initialize = () => {
     helpers.set_tab("upgrade");
+    helpers.set_sponsorship_form();
     $("#add-card-button").on("click", (e) => {
         const license_management = $("input[type=radio][name=license_management]:checked").val();
         if (
@@ -33,16 +34,6 @@ export const initialize = () => {
         e.preventDefault();
         helpers.create_ajax_request("/json/billing/upgrade", "invoice", [], "POST", () =>
             window.location.replace("/billing/"),
-        );
-    });
-
-    $("#sponsorship-button").on("click", (e) => {
-        if (!helpers.is_valid_input($("#sponsorship-form"))) {
-            return;
-        }
-        e.preventDefault();
-        helpers.create_ajax_request("/json/billing/sponsorship", "sponsorship", [], "POST", () =>
-            window.location.replace("/"),
         );
     });
 

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -374,4 +374,12 @@ input[name="licenses"] {
         cursor: pointer;
         background-color: hsl(0deg 0% 100%);
     }
+
+    & input[name="website"] {
+        width: 100%;
+    }
+
+    & textarea[name="description"] {
+        width: 100%;
+    }
 }

--- a/web/tests/billing.test.js
+++ b/web/tests/billing.test.js
@@ -20,6 +20,7 @@ const location = set_global("location", {});
 
 const helpers = mock_esm("../src/billing/helpers", {
     set_tab() {},
+    set_sponsorship_form() {},
 });
 
 zrequire("billing/billing");
@@ -30,8 +31,13 @@ run_test("initialize", ({override}) => {
         assert.equal(page_name, "billing");
         set_tab_called = true;
     });
+    let set_sponsorship_form_called = false;
+    override(helpers, "set_sponsorship_form", () => {
+        set_sponsorship_form_called = true;
+    });
     $.get_initialize_function()();
     assert.ok(set_tab_called);
+    assert.ok(set_sponsorship_form_called);
 });
 
 run_test("card_update", ({override}) => {


### PR DESCRIPTION
Previously this was only available on the upgrade page - meaning an
organization that already bought a plan wouldn't be able to request a
sponsorship to get a discount or such, even if qualified.

This is how it looks on the Billing page. Same thing as on the Upgrade page visually.
![image](https://user-images.githubusercontent.com/45007152/218560993-7f7cc496-7bfc-4dad-9793-4c26d6e6023b.png)


Bonus commit adding the hint to message support@zulip.com screenshot:
![image](https://user-images.githubusercontent.com/45007152/225410888-933b9f3c-abfa-42be-ad56-bf113817badf.png)

