### PR TITLE
docs: Tell people to set X-Forwarded-Proto

### DIFF
--- a/puppet/zulip/files/nginx/uwsgi_params
+++ b/puppet/zulip/files/nginx/uwsgi_params
@@ -14,5 +14,7 @@ uwsgi_param SERVER_ADDR     $server_addr;
 uwsgi_param SERVER_PORT     $server_port;
 uwsgi_param SERVER_NAME     $server_name;
 uwsgi_param HTTP_X_REAL_IP  $remote_addr;
+uwsgi_param HTTP_X_FORWARDED_PROTO $trusted_x_forwarded_proto;
+uwsgi_param HTTP_X_FORWARDED_SSL "";
 
 uwsgi_pass django;

--- a/puppet/zulip/files/nginx/zulip-include-common/proxy
+++ b/puppet/zulip/files/nginx/zulip-include-common/proxy
@@ -3,7 +3,7 @@ proxy_http_version 1.1;
 # http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
 proxy_set_header Connection "";
 proxy_set_header Host $host;
-proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Proto $trusted_x_forwarded_proto;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Real-Ip $remote_addr;
 proxy_next_upstream off;

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -55,6 +55,17 @@ class zulip::nginx {
     content => template('zulip/nginx.conf.template.erb'),
   }
 
+  $loadbalancers = split(zulipconf('loadbalancer', 'ips', ''), ',')
+  file { '/etc/nginx/zulip-include/trusted-proto':
+    ensure  => file,
+    require => Package[$zulip::common::nginx],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    notify  => Service['nginx'],
+    content => template('zulip/nginx/trusted-proto.template.erb'),
+  }
+
   file { '/etc/nginx/uwsgi_params':
     ensure  => file,
     require => Package[$zulip::common::nginx],

--- a/puppet/zulip/templates/nginx/trusted-proto.template.erb
+++ b/puppet/zulip/templates/nginx/trusted-proto.template.erb
@@ -1,0 +1,18 @@
+<% if @loadbalancers.empty? %>
+set $trusted_x_forwarded_proto $scheme;
+<% else %>
+# We do this in two steps because `geo` does not support variable
+# interpolation in the value, but does support CIDR notation,
+# which the loadbalancer list may use.
+geo $realip_remote_addr $is_x_forwarded_proto_trusted {
+    default 0;
+<% @loadbalancers.each do |host| -%>
+    <%= host %> 1;
+<% end -%>
+}
+
+map $is_x_forwarded_proto_trusted $trusted_x_forwarded_proto {
+    0 $scheme;
+    1 $http_x_forwarded_proto;
+}
+<% end %>

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -12,6 +12,7 @@ server {
 }
 <% end -%>
 
+include /etc/nginx/zulip-include/trusted-proto;
 include /etc/nginx/zulip-include/s3-cache;
 include /etc/nginx/zulip-include/upstreams;
 include /etc/zulip/nginx_sharding_map.conf;


### PR DESCRIPTION
This has been required since a change in Django 4.0

This did not come out until people had http zulip servers accessed over https proxies.

Fixes: 
- https://github.com/zulip/zulip/issues/24599
- https://chat.zulip.org/#narrow/stream/9-issues/topic/Zulip.206.2E0.20behind.20reverse.20proxy.20-.20CSRF.20verification.20failed

<details>
<summary>Self-review checklist</summary>

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.). *Not Applicable*

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
