### PR TITLE
popovers: Add a confirmation modal for marking all messages as read.

### DIFF
--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -680,8 +680,8 @@ export function register_stream_handlers() {
     // Mark all messages as read
     $("body").on("click", "#mark_all_messages_as_read", (e) => {
         hide_all_messages_popover();
-        unread_ops.mark_all_as_read();
         e.stopPropagation();
+        unread_ops.confirm_mark_all_as_read();
     });
 
     // Unstar all messages

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -1,7 +1,11 @@
 import $ from "jquery";
 
+import render_confirm_mark_all_as_read from "../templates/confirm_dialog/confirm_mark_all_as_read.hbs";
+
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
+import * as confirm_dialog from "./confirm_dialog";
+import * as dialog_widget from "./dialog_widget";
 import {$t_html} from "./i18n";
 import * as loading from "./loading";
 import * as message_flags from "./message_flags";
@@ -26,6 +30,17 @@ let loading_indicator_displayed = false;
 // the progress indicator experience of 1000, 3000, etc. feels weird.
 const INITIAL_BATCH_SIZE = 1000;
 const FOLLOWUP_BATCH_SIZE = 1000;
+
+export function confirm_mark_all_as_read() {
+    const html_body = render_confirm_mark_all_as_read();
+
+    confirm_dialog.launch({
+        html_heading: $t_html({defaultMessage: "Mark all messages as read?"}),
+        html_body,
+        on_click: mark_all_as_read,
+        loading_spinner: true,
+    });
+}
 
 export function mark_all_as_read(args = {}) {
     args = {
@@ -116,6 +131,7 @@ export function mark_all_as_read(args = {}) {
                     blueslip.log("Cleared old_unreads_missing after bankruptcy.");
                 }
             }
+            dialog_widget.close_modal();
         },
         error(xhr) {
             // If we hit the rate limit, just continue without showing any error.
@@ -127,6 +143,7 @@ export function mark_all_as_read(args = {}) {
                 // the user needs to know that our operation failed.
                 blueslip.error("Failed to mark messages as read: " + xhr.responseText);
             }
+            dialog_widget.hide_dialog_spinner();
         },
     });
 }

--- a/web/templates/confirm_dialog/confirm_mark_all_as_read.hbs
+++ b/web/templates/confirm_dialog/confirm_mark_all_as_read.hbs
@@ -1,0 +1,5 @@
+<p>
+    {{#tr}}
+        Are you sure you want to mark all messages as read? This action cannot be undone.
+    {{/tr}}
+</p>


### PR DESCRIPTION
- [x] Add a confirmation modal for marking all messages as read.

-----------------------

Fixes: #24624
CZO: [Thread](https://chat.zulip.org/#narrow/stream/101-design/topic/mark.20as.20read.20confirmation)

----------------------------


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>
<br>

![before](https://user-images.githubusercontent.com/66828942/224396791-f1a84145-0ac9-4a2e-979d-6a9d26130433.gif)

</details>

<details>
<summary>After:</summary>
<br>


![fun_](https://user-images.githubusercontent.com/66828942/224453134-86bbfd28-be30-481a-8519-572114082fa5.gif)

</details>

<details>
<summary>Confirmation modal:</summary>
<br>

![Screenshot from 2023-03-11 00-01-26](https://user-images.githubusercontent.com/66828942/224396175-59cf4cd1-e2a1-4859-a12f-53f5667d14eb.png)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
