### PR TITLE
Solve dependency cycle

### DIFF
--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -4,7 +4,6 @@ import render_admin_tab from "../templates/settings/admin_tab.hbs";
 import render_settings_organization_settings_tip from "../templates/settings/organization_settings_tip.hbs";
 
 import {$t, get_language_name, language_list} from "./i18n";
-import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as settings from "./settings";
@@ -234,7 +233,7 @@ export function launch(section) {
     build_page();
     settings_sections.reset_sections();
 
-    overlays.open_settings();
+    settings.open_settings_overlay();
     settings_panel_menu.org_settings.activate_section_or_default(section);
     settings_toggle.highlight_toggle("organization");
 }

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -23,6 +23,7 @@ import {page_params} from "./page_params";
 import * as pm_list from "./pm_list";
 import * as recent_senders from "./recent_senders";
 import * as recent_topics_ui from "./recent_topics_ui";
+import * as recent_topics_util from "./recent_topics_util";
 import * as stream_list from "./stream_list";
 import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
@@ -225,7 +226,10 @@ export function update_messages(events) {
             msg.raw_content = event.content;
         }
 
-        unread.update_message_for_mention(msg, any_message_content_edited);
+        if (unread.update_message_for_mention(msg, any_message_content_edited)) {
+            const topic_key = recent_topics_util.get_topic_key(msg.stream_id, msg.topic);
+            recent_topics_ui.inplace_rerender(topic_key);
+        }
 
         // new_topic will be undefined if the topic is unchanged.
         const new_topic = util.get_edit_event_topic(event);

--- a/web/src/overlays.js
+++ b/web/src/overlays.js
@@ -2,7 +2,6 @@ import $ from "jquery";
 import Micromodal from "micromodal";
 
 import * as blueslip from "./blueslip";
-import * as browser_history from "./browser_history";
 
 let $active_overlay;
 let close_handler;
@@ -317,16 +316,6 @@ export function close_for_hash_change() {
     if ($active_overlay) {
         close_handler();
     }
-}
-
-export function open_settings() {
-    open_overlay({
-        name: "settings",
-        $overlay: $("#settings_overlay_container"),
-        on_close() {
-            browser_history.exit_overlay();
-        },
-    });
 }
 
 export function initialize() {

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -56,11 +56,6 @@ let userlist_placement = "right";
 
 let list_of_popovers = [];
 
-export function initialize() {
-    overlays.register_pre_open_hook(hide_all);
-    overlays.register_pre_close_hook(hide_all);
-}
-
 export function clear_for_testing() {
     $current_message_info_popover_elem = undefined;
     $current_user_info_popover_elem = undefined;
@@ -1220,4 +1215,9 @@ export function compute_placement(
     }
 
     return placement;
+}
+
+export function initialize() {
+    overlays.register_pre_open_hook(hide_all);
+    overlays.register_pre_close_hook(hide_all);
 }

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -7,6 +7,7 @@ import render_settings_tab from "../templates/settings_tab.hbs";
 
 import * as admin from "./admin";
 import * as blueslip from "./blueslip";
+import * as browser_history from "./browser_history";
 import {$t, $t_html} from "./i18n";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -120,12 +121,22 @@ export function build_page() {
     $(".settings-box").html(rendered_settings_tab);
 }
 
+export function open_settings_overlay() {
+    overlays.open_overlay({
+        name: "settings",
+        $overlay: $("#settings_overlay_container"),
+        on_close() {
+            browser_history.exit_overlay();
+        },
+    });
+}
+
 export function launch(section) {
     build_page();
     admin.build_page();
     settings_sections.reset_sections();
 
-    overlays.open_settings();
+    open_settings_overlay();
     settings_panel_menu.normal_settings.activate_section_or_default(section);
     settings_toggle.highlight_toggle("settings");
 }

--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -2,7 +2,6 @@ import * as blueslip from "./blueslip";
 import {FoldDict} from "./fold_dict";
 import * as message_store from "./message_store";
 import * as people from "./people";
-import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
@@ -637,10 +636,14 @@ export function process_unread_message(message) {
 }
 
 export function update_message_for_mention(message, content_edited = false) {
+    // Returns true if this is a stream message whose content was
+    // changed, and thus the caller might need to trigger a rerender
+    // of UI elements displaying whether the message's topic contains
+    // an unread mention of the user.
     if (!message.unread) {
         unread_mentions_counter.delete(message.id);
         remove_message_from_unread_mention_topics(message.id);
-        return;
+        return false;
     }
 
     const is_unmuted_mention =
@@ -657,11 +660,9 @@ export function update_message_for_mention(message, content_edited = false) {
     }
 
     if (content_edited && message.type === "stream") {
-        // We only need to update recent topics here if this was a content change in an unread
-        // mention, since in other cases recent topics gets rerendered by other functions.
-        const topic_key = recent_topics_util.get_topic_key(message.stream_id, message.topic);
-        recent_topics_ui.inplace_rerender(topic_key);
+        return true;
     }
+    return false;
 }
 
 export function mark_as_read(message_id) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This is a Prep PR for #24426.

Commit 1: [Fix dependency cycle in unread.js.](https://github.com/zulip/zulip/commit/1bee1c5d193e62f8c1047074d8a16b054c1c7bbe):
Removed import of recent_topics_ui.js from unread.js as suggested [here](https://chat.zulip.org/#narrow/stream/21-provision-help/topic/import.20dependency.20cycle/near/1521987).

Commit 2: [Fix dependency cycle in overlays.js.](https://github.com/zulip/zulip/commit/e9e0f7349b2f4ba4bb89f321efc2c3ddc78815a0):
Removing browser_history import in overlays.js
helps to completely solve the dependency cycle issue for
importing dialog_widget.js in upload_widget.ts in PR #24426.

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
