### PR TITLE
organization_settings: Add dropdown to filter users list by role.

### DIFF
--- a/web/src/admin.js
+++ b/web/src/admin.js
@@ -201,6 +201,15 @@ export function build_page() {
         realm_enable_read_receipts: page_params.realm_enable_read_receipts,
         allow_sorting_deactivated_users_list_by_email:
             settings_users.allow_sorting_deactivated_users_list_by_email(),
+        roles: [
+            {role: $t({defaultMessage: "All roles"}), code: 0},
+            ...Object.values(settings_config.user_role_values)
+                .reverse()
+                .map((value) => ({
+                    role: value.description,
+                    code: value.code,
+                })),
+        ],
     };
 
     if (options.realm_logo_source !== "D" && options.realm_night_logo_source === "D") {

--- a/web/src/list_widget.js
+++ b/web/src/list_widget.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import * as blueslip from "./blueslip";
 import * as scroll_util from "./scroll_util";
+import * as settings_users from "./settings_users";
 
 const DEFAULTS = {
     INITIAL_RENDER_COUNT: 80,
@@ -68,6 +69,17 @@ export function get_filtered_items(value, list, opts) {
     }
 
     return list.filter((item) => predicate(item));
+}
+
+export function get_filtered_roles(value, list, opts) {
+    if (value === 0) {
+        return list;
+    }
+
+    if (opts.filter.role_filterer) {
+        return opts.filter.role_filterer(list, value);
+    }
+    return list;
 }
 
 export function alphabetic_sort(prop) {
@@ -161,6 +173,7 @@ export function create($container, list, opts) {
         filtered_list: list,
         reverse_mode: false,
         filter_value: "",
+        role_filter_value: 0,
     };
 
     if (!valid_filter_opts(opts)) {
@@ -180,6 +193,7 @@ export function create($container, list, opts) {
 
     widget.filter_and_sort = function () {
         meta.filtered_list = get_filtered_items(meta.filter_value, meta.list, opts);
+        meta.filtered_list = get_filtered_roles(meta.role_filter_value, meta.filtered_list, opts);
 
         if (meta.sorting_function) {
             meta.filtered_list.sort(meta.sorting_function);
@@ -286,6 +300,10 @@ export function create($container, list, opts) {
         meta.filter_value = filter_value;
     };
 
+    widget.set_role_filter_value = function (filter_value) {
+        meta.role_filter_value = filter_value;
+    };
+
     widget.set_reverse_mode = function (reverse_mode) {
         meta.reverse_mode = reverse_mode;
     };
@@ -335,6 +353,14 @@ export function create($container, list, opts) {
             opts.filter.$element.on("input.list_widget_filter", function () {
                 const value = this.value.toLocaleLowerCase();
                 widget.set_filter_value(value);
+                widget.hard_redraw();
+            });
+        }
+
+        if (opts.filter && opts.filter.role_element) {
+            opts.filter.role_element.on("change", function () {
+                const value = this.value;
+                widget.set_role_filter_value(Number.parseInt(value, 10));
                 widget.hard_redraw();
             });
         }

--- a/web/src/list_widget.js
+++ b/web/src/list_widget.js
@@ -167,6 +167,7 @@ export function create($container, list, opts) {
         generic_sorting_functions: {
             alphabetic: alphabetic_sort,
             numeric: numeric_sort,
+            role: settings_users.sort_role,
         },
         offset: 0,
         list,

--- a/web/src/people.js
+++ b/web/src/people.js
@@ -1346,6 +1346,10 @@ export function filter_for_user_settings_search(persons, query) {
     return persons.filter((person) => matches_user_settings_search(person, query));
 }
 
+export function filter_for_user_settings_role(persons, value) {
+    return persons.filter((person) => person.role === value);
+}
+
 export function maybe_incr_recipient_count(message) {
     if (message.type !== "private") {
         return;

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -69,8 +69,10 @@ function sort_bot_email(a, b) {
     return compare_a_b(email(a), email(b));
 }
 
-function sort_role(a, b) {
-    return compare_a_b(a.role, b.role);
+export function sort_role() {
+    return function (a, b) {
+        return compare_a_b(a.role, b.role);
+    };
 }
 
 function sort_bot_owner(a, b) {
@@ -332,7 +334,7 @@ section.active.create_table = (active_users) => {
             onupdate: reset_scrollbar($users_table),
         },
         $parent_container: $("#admin-user-list").expectOne(),
-        init_sort: ["alphabetic", "full_name"],
+        init_sort: ["role", "role"],
         sort_fields: {
             email: sort_email,
             last_active: sort_last_active,

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -327,6 +327,8 @@ section.active.create_table = (active_users) => {
         filter: {
             $element: $users_table.closest(".settings-section").find(".search"),
             filterer: people.filter_for_user_settings_search,
+            role_element: $("#user_roles"),
+            role_filterer: people.filter_for_user_settings_role,
             onupdate: reset_scrollbar($users_table),
         },
         $parent_container: $("#admin-user-list").expectOne(),

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1937,6 +1937,10 @@ $option_title_width: 180px;
         margin-top: 12px;
     }
 
+    .admin_user_list_heading {
+        margin-bottom: unset;
+    }
+
     .admin_user_list_filter {
         display: flex;
         float: right;
@@ -1947,6 +1951,7 @@ $option_title_width: 180px;
 
         & input.search {
             margin-top: unset;
+            margin-bottom: 10px;
         }
 
         & select.settings_select {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1936,6 +1936,24 @@ $option_title_width: 180px;
         max-width: 160px;
         margin-top: 12px;
     }
+
+    .admin_user_list_filter {
+        display: flex;
+        float: right;
+        font-size: 1em;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 10px;
+
+        & input.search {
+            margin-top: unset;
+        }
+
+        & select.settings_select {
+            width: fit-content;
+            min-width: 120px;
+        }
+    }
 }
 
 #add-new-custom-profile-field-form,

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -3,7 +3,7 @@
     <div class="clear-float"></div>
 
     <div class="settings_panel_list_header">
-        <h3>{{t "Users"}}</h3>
+        <h3 class="admin_user_list_heading">{{t "Users"}}</h3>
         <div class="alert-notification" id="user-field-status"></div>
         <div class="admin_user_list_filter">
             <select name="roles" id="user_roles" class="bootstrap-focus-style settings_select">

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -5,7 +5,16 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Users"}}</h3>
         <div class="alert-notification" id="user-field-status"></div>
-        <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+        <div class="admin_user_list_filter">
+            <select name="roles" id="user_roles" class="bootstrap-focus-style settings_select">
+                {{#each roles}}
+                    <option value="{{ this.code }}">{{ this.role }}</option>
+                {{/each}}
+            </select>
+            <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}" />
+        </div>
+
+
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -1190,6 +1190,16 @@ test_people("matches_user_settings_search", () => {
     assert.equal(match({full_name: "Joe Frederick"}, "re"), true);
 });
 
+test_people("filter_for_user_settings_role", () => {
+    page_params.is_admin = false;
+
+    const persons = [realm_admin, guest, realm_owner, moderator];
+
+    assert.deepEqual(people.filter_for_user_settings_role(persons, 100), [realm_owner]);
+
+    assert.deepEqual(people.filter_for_user_settings_role(persons, 300), [moderator]);
+});
+
 test_people("is_valid_full_name_and_user_id", () => {
     assert.ok(!people.is_valid_full_name_and_user_id("bogus", 99));
     assert.ok(!people.is_valid_full_name_and_user_id(me.full_name, 99));


### PR DESCRIPTION
- [x] Adds a dropdown in the `organization settings>users list` page to filter the users list by role.
- [x] By default the user_list will be sorted according to the role, from highest permissions to lowest permissions (Owners, Administrators, moderators, members, guests).
- [x] Dropdown works for different languages also.

----------------------------------

Fixes: #18617

--------------------------------

**Screenshots and screen captures:**

<details>
<summary>Users list header:</summary>
<br>

- Before:

![Screenshot from 2023-03-14 01-14-28](https://user-images.githubusercontent.com/66828942/224815658-412fdb40-815c-4cd2-a8a7-1eef1df1eaa1.png)

<br>

- After:

![Screenshot from 2023-03-31 05-22-38](https://user-images.githubusercontent.com/66828942/228989635-b3905e6f-a169-4ade-a1bc-f79560beb031.png)

<br>

- Narrow Screen:

![Screenshot from 2023-03-31 05-22-52](https://user-images.githubusercontent.com/66828942/228989661-ff260c3a-d5ed-4f9e-9884-2fec21da3c06.png)


</details>
<details>
<summary>Filter users list (demo):</summary>
<br>

- **English:**
![filter](https://user-images.githubusercontent.com/66828942/224816169-28200dc1-9de6-482d-a5d0-133a5c01a3aa.gif)


- **Other language:**

![fil](https://user-images.githubusercontent.com/66828942/224817080-8d38d06d-99e0-46ca-b981-6b420f894fc4.gif)

</details>

<details>
<summary>Default users list:</summary>
<br>

![Screenshot from 2023-03-14 01-18-26](https://user-images.githubusercontent.com/66828942/224816349-8804ca4e-fe2a-4c06-83aa-a329a2c907c9.png)


</details>

-----------------------------------------

- Difference from previous plan:
> The issue description said to implement a `multiSelectDropdown`, however, we have not tested the `multiSelectDropdownList` properly. So, we can just go ahead with the `singleSelectDropdown` for the first iteration and then migrate to multi once it has been tested properly.

-------------------------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
