### PR TITLE
popovers: Close user popovers on button click.

### DIFF
--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -16,6 +16,7 @@ import * as ListWidget from "./list_widget";
 import * as loading from "./loading";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as popovers from "./popovers";
 import * as presence from "./presence";
 import * as settings_account from "./settings_account";
 import * as settings_bots from "./settings_bots";
@@ -504,6 +505,7 @@ function handle_deactivation($tbody) {
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         const $row = $(e.target).closest(".user_row");
         const user_id = $row.data("user-id");
@@ -528,6 +530,7 @@ function handle_bot_deactivation($tbody) {
     $tbody.on("click", ".deactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         const $button_elem = $(e.target);
         const $row = $button_elem.closest(".user_row");
@@ -569,6 +572,8 @@ function handle_reactivation($tbody) {
     $tbody.on("click", ".reactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
+
         // Go up the tree until we find the user row, then grab the email element
         const $button_elem = $(e.target);
         const $row = $button_elem.closest(".user_row");
@@ -675,6 +680,8 @@ function handle_human_form($tbody) {
     $tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
+        popovers.hide_all();
+
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         show_edit_user_info_modal(user_id, false);
     });
@@ -684,6 +691,8 @@ function handle_bot_form($tbody) {
     $tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
+        popovers.hide_all();
+
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
         settings_bots.show_edit_bot_info_modal(user_id, false);
     });


### PR DESCRIPTION
[CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/popover.20bug.20in.20bot.20settings)

Close the user or bot popovers in Users, Deactivated users, bots tab of Organization settings, on clicking Edit user button, Deactivate button or Reactivate button.

**Screenshots:**

**Before -**

1) user edit button - 

![user-edit-before](https://user-images.githubusercontent.com/96468766/221585401-31e863d7-1b7e-4059-8d84-bab7ae718270.png)

2) user deactivate button - 

![user-deactivate-before](https://user-images.githubusercontent.com/96468766/221585391-83cdec72-2c2b-439f-a69b-debe85fd768b.png)

3) user reactivate button - 

![user-reactivate-before](https://user-images.githubusercontent.com/96468766/221585404-0f6a770c-26e3-40cd-9fdd-52e69fd6b7bb.png)

4) bot edit button - 

![bot-edit-before](https://user-images.githubusercontent.com/96468766/221585385-3384a65a-6aaf-45d5-af86-c3710526e6de.png)

5) bot deactivate button - 

![bot-deactivate-before](https://user-images.githubusercontent.com/96468766/221585379-7961a864-3fc3-4a90-9935-326e256403e8.png)

**After -**

1) user edit button - 

![user-edit-after](https://user-images.githubusercontent.com/96468766/221585505-36d0c028-0d82-44b2-b5be-c81fa84a7083.png)

2) user deactivate button - 

![user-deactivate-after](https://user-images.githubusercontent.com/96468766/221585499-0f39a67e-81ce-4691-90e9-0212021f73ed.png)

3) user reactivate button - 

![user-reactivate-after](https://user-images.githubusercontent.com/96468766/221585510-a1828508-7f36-490c-8b30-e4af7d54eab7.png)

4) bot edit button - 

![bot-edit-after](https://user-images.githubusercontent.com/96468766/221585495-c121dc25-c3ec-448d-bb7d-3cfc7c3f1252.png)

5) bot deactivate button - 

![bot-deactivate-after](https://user-images.githubusercontent.com/96468766/221586054-80559380-0b37-40c5-a6c7-493a6fc5d8ae.png)

<details>
![bot-deactivate-after](https://user-images.githubusercontent.com/96468766/221585482-e5f91289-48b6-468d-aa54-4b6cbda65947.png)

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
