### PR TITLE
UI redesign: use modern tooltip style for remaining tooltip elements

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -280,6 +280,20 @@ export function initialize() {
                 user_settings.enter_sends = selected_behaviour;
                 $(`.enter_sends_${!selected_behaviour}`).hide();
                 $(`.enter_sends_${selected_behaviour}`).show();
+                if (user_settings.enter_sends) {
+                    $("#compose-send-button").attr(
+                        "data-tooltip-template-id",
+                        "send-enter-tooltip-template",
+                    );
+                } else {
+                    $("#compose-send-button").attr(
+                        "data-tooltip-template-id",
+                        "send-ctrl-enter-tooltip-template",
+                    );
+                }
+                // Destroy the existing tippy tooltip so that a new tooltip is created
+                // with a template corresponding to the updated data-tooltip-template-id.
+                $("#compose-send-button")[0]._tippy?.destroy();
 
                 // Refocus in the content box so you can continue typing or
                 // press Enter to send.

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -105,6 +105,16 @@ export function initialize() {
         target: ".tippy-zulip-tooltip",
     });
 
+    // variant of tippy-zulip-tooltip above having delay=LONG_HOVER_DELAY.
+    // default placement="bottom" which can be changed by using
+    // data-tippy-placement on element in case of custom placement.
+    delegate("body", {
+        target: ".tippy-zulip-delayed-tooltip",
+        placement: "bottom",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+    });
+
     // The below definitions are for specific tooltips that require
     // custom JavaScript code or configuration.  Note that since the
     // below specify the target directly, elements using those should
@@ -449,24 +459,6 @@ export function initialize() {
             }
             return true;
         },
-        delay: LONG_HOVER_DELAY,
-        appendTo: () => document.body,
-    });
-
-    delegate("body", {
-        target: "#show_all_private_messages",
-        placement: "bottom",
-        content: $t({
-            defaultMessage: "All direct messages (P)",
-        }),
-        appendTo: () => document.body,
-    });
-
-    delegate("body", {
-        target: ".view_user_card_tooltip",
-        content: $t({
-            defaultMessage: "View user card (u)",
-        }),
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
     });

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -227,6 +227,7 @@ function initialize_compose_box() {
             giphy_enabled: giphy.is_giphy_enabled(),
             max_stream_name_length: page_params.max_stream_name_length,
             max_topic_length: page_params.max_topic_length,
+            enter_sends_true: user_settings.enter_sends,
         }),
     );
     $(`.enter_sends_${user_settings.enter_sends}`).show();

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -108,10 +108,18 @@
                             <div id="below-compose-content">
                                 <div class="compose_bottom_top_container">
                                     <div class="compose_right_float_container order-3">
-                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)">
+                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button tippy-zulip-delayed-tooltip" data-tippy-placement="top" data-tooltip-template-id="send-{{#if enter_sends_true}}enter{{else}}ctrl-enter{{/if}}-tooltip-template">
                                             <img class="loader" alt="" src="" />
                                             <span>{{t 'Send' }}</span>
                                         </button>
+                                        <template id="send-enter-tooltip-template">
+                                            {{t 'Send' }}
+                                            {{tooltip_hotkey_hints "Enter"}}
+                                        </template>
+                                        <template id="send-ctrl-enter-tooltip-template">
+                                            {{t 'Send' }}
+                                            {{tooltip_hotkey_hints "Ctrl" "Enter"}}
+                                        </template>
                                     </div>
                                     {{> compose_control_buttons }}
                                 </div>

--- a/web/templates/gear_menu.hbs
+++ b/web/templates/gear_menu.hbs
@@ -1,8 +1,12 @@
 <ul class="nav" role="navigation">
     <li class="dropdown actual-dropdown-menu" id="gear-menu">
-        <a id="settings-dropdown" tabindex="0" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{t 'Menu' }} (g)">
+        <a id="settings-dropdown" tabindex="0" role="button" class="dropdown-toggle tippy-zulip-delayed-tooltip" data-target="nada" data-toggle="dropdown" data-tooltip-template-id="menu-tooltip-template">
             <i class="fa fa-cog settings-dropdown-cog" aria-hidden="true"></i>
         </a>
+        <template id="menu-tooltip-template">
+            {{t 'Menu' }}
+            {{tooltip_hotkey_hints "G"}}
+        </template>
         <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
             <li class="org-info org-name">{{realm_name}}</li>
             <li class="org-info org-url">{{realm_uri}}</li>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -43,7 +43,7 @@
                     {{t 'Mentions' }}
                 </template>
             </li>
-            <li class="top_left_starred_messages top_left_row hidden-for-spectators" title="{{t 'Starred messages' }}">
+            <li class="top_left_starred_messages top_left_row hidden-for-spectators tippy-zulip-delayed-tooltip" data-tooltip-template-id="starred-messages-tooltip-template">
                 <a href="#narrow/is/starred">
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>
@@ -52,6 +52,9 @@
                     <span>{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
+                <template id="starred-messages-tooltip-template">
+                    {{t 'Starred messages' }}
+                </template>
                 <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_drafts top_left_row hidden-for-spectators" title="{{t 'Drafts' }} (d)">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -17,7 +17,7 @@
                 </template>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_recent_topics top_left_row" title="{{t 'Recent conversations' }} (t)">
+            <li class="top_left_recent_topics top_left_row tippy-zulip-delayed-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
                 <a href="#recent">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
@@ -25,6 +25,10 @@
                     {{~!-- squash whitespace --~}}
                     <span>{{t 'Recent conversations' }}</span>
                 </a>
+                <template id="recent-conversations-tooltip-template">
+                    {{t 'Recent conversations' }}
+                    {{tooltip_hotkey_hints "T"}}
+                </template>
             </li>
             <li class="top_left_mentions top_left_row hidden-for-spectators" title="{{t 'Mentions' }}">
                 <a href="#narrow/is/mentioned">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -30,7 +30,7 @@
                     {{tooltip_hotkey_hints "T"}}
                 </template>
             </li>
-            <li class="top_left_mentions top_left_row hidden-for-spectators" title="{{t 'Mentions' }}">
+            <li class="top_left_mentions top_left_row hidden-for-spectators tippy-zulip-delayed-tooltip" data-tooltip-template-id="mentions-tooltip-template">
                 <a href="#narrow/is/mentioned">
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
@@ -39,6 +39,9 @@
                     <span>{{t 'Mentions' }}</span>
                     <span class="unread_count"></span>
                 </a>
+                <template id="mentions-tooltip-template">
+                    {{t 'Mentions' }}
+                </template>
             </li>
             <li class="top_left_starred_messages top_left_row hidden-for-spectators" title="{{t 'Starred messages' }}">
                 <a href="#narrow/is/starred">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -65,7 +65,7 @@
                     <h4 class="sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
                 </span>
                 <span class="unread_count"></span>
-                <a id="show_all_private_messages" href="#narrow/is/private">
+                <a id="show_all_private_messages" class="tippy-zulip-delayed-tooltip" href="#narrow/is/private" data-tooltip-template-id="show-all-pms-template">
                     <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
                 </a>
             </div>
@@ -74,6 +74,10 @@
             <span> {{t 'back to streams' }}</span>
         </a>
     </div>
+    <template id="show-all-pms-template">
+        {{t 'All direct messages' }}
+        {{tooltip_hotkey_hints "P"}}
+    </template>
     {{~!-- squash whitespace --~}}
     <div id="left_sidebar_scroll_container" class="scrolling_list" data-simplebar>
         <div class="private_messages_container zoom-out hidden-for-spectators">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -57,7 +57,7 @@
                 </template>
                 <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_drafts top_left_row hidden-for-spectators" title="{{t 'Drafts' }} (d)">
+            <li class="top_left_drafts top_left_row hidden-for-spectators tippy-zulip-delayed-tooltip" data-tooltip-template-id="drafts-tooltip-template">
                 <a href="#drafts">
                     <span class="filter-icon">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
@@ -70,6 +70,10 @@
             </li>
         </ul>
     </div>
+    <template id="drafts-tooltip-template">
+        {{t 'Drafts' }}
+        {{tooltip_hotkey_hints "D"}}
+    </template>
 
     <div id="private_messages_sticky_header" class="private_messages_container zoom-out hidden-for-spectators">
         <div id="private_messages_section">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -2,7 +2,7 @@
     <div class="narrows_panel">
         <ul id="global_filters" class="filters">
             {{!-- Special-case this link so we don't actually go to page top. --}}
-            <li class="top_left_all_messages top_left_row" title="{{t 'All messages' }} (a)">
+            <li class="top_left_all_messages top_left_row tippy-zulip-delayed-tooltip" data-tooltip-template-id="all-message-tooltip-template">
                 <a href="#all_messages" class="home-link">
                     <span class="filter-icon">
                         <i class="fa fa-align-left" aria-hidden="true"></i>
@@ -11,6 +11,10 @@
                     <span>{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
+                <template id="all-message-tooltip-template">
+                    {{t 'All messages' }}
+                    {{tooltip_hotkey_hints "A"}}
+                </template>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_recent_topics top_left_row" title="{{t 'Recent conversations' }} (t)">

--- a/web/templates/me_message.hbs
+++ b/web/templates/me_message.hbs
@@ -7,7 +7,7 @@
 
     <span class="sender-status">
         <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">
-            <span class="view_user_card_tooltip">
+            <span class="tippy-zulip-delayed-tooltip" data-tippy-placement="top" data-tooltip-template-id="view-user-card-tooltip-template">
                 {{msg/sender_full_name}}
             </span>
         </span>

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip" aria-hidden="true">
+<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} tippy-zulip-delayed-tooltip" data-tippy-placement="top" aria-hidden="true" data-tooltip-template-id="view-user-card-tooltip-template">
     <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
 </div>
 {{~! remove whitespace ~}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -4,9 +4,13 @@
     <span>
         {{> message_avatar ~}}
         <span class="sender_name auto-select" role="button" tabindex="0">
-            <span class="sender_name_padding view_user_card_tooltip"></span>
-            <span class="view_user_card_tooltip">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
+            <span class="sender_name_padding tippy-zulip-delayed-tooltip" data-tippy-placement="top" data-tooltip-template-id="view-user-card-tooltip-template" ></span>
+            <span class="tippy-zulip-delayed-tooltip" data-tippy-placement="top" data-tooltip-template-id="view-user-card-tooltip-template">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
         </span>
+        <template id="view-user-card-tooltip-template">
+            {{t 'View user card' }}
+            {{tooltip_hotkey_hints "U"}}
+        </template>
         {{#if sender_is_bot}}
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -56,8 +56,17 @@
 <div class="message_edit">
     <div class="message_edit_form"></div>
 </div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More…]" }}</div>
-<div class="message_condenser message_length_controller" title="{{t 'Show less' }} (-)">[{{t "Show less" }}]</div>
+<div class="message_expander message_length_controller tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "[More…]" }}</div>
+<div class="message_condenser message_length_controller tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">[{{t "Show less" }}]</div>
+
+<template id="message-expander-tooltip-template">
+    {{t 'Expand message' }}
+    {{tooltip_hotkey_hints "-"}}
+</template>
+<template id="message-condenser-tooltip-template">
+    {{t 'Show less' }}
+    {{tooltip_hotkey_hints "-"}}
+</template>
 
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -3,7 +3,7 @@
     {{#with sub}}
     <div class="button-group">
         <div class="sub_unsub_button_wrapper inline-block">
-            <button class="button small rounded subscribe-button sub_unsub_button {{#if should_display_subscription_button}}tippy-zulip-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}data-tippy-content="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
+            <button class="button small rounded subscribe-button sub_unsub_button {{#if should_display_subscription_button}}tippy-zulip-delayed-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}} data-tooltip-template-id="toggle-subscription-tooltip-template" {{else}}disabled="disabled"{{/if}}>
                 {{#if subscribed }}
                     {{t "Unsubscribe" }}
                 {{else}}
@@ -11,7 +11,10 @@
                 {{/if}}
             </button>
         </div>
-        <a href="{{preview_url}}" class="button small rounded tippy-zulip-tooltip" id="preview-stream-button" role="button" data-tippy-content="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
+        <template id="toggle-subscription-tooltip-template">
+            {{t 'Toggle subscription' }}
+            {{tooltip_hotkey_hints "S"}}
+        </template>
         {{#if is_realm_admin}}
         <button class="button small rounded btn-danger deactivate tippy-zulip-tooltip" type="button" name="delete_button" data-tippy-content="{{t 'Archive stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
         {{/if}}

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -15,10 +15,15 @@
             {{t 'Toggle subscription' }}
             {{tooltip_hotkey_hints "S"}}
         </template>
+        <a href="{{preview_url}}" class="button small rounded tippy-zulip-delayed-tooltip" id="preview-stream-button" role="button" data-tooltip-template-id="view-stream-tooltip-template" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
         {{#if is_realm_admin}}
         <button class="button small rounded btn-danger deactivate tippy-zulip-tooltip" type="button" name="delete_button" data-tippy-content="{{t 'Archive stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
         {{/if}}
     </div>
+    <template id="view-stream-tooltip-template">
+        {{t 'View stream' }}
+        {{tooltip_hotkey_hints "V"}}
+    </template>
     {{/with}}
 </div>
 <div class="subscription_settings" data-stream-id="{{sub.stream_id}}">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -12,9 +12,13 @@
                 <div class="search-container">
                     <div id="add_new_subscription">
                         {{#if can_create_streams}}
-                        <button class="create_stream_button create_stream_plus_button tippy-zulip-tooltip" data-tippy-content="{{t 'Create new stream' }} (n)" data-tippy-placement="bottom">
+                        <button class="create_stream_button create_stream_plus_button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template">
                             <span>+</span>
                         </button>
+                        <template id="create-new-stream-tooltip-template">
+                            {{t 'Create new stream' }}
+                            {{tooltip_hotkey_hints "N"}}
+                        </template>
                         {{/if}}
                         <div class="float-clear"></div>
                     </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
change style of tooltip elements mentioned in issue #24311 to modern hotkey_hints tooltip style

Fixes: <!-- Issue link, or clear description.-->
#24311 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

* All private message:

![image](https://user-images.githubusercontent.com/64723994/221901746-ef210fac-ac38-4dbf-ab0a-a24bcad68c28.png)
![image](https://user-images.githubusercontent.com/64723994/221901607-4f851125-8df9-4989-8eb1-c08d2ce6f4f1.png)

* View user card:
![image](https://user-images.githubusercontent.com/64723994/219296022-6758ca36-88f1-4f61-b897-cb48537de103.png)

* Expand/condense Message:
![image](https://user-images.githubusercontent.com/64723994/219296467-71ea8b09-600f-470b-852a-d743e7cf4a69.png)

* Menu(setting menu icon):
![image](https://user-images.githubusercontent.com/64723994/221906013-a66487a8-666e-4805-a963-d09625782856.png)



some more elements advertising keyboard shortcut:

In left sidebar:

* All messages:
![image](https://user-images.githubusercontent.com/64723994/219298133-8999a66c-1589-486e-ac90-c7cd8668523e.png)

* Recent conversations:
![image](https://user-images.githubusercontent.com/64723994/219298296-a03c31dd-9c25-4855-9a9a-c08193f3ac75.png)

* Drafts:
![image](https://user-images.githubusercontent.com/64723994/219298408-655a3575-2db0-4229-bdc1-b8fd918a6aff.png)



3 elements in streams settings:

* Create new stream:
![image](https://user-images.githubusercontent.com/64723994/221924841-f431d000-d0e5-4efc-9779-563b43e75535.png)

* Toggle subscription:
![image](https://user-images.githubusercontent.com/64723994/221924922-2d33fde7-32ab-4bb9-809b-5305d684efdc.png)

* View stream:
![image](https://user-images.githubusercontent.com/64723994/221925022-87ee4d30-fe9c-456f-a00b-4b416fd2316d.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
