### PR TITLE
integrations: Increase font size of trademark disclaimer.

### DIFF
--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -570,7 +570,7 @@ $category-text: hsl(219, 23%, 33%);
             }
 
             .logos_disclaimer {
-                font-size: 13px;
+                font-size: 14px;
                 font-style: italic;
             }
 


### PR DESCRIPTION
This is to address Google complaining that the font size is too small to read on the integration pages.

before:
<img width="1357" alt="Screenshot 2023-02-23 at 12 33 40 PM" src="https://user-images.githubusercontent.com/25124304/220839778-37da3a33-5ea8-42fa-8eec-276df21a039e.png">
after:

<img width="1357" alt="Screenshot 2023-02-23 at 12 33 27 PM" src="https://user-images.githubusercontent.com/25124304/220839806-c0501afc-1868-41a0-b87a-1d0415ad4cb4.png">
