### PR TITLE
markdown: Untangle generate_code_example from tab switcher

### DIFF
--- a/api_docs/api-doc-template.md
+++ b/api_docs/api-doc-template.md
@@ -4,7 +4,11 @@
 
 {start_tabs}
 
+{tab|python}
+
 {generate_code_example(python)|API_ENDPOINT_NAME|example}
+
+{tab|js}
 
 {generate_code_example(javascript)|API_ENDPOINT_NAME|example}
 

--- a/api_docs/mark-all-as-read.md
+++ b/api_docs/mark-all-as-read.md
@@ -4,7 +4,11 @@
 
 {start_tabs}
 
+{tab|python}
+
 {generate_code_example(python)|/mark_all_as_read:post|example}
+
+{tab|js}
 
 {generate_code_example(javascript)|/mark_all_as_read:post|example}
 
@@ -34,7 +38,11 @@
 
 {start_tabs}
 
+{tab|python}
+
 {generate_code_example(python)|/mark_stream_as_read:post|example}
+
+{tab|js}
 
 {generate_code_example(javascript)|/mark_all_as_read:post|example}
 
@@ -64,7 +72,11 @@
 
 {start_tabs}
 
+{tab|python}
+
 {generate_code_example(python)|/mark_topic_as_read:post|example}
+
+{tab|js}
 
 {generate_code_example(javascript)|/mark_all_as_read:post|example}
 

--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -4,7 +4,11 @@
 
 {start_tabs}
 
+{tab|python}
+
 {generate_code_example(python)|/messages:post|example}
+
+{tab|js}
 
 {generate_code_example(javascript)|/messages:post|example}
 

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -149,8 +149,7 @@ def render_python_code_example(
 
     snippets = extract_code_example(function_source_lines, [], PYTHON_EXAMPLE_REGEX)
 
-    code_example = ["{tab|python}\n"]
-    code_example.append("```python")
+    code_example = ["```python"]
     code_example.extend(config)
 
     for snippet in snippets:
@@ -183,7 +182,6 @@ def render_javascript_code_example(
         config = JS_CLIENT_CONFIG.splitlines()
 
     code_example = [
-        "{tab|js}\n",
         "More examples and documentation can be found [here](https://github.com/zulip/zulip-js).",
     ]
 


### PR DESCRIPTION
This effectively reverts:

- commit 0c4330f926f1960c934958de8c65d08aa79d0274 (#18573)
- commit 274f73d117ae109f32d12578bd033e2a67b26204 (#18776)

It doesn’t make sense for these two syntaxes to be entangled like this.