### PR TITLE
docs: Update 'Include organization name in subject line' settings' docs.

### DIFF
--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -57,14 +57,24 @@ To configure the delay for message notification emails:
 If you belong to multiple Zulip organizations, it can be helpful to have the
 name of the organization in the subject line of your message notification emails.
 
+By default, Zulip includes the organization name if, and only if, your email is
+associated with multiple Zulip organizations.
+
+You can configure Zulip to always or never include the organization name in the
+subject line.
+
 {start_tabs}
 
 {settings_tab|notifications}
 
-1. Under **Email message notifications**, toggle
+1. Under **Email message notifications**, configure
    **Include organization name in subject of message notification emails**.
 
 {end_tabs}
+
+The default is **Automatic**, which includes the organization name if, and only if, your email is
+associated with multiple Zulip organizations. **Always** and **Never** either include or don't include
+the organization name, regardless of how many organizations you are part of.
 
 
 ### Hide message content


### PR DESCRIPTION
This commit updates the help page 'email-notification.md' to reflect the change in zulip#24075 from a checkbox to a dropdown for the 'Include organisation name in subject line' setting.

Earlier the [commit](https://github.com/prakhar1144/zulip/commit/86b41a6838e898538d03bd9bbb9807a9814fe919) was dropped from the PR because:

[Alya Abbott said](https://github.com/zulip/zulip/pull/24075#issuecomment-1401446057):
> Please don't merge the documentation commit; I will tweak it once the feature has been integrated.

<!-- Describe your pull request here.-->

Fixes: follow-up PR to #24075 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

**Screenshots and screen captures:**

  <details>
  <summary><b>Current Doc</b></summary>
  <img src="https://user-images.githubusercontent.com/56781761/225292482-037c923b-a68a-4cae-bb37-1c68cdb4baa3.png"/>
  </details>
  
  
  <details>
  <summary><b>Updated Doc</b></summary>
  <img src="https://user-images.githubusercontent.com/56781761/225292061-92a6a195-5532-4f23-8e2d-f76325d6a776.png"/>
  </details>

---

<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
