### PR TITLE
multiuse-invites: Add edit feature for multiuse invites

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -22,6 +22,8 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 171**
 
+* `PATCH /invites/multiuse`: Added support for editing multiuse invites
+  to users as admin with regards to role and associated streams.
 * `GET /invites`: Added the `stream_ids` field to be returned for all
   multiuse invite objects.
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 171**
+
+* `GET /invites`: Added the `stream_ids` field to be returned for all
+  multiuse invite objects.
+
 **Feature level 170**
 
 * [`POST /user_topics`](/api/update-user-topic):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 170
+API_FEATURE_LEVEL = 171
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/invite.js
+++ b/web/src/invite.js
@@ -242,6 +242,7 @@ function open_invite_user_modal(e) {
 
     gear_menu.close();
 
+    const streams = get_invite_streams();
     const time_unit_choices = ["minutes", "hours", "days", "weeks"];
     const html_body = render_invite_user_modal({
         is_admin: page_params.is_admin,
@@ -256,6 +257,9 @@ function open_invite_user_modal(e) {
 
     function invite_user_modal_post_render() {
         $("#invite-user-modal .dialog_submit_button").prop("disabled", true);
+        for (const stream of streams.filter((stream) => stream.default_stream)) {
+            $(`input[value=${stream.stream_id}]`).prop("checked", true);
+        }
 
         autosize($("#invitee_emails").trigger("focus"));
 

--- a/web/src/invite.js
+++ b/web/src/invite.js
@@ -58,7 +58,7 @@ function get_common_invitation_data() {
     return data;
 }
 
-function beforeSend() {
+export function beforeSend() {
     reset_error_messages();
     // TODO: You could alternatively parse the textarea here, and return errors to
     // the user if they don't match certain constraints (i.e. not real email addresses,

--- a/web/src/settings_invites.js
+++ b/web/src/settings_invites.js
@@ -102,7 +102,7 @@ function populate_invites(invites_data) {
 function do_revoke_invite() {
     const modal_invite_id = $(".dialog_submit_button").attr("data-invite-id");
     const modal_is_multiuse = $(".dialog_submit_button").attr("data-is-multiuse");
-    const $revoke_button = meta.$current_revoke_invite_user_modal_row.find("button.revoke");
+    const $revoke_button = meta.$current_revoke_invite_user_modal_row.find("button.revoke-invite");
 
     if (modal_invite_id !== meta.invite_id || modal_is_multiuse !== meta.is_multiuse) {
         blueslip.error("Invite revoking canceled due to non-matching fields.");
@@ -133,7 +133,7 @@ function do_revoke_invite() {
 
 function do_resend_invite() {
     const modal_invite_id = $(".dialog_submit_button").attr("data-invite-id");
-    const $resend_button = meta.$current_resend_invite_user_modal_row.find("button.resend");
+    const $resend_button = meta.$current_resend_invite_user_modal_row.find("button.resend-invite");
 
     if (modal_invite_id !== meta.invite_id) {
         blueslip.error("Invite resending canceled due to non-matching fields.");
@@ -183,7 +183,7 @@ export function on_load_success(invites_data, initialize_event_handlers) {
     if (!initialize_event_handlers) {
         return;
     }
-    $(".admin_invites_table").on("click", ".revoke", (e) => {
+    $(".admin_invites_table").on("click", ".revoke-invite", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();
@@ -213,7 +213,7 @@ export function on_load_success(invites_data, initialize_event_handlers) {
         $(".dialog_submit_button").attr("data-is-multiuse", meta.is_multiuse);
     });
 
-    $(".admin_invites_table").on("click", ".resend", (e) => {
+    $(".admin_invites_table").on("click", ".resend-invite", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -470,4 +470,9 @@ export function initialize() {
         delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
     });
+
+    delegate("body", {
+        target: ".revoke-invite, .resend-invite",
+        appendTo: () => document.querySelector(".organization-box"),
+    });
 }

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -472,7 +472,7 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: ".revoke-invite, .resend-invite",
+        target: ".edit-invite, .revoke-invite, .resend-invite",
         appendTo: () => document.querySelector(".organization-box"),
     });
 }

--- a/web/templates/invite_role_and_streams_form.hbs
+++ b/web/templates/invite_role_and_streams_form.hbs
@@ -1,0 +1,42 @@
+<div>
+    <div class="input-group">
+        <label for="invite_as">{{t "User(s) join as" }}</label>
+        <select id="invite_as" class="invite-as bootstrap-focus-style">
+            <option name="invite_as" value="{{ invite_as_options.guest.code }}">{{t "Guests" }}</option>
+            <option name="invite_as" value="{{ invite_as_options.member.code }}">{{t "Members" }}</option>
+            {{#if is_admin}}
+            <option name="invite_as" value="{{ invite_as_options.moderator.code }}">{{t "Moderators" }}</option>
+            <option name="invite_as" value="{{ invite_as_options.admin.code }}">{{t "Organization administrators" }}</option>
+            {{/if}}
+            {{#if is_owner}}
+            <option name="invite_as" value="{{ invite_as_options.owner.code }}">{{t "Organization owners" }}</option>
+            {{/if}}
+        </select>
+    </div>
+
+    <div class="input-group">
+        <label>{{t "Streams they should join" }}</label>
+        <div id="streams_to_add">
+            <div class="invite-stream-controls">
+                <button class="btn btn-link" type="button" id="invite_check_all_button">{{t "Check all" }}</button> |
+                <button class="btn btn-link" type="button" id="invite_uncheck_all_button">{{t "Uncheck all" }}</button>
+            </div>
+            <div id="invite-stream-checkboxes" class="new-style">
+                {{#each streams}}
+                    <label class="checkbox display-block">
+                        <input type="checkbox" name="stream" value="{{stream_id}}"/>
+                        <span></span>
+
+                        {{#if (or invite_only is_web_public)}} {{>stream_privacy}} {{name}}
+                        {{else}}# {{name}}
+                        {{/if}}
+
+                        {{#if (eq name ../notifications_stream)}}
+                            <i>({{t 'Receives new stream announcements' }})</i>
+                        {{/if}}
+                    </label>
+                {{/each}}
+            </div>
+        </div>
+    </div>
+</div>

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -37,46 +37,6 @@
             <p id="custom_expires_on"></p>
         </div>
     </div>
-    <div class="input-group">
-        <label for="invite_as">{{t "User(s) join as" }}
-            {{> help_link_widget link="/help/roles-and-permissions" }}
-        </label>
-        <select id="invite_as" class="invite-as bootstrap-focus-style">
-            <option name="invite_as" value="{{ invite_as_options.guest.code }}">{{t "Guests" }}</option>
-            <option name="invite_as" selected="selected" value="{{ invite_as_options.member.code }}">{{t "Members" }}</option>
-            {{#if is_admin}}
-            <option name="invite_as" value="{{ invite_as_options.moderator.code }}">{{t "Moderators" }}</option>
-            <option name="invite_as" value="{{ invite_as_options.admin.code }}">{{t "Organization administrators" }}</option>
-            {{/if}}
-            {{#if is_owner}}
-            <option name="invite_as" value="{{ invite_as_options.owner.code }}">{{t "Organization owners" }}</option>
-            {{/if}}
-        </select>
-    </div>
-    <div>
-        <label>{{t "Streams they should join" }}</label>
-        <div id="streams_to_add">
-            <div class="invite-stream-controls">
-                <button class="btn btn-link" type="button" id="invite_check_all_button">{{t "Check all" }}</button> |
-                <button class="btn btn-link" type="button" id="invite_uncheck_all_button">{{t "Uncheck all" }}</button>
-            </div>
-            <div id="invite-stream-checkboxes" class="new-style">
-                {{#each streams}}
 
-                    <label class="checkbox display-block">
-                        <input type="checkbox" name="stream" value="{{stream_id}}"
-                          {{#if default_stream}}checked="checked"{{/if}} />
-                        <span></span>
-                        {{#if (or invite_only is_web_public)}} {{>stream_privacy}} {{name}}
-                        {{else}}
-                        #{{name}}
-                        {{/if}}
-                        {{#if (eq name ../notifications_stream)}}
-                        <i>({{t 'Receives new stream announcements' }})</i>
-                        {{/if}}
-                    </label>
-                {{/each}}
-            </div>
-        </div>
-    </div>
+    {{>invite_role_and_streams_form}}
 </form>

--- a/web/templates/settings/admin_invites_list.hbs
+++ b/web/templates/settings/admin_invites_list.hbs
@@ -32,7 +32,17 @@
         <span>{{invited_as_text}}</span>
     </td>
     <td class="actions">
-        {{#unless is_multiuse}}
+        {{#if is_multiuse}}
+        <button
+          class="button rounded small edit-invite btn-warning"
+          {{#if disable_buttons}}disabled="disabled"{{/if}}
+          data-invite-id="{{id}}"
+          data-is-multiuse="{{is_multiuse}}"
+          data-tippy-content="{{t 'Edit'}}"
+          >
+            <i class="fa fa-pencil"></i>
+        </button>
+        {{else}}
         <button
           class="button rounded small resend-invite btn-warning"
           {{#if disable_buttons}}disabled="disabled"{{/if}}
@@ -41,7 +51,7 @@
           >
             <i class="fa fa-paper-plane"></i>
         </button>
-        {{/unless}}
+        {{/if}}
         <button
           class="button rounded small revoke-invite btn-danger"
           {{#if disable_buttons}}disabled="disabled"{{/if}}

--- a/web/templates/settings/admin_invites_list.hbs
+++ b/web/templates/settings/admin_invites_list.hbs
@@ -33,12 +33,23 @@
     </td>
     <td class="actions">
         {{#unless is_multiuse}}
-        <button class="button rounded small resend btn-warning" {{#if disable_buttons}}disabled="disabled"{{/if}} data-invite-id="{{id}}">
-            {{t "Resend" }}
+        <button
+          class="button rounded small resend-invite btn-warning"
+          {{#if disable_buttons}}disabled="disabled"{{/if}}
+          data-invite-id="{{id}}"
+          data-tippy-content="{{t 'Resend'}}"
+          >
+            <i class="fa fa-paper-plane"></i>
         </button>
         {{/unless}}
-        <button class="button rounded small revoke btn-danger" {{#if disable_buttons}}disabled="disabled"{{/if}} data-invite-id="{{id}}" data-is-multiuse="{{is_multiuse}}">
-            {{t "Revoke" }}
+        <button
+          class="button rounded small revoke-invite btn-danger"
+          {{#if disable_buttons}}disabled="disabled"{{/if}}
+          data-invite-id="{{id}}"
+          data-is-multiuse="{{is_multiuse}}"
+          data-tippy-content="{{t 'Revoke'}}"
+          >
+            <i class="fa fa-trash"></i>
         </button>
     </td>
 </tr>

--- a/web/templates/settings/edit_invite_user_modal.hbs
+++ b/web/templates/settings/edit_invite_user_modal.hbs
@@ -1,0 +1,3 @@
+<form id="edit-invite-form">{{ csrf_input }}
+    {{>../invite_role_and_streams_form}}
+</form>

--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -476,6 +476,20 @@ def do_revoke_multi_use_invite(multiuse_invite: MultiuseInvite) -> None:
     notify_invites_changed(realm)
 
 
+def do_edit_multiuse_invite_link(
+    multiuse_invite: MultiuseInvite,
+    invited_as: int,
+    streams: Sequence[Stream],
+) -> None:
+    # The `streams` and `invited_as` fields of a `multiuse_invite` can be edited.
+    multiuse_invite.streams.set(streams)
+    multiuse_invite.invited_as = invited_as
+    multiuse_invite.save()
+
+    realm = multiuse_invite.referred_by.realm
+    notify_invites_changed(realm)
+
+
 def do_resend_user_invite_email(prereg_user: PreregistrationUser) -> int:
     # These are two structurally for the caller's code path.
     assert prereg_user.referred_by is not None

--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -388,6 +388,7 @@ def do_get_invites_controlled_by_user(user_profile: UserProfile) -> List[Dict[st
                 ),
                 invited_as=invite.invited_as,
                 is_multiuse=True,
+                stream_ids=list(invite.streams.values_list("id", flat=True)),
             )
         )
     return invites

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -57,6 +57,7 @@ from zerver.views.events_register import events_register_backend
 from zerver.views.home import accounts_accept_terms, desktop_home, home
 from zerver.views.hotspots import mark_hotspot_as_read
 from zerver.views.invite import (
+    edit_multiuse_invite,
     generate_multiuse_invite_backend,
     get_user_invites,
     invite_users_backend,
@@ -313,7 +314,11 @@ v1_api_and_json_patterns = [
     # invites/multiuse -> zerver.views.invite
     rest_path("invites/multiuse", POST=generate_multiuse_invite_backend),
     # invites/multiuse -> zerver.views.invite
-    rest_path("invites/multiuse/<int:invite_id>", DELETE=revoke_multiuse_invite),
+    rest_path(
+        "invites/multiuse/<int:invite_id>",
+        DELETE=revoke_multiuse_invite,
+        PATCH=edit_multiuse_invite,
+    ),
     # mark messages as read (in bulk)
     rest_path("mark_all_as_read", POST=mark_all_as_read),
     rest_path("mark_stream_as_read", POST=mark_stream_as_read),


### PR DESCRIPTION
> I am a GSoC '23 applicant, and this is my first PR :rocket: 

This pull request adds the feature to allow the editing of multiuse invites.

Partially fixes: GH-22099
- [ ] Blocking PR: GH-24977

### Screenshots and Screencast

**Added an "Edit" button on `SETTINGS / INVITATIONS` modal.**
<details><summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/55971005/223925453-1eedcf18-753e-442b-8f4b-223ddecf25b8.png">
</details>

**On clicking the "Edit" button, the "Edit Invite to Users" modal opens up. The only editable fields are `invite_as` and `streams`. The link itself is not editable, or shown in this modal.**
<details><summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/55971005/223925849-641e2e51-1e5a-4fdf-a6ac-a4100e98be21.png">
</details>

**On successful edit operation.**
<details><summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/55971005/223926382-d3f12e75-643a-4ddd-8a5d-ec58548cd458.png">
</details>

### Screencast of the Feature
[screen-recorder-thu-mar-09-2023-10-42-32.webm](https://user-images.githubusercontent.com/55971005/223926672-ad84a0f4-5146-4474-9453-f6b0040798ab.webm)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
