### PR TITLE
help: Tweak documentation on migrating from other chat tools.

### DIFF
--- a/help/include/migrating-from-other-chat-tools.md
+++ b/help/include/migrating-from-other-chat-tools.md
@@ -1,10 +1,15 @@
-We have tools for importing your data from other chat tools, including
-users, channels, messages, and more.
+If your organization is moving to Zulip from another chat tool, you can use
+Zulip's tools to import your data, including users, channels, messages, and
+more. Follow the detailed import guides:
 
-Note that importing data from another chat app creates a new
-Zulip organization containing only imported data.
-
-* [Import from Slack](/help/import-from-slack)
+* [Import from Slack](/help/import-from-slack). Zulip's [Slack-compatible
+  incoming webhook](https://zulip.com/integrations/doc/slack_incoming) also
+  makes it easy to migrate any integrations.
 * [Import from Mattermost](/help/import-from-mattermost)
 * [Import from Gitter](/help/import-from-gitter)
 * [Import from Rocket.Chat](/help/import-from-rocketchat)
+
+!!! warn ""
+
+    **You can only import a workspace as a new Zulip organization.** Your imported
+    message history cannot be added into an existing Zulip organization.


### PR DESCRIPTION
- Add a note about the Slack-compatible webhook.
- Make page more consistent with documentation style guidelines.

Current: https://zulip.com/help/migrating-from-other-chat-tools

Updated:
![Screen Shot 2023-03-09 at 4 07 35 PM](https://user-images.githubusercontent.com/2090066/224189814-5e62de17-5036-4f44-91c2-a508da785403.png)


The same text appears on https://zulip.com/help/getting-your-organization-started-with-zulip#migrating-from-other-chat-tools.

Updated screenshot:
![Screen Shot 2023-03-09 at 4 08 05 PM](https://user-images.githubusercontent.com/2090066/224189887-b1c15abd-e1fa-4d29-afb4-d36eb6fe7a9b.png)
