### PR TITLE
help: Add section on privacy settings to /help/review-your-settings.

### DIFF
--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -42,10 +42,10 @@
 * [Logging out](/help/logging-out)
 * [Switching between organizations](/help/switching-between-organizations)
 * [Import your settings](/help/import-your-settings)
+* [Review your settings](/help/review-your-settings)
 * [Deactivate your account](/help/deactivate-your-account)
 
 ## Display settings
-* [Review your settings](/help/review-your-settings)
 * [Dark theme](/help/dark-theme)
 * [Change your language](/help/change-your-language)
 * [Change your time zone](/help/change-your-timezone)

--- a/help/review-your-settings.md
+++ b/help/review-your-settings.md
@@ -4,7 +4,7 @@ We recommend reviewing all of your settings when you start using Zulip, and
 then once again a few weeks later once you've gotten a better feel for how
 you use Zulip.
 
-### Review your settings
+## Review your settings
 
 {start_tabs}
 
@@ -14,13 +14,23 @@ you use Zulip.
 
 {end_tabs}
 
-### Review your display settings
+## Review your display settings
 
 {start_tabs}
 
 {relative|gear|settings}
 
 1. Click on the **Display settings** tab on the left.
+
+{end_tabs}
+
+## Review your privacy settings
+
+{start_tabs}
+
+{relative|gear|settings}
+
+1. Click on the **Account & privacy** tab on the left.
 
 {end_tabs}
 


### PR DESCRIPTION
Also move "Review your settings" page to the "Account basics" section in the left sidebar.

I don't think we need to document every panel on this page, but the privacy settings seem worth calling out.


Current: https://zulip.com/help/review-your-settings

Updated:

![Screen Shot 2023-02-22 at 3 18 18 PM](https://user-images.githubusercontent.com/2090066/220785560-8232e48c-87b5-41d6-8768-166e19ec2840.png)

