### PR TITLE
queue: Only set QOS on a newly-opened channel, once.

### DIFF
--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -160,9 +160,10 @@ class SimpleQueueClient(QueueClient[BlockingChannel]):
         the callback with no arguments."""
         if self.connection is None or not self.connection.is_open:
             self._connect()
-
-        assert self.channel is not None
-        self.channel.basic_qos(prefetch_count=self.prefetch)
+            assert self.channel is not None
+            self.channel.basic_qos(prefetch_count=self.prefetch)
+        else:
+            assert self.channel is not None
 
         if queue_name not in self.queues:
             self.channel.queue_declare(queue=queue_name, durable=True)


### PR DESCRIPTION
As written, the QOS parameters are (re)set every time ensure_queue is called, which is every time a message is enqueued. This is wasteful -- particularly QOS parameters only apply for consumers, and setting them takes a RTT to the server.

Switch to only setting the QOS once, when a connection is (re)established.  In profiling, this reduces the time to call `queue_json_publish("noop", {})` from 878µs to 150µs.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
