### PR TITLE
recent_conversations: Exclude muted user PMs from recent conversations.

### DIFF
--- a/web/src/people.js
+++ b/web/src/people.js
@@ -347,7 +347,7 @@ export function get_full_names_for_poll_option(user_ids) {
     return get_display_full_names(user_ids).join(", ");
 }
 
-function get_display_full_name(user_id) {
+export function get_display_full_name(user_id) {
     const person = get_by_user_id(user_id);
     if (!person) {
         blueslip.error("Unknown user id " + user_id);

--- a/web/src/people.js
+++ b/web/src/people.js
@@ -50,7 +50,7 @@ export function init() {
 // WE INITIALIZE DATA STRUCTURES HERE!
 init();
 
-function split_to_ints(lst) {
+export function split_to_ints(lst) {
     return lst.split(",").map((s) => Number.parseInt(s, 10));
 }
 

--- a/web/src/pm_conversations.js
+++ b/web/src/pm_conversations.js
@@ -15,7 +15,7 @@ export function is_partner(user_id) {
 function filter_muted_pms(conversation) {
     // We hide muted users from the top left corner, as well as those huddles
     // in which all participants are muted.
-    const recipients = conversation.user_ids_string.split(",").map((id) => Number.parseInt(id, 10));
+    const recipients = people.split_to_ints(conversation.user_ids_string);
 
     if (recipients.every((id) => muted_users.is_user_muted(id))) {
         return false;

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -17,6 +17,7 @@ import * as message_store from "./message_store";
 import * as message_util from "./message_util";
 import * as message_view_header from "./message_view_header";
 import * as muted_topics_ui from "./muted_topics_ui";
+import * as muted_users from "./muted_users";
 import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
@@ -548,6 +549,14 @@ export function filters_should_hide_topic(topic_data) {
 
     if (!filters.has("include_private") && topic_data.type === "private") {
         return true;
+    }
+
+    if (filters.has("include_private") && topic_data.type === "private") {
+        const recipients = people.split_to_ints(msg.to_user_ids);
+
+        if (recipients.every((id) => muted_users.is_user_muted(id))) {
+            return true;
+        }
     }
 
     const search_keyword = $("#recent_topics_search").val();

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -413,10 +413,11 @@ function format_conversation(conversation_data) {
             )
             .map((user) =>
                 render_user_with_status_icon({
-                    name: user.full_name,
+                    name: people.get_display_full_name(user.id),
                     status_emoji_info: user_status.get_status_emoji(user.id),
                 }),
             )
+            .sort()
             .join(", ");
         context.recipient_id = last_msg.recipient_id;
         context.pm_url = last_msg.pm_with_url;

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -192,9 +192,15 @@ people.add_active_user({
     user_id: 3,
     full_name: "Spike Spiegel",
 });
+people.add_active_user({
+    email: "eren@zulip.com",
+    user_id: 4,
+    full_name: "Eren Yeager",
+});
 
 people.initialize_current_user(1);
 muted_users.add_muted_user(2, 17947949);
+muted_users.add_muted_user(4, 17947949);
 
 let id = 0;
 
@@ -305,6 +311,22 @@ private_messages[0] = {
     to_user_ids: "2,3",
     type: "private",
     display_recipient: [{id: 1}, {id: 2}, {id: 3}],
+    pm_with_url: test_url(),
+};
+private_messages[1] = {
+    id: (id += 1),
+    sender_id: sender1,
+    to_user_ids: "2,4",
+    type: "private",
+    display_recipient: [{id: 1}, {id: 2}, {id: 4}],
+    pm_with_url: test_url(),
+};
+private_messages[2] = {
+    id: (id += 1),
+    sender_id: sender1,
+    to_user_ids: "3",
+    type: "private",
+    display_recipient: [{id: 1}, {id: 3}],
     pm_with_url: test_url(),
 };
 
@@ -508,6 +530,10 @@ test("test_filter_pm", ({mock_template}) => {
     ];
 
     rt.process_messages([private_messages[0]]);
+
+    assert.deepEqual(rt.filters_should_hide_topic({type: "private", last_msg_id: 12}), false);
+    assert.deepEqual(rt.filters_should_hide_topic({type: "private", last_msg_id: 13}), true);
+    assert.deepEqual(rt.filters_should_hide_topic({type: "private", last_msg_id: 14}), false);
 });
 
 test("test_filter_unread", ({mock_template}) => {


### PR DESCRIPTION
Earlier muted private conversations were shown in recent conversations. This commit exclude them from recent conversations.

<!-- Describe your pull request here.-->

Fixes: #24299

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
