### PR TITLE
ci: Run generate-failure-message from the right path

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Generate failure report string
         id: failure_report_string
         if: ${{ failure() && github.repository == 'zulip/zulip' && github.event_name == 'push' }}
-        run: tools/ci/generate-failure-message >> $GITHUB_OUTPUT
+        run: /tmp/generate-failure-message >> $GITHUB_OUTPUT
 
       - name: Report status to CZO
         if: ${{ failure() && github.repository == 'zulip/zulip' && github.event_name == 'push' }}
@@ -296,7 +296,7 @@ jobs:
       - name: Generate failure report string
         id: failure_report_string
         if: ${{ failure() && github.repository == 'zulip/zulip' && github.event_name == 'push' }}
-        run: tools/ci/generate-failure-message >> $GITHUB_OUTPUT
+        run: /tmp/generate-failure-message >> $GITHUB_OUTPUT
 
       - name: Report status to CZO
         if: ${{ failure() && github.repository == 'zulip/zulip' && github.event_name == 'push' }}


### PR DESCRIPTION
This was broken by commit 3a0620a40c2b1d22ecd7ff65e8ab0c7a604d5e5f (#23719).