### PR TITLE
popovers: Close popover in recent topics ui.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -230,6 +230,7 @@ export function initialize() {
 
     $("#main_div").on("click", ".message_reaction", function (e) {
         e.stopPropagation();
+        popovers.hide_all();
 
         if (page_params.is_spectator) {
             spectators.login_to_access();
@@ -248,6 +249,7 @@ export function initialize() {
         message_lists.current.view.reveal_hidden_message(message_id);
         e.stopPropagation();
         e.preventDefault();
+        popovers.hide_all();
     });
 
     $("#main_div").on("click", "a.stream", function (e) {
@@ -265,6 +267,7 @@ export function initialize() {
     $("body").on("click", "#scroll-to-bottom-button-clickable-area", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         navigate.to_end();
     });
@@ -369,6 +372,7 @@ export function initialize() {
     // RESOLVED TOPICS
     $("body").on("click", ".message_header .on_hover_topic_resolve", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         const $recipient_row = $(e.target).closest(".recipient_row");
         const message_id = rows.id_for_recipient_row($recipient_row);
         const topic_name = $(e.target).attr("data-topic-name");
@@ -377,6 +381,7 @@ export function initialize() {
 
     $("body").on("click", ".message_header .on_hover_topic_unresolve", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         const $recipient_row = $(e.target).closest(".recipient_row");
         const message_id = rows.id_for_recipient_row($recipient_row);
         const topic_name = $(e.target).attr("data-topic-name");
@@ -386,11 +391,13 @@ export function initialize() {
     // TOPIC MUTING
     $("body").on("click", ".message_header .on_hover_topic_mute", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         muted_topics_ui.mute_or_unmute_topic($(e.target), true);
     });
 
     $("body").on("click", ".message_header .on_hover_topic_unmute", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         muted_topics_ui.mute_or_unmute_topic($(e.target), false);
     });
 
@@ -688,6 +695,7 @@ export function initialize() {
 
     $(".streams_filter_icon").on("click", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         stream_list.toggle_filter_displayed(e);
     });
 
@@ -702,6 +710,7 @@ export function initialize() {
 
             e.preventDefault();
             e.stopPropagation();
+            popovers.hide_all();
             const $left_sidebar_scrollbar = $(
                 "#left_sidebar_scroll_container .simplebar-content-wrapper",
             );
@@ -727,6 +736,7 @@ export function initialize() {
         (e) => {
             e.preventDefault();
             e.stopPropagation();
+            popovers.hide_all();
 
             window.location.hash = "narrow/is/private";
         },

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -21,6 +21,7 @@ import * as message_edit from "./message_edit";
 import * as narrow from "./narrow";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as popovers from "./popovers";
 import * as reminder from "./reminder";
 import * as rendered_markdown from "./rendered_markdown";
 import * as resize from "./resize";
@@ -582,6 +583,7 @@ export function initialize() {
     $("#compose").on("click", ".compose_upload_file", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         $("#compose .file_input").trigger("click");
     });
@@ -589,6 +591,7 @@ export function initialize() {
     $("body").on("click", ".video_link", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         let $target_textarea;
         let edit_message_id;
@@ -674,6 +677,7 @@ export function initialize() {
     $("body").on("click", ".time_pick", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         $(e.target).toggleClass("has_popover");
 
@@ -708,6 +712,7 @@ export function initialize() {
     $("#compose").on("click", ".markdown_preview", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         const content = $("#compose-textarea").val();
         $("#compose-textarea").hide();
@@ -726,6 +731,7 @@ export function initialize() {
     $("#compose").on("click", ".undo_markdown_preview", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         clear_preview_area();
     });
@@ -733,6 +739,7 @@ export function initialize() {
     $("#compose").on("click", ".expand_composebox_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         compose_ui.make_compose_box_full_size();
     });
@@ -745,6 +752,7 @@ export function initialize() {
     $("#compose").on("click", ".collapse_composebox_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
 
         compose_ui.make_compose_box_original_size();
     });

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -14,6 +14,7 @@ import * as narrow from "./narrow";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import * as popovers from "./popovers";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as search from "./search";
@@ -401,6 +402,7 @@ function hashchanged(from_reload, e) {
 export function initialize() {
     $(window).on("hashchange", (e) => {
         hashchanged(false, e.originalEvent);
+        popovers.hide_all();
     });
     hashchanged(true);
 }

--- a/web/src/invite.js
+++ b/web/src/invite.js
@@ -14,6 +14,7 @@ import * as dialog_widget from "./dialog_widget";
 import * as gear_menu from "./gear_menu";
 import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
+import * as popovers from "./popovers";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
 import * as ui from "./ui";
@@ -239,6 +240,7 @@ function set_custom_time_inputs_visibility() {
 function open_invite_user_modal(e) {
     e.stopPropagation();
     e.preventDefault();
+    popovers.hide_all();
 
     gear_menu.close();
 

--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -6,6 +6,7 @@ import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
+import * as popovers from "./popovers";
 import * as recent_topics_util from "./recent_topics_util";
 import * as rendered_markdown from "./rendered_markdown";
 import * as search from "./search";
@@ -98,6 +99,7 @@ function bind_title_area_handlers() {
         search.initiate_search();
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
     });
 
     $("#message_view_header .navbar-click-opens-search").on("click", (e) => {
@@ -111,6 +113,7 @@ function bind_title_area_handlers() {
             search.initiate_search();
             e.preventDefault();
             e.stopPropagation();
+            popovers.hide_all();
         }
     });
 
@@ -175,6 +178,7 @@ export function initialize() {
         exit_search();
         e.preventDefault();
         e.stopPropagation();
+        popovers.hide_all();
     });
 }
 

--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -3,6 +3,7 @@ import _ from "lodash";
 
 import * as pm_list_data from "./pm_list_data";
 import * as pm_list_dom from "./pm_list_dom";
+import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as scroll_util from "./scroll_util";
 import * as topic_zoom from "./topic_zoom";
@@ -208,6 +209,7 @@ export function initialize() {
     $(".private_messages_container").on("click", "#show_more_private_messages", (e) => {
         e.stopPropagation();
         e.preventDefault();
+        popovers.hide_all();
 
         zoom_in();
     });
@@ -215,6 +217,7 @@ export function initialize() {
     $(".private_messages_container").on("click", "#hide_more_private_messages", (e) => {
         e.stopPropagation();
         e.preventDefault();
+        popovers.hide_all();
 
         zoom_out();
     });

--- a/web/src/poll_widget.js
+++ b/web/src/poll_widget.js
@@ -8,6 +8,7 @@ import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
 import * as keydown_util from "./keydown_util";
 import * as people from "./people";
+import * as popovers from "./popovers";
 
 export function activate({
     $elem,
@@ -141,21 +142,25 @@ export function activate({
 
         $elem.find(".poll-edit-question").on("click", (e) => {
             e.stopPropagation();
+            popovers.hide_all();
             start_editing();
         });
 
         $elem.find("button.poll-question-check").on("click", (e) => {
             e.stopPropagation();
+            popovers.hide_all();
             submit_question();
         });
 
         $elem.find("button.poll-question-remove").on("click", (e) => {
             e.stopPropagation();
+            popovers.hide_all();
             abort_edit();
         });
 
         $elem.find("button.poll-option").on("click", (e) => {
             e.stopPropagation();
+            popovers.hide_all();
             check_option_button();
             submit_option();
         });
@@ -203,6 +208,7 @@ export function activate({
             .off("click")
             .on("click", (e) => {
                 e.stopPropagation();
+                popovers.hide_all();
                 const key = $(e.target).attr("data-key");
                 submit_vote(key);
             });

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -1249,6 +1249,7 @@ export function initialize() {
 
     $("body").on("click", "#recent_topics_table .on_hover_topic_unmute", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         const $elt = $(e.target);
         const topic_row_index = $elt.closest("tr").index();
         focus_clicked_element(topic_row_index, COLUMNS.mute);
@@ -1259,6 +1260,7 @@ export function initialize() {
 
     $("body").on("click", "#recent_topics_table .on_hover_topic_mute", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         const $elt = $(e.target);
         const topic_row_index = $elt.closest("tr").index();
         focus_clicked_element(topic_row_index, COLUMNS.mute);
@@ -1267,11 +1269,13 @@ export function initialize() {
 
     $("body").on("click", "#recent_topics_search", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         change_focused_element($(e.target), "click");
     });
 
     $("body").on("click", "#recent_topics_table .on_hover_topic_read", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         const $elt = $(e.currentTarget);
         const topic_row_index = $elt.closest("tr").index();
         focus_clicked_element(topic_row_index, COLUMNS.read);
@@ -1296,6 +1300,7 @@ export function initialize() {
 
     $("body").on("click", ".btn-recent-filters", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         if (page_params.is_spectator) {
             // Filter buttons are disabled for spectator.
             return;
@@ -1309,6 +1314,7 @@ export function initialize() {
 
     $("body").on("click", "td.recent_topic_stream", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         const topic_row_index = $(e.target).closest("tr").index();
         focus_clicked_element(topic_row_index, COLUMNS.stream);
         window.location.href = $(e.currentTarget).find("a").attr("href");
@@ -1316,6 +1322,7 @@ export function initialize() {
 
     $("body").on("click", "td.recent_topic_name", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         // The element's parent may re-render while it is being passed to
         // other functions, so, we get topic_key first.
         const $topic_row = $(e.target).closest("tr");
@@ -1337,6 +1344,7 @@ export function initialize() {
 
     $("body").on("click", "#recent_topics_search_clear", (e) => {
         e.stopPropagation();
+        popovers.hide_all();
         $("#recent_topics_search").val("");
         update_filters_view();
     });

--- a/web/src/todo_widget.js
+++ b/web/src/todo_widget.js
@@ -7,6 +7,7 @@ import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as popovers from "./popovers";
 import * as util from "./util";
 
 // Any single user should send add a finite number of tasks
@@ -171,6 +172,7 @@ export function activate(opts) {
 
         $elem.find("button.add-task").on("click", (e) => {
             e.stopPropagation();
+            popovers.hide_all();
             $elem.find(".widget-error").text("");
             const task = $elem.find("input.add-task").val().trim();
             const desc = $elem.find("input.add-desc").val().trim();

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -30,6 +30,9 @@ const fake_now = 555;
 const autosize = () => {};
 autosize.update = () => {};
 mock_esm("autosize", {default: autosize});
+mock_esm("../src/popovers", {
+    hide_all() {},
+});
 
 const channel = mock_esm("../src/channel");
 const compose_actions = mock_esm("../src/compose_actions");

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -14,6 +14,9 @@ const upload = mock_esm("../src/upload");
 mock_esm("../src/resize", {
     watch_manual_resize() {},
 });
+mock_esm("../src/popovers", {
+    hide_all() {},
+});
 set_global("document", {
     querySelector() {},
 });

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -14,6 +14,9 @@ set_global("to_$", () => $window_stub);
 mock_esm("../src/search", {
     update_button_visibility() {},
 });
+mock_esm("../src/popovers", {
+    hide_all() {},
+});
 set_global("document", "document-stub");
 const history = set_global("history", {});
 

--- a/web/tests/poll_widget.test.js
+++ b/web/tests/poll_widget.test.js
@@ -2,10 +2,14 @@
 
 const {strict: assert} = require("assert");
 
-const {zrequire} = require("./lib/namespace");
+const {mock_esm, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
+
+mock_esm("../src/popovers", {
+    hide_all() {},
+});
 
 const {PollData} = zrequire("../shared/src/poll_data");
 


### PR DESCRIPTION
Fixes: #24274

We had bugs where in different parts of the Zulip web the popovers did not close on different click events. Also, the popovers persisted on hash changes.

This PR fixes the bug by calling the "popovers.hide_all()" function on hash changes and for the elements that have "stopPropagation" on click.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
