### PR TITLE
emails: Improve "contact us" line in onboarding emails.

### DIFF
--- a/templates/zerver/emails/confirm_registration.html
+++ b/templates/zerver/emails/confirm_registration.html
@@ -20,5 +20,11 @@
     {% endif %}
     <a class="button" href="{{ activate_url }}">{{ _('Complete registration') }}</a>
 </p>
-<p>{% trans support_email=macros.email_tag(support_email) %}Contact us any time at {{ support_email }} if you run into trouble, have any feedback, or just want to chat!{% endtrans %}</p>
+<p>
+    {% if corporate_enabled %}
+        {{macros.contact_us_zulip_cloud(support_email)}}
+    {% else %}
+        {{macros.contact_us_self_hosted(support_email)}}
+    {% endif %}
+</p>
 {% endblock %}

--- a/templates/zerver/emails/followup_day1.html
+++ b/templates/zerver/emails/followup_day1.html
@@ -53,7 +53,10 @@
 </p>
 
 <p>
-    {% trans support_email=macros.email_tag(support_email) %}Questions? Contact
-us any time at {{ support_email }}.{% endtrans %}
+    {% if corporate_enabled %}
+        {% trans %}Questions? <a href="{{ support_email }}">Contact us</a> — we'd love to help!{% endtrans %}
+    {% else %}
+        {{macros.contact_us_self_hosted(support_email)}}
+    {% endif %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/invitation.html
+++ b/templates/zerver/emails/invitation.html
@@ -16,6 +16,10 @@
     <a class="button" href="{{ activate_url }}">{{ _("Complete registration") }}</a>
 </p>
 <p>
-    {% trans support_email=macros.email_tag(support_email) %}Contact us any time at {{ support_email }} if you run into trouble, have any feedback, or just want to chat!{% endtrans %}
+    {% if corporate_enabled %}
+        {{macros.contact_us_zulip_cloud(support_email)}}
+    {% else %}
+        {{macros.contact_us_self_hosted(support_email)}}
+    {% endif %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/macros.html
+++ b/templates/zerver/emails/macros.html
@@ -9,3 +9,11 @@
 {% macro link_tag(url, text) -%}
     <a href="{{ url }}">{{ text | default(url) }}</a>
 {%- endmacro %}
+
+{% macro contact_us_self_hosted(email) -%}
+    {% trans %}If you have any questions, please contact this Zulip server's administrators at <a href="{{ email }}">{{ email }}</a>.{% endtrans %}
+{%- endmacro %}
+
+{% macro contact_us_zulip_cloud(email) -%}
+    {% trans %}Do you have questions or feedback to share? <a href="{{ email }}">Contact us</a> — we'd love to help!{% endtrans %}
+{%- endmacro %}

--- a/templates/zerver/emails/realm_reactivation.html
+++ b/templates/zerver/emails/realm_reactivation.html
@@ -16,5 +16,11 @@
 
 <p>{% trans %}If the request was in error, you can take no action and this link will expire in 24 hours.{% endtrans %}</p>
 
-<p>{% trans support_email=macros.email_tag(support_email) %}Contact us any time at {{ support_email }} if you run into trouble, have any feedback, or just want to chat!{% endtrans %}</p>
+<p>
+    {% if corporate_enabled %}
+        {{macros.contact_us_zulip_cloud(support_email)}}
+    {% else %}
+        {{macros.contact_us_self_hosted(support_email)}}
+    {% endif %}
+</p>
 {% endblock %}


### PR DESCRIPTION
Improve "contact us" line in onboarding emails

as per the issue:
-> make macros
-> use different lines for self hosted and cloud
-> alter the line in follow-up html
Fixes:
https://github.com/zulip/zulip/issues/24260
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
### Self hosted alternative
<details>
<summary>confirm registration</summary>

![self confrimregistration](https://user-images.githubusercontent.com/96613056/219983866-0abf7467-c290-4f71-8e2e-a306fce2bed4.png)
</details>

<details>
<summary>Follow up day 1</summary>

![self followupday1](https://user-images.githubusercontent.com/96613056/219983880-d0e6d396-7d84-4900-ad51-5b7f1a816dae.png)
</details>

<details>
<summary>Invitation</summary>

![self invitation](https://user-images.githubusercontent.com/96613056/219983913-fc4c9cc1-b97b-4ee0-8d85-88f32ab57495.png)
</details>

<details>
<summary>realm reactivation</summary>

![self realmreactivation](https://user-images.githubusercontent.com/96613056/219983947-aa9ddfd6-4302-4525-94ef-536e650eb037.png)
</details>

### Cloud Alternative
<details>
<summary>confirm registration</summary>

![cloud confirmregistration](https://user-images.githubusercontent.com/96613056/219983986-cdac38ea-55f9-4e7d-ac1e-b2eb6709ce73.png)
</details>

<details>
<summary>Follow up day 1</summary>

![cloud followupday1](https://user-images.githubusercontent.com/96613056/219984001-cbcbf5dc-9fbc-4ef9-94d6-fa6c8d792bab.png)
</details>

<details>
<summary>Invitation</summary>

![cloud invitation](https://user-images.githubusercontent.com/96613056/219984010-72d85161-8a41-4c18-9077-4756fb2ca634.png)
</details>

<details>
<summary>Realm reactivation</summary>

![cloud realmreactivation](https://user-images.githubusercontent.com/96613056/219984034-eb16d596-815d-4c42-b031-77a1d958bdee.png)
</details>



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
