### PR TITLE
create_user: Fix a race with get_realm_user_dicts' cache.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -18,6 +18,7 @@ from zerver.actions.streams import bulk_add_subscriptions, send_peer_subscriber_
 from zerver.actions.user_groups import do_send_user_group_members_update_event
 from zerver.actions.users import change_user_is_active, get_service_dicts_for_bot
 from zerver.lib.avatar import avatar_url
+from zerver.lib.cache import flush_user_profile
 from zerver.lib.create_user import create_user
 from zerver.lib.email_notifications import enqueue_welcome_emails
 from zerver.lib.mention import silent_mention_syntax_for_user
@@ -410,6 +411,7 @@ def do_create_user(
         source_profile=source_profile,
         enable_marketing_emails=enable_marketing_emails,
     )
+    transaction.on_commit(lambda: flush_user_profile(sender=UserProfile, instance=user_profile))
 
     event_time = user_profile.date_joined
     if not acting_user:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -958,7 +958,7 @@ class LoginTest(ZulipTestCase):
         ContentType.objects.clear_cache()
 
         # Ensure the number of queries we make is not O(streams)
-        with self.assert_database_query_count(95), cache_tries_captured() as cache_tries:
+        with self.assert_database_query_count(96), cache_tries_captured() as cache_tries:
             with self.captureOnCommitCallbacks(execute=True):
                 self.register(self.nonreg_email("test"), "test")
 

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -789,7 +789,7 @@ class QueryCountTest(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
 
-        with self.assert_database_query_count(90):
+        with self.assert_database_query_count(91):
             with cache_tries_captured() as cache_tries:
                 with self.tornado_redirected_to_list(events, expected_num_events=11):
                     fred = do_create_user(


### PR DESCRIPTION
UserProfile calls `flush_user_profile` by way of a `post_save` hook. However, this is called while the transaction is still open, and thus the new user is not visible in the database.  This opens a window where a parallel request may fill the `get_realm_user_dicts` cache with a list of users which does not include the
currently-being-created user.

851d68e0fc36 widened the window of possibility, as more actions happen within the transaction, making the race more likely, but the possibility has existed since create_user started being done in a transaction, in 168f241ff0a5.

The user will, upon first request to `/`, get a blank page and a Javascript error:

    Unknown user_id in get_by_user_id: 12345

...where 12345 is their own user-id.  This error will persist until the cache expires (in 7 days) or something else expunges it.

Explicitly trigger an additional cache purge when the transaction has committed.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
