### PR TITLE
help: Merge two similar sections in `marking messages as read`.

### DIFF
--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -9,25 +9,10 @@ configure whether messages are marked as read automatically when you scroll.
 
 ## Configure whether messages are automatically marked as read
 
-{start_tabs}
-
-{tab|mobile}
-
-{!mobile-profile-menu.md!}
-
-1. Tap **Settings**.
-
-1. Tap **Mark messages as read on scroll**.
-
-1. Select **Always**, **Never** or **Only in conversation views**.
-
-{end_tabs}
-
-## Do not mark messages as read
-
-You may want to configure the Zulip mobile app to never mark messages as read
-automatically. For example, this can be useful if you often want to follow up
-on messages when you are at your computer. You will still be able to
+You may want to configure whether or not the Zulip mobile app will automatically
+mark messages as read. For example, it can be useful to set the app to never
+mark messages as read if you often want to follow up on messages when you
+are at your computer. You will still be able to
 [manually](#mark-all-messages-as-read) mark messages as read.
 
 {start_tabs}
@@ -40,7 +25,7 @@ on messages when you are at your computer. You will still be able to
 
 1. Tap **Mark messages as read on scroll**.
 
-1. Select **Never**.
+1. Select **Always**, **Never** or **Only in conversation views**.
 
 {end_tabs}
 


### PR DESCRIPTION
Previously, there was a two similar sections in `marking messages as read`. We want to move the intro paragraph from the second section to the first section. Then drop the "Do not mark as read" section altogether.

[CZO discussion](https://chat.zulip.org/#narrow/stream/19-documentation/topic/duplicate.20sections)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/62449508/224127792-b0c82ba8-9e31-4a98-bfc5-bab26b2d7627.png)
</details>
<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/62449508/224435541-4023f14a-debf-452b-9e16-e962848021d3.png)
</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
