### PR TITLE
docs: Document how to use SMTP without authentication.

### DIFF
--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -12,7 +12,9 @@ email addresses and send notifications.
 1. Fill out the section of `/etc/zulip/settings.py` headed "Outgoing
    email (SMTP) settings". This includes the hostname and typically
    the port to reach your SMTP provider, and the username to log in to
-   it. You'll also want to fill out the noreply email section.
+   it. If your SMTP server does not require authentication, leave
+   `EMAIL_HOST_USER` empty. You'll also want to fill out the noreply
+   email section.
 
 1. Put the password for the SMTP user account in
    `/etc/zulip/zulip-secrets.conf` by setting `email_password`. For

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -599,5 +599,6 @@ def log_email_config_errors() -> None:
     """
     if settings.EMAIL_HOST_USER and settings.EMAIL_HOST_PASSWORD is None:
         logger.error(
-            "An SMTP username was set (EMAIL_HOST_USER), but password is unset (EMAIL_HOST_PASSWORD)."
+            "An SMTP username was set (EMAIL_HOST_USER), but password is unset (EMAIL_HOST_PASSWORD).  "
+            "To disable SMTP authentication, set EMAIL_HOST_USER to an empty string."
         )

--- a/zerver/tests/test_send_email.py
+++ b/zerver/tests/test_send_email.py
@@ -165,7 +165,8 @@ class TestSendEmail(ZulipTestCase):
             error_log.output,
             [
                 "ERROR:zulip.send_email:"
-                "An SMTP username was set (EMAIL_HOST_USER), but password is unset (EMAIL_HOST_PASSWORD)."
+                "An SMTP username was set (EMAIL_HOST_USER), but password is unset (EMAIL_HOST_PASSWORD).  "
+                "To disable SMTP authentication, set EMAIL_HOST_USER to an empty string."
             ],
         )
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -71,7 +71,9 @@ EXTERNAL_HOST = "zulip.example.com"
 ## advice for troubleshooting, see the Zulip documentation:
 ##   https://zulip.readthedocs.io/en/latest/production/email.html
 
-## EMAIL_HOST and EMAIL_HOST_USER are generally required.
+## EMAIL_HOST and EMAIL_HOST_USER are generally required.  If your
+## SMTP server does not require authentication, leave EMAIL_HOST_USER
+## commented out.
 # EMAIL_HOST = "smtp.example.com"
 # EMAIL_HOST_USER = ""
 


### PR DESCRIPTION
This is the behaviour inherited from Django[^1].  While setting the password to empty (`email_password = `) in
`/etc/zulip/zulip-secrets.conf` also would suffice, it's unclear what the user would have been putting into `EMAIL_HOST_USER` in that context.

Because we previously did not warn when `email_password` was not present in `zulip-secrets.conf`, having the error message clarify the correct configuration for disabling SMTP auth is important.

Fixes: #23938.

[^1]: https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-EMAIL_HOST_USER

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
