### PR TITLE
tests: Remove ignored `realm_str` parameter from message send test.

### DIFF
--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1351,7 +1351,6 @@ class ScheduledMessageTest(ZulipTestCase):
         defer_until: str = "",
         tz_guess: str = "",
         delivery_type: str = "send_later",
-        realm_str: str = "zulip",
     ) -> "TestHttpResponse":
         self.login("hamlet")
 
@@ -1364,7 +1363,6 @@ class ScheduledMessageTest(ZulipTestCase):
             "to": orjson.dumps(to).decode(),
             "content": msg,
             "topic": topic_name,
-            "realm_str": realm_str,
             "delivery_type": delivery_type,
             "tz_guess": tz_guess,
         }


### PR DESCRIPTION
In commit 8181ec4b56abf, we removed the `realm_str` as a parameter for `send_message_backed`. This removes a missed test that included this as a parameter for that endpoint/function.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
