### PR TITLE
UserTopic: Don't raise errors on duplicate requests.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 169**
+
+* [`PATCH /users/me/subscriptions/muted_topics`](/api/mute-topic):
+  Trying to mute a topic that is already muted or unmute a topic
+  that was not previously muted now results in a success response
+  rather than an error.
+
 **Feature level 168**
 
 * [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults),

--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -809,7 +809,6 @@ def do_update_message(
                     new_stream if new_stream is not None else stream_being_edited,
                     topic_name if topic_name is not None else orig_topic_name,
                     visibility_policy=UserTopic.VisibilityPolicy.MUTED,
-                    ignore_duplicate=True,
                 )
 
     send_event(user_profile.realm, event, users_to_be_notified)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8202,6 +8202,10 @@ paths:
         This endpoint mutes/unmutes a topic within a stream that the current
         user is subscribed to. Muted topics are displayed faded in the Zulip
         UI, and are not included in the user's unread count totals.
+
+        **Changes**: Before Zulip 7.0 (feature level 169), this endpoint
+        returned an error if asked to mute a topic that was already muted
+        or asked to unmute a topic that had not previously been muted.
       x-curl-examples-parameters:
         oneOf:
           - type: exclude
@@ -8257,26 +8261,6 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
-        "400":
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example:
-                          {"msg": "Topic already muted", "result": "error"}
-                        description: |
-                          An example JSON response for when an `add` operation is requested for a topic
-                          that has already been muted:
-                  - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example:
-                          {"msg": "Topic is not muted", "result": "error"}
-                        description: |
-                          An example JSON response for when a `remove` operation is requested for a
-                          topic that had not been previously muted:
   /users/me/muted_users/{muted_user_id}:
     post:
       operationId: mute-user


### PR DESCRIPTION
This is a follow-up PR to #24236 ([comment](https://github.com/zulip/zulip/pull/24236#issuecomment-1457423519))

CZO discussion: [api design > duplicate request to update UserTopic row](https://chat.zulip.org/#narrow/stream/378-api-design/topic/duplicate.20request.20to.20update.20UserTopic.20row/near/1519868) 

First commit includes the changes to:
* Not raise error in the case of duplicate requests to update the visibility_policy.
* Don't send duplicate event in this case.
* Docuumented API changes.

Second commit includes the changes to: ([Discussion](https://chat.zulip.org/#narrow/stream/378-api-design/topic/duplicate.20request.20to.20update.20UserTopic.20row/near/1523806))
* Not raise error when the request is to delete a UserTopic row and the user doesn't already have a visibility_policy for the topic yet (possibly a duplicate request).
* Don't send duplicate event in such case.
* Documented API changes.

Fixes: follow-up PR to #24236

---
### Reason for decrease in db query count:
**In 'zerver/lib/user_topics.py'**

Earlier we were using `UserTopic.objects.get().delete()`, which accounts for 2 queries.
Now, we are using `UserTopic.objects.filter.delete()`, which accounts for 1 query.

### Technical Choice
* To avoid duplicate event send ( in the case of duplicate requests), I have used the approach of --`set_user_topic_visibility_policy_in_database` returning a bool variable named `skip_send_event`, using which we determine - 'whether to send event or skip'. **Let me know, if there is some better way to handle this or it is fine.**
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
