### PR TITLE
ts: Convert portico/tabbed-instructions.js to TypeScript.

### DIFF
--- a/web/src/portico/tabbed-instructions.ts
+++ b/web/src/portico/tabbed-instructions.ts
@@ -1,8 +1,11 @@
 import $ from "jquery";
 
+import * as blueslip from "../blueslip";
 import * as common from "../common";
 
-export function detect_user_os() {
+export type UserOS = "android" | "ios" | "mac" | "windows" | "linux";
+
+export function detect_user_os(): UserOS {
     if (/android/i.test(navigator.userAgent)) {
         return "android";
     }
@@ -21,7 +24,7 @@ export function detect_user_os() {
     return "mac"; // if unable to determine OS return Mac by default
 }
 
-export function activate_correct_tab($codeSection) {
+export function activate_correct_tab($codeSection: JQuery<HTMLElement>): void {
     const user_os = detect_user_os();
     const desktop_os = new Set(["mac", "linux", "windows"]);
     const $li = $codeSection.find("ul.nav li");
@@ -56,7 +59,11 @@ export function activate_correct_tab($codeSection) {
     if (!$active_list_items.length) {
         $li.first().addClass("active");
         const language = $li.first()[0].dataset.language;
-        $blocks.filter("[data-language=" + language + "]").addClass("active");
+        if (language) {
+            $blocks.filter("[data-language=" + language + "]").addClass("active");
+        } else {
+            blueslip.error("Tabbed instructions widget has no tabs to activate!");
+        }
     }
 }
 


### PR DESCRIPTION
This converts `portico/tabbed-instructions.js` to TypeScript.
It's required for the conversion of `portico/integrations.js` to TypeScript.

I was not sure of what error message to throw when the `language` property was not present in the `dataset`.
Right now it throws an Error with message `Language Not Found in the Dataset`. It can be something else as well if required. 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
