### PR TITLE
templates: Update `reset_done.html` page text and title.

### DIFF
--- a/templates/zerver/reset_done.html
+++ b/templates/zerver/reset_done.html
@@ -1,7 +1,7 @@
 {% extends "zerver/portico_signup.html" %}
 
 {% block title %}
-<title>{{ _("Password successfully reset") }} | Zulip</title>
+<title>{{ _(" New password successfully set") }} | Zulip</title>
 {% endblock %}
 
 {% block portico_content %}
@@ -10,7 +10,7 @@
         <div class="inline-block">
 
             <div class="get-started">
-                <h1>{{ _("We've reset your password!") }}</h1>
+                <h1>{{ _("You've set a new password!") }}</h1>
             </div>
 
             <div class="white-box">

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -772,7 +772,7 @@ class PasswordResetTest(ZulipTestCase):
         self.assert_in_success_response(["Check your email"], result)
 
         result = self.client_get("/accounts/password/done/")
-        self.assert_in_success_response(["We've reset your password!"], result)
+        self.assert_in_success_response(["You've set a new password!"], result)
 
         result = self.client_get("/accounts/send_confirm/?email=alice@example.com")
         self.assert_in_success_response(["/accounts/home/"], result)


### PR DESCRIPTION
Updates the text and title used when the password reset done page (`templates/zerver/reset_done.html`) to work for situations where the user is resetting a forgotten password and for situations where the user is setting a password for the first time (e.g. SSO login, demo organizations).

See [point 3 in this comment](https://github.com/zulip/zulip/pull/22666#issuecomment-1438763932) for more context on these changes. Related to demo organization work.

---

**Screenshots and screen captures:**

<details>
<summary>Password set page</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/221658132-b9ba8f03-75d1-47dc-abdf-16da7c3b1796.png) | ![image](https://user-images.githubusercontent.com/63245456/221840551-16045cbf-fafd-4ffb-9438-8e3b6211ae65.png)


</details>
<details>
<summary>Password set title</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/221658445-52f565d5-da70-4d49-bcd4-f9780366dda6.png) | ![image](https://user-images.githubusercontent.com/63245456/221658218-f6c2f9f3-b969-4dd7-be52-a5522dbed3d7.png)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
