### PR TITLE
left_sidebar: Add option to show left sidebar shortcuts as icons.

### DIFF
--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -242,6 +242,10 @@ function draft_notify() {
         placement: "right",
     })[0];
     instance.show();
+    if (instance.popper) {
+        // to keep `saved as draft` tooltip in single line by preventing text from wrapping to the next line
+        instance.popper.querySelector(".tippy-content").style.whiteSpace = "nowrap";
+    }
     function remove_instance() {
         instance.destroy();
     }

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -92,6 +92,7 @@ export function build_page() {
             settings_config.web_mark_read_on_scroll_policy_values,
         user_list_style_values: settings_config.user_list_style_values,
         color_scheme_values: settings_config.color_scheme_values,
+        button_label_values: settings_config.button_label_values,
         default_view_values: settings_config.default_view_values,
         twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
         general_settings: settings_config.all_notifications(user_settings).general_settings,
@@ -121,6 +122,10 @@ export function build_page() {
 
     settings_bots.update_bot_settings_tip($("#personal-bot-settings-tip"), false);
     $(".settings-box").html(rendered_settings_tab);
+
+    $("#user_button_label").on("input", () => {
+        $("#global_filters").toggleClass("top-left-layout-icons");
+    });
 }
 
 export function open_settings_overlay() {

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -96,6 +96,17 @@ export const color_scheme_values = {
     },
 };
 
+export const button_label_values = {
+    text: {
+        code: 1,
+        description: $t({defaultMessage: "Text"}),
+    },
+    button: {
+        code: 2,
+        description: $t({defaultMessage: "Icons"}),
+    },
+};
+
 export const twenty_four_hour_time_values = {
     twenty_four_hour_clock: {
         value: true,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -724,7 +724,8 @@
     }
 
     #message_edit_tooltip:hover,
-    .clear_search_button:hover {
+    .clear_search_button:hover,
+    .top-left-sidebar-menu-icon:hover .zulip-icon {
         color: hsl(0deg 0% 100%);
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -627,6 +627,72 @@ li.topic-list-item:hover .topic-sidebar-menu-icon {
     color: hsl(0deg 0% 53%);
 }
 
+.top-left-sidebar-menu-icon {
+    display: none;
+}
+
+#left-sidebar .top-left-layout-icons {
+    padding: 10px 0 5px;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+
+    .top_left_texts {
+        display: none;
+    }
+
+    .filter-icon i {
+        padding-right: 0 !important;
+    }
+
+    .unread_count {
+        position: absolute;
+        bottom: 1rem;
+        left: 1.2rem;
+    }
+
+    .top_left_starred_messages .unread_count,
+    .top_left_drafts .unread_count {
+        background-color: hsl(0deg 0.55% 71.18%);
+        border: 0;
+        color: hsl(0deg 0% 100%);
+        opacity: 0.8;
+    }
+
+    .fa,
+    i.fa-at,
+    i.fa-star {
+        font-size: 20px;
+    }
+
+    .all-messages-sidebar-menu-icon,
+    .starred-messages-sidebar-menu-icon,
+    .drafts-sidebar-menu-icon {
+        display: none;
+    }
+
+    .top_left_all_messages:hover .all-messages-sidebar-menu-icon,
+    .top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,
+    .top_left_drafts:hover .drafts-sidebar-menu-icon {
+        display: none;
+    }
+
+    .top-left-sidebar-menu-icon {
+        height: 15px;
+        width: 15px;
+        display: block;
+        cursor: pointer;
+
+        .zulip-icon {
+            font-size: 15px;
+        }
+
+        &:hover {
+            color: hsl(0deg 0% 0%);
+        }
+    }
+}
+
 ul.topic-list {
     list-style-type: none;
     font-weight: normal;

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -8,7 +8,7 @@
                         <i class="fa fa-align-left" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span>{{t 'All messages' }}</span>
+                    <span class="top_left_texts">{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
@@ -19,7 +19,7 @@
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span>{{t 'Recent conversations' }}</span>
+                    <span class="top_left_texts">{{t 'Recent conversations' }}</span>
                 </a>
             </li>
             <li class="top_left_mentions top_left_row hidden-for-spectators">
@@ -28,7 +28,7 @@
                         <i class="fa fa-at" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span>{{t 'Mentions' }}</span>
+                    <span class="top_left_texts">{{t 'Mentions' }}</span>
                     <span class="unread_count"></span>
                 </a>
             </li>
@@ -38,7 +38,7 @@
                         <i class="fa fa-star" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span>{{t 'Starred messages' }}</span>
+                    <span class="top_left_texts">{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
@@ -49,7 +49,7 @@
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span>{{t 'Drafts' }}</span>
+                    <span class="top_left_texts">{{t 'Drafts' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
@@ -63,6 +63,9 @@
                     <span>{{t 'Scheduled messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
+            </li>
+            <li>
+                <span class="arrow top-left-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
         </ul>
     </div>

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -27,6 +27,12 @@
                 {{> dropdown_options_widget option_values=color_scheme_values}}
             </select>
         </div>
+        <div class="input-group">
+            <label for="button_label" class="dropdown-title">{{t "Style for left sidebar links" }}</label>
+            <select name="button_label" class="setting_button_label prop-element settings_select bootstrap-focus-style" id="{{prefix}}button_label" data-setting-widget-type="number">
+                {{> dropdown_options_widget option_values=button_label_values}}
+            </select>
+        </div>
     </div>
 
     <div class="emoji-display-settings {{#if for_realm_settings}}settings-subsection-parent{{else}}subsection-parent{{/if}}">


### PR DESCRIPTION
Added a dropdown in display settings having 2 options:
-Text
-Icons

selecting text will keep the left_sidebar layout same as it is, 
while icons will change the layout to only icons in the top horizontal line.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#24434

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/64723994/222910324-f8306685-a7c1-4972-bd1a-11521f4417fd.png)

![image](https://user-images.githubusercontent.com/64723994/222911342-6e298f81-3d22-4c91-b7f7-ca1d19939eea.png)

![image](https://user-images.githubusercontent.com/64723994/222910626-d560ebbf-d33e-490f-b07b-333e9766f237.png)

![image](https://user-images.githubusercontent.com/64723994/222910637-893d9ac2-910c-455f-971f-f7b1fac89cb5.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
