### PR TITLE
ts: Convert typing_data.js to TypeScript.

### DIFF
--- a/web/src/typing_data.ts
+++ b/web/src/typing_data.ts
@@ -3,55 +3,49 @@ import * as util from "./util";
 
 // See docs/subsystems/typing-indicators.md for details on typing indicators.
 
-const typist_dct = new Map();
-const inbound_timer_dict = new Map();
+const typist_dct = new Map<string, number[]>();
+const inbound_timer_dict = new Map<string, ReturnType<typeof setInterval> | undefined>();
 
-export function clear_for_testing() {
+export function clear_for_testing(): void {
     typist_dct.clear();
     inbound_timer_dict.clear();
 }
 
-function to_int(s) {
-    return Number.parseInt(s, 10);
-}
-
-function get_key(group) {
+function get_key(group: number[]): string {
     const ids = util.sorted_ids(group);
     return ids.join(",");
 }
 
-export function add_typist(group, typist) {
+export function add_typist(group: number[], typist: number): void {
     const key = get_key(group);
     const current = typist_dct.get(key) || [];
-    typist = to_int(typist);
     if (!current.includes(typist)) {
         current.push(typist);
     }
     typist_dct.set(key, util.sorted_ids(current));
 }
 
-export function remove_typist(group, typist) {
+export function remove_typist(group: number[], typist: number): boolean {
     const key = get_key(group);
     let current = typist_dct.get(key) || [];
 
-    typist = to_int(typist);
     if (!current.includes(typist)) {
         return false;
     }
 
-    current = current.filter((user_id) => to_int(user_id) !== to_int(typist));
+    current = current.filter((user_id) => user_id !== typist);
 
     typist_dct.set(key, current);
     return true;
 }
 
-export function get_group_typists(group) {
+export function get_group_typists(group: number[]): number[] {
     const key = get_key(group);
     const user_ids = typist_dct.get(key) || [];
     return muted_users.filter_muted_user_ids(user_ids);
 }
 
-export function get_all_typists() {
+export function get_all_typists(): number[] {
     let typists = [...typist_dct.values()].flat();
     typists = util.sorted_ids(typists);
     return muted_users.filter_muted_user_ids(typists);
@@ -59,7 +53,7 @@ export function get_all_typists() {
 
 // The next functions aren't pure data, but it is easy
 // enough to mock the setTimeout/clearTimeout functions.
-export function clear_inbound_timer(group) {
+export function clear_inbound_timer(group: number[]): void {
     const key = get_key(group);
     const timer = inbound_timer_dict.get(key);
     if (timer) {
@@ -68,7 +62,11 @@ export function clear_inbound_timer(group) {
     }
 }
 
-export function kickstart_inbound_timer(group, delay, callback) {
+export function kickstart_inbound_timer(
+    group: number[],
+    delay: number,
+    callback: () => void,
+): void {
     const key = get_key(group);
     clear_inbound_timer(group);
     const timer = setTimeout(callback, delay);

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -220,11 +220,9 @@ export function is_mobile(): boolean {
     return new RegExp(regex, "i").test(window.navigator.userAgent);
 }
 
-export function sorted_ids(ids: string[]): number[] {
-    // This mapping makes sure we are using ints, and
-    // it also makes sure we don't mutate the list.
-    let id_list = ids.map((s) => Number.parseInt(s, 10));
-    id_list = [...new Set(id_list)];
+export function sorted_ids(ids: number[]): number[] {
+    // This makes sure we don't mutate the list.
+    const id_list = [...new Set(ids)];
     id_list.sort((a, b) => a - b);
 
     return id_list;

--- a/web/tests/typing_data.test.js
+++ b/web/tests/typing_data.test.js
@@ -18,8 +18,7 @@ function test(label, f) {
 
 test("basics", () => {
     // The typing_data needs to be robust with lists of
-    // user ids being in arbitrary sorting order and
-    // possibly in string form instead of integer. So all
+    // user ids being in arbitrary sorting order. So all
     // the apparent randomness in these tests has a purpose.
     typing_data.add_typist([5, 10, 15], 15);
     assert.deepEqual(typing_data.get_group_typists([15, 10, 5]), [15]);
@@ -28,18 +27,18 @@ test("basics", () => {
     typing_data.add_typist([5, 10, 15], 15);
 
     // add another id to our first group
-    typing_data.add_typist([5, 10, 15], "10");
+    typing_data.add_typist([5, 10, 15], 10);
     assert.deepEqual(typing_data.get_group_typists([10, 15, 5]), [10, 15]);
 
     // start adding to a new group
     typing_data.add_typist([7, 15], 7);
-    typing_data.add_typist([7, "15"], 15);
+    typing_data.add_typist([7, 15], 15);
 
     // test get_all_typists
     assert.deepEqual(typing_data.get_all_typists(), [7, 10, 15]);
 
     // test basic removal
-    assert.ok(typing_data.remove_typist([15, 7], "7"));
+    assert.ok(typing_data.remove_typist([15, 7], 7));
     assert.deepEqual(typing_data.get_group_typists([7, 15]), [15]);
 
     // test removing an id that is not there
@@ -49,7 +48,7 @@ test("basics", () => {
 
     // remove user from one group, but "15" will still be among
     // "all typists"
-    assert.ok(typing_data.remove_typist(["15", 7], "15"));
+    assert.ok(typing_data.remove_typist([15, 7], 15));
     assert.deepEqual(typing_data.get_all_typists(), [10, 15]);
 
     // now remove from the other group


### PR DESCRIPTION
Added proper types in `typing_data.js` and converted it into a typescript file. Also modified the `sorted_ids` function a little bit in `utils.ts` to make it work with `typing_data.ts`.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
