### PR TITLE
Added feature of copying bot email and apikey in personal settings

### DIFF
--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -126,6 +126,27 @@ export function generate_botserverrc_content(email, api_key, token) {
         "\n"
     );
 }
+export function copy_bot_email(bot){
+    let token;
+
+    if(bot.bot_type==3){
+        token = bot_data.get_services(bot.user_id)[0].token;
+    }
+    return(
+        bot.email
+    );
+}
+
+export function copy_bot_apikey(bot){
+    let token;
+
+    if(bot.bot_type==3){
+        token = bot_data.get_services(bot.user_id)[0].token;
+    }
+    return(
+        bot.api_key
+    );
+}
 
 export const bot_creation_policy_values = {
     admins_only: {
@@ -595,6 +616,27 @@ export function set_up() {
         },
     });
 
+    // for bot-email-copy
+    new ClipboardJS("#copy-bot-email", {
+        text(trigger) {
+            const $bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
+            const bot_id = Number.parseInt($bot_info.attr("data-user-id"), 10);
+            const bot = bot_data.get(bot_id);
+            const data = copy_bot_email(bot); 
+            return data;
+        },
+    });
+    // for bot-apikey copy
+    new ClipboardJS("#copy-bot-apikey", {
+        text(trigger) {
+            const $bot_info = $(trigger).closest(".bot-information-box").find(".bot_info");
+            const bot_id = Number.parseInt($bot_info.attr("data-user-id"), 10);
+            const bot = bot_data.get(bot_id);
+            const data = copy_bot_apikey(bot); 
+            return data;
+        },
+    });
+    
     $("#bots_lists_navbar .active-bots-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -127,22 +127,12 @@ export function generate_botserverrc_content(email, api_key, token) {
     );
 }
 export function copy_bot_email(bot){
-    let token;
-
-    if(bot.bot_type==3){
-        token = bot_data.get_services(bot.user_id)[0].token;
-    }
     return(
         bot.email
     );
 }
 
 export function copy_bot_apikey(bot){
-    let token;
-
-    if(bot.bot_type==3){
-        token = bot_data.get_services(bot.user_id)[0].token;
-    }
     return(
         bot.api_key
     );

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -755,7 +755,7 @@ input[type="checkbox"] {
 
     .regenerate_bot_api_key {
         position: relative;
-        margin-left: 5px;
+        margin-left: 3px;
         color: hsl(0, 0%, 67%);
         transition: all 0.3s ease;
 
@@ -821,6 +821,28 @@ input[type="checkbox"] {
         border-radius: 4px;
         vertical-align: top;
         box-shadow: 0 0 4px hsla(0, 0%, 0%, 0.1);
+    }
+
+    .email-copy-container{
+        display: flex;
+    }
+    .bot-email-icon{
+        color: grey;
+        font-size: 12px;
+        margin-left: 3px;
+    }
+    .btn-email-icon{
+        border: none;
+        background: transparent;
+        padding: 2px;
+    }
+    .btn-apicopy-icon{
+        border: none;
+        background: transparent;
+        padding: 2px;
+        color: grey;
+        font-size: 12px;
+        margin-right: 5px;
     }
 
     .email,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -826,21 +826,24 @@ input[type="checkbox"] {
     .email-copy-container{
         display: flex;
     }
+
     .bot-email-icon{
-        color: grey;
+        color: rgb(169,169,169);
         font-size: 12px;
         margin-left: 3px;
     }
+
     .btn-email-icon{
         border: none;
         background: transparent;
         padding: 2px;
     }
+
     .btn-apicopy-icon{
         border: none;
         background: transparent;
         padding: 2px;
-        color: grey;
+        color: rgb(169,169,169);
         font-size: 12px;
         margin-right: 5px;
     }

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -31,7 +31,10 @@
         </div>
         <div class="email">
             <div class="field">{{t "Bot email" }}</div>
-            <div class="value">{{email}}</div>
+            <div class="email-copy-container">
+                <div class="value">{{email}}</div>
+                <button id="copy-bot-email" class=" btn btn-email-icon"><i class="fa fa-clipboard bot-email-icon" aria-hidden="true"></i></button>
+            </div>
         </div>
         {{#if is_active}}
         <div class="api_key">
@@ -39,6 +42,7 @@
             <div class="api-key-value-and-button no-select">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
+                <button id="copy-bot-apikey" class=" btn btn-apicopy-icon"><i class="fa fa-clipboard bot-email-icon" aria-hidden="true"></i></button>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-refresh" aria-hidden="true"></i>
                 </button>


### PR DESCRIPTION
Added a copy icon right of the bot-email and the apikey generated so that anyone can copy their name or apikey whenever it is needed

Below are the screenshots i am adding

<img width="1026" alt="Screenshot 2023-03-06 at 2 42 59 PM" src="https://user-images.githubusercontent.com/68219099/223083889-d90d3ac5-874c-43c5-bef6-5b027242b0e8.png">

<img width="600" alt="Screenshot 2023-03-06 at 2 44 04 PM" src="https://user-images.githubusercontent.com/68219099/223083954-235a250a-01f1-44de-a019-5da28bd3a4cf.png">
