### PR TITLE
help: Add open link icon in "Add a custom linkifier".

### DIFF
--- a/help/add-a-custom-linkifier.md
+++ b/help/add-a-custom-linkifier.md
@@ -7,8 +7,9 @@ party issue trackers, like GitHub, Salesforce, Zendesk, and others.
 For instance, you can add a linkifier that automatically turns `#2468`
 into a link to `https://github.com/zulip/zulip/issues/2468`.
 
-If the pattern appears in a message topic, Zulip adds a little button to the
-right of the topic that links to the appropriate URL.
+If the pattern appears in a topic, Zulip adds an **Open**
+(<i class="fa fa-external-link-square"></i>) button to the right of the
+topic in the message recipient bar that links to the appropriate URL.
 
 ### Add a custom linkifier
 


### PR DESCRIPTION
- Adds the "Open link" icon to the last paragraph and tweaks wording.

**Screenshots and screen captures:**

- https://zulip.com/help/add-a-custom-linkifier

![image](https://user-images.githubusercontent.com/2343554/222303795-761e1b4e-4171-4f05-8cc8-647e8491a089.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>

