### PR TITLE
message_feed: Hide compose banner when unsubbing from stream.

### DIFF
--- a/web/src/stream_events.js
+++ b/web/src/stream_events.js
@@ -167,7 +167,13 @@ export function mark_unsubscribed(sub) {
     }
 
     if (narrow_state.is_for_stream_id(sub.stream_id)) {
+        // Update UI components if we just unsubscribed from the
+        // currently viewed stream.
         message_lists.current.update_trailing_bookend();
+
+        // This update would likely be better implemented by having it
+        // disappear whenever no unread messages remain.
+        unread_ui.hide_mark_as_read_turned_off_banner();
     }
 
     // Unread messages in the now-unsubscribe stream need to be

--- a/web/tests/stream_events.test.js
+++ b/web/tests/stream_events.test.js
@@ -401,6 +401,7 @@ test("mark_unsubscribed (render_title_area)", ({override}) => {
     override(stream_list, "remove_sidebar_row", noop);
     override(stream_list, "update_subscribe_to_more_streams_link", noop);
     override(unread_ui, "update_unread_counts", noop);
+    override(unread_ui, "hide_mark_as_read_turned_off_banner", noop);
 
     stream_events.mark_unsubscribed(sub);
 


### PR DESCRIPTION
Currently, when a user marks messages as unread in a stream/topic and unsubscribes from the stream, both subscribe button and compose banner will remain visible. This change will hide the compose banner when the user unsubscribes from the stream and hopes to create a better flow and reduce confusion.

[CZO discussion](https://chat.zulip.org/#narrow/stream/137-feedback/topic/compose.20banner.20after.20unsubbing.20from.20stream)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before: 
![image](https://user-images.githubusercontent.com/62449508/218654384-8cfcc74f-0249-4fda-9fb9-1923e0b90cf2.png)

After: 
![image](https://user-images.githubusercontent.com/62449508/218654346-2e99d44b-cf42-4b88-85af-d16084f13345.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
