### PR TITLE
css setting drop down menu bug fix

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1988,13 +1988,18 @@ div.focused_table {
 }
 
 .nav .dropdown-menu {
+    --dropdown-menu-position-top: 30px;
     left: auto;
     right: 0;
-    top: 30px;
+    top: var(--dropdown-menu-position-top);
     /* Match the width of the right sidebar so that we don't have
        the presence dots distracting you when looking at this. */
     min-width: 240px;
     box-shadow: 0 0 5px hsla(0, 0%, 0%, 0.2);
+
+    /* make the max height equal to the height of the dropdown menu */
+    max-height: calc(100vh - var(--dropdown-menu-position-top) - 100px);
+    overflow-y: scroll;
 
     &::after {
         position: absolute;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Issue is fixes the drop down menu, as it gets hidden if we resize the window, so the solution was:
- determine the max height of the menu to be the height of the viewport to let the overflow works 
when the bottom of the view port touches the bottom of the menu

Fixes: [24652](https://github.com/zulip/zulip/issues/24652) <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
| ---- | ----- |
| ![before](https://user-images.githubusercontent.com/62177195/224559705-158d1cbe-42a0-47cc-88be-84b1cf808913.gif) | ![after](https://user-images.githubusercontent.com/62177195/224559728-21f32436-af87-447b-9e31-649e585a22c8.gif) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
