### PR TITLE
message-send: Deduplicate check of `settings.MAX_MESSAGE_LENGTH`.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1500,10 +1500,6 @@ def _internal_prep_message(
     messages together as one database query.
     Call do_send_messages with a list of the return values of this method.
     """
-    # Remove any null bytes from the content
-    if len(content) > settings.MAX_MESSAGE_LENGTH:
-        content = content[0:3900] + "\n\n[message was too long and has been truncated]"
-
     # If we have a stream name, and the stream doesn't exist, we
     # create it here (though this code path should probably be removed
     # eventually, moving that responsibility to the caller).  If

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2258,14 +2258,15 @@ class InternalPrepTest(ZulipTestCase):
     def test_error_handling(self) -> None:
         sender = self.example_user("cordelia")
         recipient_user = self.example_user("hamlet")
-        content = "x" * 15000
+        MAX_MESSAGE_LENGTH = settings.MAX_MESSAGE_LENGTH
+        content = "x" * (MAX_MESSAGE_LENGTH + 10)
 
         result = internal_prep_private_message(
             sender=sender, recipient_user=recipient_user, content=content
         )
         assert result is not None
         message = result.message
-        self.assertIn("message was too long", message.content)
+        self.assertIn("message truncated", message.content)
 
         # Simulate sending a message to somebody not in the
         # realm of the sender.


### PR DESCRIPTION
Removes the initial check in `_internal_prep_message` of the length of the message content because the `check_message` in the try block will call `normalize_body` on the message content string, which does a more robust check of the message content (empty string, null bytes, length). If the message content length exceeds the value of `settings.MAX_MESSAGE_LENGTH`, then it is truncated based on that value.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/max.20message.20size/near/1508147) for more context.

**Notes**:
- The removed length check would truncate the message content with a hard coded value instead of using the value for
`settings.MAX_MESSAGE_LENGTH`.
- Also, removes an extraneous comment about removing null bytes. If there are null bytes in the message content, then `normalize_body` will raise an error.
- Updates associated tests to use `settings.MAX_MESSAGE_LENGTH` and the message truncation text used by `normalize_body`.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
