### PR TITLE
typeahead: Prefer word boundary matches to arbitrary substring matches.

### DIFF
--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -128,40 +128,44 @@ export function triage<T>(
         `matches` and then call the rest `rest`.
     */
 
-    const exactMatch = [];
-    const beginswithCaseSensitive = [];
-    const beginswithCaseInsensitive = [];
-    const noMatch = [];
-    const lowerQuery = query ? query.toLowerCase() : "";
+    const exact_matches = [];
+    const begins_with_case_sensitive_matches = [];
+    const begins_with_case_insensitive_matches = [];
+    const no_matches = [];
+    const lower_query = query ? query.toLowerCase() : "";
 
     for (const obj of objs) {
         const item = get_item(obj);
-        const lowerItem = item.toLowerCase();
+        const lower_item = item.toLowerCase();
 
-        if (lowerItem === lowerQuery) {
-            exactMatch.push(obj);
+        if (lower_item === lower_query) {
+            exact_matches.push(obj);
         } else if (item.startsWith(query)) {
-            beginswithCaseSensitive.push(obj);
-        } else if (lowerItem.startsWith(lowerQuery)) {
-            beginswithCaseInsensitive.push(obj);
+            begins_with_case_sensitive_matches.push(obj);
+        } else if (lower_item.startsWith(lower_query)) {
+            begins_with_case_insensitive_matches.push(obj);
         } else {
-            noMatch.push(obj);
+            no_matches.push(obj);
         }
     }
 
     if (sorting_comparator) {
         const non_exact_sorted_matches = [
-            ...beginswithCaseSensitive,
-            ...beginswithCaseInsensitive,
+            ...begins_with_case_sensitive_matches,
+            ...begins_with_case_insensitive_matches,
         ].sort(sorting_comparator);
         return {
-            matches: [...exactMatch.sort(sorting_comparator), ...non_exact_sorted_matches],
-            rest: noMatch.sort(sorting_comparator),
+            matches: [...exact_matches.sort(sorting_comparator), ...non_exact_sorted_matches],
+            rest: no_matches.sort(sorting_comparator),
         };
     }
     return {
-        matches: [...exactMatch, ...beginswithCaseSensitive, ...beginswithCaseInsensitive],
-        rest: noMatch,
+        matches: [
+            ...exact_matches,
+            ...begins_with_case_sensitive_matches,
+            ...begins_with_case_insensitive_matches,
+        ],
+        rest: no_matches,
     };
 }
 

--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -155,7 +155,7 @@ export function triage<T>(
             ...beginswithCaseInsensitive,
         ].sort(sorting_comparator);
         return {
-            matches: [...exactMatch, ...non_exact_sorted_matches],
+            matches: [...exactMatch.sort(sorting_comparator), ...non_exact_sorted_matches],
             rest: noMatch.sort(sorting_comparator),
         };
     }

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1805,11 +1805,9 @@ test("message people", ({override, override_rewire}) => {
     let results;
 
     /*
-        We will simulate that we talk to Hal and Harry,
-        while we don't talk to King Hamlet.  This will
-        knock King Hamlet out of consideration in the
-        filtering pass.  Then Hal will be truncated in
-        the sorting step.
+        We will initially simulate that we talk to Hal and Harry, while
+        we don't talk to King Hamlet or Characters of Hamlet. This
+        will knock these 2 out of consideration in the filtering pass.
     */
 
     let user_ids = [hal.user_id, harry.user_id];
@@ -1823,23 +1821,20 @@ test("message people", ({override, override_rewire}) => {
     };
 
     results = ct.get_person_suggestions("Ha", opts);
-    assert.deepEqual(results, [harry, hamletcharacters]);
+    assert.deepEqual(results, [harry, hal]);
 
-    // Now let's exclude Hal.
+    // Now let's exclude Hal and include King Hamlet.
     user_ids = [hamlet.user_id, harry.user_id];
 
     results = ct.get_person_suggestions("Ha", opts);
-    assert.deepEqual(results, [harry, hamletcharacters]);
+    assert.deepEqual(results, [harry, hamlet]);
 
+    // Reincluding Hal and deactivating harry
     user_ids = [hamlet.user_id, harry.user_id, hal.user_id];
-
-    results = ct.get_person_suggestions("Ha", opts);
-    assert.deepEqual(results, [harry, hamletcharacters]);
-
     people.deactivate(harry);
     results = ct.get_person_suggestions("Ha", opts);
     // harry is excluded since it has been deactivated.
-    assert.deepEqual(results, [hamletcharacters, hal]);
+    assert.deepEqual(results, [hal, hamlet]);
 });
 
 test("muted users excluded from results", () => {

--- a/web/tests/typeahead.test.js
+++ b/web/tests/typeahead.test.js
@@ -150,6 +150,26 @@ run_test("triage", () => {
     );
 });
 
+run_test("triage: prioritise word boundary matches to arbitrary substring matches", () => {
+    const book = {name: "book"};
+    const hyphen_ok = {name: "hyphen_ok"};
+    const space_ok = {name: "space ok"};
+    const no_space_ok = {name: "nospaceok"};
+    const number_ok = {name: "number1ok"};
+    const okay = {name: "okay"};
+    const ok = {name: "ok"};
+
+    const emojis = [book, hyphen_ok, space_ok, no_space_ok, number_ok, okay, ok];
+
+    assert.deepEqual(
+        typeahead.triage("ok", emojis, (r) => r.name),
+        {
+            matches: [ok, okay, hyphen_ok, space_ok],
+            rest: [book, no_space_ok, number_ok],
+        },
+    );
+});
+
 function sort_emojis(emojis, query) {
     return typeahead.sort_emojis(emojis, query).map((emoji) => emoji.emoji_name);
 }

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -339,9 +339,9 @@ test("sort_recipients", () => {
         "b_user_2@zulip.net",
         "b_user_3@zulip.net",
         "b_bot@example.com",
+        "a_bot@zulip.com",
         "a_user@zulip.org",
         "zman@test.net",
-        "a_bot@zulip.com",
     ]);
 
     // Typeahead for direct message [query, "", ""]
@@ -394,9 +394,9 @@ test("sort_recipients", () => {
         subscriber_email_2,
         subscriber_email_1,
         "b_user_1@zulip.net",
+        "a_bot@zulip.com",
         "zman@test.net",
         "a_user@zulip.org",
-        "a_bot@zulip.com",
     ]);
 
     recent_senders.process_stream_message({
@@ -507,10 +507,10 @@ test("sort_recipients dup bots", () => {
         "b_user_2@zulip.net",
         "b_user_3@zulip.net",
         "b_bot@example.com",
+        "a_bot@zulip.com",
+        "a_bot@zulip.com",
         "a_user@zulip.org",
         "zman@test.net",
-        "a_bot@zulip.com",
-        "a_bot@zulip.com",
     ];
     assert.deepEqual(recipients_email, expected);
 });


### PR DESCRIPTION
So far, when ordering typeahead suggestions, any query matches that did not occur at the start of the target string were considered equally. So for example, for the query "ok", "squared_ok" and "smoking" were allotted equal priority, which does not make sense.

Now, matches from a word boundary (space, hyphen, dash or slash) are given priority, so that in the above example, "squared_ok" is regarded as a better match than "smoking".

Fixes: #24127.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
![image](https://user-images.githubusercontent.com/68962290/222751740-63419846-9b01-4534-8cd4-7483078e3af3.png)

After:
![image](https://user-images.githubusercontent.com/68962290/222751307-70567be9-5f87-4ca0-8c69-cfbe4ce45f03.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
