### PR TITLE
message_events: Don't show scroll to view msg notice in recent conver…

### DIFF
--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -47,8 +47,8 @@ function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) 
         },
         timeout: 5000,
         success(data) {
-            if (msg_list !== message_lists.current) {
-                // We unnarrowed in the mean time
+            if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
+                // We unnarrowed or moved to Recent Topics in the meantime.
                 return;
             }
 
@@ -81,7 +81,7 @@ function maybe_add_narrowed_messages(messages, msg_list, callback, attempt = 1) 
             notifications.notify_messages_outside_current_search(elsewhere_messages);
         },
         error(xhr) {
-            if (msg_list.narrowed && msg_list !== message_lists.current) {
+            if (!narrow_state.is_message_feed_visible() || msg_list !== message_lists.current) {
                 return;
             }
             if (xhr.status === 400) {

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -141,7 +141,8 @@ export function insert_new_messages(messages, sent_by_this_client) {
         // looks at message feed scroll positions to see whether the
         // newly arrived message will be visible, is only valid if
         // this message list is the currently visible message list.
-        const is_currently_visible = list === message_lists.current;
+        const is_currently_visible =
+            narrow_state.is_message_feed_visible() && list === message_lists.current;
         if (is_currently_visible && render_info && render_info.need_user_to_scroll) {
             need_user_to_scroll = true;
         }

--- a/web/tests/example5.test.js
+++ b/web/tests/example5.test.js
@@ -30,7 +30,17 @@ const stream_list = mock_esm("../src/stream_list");
 const unread_ops = mock_esm("../src/unread_ops");
 const unread_ui = mock_esm("../src/unread_ui");
 
-message_lists.home = {};
+message_lists.current = {
+    data: {
+        filter: {
+            can_apply_locally() {
+                return true;
+            },
+        },
+    },
+};
+message_lists.home = message_lists.current;
+message_lists.all_rendered_message_lists = () => [message_lists.home, message_lists.current];
 
 // And we will also test some real code, of course.
 const message_events = zrequire("message_events");
@@ -108,6 +118,7 @@ run_test("insert_message", ({override}) => {
     assert.deepEqual(helper.events, [
         [huddle_data, "process_loaded_messages"],
         [message_util, "add_new_messages_data"],
+        [message_util, "add_new_messages"],
         [message_util, "add_new_messages"],
         [unread_ui, "update_unread_counts"],
         [unread_ops, "process_visible"],


### PR DESCRIPTION
…sations.

This fixes a bug where user can see the notice
"Scroll down to view your message." when sending a message in recent conversation. This happened because it doesn't take into account recent conversations being visible.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/message.20sent.20banner.20in.20recent.20conversations