### PR TITLE
presence: Switch webapp to use server-provided params.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 164**
+
+* [`POST /register`](/api/register-queue) Added the
+  `server_presence_ping_interval_seconds` and `server_presence_offline_threshold_seconds`
+  attributes.
+
 **Feature level 163**
 
 * [`GET /users`](/api/get-users), [`GET /users/{user_id}`](/api/get-user),

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -577,8 +577,8 @@ test("update_presence_info", ({override}) => {
     override(pm_list, "update_private_messages", () => {});
 
     page_params.realm_presence_disabled = false;
-    page_params.server_presence_ping_interval_seconds = 50;
-    page_params.server_presence_offline_threshold_seconds = 140;
+    page_params.server_presence_ping_interval_seconds = 60;
+    page_params.server_presence_offline_threshold_seconds = 200;
 
     const server_time = 500;
     const info = {

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -577,6 +577,8 @@ test("update_presence_info", ({override}) => {
     override(pm_list, "update_private_messages", () => {});
 
     page_params.realm_presence_disabled = false;
+    page_params.server_presence_ping_interval_seconds = 50;
+    page_params.server_presence_offline_threshold_seconds = 140;
 
     const server_time = 500;
     const info = {

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -422,6 +422,8 @@ test("always show me", () => {
 });
 
 test("level", () => {
+    page_params.server_presence_offline_threshold_seconds = 140;
+
     add_canned_users();
     assert.equal(buddy_data.level(me.user_id), 0);
     assert.equal(buddy_data.level(selma.user_id), 3);

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -422,7 +422,7 @@ test("always show me", () => {
 });
 
 test("level", () => {
-    page_params.server_presence_offline_threshold_seconds = 140;
+    page_params.server_presence_offline_threshold_seconds = 200;
 
     add_canned_users();
     assert.equal(buddy_data.level(me.user_id), 0);

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -5,7 +5,7 @@ const {strict: assert} = require("assert");
 const {mock_esm, zrequire} = require("../zjsunit/namespace");
 const {run_test} = require("../zjsunit/test");
 const blueslip = require("../zjsunit/zblueslip");
-const {user_settings} = require("../zjsunit/zpage_params");
+const {page_params, user_settings} = require("../zjsunit/zpage_params");
 
 const reload_state = mock_esm("../../static/js/reload_state", {
     is_in_progress: () => false,
@@ -78,6 +78,7 @@ people.initialize_current_user(me.user_id);
 
 function test(label, f) {
     run_test(label, ({override}) => {
+        page_params.server_presence_offline_threshold_seconds = OFFLINE_THRESHOLD_SECS;
         user_settings.presence_enabled = true;
         presence.clear_internal_data();
         f({override});

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -15,7 +15,7 @@ const people = zrequire("people");
 const watchdog = zrequire("watchdog");
 const presence = zrequire("presence");
 
-const OFFLINE_THRESHOLD_SECS = 140;
+const OFFLINE_THRESHOLD_SECS = 200;
 
 const me = {
     email: "me@zulip.com",

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -27,8 +27,6 @@ export let user_filter;
 
 /* Broadcast "idle" to server after 5 minutes of local inactivity */
 const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
-/* Time between keep-alive pings */
-const ACTIVE_PING_INTERVAL_MS = 50 * 1000;
 
 /* Keep in sync with views.py:update_active_status_backend() */
 export const ACTIVE = "active";
@@ -246,7 +244,9 @@ export function initialize() {
         send_presence_to_server(true);
     }
 
-    util.call_function_periodically(get_full_presence_list_update, ACTIVE_PING_INTERVAL_MS);
+    /* Time between keep-alive pings */
+    const active_ping_interval_ms = page_params.server_presence_ping_interval_seconds * 1000;
+    util.call_function_periodically(get_full_presence_list_update, active_ping_interval_ms);
 
     // Let the server know we're here, but pass "false" for
     // want_redraw, since we just got all this info in page_params.

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 163
+API_FEATURE_LEVEL = 164
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -696,10 +696,7 @@ def filter_presence_idle_user_ids(user_ids: Set[int]) -> List[int]:
     if not user_ids:
         return []
 
-    # Matches presence.js constant
-    OFFLINE_THRESHOLD_SECS = 140
-
-    recent = timezone_now() - datetime.timedelta(seconds=OFFLINE_THRESHOLD_SECS)
+    recent = timezone_now() - datetime.timedelta(seconds=settings.OFFLINE_THRESHOLD_SECS)
     rows = (
         UserPresence.objects.filter(
             user_profile_id__in=user_ids,

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -354,6 +354,10 @@ def fetch_initial_state_data(
                 realm.demo_organization_scheduled_deletion_date
             )
 
+        # Presence system parameters for client behavior.
+        state["server_presence_ping_interval_seconds"] = settings.PRESENCE_PING_INTERVAL_SECS
+        state["server_presence_offline_threshold_seconds"] = settings.OFFLINE_THRESHOLD_SECS
+
     if want("realm_user_settings_defaults"):
         realm_user_default = RealmUserDefault.objects.get(realm=realm)
         state["realm_user_settings_defaults"] = {}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10260,6 +10260,31 @@ paths:
 
                           **Changes**: New in Zulip 4.0 (feature level 53). Previously,
                           this property always had a value of 10000.
+                      server_presence_ping_interval_seconds:
+                        type: integer
+                        description: |
+                          For clients implementing the [presence](/api/get-presence) system,
+                          the time interval the client should use for sending presence requests
+                          to the server (and thus receive presence updates from the server).
+
+                          It is important for presence implementatios to use both this and
+                          `server_presence_offline_threshold_seconds` correctly, so that a Zulip
+                          server can change these values to manage the trade-off between load and
+                          freshness of presence data.
+
+                          **Changes**: New in Zulip 7.0 (feature level 164). Clients should use 60
+                          for older Zulip servers, since that's the value that was hardcoded in the
+                          the Zulip mobile apps prior to this parameter being introduced.
+                      server_presence_offline_threshold_seconds:
+                        type: integer
+                        description: |
+                          How old a presence timestamp for a given user can be before the user
+                          should be displayed as offline by clients displaying Zulip presence
+                          data. See the related `server_presence_ping_interval_seconds` for details.
+
+                          **Changes**: New in Zulip 7.0 (feature level 164). Clients should use 140
+                          for older Zulip servers, since that's the value that was hardcoded in the
+                          Zulip client apps prior to this parameter being introduced.
                       muted_topics:
                         type: array
                         deprecated: true

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -196,6 +196,8 @@ class HomeTest(ZulipTestCase):
         "server_inline_url_embed_preview",
         "server_name_changes_disabled",
         "server_needs_upgrade",
+        "server_presence_offline_threshold_seconds",
+        "server_presence_ping_interval_seconds",
         "server_timestamp",
         "server_web_public_streams_enabled",
         "settings_send_digest_emails",

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -487,14 +487,26 @@ LOG_API_EVENT_TYPES = False
 # TODO: Replace this with a smarter "run on only one server" system.
 STAGING = False
 
-# How long to wait before presence should treat a user as offline.
-OFFLINE_THRESHOLD_SECS = 140
-
+# Presence tuning parameters. These values were hardcoded in clients
+# before Zulip 7.0 (feature level 164); modern clients should get them
+# via the /register API response, making it possible to tune these to
+# adjust the trade-off between freshness and presence-induced load.
+#
+# The default for OFFLINE_THRESHOLD_SECS is chosen as
+# `PRESENCE_PING_INTERVAL_SECS * 3 + 20`, which is designed to allow 2
+# round trips, plus an extra in case an update fails. See
+# https://zulip.readthedocs.io/en/latest/subsystems/presence.html for
+# details on the presence architecture.
+#
+# How long to wait before clients should treat a user as offline.
+OFFLINE_THRESHOLD_SECS = 200
 # How often a client should ping by asking for presence data of all users.
-PRESENCE_PING_INTERVAL_SECS = 50
-
-# Specifies the number of active users in the realm
-# above which sending of presence update events will be disabled.
+PRESENCE_PING_INTERVAL_SECS = 60
+# Zulip sends immediate presence updates via the events system when a
+# user joins or becomes online. In larger organizations, this can
+# become prohibitively expensive, so we limit how many active users an
+# organization can have before these presence update events are
+# disabled.
 USER_LIMIT_FOR_SENDING_PRESENCE_UPDATE_EVENTS = 100
 
 # How many days deleted messages data should be kept before being

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -488,10 +488,8 @@ LOG_API_EVENT_TYPES = False
 STAGING = False
 
 # How long to wait before presence should treat a user as offline.
-# TODO: Figure out why this is different from the corresponding
-# value in static/js/presence.js.  Also, probably move it out of
-# default_settings, since it likely isn't usefully user-configurable.
-OFFLINE_THRESHOLD_SECS = 5 * 60
+# Should match the presence.js constant.
+OFFLINE_THRESHOLD_SECS = 140
 
 # Specifies the number of active users in the realm
 # above which sending of presence update events will be disabled.

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -488,7 +488,6 @@ LOG_API_EVENT_TYPES = False
 STAGING = False
 
 # How long to wait before presence should treat a user as offline.
-# Should match the presence.js constant.
 OFFLINE_THRESHOLD_SECS = 140
 
 # How often a client should ping by asking for presence data of all users.

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -491,6 +491,9 @@ STAGING = False
 # Should match the presence.js constant.
 OFFLINE_THRESHOLD_SECS = 140
 
+# How often a client should ping by asking for presence data of all users.
+PRESENCE_PING_INTERVAL_SECS = 50
+
 # Specifies the number of active users in the realm
 # above which sending of presence update events will be disabled.
 USER_LIMIT_FOR_SENDING_PRESENCE_UPDATE_EVENTS = 100


### PR DESCRIPTION
Preparatory PR for https://github.com/zulip/zulip/pull/16381 - implementing the plan discussed around https://chat.zulip.org/#narrow/stream/3-backend/topic/UserPresence.20system.20rewrite/near/1506240 