### PR TITLE
tippy: Add more delay to compose and message control button tooltips.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -71,26 +71,20 @@ const LONG_HOVER_DELAY = [750, 20];
 // so make sure to check this too after checking tippyjs
 // documentation for default properties.
 tippy.setDefaultProps({
-    // We don't want tooltips
-    // to take more space than
-    // mobile widths ever.
+    // Tooltips shouldn't take more space than mobile widths.
     maxWidth: 300,
-
     delay: INSTANT_HOVER_DELAY,
     placement: "top",
-
-    // disable animations to make the
-    // tooltips feel snappy
+    // Disable animations to make the tooltips feel snappy.
     animation: false,
-
-    // Show tooltips on long press on touch based
-    // devices.
+    // Show tooltips on long press on touch based devices.
     touch: ["hold", 750],
-
-    // This has the side effect of some properties of parent applying to
-    // tooltips.
+    // Create the tooltip inside the parent element. This has the
+    // undesirable side effect of CSS properties of the parent elements
+    // applying to tooltips, which causes ugly clipping if the parent
+    // element has overflow rules. We override this in many specific
+    // tooltips, and may want to change the default.
     appendTo: "parent",
-
     // To add a text tooltip, override this by setting data-tippy-content.
     // To add an HTML tooltip, set data-tooltip-template-id to the id of a <template>.
     // Or, override this with a function returning string (text) or DocumentFragment (HTML).

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -59,6 +59,14 @@ function hide_tooltip_if_reference_removed(
     observer.observe(target_node, config);
 }
 
+// We use two delay settings for tooltips. The default "instant"
+// version has just a tiny bit of delay to create a natural feeling
+// transition, while the "long" version is intended for elements where
+// we want to avoid distracting the user with the tooltip
+// unnecessarily.
+const INSTANT_HOVER_DELAY = [100, 20];
+const LONG_HOVER_DELAY = [750, 20];
+
 // We override the defaults set by tippy library here,
 // so make sure to check this too after checking tippyjs
 // documentation for default properties.
@@ -68,9 +76,7 @@ tippy.setDefaultProps({
     // mobile widths ever.
     maxWidth: 300,
 
-    // Some delay to showing / hiding the tooltip makes
-    // it look less forced and more natural.
-    delay: [100, 20],
+    delay: INSTANT_HOVER_DELAY,
     placement: "top",
 
     // disable animations to make the
@@ -149,7 +155,7 @@ export function initialize() {
         // Add some additional delay when they open
         // so that regular users don't have to see
         // them unless they want to.
-        delay: [300, 20],
+        delay: LONG_HOVER_DELAY,
         // This ensures that the upload files tooltip
         // doesn't hide behind the left sidebar.
         appendTo: () => document.body,
@@ -163,7 +169,7 @@ export function initialize() {
         // Add some additional delay when they open
         // so that regular users don't have to see
         // them unless they want to.
-        delay: [300, 20],
+        delay: LONG_HOVER_DELAY,
         onShow(instance) {
             // Handle dynamic "starred messages" and "edit" widgets.
             const $elem = $(instance.reference);
@@ -443,7 +449,7 @@ export function initialize() {
             }
             return true;
         },
-        delay: [500, 20],
+        delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
     });
 
@@ -461,7 +467,7 @@ export function initialize() {
         content: $t({
             defaultMessage: "View user card (u)",
         }),
-        delay: [500, 20],
+        delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
     });
 }


### PR DESCRIPTION
This now matches the delay we have for other tooltips so that they feel less intrusive for regular users.

discussion: https://chat.zulip.org/#narrow/stream/431-redesign-project/topic/UI.20redesign.3A.20tooltip.20style.20and.20hotkey.20representation.20.2321753
