### PR TITLE
poll_widget: Make the poll-vote button the top layer.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -109,6 +109,11 @@
     }
 
     .poll-vote {
+        /* This is to ensure that even when the list of poll-names overflows,
+        the voting button remains clickable and on top of all other containers. */
+        position: relative;
+        z-index: 1;
+
         color: hsl(156, 41%, 40%);
         border-color: hsl(156, 28%, 70%);
         border-style: solid;


### PR DESCRIPTION
Fixes #24409.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
