### PR TITLE
stream_popover: Migrate Bootstrap to Tippy in starred messages' popover.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -362,6 +362,11 @@ function handle_popover_events(event_name) {
         return true;
     }
 
+    if (popover_menus.is_starred_messages_visible()) {
+        popover_menus.starred_messages_sidebar_menu_handle_keyboard(event_name);
+        return true;
+    }
+
     if (popovers.user_info_manage_menu_popped()) {
         popovers.user_info_popover_manage_menu_handle_keyboard(event_name);
         return true;
@@ -397,10 +402,6 @@ function handle_popover_events(event_name) {
         return true;
     }
 
-    if (stream_popover.starred_messages_popped()) {
-        stream_popover.starred_messages_sidebar_menu_handle_keyboard(event_name);
-        return true;
-    }
     return false;
 }
 

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1142,7 +1142,6 @@ export function hide_all_except_sidebars(opts) {
     stream_popover.hide_stream_popover();
     stream_popover.hide_topic_popover();
     stream_popover.hide_all_messages_popover();
-    stream_popover.hide_starred_messages_popover();
     stream_popover.hide_drafts_popover();
     hide_all_user_info_popovers();
     hide_playground_links_popover();

--- a/web/src/starred_messages.js
+++ b/web/src/starred_messages.js
@@ -1,5 +1,6 @@
 import * as message_store from "./message_store";
 import {page_params} from "./page_params";
+import * as popover_menus from "./popover_menus";
 import * as stream_popover from "./stream_popover";
 import * as top_left_corner from "./top_left_corner";
 import {user_settings} from "./user_settings";
@@ -81,6 +82,6 @@ export function rerender_ui() {
     }
 
     stream_popover.hide_topic_popover();
+    popover_menus.get_starred_messages_popover()?.hide();
     top_left_corner.update_starred_count(count);
-    stream_popover.hide_starred_messages_popover();
 }

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -100,10 +100,8 @@ i.zulip-icon.zulip-icon-bot {
 }
 
 .tippy-content {
-    /* This actually sets the
-     * default font size of only
-     * tooltips; popovers should define
-     * font-size of their own.
+    /* Set the default font size for tooltips. Popovers override this with
+       a rule looking at the data-theme.
      */
     font-size: 12px;
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -1,3 +1,26 @@
+/*
+  Our Tippy popovers use the strangely named "light-border" Tippy
+  theme, so this block defines the common styling for all of our Tippy
+  popovers. (Tippy tooltips are defined in tooltips.css).
+*/
+.tippy-box[data-theme="light-border"] {
+    /* TODO: Clean this logic up after drop Bootstrap styling */
+    & ul.nav {
+        /* Override default padding of tippyjs */
+        margin: 0 -9px;
+
+        /* Override bootstrap defaults */
+        .nav-list > li > a {
+            padding: 3px 15px;
+        }
+
+        /* Override bootstrap defaults */
+        & hr {
+            margin: 5px 0;
+        }
+    }
+}
+
 .popover {
     width: auto;
     max-width: 100%;
@@ -206,19 +229,6 @@ ul {
 }
 
 .actions_popover {
-    /* Override default padding of tippyjs */
-    margin: 0 -9px;
-
-    /* Override bootstrap defaults */
-    .nav-list > li > a {
-        padding: 3px 15px;
-    }
-
-    /* Override bootstrap defaults */
-    & hr {
-        margin: 5px 0;
-    }
-
     .mark_as_unread {
         .unread_count {
             /* The icon for this menu item is in the form of an unread count from

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -4,6 +4,10 @@
   popovers. (Tippy tooltips are defined in tooltips.css).
 */
 .tippy-box[data-theme="light-border"] {
+    .tippy-content {
+        font-size: 14px;
+    }
+
     /* TODO: Clean this logic up after drop Bootstrap styling */
     & ul.nav {
         /* Override default padding of tippyjs */

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -66,6 +66,7 @@ const popovers = mock_esm("../src/popovers", {
 });
 const popover_menus = mock_esm("../src/popover_menus", {
     actions_popped: () => false,
+    is_starred_messages_visible: () => false,
 });
 const reactions = mock_esm("../src/reactions");
 const search = mock_esm("../src/search");
@@ -86,7 +87,6 @@ const stream_popover = mock_esm("../src/stream_popover", {
     stream_popped: () => false,
     topic_popped: () => false,
     all_messages_popped: () => false,
-    starred_messages_popped: () => false,
 });
 
 message_lists.current = {

--- a/web/tests/popovers.test.js
+++ b/web/tests/popovers.test.js
@@ -33,7 +33,6 @@ mock_esm("../src/stream_popover", {
     hide_stream_popover: noop,
     hide_topic_popover: noop,
     hide_all_messages_popover: noop,
-    hide_starred_messages_popover: noop,
     hide_drafts_popover: noop,
     hide_streamlist_sidebar: noop,
 });

--- a/web/tests/starred_messages.test.js
+++ b/web/tests/starred_messages.test.js
@@ -12,7 +12,6 @@ const top_left_corner = mock_esm("../src/top_left_corner", {
 });
 const stream_popover = mock_esm("../src/stream_popover", {
     hide_topic_popover() {},
-    hide_starred_messages_popover() {},
 });
 
 const message_store = zrequire("message_store");


### PR DESCRIPTION
This PR is part of popovers migration to Tippy.JS.

- [x] fix styles to match previous popover
- [x] keyboard handling
- [x] popover positioning on mobile

![localhost_9991_](https://user-images.githubusercontent.com/53193850/224336416-b1b6aee5-a99d-4173-9293-6892f38cb237.png)
![localhost_9991_(iPhone 12 Pro)](https://user-images.githubusercontent.com/53193850/224336440-0168fafc-607f-4099-93a8-0c592d162595.png)



<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>