### PR TITLE
message feed ui: added new approach to mark message as unread

### DIFF
--- a/web/src/message_live_update.js
+++ b/web/src/message_live_update.js
@@ -8,6 +8,19 @@ export function rerender_messages_view() {
     }
 }
 
+export function rerender_messages_view_by_message_ids(message_ids) {
+    const messages_to_render = [];
+    for (const id of message_ids) {
+        const message = message_store.get(id);
+        if (message !== undefined) {
+            messages_to_render.push(message);
+        }
+    }
+    for (const list of message_lists.all_rendered_message_lists()) {
+        list.view.rerender_messages(messages_to_render);
+    }
+}
+
 function rerender_messages_view_for_user(user_id) {
     for (const list of message_lists.all_rendered_message_lists()) {
         const messages = list.data.get_messages_sent_by_user(user_id);

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -329,7 +329,7 @@ export function process_unread_messages_event({message_ids, message_details}) {
         The main downside of doing a full rerender is that it can be
         user-visible in the form of users' avatars flickering.
     */
-    message_live_update.rerender_messages_view();
+    message_live_update.rerender_messages_view_by_message_ids(message_ids);
     recent_topics_ui.complete_rerender();
 
     if (


### PR DESCRIPTION
Added new approach for mark as unread message as suggested in the issue

Fixes: #24263 

Self-review checklist
- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

 - [x] Visual appearance of the changes.
 - [x] Responsiveness and internationalization.
 - [x] Strings and tooltips.
 - [x] End-to-end functionality of buttons, interactions and flows.
 - [x] Corner cases, error conditions, and easily imagined bugs.