### PR TITLE
templates: Revise linkifier and code playground explanatory text in org settings overlay.

### DIFF
--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -3,40 +3,32 @@
 
         <p>
             {{#tr}}
-            Configure regular expression patterns that will be
-            automatically linkified when used in Zulip message bodies or
-            topics.  For example to automatically linkify commit IDs and
-            issue numbers (e.g. #123) to the corresponding items in a GitHub
-            project, you could use the following:
+            Configure regular expression patterns that will be used to
+            automatically transform any matching text in Zulip messages
+            and topics into links.
+            {{/tr}}
+        </p>
+        <p>
+            {{#tr}}
+            Linkifiers make it easy to refer to issues or tickets in
+            third party issue trackers, like GitHub, Salesforce, Zendesk,
+            and others. For instance, you can add a linkifier that
+            automatically turns #2468 into a link to the GitHub issue
+            in the Zulip repository with:
             {{/tr}}
         </p>
         <ul>
             <li>
-                <code>#(?P&lt;id&gt;[0-9]+)</code>
-                {{t "and" }}
-                <code>https://github.com/zulip/zulip/issues/%(id)s</code>
+                {{t "Pattern" }}: <span class="rendered_markdown"><code>#(?P&lt;id&gt;[0-9]+)</code></span>
             </li>
             <li>
-                <code>(?P&lt;id&gt;[0-9a-f]{40})</code>
-                {{t "and" }}
-                <code>https://github.com/zulip/zulip/commit/%(id)s</code>
+                {{t "URL format string" }}: <span class="rendered_markdown"><code>https://github.com/zulip/zulip/issues/%(id)s</code></span>
             </li>
         </ul>
         <p>
             {{#tr}}
-            Or, to automatically linkify GitHub's <code>org/repo#1234</code> syntax:
-            {{/tr}}
-        </p>
-        <ul>
-            <li>
-                <code>(?P&lt;org&gt;[a-zA-Z0-9_-]+)/(?P&lt;repo&gt;[a-zA-Z0-9_-]+)#(?P&lt;id&gt;[0-9]+)</code>
-                {{t "and" }}
-                <code>https://github.com/%(org)s/%(repo)s/issues/%(id)s</code>
-            </li>
-        </ul>
-        <p>
-            {{#tr}}
-                More details are available <z-link>in the Help Center article</z-link>.
+                For more examples, see the <z-link>help center documentation</z-link>
+                on adding linkifiers.
                 {{#*inline "z-link"}}<a href="/help/add-a-custom-linkifier" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </p>
@@ -45,7 +37,10 @@
         <form class="admin-linkifier-form">
             <div class="add-new-linkifier-box grey-box">
                 <div class="new-linkifier-form wrapper">
-                    <div class="settings-section-title new-linkifier-section-title">{{t "Add a new linkifier" }}</div>
+                    <div class="settings-section-title new-linkifier-section-title">
+                        {{t "Add a new linkifier" }}
+                        {{> ../help_link_widget link="/help/add-a-custom-linkifier" }}
+                    </div>
                     <div class="alert" id="admin-linkifier-status"></div>
                     <div class="input-group">
                         <label for="linkifier_pattern">{{t "Pattern" }}</label>

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -2,24 +2,39 @@
     <div class="admin-table-wrapper">
         <p>
             {{#tr}}
-                Configure external code playgrounds for your Zulip organization. Code playgrounds are interactive in-browser development
-                environments, such as <z-link-repl>replit</z-link-repl>, that are designed to make it convenient to edit and debug
-                code. Zulip code blocks that are <z-link-markdown-help>tagged with a programming language</z-link-markdown-help> will have
-                a button visible on hover that allows you to open the code block in the code playground site.
+                Code playgrounds are interactive in-browser development environments,
+                such as <z-link-repl>replit</z-link-repl>, that are designed to make
+                it convenient to edit and debug code. Zulip <z-link-code-blocks>code blocks</z-link-code-blocks>
+                that are tagged with a programming language will have a button visible on
+                hover that allows users to open the code block on the code playground site.
                 {{#*inline "z-link-repl"}}<a href="https://replit.com/" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
-                {{#*inline "z-link-markdown-help"}}<a href="/help/code-blocks" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link-code-blocks"}}<a href="/help/code-blocks" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
             {{/tr}}
         </p>
         <p>
             {{#tr}}
-            For example, to configure code playgrounds for languages like Python or JavaScript, you could specify the <i>Language</i>
-            and <i>URL prefix</i> fields as:
+            For example, to configure a code playground for code blocks tagged as Python,
+            you can set:
             {{/tr}}
         </p>
         <ul>
-            <li><code>Python</code> {{t "and" }} <code>https://replit.com/languages/python3/?code=</code></li>
-            <li><code>JavaScript</code> {{t "and" }} <code>https://replit.com/languages/javascript/?code=</code></li>
+            <li>
+                {{t "Language" }}: <span class="rendered_markdown"><code>Python</code></span>
+            </li>
+            <li>
+                {{t "Name" }}: <span class="rendered_markdown"><code>Python3 playground</code></span>
+            </li>
+            <li>
+                {{t "URL prefix" }}: <span class="rendered_markdown"><code>https://replit.com/languages/python3/?code=</code></span>
+            </li>
         </ul>
+        <p>
+            {{#tr}}
+                For more examples and technical details, see the <z-link>help center documentation</z-link>
+                on adding code playgrounds.
+                {{#*inline "z-link"}}<a href="/help/code-blocks#code-playgrounds" target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        </p>
 
         {{#if is_admin}}
         <form class="admin-playground-form">


### PR DESCRIPTION
Revises descriptive text and examples at the top of the linkifiers and code playgrounds tabs in the organization settings overlay. See [relevant CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/descriptions.20on.20linkifiers.20and.20code.20playground.20tabs/near/1511344). 

**Notes**:
- Adds the `rendered_markdown` class to the HTML code elements, via an HTML span element so that the specific CSS rules for code elements with that class will be applied to these examples. See [relevant comment in pull request](https://github.com/zulip/zulip/pull/24430#issuecomment-1438925792).

---

**Screenshots and screen captures:**

<details>
<summary>Linkifiers tab - narrowed for before and after comparison</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/221880402-fc7a170f-b695-40f5-a04b-0ae7fce88cde.png) | ![image](https://user-images.githubusercontent.com/63245456/221880471-328f65b8-367b-47c3-9d2d-45331f543a16.png)
</details>
<details>
<summary>Code playgrounds tab - narrowed for before and after comparison</summary>

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/63245456/221880786-ad736398-6f86-461f-89c3-74f6a0bfec5e.png) | ![image](https://user-images.githubusercontent.com/63245456/221880870-da7685f2-1faf-4285-8059-d531f9d49d69.png)
</details>

<details>
<summary>Linkifiers tab - updated version in both themes, not narrowed</summary>

![Screenshot from 2023-02-28 15-22-16](https://user-images.githubusercontent.com/63245456/221881716-72ea3abe-40c6-4b1e-9d0c-abdd4a992a74.png)
![Screenshot from 2023-02-28 15-22-28](https://user-images.githubusercontent.com/63245456/221881720-8d82db50-ea03-4349-906d-c7f09554d2c0.png)
</details>

<details>
<summary>Code playgrounds tab - updated version in both themes, not narrowed</summary>

![Screenshot from 2023-02-28 15-22-52](https://user-images.githubusercontent.com/63245456/221881853-2b2df405-a4ae-4123-8b2f-9878550b37a0.png)
![Screenshot from 2023-02-28 15-23-02](https://user-images.githubusercontent.com/63245456/221881859-3fb33d10-494c-4538-868b-587b212b6980.png)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
