### PR TITLE
settings: Prevent text-overflow in dropdowns inside bot management modal, organization settings > stream announcement & user announcement

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -874,21 +874,28 @@ input[type="checkbox"] {
     margin-top: 5px;
 }
 
-.edit_bot_form {
-    font-size: 100%;
-    margin: 0;
-    padding: 0;
+#edit_bot_modal {
+    padding-right: 24px;
 
-    .buttons {
-        margin: 10px 0 5px;
+    .edit_bot_modal {
+        padding-right: unset;
     }
 
-    #current_bot_avatar_image {
-        margin: 5px 0 8px;
-    }
+    .edit_bot_form {
+        font-size: 100%;
+        margin: 0;
 
-    .edit_bot_avatar_preview_text {
-        display: none;
+        .buttons {
+            margin: 10px 0 5px;
+        }
+
+        #current_bot_avatar_image {
+            margin: 5px 0 8px;
+        }
+
+        .edit_bot_avatar_preview_text {
+            display: none;
+        }
     }
 }
 
@@ -1481,6 +1488,10 @@ $option_title_width: 180px;
         width: max(206px, 25vw);
         max-width: 320px;
     }
+}
+
+#edit_bot_owner_name {
+    min-width: 220px;
 }
 
 .dropdown-list-widget {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -440,6 +440,8 @@ input[type="checkbox"] {
 }
 
 .admin-realm-form {
+    overflow-x: auto;
+
     & h3 {
         margin-bottom: 10px;
     }
@@ -1497,6 +1499,9 @@ $option_title_width: 180px;
 .dropdown-list-widget {
     & button.dropdown-toggle {
         text-align: left;
+        display: inline-flex;
+        justify-content: space-between;
+        white-space: nowrap;
 
         .fa-chevron-down {
             float: right;

--- a/web/templates/dialog_widget.hbs
+++ b/web/templates/dialog_widget.hbs
@@ -1,7 +1,7 @@
 <div class="micromodal" id="dialog_widget_modal" aria-hidden="true">
     <div class="modal__overlay" tabindex="-1">
         <div {{#if id}}id="{{id}}" {{/if}}class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
-            <header class="modal__header">
+            <header class="modal__header {{id}}">
                 <h1 class="modal__title dialog_heading">
                     {{{ heading_text }}}
                     {{#if link}}
@@ -14,7 +14,7 @@
                 <div class="alert" id="dialog_error"></div>
                 {{{ html_body }}}
             </main>
-            <footer class="modal__footer">
+            <footer class="modal__footer {{id}}">
                 {{#unless single_footer_button}}
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}


### PR DESCRIPTION
 - To ensure consistency among all input groups within the bot-management modal, set the maximum width of `bot_owner` to `190px`.
 -  To ensure consistency among all input groups within the organization settings panel, set the maximum width of `stream announcement` and `user announcement` to `220px`.
- Allow dropdowns inside the bot management modal and organization settings panel to overflow with a scrollbar.
- Prevent the text content from wrapping into multiple lines inside the dropdown. Instead, ensure that the content remains within the dropdown container in single line even if it is long.

------------------------
Fixes: #23266 , #24539 
CZO: [Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/settings.20.3E.20text.20overflow)

------------------------

```console
  $ git grep admin-realm-form

web/src/settings_org.js:    register_save_discard_widget_handlers($(".admin-realm-form"), "/json/realm", false);
web/styles/settings.css:.admin-realm-form {
web/templates/settings/auth_methods_settings_admin.hbs:    <form class="admin-realm-form org-authentications-form">
web/templates/settings/organization_permissions_admin.hbs:    <form class="admin-realm-form org-permissions-form">
web/templates/settings/organization_profile_admin.hbs:    <form class="admin-realm-form org-profile-form">
web/templates/settings/organization_settings_admin.hbs:    <form class="admin-realm-form org-settings-form">
web/tests/settings_org.test.js:        $(".admin-realm-form").get_on_handler(
web/tests/settings_org.test.js:        $(".admin-realm-form").get_on_handler(
  ```

------------------------


**Screenshots and screen captures:**

<details>
<summary>Before:</summary>

![Screenshot from 2023-02-26 05-59-41](https://user-images.githubusercontent.com/66828942/221385853-87207dfd-5add-4fe3-93d6-1a8ef762f990.png)

![Screenshot from 2023-02-26 07-27-06](https://user-images.githubusercontent.com/66828942/222324591-82d4dbfe-4658-43ea-a5d0-a5ef023094aa.png)

</details>

<details>
<summary>New changes:</summary>

**Bot management modal:**

- width consistency:

![Screenshot from 2023-03-05 11-24-56](https://user-images.githubusercontent.com/66828942/222944373-f927ab58-7be6-4f3f-bc2e-bfe05b9e86d6.png)

- overflow with scrollbar:

![dropdown](https://user-images.githubusercontent.com/66828942/222944379-f0532336-93f3-4980-acdf-d36e1d050222.gif)

**Organization settings:**

- width consistency:

![Screenshot from 2023-03-05 11-26-44](https://user-images.githubusercontent.com/66828942/222944434-389be36d-d080-4418-a065-2848bf1dc168.png)

- overflow wit scrollbar:

![organization_settings](https://user-images.githubusercontent.com/66828942/222944447-cbd89bd3-10d8-4ab5-ae44-c8a258c73b19.gif)




</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
