### PR TITLE
markdown: Fix use of pure_markdown for non-pure markdown rendering.

### DIFF
--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -16,11 +16,11 @@
             {% endif %}
 
             {% if page_is_policy_center %}
-            {{ render_markdown_path(sidebar_index, pure_markdown=True) }}
+            {{ render_markdown_path(sidebar_index) }}
             {% elif page_is_help_center %}
-            {{ render_markdown_path(sidebar_index, pure_markdown=True) }}
+            {{ render_markdown_path(sidebar_index) }}
             {% else %}
-            {{ render_markdown_path(sidebar_index, context=api_uri_context, pure_markdown=True) }}
+            {{ render_markdown_path(sidebar_index, context=api_uri_context) }}
             {% endif %}
 
             {% if not page_is_policy_center %}
@@ -36,11 +36,11 @@
     <div class="markdown">
         <div class="content">
             {% if page_is_policy_center %}
-            {{ render_markdown_path(article, pure_markdown=True) }}
+            {{ render_markdown_path(article) }}
             {% elif page_is_help_center %}
-            {{ render_markdown_path(article, context=api_uri_context, help_center=True, pure_markdown=True) }}
+            {{ render_markdown_path(article, context=api_uri_context, help_center=True) }}
             {% else %}
-            {{ render_markdown_path(article, context=api_uri_context, pure_markdown=True) }}
+            {{ render_markdown_path(article, context=api_uri_context) }}
             {% endif %}
 
             <div class="documentation-footer">

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -544,7 +544,7 @@ class FencedBlockPreprocessor(Preprocessor):
         return txt
 
 
-def makeExtension(*args: Any, **kwargs: None) -> FencedCodeExtension:
+def makeExtension(*args: Any, **kwargs: Any) -> FencedCodeExtension:
     return FencedCodeExtension(kwargs)
 
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -1,5 +1,6 @@
 import random
 import re
+import tempfile
 from datetime import datetime, timedelta, timezone
 from email.headerregistry import Address
 from typing import List, Optional, Sequence
@@ -38,23 +39,31 @@ class TestCustomEmails(ZulipTestCase):
         email_subject = "subject_test"
         reply_to = "reply_to_test"
         from_name = "from_name_test"
-        markdown_template_path = "templates/zerver/emails/email_base_default.source.html"
-        send_custom_email(
-            [hamlet],
-            options={
-                "markdown_template_path": markdown_template_path,
-                "reply_to": reply_to,
-                "subject": email_subject,
-                "from_name": from_name,
-                "dry_run": False,
-            },
-        )
+
+        with tempfile.NamedTemporaryFile() as markdown_template:
+            markdown_template.write(b"# Some heading\n\nSome content\n{{ realm_name }}")
+            markdown_template.flush()
+            send_custom_email(
+                [hamlet],
+                options={
+                    "markdown_template_path": markdown_template.name,
+                    "reply_to": reply_to,
+                    "subject": email_subject,
+                    "from_name": from_name,
+                    "dry_run": False,
+                },
+            )
         self.assert_length(mail.outbox, 1)
         msg = mail.outbox[0]
         self.assertEqual(msg.subject, email_subject)
         self.assert_length(msg.reply_to, 1)
         self.assertEqual(msg.reply_to[0], reply_to)
         self.assertNotIn("{% block content %}", msg.body)
+        self.assertIn("# Some heading", msg.body)
+        self.assertIn("Zulip Dev", msg.body)
+
+        assert isinstance(msg, EmailMultiAlternatives)
+        self.assertIn("Some heading</h1>", str(msg.alternatives[0][0]))
 
     def test_send_custom_email_remote_server(self) -> None:
         email_subject = "subject_test"
@@ -81,9 +90,10 @@ class TestCustomEmails(ZulipTestCase):
         self.assertEqual(msg.reply_to[0], reply_to)
         self.assertNotIn("{% block content %}", msg.body)
         # Verify that the HTML version contains the footer.
+        assert isinstance(msg, EmailMultiAlternatives)
         self.assertIn(
             "You are receiving this email to update you about important changes to Zulip",
-            str(msg.message()),
+            str(msg.alternatives[0][0]),
         )
 
     def test_send_custom_email_headers(self) -> None:


### PR DESCRIPTION
`render_markdown_path` renders Markdown, and also (since baff121115a1) runs Jinja2 on the resulting HTML.

The `pure_markdown` flag was added in 0a99fa2fd669, and did two things: retried the path directly in the filesystem if it wasn't found by the Jinja2 resolver, and also skipped the subsequent Jinja2 templating step (regardless of where the content was found).  In this context, the name `pure_markdown` made some sense.  The only two callsites were the TOS and privacy policy renders, which might have had user-supplied arbitrary paths, and we wished to handle absolute paths in addition to ones inside `templates/`.

Unfortunately, the follow-up of 01bd55bbcbf7 did not refactor the logic -- it changed it, by making `pure_markdown` only do the former of the two behaviors.  Passing `pure_markdown=True` after that commit still caused it to always run Jinja2, but allowed it to look elsewhere in the filesystem.

This set the stage for calls, such as the one introduced in dedea237456b, which passed both a context for Jinja2, as well as `pure_markdown=True` implying that Jinja2 was not to be used.

Split the two previous behaviors of the `pure_markdown` flag, and use pre-existing data to control them, rather than an explicit flag.  For handling policy information which is stored at an absolute path outside of the template root, we switch to using the template search path if and only if the path is relative.  This also closes the potential inconsistency based on CWD when `pure_markdown=True` was passed and the path was relative, not absolute.

Decide whether to run Jinja2 based on if a context is passed in at all.  This restores the behavior in the initial 0a99fa2fd669 where a call to `rendar_markdown_path` could be made to just render markdown, and not some other unmentioned and unrelated templating language as well.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
