### PR TITLE
api-docs: Update content parameter descriptions for `max_message_length`.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10254,12 +10254,12 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The maximum allowed length for a message. Clients should use
-                          these properties rather than hardcoding field sizes, as they may
-                          change in a future Zulip release.
+                          The maximum allowed length for a message, in Unicode code points.
+                          Clients should use this property rather than hardcoding field
+                          sizes.
 
                           **Changes**: New in Zulip 4.0 (feature level 53). Previously,
-                          this always had value 10000.
+                          this property always had a value of 10000.
                       muted_topics:
                         type: array
                         deprecated: true
@@ -17518,7 +17518,11 @@ components:
       name: content
       in: query
       description: |
-        The content of the message. Maximum message size of 10000 bytes.
+        The content of the message.
+
+        Clients should use the `max_message_length` returned by the
+        [`POST /register`](/api/register-queue) endpoint to determine
+        the maximum message size.
       schema:
         type: string
       example: Hello
@@ -17527,8 +17531,11 @@ components:
       name: content
       in: query
       description: |
-        The updated content of the target message. Maximum message size of
-        10000 bytes.
+        The updated content of the target message.
+
+        Clients should use the `max_message_length` returned by the
+        [`POST /register`](/api/register-queue) endpoint to determine
+        the maximum message size.
 
         Note that a message's content and stream cannot be changed at the
         same time, so sending both `content` and `stream_id` parameters will


### PR DESCRIPTION
Updates the descriptions of content parameters (optional and required) to note that the maximum size of the message content should be based on the `max_message_length` value returned by the register endpoint.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/max.20message.20size/near/1508146) for more context.

**Notes**:
- Previously these descriptions had a hard coded value of 10000 bytes as the maximum message size.
- Also, updates the description of `max_message_length` to clarify that the value represents Unicode code points.

---

**Screenshots and screen captures:**

<details>
<summary>Description of max_message_length return value for register-queue endpoint</summary>

[Current documentation](https://zulip.com/api/register-queue)
![Screenshot from 2023-02-16 12-14-56](https://user-images.githubusercontent.com/63245456/219350452-846850db-2275-4e6b-b76b-4988f2ac07fa.png)
</details>
<details>
<summary>Required content parameter (send-message and render-message endpoints)</summary>

[Current documentation](https://zulip.com/api/send-message#parameter-content)
![Screenshot from 2023-02-16 11-44-50](https://user-images.githubusercontent.com/63245456/219344568-c9fc303b-8d19-4ddc-9f50-af88f9e66bd4.png)
</details><details>
<summary>Optional content parameter (edit-message endpoint)</summary>

[Current documentation](https://zulip.com/api/update-message#parameter-content)
![Screenshot from 2023-02-16 11-45-12](https://user-images.githubusercontent.com/63245456/219344551-cf34377c-365c-40bb-86de-3ba957b0b850.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
