### PR TITLE
deliver_scheduled_emails: Use a queue, instead of infinite retries.

### DIFF
--- a/puppet/kandra/files/nagios4/conf.d/services.cfg
+++ b/puppet/kandra/files/nagios4/conf.d/services.cfg
@@ -390,6 +390,12 @@ define service {
 
 define service {
         use                             rabbitmq-consumer-service
+        service_description             Check RabbitMQ deferred_email_senders consumers
+        check_command                   check_rabbitmq_consumers!deferred_email_senders
+}
+
+define service {
+        use                             rabbitmq-consumer-service
         service_description             Check RabbitMQ embed_links consumers
         check_command                   check_rabbitmq_consumers!embed_links
 

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -151,6 +151,7 @@ class zulip::app_frontend_base {
     'embed_links',
     'embedded_bots',
     'email_senders',
+    'deferred_email_senders',
     'missedmessage_emails',
     'missedmessage_mobile_notifications',
     'outgoing_webhooks',

--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -14,6 +14,7 @@ from scripts.lib.zulip_tools import atomic_nagios_write, get_config, get_config_
 
 normal_queues = [
     "deferred_work",
+    "deferred_email_senders",
     "digest_emails",
     "email_mirror",
     "email_senders",
@@ -49,7 +50,7 @@ MAX_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     digest_emails=1200,
     missedmessage_mobile_notifications=120,
     embed_links=60,
-    email_senders=240,
+    deferred_email_senders=240,
 )
 CRITICAL_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     lambda: 60,
@@ -57,7 +58,7 @@ CRITICAL_SECONDS_TO_CLEAR: defaultdict[str, int] = defaultdict(
     missedmessage_mobile_notifications=180,
     digest_emails=1800,
     embed_links=90,
-    email_senders=300,
+    deferred_email_senders=300,
 )
 
 

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -76,7 +76,6 @@ not_yet_fully_covered = [
     "zerver/lib/markdown/nested_code_blocks.py",
     # Workers should get full coverage; many have it already
     "zerver/worker/deferred_work.py",
-    "zerver/worker/email_senders.py",
     "zerver/worker/invites.py",
     "zerver/worker/missedmessage_emails.py",
     # Worker-associated files; lower-priority to get testing on

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -76,7 +76,6 @@ not_yet_fully_covered = [
     "zerver/lib/markdown/nested_code_blocks.py",
     # Workers should get full coverage; many have it already
     "zerver/worker/deferred_work.py",
-    "zerver/worker/invites.py",
     "zerver/worker/missedmessage_emails.py",
     # Worker-associated files; lower-priority to get testing on
     "zerver/worker/base.py",

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -404,7 +404,7 @@ def bulk_handle_digest_email(user_ids: list[int], cutoff: float) -> None:
             continue
 
         digest_users.append(user)
-        logger.info("Sending digest email for user %s", user.id)
+        logger.info("Enqueuing digest email for user %s", user.id)
 
         # Send now, as a ScheduledEmail
         send_future_email(

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -381,6 +381,14 @@ def send_future_email(
         )
         # For logging the email
 
+    if delay == timedelta(0):
+        # Immediately queue, rather than go through the ScheduledEmail table
+        queue_event_on_commit(
+            "deferred_email_senders",
+            {**email_fields, "to_user_ids": to_user_ids, "to_emails": to_emails},
+        )
+        return
+
     assert (to_user_ids is None) ^ (to_emails is None)
     with transaction.atomic(savepoint=False):
         email = ScheduledEmail.objects.create(

--- a/zerver/management/commands/deliver_scheduled_emails.py
+++ b/zerver/management/commands/deliver_scheduled_emails.py
@@ -16,7 +16,7 @@ from typing_extensions import override
 
 from zerver.lib.logging_util import log_to_file
 from zerver.lib.management import ZulipBaseCommand
-from zerver.lib.send_email import EmailNotDeliveredError, deliver_scheduled_emails
+from zerver.lib.send_email import EmailNotDeliveredError, queue_scheduled_emails
 from zerver.models import ScheduledEmail
 
 ## Setup ##
@@ -47,7 +47,7 @@ Usage: ./manage.py deliver_scheduled_emails
                     )
                     if job:
                         try:
-                            deliver_scheduled_emails(job)
+                            queue_scheduled_emails(job)
                         except EmailNotDeliveredError:
                             logger.warning("%r not delivered", job)
                     else:

--- a/zerver/tests/test_email_log.py
+++ b/zerver/tests/test_email_log.py
@@ -32,7 +32,7 @@ class EmailLogTest(ZulipTestCase):
             output_log = (
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )
-            self.assertEqual(m.output, [output_log for i in range(18)])
+            self.assertEqual(m.output, [output_log for i in range(20)])
 
     def test_forward_address_details(self) -> None:
         try:

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -17,7 +17,7 @@ from zerver.lib.email_notifications import (
     send_account_registered_email,
 )
 from zerver.lib.send_email import (
-    deliver_scheduled_emails,
+    queue_scheduled_emails,
     send_custom_email,
     send_custom_server_email,
 )
@@ -490,7 +490,8 @@ class TestFollowupEmails(ZulipTestCase):
             "zerver/emails/onboarding_team_to_zulip",
         )
 
-        deliver_scheduled_emails(scheduled_emails[0])
+        with self.captureOnCommitCallbacks(execute=True):
+            queue_scheduled_emails(scheduled_emails[0])
         from django.core.mail import outbox
 
         self.assert_length(outbox, 1)
@@ -525,7 +526,8 @@ class TestFollowupEmails(ZulipTestCase):
             "zerver/emails/onboarding_team_to_zulip",
         )
 
-        deliver_scheduled_emails(scheduled_emails[0])
+        with self.captureOnCommitCallbacks(execute=True):
+            queue_scheduled_emails(scheduled_emails[0])
         from django.core.mail import outbox
 
         self.assert_length(outbox, 1)

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -419,7 +419,7 @@ class TestDevelopmentEmailsLog(ZulipTestCase):
             )
 
             # info_log.output is a list of all the log messages captured.
-            self.assertEqual(info_log.output, [expected_log_line] * 18)
+            self.assertEqual(info_log.output, [expected_log_line] * 20)
 
             # Now, lets actually go the URL the above call redirects to, i.e., /emails/
             result = self.client_get(result["Location"])

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -32,7 +32,7 @@ from zerver.models.streams import get_stream
 from zerver.tornado.event_queue import build_offline_notification
 from zerver.worker import base as base_worker
 from zerver.worker.email_mirror import MirrorWorker
-from zerver.worker.email_senders import EmailSendingWorker
+from zerver.worker.email_senders import ImmediateEmailSenderWorker
 from zerver.worker.embed_links import FetchLinksEmbedData
 from zerver.worker.missedmessage_emails import MissedMessageWorker
 from zerver.worker.missedmessage_mobile_notifications import PushNotificationsWorker
@@ -695,7 +695,7 @@ class WorkerTest(ZulipTestCase):
             fake_client.enqueue(queue_name, event)
 
         with simulated_queue_client(fake_client):
-            worker = EmailSendingWorker()
+            worker = ImmediateEmailSenderWorker()
             worker.setup()
             with (
                 patch("zerver.lib.send_email.build_email", side_effect=EmailNotDeliveredError),

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1017,8 +1017,8 @@ class QueryCountTest(ZulipTestCase):
         prereg_user = PreregistrationUser.objects.get(email="fred@zulip.com")
 
         with (
-            self.assert_database_query_count(87),
-            self.assert_memcached_count(19),
+            self.assert_database_query_count(86),
+            self.assert_memcached_count(20),
             self.capture_send_event_calls(expected_num_events=10) as events,
         ):
             fred = do_create_user(

--- a/zerver/worker/deferred_email_senders.py
+++ b/zerver/worker/deferred_email_senders.py
@@ -3,6 +3,6 @@ from zerver.worker.base import assign_queue
 from zerver.worker.email_senders_base import EmailSendingWorker
 
 
-@assign_queue("email_senders")
+@assign_queue("deferred_email_senders")
 class ImmediateEmailSenderWorker(EmailSendingWorker):
     pass

--- a/zerver/worker/email_senders_base.py
+++ b/zerver/worker/email_senders_base.py
@@ -1,0 +1,85 @@
+# Documented in https://zulip.readthedocs.io/en/latest/subsystems/queuing.html
+import copy
+import logging
+import socket
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from django.core.mail.backends.base import BaseEmailBackend
+from typing_extensions import override
+
+from zerver.lib.queue import retry_event
+from zerver.lib.send_email import (
+    EmailNotDeliveredError,
+    handle_send_email_format_changes,
+    initialize_connection,
+    send_email,
+)
+from zerver.models import Realm
+from zerver.worker.base import ConcreteQueueWorker, LoopQueueProcessingWorker
+
+logger = logging.getLogger(__name__)
+
+
+# If you change the function on which this decorator is used be careful that the new
+# function doesn't delete the "failed_tries" attribute of "data" which is needed for
+# "retry_event" to work correctly; see EmailSendingWorker for an example with deepcopy.
+def retry_send_email_failures(
+    func: Callable[[ConcreteQueueWorker, dict[str, Any]], None],
+) -> Callable[[ConcreteQueueWorker, dict[str, Any]], None]:
+    @wraps(func)
+    def wrapper(worker: ConcreteQueueWorker, data: dict[str, Any]) -> None:
+        try:
+            func(worker, data)
+        except (socket.gaierror, TimeoutError, EmailNotDeliveredError) as e:
+            error_class_name = type(e).__name__
+
+            def on_failure(event: dict[str, Any]) -> None:
+                logging.exception(
+                    "Event %r failed due to exception %s", event, error_class_name, stack_info=True
+                )
+
+            retry_event(worker.queue_name, data, on_failure)
+
+    return wrapper
+
+
+class EmailSendingWorker(LoopQueueProcessingWorker):
+    def __init__(
+        self,
+        threaded: bool = False,
+        disable_timeout: bool = False,
+        worker_num: int | None = None,
+    ) -> None:
+        super().__init__(threaded, disable_timeout, worker_num)
+        self.connection: BaseEmailBackend | None = None
+
+    @retry_send_email_failures
+    def send_email(self, event: dict[str, Any]) -> None:
+        # Copy the event, so that we don't pass the `failed_tries'
+        # data to send_email (which neither takes that
+        # argument nor needs that data).
+        copied_event = copy.deepcopy(event)
+        if "failed_tries" in copied_event:
+            del copied_event["failed_tries"]
+        handle_send_email_format_changes(copied_event)
+        if "realm_id" in copied_event:
+            # "realm" does not serialize over the queue, so we send the realm_id
+            copied_event["realm"] = Realm.objects.get(id=copied_event["realm_id"])
+            del copied_event["realm_id"]
+        self.connection = initialize_connection(self.connection)
+        send_email(**copied_event, connection=self.connection)
+
+    @override
+    def consume_batch(self, events: list[dict[str, Any]]) -> None:
+        for event in events:
+            self.send_email(event)
+
+    @override
+    def stop(self) -> None:  # nocoverage
+        try:
+            if self.connection is not None:
+                self.connection.close()
+        finally:
+            super().stop()


### PR DESCRIPTION
`deliver_scheduled_emails` tries to deliver the email synchronously, and if it fails, it retries after 10 seconds.  Since it does not track retries, and always tries the earliest-scheduled-but-due message first, the worker will not make forward progress if there is a persistent failure with that message, and will retry indefinitely. This can result in excessive network or email delivery charges from the remote SMTP server.

Switch to delivering emails via a new queue worker.  The `deliver_scheduled_emails` job now serves only to pull deferred jobs out of the table once they are due, insert them into RabbitMQ, and then delete them.  This limits the potential for head-of-queue failures to failures inserting into RabbitMQ, which is more reasonable than failures speaking to a complex external system we do not control. Retries and any connections to the SMTP server are left to the RabbitMQ consumer.

We build a new RabbitMQ queue, rather than use the existing `email_senders` queue, because that queue is expected to be reasonably low-latency, for things like missed message notifications.  The `send_future_email` codepath which inserts into ScheduledEmails is also (ab)used to digest emails, which are extremely bursty in their frequency -- and a large burst could significantly delay emails behind it in the queue.

The new queue is explicitly only for messages which were not initiated by user actions (invitation reminders, digests, new account follow-ups) which are thus not latency-sensitive.

Fixes: #32463.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
