### PR TITLE
google_analytics: Track realm registration separately from user signup.

### DIFF
--- a/templates/confirmation/confirm_preregistrationuser.html
+++ b/templates/confirmation/confirm_preregistrationuser.html
@@ -13,7 +13,7 @@ requisite context to make a useful signup form. Therefore, we immediately
 post to another view which executes in our code to produce the desired form.
 #}
 
-<form id="register" action="/accounts/register/" method="post">
+<form id="register" action="{{ registration_url }}" method="post">
     {{ csrf_input }}
     <input type="hidden" value="{{ key }}" name="key"/>
     <input type="hidden" value="1" name="from_confirmation"/>

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -306,7 +306,7 @@ class TestGenerateRealmCreationLink(ZulipTestCase):
 
         # Bypass sending mail for confirmation, go straight to creation form
         result = self.client_get(result["Location"])
-        self.assert_in_response('action="/accounts/register/"', result)
+        self.assert_in_response('action="/realm/register/"', result)
 
         # Original link is now dead
         result = self.client_get(generated_link)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3625,7 +3625,7 @@ class RealmCreationTest(ZulipTestCase):
             "key": find_key_by_email(email),
             "from_confirmation": "1",
         }
-        result = self.client_post("/accounts/register/", payload)
+        result = self.client_post("/realm/register/", payload)
         # Assert that the form did not prompt the user for enabling
         # marketing emails.
         self.assert_not_in_success_response(['input id="id_enable_marketing_emails"'], result)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -127,6 +127,7 @@ from zerver.views.registration import (
     get_prereg_key_and_redirect,
     new_realm_send_confirm,
     realm_redirect,
+    realm_register,
     signup_send_confirm,
 )
 from zerver.views.report import (
@@ -579,6 +580,7 @@ i18n_urls = [
         name="new_realm_send_confirm",
     ),
     path("accounts/register/", accounts_register, name="accounts_register"),
+    path("realm/register/", realm_register, name="realm_register"),
     path(
         "accounts/do_confirm/<confirmation_key>",
         get_prereg_key_and_redirect,


### PR DESCRIPTION
While the function which processes the realm registration and signup remains the same, we use different urls and functions to call the process so that we can separately track them. This will help us know the conversion rate of realm registration after receiving the confirmation link.
