### PR TITLE
data_import: Stop tar'ing up converted data.

### DIFF
--- a/zerver/data_import/gitter.py
+++ b/zerver/data_import/gitter.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 from typing import Any, Dict, List, Set, Tuple
 
 import dateutil.parser
@@ -387,8 +386,6 @@ def do_convert_data(gitter_data_file: str, output_dir: str, threads: int = 6) ->
     create_converted_data_files([], output_dir, "/uploads/records.json")
     # IO attachments records
     create_converted_data_files(attachment, output_dir, "/attachment.json")
-
-    subprocess.check_call(["tar", "-czf", output_dir + ".tar.gz", output_dir, "-P"])
 
     logging.info("######### DATA CONVERSION FINISHED #########\n")
     logging.info("Zulip data dump created at %s", output_dir)

--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -1002,7 +1002,3 @@ def do_convert_data(mattermost_data_dir: str, output_dir: str, masking_content: 
         attachment: Dict[str, List[Any]] = {"zerver_attachment": zerver_attachment}
         create_converted_data_files(uploads_list, realm_output_dir, "/uploads/records.json")
         create_converted_data_files(attachment, realm_output_dir, "/attachment.json")
-
-        logging.info("Start making tarball")
-        subprocess.check_call(["tar", "-czf", realm_output_dir + ".tar.gz", realm_output_dir, "-P"])
-        logging.info("Done making tarball")

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -2,7 +2,6 @@ import logging
 import os
 import random
 import secrets
-import subprocess
 import uuid
 from typing import Any, Dict, List, Set, Tuple
 
@@ -1257,7 +1256,3 @@ def do_convert_data(rocketchat_data_dir: str, output_dir: str) -> None:
     attachment: Dict[str, List[Any]] = {"zerver_attachment": zerver_attachment}
     create_converted_data_files(attachment, output_dir, "/attachment.json")
     create_converted_data_files(uploads_list, output_dir, "/uploads/records.json")
-
-    logging.info("Start making tarball")
-    subprocess.check_call(["tar", "-czf", output_dir + ".tar.gz", output_dir, "-P"])
-    logging.info("Done making tarball")

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -4,7 +4,6 @@ import posixpath
 import random
 import secrets
 import shutil
-import subprocess
 import zipfile
 from collections import defaultdict
 from email.headerregistry import Address
@@ -1418,7 +1417,6 @@ def do_convert_data(original_path: str, output_dir: str, token: str, threads: in
     # Clean up the directory if we unpacked it ourselves.
     if original_path != slack_data_dir:
         rm_tree(slack_data_dir)
-    subprocess.check_call(["tar", "-czf", output_dir + ".tar.gz", output_dir, "-P"])
 
     logging.info("######### DATA CONVERSION FINISHED #########\n")
     logging.info("Zulip data dump created at %s", output_dir)

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -887,8 +887,6 @@ class RocketChatImporter(ZulipTestCase):
                 "INFO:root:Starting to process custom emoji",
                 "INFO:root:Done processing emoji",
                 "INFO:root:skipping direct messages discussion mention: Discussion with Hermione",
-                "INFO:root:Start making tarball",
-                "INFO:root:Done making tarball",
             ],
         )
 

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -1151,8 +1151,6 @@ class SlackImporter(ZulipTestCase):
         Realm.objects.filter(name=test_realm_subdomain).delete()
 
         remove_folder(output_dir)
-        # remove tar file created in 'do_convert_data' function
-        os.remove(output_dir + ".tar.gz")
         self.assertFalse(os.path.exists(output_dir))
 
     def test_message_files(self) -> None:


### PR DESCRIPTION
`./manage.py import` does not take a tarball; it takes a directory. Making a separate tarball is a waste of CPU time and disk, as it is never used.

This was included in the commit of the initial Slack conversion code in 5b37c5562bfc and propagated from there into every conversion tool.

Remove the unnecessary tarball creation.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
