### PR TITLE
Issue 20073: Add "nudge" animation when pressing Enter on search keys with no value

### DIFF
--- a/web/src/search.js
+++ b/web/src/search.js
@@ -16,6 +16,8 @@ import * as ui_util from "./ui_util";
 // Exported for unit testing
 export let is_using_input_method = false;
 
+const regexSearchWithoutValue = /^[A-Za-z-]+:['"\s]*$/
+
 export function narrow_or_search_for_term(search_string) {
     const $search_query_box = $("#search_query");
     if (is_using_input_method) {
@@ -122,6 +124,7 @@ export function initialize() {
         // Use our custom typeahead `on_escape` hook to exit
         // the search bar as soon as the user hits Esc.
         on_escape: message_view_header.exit_search,
+        validate_selection: (sel) => !sel || !sel.match(regexSearchWithoutValue),
     });
 
     $searchbox_form.on("compositionend", () => {
@@ -148,8 +151,12 @@ export function initialize() {
                 is_using_input_method = false;
                 return;
             }
-
-            if (keydown_util.is_enter_event(e) && $search_query_box.is(":focus")) {
+            const is_enter = keydown_util.is_enter_event(e);
+            if (is_enter && (e.target?.value || "").match(regexSearchWithoutValue)) {
+                e.preventDefault();
+                return
+            }
+            if (is_enter && $search_query_box.is(":focus")) {
                 // We just pressed Enter and the box had focus, which
                 // means we didn't use the typeahead at all.  In that
                 // case, we should act as though we're searching by

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -16,7 +16,7 @@ import * as ui_util from "./ui_util";
 // Exported for unit testing
 export let is_using_input_method = false;
 
-const regexSearchWithoutValue = /^[A-Za-z-]+:['"\s]*$/
+const regexSearchWithoutValue = /^[A-Za-z-]+:[\s'"]*$/
 
 export function narrow_or_search_for_term(search_string) {
     const $search_query_box = $("#search_query");
@@ -124,7 +124,7 @@ export function initialize() {
         // Use our custom typeahead `on_escape` hook to exit
         // the search bar as soon as the user hits Esc.
         on_escape: message_view_header.exit_search,
-        validate_selection: (sel) => !sel || !sel.match(regexSearchWithoutValue),
+        validate_selection: (sel) => !sel || !regexSearchWithoutValue.test(sel),
     });
 
     $searchbox_form.on("compositionend", () => {
@@ -152,10 +152,7 @@ export function initialize() {
                 return;
             }
             const is_enter = keydown_util.is_enter_event(e);
-            if (is_enter && (e.target?.value || "").match(regexSearchWithoutValue)) {
-                const $active_item = $(".typeahead-menu .active")
-                $active_item.addClass("nudge-down");
-                setTimeout(() => $active_item.removeClass("nudge-down"), 600);
+            if (is_enter && regexSearchWithoutValue.test(e.target?.value || "")) {
                 e.preventDefault();
                 return
             }

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -153,6 +153,9 @@ export function initialize() {
             }
             const is_enter = keydown_util.is_enter_event(e);
             if (is_enter && regexSearchWithoutValue.test(e.target?.value || "")) {
+                const $active_item = $(".typeahead-menu .active")
+                $active_item.addClass("nudge-down");
+                setTimeout(() => $active_item.removeClass("nudge-down"), 600);
                 e.preventDefault();
                 return
             }

--- a/web/src/search.js
+++ b/web/src/search.js
@@ -153,6 +153,9 @@ export function initialize() {
             }
             const is_enter = keydown_util.is_enter_event(e);
             if (is_enter && (e.target?.value || "").match(regexSearchWithoutValue)) {
+                const $active_item = $(".typeahead-menu .active")
+                $active_item.addClass("nudge-down");
+                setTimeout(() => $active_item.removeClass("nudge-down"), 600);
                 e.preventDefault();
                 return
             }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -724,6 +724,25 @@ strong {
     display: none;
 }
 
+@keyframes nudgeBackgroundDown {
+    0% { transform: translateY(0px); }
+    50% { transform: translateY(5px); }
+    100% { transform: translateY(0px); }
+}
+  
+@keyframes nudgeBackgroundUp {
+    0% { transform: translateY(0px); }
+    50% { transform: translateY(-5px); }
+    100% { transform: translateY(0px); }
+}
+
+.nudge-down {
+    animation: nudgeBackgroundDown 500ms ease-in-out 1;
+    span:not(.pill-value) {
+        animation: nudgeBackgroundUp 500ms ease-in-out 1;
+    }
+}
+
 /* .dropdown-menu from v2.3.2
    + https://github.com/zulip/zulip/commit/7a3a3be7e547d3e8f0ed00820835104867f2433d
    basic idea of this fix is to remove decorations from :hover and apply them only

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -725,19 +725,36 @@ strong {
 }
 
 @keyframes nudgeBackgroundDown {
-    0% { transform: translateY(0px); }
-    50% { transform: translateY(5px); }
-    100% { transform: translateY(0px); }
+    0% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(5px);
+    }
+
+    100% {
+        transform: translateY(0);
+    }
 }
   
 @keyframes nudgeBackgroundUp {
-    0% { transform: translateY(0px); }
-    50% { transform: translateY(-5px); }
-    100% { transform: translateY(0px); }
+    0% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(-5px);
+    }
+
+    100% {
+        transform: translateY(0);
+    }
 }
 
 .nudge-down {
     animation: nudgeBackgroundDown 500ms ease-in-out 1;
+
     span:not(.pill-value) {
         animation: nudgeBackgroundUp 500ms ease-in-out 1;
     }

--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -98,6 +98,11 @@
  *   We add a new event handler, resizeHandler, for window.on('resize', ...)
  *   that calls this.show to re-render the typeahead in the correct position.
  *
+ * 10. Selection validation:
+ *
+ *   We add an optional callback, `validate_selection`, passing in the text field string.
+ *   If a falsy value is returned, auto selection behavior (enter/tab keys) is cancelled.
+ *
  * ============================================================ */
 
 import {insert} from "text-field-edit";
@@ -136,6 +141,7 @@ import {get_string_diff} from "../../src/util";
     this.fixed = this.options.fixed || false;
     this.automated = this.options.automated || this.automated;
     this.trigger_selection = this.options.trigger_selection || this.trigger_selection;
+    this.validate_selection = this.options.validate_selection || this.validate_selection;
     this.on_move = this.options.on_move;
     this.on_escape = this.options.on_escape;
     this.header = this.options.header || this.header;
@@ -191,6 +197,10 @@ import {get_string_diff} from "../../src/util";
 
   , trigger_selection: function() {
     return false;
+  }
+
+  , validate_selection: function() {
+    return true;
   }
 
   , header: function() {
@@ -464,7 +474,9 @@ import {get_string_diff} from "../../src/util";
         case 9: // tab
         case 13: // enter
           if (!this.shown) return
-          this.select(e)
+          if (this.validate_selection(this.$element.val())) {
+            this.select(e)
+          }
           break
 
         case 27: // escape


### PR DESCRIPTION
Currently, when entering `pm-with:` with no search value into the top search bar, and hitting enter, the search input field disappears, differing from the behavior of other empty search values (eg `sender:`), where the search text stays visible. In the current (working) flow, the search value actually hides, and then is immediately shown again, with the browser repainting without the user noticing. Both the hiding and showing logic are in the `build_message_view_header()` function of `message_view_header.js`.

The underlying cause appears to be the `is_common_narrow` function in `filter.js`, which currently contains a `TODO` about piggybacking unwanted behavior on the `can_mark_messages_read` value. The preferred behavior can be validated by hand-setting that return to `false`.

However: there doesn't seem to be any UX upside to round-tripping a search request that we know will fail. So this draft/experimental MR takes a different approach: adding a new optional `validate_selection` callback to the forked bootstrap typeahead library. When the enter key is pressed, the callback is invoked (with a truthy no-op if left absent); if the result is falsy, the submit events are suppressed.

For this particular use case, we then check the current string value with regex, and if it appears to be a search key with a colon but no value, we trigger an animation to "nudge" the user to select a drop-down option. (See screenshot clip.)

If we decide to pursue this approach further, the remaining work to be done:

- Validating no regressions to other search keys or UI paths
- Proper handling of `tab` key (adding keycode to callback)
- Fine-tuning animation
- Internationalization (currently assumes Latin characters for search string)
- Test coverage

Fixes: https://github.com/zulip/zulip/issues/20073

**Screenshots and screen captures:**

Animation below is in response to pressing "Enter" key:

https://user-images.githubusercontent.com/1388621/225384573-5d0ea549-9682-498e-9345-ed00ac559600.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
