### PR TITLE
portico: Fix portico footer broken on mobile widths.

### DIFF
--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -458,10 +458,6 @@ input.text-error {
     .footer-section ul {
         margin: 0;
     }
-
-    @media (width <= 500px) {
-        flex-direction: column;
-    }
 }
 
 /* -- end new footer -- */


### PR DESCRIPTION
I am not sure why I added this change in flex-direction but right now, it doesn't seem to be correct since it forces the footer to overflow mobile width.

Found this while addressing https://github.com/zulip/zulip/issues/23249#issuecomment-1445294124

before:
<img width="325" alt="image" src="https://user-images.githubusercontent.com/25124304/221604780-7e663db1-9c35-4f82-9eb9-744c91370915.png">

after:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/25124304/221604685-f95d9145-bc49-41a1-aa8f-b964878135d0.png">
