### PR TITLE
ts: Convert portico/team.js to TypeScript.

### DIFF
--- a/corporate/views/portico.py
+++ b/corporate/views/portico.py
@@ -92,7 +92,7 @@ def team_view(request: HttpRequest) -> HttpResponse:
         with open(settings.CONTRIBUTOR_DATA_FILE_PATH, "rb") as f:
             data = orjson.loads(f.read())
     except FileNotFoundError:
-        data = {"contributors": {}, "date": "Never ran."}
+        data = {"contributors": [], "date": "Never ran."}
 
     return TemplateResponse(
         request,

--- a/web/src/portico/landing-page.js
+++ b/web/src/portico/landing-page.js
@@ -5,6 +5,7 @@ import microsoft_image from "../../images/app-screenshots/microsoft.png";
 import ubuntu_image from "../../images/app-screenshots/ubuntu.png";
 import android_image from "../../images/app-screenshots/zulip-android.png";
 import iphone_image from "../../images/app-screenshots/zulip-iphone-rough.png";
+import {page_params} from "../page_params";
 
 import {detect_user_os} from "./tabbed-instructions";
 import render_tabs from "./team";
@@ -194,7 +195,9 @@ $(() => {
     events();
 
     if (window.location.pathname === "/team/") {
-        render_tabs();
+        const contributors = page_params.contributors;
+        delete page_params.contributors;
+        render_tabs(contributors);
     }
 
     // Source: https://stackoverflow.com/questions/819416/adjust-width-and-height-of-iframe-to-fit-with-content-in-it

--- a/web/src/portico/team.js
+++ b/web/src/portico/team.js
@@ -1,8 +1,6 @@
 import $ from "jquery";
 import _ from "lodash";
 
-import {page_params} from "../page_params";
-
 const repo_name_to_tab_name = {
     zulip: "server",
     "zulip-desktop": "desktop",
@@ -63,12 +61,12 @@ function exclude_bot_contributors(contributor) {
 // TODO (for v2 of /team/ contributors):
 //   - Make tab header responsive.
 //   - Display full name instead of GitHub username.
-export default function render_tabs() {
+export default function render_tabs(contributors) {
     const template = _.template($("#contributors-template").html());
     const count_template = _.template($("#count-template").html());
     const total_count_template = _.template($("#total-count-template").html());
-    const contributors_list = page_params.contributors
-        ? page_params.contributors.filter((c) => exclude_bot_contributors(c))
+    const contributors_list = contributors
+        ? contributors.filter((c) => exclude_bot_contributors(c))
         : [];
     const mapped_contributors_list = contributors_list.map((c) => ({
         name: get_display_name(c),

--- a/web/src/portico/team.js
+++ b/web/src/portico/team.js
@@ -115,7 +115,7 @@ export default function render_tabs() {
                             name: get_display_name(c),
                             github_username: c.github_username,
                             avatar: c.avatar,
-                            profile_url: get_profile_url(c),
+                            profile_url: get_profile_url(c, tab_name),
                             commits: c[repo_name],
                         }),
                     )

--- a/web/src/portico/team.ts
+++ b/web/src/portico/team.ts
@@ -1,7 +1,26 @@
 import $ from "jquery";
 import _ from "lodash";
 
-const repo_name_to_tab_name = {
+// The list of repository names is duplicated here in order to provide
+// a clear type for Contributor objects.
+//
+// TODO: We can avoid this if we introduce a `contributions` object
+// referenced from Contributor, rather than having repository names be
+// direct keys in the namespace that also has `email`.
+const all_repository_names = [
+    "zulip",
+    "zulip-desktop",
+    "zulip-mobile",
+    "python-zulip-api",
+    "zulip-js",
+    "zulipbot",
+    "zulip-terminal",
+    "zulip-ios-legacy",
+    "zulip-android",
+] as const;
+type RepositoryName = (typeof all_repository_names)[number];
+
+const repo_name_to_tab_name: Record<RepositoryName, string> = {
     zulip: "server",
     "zulip-desktop": "desktop",
     "zulip-mobile": "mobile",
@@ -13,26 +32,36 @@ const repo_name_to_tab_name = {
     "zulip-android": "",
 };
 
+export type Contributor = {
+    avatar: string;
+    email?: string;
+    github_username?: string;
+    name: string;
+} & {
+    [K in RepositoryName]?: number;
+};
+
 // Remember the loaded repositories so that HTML is not redundantly edited
 // if a user leaves and then revisits the same tab.
-const loaded_repos = [];
+const loaded_repos: string[] = [];
 
-function calculate_total_commits(contributor) {
+function calculate_total_commits(contributor: Contributor): number {
     let commits = 0;
-    for (const repo_name of Object.keys(repo_name_to_tab_name)) {
+    for (const repo_name of all_repository_names) {
         commits += contributor[repo_name] || 0;
     }
     return commits;
 }
 
-function get_profile_url(contributor, tab_name) {
-    const commit_email_linked_to_github = "github_username" in contributor;
-
-    if (commit_email_linked_to_github) {
-        return "https://github.com/" + contributor.github_username;
+function get_profile_url(contributor: Contributor, tab_name?: string): string | undefined {
+    if (contributor.github_username) {
+        return `https://github.com/${contributor.github_username}`;
     }
 
     const email = contributor.email;
+    if (!email) {
+        return undefined;
+    }
 
     if (tab_name) {
         return `https://github.com/zulip/${tab_name}/commits?author=${email}`;
@@ -47,21 +76,21 @@ function get_profile_url(contributor, tab_name) {
     return undefined;
 }
 
-function get_display_name(contributor) {
+function get_display_name(contributor: Contributor): string {
     if (contributor.github_username) {
         return "@" + contributor.github_username;
     }
     return contributor.name;
 }
 
-function exclude_bot_contributors(contributor) {
+function exclude_bot_contributors(contributor: Contributor): boolean {
     return contributor.github_username !== "dependabot[bot]";
 }
 
 // TODO (for v2 of /team/ contributors):
 //   - Make tab header responsive.
 //   - Display full name instead of GitHub username.
-export default function render_tabs(contributors) {
+export default function render_tabs(contributors: Contributor[]): void {
     const template = _.template($("#contributors-template").html());
     const count_template = _.template($("#count-template").html());
     const total_count_template = _.template($("#total-count-template").html());
@@ -93,7 +122,7 @@ export default function render_tabs(contributors) {
         }),
     );
 
-    for (const repo_name of Object.keys(repo_name_to_tab_name)) {
+    for (const repo_name of all_repository_names) {
         const tab_name = repo_name_to_tab_name[repo_name];
         if (!tab_name) {
             continue;
@@ -103,11 +132,13 @@ export default function render_tabs(contributors) {
 
         $(`#${CSS.escape(tab_name)}`).on("click", () => {
             if (!loaded_repos.includes(repo_name)) {
-                const filtered_by_repo = contributors_list.filter((c) => c[repo_name]);
+                const filtered_by_repo = contributors_list.filter((c) => c[repo_name] || 0);
                 const html = filtered_by_repo
-                    .sort((a, b) =>
-                        a[repo_name] < b[repo_name] ? 1 : a[repo_name] > b[repo_name] ? -1 : 0,
-                    )
+                    .sort((a, b) => {
+                        const a_commits = a[repo_name] || 0;
+                        const b_commits = b[repo_name] || 0;
+                        return a_commits < b_commits ? 1 : a_commits > b_commits ? -1 : 0;
+                    })
                     .map((c) =>
                         template({
                             name: get_display_name(c),
@@ -121,9 +152,10 @@ export default function render_tabs(contributors) {
 
                 $(`#tab-${CSS.escape(tab_name)} .contributors-grid`).html(html);
                 const contributor_count = filtered_by_repo.length;
-                const hundred_plus_contributor_count = filtered_by_repo.filter(
-                    (c) => c[repo_name] >= 100,
-                ).length;
+                const hundred_plus_contributor_count = filtered_by_repo.filter((c) => {
+                    const commits = c[repo_name] || 0;
+                    return commits >= 100;
+                }).length;
                 const repo_url = `https://github.com/zulip/${repo_name}`;
                 $(`#tab-${CSS.escape(tab_name)}`).prepend(
                     count_template({


### PR DESCRIPTION
This PR converts `portico/team.js` to TypeScript.

To convert `portico/team.js` it was necessary to add `contributors` property  to `page_params` in `page_params.ts`.
It also creates and exports the type `Contributor`. Type `Contributor` is an intersection type of `ContributorProfile` and `RepositoryDetails`.

- I have made `github_username` field in `ContributorProfile` as optional, not sure what other fields can also be optional.
- The function `get_profile_url` in `team.ts` takes two parameters but the second param `tab_name` was not provided in any of the function calls. So I had two choices, first was to either remove the param itself, second was to assign  a default value, I have gone with the second one and set it's default value as 0. But I am not sure on this one, whether this is the correct way to do it or not.

**UPD:**

This PR now does the following things:
- Refactors `team.js` to remove an unused parameter named `tab_name` from the function `get_profile_url`, since it was not given as an argument in any of its call.
- Pop `contributors` from `page_params` and passes it to `render_tabs` hence avoiding the access of it from `team.js`.
- Converts `portico/team.js` to TypeScript as well as add the required type definitions.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
