### PR TITLE
create-user: Remove notifications sent to admin realm.

### DIFF
--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -11,7 +11,6 @@ from corporate.lib.stripe import get_latest_seat_count
 from zerver.actions.create_user import notify_new_user
 from zerver.actions.user_settings import do_change_user_setting
 from zerver.lib.initial_password import initial_password
-from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import Message, Realm, Recipient, Stream, UserProfile, get_realm
 from zerver.signals import JUST_CREATED_THRESHOLD, get_device_browser, get_device_os
@@ -275,45 +274,24 @@ class TestNotifyNewUser(ZulipTestCase):
     def test_notify_realm_of_new_user(self) -> None:
         realm = get_realm("zulip")
         new_user = self.example_user("cordelia")
-        admin_realm = get_realm("zulipinternal")
-        admin_realm_signups_stream, created = create_stream_if_needed(admin_realm, "signups")
         message_count = self.get_message_count()
 
         notify_new_user(new_user)
-        self.assertEqual(self.get_message_count(), message_count + 2)
-        message = self.get_second_to_last_message()
+        self.assertEqual(self.get_message_count(), message_count + 1)
+        message = self.get_last_message()
         self.assertEqual(message.recipient.type, Recipient.STREAM)
         actual_stream = Stream.objects.get(id=message.recipient.type_id)
         self.assertEqual(actual_stream.name, Realm.INITIAL_PRIVATE_STREAM_NAME)
         self.assertIn(
             f"@_**Cordelia, Lear's daughter|{new_user.id}** just signed up for Zulip.",
-            message.content,
-        )
-        message = self.get_last_message()
-        self.assertEqual(message.recipient.type, Recipient.STREAM)
-        actual_stream = Stream.objects.get(id=message.recipient.type_id)
-        self.assertEqual(actual_stream.name, "signups")
-        self.assertIn(
-            f"Cordelia, Lear's daughter <`{new_user.email}`> just signed up for Zulip. (total:",
             message.content,
         )
 
-        admin_realm_signups_stream.delete()
-        notify_new_user(new_user)
-        self.assertEqual(self.get_message_count(), message_count + 3)
-        message = self.get_last_message()
-        self.assertEqual(message.recipient.type, Recipient.STREAM)
-        actual_stream = Stream.objects.get(id=message.recipient.type_id)
-        self.assertEqual(actual_stream.name, Realm.INITIAL_PRIVATE_STREAM_NAME)
-        self.assertIn(
-            f"@_**Cordelia, Lear's daughter|{new_user.id}** just signed up for Zulip.",
-            message.content,
-        )
         realm.signup_notifications_stream = None
         realm.save(update_fields=["signup_notifications_stream"])
         new_user.refresh_from_db()
         notify_new_user(new_user)
-        self.assertEqual(self.get_message_count(), message_count + 3)
+        self.assertEqual(self.get_message_count(), message_count + 1)
 
     def test_notify_realm_of_new_user_in_manual_license_management(self) -> None:
         realm = get_realm("zulip")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -958,7 +958,7 @@ class LoginTest(ZulipTestCase):
         ContentType.objects.clear_cache()
 
         # Ensure the number of queries we make is not O(streams)
-        with self.assert_database_query_count(95), cache_tries_captured() as cache_tries:
+        with self.assert_database_query_count(93), cache_tries_captured() as cache_tries:
             with self.captureOnCommitCallbacks(execute=True):
                 self.register(self.nonreg_email("test"), "test")
 
@@ -966,7 +966,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        self.assert_length(cache_tries, 22)
+        self.assert_length(cache_tries, 20)
 
         user_profile = self.nonreg_user("test")
         self.assert_logged_in_user_id(user_profile.id)
@@ -3451,10 +3451,9 @@ class RealmCreationTest(ZulipTestCase):
         # Check signup messages
         recipient = signups_stream.recipient
         messages = Message.objects.filter(recipient=recipient).order_by("id")
-        self.assert_length(messages, 2)
+        self.assert_length(messages, 1)
         self.assertIn("Signups enabled", messages[0].content)
-        self.assertIn("signed up", messages[1].content)
-        self.assertEqual("zuliptest", messages[1].topic_name())
+        self.assertEqual("zuliptest", messages[0].topic_name())
 
         realm_creation_audit_log = RealmAuditLog.objects.get(
             realm=realm, event_type=RealmAuditLog.REALM_CREATED

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -790,7 +790,7 @@ class QueryCountTest(ZulipTestCase):
 
         events: List[Mapping[str, Any]] = []
 
-        with self.assert_database_query_count(90):
+        with self.assert_database_query_count(88):
             with cache_tries_captured() as cache_tries:
                 with self.tornado_redirected_to_list(events, expected_num_events=11):
                     fred = do_create_user(
@@ -802,7 +802,7 @@ class QueryCountTest(ZulipTestCase):
                         acting_user=None,
                     )
 
-        self.assert_length(cache_tries, 28)
+        self.assert_length(cache_tries, 26)
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]
 
         notifications = set()


### PR DESCRIPTION
Removes the notification message that was sent when a new user registers for a Zulip organization if a stream named "signups" exists in the `settings.SYSTEM_BOT_REALM`. 

**Notes**:
- This was a undocumented feature that would send a notification message when a new user registered with a Zulip organization that was hosted by an admin realm (like Zulip Cloud).
- This removes two database queries when a new user is created: one to get the system bot realm and the other to get the notification bot in said realm.
- Note that there are still notification messages sent when a new organization is registered with the admin realm if the "signups" stream exists in the system bot realm.
- And notification messages are still sent to the Zulip organization that the user is registering for if that organization has configured / enabled a stream for new user announcements (see [configure notification bot documentation](https://zulip.com/help/configure-notification-bot#new-user-announcements)).

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
