### PR TITLE
portico and help: Link to new /try-zulip page from /development-community and help center.

### DIFF
--- a/help/include/trying-out-zulip.md
+++ b/help/include/trying-out-zulip.md
@@ -5,7 +5,15 @@ and delightful.
 
 We also highly recommend trying Zulip for yourself! You can:
 
-* [Create a Zulip Cloud organization](/new/) for free with just a few
-  clicks.
-* [Join the Zulip development community](/development-community/) to see
-  Zulip in action. Feel free to introduce yourself and ask questions!
+* [Check out the Zulip app](https://zulip.com/try-zulip/) by viewing the Zulip
+  development community, where hundreds of participants collaborate to improve
+  Zulip. Many parts of the community are open for [public
+  access](/help/public-access-option), so you can start exploring without
+  creating an account.
+
+* [Create a Zulip Cloud organization](https://zulip.com/new/) for free in just a
+  few minutes.
+
+* [See how Zulip is being used](https://zulip.com/communities/) in open
+  organizations that have opted in to be listed in the [Zulip communities
+  directory](/help/communities-directory).

--- a/templates/corporate/development-community.md
+++ b/templates/corporate/development-community.md
@@ -23,6 +23,11 @@ developers during daylight hours in North America (roughly between
 15:00 UTC and 1:00 UTC), but the sun never sets on the Zulip
 community. Most questions get a reply within minutes to a few hours.
 
+You can also [read conversations](https://chat.zulip.org/) in the community
+without creating an account. If you are evaluating using Zulip for your
+organization, check out these [tips](/try-zulip/) for exploring the product in
+action in the development community.
+
 <br/>
 # Community norms
 


### PR DESCRIPTION
This PR is a follow-up to #24603.

## Changes on https://zulip.com/development-community/:

![Screen Shot 2023-03-14 at 2 12 04 PM](https://user-images.githubusercontent.com/2090066/225155456-3cadd35b-e9a1-4067-bc82-4da920b4343c.png)

## Help center pages (same changes on both, using an `include` block):

- Link to the new /try-zulip/ page instead of directly to CZO. There is intentionally no CZO link in this section.
- Link to the communities directory.
- Tweak wording about creating a new organization, since you need to type things, not just click, in order to make a new org.

**Note**: These changes should not be deployed prior to 005ca2b033f. Otherwise, links were manually tested.

Update of https://zulip.com/help/trying-out-zulip:
![Screen Shot 2023-03-14 at 3 18 57 PM](https://user-images.githubusercontent.com/2090066/225156142-62e34cc1-4d66-4bf5-bfcb-925ef5c5ca8c.png)

Update of https://zulip.com/help/getting-your-organization-started-with-zulip:
![Screen Shot 2023-03-14 at 3 18 50 PM](https://user-images.githubusercontent.com/2090066/225156148-b7fd744a-e0fa-4423-bd77-4fd57fb7d047.png)

