### PR TITLE
css: Move inline and block code rules to `rendered_markdown` block.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -19,6 +19,10 @@
 
     a:hover {
         color: hsl(200, 79%, 66%);
+
+        code {
+            color: hsl(200, 79%, 66%);
+        }
     }
 
     ul.filters a:hover {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -540,6 +540,21 @@
     }
 
     pre {
+        direction: ltr;
+        /* code block text is a bit smaller than normal text */
+        font-size: 0.825em;
+        line-height: 1.4;
+        white-space: pre;
+        overflow-x: auto;
+        word-break: break-all;
+        word-wrap: normal;
+        margin: 5px 0;
+        padding: 5px 7px 3px;
+        color: hsl(0, 0%, 20%);
+        display: block;
+        border: 1px solid hsla(0, 0%, 0%, 0.15);
+        border-radius: 4px;
+
         &:hover .copy_codeblock,
         &:hover .code_external_link {
             visibility: visible;
@@ -641,37 +656,16 @@
     }
 }
 
-/* Inline and block code.
-
-TODO: It is likely that this CSS can and should be moved into the
-rendered_markdown block; we just need to do further analysis to
-confirm doing so won't break anything. */
-
 .codehilite {
     display: block !important;
     border: none !important;
     background: none !important;
 }
 
-pre {
-    direction: ltr;
-    /* code block text is a bit smaller than normal text */
-    font-size: 0.825em;
-    line-height: 1.4;
-    white-space: pre;
-    overflow-x: auto;
-    word-wrap: normal;
-    /* Bootstrap's default here is top: 0px, bottom: 10px */
-    margin-top: 5px;
-    margin-bottom: 5px;
-    /* Bootstrap's default here is 9.5 on all sides */
-    padding: 5px 7px 3px;
-}
-
 /* Both the horizontal scrollbar in <pre/> as well as
    vertical scrollbar in the <textarea/> is styled similarly. */
 .message_edit_form textarea,
-pre {
+.rendered_markdown pre {
     /* Ensure the horizontal scrollbar is visible on Mac */
     &::-webkit-scrollbar {
         height: 8px;

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -524,10 +524,18 @@
         color: hsl(200, 100%, 40%);
         text-decoration: none;
 
+        code {
+            color: hsl(200, 100%, 40%);
+        }
+
         &:hover,
         &:focus {
             color: hsl(200, 100%, 25%);
             text-decoration: underline;
+
+            code {
+                color: hsl(200, 100%, 25%);
+            }
         }
     }
 
@@ -545,6 +553,21 @@
         overflow-x: scroll;
         color: inherit;
         border: 0;
+    }
+
+    code {
+        /* 11.55px when body is the default 14px; this is chosen to be
+        slightly above the 11.5px threshold where the height jumps by a
+        pixel on most platforms. */
+        font-size: 0.825em;
+        unicode-bidi: embed;
+        direction: ltr;
+        color: hsl(0, 0%, 0%);
+        white-space: pre-wrap;
+        padding: 0 4px;
+        background-color: hsl(0, 0%, 100%);
+        border: 1px solid hsl(240, 13%, 90%);
+        border-radius: 3px;
     }
 
     /* Style copy-to-clipboard button inside code blocks */
@@ -624,27 +647,6 @@ TODO: It is likely that this CSS can and should be moved into the
 rendered_markdown block; we just need to do further analysis to
 confirm doing so won't break anything. */
 
-code {
-    /* 11.55px when body is the default 14px; this is chosen to be
-       slightly above the 11.5px threshold where the height jumps by a
-       pixel on most platforms. */
-    font-size: 0.825em;
-    unicode-bidi: embed;
-    direction: ltr;
-    color: hsl(0, 0%, 0%);
-    white-space: pre;
-    padding: 2px 4px;
-    background-color: hsl(240, 14%, 97%);
-    border: 1px solid hsl(240, 13%, 90%);
-    border-radius: 3px;
-}
-
-.rendered_markdown code {
-    white-space: pre-wrap;
-    padding: 0 4px;
-    background-color: hsl(0, 0%, 100%);
-}
-
 .codehilite {
     display: block !important;
     border: none !important;
@@ -686,16 +688,6 @@ pre {
     &::-webkit-scrollbar-thumb:hover {
         background-color: hsla(0, 0%, 0%, 0.6);
     }
-}
-
-/* Style inline code inside a link
-   to look more like a normal link */
-a code {
-    color: hsl(200, 100%, 40%);
-}
-
-a:hover code {
-    color: hsl(200, 100%, 25%);
 }
 
 /* Search highlight used in both topics and rendered_markdown */

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -520,6 +520,17 @@
         border: none;
     }
 
+    a {
+        color: hsl(200, 100%, 40%);
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+            color: hsl(200, 100%, 25%);
+            text-decoration: underline;
+        }
+    }
+
     pre {
         &:hover .copy_codeblock,
         &:hover .code_external_link {


### PR DESCRIPTION
In `web/styles/rendered_markdown.css`, moves the CSS rules for `code` and `pre` elements to be in the `rendered_markdown` class rules.

Follow-up to #24565.

**Notes**:
- There's a prep commit that adds the color and text-decoration rules for `anchor` elements from bootstrap so that the hover color rules can be specific enough in the following commit.
- The `-moz` and `-webkit` prefixed `border-radius` rules in bootstrap aren't moved/copied in these changes. According to [mdn docs on border-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius#browser_compatibility), non-prefixed support has been in Firefox since 2011 and in Edge since 2015.
- Most `pre` CSS reset rules were already in `rendered_markdown.css`. The `pre` CSS reset rules that are moved from bootstrap and applied in the final commit are (see devtools screenshots below):
  - color
  - display
  - word-break
  - border
  - border-radius

---

**Screenshots and screen captures:**

<details>
<summary>Light theme examples</summary>

  | Before | After |
  | --- | --- |
  | ![Screenshot from 2023-03-13 20-31-10](https://user-images.githubusercontent.com/63245456/224812727-f7e98c5c-165d-46d6-9eee-773fc10b6aa1.png) | ![Screenshot from 2023-03-13 20-30-55](https://user-images.githubusercontent.com/63245456/224812830-d9513389-2850-4ed5-a877-9b6a95e79c42.png)
</details>
<details>
<summary>Dark theme examples</summary>

  | Before | After |
  | --- | --- |
  | ![Screenshot from 2023-03-13 20-31-23](https://user-images.githubusercontent.com/63245456/224812784-f2058e6f-bda6-43ec-9420-56f9800636d9.png) | ![Screenshot from 2023-03-13 20-30-41](https://user-images.githubusercontent.com/63245456/224812857-e734231e-2aa4-4b03-b11d-f2edf9fc6433.png)
</details>
<details>
<summary>Devtools in light theme</summary>

  | Before | After |
  | --- | --- |
  | ![Screenshot from 2023-03-13 20-37-36](https://user-images.githubusercontent.com/63245456/224814380-dc9fbaec-4a8c-45de-ba07-0bc1a668ea41.png) | ![Screenshot from 2023-03-13 20-38-17](https://user-images.githubusercontent.com/63245456/224814426-1d19f077-11c5-4e53-9bd4-d59df1b92472.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
