### PR TITLE
[WIP] emails: Add a welcome email advertising /for/X pages.

### DIFF
--- a/templates/zerver/emails/for_x_email.source.html
+++ b/templates/zerver/emails/for_x_email.source.html
@@ -1,0 +1,28 @@
+{% extends "zerver/emails/compiled/email_base_default.html" %}
+
+{% block illustration %}
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+
+<p>{{ _("We hope you have been enjoying Zulip so far!") }}</p>
+
+<p>{{ _("As you are getting started, check out this guide to key Zulip features
+for organizations like yours.") }}</p>
+
+<a class="button" href="{{ for_business_link }}">{{ _("View Zulip's guide for business organizations") }}</a>
+
+<p>
+    {% trans support_email=macros.email_tag(support_email) %}Questions? Contact
+us any time at {{ support_email }}.{% endtrans %}
+</p>
+
+{% endblock %}
+
+{% block manage_preferences %}
+<p>
+    <a href="{{ realm_uri }}/#settings/notifications">{{ _("Manage email preferences") }}</a> |
+    <a href="{{ unsubscribe_link }}">{{ _("Unsubscribe from welcome emails") }}</a>
+</p>
+{% endblock %}

--- a/templates/zerver/emails/for_x_email.subject.txt
+++ b/templates/zerver/emails/for_x_email.subject.txt
@@ -1,0 +1,1 @@
+{% trans %}Learn about Zulip's features for business organizations {% endtrans %}

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -708,6 +708,9 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> N
     )
     context["getting_user_started_link"] = user.realm.uri + "/help/getting-started-with-zulip"
 
+    # /for/X links
+    context["for_business_link"] = "https://zulip.com/for/business"
+
     # Imported here to avoid import cycles.
     from zproject.backends import ZulipLDAPAuthBackend, email_belongs_to_ldap
 
@@ -740,6 +743,16 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> N
             context=context,
             delay=followup_day2_email_delay(user),
         )
+
+    send_future_email(
+        "zerver/emails/for_x_email",
+        user.realm,
+        to_user_ids=[user.id],
+        from_name=from_name,
+        from_address=from_address,
+        context=context,
+        delay=followup_day2_email_delay(user),
+    )
 
 
 def convert_html_to_markdown(html: str) -> str:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4301,6 +4301,7 @@ class ScheduledMessage(models.Model):
 EMAIL_TYPES = {
     "followup_day1": ScheduledEmail.WELCOME,
     "followup_day2": ScheduledEmail.WELCOME,
+    "for_x_email": ScheduledEmail.WELCOME,
     "digest": ScheduledEmail.DIGEST,
     "invitation_reminder": ScheduledEmail.INVITATION_REMINDER,
 }


### PR DESCRIPTION
Sketch for adding a new welcome email.

<details>
<summary>
Screenshot
</summary>

![Screen Shot 2023-03-08 at 2 46 22 PM](https://user-images.githubusercontent.com/2090066/223870734-b621f097-7d7e-4fff-bda9-2d8c82e6236d.png)

</details

---

## Known remaining steps:

1.  Add conditionals based on organization type for:
  - subject line
  - /for/x link button

Subject line structure should be updated to: "Zulip guide for X".

Organization type -> subject word and link mapping:
  - 0 = Unspecified -> no email
  - 10 = Business -> businesses; /for/business
  - 20 = Open-source project -> open-source projects; /for/open-source
  - 30 = Education (non-profit) -> education; /for/education
  - 35 = Education (for-profit) -> education; /for/education
  - 40 = Research -> research; /for/research
  - 50 = Event or conference -> events and conferences; /for/events
  - 60 = Non-profit (registered) -> non-profits; /for/communities
  - 70 = Government -> no email
  - 80 = Political group -> no email
  - 90 = Community -> communities; /for/communities
  - 100 = Personal -> no email
  - 1000 = Other -> no email

I'm not too picky about what happens if the org type changes between when the user registers and the email is getting sent. I expect this to be a rare case.

2. For scheduling, use equivalent logic to `followup_day2_email_delay`, but with `days_to_delay` = 4 [we might play with this value]. The code should be written with the expectation that more emails will be created with similar logic.
3. Create a text-only version of this email.
4. Probably rename this template, since we don't usually put `_email` in template names? Just `for_x` seemed confusing to me, but maybe it's all right. Anyway, leaving it up to an engineer to decide. :)
5. Update and add tests as needed.
6. [for @alya ] Update followup_day2 to not imply that there will be no future emails.

## Topics for feedback/discussion
- Subject line and content
- Should the /for/X link have UTM tracking? [**Plan**: no]
- Any edits on org type -> /for/X pages mapping? E.g., I could imagine sending  /for/communities to political groups.
- Finalizing `days_to_delay` value.
- Should we encourage demo orgs to set an org type early on (prior to converting the org)? Otherwise, users joining demo orgs won't receive this email.
- Should we send this email to users who already have a Zulip account? I'm thinking "yes", especially since their existing account might be in a different org type. It might be a bit annoying if you, e.g., create a test org, and then make the actual org shortly thereafter, but I think it's OK. [**Plan**: yes, send]

## Follow-ups

- [ ] Tweak https://zulip.com/help/organization-type
- [ ] In #24260, update the "Questions? Contact us any time at {{ support_email }}." line in the way that's described.
