### PR TITLE
alertmanager: Indent a documentation code block into its list item

### DIFF
--- a/zerver/webhooks/alertmanager/doc.md
+++ b/zerver/webhooks/alertmanager/doc.md
@@ -12,11 +12,11 @@ Get Zulip notifications from Alertmanager!
 
 1. In your Alertmanager config, set up a new webhook receiver, like so:
 
-```
-- name: ops-zulip
-  webhook_configs:
-    - url: "<the URL constructed above>"
-```
+    ```
+    - name: ops-zulip
+      webhook_configs:
+        - url: "<the URL constructed above>"
+    ```
 
 {!congrats.md!}
 


### PR DESCRIPTION
The last code block in [/integrations/doc/alertmanager](https://chat.zulip.org/integrations/doc/alertmanager) is horizontally misaligned; fix it.