### PR TITLE
docs: Move homepage link to TOC tree

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -9,7 +9,3 @@
 .wy-table-responsive {
     overflow: visible !important;
 }
-
-.wy-side-nav-search > a.home-link {
-    font-weight: 100;
-}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,29 +1,5 @@
 {% extends "!layout.html" %}
 
-{% block sidebartitle %}
-    {%- if logo and theme_logo_only %}
-        <a href="{{ pathto(root_doc) }}">
-            <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
-        </a>
-    {%- endif %}
-
-    {%- if theme_display_version %}
-        {%- set nav_version = version %}
-        {%- if READTHEDOCS and current_version %}
-            {%- set nav_version = current_version %}
-        {%- endif %}
-        {%- if nav_version %}
-            <div class="version">
-                {{ nav_version }}
-            </div>
-        {%- endif %}
-    {%- endif %}
-
-    <a class="reference external home-link" href="https://zulip.com/">Zulip homepage</a>
-
-    {%- include "searchbox.html" %}
-{% endblock %}
-
 {% block document %}
     {#
     # This allows us to insert a warning that appears only on the development

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ Contents:
 maxdepth: 3
 ---
 
+Zulip homepage <https://zulip.com/>
 overview/index
 ```
 

--- a/tools/check-templates
+++ b/tools/check-templates
@@ -28,8 +28,6 @@ EXCLUDED_FILES = [
     "web/images/icons/template.hbs",
     # Template checker recommends very hard to read indentation.
     "web/templates/bookend.hbs",
-    # The parser does not like the indentation of custom ReadTheDocs templates
-    "docs/_templates/layout.html",
 ]
 
 


### PR DESCRIPTION
This lets us avoid maintaining a forked copy of sphinx_rtd_theme’s `sidebartitle` block (ef6582edb8d6ac61f528e20f6b532f9dbca2e8dd).

![screenshot](https://user-images.githubusercontent.com/26471/222879632-2c5f6d36-3fe7-446b-b0f4-3ef25f88da2d.png)

[Read the Docs preview build](https://zulip--24576.org.readthedocs.build/en/24576/)