### PR TITLE
typeahead: Add option for word order not mattering for query matching.

### DIFF
--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -62,6 +62,9 @@ export function query_matches_string(
     source_str = source_str.toLowerCase();
     source_str = remove_diacritics(source_str);
 
+    query = query.toLowerCase();
+    query = remove_diacritics(query);
+
     if (!query.includes(split_char)) {
         // If query is a single token (doesn't contain a separator),
         // the match can be anywhere in the string.

--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -54,7 +54,7 @@ export function remove_diacritics(s: string): string {
 // * query is the user-entered search query
 // * source_str is the string we're matching in, e.g. a user's name
 // * split_char is the separator for this syntax (e.g. ' ').
-export function query_matches_string(
+export function query_matches_string_in_order(
     query: string,
     source_str: string,
     split_char: string,
@@ -111,7 +111,7 @@ export function get_emoji_matcher(query: string): (emoji: Emoji) => boolean {
         const matches_emoji_literal =
             emoji.reaction_type === "unicode_emoji" &&
             parse_unicode_emoji_code(emoji.emoji_code) === query;
-        return matches_emoji_literal || query_matches_string(query, emoji.emoji_name, "_");
+        return matches_emoji_literal || query_matches_string_in_order(query, emoji.emoji_name, "_");
     };
 }
 

--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -50,7 +50,36 @@ export function remove_diacritics(s: string): string {
     return s.normalize("NFKD").replace(unicode_marks, "");
 }
 
-// This function attempts to match a query with a source text.
+export function last_prefix_match(prefix: string, words: string[]): number | null {
+    // This function takes in a lexicographically sorted array of `words`,
+    // and a `prefix` string. It uses binary search to compute the index
+    // of `prefix`'s upper bound, that is, the string immediately after
+    // the lexicographically last prefix match of `prefix`. So, the return
+    // value is the upper bound minus 1, that is, the last prefix match's
+    // index. When no prefix match is found, we return null.
+    let left = 0;
+    let right = words.length;
+    let found = false;
+    while (left < right) {
+        const mid = Math.floor((left + right) / 2);
+        if (words[mid].startsWith(prefix)) {
+            // Note that left can never be 0 if `found` is true,
+            // since it is incremented at least once here.
+            left = mid + 1;
+            found = true;
+        } else if (words[mid] < prefix) {
+            left = mid + 1;
+        } else {
+            right = mid;
+        }
+    }
+    if (found) {
+        return left - 1;
+    }
+    return null;
+}
+
+// This function attempts to match a query in order with a source text.
 // * query is the user-entered search query
 // * source_str is the string we're matching in, e.g. a user's name
 // * split_char is the separator for this syntax (e.g. ' ').
@@ -76,6 +105,68 @@ export function query_matches_string_in_order(
     // (E.g. for 'ab cd ef', query could be 'ab c' or 'cd ef',
     // but not 'b cd ef'.)
     return source_str.startsWith(query) || source_str.includes(split_char + query);
+}
+
+// Match the words in the query to the words in the source text, in any order.
+//
+// The query matches the source if each word in the query can be matched to
+// a different word in the source. The order the words appear in the query
+// or in the source does not affect the result.
+//
+// A query word matches a source word if it is a prefix of the source word,
+// after both words are converted to lowercase and diacritics are removed.
+//
+// Returns true if the query matches, and false if not.
+//
+// * query is the user-entered search query
+// * source_str is the string we're matching in, e.g. a user's name
+// * split_char is the separator for this syntax (e.g. ' ').
+export function query_matches_string_in_any_order(
+    query: string,
+    source_str: string,
+    split_char: string,
+): boolean {
+    source_str = source_str.toLowerCase();
+    source_str = remove_diacritics(source_str);
+
+    query = query.toLowerCase();
+    query = remove_diacritics(query);
+
+    const search_words = query.split(split_char).filter(Boolean);
+    const source_words = source_str.split(split_char).filter(Boolean);
+    if (search_words.length > source_words.length) {
+        return false;
+    }
+
+    // We go through the search words in reverse lexicographical order, and to select
+    // the corresponding source word for each, one by one, we find the lexicographically
+    // last possible prefix match and immediately then remove it from consideration for
+    // remaining search words.
+
+    // This essentially means that there is no search word lexicographically greater than
+    // our current search word (say, q1) which might require the current corresponding source
+    // word (as all search words lexicographically greater than it have already been matched)
+    // and also that all search words lexicographically smaller than it have the best possible
+    // chance for getting matched.
+
+    // This is because if the source word we just removed (say, s1) is the sole match for
+    // another search word (say, q2 - obviously lexicographically smaller than q1), this
+    // means that either q2 = q1 or that q2 is a prefix of q1. In either case, the final
+    // return value of this function should anyway be false, as s1 would be the sole match
+    // for q1 too; while we need unique matches for each search word.
+
+    search_words.sort().reverse();
+    source_words.sort();
+    for (const word of search_words) {
+        // `match_index` is the index of the best possible match of `word`.
+        const match_index = last_prefix_match(word, source_words);
+        if (match_index === null) {
+            // We return false if no match was found for `word`.
+            return false;
+        }
+        source_words.splice(match_index, 1);
+    }
+    return true;
 }
 
 function clean_query(query: string): string {

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -91,14 +91,14 @@ function get_language_matcher(query) {
 
 export function query_matches_person(query, person) {
     return (
-        typeahead.query_matches_string(query, person.full_name, " ") ||
+        typeahead.query_matches_string_in_order(query, person.full_name, " ") ||
         (Boolean(person.delivery_email) &&
-            typeahead.query_matches_string(query, people.get_visible_email(person), " "))
+            typeahead.query_matches_string_in_order(query, people.get_visible_email(person), " "))
     );
 }
 
 export function query_matches_name(query, user_group_or_stream) {
-    return typeahead.query_matches_string(query, user_group_or_stream.name, " ");
+    return typeahead.query_matches_string_in_order(query, user_group_or_stream.name, " ");
 }
 
 function get_stream_or_user_group_matcher(query) {
@@ -115,8 +115,8 @@ function get_slash_matcher(query) {
 
     return function (item) {
         return (
-            typeahead.query_matches_string(query, item.name, " ") ||
-            typeahead.query_matches_string(query, item.aliases, " ")
+            typeahead.query_matches_string_in_order(query, item.name, " ") ||
+            typeahead.query_matches_string_in_order(query, item.aliases, " ")
         );
     };
 }
@@ -129,7 +129,7 @@ function get_topic_matcher(query) {
             topic,
         };
 
-        return typeahead.query_matches_string(query, obj.topic, " ");
+        return typeahead.query_matches_string_in_order(query, obj.topic, " ");
     };
 }
 

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import _ from "lodash";
 
+import * as typeahead from "../shared/src/typeahead";
 import render_introduce_zulip_view_modal from "../templates/introduce_zulip_view_modal.hbs";
 import render_recent_view_filters from "../templates/recent_view_filters.hbs";
 import render_recent_view_row from "../templates/recent_view_row.hbs";
@@ -635,8 +636,7 @@ export function topic_in_search_results(keyword, stream_name, topic) {
         return true;
     }
     const text = (stream_name + " " + topic).toLowerCase();
-    const search_words = keyword.toLowerCase().split(/\s+/);
-    return search_words.every((word) => text.includes(word));
+    return typeahead.query_matches_string_in_any_order(keyword, text, " ");
 }
 
 export function update_topics_of_deleted_message_ids(message_ids) {

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -1120,22 +1120,24 @@ test("test_search", () => {
     assert.equal(rt.topic_in_search_results("recent", "general", "Recent topic"), true);
     assert.equal(rt.topic_in_search_results("RECENT", "general", "Recent topic"), true);
 
-    // match in any order of words
+    // Match (by prefix) in any order of words.
     assert.equal(rt.topic_in_search_results("topic recent", "general", "Recent topic"), true);
-
-    // Matches any sequence of words.
-    assert.equal(rt.topic_in_search_results("o", "general", "Recent topic"), true);
-    assert.equal(rt.topic_in_search_results("nt to", "general", "Recent topic"), true);
-    assert.equal(rt.topic_in_search_results("z", "general", "Recent topic"), false);
+    assert.equal(rt.topic_in_search_results("o", "general", "Recent topic"), false);
+    assert.equal(rt.topic_in_search_results("to recen", "general", "Recent topic"), true);
+    assert.equal(rt.topic_in_search_results("ner opic", "general", "Recent topic"), false);
+    assert.equal(rt.topic_in_search_results("pr pro", "general", "pro PRs"), true);
+    assert.equal(rt.topic_in_search_results("pr pro pr pro", "general", "pro PRs"), false);
+    assert.equal(rt.topic_in_search_results("co cows", "general", "one cow 2 cows"), true);
+    assert.equal(rt.topic_in_search_results("cows cows", "general", "one cow 2 cows"), false);
 
     assert.equal(rt.topic_in_search_results("?", "general", "Recent topic"), false);
 
     // Test special character match
     assert.equal(rt.topic_in_search_results(".*+?^${}()[]\\", "general", "Recent topic"), false);
-    assert.equal(rt.topic_in_search_results("?", "general", "not-at-start?"), true);
+    assert.equal(rt.topic_in_search_results("?", "general", "?at-start"), true);
 
     assert.equal(rt.topic_in_search_results("?", "general", "?"), true);
-    assert.equal(rt.topic_in_search_results("?", "general", "\\?"), true);
+    assert.equal(rt.topic_in_search_results("?", "general", "\\?"), false);
 
     assert.equal(rt.topic_in_search_results("\\", "general", "\\"), true);
     assert.equal(rt.topic_in_search_results("\\", "general", "\\\\"), true);

--- a/web/tests/typeahead.test.js
+++ b/web/tests/typeahead.test.js
@@ -272,3 +272,51 @@ run_test("sort_emojis: prioritise perfect matches", () => {
     ];
     assert.deepEqual(typeahead.sort_emojis(emoji_list, "thank you"), emoji_list);
 });
+
+run_test("last_prefix_match", () => {
+    let words = [
+        "apple",
+        "banana",
+        "cantaloupe",
+        "cherry",
+        "kiwi",
+        "melon",
+        "pear",
+        "plum",
+        "raspberry",
+        "watermelon",
+    ];
+    let prefix = "p";
+    assert.equal(typeahead.last_prefix_match(prefix, words), 7);
+
+    prefix = "ch";
+    assert.equal(typeahead.last_prefix_match(prefix, words), 3);
+
+    prefix = "pom";
+    assert.equal(typeahead.last_prefix_match(prefix, words), null);
+
+    prefix = "aa";
+    assert.equal(typeahead.last_prefix_match(prefix, words), null);
+
+    prefix = "zu";
+    assert.equal(typeahead.last_prefix_match(prefix, words), null);
+
+    prefix = "";
+    assert.equal(typeahead.last_prefix_match(prefix, words), 9);
+
+    words = ["one"];
+    prefix = "one";
+    assert.equal(typeahead.last_prefix_match(prefix, words), 0);
+
+    words = ["aa", "pr", "pra", "pre", "pri", "pro", "pru", "zz"];
+    prefix = "pr";
+    assert.equal(typeahead.last_prefix_match(prefix, words), 6);
+
+    words = ["same", "same", "same", "same", "same"];
+    prefix = "same";
+    assert.equal(typeahead.last_prefix_match(prefix, words), 4);
+
+    words = [];
+    prefix = "empty";
+    assert.equal(typeahead.last_prefix_match(prefix, words), null);
+});


### PR DESCRIPTION
Fixes: Uptil now, the `query_matches_string` function always respected the order of words in the query string when matching a source string. This meant that for query "two one", the source string "one two three" would not be matched.

To make this more flexible, a default parameter `order_matters` has been added to the function. When it's passed in as false, the function returns true if each word in the query string matches the prefix of any distinct word in the source string, else it returns false.

The algorithm for computing this is quadratic in terms of the source word count so can be a little expensive but it is only currently used for searching topics in Recent Conversations, where the strings' length is limited by the max stream / topic name length allowed, so this should be performant enough for this use case.

Related CZO thread: https://chat.zulip.org/#narrow/stream/9-issues/topic/Filter.20Stream.20List/near/1501097

**Screenshots and screen captures:**
Before:
![image](https://user-images.githubusercontent.com/68962290/223473664-c13637cc-973c-4f45-98d1-d987dbfc72dd.png)

After:
![image](https://user-images.githubusercontent.com/68962290/223473945-6f780655-6cc9-41ac-ae18-26fabc13624a.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
