### PR TITLE
stream_edit: Remove Saving/Saved Notices and Use Loading Spinner

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -79,13 +79,17 @@ export function hide_dialog_spinner(): void {
 }
 
 export function show_dialog_spinner(): void {
-    $(".dialog_submit_button span").hide();
     // Disable both the buttons.
     $("#dialog_widget_modal .modal__btn").prop("disabled", true);
 
     const $spinner = $("#dialog_widget_modal .modal__spinner");
     const dialog_submit_button_span_width = $(".dialog_submit_button span").width();
     const dialog_submit_button_span_height = $(".dialog_submit_button span").height();
+
+    // Hide the submit button after computing its height, since submit
+    // buttons with long text might affect the size of the button.
+    $(".dialog_submit_button span").hide();
+
     loading.make_indicator($spinner, {
         width: dialog_submit_button_span_width,
         height: dialog_submit_button_span_height,

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -432,6 +432,7 @@ export function initialize() {
             ),
             html_body: change_stream_info_modal,
             id: "change_stream_info_modal",
+            loading_spinner: true,
             on_click: save_stream_info,
             post_render() {
                 $("#change_stream_info_modal .dialog_submit_button")
@@ -461,6 +462,7 @@ export function initialize() {
         const new_description = $("#change_stream_description").val().trim();
 
         if (new_name === sub.name && new_description === sub.description) {
+            dialog_widget.hide_dialog_spinner();
             return;
         }
         if (new_name !== sub.name) {
@@ -470,9 +472,7 @@ export function initialize() {
             data.description = new_description;
         }
 
-        const $status_element = $(".stream_change_property_info");
-        dialog_widget.close_modal();
-        settings_ui.do_settings_change(channel.patch, url, data, $status_element);
+        dialog_widget.submit_api_request(channel.patch, url, data);
     }
 
     $("#streams_overlay_container").on("click", ".copy_email_button", (e) => {


### PR DESCRIPTION
Fixes: #24535

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/72064462/222686226-0bde482f-54c8-4d88-ab1f-f77266f9385f.mov

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
