### PR TITLE
Allow users to set `email_address_visibility` during account creation.

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -118,8 +118,29 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
                 <div class="input-box no-validation">
                     <input type='hidden' name='key' value='{{ key }}' />
                     <input type='hidden' name='timezone' id='timezone'/>
+                    <input type="hidden" name="email_address_visibility" id="email_address_visibility"/>
                     <label for="id_email" class="inline-block label-title">{{ _('Email') }}</label>
                     <div id="id_email">{{ email }}</div>
+                    {% if not creating_new_team %}
+                    <p id="new-user-email-address-visibility">
+                        <span class="current-selected-option">
+                            {% if default_email_address_visibility == email_address_visibility_admins_only %}
+                                {% trans %}Administrators of this Zulip organization will be able to see this email address.
+                                {% endtrans %}
+                            {% elif default_email_address_visibility == email_address_visibility_moderators %}
+                                {% trans %}Administrators and moderators of this Zulip organization will be able to see this email address.
+                                {% endtrans %}
+                            {% elif default_email_address_visibility == email_address_visibility_nobody %}
+                                {% trans %}Nobody in this Zulip organization will be able to see this email address.
+                                {% endtrans %}
+                            {% else %}
+                                {% trans %}Other users in this Zulip organization will be able to see this email address.
+                                {% endtrans %}
+                            {% endif %}
+                        </span>
+                        <a target="_blank" class="change_email_address_visibility" rel="noopener noreferrer">{{ _('Change') }}</a>
+                    </p>
+                    {% endif %}
                 </div>
 
                 {% if accounts %}
@@ -276,5 +297,41 @@ Form is validated both client-side using jquery-validation (see signup.js) and s
 
     </div>
 </div>
+
+{% if not creating_new_team %}
+<div class="micromodal" id="change-email-address-visibility-modal" aria-hidden="true">
+    <div class="modal__overlay" tabindex="-1">
+        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
+            <header class="modal__header">
+                <h1 class="modal__title dialog_heading">
+                    {{ _('Configure email address privacy') }}
+                </h1>
+                <button class="modal__close" aria-label="{{ _('Close modal') }}" data-micromodal-close></button>
+            </header>
+            <main class="modal__content">
+                <p>
+                    {{ _('Zulip lets you control which roles in the organization can view your email address.') }}
+                    {{ _('Do you want to change the privacy setting for your email from the default configuration for this organization?') }}
+                </p>
+                <label for="new_user_email_address_visibility">{{ _('Who can access your email address') }}</label>
+                <select id="new_user_email_address_visibility" class="modal_select">
+                    {% for value, name in email_address_visibility_options_dict.items() %}
+                        <option value="{{ value }}" {% if value == default_email_address_visibility %}selected{% endif %}>{{name}}</option>
+                    {% endfor %}
+                </select>
+                <p>
+                    {% trans %}You can also change this setting <a href="{{ root_domain_uri }}/help/configure-email-visibility" target="_blank" rel="noopener noreferrer">after you join</a>.{% endtrans %}
+                </p>
+            </main>
+            <footer class="modal__footer">
+                <button class="modal__btn dialog_cancel_button" aria-label="{{ '(Close this dialog window)' }}" data-micromodal-close>{{ _('Cancel') }}</button>
+                <button class="modal__btn dialog_submit_button">
+                    <span>{{ _('Confirm') }}</span>
+                </button>
+            </footer>
+        </div>
+    </div>
+</div>
+{% endif %}
 
 {% endblock %}

--- a/web/src/bundles/common.js
+++ b/web/src/bundles/common.js
@@ -12,6 +12,7 @@ import "../../images/icons/zulip-icons.font";
 import "source-sans/source-sans-3.css";
 import "source-code-pro/source-code-pro.css";
 import "../../styles/alerts.css";
+import "../../styles/modal.css";
 import "../../styles/pygments.css";
 import "@uppy/core/dist/style.css";
 import "@uppy/progress-bar/dist/style.css";

--- a/web/src/portico/signup.js
+++ b/web/src/portico/signup.js
@@ -1,7 +1,10 @@
 import $ from "jquery";
+import Micromodal from "micromodal";
 
 import * as common from "../common";
+import {$t} from "../i18n";
 import {password_quality, password_warning} from "../password_quality";
+import * as settings_config from "../settings_config";
 
 $(() => {
     // NB: this file is included on multiple pages.  In each context,
@@ -229,5 +232,56 @@ $(() => {
     // GitHub auth
     $("body").on("click", "#choose_email .choose-email-box", function () {
         this.parentNode.submit();
+    });
+
+    $("#new-user-email-address-visibility .change_email_address_visibility").on("click", () => {
+        Micromodal.show("change-email-address-visibility-modal", {
+            disableFocus: true,
+            openClass: "modal--opening",
+        });
+    });
+
+    $("#change-email-address-visibility-modal .dialog_submit_button").on("click", () => {
+        const selected_val = Number.parseInt($("#new_user_email_address_visibility").val(), 10);
+        $("#email_address_visibility").val(selected_val);
+        Micromodal.close("change-email-address-visibility-modal");
+
+        let selected_option_text;
+
+        // These strings should be consistent with those defined for the same element in
+        // 'templates/zerver/register.html'.
+        switch (selected_val) {
+            case settings_config.email_address_visibility_values.admins_only.code: {
+                selected_option_text = $t({
+                    defaultMessage:
+                        "Administrators of this Zulip organization will be able to see this email address.",
+                });
+
+                break;
+            }
+            case settings_config.email_address_visibility_values.moderators.code: {
+                selected_option_text = $t({
+                    defaultMessage:
+                        "Administrators and moderators this Zulip organization will be able to see this email address.",
+                });
+
+                break;
+            }
+            case settings_config.email_address_visibility_values.nobody.code: {
+                selected_option_text = $t({
+                    defaultMessage:
+                        "Nobody in this Zulip organization will be able to see this email address.",
+                });
+
+                break;
+            }
+            default: {
+                selected_option_text = $t({
+                    defaultMessage:
+                        "Other users in this Zulip organization will be able to see this email address.",
+                });
+            }
+        }
+        $("#new-user-email-address-visibility .current-selected-option").text(selected_option_text);
     });
 });

--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -635,6 +635,37 @@ html {
     }
 }
 
+#new-user-email-address-visibility {
+    text-align: left;
+    font-size: 0.8em;
+    line-height: normal;
+    margin-left: 2px;
+
+    .change_email_address_visibility {
+        cursor: pointer;
+    }
+}
+
+#change-email-address-visibility-modal {
+    font-weight: 400;
+
+    label {
+        font-size: inherit;
+    }
+
+    h1 {
+        font-weight: 600;
+        font-family: inherit;
+    }
+
+    select {
+        margin-bottom: 10px;
+        width: auto;
+        font-size: 16px;
+        font-family: inherit;
+    }
+}
+
 /* -- /accounts/register/ page -- */
 .portico-page {
     .pitch {

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -390,6 +390,7 @@ def do_create_user(
     *,
     acting_user: Optional[UserProfile],
     enable_marketing_emails: bool = True,
+    email_address_visibility: Optional[int] = None,
 ) -> UserProfile:
     with transaction.atomic():
         user_profile = create_user(
@@ -409,6 +410,7 @@ def do_create_user(
             default_all_public_streams=default_all_public_streams,
             source_profile=source_profile,
             enable_marketing_emails=enable_marketing_emails,
+            email_address_visibility=email_address_visibility,
         )
 
         event_time = user_profile.date_joined

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -115,6 +115,15 @@ class RegistrationForm(forms.Form):
     realm_type = forms.IntegerField(required=False)
     is_demo_organization = forms.BooleanField(required=False)
     enable_marketing_emails = forms.BooleanField(required=False)
+    email_address_visibility = forms.TypedChoiceField(
+        required=False,
+        coerce=int,
+        empty_value=None,
+        choices=[
+            (value, name)
+            for value, name in UserProfile.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP.items()
+        ],
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # Since the superclass doesn't except random extra kwargs, we

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -755,6 +755,7 @@ Output:
         key: Optional[str] = None,
         realm_type: int = Realm.ORG_TYPES["business"]["id"],
         enable_marketing_emails: Optional[bool] = None,
+        email_address_visibility: Optional[int] = None,
         is_demo_organization: bool = False,
         **extra: str,
     ) -> "TestHttpResponse":
@@ -783,6 +784,8 @@ Output:
         }
         if enable_marketing_emails is not None:
             payload["enable_marketing_emails"] = enable_marketing_emails
+        if email_address_visibility is not None:
+            payload["email_address_visibility"] = email_address_visibility
         if password is not None:
             payload["password"] = password
         if realm_in_root_domain is not None:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1612,13 +1612,16 @@ class UserBaseSettings(models.Model):
     email_address_visibility = models.PositiveSmallIntegerField(
         default=EMAIL_ADDRESS_VISIBILITY_EVERYONE,
     )
-    EMAIL_ADDRESS_VISIBILITY_TYPES = [
-        EMAIL_ADDRESS_VISIBILITY_EVERYONE,
-        EMAIL_ADDRESS_VISIBILITY_MEMBERS,
-        EMAIL_ADDRESS_VISIBILITY_ADMINS,
-        EMAIL_ADDRESS_VISIBILITY_NOBODY,
-        EMAIL_ADDRESS_VISIBILITY_MODERATORS,
-    ]
+
+    EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP = {
+        EMAIL_ADDRESS_VISIBILITY_EVERYONE: gettext_lazy("Admins, moderators, members and guests"),
+        EMAIL_ADDRESS_VISIBILITY_MEMBERS: gettext_lazy("Admins, moderators and members"),
+        EMAIL_ADDRESS_VISIBILITY_MODERATORS: gettext_lazy("Admins and moderators"),
+        EMAIL_ADDRESS_VISIBILITY_ADMINS: gettext_lazy("Admins only"),
+        EMAIL_ADDRESS_VISIBILITY_NOBODY: gettext_lazy("Nobody"),
+    }
+
+    EMAIL_ADDRESS_VISIBILITY_TYPES = list(EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP.keys())
 
     display_settings_legacy = dict(
         # Don't add anything new to this legacy dict.

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -350,6 +350,7 @@ def accounts_register(
 
         full_name = form.cleaned_data["full_name"]
         enable_marketing_emails = form.cleaned_data["enable_marketing_emails"]
+        email_address_visibility = form.cleaned_data["email_address_visibility"]
         default_stream_group_names = request.POST.getlist("default_stream_group")
         default_stream_groups = lookup_default_stream_groups(default_stream_group_names, realm)
 
@@ -464,6 +465,7 @@ def accounts_register(
                 realm_creation=realm_creation,
                 acting_user=None,
                 enable_marketing_emails=enable_marketing_emails,
+                email_address_visibility=email_address_visibility,
             )
 
         if realm_creation:

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -63,6 +63,7 @@ from zerver.models import (
     MultiuseInvite,
     PreregistrationUser,
     Realm,
+    RealmUserDefault,
     Stream,
     UserProfile,
     get_default_stream_groups,
@@ -496,6 +497,11 @@ def accounts_register(
         assert isinstance(auth_result, UserProfile)
         return login_and_go_to_home(request, auth_result)
 
+    default_email_address_visibility = None
+    if realm is not None:
+        realm_user_default = RealmUserDefault.objects.get(realm=realm)
+        default_email_address_visibility = realm_user_default.email_address_visibility
+
     return TemplateResponse(
         request,
         "zerver/register.html",
@@ -523,6 +529,11 @@ def accounts_register(
             "sorted_realm_types": sorted(
                 Realm.ORG_TYPES.values(), key=lambda d: d["display_order"]
             ),
+            "default_email_address_visibility": default_email_address_visibility,
+            "email_address_visibility_admins_only": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_ADMINS,
+            "email_address_visibility_moderators": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_MODERATORS,
+            "email_address_visibility_nobody": RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_NOBODY,
+            "email_address_visibility_options_dict": UserProfile.EMAIL_ADDRESS_VISIBILITY_ID_TO_NAME_MAP,
         },
     )
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit adds backend code to set `email_address_visibility` during account creation.
- Second commit adds UI to allow user to set `email_address_visibility` during account creation.

Fixes: <!-- Issue link, or clear description.-->#24310

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![email-visibility-nobody](https://user-images.githubusercontent.com/35494118/218992137-33931e0a-1274-40b2-948a-63ada79fe117.png)
![email-visibility-admins](https://user-images.githubusercontent.com/35494118/218992212-fd306dc1-d9bb-41cd-9e0d-ebeea514dd1e.png)
![email-visibility-others](https://user-images.githubusercontent.com/35494118/218992289-7b64eeb8-6921-4297-a366-c40f7be82a61.png)

![create-user-email-setting](https://user-images.githubusercontent.com/35494118/218992333-72ea386b-7a23-4d9e-acbe-824744a49078.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
