### PR TITLE
css: Remove bootstrap `code` element styling.

### DIFF
--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -72,16 +72,6 @@ $category-text: hsl(219, 23%, 33%);
         list-style: circle;
     }
 
-    code {
-        display: inline-block;
-        vertical-align: middle;
-        max-width: 100%;
-        overflow: auto;
-
-        font-family: "Source Code Pro", monospace;
-        font-size: 0.85em;
-    }
-
     .integration-main-text {
         padding: 0 15px;
     }

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -217,6 +217,10 @@
     a {
         color: hsl(176, 46%, 41%);
         font-weight: 600;
+
+        code {
+            color: hsl(176, 46%, 41%);
+        }
     }
 
     strong {
@@ -363,20 +367,18 @@
     }
 
     code {
-        /* Different from zulip.css */
-        font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+        /* Same font-family as zulip.css */
+        font-family: "Source Code Pro", monospace;
         /* Same as base rules for code elements in rendered_markdown.css */
         font-size: 0.825em;
         unicode-bidi: embed;
         direction: ltr;
         color: hsl(0, 0%, 0%);
-        border: 1px solid hsl(240, 13%, 90%);
         border-radius: 3px;
         /* Different from base rules for code elements in rendered_markdown.css */
         white-space: initial;
-        padding: 0;
-        padding-right: 4px;
-        background-color: hsl(0, 0%, 100%);
+        padding: 0 4px;
+        background-color: hsl(0, 0%, 93%);
     }
 
     pre {

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -363,10 +363,16 @@
     }
 
     code {
-        /* Copied from rendered_markdown.css */
+        /* Different from zulip.css */
+        font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+        /* Same as base rules for code elements in rendered_markdown.css */
         font-size: 0.825em;
         unicode-bidi: embed;
         direction: ltr;
+        color: hsl(0, 0%, 0%);
+        border: 1px solid hsl(240, 13%, 90%);
+        border-radius: 3px;
+        /* Different from base rules for code elements in rendered_markdown.css */
         white-space: initial;
         padding: 0;
         padding-right: 4px;
@@ -378,6 +384,9 @@
             font-size: 14px;
             white-space: pre-wrap;
             padding: 0;
+            color: inherit;
+            background-color: transparent;
+            border: 0;
         }
     }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -613,6 +613,10 @@ code {
     direction: ltr;
     color: hsl(0, 0%, 0%);
     white-space: pre;
+    padding: 2px 4px;
+    background-color: hsl(240, 14%, 97%);
+    border: 1px solid hsl(240, 13%, 90%);
+    border-radius: 3px;
 }
 
 .rendered_markdown code {
@@ -673,6 +677,10 @@ pre {
 pre code {
     overflow-x: scroll;
     white-space: pre;
+    padding: 0;
+    color: inherit;
+    background-color: transparent;
+    border: 0;
 }
 
 /* Style inline code inside a link

--- a/web/third/bootstrap/css/bootstrap.css
+++ b/web/third/bootstrap/css/bootstrap.css
@@ -281,7 +281,6 @@ blockquote:before,
 blockquote:after {
   content: "";
 }
-code,
 pre {
   padding: 0 3px 2px;
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
@@ -290,13 +289,6 @@ pre {
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
-}
-code {
-  padding: 2px 4px;
-  color: #d14;
-  background-color: #f7f7f9;
-  border: 1px solid #e1e1e8;
-  white-space: nowrap;
 }
 pre {
   display: block;
@@ -314,14 +306,6 @@ pre {
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
-}
-pre code {
-  padding: 0;
-  color: inherit;
-  white-space: pre;
-  white-space: pre-wrap;
-  background-color: transparent;
-  border: 0;
 }
 .label {
   display: inline-block;


### PR DESCRIPTION
Moves all HTML `code` element CSS rules from `bootstrap.css` to `markdown.css` and `rendered_markdown.css`.

[Relevant CZO conversation](https://chat.zulip.org/#narrow/stream/19-documentation/topic/color.20of.20code.20elements/near/1510666).

**Notes**:
- **Web-app changes**:
  - All code element rules are now in `rendered_markdown.css`.
  - The linkifiers and code playground tabs in the **Organization settings** overlay have code elements that are not styled with the `rendered_markdown` class, so the general rules for code elements cannot be removed, see `TODO` comment in `rendered_markdown.css`.
  - Does not make any style changes for the redesign project. But does isolate the CSS for code elements in the web-app from the CSS in the documentation pages. In the screenshots below, no changes are shown between the current main branch and these changes.
- **Documentation changes**:
  - In the first commit, the code element rules are moved to `markdown.css`. The only style change is removing the pink/fucsia color from the inline code elements, so that they are styled with `color: hsl(0, 0%, 20%);` instead.
  - In the second commit, restyles the code elements in the documentation (see screenshots below) such that:
    - Changes the font-family to match the one used in `zulip.css` for the web-app.
    - There are no longer borders around inline code elements. Instead there is a grey background color. Removes the background color for block code elements.
    - Makes the right and left padding for inline code elements symmetrical. Previously there was only padding on the right.
    - Has inline code elements inherit the color from the anchor element if they are links.
    - Removes the `color: inherit;` rule for pre code elements, which was inheriting the color from the bootstrap body rule. Now if that bootstrap rule is removed, the color of these elements won't change unexpectedly.  

---

### Screenshots and screen captures

**Web app screenshots (there should be no differences between before and after)**:

<details>
<summary>Help menu - message formatting - dark theme</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/220366387-b28532a6-35d5-469b-b2be-adabc26b934f.png) | ![image](https://user-images.githubusercontent.com/63245456/220366414-3137432f-0a08-44d5-8050-152bab388dbd.png)
</details>
<details>
<summary>Help menu - message formatting - light theme</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/220366455-f3d676d9-5df2-4fdc-8d1d-d9508c8fe495.png) | ![image](https://user-images.githubusercontent.com/63245456/220366484-dba248da-5225-4da0-9258-a66595dba4b9.png)
</details>
<details>
<summary>Organization settings - linkifiers - light theme</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/220366518-94036884-a1be-4bdb-9202-daffd9891c1a.png) | ![image](https://user-images.githubusercontent.com/63245456/220366554-957dd473-532c-4f9c-a982-4d6b360fdd89.png)

**CSS in dev tools**
![Screenshot from 2023-02-21 17-37-45](https://user-images.githubusercontent.com/63245456/220405623-622aae35-9354-4c3e-a2c4-0da3ab9fbff5.png)

</details>
<details>
<summary>Organization settings - linkifiers - dark theme</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/220366599-903d2468-ce96-4846-8c0e-3bcb378cbea4.png) | ![image](https://user-images.githubusercontent.com/63245456/220366634-e10a4785-fb6b-4a47-b131-e5d94d5d7889.png)
</details>
<details>
<summary>Message feed - dark theme</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/220366667-443023c2-28c3-48a9-b45b-d13ac98e98dc.png) | ![image](https://user-images.githubusercontent.com/63245456/220366691-9421ad8c-45fd-4c0d-aa26-338dc3fdb418.png)
</details>
<details>
<summary>Message feed - light theme</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/220366747-13666c1b-3c35-4255-abe7-5e9ce46a69f0.png) | ![image](https://user-images.githubusercontent.com/63245456/220366782-9c45b43b-ce93-4b75-a9f3-7b108d1c4d78.png)

**CSS in dev tools**
![Screenshot from 2023-02-21 17-33-39](https://user-images.githubusercontent.com/63245456/220405078-d32a5fbf-7eea-4f59-8381-ccf077a85c8a.png)
![Screenshot from 2023-02-21 17-35-19](https://user-images.githubusercontent.com/63245456/220405092-687a35b4-df25-411b-a855-fb2e12be7a59.png)
![Screenshot from 2023-02-21 17-35-44](https://user-images.githubusercontent.com/63245456/220405096-bba87c09-745a-4476-9f86-e15d34438785.png)

</details>

**Documentation screenshots**:

<details>
<summary>Help docs: Import from Mattermost</summary>

[Current documentation](https://zulip.com/help/import-from-mattermost#export-your-mattermost-data)
![Screenshot from 2023-02-21 15-11-54](https://user-images.githubusercontent.com/63245456/220368635-6709cc75-403f-4fe1-be78-1d5253784350.png)

</details>
<details>
<summary>Help docs: Emoji and emoticons</summary>

[Current documentation](https://zulip.com/help/emoji-and-emoticons)
![Screenshot from 2023-02-21 15-11-16](https://user-images.githubusercontent.com/63245456/220368458-01ec5b1e-c6b7-46b7-ba8c-0249ebe681a8.png)

</details>
<details>
<summary>Help docs: Message formatting</summary>

[Current documentation](https://zulip.com/help/format-your-message-using-markdown#emphasis)
![Screenshot from 2023-02-21 15-10-42](https://user-images.githubusercontent.com/63245456/220368351-ef09fedc-009c-4185-8ea5-ba3984ebde58.png)

</details>
<details>
<summary>API docs: Changelog</summary>

[Current documentation](https://zulip.com/api/changelog)
![Screenshot from 2023-02-21 15-08-16](https://user-images.githubusercontent.com/63245456/220368052-b9799bc7-59f2-403d-b511-b00112172275.png)
</details>
<details>
<summary>API docs: Get events endpoint</summary>

[Current documentation](https://zulip.com/api/get-events)
![Screenshot from 2023-02-21 15-06-46](https://user-images.githubusercontent.com/63245456/220367978-53d9b813-e69f-4506-be39-2fcb826f7595.png)
![Screenshot from 2023-02-21 15-06-57](https://user-images.githubusercontent.com/63245456/220367990-a78e05fa-55ea-46d6-b2d4-e693281e2266.png)
![Screenshot from 2023-02-21 15-07-07](https://user-images.githubusercontent.com/63245456/220368005-5f7b5fd2-a3e2-4abd-9331-f32feb6e43ac.png)
</details>
<details>
<summary>Github integration doc</summary>

[Current documentation](https://zulip.com/integrations/doc/github)
![Screenshot from 2023-02-22 17-15-47](https://user-images.githubusercontent.com/63245456/220689815-5969d94c-6cce-4c82-90fb-94ae9c22c187.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
