### PR TITLE
hotkey: Fix "z" shortcut add duplicate entry to browser history.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -423,7 +423,13 @@ export function activate(raw_operators, opts) {
     // Open tooltips are only interesting for current narrow,
     // so hide them when activating a new one.
     $(".tooltip").hide();
-
+    if (
+        narrow_state.filter() !== undefined &&
+        filter !== undefined &&
+        JSON.stringify(narrow_state.filter()._operators) === JSON.stringify(filter._operators)
+    ) {
+        return;
+    }
     update_narrow_title(filter);
 
     blueslip.debug("Narrowed", {


### PR DESCRIPTION
Each time a user presses "z" for narrowing to a message it creates a new log even if the message has been narrowed. This leads to use backward multiple times. As a fix for this issue- If the message has already been narrowed then their is no need
to perform the narrow functionality again.

Fixes #24468.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
