### PR TITLE
api_docs: Fix syntax highlighting for curl examples

### DIFF
--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -10,7 +10,7 @@
 
 {tab|curl}
 
-``` curl
+```bash
 # For stream messages
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -269,7 +269,7 @@ def generate_curl_example(
     exclude: Optional[List[str]] = None,
     include: Optional[List[str]] = None,
 ) -> List[str]:
-    lines = ["```curl"]
+    lines = ["```bash"]
     operation = endpoint + ":" + method.lower()
     operation_entry = openapi_spec.openapi()["paths"][endpoint][method.lower()]
     global_security = openapi_spec.openapi()["security"]

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -872,7 +872,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
     def test_generate_and_render_curl_example(self) -> None:
         generated_curl_example = self.curl_example("/get_stream_id", "GET")
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX GET -G http://localhost:9991/api/v1/get_stream_id \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             "    --data-urlencode stream=Denmark",
@@ -889,7 +889,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
     def test_generate_and_render_curl_without_auth(self) -> None:
         generated_curl_example = self.curl_example("/dev_fetch_api_key", "POST")
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX POST http://localhost:9991/api/v1/dev_fetch_api_key \\",
             "    --data-urlencode username=iago@zulip.com",
             "```",
@@ -901,7 +901,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_without_examples
         generated_curl_example = self.curl_example("/mark_stream_as_read", "POST")
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX POST http://localhost:9991/api/v1/mark_stream_as_read \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             "    --data-urlencode stream_id=1 \\",
@@ -919,7 +919,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
     def test_generate_and_render_curl_with_array_example(self) -> None:
         generated_curl_example = self.curl_example("/messages", "GET")
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX GET -G http://localhost:9991/api/v1/messages \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             "    --data-urlencode anchor=43 \\",
@@ -939,7 +939,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_using_object
         generated_curl_example = self.curl_example("/endpoint", "GET")
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             '    --data-urlencode \'param1={"key": "value"}\'',
@@ -968,7 +968,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         spec_mock.return_value = self.spec_mock_using_param_in_path
         generated_curl_example = self.curl_example("/endpoint/{param1}", "GET")
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX GET -G http://localhost:9991/api/v1/endpoint/35 \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             '    --data-urlencode \'param2={"key": "value"}\'',
@@ -981,7 +981,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "/get_stream_id:GET:email:key", api_url="https://zulip.example.com/api"
         )
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX GET -G https://zulip.example.com/api/v1/get_stream_id \\",
             "    -u email:key \\",
             "    --data-urlencode stream=Denmark",
@@ -994,7 +994,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             "/messages", "GET", exclude=["client_gravatar", "apply_markdown"]
         )
         expected_curl_example = [
-            "```curl",
+            "```bash",
             "curl -sSX GET -G http://localhost:9991/api/v1/messages \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             "    --data-urlencode anchor=43 \\",


### PR DESCRIPTION
‘curl’ is not a language.