### PR TITLE
message_list: Fix duplicate date headers at the top of message feed.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1534,5 +1534,31 @@ export class MessageListView {
         const today = new Date();
         const rendered_date = timerender.render_date(time, undefined, today);
         $sticky_header.find(".recipient_row_date").html(rendered_date);
+
+        // The following prevents a broken looking situation where
+        // there's a recipient row (possibly partially) visible just
+        // above the sticky recipient row, with an identical
+        // date. (E.g., both displaying "today"). We avoid this by
+        // hiding the date display on the non-sticky previous
+        // recipient row.
+        $(".hide-date-separator-header").removeClass("hide-date-separator-header");
+        // The hide-date CSS class is set on recipient_row_date
+        // elements where the previous row had the same date; these
+        // will only display the date when sticky. Since this corner
+        // case only is relevant with an identical date, we start by
+        // checking whether the hide-date class is present.
+        if ($sticky_header.find(".recipient_row_date.hide-date").length) {
+            const $prev_recipient_row = $sticky_header
+                .closest(".recipient_row")
+                .prev(".recipient_row");
+            if (!$prev_recipient_row.length) {
+                return;
+            }
+            const $prev_header_date_row = $prev_recipient_row.find(".recipient_row_date");
+            // Check if the recipient row before sticky header is a date separator.
+            if (!$prev_header_date_row.hasClass("hide-date")) {
+                $prev_header_date_row.addClass("hide-date-separator-header");
+            }
+        }
     }
 }

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -116,12 +116,12 @@ function update_group_date(group, message_container, prev) {
     const today = new Date();
 
     // Show the date in the recipient bar if the previous message was from a different day.
-    group.show_recipient_bar_date = !same_day(message_container, prev);
+    group.date_unchanged = same_day(message_container, prev);
     group.group_date_html = timerender.render_date(time, today)[0].outerHTML;
 }
 
 function clear_group_date(group) {
-    group.show_recipient_bar_date = true;
+    group.date_unchanged = false;
     group.group_date_html = undefined;
 }
 
@@ -1542,12 +1542,9 @@ export class MessageListView {
         // hiding the date display on the non-sticky previous
         // recipient row.
         $(".hide-date-separator-header").removeClass("hide-date-separator-header");
-        // The hide-date CSS class is set on recipient_row_date
-        // elements where the previous row had the same date; these
-        // will only display the date when sticky. Since this corner
-        // case only is relevant with an identical date, we start by
-        // checking whether the hide-date class is present.
-        if ($sticky_header.find(".recipient_row_date.hide-date").length) {
+        // This corner case only occurs when the date is unchanged
+        // from the previous recipient row.
+        if ($sticky_header.find(".recipient_row_date.recipient_row_date_unchanged").length) {
             const $prev_recipient_row = $sticky_header
                 .closest(".recipient_row")
                 .prev(".recipient_row");
@@ -1556,7 +1553,7 @@ export class MessageListView {
             }
             const $prev_header_date_row = $prev_recipient_row.find(".recipient_row_date");
             // Check if the recipient row before sticky header is a date separator.
-            if (!$prev_header_date_row.hasClass("hide-date")) {
+            if (!$prev_header_date_row.hasClass("recipient_row_date_unchanged")) {
                 $prev_header_date_row.addClass("hide-date-separator-header");
             }
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1100,12 +1100,6 @@ td.pointer {
         top: var(--sidebar-top);
         z-index: 3;
         box-shadow: 0 -1px 0 0 hsl(0, 0%, 100%);
-
-        &.sticky_header {
-            .recipient_row_date {
-                display: block;
-            }
-        }
     }
 }
 
@@ -1181,7 +1175,15 @@ td.pointer {
     letter-spacing: 0.04em;
     text-transform: uppercase;
 
-    &.hide-date,
+    /* Display the date when unchanged only for sticky headers. */
+    &.recipient_row_date_unchanged {
+        display: none;
+
+        .sticky_header & {
+            display: block;
+        }
+    }
+
     &.hide-date-separator-header {
         display: none;
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1181,7 +1181,8 @@ td.pointer {
     letter-spacing: 0.04em;
     text-transform: uppercase;
 
-    &.hide-date {
+    &.hide-date,
+    &.hide-date-separator-header {
         display: none;
     }
 }

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -77,7 +77,7 @@
                     </template>
                 {{/if}}
             </span>
-            <span class="recipient_row_date {{#if show_recipient_bar_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date {{#if date_unchanged}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
         </div>
     </div>
 </div>
@@ -91,7 +91,7 @@
                 {{t "You and {display_reply_to}" }}
             </a>
 
-            <span class="recipient_row_date {{#if show_recipient_bar_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
+            <span class="recipient_row_date {{#if date_unchanged}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Hide the date on the date separator when it is above a sticky header to fix it.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/duplicate.20date.20headers

Steps to reproduce:
* Scroll to a recipient bar which has date always visible because of it being a date separator (like "Yesterday" or "Today").
* Scroll it to the top of message feed until the date on the recipient bar next to it is visible due to it being sticky.
* You will notice duplicate date without this PR and the date only on the sticky header with this PR.