### PR TITLE
Remove realm_str param from POST /messages API

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 166**
+* [`POST /messages`](/api/send-message): Eliminated the `realm_str` parameter. This parameter
+  was already redundant due to it needing to match the realm of the user making the request,
+  otherwise returning an authorization error. With this, the parameter is removed, meaning
+  that if provided in the API request, it'll be ignored.
+
 **Feature level 165**
 * [`PATCH /user_groups/{user_group_id}`](/api/update-user-group): The
   `name` and `description` parameters are now optional.

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 165
+API_FEATURE_LEVEL = 166
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -237,7 +237,7 @@ def send_message_backend(
     if forged and not can_forge_sender:
         raise JsonableError(_("User not authorized for this query"))
 
-    realm = None
+    realm = user_profile.realm
     if realm_str and realm_str != user_profile.realm.string_id:
         # The realm_str parameter does nothing, because it has to match
         # the user's realm - but we keep it around for backward compatibility.

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -198,7 +198,6 @@ def send_message_backend(
     topic_name: Optional[str] = REQ_topic(),
     message_content: str = REQ("content"),
     widget_content: Optional[str] = REQ(default=None, documentation_pending=True),
-    realm_str: Optional[str] = REQ("realm_str", default=None, documentation_pending=True),
     local_id: Optional[str] = REQ(default=None),
     queue_id: Optional[str] = REQ(default=None),
     delivery_type: str = REQ("delivery_type", default="send_now", documentation_pending=True),
@@ -238,10 +237,6 @@ def send_message_backend(
         raise JsonableError(_("User not authorized for this query"))
 
     realm = user_profile.realm
-    if realm_str and realm_str != user_profile.realm.string_id:
-        # The realm_str parameter does nothing, because it has to match
-        # the user's realm - but we keep it around for backward compatibility.
-        raise JsonableError(_("User not authorized for this query"))
 
     if client.name in ["zephyr_mirror", "irc_mirror", "jabber_mirror", "JabberMirror"]:
         # Here's how security works for mirroring:


### PR DESCRIPTION
As discussed in https://chat.zulip.org/#narrow/stream/378-api-design/topic/realm.20string_id

This (well, the first commit) also makes a bit of progress towards always passing a `realm` value (instead of `None`) down the codepaths to `check_message()`as proposed in https://github.com/zulip/zulip/pull/24412#discussion_r1112294414