### PR TITLE
drafts: Space draft message content from restore draft button by 5px.

### DIFF
--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -108,6 +108,8 @@
 
             .message_content {
                 grid-column: 1 / 2;
+                /* to space from restore draft button */
+                margin-right: 5px;
             }
 
             .message_top_line {


### PR DESCRIPTION
When the 1st line of a draft message took up the maximum horizontal space possible, the last character was way too close to the pencil icon. More noticeably, when a message began with a code block, it's right edge would touch the icon.

To space the message contents and the restore draft button, now a margin of 5px has been added to the draft message content. This makes the message content narrower by 5px.

Fixes: [Issue described here on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/code.20block.20in.20drafts.20too.20close.20to.20restore.20button)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before:
![image](https://user-images.githubusercontent.com/68962290/223226399-3ee884ac-a82a-405e-85c3-56b6cc5da78e.png)

After:
![image](https://user-images.githubusercontent.com/68962290/223226325-44c16ac9-83fa-47ca-834e-b0faddac62f5.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
