### PR TITLE
Stream-settings: Aligning edit button on stream settings.

### DIFF
--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -201,6 +201,7 @@ export function initialize() {
         const template_data = {
             group_name: user_group.name,
             group_description: user_group.description,
+            max_user_group_name_length: 100,
         };
         const change_user_group_info_modal = render_change_user_group_info_modal(template_data);
         dialog_widget.launch({

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -407,8 +407,9 @@ h4.user_group_setting_subsection_title {
                 display: none;
                 font-size: 1.5em;
                 line-height: 1;
-                margin: 9px 0;
+                margin: 9px;
                 font-weight: 600;
+                overflow-wrap: break-word;
 
                 .large-icon {
                     display: inline-block;
@@ -441,6 +442,11 @@ h4.user_group_setting_subsection_title {
             text-align: left;
         }
     }
+}
+
+#change_group_info_modal .modal__title,
+#change_stream_info_modal .modal__title {
+    word-break: break-all;
 }
 
 #search_stream_name,
@@ -767,7 +773,7 @@ h4.user_group_setting_subsection_title {
         .button-group {
             padding-top: 5px;
             margin-left: auto;
-            margin-right: 15px;
+            margin-right: 18px;
 
             .subscribe-button,
             #preview-stream-button,
@@ -783,6 +789,7 @@ h4.user_group_setting_subsection_title {
         white-space: nowrap;
         padding-top: 10px;
         display: flex;
+        gap: 3px;
         align-items: center;
 
         .group-name-wrapper,
@@ -794,6 +801,7 @@ h4.user_group_setting_subsection_title {
             margin-left: -3px;
             margin-top: -5px;
             white-space: nowrap;
+            overflow-x: clip;
 
             .group-name,
             .sub-stream-name {
@@ -805,7 +813,7 @@ h4.user_group_setting_subsection_title {
         }
 
         .button-group {
-            margin-left: 1rem;
+            margin-left: auto;
 
             .deactivate {
                 margin-right: 3px;
@@ -843,7 +851,9 @@ h4.user_group_setting_subsection_title {
         .group_change_property_info,
         .stream_change_property_info {
             vertical-align: top;
-            margin: -5px 0 0;
+            margin: 0;
+            padding: 3px 15px;
+            display: none;
         }
     }
 

--- a/web/templates/user_group_settings/change_user_group_info_modal.hbs
+++ b/web/templates/user_group_settings/change_user_group_info_modal.hbs
@@ -2,7 +2,7 @@
     <label for="change_user_group_name">
         {{t 'User group name' }}
     </label>
-    <input type="text" id="change_user_group_name" value="{{ group_name }}" />
+    <input type="text" id="change_user_group_name" value="{{ group_name }}" maxlength="{{max_user_group_name_length}}" />
 </div>
 <div>
     <label for="change_user_group_description">

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -9,7 +9,7 @@
                     {{t "User group name" }}
                 </label>
                 <input type="text" name="user_group_name" id="create_user_group_name"
-                  placeholder="{{t 'User group name' }}" value="" autocomplete="off" />
+                  placeholder="{{t 'User group name' }}" value="" autocomplete="off" maxlength="100"/>
                 <div id="user_group_name_error" class="user_group_creation_error"></div>
             </section>
             <section class="block">


### PR DESCRIPTION
Aligning edit button in stream-name and group-name.
Also, Fixed abbreviation in group-name.

This is a follow-up PR to incorporate changes suggested by @m-e-l-u-h-a-n [here](https://github.com/zulip/zulip/pull/24514/files/0f019980a4f7a89608400e354e78e71acc0016ef#r1124730555).

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/64723994/223075368-508bd4b1-6674-4970-a662-320a0a920efd.png)
![image](https://user-images.githubusercontent.com/64723994/223075400-4d6ad216-db32-4e61-85f0-d8629ffcedef.png)
![image](https://user-images.githubusercontent.com/64723994/223075436-c536bb26-0cac-4d8f-939a-a70f810bb01e.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
