### PR TITLE
docs: Change extension from .js to .ts for some filenames.

### DIFF
--- a/docs/subsystems/html-css.md
+++ b/docs/subsystems/html-css.md
@@ -200,10 +200,10 @@ needs to be accessible from one of the entry points defined either in
 
 - If you plan to only use the file within the app proper, and not on the login
   page or other standalone pages, put it in the `app` bundle by importing it
-  in `web/src/bundles/app.js`.
+  in `web/src/bundles/app.ts`.
 - If it needs to be available both in the app and all
   logged-out/portico pages, import it to
-  `web/src/bundles/common.js` which itself is imported to the
+  `web/src/bundles/common.ts` which itself is imported to the
   `app` and `common` bundles.
 - If it's just used on a single standalone page which is only used in
   a development environment (e.g. `/devlogin`) create a new entry

--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -191,7 +191,7 @@ might use). In development, this means displaying a highly visible
 overlay over the message view area, to make exceptions in testing a
 new feature hard to miss.
 
-- Blueslip is implemented in `web/src/blueslip.js`.
+- Blueslip is implemented in `web/src/blueslip.ts`.
 - In order to capture essentially any error occurring in the browser,
   Blueslip listens for the `error` event on `window`, and has methods
   for being manually triggered by Zulip JavaScript code for warnings

--- a/docs/subsystems/typing-indicators.md
+++ b/docs/subsystems/typing-indicators.md
@@ -115,7 +115,7 @@ The main goal is then to triage which events should lead to
 display changes.
 
 The web app client maintains a list of incoming "typists" using
-code in `web/src/typing_data.js`. The API here has functions
+code in `web/src/typing_data.ts`. The API here has functions
 like the following:
 
 - `add_typist`

--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -239,7 +239,7 @@ $("#foo").html(
 
 The only HTML tags allowed directly in translated strings are the
 simple HTML tags enumerated in `default_html_elements`
-(`web/src/i18n.js`) with no attributes. This helps to avoid
+(`web/src/i18n.ts`) with no attributes. This helps to avoid
 exposing HTML details to translators. If you need to include more
 complex markup such as a link, you can define a custom HTML tag
 locally to the translation:

--- a/web/tests/example1.test.js
+++ b/web/tests/example1.test.js
@@ -20,7 +20,7 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const util = zrequire("util");
 
-// Let's start with testing a function from util.js.
+// Let's start with testing a function from util.ts.
 //
 // The most basic unit tests load up code, call functions,
 // and assert truths:

--- a/web/tests/i18n.test.js
+++ b/web/tests/i18n.test.js
@@ -26,7 +26,7 @@ require("../src/templates");
 
 // All of our other tests stub out i18n activity;
 // here we do a quick sanity check on the engine itself.
-// `i18n.js` initializes FormatJS and is imported by
+// `i18n.ts` initializes FormatJS and is imported by
 // `templates.js`.
 unmock_module("../src/i18n");
 const {$t, $t_html, get_language_name, get_language_list_columns, initialize} = zrequire("i18n");


### PR DESCRIPTION
As we are currently in the process of migrating from JavaScript to TypeScript, some file names mentioned in the documentation still have their old extension `.js`. 
This pull request aims to update the file extensions of those file names to the appropriate `.ts` format.

Updated the file extensions in following sections:

<details>
<summary>HTML and CSS - Adding Static Files</summary>

[Link to the Page](https://zulip.readthedocs.io/en/latest/subsystems/html-css.html#adding-static-files)

![HTML CSS](https://user-images.githubusercontent.com/35286603/224478750-8f43ce28-048a-4ea2-9069-39c8507ee4f5.png)

</details>

<details>
<summary>Logging - Blueslip frontend error reporting</summary>

[Link to the Page](https://zulip.readthedocs.io/en/latest/subsystems/logging.html#blueslip-frontend-error-reporting)

![Logging](https://user-images.githubusercontent.com/35286603/224478519-b673d80e-c826-4349-87a0-7d3f293cae54.png)

</details>

<details>
<summary>Typing Indicators - Receiving user</summary>

[Link to the Page](https://zulip.readthedocs.io/en/latest/subsystems/typing-ndicators.html#receiving-user)

![Typing Indicators](https://user-images.githubusercontent.com/35286603/224478515-cc2c905c-a931-4505-a7b2-42ac5e73489c.png)

</details>

<details>
<summary>Internationalization - Frontend translations</summary>

[Link to the Page](https://zulip.readthedocs.io/en/latest/translating/internationalization.html#frontend-translations)

![i18n](https://user-images.githubusercontent.com/35286603/224478513-004be0b2-a049-4ccd-a105-1cc1bed580a7.png)
</details>

<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
