### PR TITLE
Fix: make date in recipient bar sticky

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -1167,10 +1167,6 @@ td.pointer {
     padding: 3px 11px 2px 10px;
     height: 17px;
     line-height: 17px;
-
-    &.hide-date {
-        display: none;
-    }
 }
 
 .recipient_bar_icon {

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -77,7 +77,7 @@
                     </template>
                 {{/if}}
             </span>
-            <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date">{{{date}}}</span>
         </div>
     </div>
 </div>
@@ -91,7 +91,7 @@
                 {{#tr}}You and {display_reply_to}{{/tr}}
             </a>
 
-            <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date">{{{date}}}</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
removed hide-date class that was making date display none on scroll

Fixes #24323

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#24323
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
