### PR TITLE
help: Document modifying email visibility on sign-up.

### DIFF
--- a/help/configure-email-visibility.md
+++ b/help/configure-email-visibility.md
@@ -9,6 +9,17 @@ for new users in the organization.
 
 {start_tabs}
 
+{tab|on-sign-up}
+
+1. After confirming your email, click **Change** below your email address.
+
+1. Configure **Who can access your email address**.
+
+1. Click **Confirm** to apply your changes, and continue the account registration
+   process.
+
+{tab|desktop-web}
+
 {settings_tab|account-and-privacy}
 
 1. Under **Privacy**, configure **Who can access your email address**.

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -92,6 +92,7 @@ TAB_SECTION_LABELS = {
     "logged-out": "If you are logged out",
     "user": "User",
     "bot": "Bot",
+    "on-sign-up": "On sign-up",
 }
 
 


### PR DESCRIPTION
This documents the functionality in #24394, and should not be merged before that PR.

Changes: adds a new tab to the first instruction block on `/help/configure-email-visibility`.

![Screen Shot 2023-02-23 at 2 33 07 PM](https://user-images.githubusercontent.com/2090066/221046127-9806516a-bf52-49fd-901e-8a804807fe8a.png)

