### PR TITLE
puppet: wal-g is a tarball with a single file, not a directory.

### DIFF
--- a/puppet/zulip/manifests/external_dep.pp
+++ b/puppet/zulip/manifests/external_dep.pp
@@ -42,7 +42,7 @@ define zulip::external_dep(
       before       => File[$path],
     }
     file { $path:
-      ensure => directory,
+      ensure => present,
     }
   }
 


### PR DESCRIPTION
5db55c38dce5 switched from `ensure => present` to the more specific `ensure => directory` on the premise that tarballs would result in more than one file being copied out of them.  However, we only extract a single file from the wal-g tarball, and install it at the output path.  The new rule attempts to replace it with an empty directory after extraction.

Switch back to `ensure => present` for the tarball codepath.

**Screenshots and screen captures:**

Before:
```
# /home/zulip/deployments/current/scripts/zulip-puppet-apply
Notice: Compiled catalog for hostname in environment production in 4.91 seconds
Notice: /Stage[main]/Zulip::Wal_g/Zulip::External_dep[wal-g]/File[/srv/zulip-wal-g-2.0.1]/ensure: current_value 'file', should be 'directory' (noop)
Notice: Zulip::External_dep[wal-g]: Would have triggered 'refresh' from 1 event
Notice: Class[Zulip::Wal_g]: Would have triggered 'refresh' from 1 event
Notice: Stage[main]: Would have triggered 'refresh' from 1 event
Notice: Applied catalog in 1.86 seconds
```

After:
```
# /home/zulip/deployments/current/scripts/zulip-puppet-apply
Notice: Compiled catalog for hostname in environment production in 5.40 seconds
Notice: Applied catalog in 1.82 seconds
```

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
