### PR TITLE
UserTopic: Refactor 'do_set_user_topic_visibility_policy'.

### DIFF
--- a/zerver/actions/user_topics.py
+++ b/zerver/actions/user_topics.py
@@ -2,15 +2,13 @@ import datetime
 from typing import Any, Dict, Optional
 
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import gettext as _
 
-from zerver.lib.exceptions import JsonableError
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.user_topics import (
     get_topic_mutes,
     set_user_topic_visibility_policy_in_database,
 )
-from zerver.models import Stream, UserProfile, UserTopic
+from zerver.models import Stream, UserProfile
 from zerver.tornado.django_api import send_event
 
 
@@ -27,24 +25,15 @@ def do_set_user_topic_visibility_policy(
     if last_updated is None:
         last_updated = timezone_now()
 
-    if visibility_policy == UserTopic.VISIBILITY_POLICY_INHERIT:
-        try:
-            set_user_topic_visibility_policy_in_database(
-                user_profile, stream.id, topic, visibility_policy=visibility_policy
-            )
-        except UserTopic.DoesNotExist:
-            raise JsonableError(_("Nothing to be done"))
-    else:
-        assert stream.recipient_id is not None
-        set_user_topic_visibility_policy_in_database(
-            user_profile,
-            stream.id,
-            topic,
-            visibility_policy=visibility_policy,
-            recipient_id=stream.recipient_id,
-            last_updated=last_updated,
-            ignore_duplicate=ignore_duplicate,
-        )
+    set_user_topic_visibility_policy_in_database(
+        user_profile,
+        stream.id,
+        topic,
+        visibility_policy=visibility_policy,
+        recipient_id=stream.recipient_id,
+        last_updated=last_updated,
+        ignore_duplicate=ignore_duplicate,
+    )
 
     # This first muted_topics event is deprecated and will be removed
     # once clients are migrated to handle the user_topic event type

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -120,16 +120,20 @@ def set_user_topic_visibility_policy_in_database(
     ignore_duplicate: bool = False,
 ) -> None:
     if visibility_policy == UserTopic.VISIBILITY_POLICY_INHERIT:
-        # Will throw UserTopic.DoesNotExist if the user doesn't
-        # already have a visibility policy for this topic.
-        UserTopic.objects.get(
-            user_profile=user_profile,
-            stream_id=stream_id,
-            topic_name__iexact=topic_name,
-        ).delete()
-        return
+        try:
+            # Will throw UserTopic.DoesNotExist if the user doesn't
+            # already have a visibility policy for this topic.
+            UserTopic.objects.get(
+                user_profile=user_profile,
+                stream_id=stream_id,
+                topic_name__iexact=topic_name,
+            ).delete()
+            return
+        except UserTopic.DoesNotExist:
+            raise JsonableError(_("Nothing to be done"))
 
     assert last_updated is not None
+    assert recipient_id is not None
     (row, created) = UserTopic.objects.get_or_create(
         user_profile=user_profile,
         stream_id=stream_id,


### PR DESCRIPTION
As mentioned in #24236  [(comment)](https://github.com/zulip/zulip/pull/24236#issuecomment-1457423519):
> we probably do want to either inline **set_user_topic_visibility_policy_in_database** or reorganize this block in **do_set_user_topic_visibility_policy** to remove the if/else clause and just have a single call to **set_user_topic_visibility_policy_in_database**;
it'd be very nice to contain the branching behavior to one place.
I think my current temptation is to not inline.

This commit refactors `do_set_user_topic_visibility_policy` to remove the if/else block and just have a single call to `set_user_topic_visibility_policy_in_database`.

The branching out behaviour based on the user_topic visibility_policy is reduced to one place, i.e.,
`set_user_topic_visibility_policy_in_database`.

<!-- Describe your pull request here.-->

Fixes: follow-up PR to #24236 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
