### PR TITLE
title: Change the title of send button dynamically.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -246,6 +246,11 @@ export function initialize() {
                 user_settings.enter_sends = selected_behaviour;
                 $(`.enter_sends_${!selected_behaviour}`).hide();
                 $(`.enter_sends_${selected_behaviour}`).show();
+                if (user_settings.enter_sends) {
+                    $("#compose-send-button").prop("title", "Send (Enter)");
+                } else {
+                    $("#compose-send-button").prop("title", "Send (Ctrl + Enter)");
+                }
 
                 // Refocus in the content box so you can continue typing or
                 // press Enter to send.

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -226,6 +226,7 @@ function initialize_compose_box() {
             giphy_enabled: giphy.is_giphy_enabled(),
             max_stream_name_length: page_params.max_stream_name_length,
             max_topic_length: page_params.max_topic_length,
+            enter_sends_true: user_settings.enter_sends,
         }),
     );
     $(`.enter_sends_${user_settings.enter_sends}`).show();

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -109,7 +109,7 @@
                             <div id="below-compose-content">
                                 <div class="compose_bottom_top_container">
                                     <div class="compose_right_float_container order-3">
-                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)">
+                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button"  title="{{#if enter_sends_true}}{{t 'Send (Enter)'}}{{else}}{{t 'Send (Ctrl + Enter)'}}{{/if}}">
                                             <img class="loader" alt="" src="" />
                                             <span>{{t 'Send' }}</span>
                                         </button>


### PR DESCRIPTION
Previously, the title of the send button in the compose box was always `Ctrl+Enter`, regardless of the user's preferences.
Now if the user changes their preference the title will also change accordingly.

Fixes #24619.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots:**

***Before***

![Screenshot from 2023-03-08 16-49-50](https://user-images.githubusercontent.com/86338542/223814866-80f4fb1c-ae3d-4b8a-936f-008b866fd5be.png)

***After***


![Screenshot from 2023-03-09 00-36-56](https://user-images.githubusercontent.com/86338542/223815130-116cb5b7-fbb2-4598-867c-a945dbc7d3d1.png)

![Screenshot from 2023-03-09 00-37-16](https://user-images.githubusercontent.com/86338542/223815166-8245f69c-672f-4d87-b85b-42219b77438b.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
