### PR TITLE
puppet: Switch teleport to running under systemd, not supervisord.

### DIFF
--- a/puppet/zulip_ops/files/supervisor/conf.d/teleport_db.conf
+++ b/puppet/zulip_ops/files/supervisor/conf.d/teleport_db.conf
@@ -1,8 +1,0 @@
-[program:teleport_db]
-command=/usr/local/bin/teleport start --config=/etc/teleport_db.yaml
-priority=10
-autostart=true
-autorestart=true
-user=root
-redirect_stderr=true
-stdout_logfile=/var/log/teleport_db.log

--- a/puppet/zulip_ops/files/supervisor/conf.d/teleport_node.conf
+++ b/puppet/zulip_ops/files/supervisor/conf.d/teleport_node.conf
@@ -1,8 +1,0 @@
-[program:teleport_node]
-command=/usr/local/bin/teleport start --config=/etc/teleport_node.yaml
-priority=10
-autostart=true
-autorestart=true
-user=root
-redirect_stderr=true
-stdout_logfile=/var/log/teleport_node.log

--- a/puppet/zulip_ops/files/supervisor/conf.d/teleport_server.conf
+++ b/puppet/zulip_ops/files/supervisor/conf.d/teleport_server.conf
@@ -1,8 +1,0 @@
-[program:teleport_server]
-command=/usr/local/bin/teleport start --config=/etc/teleport_server.yaml
-priority=10
-autostart=true
-autorestart=true
-user=root
-redirect_stderr=true
-stdout_logfile=/var/log/teleport_server.log

--- a/puppet/zulip_ops/manifests/profile/teleport.pp
+++ b/puppet/zulip_ops/manifests/profile/teleport.pp
@@ -6,16 +6,9 @@ class zulip_ops::profile::teleport {
     group  => 'root',
     mode   => '0644',
     source => 'puppet:///modules/zulip_ops/teleport_server.yaml',
+    notify => Service['teleport_server'],
   }
-  file { "${zulip::common::supervisor_conf_dir}/teleport_server.conf":
-    ensure  => file,
-    require => [ Package[supervisor], Package[teleport], File['/etc/teleport_server.yaml'] ],
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    source  => 'puppet:///modules/zulip_ops/supervisor/conf.d/teleport_server.conf',
-    notify  => Service[$zulip::common::supervisor_service],
-  }
+  zulip_ops::teleport::part { 'server': }
 
   # https://goteleport.com/docs/admin-guide/#ports
   # Port 443 is outward-facing, for UI

--- a/puppet/zulip_ops/manifests/teleport/base.pp
+++ b/puppet/zulip_ops/manifests/teleport/base.pp
@@ -6,7 +6,13 @@ class zulip_ops::teleport::base {
     command => "${setup_apt_repo_file} --list teleport",
     unless  => "${setup_apt_repo_file} --list teleport --verify",
   }
-  Package { 'teleport':
+  package { 'teleport':
+    ensure  => installed,
     require => Exec['setup-apt-repo-teleport'],
+  }
+  service { 'teleport':
+    ensure  => stopped,
+    enable  => mask,
+    require => Package['teleport'],
   }
 }

--- a/puppet/zulip_ops/manifests/teleport/db.pp
+++ b/puppet/zulip_ops/manifests/teleport/db.pp
@@ -11,19 +11,8 @@ class zulip_ops::teleport::db {
     group   => 'root',
     mode    => '0644',
     content => template('zulip_ops/teleport_db.yaml.template.erb'),
+    notify  => Service['teleport_db'],
   }
 
-  file { "${zulip::common::supervisor_conf_dir}/teleport_db.conf":
-    ensure  => file,
-    require => [
-      Package[supervisor],
-      Package[teleport],
-      File['/etc/teleport_db.yaml'],
-    ],
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    source  => 'puppet:///modules/zulip_ops/supervisor/conf.d/teleport_db.conf',
-    notify  => Service[$zulip::common::supervisor_service],
-  }
+  zulip_ops::teleport::part { 'db': }
 }

--- a/puppet/zulip_ops/manifests/teleport/node.pp
+++ b/puppet/zulip_ops/manifests/teleport/node.pp
@@ -10,6 +10,7 @@ class zulip_ops::teleport::node {
     owner  => 'root',
     group  => 'root',
     mode   => '0644',
+    notify => Service['teleport_node'],
   }
   concat::fragment { 'teleport_node_base':
     target => '/etc/teleport_node.yaml',
@@ -17,17 +18,5 @@ class zulip_ops::teleport::node {
     order  => '01',
   }
 
-  file { "${zulip::common::supervisor_conf_dir}/teleport_node.conf":
-    ensure  => file,
-    require => [
-      Package[supervisor],
-      Package[teleport],
-      Concat['/etc/teleport_node.yaml'],
-    ],
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    source  => 'puppet:///modules/zulip_ops/supervisor/conf.d/teleport_node.conf',
-    notify  => Service[$zulip::common::supervisor_service],
-  }
+  zulip_ops::teleport::part { 'node': }
 }

--- a/puppet/zulip_ops/manifests/teleport/part.pp
+++ b/puppet/zulip_ops/manifests/teleport/part.pp
@@ -1,0 +1,21 @@
+# @summary Adds a systemd service named teleport_$name
+#
+define zulip_ops::teleport::part() {
+  $part = $name
+  file { "/etc/systemd/system/teleport_${part}.service":
+    require => [
+      Package[teleport],
+    ],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('zulip_ops/teleport.service.template.erb'),
+    notify  => Service["teleport_${part}"],
+  }
+
+  service {"teleport_${part}":
+    ensure  => running,
+    enable  => true,
+    require => [Service['supervisor'], Service['teleport']],
+  }
+}

--- a/puppet/zulip_ops/templates/teleport.service.template.erb
+++ b/puppet/zulip_ops/templates/teleport.service.template.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=Teleport <%= @part %> Service
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+EnvironmentFile=-/etc/default/teleport_<%= @part %>
+ExecStart=/usr/local/bin/teleport start --pid-file=/run/teleport_<%= @part %>.pid --config=/etc/teleport_<%= @part %>.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+PIDFile=/run/teleport_<%= @part %>.pid
+LimitNOFILE=524288
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
There is no reason that the base node access method should be run under supervisor, which exists primarily to give access to the `zulip` user to restart its managed services.  This access is unnecessary for Teleport, and also causes unwanted restarts of Teleport services when the `supervisor` base configuration changes.  Additionally, supervisor does not support the in-place upgrade process that Teleport uses, as it replaces its core process with a new one.

Switch to installing a systemd configuration file (as generated by `teleport install systemd`) but customized to pass a `--config` path.

----

Tested on a test host with Teleport set up (but actually joined to a cluster).  Verified that the old teleport processes stopped showing up under Supervisor, and that `service teleport_node` showed a successful start.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
