### PR TITLE
file_drop: Open compose immediately on file drop or paste event.

### DIFF
--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -262,6 +262,9 @@ export function setup_upload(config) {
     $drag_drop_container.on("drop", (event) => {
         event.preventDefault();
         const files = event.originalEvent.dataTransfer.files;
+        if (config.mode === "compose" && !compose_state.composing()) {
+            compose_actions.respond_to_message({trigger: "file drop or paste"});
+        }
         upload_files(uppy, config, files);
     });
 
@@ -279,6 +282,9 @@ export function setup_upload(config) {
             const file = item.getAsFile();
             files.push(file);
         }
+        if (config.mode === "compose" && !compose_state.composing()) {
+            compose_actions.respond_to_message({trigger: "file drop or paste"});
+        }
         upload_files(uppy, config, files);
     });
 
@@ -289,9 +295,6 @@ export function setup_upload(config) {
         }
         const split_url = url.split("/");
         const filename = split_url.at(-1);
-        if (config.mode === "compose" && !compose_state.composing()) {
-            compose_actions.start("stream");
-        }
         const filename_url = "[" + filename + "](" + url + ")";
         compose_ui.replace_syntax(
             get_translated_status(file),

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -405,7 +405,7 @@ test("file_input", ({override_rewire}) => {
     assert.ok(upload_files_called);
 });
 
-test("file_drop", ({override_rewire}) => {
+test("file_drop", ({override, override_rewire}) => {
     upload.setup_upload({mode: "compose"});
 
     let prevent_default_counter = 0;
@@ -438,12 +438,17 @@ test("file_drop", ({override_rewire}) => {
     override_rewire(upload, "upload_files", () => {
         upload_files_called = true;
     });
+    let compose_actions_start_called = false;
+    override(compose_actions, "respond_to_message", () => {
+        compose_actions_start_called = true;
+    });
     drop_handler(drop_event);
+    assert.ok(compose_actions_start_called);
     assert.equal(prevent_default_counter, 3);
     assert.equal(upload_files_called, true);
 });
 
-test("copy_paste", ({override_rewire}) => {
+test("copy_paste", ({override, override_rewire}) => {
     upload.setup_upload({mode: "compose"});
 
     const paste_handler = $("#compose").get_on_handler("paste");
@@ -469,11 +474,15 @@ test("copy_paste", ({override_rewire}) => {
     override_rewire(upload, "upload_files", () => {
         upload_files_called = true;
     });
+    let compose_actions_start_called = false;
+    override(compose_actions, "respond_to_message", () => {
+        compose_actions_start_called = true;
+    });
 
     paste_handler(event);
     assert.ok(get_as_file_called);
     assert.ok(upload_files_called);
-
+    assert.ok(compose_actions_start_called);
     upload_files_called = false;
     event = {
         originalEvent: {},
@@ -482,7 +491,7 @@ test("copy_paste", ({override_rewire}) => {
     assert.equal(upload_files_called, false);
 });
 
-test("uppy_events", ({override, override_rewire, mock_template}) => {
+test("uppy_events", ({override_rewire, mock_template}) => {
     $("#compose_banners .upload_banner .moving_bar").css = () => {};
     $("#compose_banners .upload_banner").length = 0;
 
@@ -528,10 +537,7 @@ test("uppy_events", ({override, override_rewire, mock_template}) => {
             uri: "/user_uploads/4/cb/rue1c-MlMUjDAUdkRrEM4BTJ/copenhagen.png",
         },
     };
-    let compose_actions_start_called = false;
-    override(compose_actions, "start", () => {
-        compose_actions_start_called = true;
-    });
+
     let compose_ui_replace_syntax_called = false;
     override_rewire(compose_ui, "replace_syntax", (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
@@ -547,7 +553,7 @@ test("uppy_events", ({override, override_rewire, mock_template}) => {
         compose_ui_autosize_textarea_called = true;
     });
     on_upload_success_callback(file, response);
-    assert.ok(compose_actions_start_called);
+
     assert.ok(compose_ui_replace_syntax_called);
     assert.ok(compose_ui_autosize_textarea_called);
 
@@ -556,11 +562,9 @@ test("uppy_events", ({override, override_rewire, mock_template}) => {
             uri: undefined,
         },
     };
-    compose_actions_start_called = false;
     compose_ui_replace_syntax_called = false;
     compose_ui_autosize_textarea_called = false;
     on_upload_success_callback(file, response);
-    assert.equal(compose_actions_start_called, false);
     assert.equal(compose_ui_replace_syntax_called, false);
     assert.equal(compose_ui_autosize_textarea_called, false);
 


### PR DESCRIPTION
Fixes: #24654
<!-- Describe your pull request here.-->
This commit changes the way compose box responds to a file drop or paste. 
Currently, the compose box expands only after the file is uploaded to the server, which can cause confusion if the upload fails and there is also no progress bar. 
With the update, the compose box will expand immediately upon drop or paste events showing the status of upload.


**Screenshots and screen captures:**

***Before***

https://user-images.githubusercontent.com/71015892/224507579-7c7bc2e8-c22e-431f-ae46-ebf04626c248.mp4


***After***

https://user-images.githubusercontent.com/71015892/224507580-7eab3847-4f6d-4dfd-8954-68160005a9c8.mp4



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
