### PR TITLE
modal: Do not use flex for all modal titles.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -50,7 +50,6 @@
     font-size: 1.375rem;
     font-weight: 600;
     line-height: 1.25;
-    display: flex;
 
     /* help_link_widget margin for the fa-circle-o. */
     .help_link_widget {
@@ -61,6 +60,7 @@
 .user_profile_name_heading {
     padding-right: 1rem;
     max-width: 80%;
+    display: flex;
 
     .user_profile_name {
         white-space: nowrap;

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -6,7 +6,7 @@
         {{#if is_long_text_field}}
         <textarea maxlength="500" class="custom_user_field_value settings_textarea">{{ field_value.value }}</textarea>
         {{else if is_select_field}}
-        <select class="custom_user_field_value settings_select bootstrap-focus-style">
+        <select class="custom_user_field_value settings_select modal_select bootstrap-focus-style">
             <option value=""></option>
             {{#each field_choices}}
                 <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>


### PR DESCRIPTION
The "display: flex" property was added to ".modal__title" element in 9e4aa19ac
in #24194 to fix overlay of long name in user profile modal (#23781).

Due to this change, the space between words in heading of "Archive stream"
modal is being removed.

This PR fixes it by adding "display: flex" only to the title of user profile modal and
not all the modals. There is no major change in other modals, except that the space
between heading and help-link widget has increased which was anyways the case
before adding the flex property and that can be modified later if we want to.

<!-- Describe your pull request here.-->
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before
![Screenshot from 2023-02-24 17-40-24](https://user-images.githubusercontent.com/35494118/221178453-5d795d8f-bcc8-4fe5-bf84-c3b8d574e6b1.png)
After
![Screenshot from 2023-02-24 17-37-43](https://user-images.githubusercontent.com/35494118/221178434-ec397689-f5e5-43de-84c7-3d420deb5094.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
