### PR TITLE
Fix error message location to be consistent

### DIFF
--- a/web/src/realm_icon.js
+++ b/web/src/realm_icon.js
@@ -27,7 +27,7 @@ export function build_realm_icon_widget(upload_function) {
 
     return upload_widget.build_direct_upload_widget(
         get_file_input,
-        $("#realm-icon-upload-widget .image_file_input_error").expectOne(),
+        $("#organization-profile-heading .subsection-failed-status p").expectOne(),
         $("#realm-icon-upload-widget .image_upload_button").expectOne(),
         upload_function,
         page_params.max_icon_file_size_mib,

--- a/web/src/realm_logo.js
+++ b/web/src/realm_logo.js
@@ -16,7 +16,7 @@ export function build_realm_logo_widget(upload_function, is_night) {
 
     const $delete_button_elem = $(logo_section_id + " .image-delete-button");
     const $file_input_elem = $(logo_section_id + " .image_file_input");
-    const $file_input_error_elem = $(logo_section_id + " .image_file_input_error");
+    const $file_input_error_elem = $("#organization-logo-heading .subsection-failed-status p");
     const $upload_button_elem = $(logo_section_id + " .image_upload_button");
 
     const get_file_input = function () {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -609,8 +609,8 @@ input[type="checkbox"] {
     .alert-notification.timezone-setting-status {
         padding-top: 0;
         padding-bottom: 0;
-        margin-top: 0;
         padding-left: 0;
+        margin-top: 0;
         margin-left: 5px;
         border: none;
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2933,3 +2933,7 @@ select.invite-as {
         but we don't want it to have an outline when focused anywhere in the app. */
     outline: none;
 }
+
+.margin-left {
+    margin-left: 15px;
+}

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -40,7 +40,10 @@
             </div>
         </div>
 
-        <div>{{t "Organization profile picture" }}</div>
+        <div id="organization-profile-heading">{{t "Organization profile picture" }}
+            <div class="inline-block margin-left subsection-failed-status"><p class="hide alert-error"></p></div>
+        </div>
+
         <div class="realm-icon-section">
             {{> image_upload_widget
               widget = "realm-icon"
@@ -54,10 +57,11 @@
             <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview organization profile' }}"></i>
         </a>
 
-        <div class="subsection-header">
+        <div class="subsection-header" id="organization-logo-heading">
             <h3>{{t "Organization logo" }}
                 {{> ../help_link_widget link="/help/create-your-organization-profile#add-a-wide-logo" }}
             </h3>
+            <div class="inline-block margin-left subsection-failed-status"><p class="hide alert-error"></p></div>
             {{> upgrade_tip_widget }}
         </div>
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Closes [issue 17571](https://github.com/zulip/zulip/issues/17571).

 I have made the error message location on the organization settings section consistent by showing error messages beside the heading.
 For eg: Showed the error message **File type is not supported** beside the heading **Organization profile picture**. 


**Screenshots and screen capture:**

File Type Error:
![filetype-error](https://user-images.githubusercontent.com/33905827/222944694-ee7320f5-5f16-461c-82cb-95af7940eb1d.png)

Size more than 5MB error:
![Morethan5](https://user-images.githubusercontent.com/33905827/222944737-0cfa7370-c1aa-450c-9b69-055595ceb41d.png)

File Type Error beside Organization Logo Heading
![filetype-org-logo-dark](https://user-images.githubusercontent.com/33905827/222944787-784d8886-11cd-4454-a129-3124ec357860.png)

personal profile picture error location:
![image](https://user-images.githubusercontent.com/33905827/222944835-31ae98ee-2938-48ab-ba5c-8306e0b0772e.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Testing plan:
Manually tested in the browser