### PR TITLE
reactions: Prevent multiple simultaneous requests for reaction update.

### DIFF
--- a/web/src/reactions.js
+++ b/web/src/reactions.js
@@ -14,7 +14,9 @@ import * as people from "./people";
 import * as spectators from "./spectators";
 import {user_settings} from "./user_settings";
 
-export const view = {}; // function namespace
+export const view = {
+    waiting_for_server_request_ids: new Set(),
+}; // function namespace
 
 export function get_local_reaction_id(reaction_info) {
     return [reaction_info.reaction_type, reaction_info.emoji_code].join(",");
@@ -78,6 +80,14 @@ function update_ui_and_send_reaction_ajax(message_id, reaction_info) {
     const operation = has_reacted ? "remove" : "add";
     const reaction = create_reaction(message_id, reaction_info);
 
+    // To avoid duplicate requests to the server, we construct a
+    // unique request ID combining the message ID and the local ID,
+    // which identifies just which emoji to use.
+    const reaction_request_id = [message_id, local_id].join(",");
+    if (view.waiting_for_server_request_ids.has(reaction_request_id)) {
+        return;
+    }
+
     if (operation === "add") {
         add_reaction(reaction);
     } else {
@@ -87,17 +97,17 @@ function update_ui_and_send_reaction_ajax(message_id, reaction_info) {
     const args = {
         url: "/json/messages/" + message_id + "/reactions",
         data: reaction_info,
-        success() {},
+        success() {
+            view.waiting_for_server_request_ids.delete(reaction_request_id);
+        },
         error(xhr) {
+            view.waiting_for_server_request_ids.delete(reaction_request_id);
             const response = channel.xhr_error_message("Error sending reaction", xhr);
-            // Errors are somewhat common here, due to race conditions
-            // where the user tries to add/remove the reaction when there is already
-            // an in-flight request.  We eventually want to make this a blueslip
-            // error, rather than a warning, but we need to implement either
-            // #4291 or #4295 first.
-            blueslip.warn(response);
+            blueslip.error(response);
         },
     };
+
+    view.waiting_for_server_request_ids.add(reaction_request_id);
     if (operation === "add") {
         channel.post(args);
     } else if (operation === "remove") {


### PR DESCRIPTION
Prevents multiple simultaneous requests to the API when adding or removing reactions. This commit blocks emoji state changes (including the local echo) until the request is executed.

Fixes part of #21213

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
