### PR TITLE
tests: Remove ignored parameter from `authenticated_json_view` test.

### DIFF
--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1685,7 +1685,15 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
         user = self.example_user("hamlet")
         self.login_user(user)
         response = self._do_test(user)
-        self.assertEqual(response.status_code, 200)
+        self.assert_json_success(response)
+
+    def test_authenticated_json_post_view_if_user_not_logged_in(self) -> None:
+        user = self.example_user("hamlet")
+        self.assert_json_error_contains(
+            self._do_test(user),
+            "Not logged in: API authentication or user session required",
+            status_code=401,
+        )
 
     def test_authenticated_json_post_view_with_get_request(self) -> None:
         self.login("hamlet")
@@ -1774,7 +1782,7 @@ class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
     def _do_test(self, user: UserProfile) -> "TestHttpResponse":
         stream_name = "stream name"
         self.common_subscribe_to_streams(user, [stream_name], allow_fail=True)
-        data = {"password": initial_password(user.email), "stream": stream_name}
+        data = {"stream": stream_name}
         return self.client_post("/json/subscriptions/exists", data)
 
 


### PR DESCRIPTION
The password parameter being passed in the `_do_test` helper function for `TestAuthenticatedJsonPostViewDecorator` tests was being ignored, as the user needs to be logged in. Removes the parameter from the helper function and updates the success test to use `assert_json_success` instead of just checking the status code.

**Notes**:
- Noted the ignored parameter when running tests for #22808.
- Also adds a test case for when a user is not logged in to confirm that it returns an `UnauthorizedError`.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
