### PR TITLE
popovers: Fix hide popovers during scroll in recent conversations.

### DIFF
--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -759,7 +759,7 @@ function topic_offset_to_visible_area(topic_row) {
     return "visible";
 }
 
-function set_focus_to_element_in_center() {
+function recenter_focus_if_off_screen() {
     const table_wrapper_element = document.querySelector("#recent_topics_table .table_fix_head");
     const $topic_rows = $("#recent_topics_table table tbody tr");
 
@@ -857,7 +857,7 @@ export function complete_rerender() {
             popovers.hide_all();
 
             // Update the focused element for keyboard navigation if needed.
-            set_focus_to_element_in_center();
+            recenter_focus_if_off_screen();
         },
         get_min_load_count,
     });

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -852,7 +852,13 @@ export function complete_rerender() {
         $simplebar_container: $("#recent_topics_table .table_fix_head"),
         callback_after_render: () => setTimeout(revive_current_focus, 0),
         is_scroll_position_for_render,
-        post_scroll__pre_render_callback: set_focus_to_element_in_center,
+        post_scroll__pre_render_callback() {
+            // Hide popovers on scroll in recent conversations.
+            popovers.hide_all();
+
+            // Update the focused element for keyboard navigation if needed.
+            set_focus_to_element_in_center();
+        },
         get_min_load_count,
     });
 }


### PR DESCRIPTION
The popovers do not hide when we scroll
while we are in the recent_conversations
tab. This commit fixes the same.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![fix](https://user-images.githubusercontent.com/101464851/223525680-5f814461-02a8-42d9-96ca-bdf9eecc7cf1.gif)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
