### PR TITLE
narrow_banner: Display title only for empty is-operator narrow search.

### DIFF
--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -82,7 +82,7 @@ function pick_empty_narrow_banner() {
                   },
               ),
     };
-    const empty_search_narrow_title = $t({defaultMessage: "No search results"});
+    const default_banner_for_multiple_filters = $t({defaultMessage: "No search results"});
 
     const current_filter = narrow_state.filter();
 
@@ -102,7 +102,7 @@ function pick_empty_narrow_banner() {
         // No message can have multiple streams
         if (streams.length > 1) {
             return {
-                title: empty_search_narrow_title,
+                title: default_banner_for_multiple_filters,
                 html: $t_html({
                     defaultMessage:
                         "<p>You are searching for messages that belong to more than one stream, which is not possible.</p>",
@@ -112,7 +112,7 @@ function pick_empty_narrow_banner() {
         // No message can have multiple topics
         if (current_filter.operands("topic").length > 1) {
             return {
-                title: empty_search_narrow_title,
+                title: default_banner_for_multiple_filters,
                 html: $t_html({
                     defaultMessage:
                         "<p>You are searching for messages that belong to more than one topic, which is not possible.</p>",
@@ -122,7 +122,7 @@ function pick_empty_narrow_banner() {
         // No message can have multiple senders
         if (current_filter.operands("sender").length > 1) {
             return {
-                title: empty_search_narrow_title,
+                title: default_banner_for_multiple_filters,
                 html: $t_html({
                     defaultMessage:
                         "<p>You are searching for messages that are sent by more than one person, which is not possible.</p>",
@@ -133,7 +133,7 @@ function pick_empty_narrow_banner() {
         // For empty stream searches within other narrows, we display the stop words
         if (current_filter.operands("search").length > 0) {
             return {
-                title: empty_search_narrow_title,
+                title: default_banner_for_multiple_filters,
                 search_data: retrieve_search_query_data(),
             };
         }
@@ -149,7 +149,9 @@ function pick_empty_narrow_banner() {
         }
 
         // For other multi-operator narrows, we just use the default banner
-        return default_banner;
+        return {
+            title: default_banner_for_multiple_filters,
+        };
     }
 
     switch (first_operator) {
@@ -277,7 +279,7 @@ function pick_empty_narrow_banner() {
         case "search": {
             // You are narrowed to empty search results.
             return {
-                title: empty_search_narrow_title,
+                title: $t({defaultMessage: "No search results"}),
                 search_data: retrieve_search_query_data(),
             };
         }

--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -82,7 +82,7 @@ function pick_empty_narrow_banner() {
                   },
               ),
     };
-    const default_banner_for_multiple_filters = $t({defaultMessage: "No search results"});
+    const default_banner_for_multiple_filters = $t({defaultMessage: "No search results."});
 
     const current_filter = narrow_state.filter();
 
@@ -279,7 +279,7 @@ function pick_empty_narrow_banner() {
         case "search": {
             // You are narrowed to empty search results.
             return {
-                title: $t({defaultMessage: "No search results"}),
+                title: $t({defaultMessage: "No search results."}),
                 search_data: retrieve_search_query_data(),
             };
         }

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -282,7 +282,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results", ""),
+        empty_narrow_html("translated: No search results.", ""),
     );
     page_params.is_spectator = false;
 
@@ -520,7 +520,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results"),
+        empty_narrow_html("translated: No search results."),
     );
 
     set_filter([["is", "invalid"]]);
@@ -597,7 +597,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results", undefined, expected_search_data),
+        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
     );
 
     const expected_stream_search_data = {
@@ -617,7 +617,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results", undefined, expected_stream_search_data),
+        empty_narrow_html("translated: No search results.", undefined, expected_stream_search_data),
     );
 
     const expected_stream_topic_search_data = {
@@ -640,7 +640,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results",
+            "translated: No search results.",
             undefined,
             expected_stream_topic_search_data,
         ),
@@ -663,7 +663,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results",
+            "translated: No search results.",
             "translated HTML: <p>You are searching for messages that belong to more than one stream, which is not possible.</p>",
         ),
     );
@@ -677,7 +677,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results",
+            "translated: No search results.",
             "translated HTML: <p>You are searching for messages that belong to more than one topic, which is not possible.</p>",
         ),
     );
@@ -694,7 +694,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results",
+            "translated: No search results.",
             "translated HTML: <p>You are searching for messages that are sent by more than one person, which is not possible.</p>",
         ),
     );

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -282,7 +282,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: There are no messages here.", ""),
+        empty_narrow_html("translated: No search results", ""),
     );
     page_params.is_spectator = false;
 
@@ -520,10 +520,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: There are no messages here.",
-            'translated HTML: Why not <a href="#" class="empty_feed_compose_stream">start the conversation</a>?',
-        ),
+        empty_narrow_html("translated: No search results"),
     );
 
     set_filter([["is", "invalid"]]);


### PR DESCRIPTION
- When multiple filters are used in a narrow search and there are no results, the narrow banner will simply display 
   `No search results`.

- A period has been added at the end of the default banner to create a complete and meaningful sentence.

---------------------------------------------

CZO: [Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/empty.20feed.20message)

-----------------------------------------------

**Screenshots and screen captures:**

- Search string: `is`:mentioned `stream`:Denmark 

<details>
<summary>Before:</summary>
<br>

![Screenshot from 2023-03-04 05-34-17](https://user-images.githubusercontent.com/66828942/222857570-f5699c76-5a26-4060-86c9-23bc2aacc831.png)

</details>

<details>
<summary>New Changes:</summary>
<br>

![Screenshot from 2023-03-15 02-35-16](https://user-images.githubusercontent.com/66828942/225136106-c550fea7-01ab-49e2-ab11-1026620afc93.png)


</details>


--------------------------------------
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
