### PR TITLE
models: Defer cache flushes to on transaction commit.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -65,6 +65,7 @@ from zerver.lib.cache import (
     cache_delete,
     cache_set,
     cache_with_key,
+    deferred_hook,
     flush_message,
     flush_muting_users_cache,
     flush_realm,
@@ -989,7 +990,7 @@ class Realm(models.Model):  # type: ignore[django-manager-missing] # django-stub
         return self.has_web_public_streams()
 
 
-post_save.connect(flush_realm, sender=Realm)
+deferred_hook(post_save, flush_realm, sender=Realm)
 
 
 # We register realm cache flushing in a duplicate way to be run both
@@ -1197,8 +1198,8 @@ def flush_realm_emoji(*, instance: RealmEmoji, **kwargs: object) -> None:
     )
 
 
-post_save.connect(flush_realm_emoji, sender=RealmEmoji)
-post_delete.connect(flush_realm_emoji, sender=RealmEmoji)
+deferred_hook(post_save, flush_realm_emoji, sender=RealmEmoji)
+deferred_hook(post_delete, flush_realm_emoji, sender=RealmEmoji)
 
 
 def filter_pattern_validator(value: str) -> Pattern[str]:
@@ -1362,8 +1363,8 @@ def flush_linkifiers(*, instance: RealmFilter, **kwargs: object) -> None:
         per_request_linkifiers_cache.pop(realm_id)
 
 
-post_save.connect(flush_linkifiers, sender=RealmFilter)
-post_delete.connect(flush_linkifiers, sender=RealmFilter)
+deferred_hook(post_save, flush_linkifiers, sender=RealmFilter)
+deferred_hook(post_delete, flush_linkifiers, sender=RealmFilter)
 
 
 def flush_per_request_caches() -> None:
@@ -2260,7 +2261,7 @@ def remote_user_to_email(remote_user: str) -> str:
 
 # Make sure we flush the UserProfile object from our remote cache
 # whenever we save it.
-post_save.connect(flush_user_profile, sender=UserProfile)
+deferred_hook(post_save, flush_user_profile, sender=UserProfile)
 
 
 class PreregistrationUser(models.Model):
@@ -2604,8 +2605,8 @@ class Stream(models.Model):
         ]
 
 
-post_save.connect(flush_stream, sender=Stream)
-post_delete.connect(flush_stream, sender=Stream)
+deferred_hook(post_save, flush_stream, sender=Stream)
+deferred_hook(post_delete, flush_stream, sender=Stream)
 
 
 class UserTopic(models.Model):
@@ -2683,8 +2684,8 @@ class MutedUser(models.Model):
         return f"<MutedUser: {self.user_profile.email} -> {self.muted_user.email}>"
 
 
-post_save.connect(flush_muting_users_cache, sender=MutedUser)
-post_delete.connect(flush_muting_users_cache, sender=MutedUser)
+deferred_hook(post_save, flush_muting_users_cache, sender=MutedUser)
+deferred_hook(post_delete, flush_muting_users_cache, sender=MutedUser)
 
 
 class Client(models.Model):
@@ -3020,7 +3021,7 @@ def get_context_for_message(message: Message) -> QuerySet[Message]:
     ).order_by("-id")[:10]
 
 
-post_save.connect(flush_message, sender=Message)
+deferred_hook(post_save, flush_message, sender=Message)
 
 
 class AbstractSubMessage(models.Model):
@@ -3052,7 +3053,7 @@ class ArchivedSubMessage(AbstractSubMessage):
     message = models.ForeignKey(ArchivedMessage, on_delete=CASCADE)
 
 
-post_save.connect(flush_submessage, sender=SubMessage)
+deferred_hook(post_save, flush_submessage, sender=SubMessage)
 
 
 class Draft(models.Model):
@@ -3496,8 +3497,8 @@ class Attachment(AbstractAttachment):
         }
 
 
-post_save.connect(flush_used_upload_space_cache, sender=Attachment)
-post_delete.connect(flush_used_upload_space_cache, sender=Attachment)
+deferred_hook(post_save, flush_used_upload_space_cache, sender=Attachment)
+deferred_hook(post_delete, flush_used_upload_space_cache, sender=Attachment)
 
 
 def validate_attachment_request_for_spectator_access(
@@ -4744,5 +4745,5 @@ def flush_alert_word(*, instance: AlertWord, **kwargs: object) -> None:
     flush_realm_alert_words(realm)
 
 
-post_save.connect(flush_alert_word, sender=AlertWord)
-post_delete.connect(flush_alert_word, sender=AlertWord)
+deferred_hook(post_save, flush_alert_word, sender=AlertWord)
+deferred_hook(post_delete, flush_alert_word, sender=AlertWord)


### PR DESCRIPTION
Flushing caches at model save time can open the door to race conditions if the work is currently in a transaction.  A parallel request can race and fill the caches before the transaction commits, leaving the cache filled without the newly-saved data.  This now-stale data persists until the cache expires or something else flushes it.

Adjust all of the post_save and post_delete cache flush signals to defer their flush until after the transaction commits, if in a transaction -- and otherwise to take effect immediately, as usual.

Because every test takes place in a transaction, and we are not concerned with race conditions in testing, we apply hooks immediately, rather than require a large number of tests start using `captureOnCommitCallbacks`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
