### PR TITLE
model: Handle parsed user-agents longer than 30 characters.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2688,7 +2688,8 @@ post_delete.connect(flush_muting_users_cache, sender=MutedUser)
 
 
 class Client(models.Model):
-    name = models.CharField(max_length=30, db_index=True, unique=True)
+    MAX_NAME_LENGTH = 30
+    name = models.CharField(max_length=MAX_NAME_LENGTH, db_index=True, unique=True)
 
     def __str__(self) -> str:
         return f"<Client: {self.name}>"
@@ -2705,7 +2706,7 @@ def clear_client_cache() -> None:  # nocoverage
 def get_client(name: str) -> Client:
     # Accessing KEY_PREFIX through the module is necessary
     # because we need the updated value of the variable.
-    cache_name = cache.KEY_PREFIX + name
+    cache_name = cache.KEY_PREFIX + name[0 : Client.MAX_NAME_LENGTH]
     if cache_name not in get_client_cache:
         result = get_client_remote_cache(name)
         get_client_cache[cache_name] = result
@@ -2718,7 +2719,7 @@ def get_client_cache_key(name: str) -> str:
 
 @cache_with_key(get_client_cache_key, timeout=3600 * 24 * 7)
 def get_client_remote_cache(name: str) -> Client:
-    (client, _) = Client.objects.get_or_create(name=name)
+    (client, _) = Client.objects.get_or_create(name=name[0 : Client.MAX_NAME_LENGTH])
     return client
 
 


### PR DESCRIPTION
The Client.name field is only 30 characters long, but there is no limit to the length of parsed User-Agent value which we may attempt to store in it.  This can cause requests with long user-agents to 500 when the creation of the Client row fails.

Truncate the name at 30 characters for the cache key, and passing `name` to `get_or_create`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
