### PR TITLE
css: Move `pre code` to be in `rendered_markdown` class block.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -527,6 +527,15 @@
         }
     }
 
+    pre code {
+        font-size: inherit;
+        padding: 0;
+        white-space: inherit;
+        overflow-x: scroll;
+        color: inherit;
+        border: 0;
+    }
+
     /* Style copy-to-clipboard button inside code blocks */
     .copy_codeblock {
         visibility: hidden;
@@ -646,12 +655,6 @@ pre {
     padding: 5px 7px 3px;
 }
 
-.rendered_markdown pre code {
-    font-size: inherit;
-    padding: 0;
-    white-space: inherit;
-}
-
 /* Both the horizontal scrollbar in <pre/> as well as
    vertical scrollbar in the <textarea/> is styled similarly. */
 .message_edit_form textarea,
@@ -672,15 +675,6 @@ pre {
     &::-webkit-scrollbar-thumb:hover {
         background-color: hsla(0, 0%, 0%, 0.6);
     }
-}
-
-pre code {
-    overflow-x: scroll;
-    white-space: pre;
-    padding: 0;
-    color: inherit;
-    background-color: transparent;
-    border: 0;
 }
 
 /* Style inline code inside a link


### PR DESCRIPTION
Moves and simplifies the `pre code` rules in `rendered_markdown.css` so that they are all part of the `rendered_markdown` class block.

**Notes**:
- I'm pretty sure there are no cases of `pre code` without the `rendered_markdown` and `codehilite` classes in the web-app templates, because when I added them to the linkifiers organization settings tab and the set user status modal without any classes, they are very broken in the dark theme. See first set of screenshots below.
- In the big `rendered_markdown` block, I put the `pre code` rules after the other `pre &hover` rules that were there already. But I imagine they could be moved elsewhere or they could be left at the bottom with the other `pre` and `code` rules.
- The `background: transparent` rule was being overridden by the `.rendered_markdown code` rule, so I didn't move it up to the more specific rule here. See screenshots of dev tools inspector.

**Screenshots and screen captures:**

<details>
<summary>Example of pre code block in dark theme currently - without classes</summary>

![Screenshot from 2023-03-03 16-31-16](https://user-images.githubusercontent.com/63245456/222776383-4f67e857-6fd9-469c-b16a-dfb2e7b4ce0c.png)
![Screenshot from 2023-03-03 16-30-56](https://user-images.githubusercontent.com/63245456/222776386-994b58ef-9455-4c1f-ad1a-7b2f91fea531.png)
</details>
<details>
<summary>Dark theme - code blocks in messages - no change</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-03-03 16-33-16](https://user-images.githubusercontent.com/63245456/222776837-6f2d60bb-37d7-4ab1-b3af-2bd7e634dd81.png) | ![Screenshot from 2023-03-03 16-32-26](https://user-images.githubusercontent.com/63245456/222776842-19bd79b0-b9c9-44a8-b191-1c5f70bca7c0.png)
</details>
<details>
<summary>Light theme - code blocks in messages - no change</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-03-03 17-02-06](https://user-images.githubusercontent.com/63245456/222777244-21ab537e-1941-4fd9-b6d4-4d2d1d3b9aa5.png) | ![Screenshot from 2023-03-03 17-01-32](https://user-images.githubusercontent.com/63245456/222777250-e0aacf7d-b754-498e-a4db-cc8265fe4c7f.png)
</details>
<details>
<summary>Dev tools inspector</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-03-03 16-25-21](https://user-images.githubusercontent.com/63245456/222778244-ef8ab79f-d506-4612-b3ec-be0b1fbf6d86.png) | ![Screenshot from 2023-03-03 17-43-58](https://user-images.githubusercontent.com/63245456/222778041-5902a23b-f94f-4926-b510-7426ce852d01.png)
</details>
<details>
<summary>Fake modal example above with rendered_markdown and codehilite classes</summary>

| Dark theme | Light theme |
| --- | --- |
| ![Screenshot from 2023-03-03 17-00-28](https://user-images.githubusercontent.com/63245456/222778712-3dbc878a-acba-490c-9f6c-1fed7a2eead4.png) | ![Screenshot from 2023-03-03 17-01-12](https://user-images.githubusercontent.com/63245456/222778719-46040014-fbd6-4753-bca2-68e0fe9caeea.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
