### PR TITLE
help: Document "Who can unsubscribe others from this stream?" setting.

### DIFF
--- a/help/add-or-remove-users-from-a-stream.md
+++ b/help/add-or-remove-users-from-a-stream.md
@@ -90,6 +90,29 @@ This method is useful if you need to remove one user from multiple streams.
 
 {end_tabs}
 
+## Configure who can remove users
+
+{!admin-only.md!}
+
+Organization administrators can configure who can remove other users from a
+public stream. For private streams, administrators must be subscribed to the
+stream to configure this setting.
+
+{start_tabs}
+
+{relative|stream|all}
+
+1. Select a stream.
+
+{!select-stream-view-general.md!}
+
+1. Under **Stream permissions**, configure
+   **Who can unsubscribe others from this stream?**
+
+{!save-changes.md!}
+
+{end_tabs}
+
 ## Related articles
 
 * [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams)

--- a/help/create-a-stream.md
+++ b/help/create-a-stream.md
@@ -44,6 +44,12 @@ There are several parameters you can set while creating a stream. All but
 
 * **Who can post to the stream?**: See [Stream permissions](/help/stream-permissions).
 
+* **Who can unsubscribe others from this stream?**: See
+  [Add or remove users from a stream](/help/add-or-remove-users-from-a-stream#configure-who-can-remove-users).
+
+* **Message retention period**: See
+  [Message retention policy](/help/message-retention-policy#configure-message-retention-policy-for-individual-streams).
+
 * **Choose subscribers**: You can copy the membership from an existing stream or
   [user group](/help/user-groups), add all users, or enter users one by one.
 

--- a/help/stream-permissions.md
+++ b/help/stream-permissions.md
@@ -64,6 +64,7 @@ administrator can access private stream messages:
 | Join                  | &#10004;          | &#10004;   | &#10004;  |
 | Unsubscribe           | &#9726;           | &#9726;    | &#9726;   | &#9726;
 | Add others            | &#10004;          | &#10004;   | &#10004;  |
+| Remove others         | &#10004;          | &#10038;   | &#10038;  | &#10038;
 | See subscriber list   | &#10004;          | &#10004;   | &#10004;  | &#9726;
 | See full history      | &#10004;          | &#10004;   | &#10004;  | &#9726;
 | See estimated traffic | &#10004;          | &#10004;   | &#10004;  | &#9726;
@@ -71,17 +72,17 @@ administrator can access private stream messages:
 | Change the privacy    | &#10004;          |            |           |
 | Rename                | &#10004;          |            |           |
 | Edit the description  | &#10004;          |            |           |
-| Remove others         | &#10004;          |            |           |
 | Delete                | &#10004;          |            |           |
 
 <span class="legend_symbol">&#10004;</span><span class="legend_label">Always</span>
 
 <span class="legend_symbol">&#9726;</span><span class="legend_label">If subscribed to the stream</span>
 
-<span class="legend_symbol">&#10038;</span><span class="legend_label">[Configurable](/help/stream-sending-policy).  Owners,
-administrators, and members can, by default, post to any public
-stream, and guests can only post to public streams if they are
-subscribed.</span>
+<span class="legend_symbol">&#10038;</span><span class="legend_label">
+Configurable. See [Stream posting policy](/help/stream-sending-policy) and
+[Configure who can remove users](/help/add-or-remove-users-from-a-stream#configure-who-can-remove-users)
+for details.
+</span>
 
 ### Private streams
 
@@ -92,6 +93,7 @@ subscribed.</span>
 | Join                  |                   |            |           |
 | Unsubscribe           | &#9726;           | &#9726;    | &#9726;   | &#9726;
 | Add others            | &#9726;           | &#9726;    | &#9726;   |
+| Remove others         | &#10004;          | &#10038;   | &#10038;  | &#10038;
 | See subscriber list   | &#10004;          | &#9726;    | &#9726;   | &#9726;
 | See full history      | &#10038;          | &#10038;   | &#10038;  | &#10038;
 | See estimated traffic | &#10004;          | &#9726;    | &#9726;   | &#9726;
@@ -99,15 +101,18 @@ subscribed.</span>
 | Change the privacy    | &#9726;           |            |           |
 | Rename                | &#10004;          |            |           |
 | Edit the description  | &#10004;          |            |           |
-| Remove others         | &#10004;          |            |           |
 | Delete                | &#10004;          |            |           |
 
 <span class="legend_symbol">&#10004;</span><span class="legend_label">Always</span>
 
 <span class="legend_symbol">&#9726;</span><span class="legend_label">If subscribed to the stream</span>
 
-<span class="legend_symbol">&#10038;</span><span class="legend_label">[Configurable](/help/stream-sending-policy), but at minimum
-must be subscribed to the stream.</span>
+<span class="legend_symbol">&#10038;</span><span class="legend_label">
+Configurable, but at minimum must be subscribed to the stream.
+See [Stream posting policy](/help/stream-sending-policy) and
+[Configure who can remove users](/help/add-or-remove-users-from-a-stream#configure-who-can-remove-users)
+for details.
+</span>
 
 ## Related articles
 


### PR DESCRIPTION
- Updates "Remove others" row in "Stream permissions" tables.
- Adds a section to "Add or remove users from a stream" describing how to configure the new setting.
- Documents the new setting in "Create a stream".
- Documents "Message retention period" setting in "Create a stream".

Fixes #24340.

**Screenshots and screen captures:**

- https://zulip.com/help/stream-permissions

![image](https://user-images.githubusercontent.com/2343554/222870641-0567e857-e095-4b21-981e-1c230ea72339.png)

![image](https://user-images.githubusercontent.com/2343554/222870688-1fde2d0c-2e55-4feb-81cf-cd9a828edbf3.png)

- https://zulip.com/help/add-or-remove-users-from-a-stream

![image](https://user-images.githubusercontent.com/2343554/222870744-948882ac-d014-4157-866d-1c58897d4ad0.png)

- https://zulip.com/help/create-a-stream

![image](https://user-images.githubusercontent.com/2343554/219502280-50fd98d7-71af-4144-bb45-8165a3506319.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>