### PR TITLE
settings: Refactor drafts to manage tasks by compose_actions.start.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -348,6 +348,13 @@ export function start(msg_type, opts) {
         $("#compose-textarea").data("draft-id", opts.draft_id);
     }
 
+    if (opts.content !== undefined) {
+        // If we were provided with message content, we might need to
+        // resize the compose box, or display that it's too long.
+        compose_ui.autosize_textarea($("#compose-textarea"));
+        compose_validate.check_overflow_text();
+    }
+
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);
 

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -339,14 +339,14 @@ export function start(msg_type, opts) {
         compose_state.message_content(opts.content);
     }
 
-    if (opts.draft_id) {
-        $("#compose-textarea").data("draft-id", opts.draft_id);
-    }
-
     compose_state.set_message_type(msg_type);
 
     // Show either stream/topic fields or "You and" field.
     show_compose_box(msg_type, opts);
+
+    if (opts.draft_id) {
+        $("#compose-textarea").data("draft-id", opts.draft_id);
+    }
 
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -217,6 +217,7 @@ export function restore_message(draft) {
 
     if (draft.type === "stream") {
         compose_args = {
+            draft_id: draft.id,
             type: "stream",
             stream: draft.stream,
             topic: draft.topic,
@@ -224,6 +225,7 @@ export function restore_message(draft) {
         };
     } else {
         compose_args = {
+            draft_id: draft.id,
             type: draft.type,
             private_message_recipient: draft.private_message_recipient,
             content: draft.content,
@@ -319,7 +321,6 @@ export function restore_draft(draft_id) {
     compose.clear_preview_area();
     compose_actions.start(compose_args.type, compose_args);
     compose_ui.autosize_textarea($("#compose-textarea"));
-    $("#compose-textarea").data("draft-id", draft_id);
     compose_validate.check_overflow_text();
 }
 

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -14,8 +14,6 @@ import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
-import * as compose_ui from "./compose_ui";
-import * as compose_validate from "./compose_validate";
 import * as confirm_dialog from "./confirm_dialog";
 import {$t, $t_html} from "./i18n";
 import {localstorage} from "./localstorage";
@@ -320,8 +318,6 @@ export function restore_draft(draft_id) {
     compose_fade.clear_compose();
     compose.clear_preview_area();
     compose_actions.start(compose_args.type, compose_args);
-    compose_ui.autosize_textarea($("#compose-textarea"));
-    compose_validate.check_overflow_text();
 }
 
 const DRAFT_LIFETIME = 30;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Based on Tim Abbott's [suggestion](https://github.com/zulip/zulip/pull/24372#issuecomment-1437696951), I have incorporated ```compose_actions.start()``` to manage tasks such as `draft_id` setup and overflow text verification. Consequently, I have also included `draft_id` in the `compose_args` since using `opts.draft_id` in the previous method was returning undefined.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Not required as it solely involves refactoring the existing code.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
