### PR TITLE
docs: Clarify where GSoC/Outreachy applicants should post intros.

### DIFF
--- a/docs/outreach/apply.md
+++ b/docs/outreach/apply.md
@@ -66,8 +66,10 @@ We recommend taking the following steps before diving into the issue tracker:
 
 - Join the [Zulip development
   community](https://zulip.com/development-community/), and introduce yourself
-  in the stream for the program you are participating in. Before you jump in, be
-  sure to review the [Zulip community
+  in the stream for the program you are participating in
+  ([#GSoC](https://chat.zulip.org/#narrow/stream/14-GSoC) or
+  [#Outreachy](https://chat.zulip.org/#narrow/stream/391-Outreachy)). Before you
+  jump in, be sure to review the [Zulip community
   norms](https://zulip.com/development-community/).
 
 - Follow our instructions to [install the development


### PR DESCRIPTION
Testing:
- Manually tested the new links.

<img width="744" alt="Screen Shot 2023-02-27 at 10 56 46 AM" src="https://user-images.githubusercontent.com/2090066/221657648-04271f6a-cbbc-498e-874a-23c714529b1b.png">
