### PR TITLE
portico: Add landing page about trying Zulip by visiting chat.zulip.org.

### DIFF
--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -70,6 +70,7 @@ landing_page_urls = [
     path("why-zulip/", landing_view, {"template_name": "corporate/why-zulip.html"}),
     path("self-hosting/", landing_view, {"template_name": "corporate/self-hosting.html"}),
     path("security/", landing_view, {"template_name": "corporate/security.html"}),
+    path("try-zulip/", landing_view, {"template_name": "corporate/try-zulip.html"}),
     # /for pages
     path("use-cases/", landing_view, {"template_name": "corporate/for/use-cases.html"}),
     path(

--- a/templates/corporate/case-studies/tum-case-study.md
+++ b/templates/corporate/case-studies/tum-case-study.md
@@ -31,8 +31,8 @@ when Tobias came across Zulip.
 
 ## “Better user experience than Slack”
 
-Tobias evaluated Zulip by visiting the [Zulip developer
-community][chat-zulip-org] to see it in action. “It takes a bit of
+Tobias evaluated Zulip by [visiting the Zulip development
+community](/try-zulip/) to see it in action. “It takes a bit of
 time to get used to, but Zulip has the best user experience of all the
 chat apps I’ve tried,” Tobias says. “With the discussion organized by
 topic within each stream, Zulip is the only app that makes hundreds of
@@ -84,6 +84,5 @@ and [research](/for/research)!
 
 
 [tum-ranking]: https://www.in.tum.de/en/the-department/profile-of-the-department/facts-figures/facts-and-figures-2020/
-[chat-zulip-org]: /development-community/
 [czo-patch-thread]: https://chat.zulip.org/#narrow/stream/3-backend/topic/Tornado.20performance/near/1111686
 [zulip-4-blog]: https://blog.zulip.com/2021/05/13/zulip-4-0-released/

--- a/templates/corporate/try-zulip-part1.md
+++ b/templates/corporate/try-zulip-part1.md
@@ -1,0 +1,21 @@
+You can check out the Zulip app by viewing the [Zulip development
+community](https://chat.zulip.org/), where hundreds of participants collaborate
+to improve Zulip. Many parts of the community are open for [public
+access](/help/public-access-option), so you can start exploring without creating
+an account.
+
+You can:
+
+- **Browse recent conversations**. You’ll see a list as soon as you open the
+  app, and you can always get back to it by clicking on “Recent conversations”
+  in the upper left.
+- **Click on the name of a**
+  [**stream**](/help/streams-and-topics) on the left to open a
+  list of recent conversation topics. For example, you can explore discussions
+  of changes to the design of the Zulip app in
+  [#design](https://chat.zulip.org/#narrow/stream/101-design), or see ongoing
+  issue investigations in
+  [#issues](https://chat.zulip.org/#narrow/stream/9-issues).
+- **Click on each topic** in a stream to view conversations one at a time.
+  Notice how Zulip makes it easy to have many conversations at once, without
+  them getting in each other’s way.

--- a/templates/corporate/try-zulip-part2.md
+++ b/templates/corporate/try-zulip-part2.md
@@ -1,0 +1,10 @@
+To fully experience the Zulip app, we invite you to [create an
+account](https://chat.zulip.org/join/t5crtoe62bpcxyisiyglmtvb/) in the
+development community. You’ll be able to send messages, experience the
+convenience of going through your unread messages, and much more.  Please be
+sure to follow [community guidelines](/development-community/), and send any
+test messages to the [#test
+here](https://chat.zulip.org/#narrow/stream/7-test-here) stream.
+
+You can also view <a href="/plans/">plans and pricing</a>, or create a <a
+href="/new/">new organization</a>.

--- a/templates/corporate/try-zulip.html
+++ b/templates/corporate/try-zulip.html
@@ -1,0 +1,46 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
+
+{% set PAGE_TITLE = "Try Zulip now" %}
+
+{% set PAGE_DESCRIPTION = "Check out the Zulip app by viewing the Zulip
+  development community. No account required." %}
+
+{% block customhead %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{% endblock %}
+
+{% block portico_content %}
+
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing why-page solutions-page try-zulip-now-page">
+    <div class="hero">
+        <div class="content">
+            <h1 class="center">Try Zulip now</h1>
+            <p>
+                Check out the Zulip app in the <a
+                href="https://chat.zulip.org">Zulip development
+                community</a>.<br /> No account required.
+            </p>
+        </div>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+
+            <div class="inner-content markdown">
+                {{ render_markdown_path('corporate/try-zulip-part1.md') }}
+            </div>
+            <div class="bottom-register-buttons">
+                <a href="https://chat.zulip.org/" class="try-now-button">
+                    {{ _('Try Zulip now') }}
+                </a>
+            </div>
+            <div class="inner-content markdown">
+                {{ render_markdown_path('corporate/try-zulip-part2.md') }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/web/styles/portico/landing_page.css
+++ b/web/styles/portico/landing_page.css
@@ -4391,3 +4391,37 @@ nav {
         }
     }
 }
+
+.try-zulip-now-page {
+    .bottom-register-buttons {
+        text-align: center;
+        margin-bottom: 20px;
+    }
+
+    .try-now-button {
+        padding: 11px 25px;
+        font-size: 1.2rem;
+        font-weight: 400;
+        color: hsl(0, 0%, 100%);
+        background: linear-gradient(
+            145deg,
+            hsl(191, 56%, 55%),
+            hsl(169, 65%, 42%)
+        );
+        box-shadow: 0 3px 10px hsla(0, 0%, 0%, 0.2);
+        border: 0;
+        width: 200px;
+        height: 50px;
+        outline: none;
+        border-radius: 4px;
+
+        &:visited {
+            color: hsl(0, 0%, 100%);
+        }
+
+        &:hover {
+            background-color: hsl(169, 65%, 42%);
+            box-shadow: 0 3px 10px hsla(0, 0%, 0%, 0.3);
+        }
+    }
+}

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -197,6 +197,7 @@ class DocPageTest(ZulipTestCase):
         self._test("/security/", "TLS encryption")
         self._test("/use-cases/", "Use cases and customer stories")
         self._test("/why-zulip/", "Why Zulip?")
+        self._test("/try-zulip/", "check out the Zulip app")
         # /for/... pages
         self._test("/for/open-source/", "for open source projects")
         self._test("/for/events/", "for conferences and events")


### PR DESCRIPTION
Needs fixing:
- I couldn't figure out how to make the "Try Zulip" button in the middle of the page use white font when not hovered. @amanagr could you help out? I think we should also try increasing the font size on the button.

Testing:
- Manually tested links.

Follow-ups (links to this page):
- We probably want to link to this page from https://zulip.com/development-community/.
- Link here from https://zulip.com/help/trying-out-zulip
- Should we link here from the header (Product menu?) and/or footer?
- Any other links besides the redesigned /hello page (#24082)?

Questions:
- Are we OK with the using "try-zulip" for the URL, even though in the future the "Try Zulip" button on `/hello` is expected to be used for demo orgs, and the button to go here will be "See Zulip in action"? We will probably update the title/content on this page at that point.

<details>
<summary>Screenshot</summary>

![Screen Shot 2023-03-06 at 3 15 53 PM](https://user-images.githubusercontent.com/2090066/223279436-d1069d29-8cfd-4360-858d-f7b4cd9937f4.png)

</details>