### PR TITLE
settings: Prevent long email spills over in notice.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -363,6 +363,10 @@ td .button {
         height: 30px;
         width: 220px;
     }
+
+    .account-settings-heading {
+        margin-right: 10px;
+    }
 }
 
 .settings_select {
@@ -522,6 +526,11 @@ input[type="checkbox"] {
     margin-left: 10px;
     color: hsl(156, 30%, 50%);
     padding: 3px 10px;
+
+    &.account-alert-notification {
+        margin: 0 0 10px;
+        vertical-align: middle;
+    }
 
     &:not(:empty) {
         border: 1px solid hsl(156, 30%, 50%);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -513,7 +513,9 @@ input[type="checkbox"] {
     vertical-align: top;
     height: auto !important;
     width: auto !important;
+    white-space: break-spaces !important;
 
+    overflow-wrap: anywhere;
     background-color: transparent;
     border-radius: 4px;
     margin-top: 14px;

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -3,8 +3,8 @@
     <div class="account-settings-form">
         <div class="inline-block">
             <div id="user_details_section">
-                <h3 class="inline-block">{{t "Account" }}</h3>
-                <div class="alert-notification" id="account-settings-status"></div>
+                <h3 class="inline-block account-settings-heading">{{t "Account" }}</h3>
+                <div class="alert-notification account-alert-notification" id="account-settings-status"></div>
                 <form class="grid">
                     <div class="input-group">
                         <label class="inline-block title">{{t "Email" }}</label>


### PR DESCRIPTION
- Improves the readability of alert notification banners by breaking long words into multiple lines and wrapping the content to fit the viewport.
- Prevent the notification banner content from spilling over by wrapping it inside the notice.
- Decrease the gap between the account heading and the 'account-alert-notification' banner. 

Fixes: #23653

------------------

**Screenshots and screen captures:**
<details>
<summary>Before:</summary>

<br>

![Screenshot from 2023-02-14 19-18-50](https://user-images.githubusercontent.com/66828942/218757160-7d14a0c3-ce77-42b1-a20e-95718b4e0e21.png)

</details>

**New Changes:**

<details>
<summary>When the  email is short:</summary>

<br>

![Screenshot from 2023-03-05 12-31-05](https://user-images.githubusercontent.com/66828942/222946758-3774bf1f-c8ff-406e-8191-6a0259b0abe8.png)


</details>

<details>
<summary>When the  email is long:</summary>

<br>


![Screenshot from 2023-03-10 00-20-15](https://user-images.githubusercontent.com/66828942/224127536-6e0a69d9-435a-4cf4-809b-e5bf09f0ef09.png)


</details>
<details>
<summary>View port changes:</summary>

<br>

![view_port_changes](https://user-images.githubusercontent.com/66828942/224127602-4b1306b6-e0fb-4263-b986-fa2a958e08dd.gif)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
