### PR TITLE
eslint: Prohibit import cycles in TypeScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -193,6 +193,7 @@
                 "@typescript-eslint/prefer-string-starts-ends-with": "error",
                 "@typescript-eslint/promise-function-async": "error",
                 "@typescript-eslint/unified-signatures": "error",
+                "import/no-cycle": "error",
                 "no-undef": "error"
             }
         },


### PR DESCRIPTION
Once we get to a reasonable acyclic graph, let’s never go back.