### PR TITLE
build_message_send_dict: Tweak message.realm access.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -541,7 +541,6 @@ def build_message_send_dict(
     stream: Optional[Stream] = None,
     local_id: Optional[str] = None,
     sender_queue_id: Optional[str] = None,
-    realm: Optional[Realm] = None,
     widget_content_dict: Optional[Dict[str, Any]] = None,
     email_gateway: bool = False,
     mention_backend: Optional[MentionBackend] = None,
@@ -552,9 +551,7 @@ def build_message_send_dict(
     production, this is always called by check_message, but some
     testing code paths call it directly.
     """
-    if realm is None:
-        realm = message.realm
-    assert realm == message.realm
+    realm = message.realm
 
     if mention_backend is None:
         mention_backend = MentionBackend(realm.id)
@@ -1534,7 +1531,6 @@ def check_message(
         stream=stream,
         local_id=local_id,
         sender_queue_id=sender_queue_id,
-        realm=realm,
         widget_content_dict=widget_content_dict,
         email_gateway=email_gateway,
         mention_backend=mention_backend,


### PR DESCRIPTION
message.realm is always already set at this point in the codepath. message.sender.realm not necessarily, so that access can trigger a query. In particular it does here in populate_db in send_messages:
```
    for message in messages:
        message_dict = build_message_send_dict(message=message)
```
causing a useless realm fetch in a loop.

The assert is tweaked to go by id instead of object comparison - right now it doesn't make a difference because as mentioned, message.realm is always already fetched, but might avoid a fetch in the future and is just a better practice in general in these query-count sensitive codepaths.

Eliminating this query in a loop in populate_db reduces the amount of time taken up by this message_dict block in `manage.py populate_db` in my machine by 1 second - from ~7.5s to ~6.5s.

