### PR TITLE
Make parameters optional in PATCH user_groups/<int:user_group_id>. 

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,10 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 165**
+* [`PATCH /user_groups/{user_group_id}`](/api/update-user-group): The
+  `name` and `description` parameters are now optional.
+
 **Feature level 164**
 
 * [`POST /register`](/api/register-queue): Added the

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 164
+API_FEATURE_LEVEL = 165
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -274,13 +274,9 @@ export function initialize() {
         }
         if (new_name !== group.name) {
             data.name = new_name;
-        } else {
-            data.name = group.name;
         }
         if (new_description !== group.description) {
             data.description = new_description;
-        } else {
-            data.description = group.description;
         }
 
         const $status_element = $(".group_change_property_info");

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15061,18 +15061,22 @@ paths:
           in: query
           description: |
             The new name of the group.
+
+            **Changes**: Before Zulip 7.0 (feature level 165), this was
+            a required field.
           schema:
             type: string
           example: marketing team
-          required: true
         - name: description
           in: query
           description: |
             The new description of the group.
+
+            **Changes**: Before Zulip 7.0 (feature level 165), this was
+            a required field.
           schema:
             type: string
           example: The marketing team.
-          required: true
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -283,6 +283,11 @@ class UserGroupAPITestCase(UserGroupTestCase):
         result = self.client_patch(f"/json/user_groups/{user_group.id}", info={})
         self.assert_json_error(result, "No new data supplied")
 
+        # Test when only one of name or description is supplied.
+        params = {"name": "help team"}
+        result = self.client_patch(f"/json/user_groups/{user_group.id}", info=params)
+        self.assert_json_success(result)
+
         # Test when invalid user group is supplied
         params = {"name": "help"}
         result = self.client_patch("/json/user_groups/1111", info=params)

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
@@ -62,18 +62,18 @@ def edit_user_group(
     request: HttpRequest,
     user_profile: UserProfile,
     user_group_id: int = REQ(json_validator=check_int, path_only=True),
-    name: str = REQ(default=""),
-    description: str = REQ(default=""),
+    name: Optional[str] = REQ(default=None),
+    description: Optional[str] = REQ(default=None),
 ) -> HttpResponse:
-    if not (name or description):
+    if name is None and description is None:
         raise JsonableError(_("No new data supplied"))
 
     user_group = access_user_group_by_id(user_group_id, user_profile)
 
-    if name != user_group.name:
+    if name is not None and name != user_group.name:
         do_update_user_group_name(user_group, name, acting_user=user_profile)
 
-    if description != user_group.description:
+    if description is not None and description != user_group.description:
         do_update_user_group_description(user_group, description, acting_user=user_profile)
 
     return json_success(request)


### PR DESCRIPTION
  View that handled `PATCH user_groups/<int:user_group_id>` required
  both name and description parameters to be passed. Due to this
  clients had to pass values for both these parameters even if
  one of them was changed.
  
  To resolve this name description parameters to
  `PATCH user_groups/<int:user_group_id>` are made optional.

Fixes: [CZO link](https://chat.zulip.org/#narrow/stream/378-api-design/topic/Required.20parameters.20for.20user.20group.20edit)

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
