### PR TITLE
css: sample of refactoring selectors for uniformity

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -323,6 +323,10 @@ Don't use the tag name in a selector unless you have to. In other words,
 use `.foo` instead of `span.foo`. We shouldn't have to care if the tag
 type changes in the future.
 
+Additionally, multi-word class and ID values should be hyphenated,
+also known as _kebab case_. In HTML, opt for `class="my-multiword-class"`,
+with its corresponding CSS selector as `.my-multiword-class`.
+
 ### Python
 
 - Our Python code is formatted with

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -36,7 +36,7 @@ async function test_user_status(page: Page): Promise<void> {
         () => (document.querySelector(".user-status") as HTMLInputElement).value === "In a meeting",
     );
     // It should select calendar emoji.
-    await page.waitForSelector(".selected_emoji.emoji-1f4c5");
+    await page.waitForSelector(".selected-emoji.emoji-1f4c5");
 
     // Clear everything.
     await page.click("#clear_status_message_button");
@@ -53,7 +53,7 @@ async function test_user_status(page: Page): Promise<void> {
     await page.waitForSelector(`.emoji-popover  ${tada_emoji_selector}`, {visible: true});
     await page.click(`.emoji-popover  ${tada_emoji_selector}`);
     await page.waitForSelector(".emoji-info-popover", {hidden: true});
-    await page.waitForSelector(`.selected_emoji${tada_emoji_selector}`);
+    await page.waitForSelector(`.selected-emoji${tada_emoji_selector}`);
 
     await page.click("#set-user-status-modal .dialog_submit_button");
     // It should close the modal after saving.

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -43,12 +43,12 @@ async function test_user_status(page: Page): Promise<void> {
     await page.waitForFunction(
         () => (document.querySelector(".user-status") as HTMLInputElement).value === "",
     );
-    await page.waitForSelector(".status_emoji_wrapper .smiley_icon", {visible: true});
+    await page.waitForSelector(".status-emoji-wrapper .smiley_icon", {visible: true});
 
     // Manually adding everything.
     await page.type(".user-status", "Busy");
     const tada_emoji_selector = ".emoji-1f389";
-    await page.click(".status_emoji_wrapper .smiley_icon");
+    await page.click(".status-emoji-wrapper .smiley_icon");
     // Wait until emoji popover is opened.
     await page.waitForSelector(`.emoji-popover  ${tada_emoji_selector}`, {visible: true});
     await page.click(`.emoji-popover  ${tada_emoji_selector}`);

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -60,7 +60,7 @@ async function test_user_status(page: Page): Promise<void> {
     await page.waitForSelector("#set-user-status-modal", {hidden: true});
 
     // Check if the emoji is added in user presence list.
-    await page.waitForSelector(`.user-presence-link .status_emoji${tada_emoji_selector}`);
+    await page.waitForSelector(`.user-presence-link .status-emoji${tada_emoji_selector}`);
 }
 
 async function user_status_test(page: Page): Promise<void> {

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -33,7 +33,7 @@ async function test_user_status(page: Page): Promise<void> {
     // Check by clicking on common statues.
     await page.click(".user-status-value:nth-child(2)");
     await page.waitForFunction(
-        () => (document.querySelector(".user_status") as HTMLInputElement).value === "In a meeting",
+        () => (document.querySelector(".user-status") as HTMLInputElement).value === "In a meeting",
     );
     // It should select calendar emoji.
     await page.waitForSelector(".selected_emoji.emoji-1f4c5");
@@ -41,12 +41,12 @@ async function test_user_status(page: Page): Promise<void> {
     // Clear everything.
     await page.click("#clear_status_message_button");
     await page.waitForFunction(
-        () => (document.querySelector(".user_status") as HTMLInputElement).value === "",
+        () => (document.querySelector(".user-status") as HTMLInputElement).value === "",
     );
     await page.waitForSelector(".status_emoji_wrapper .smiley_icon", {visible: true});
 
     // Manually adding everything.
-    await page.type(".user_status", "Busy");
+    await page.type(".user-status", "Busy");
     const tada_emoji_selector = ".emoji-1f389";
     await page.click(".status_emoji_wrapper .smiley_icon");
     // Wait until emoji popover is opened.

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -55,9 +55,9 @@ async function test_user_status(page: Page): Promise<void> {
     await page.waitForSelector(".emoji-info-popover", {hidden: true});
     await page.waitForSelector(`.selected_emoji${tada_emoji_selector}`);
 
-    await page.click("#set_user_status_modal .dialog_submit_button");
+    await page.click("#set-user-status-modal .dialog_submit_button");
     // It should close the modal after saving.
-    await page.waitForSelector("#set_user_status_modal", {hidden: true});
+    await page.waitForSelector("#set-user-status-modal", {hidden: true});
 
     // Check if the emoji is added in user presence list.
     await page.waitForSelector(`.user-presence-link .status_emoji${tada_emoji_selector}`);

--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -43,12 +43,12 @@ async function test_user_status(page: Page): Promise<void> {
     await page.waitForFunction(
         () => (document.querySelector(".user-status") as HTMLInputElement).value === "",
     );
-    await page.waitForSelector(".status-emoji-wrapper .smiley_icon", {visible: true});
+    await page.waitForSelector(".status-emoji-wrapper .smiley-icon", {visible: true});
 
     // Manually adding everything.
     await page.type(".user-status", "Busy");
     const tada_emoji_selector = ".emoji-1f389";
-    await page.click(".status-emoji-wrapper .smiley_icon");
+    await page.click(".status-emoji-wrapper .smiley-icon");
     // Wait until emoji popover is opened.
     await page.waitForSelector(`.emoji-popover  ${tada_emoji_selector}`, {visible: true});
     await page.click(`.emoji-popover  ${tada_emoji_selector}`);

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -303,7 +303,7 @@ function is_composition(emoji) {
 }
 
 function is_status_emoji(emoji) {
-    return $(emoji).hasClass("status_emoji");
+    return $(emoji).hasClass("status-emoji");
 }
 
 function process_enter_while_filtering(e) {
@@ -795,7 +795,7 @@ export function register_click_handlers() {
         $(".app, .header, .modal__overlay, #set-user-status-modal").css("pointer-events", "none");
     });
 
-    $(document).on("click", ".emoji-popover-emoji.status_emoji", function (e) {
+    $(document).on("click", ".emoji-popover-emoji.status-emoji", function (e) {
         e.preventDefault();
         e.stopPropagation();
         hide_emoji_popover();

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -198,7 +198,7 @@ export function hide_emoji_popover() {
         // Re-enable clicking events for other elements after closing
         // the popover.  This is the inverse of the hack of in the
         // handler that opens the "user status modal" emoji picker.
-        $(".app, .header, .modal__overlay, #set_user_status_modal").css("pointer-events", "all");
+        $(".app, .header, .modal__overlay, #set-user-status-modal").css("pointer-events", "all");
     }
     if (reactions_popped()) {
         $current_message_emoji_popover_elem.popover("destroy");
@@ -784,7 +784,7 @@ export function register_click_handlers() {
         );
     });
 
-    $("body").on("click", "#set_user_status_modal #selected_emoji", (e) => {
+    $("body").on("click", "#set-user-status-modal #selected_emoji", (e) => {
         e.preventDefault();
         e.stopPropagation();
         toggle_emoji_popover(e.target);
@@ -792,7 +792,7 @@ export function register_click_handlers() {
         // status modal, we need this hack to make clicking outside
         // the emoji picker only close the emoji picker, and not the
         // whole user status modal.
-        $(".app, .header, .modal__overlay, #set_user_status_modal").css("pointer-events", "none");
+        $(".app, .header, .modal__overlay, #set-user-status-modal").css("pointer-events", "none");
     });
 
     $(document).on("click", ".emoji-popover-emoji.status_emoji", function (e) {

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -917,7 +917,7 @@ export function register_click_handlers() {
     // Clicking on one's own status emoji should open the user status modal.
     $("#user_presences").on(
         "click",
-        ".user_sidebar_entry_me .status_emoji",
+        ".user_sidebar_entry_me .status-emoji",
         open_user_status_modal,
     );
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -190,7 +190,7 @@ function initialize_right_sidebar() {
     }
 
     $("#user_presences").on("mouseenter", ".user_sidebar_entry", (e) => {
-        const $status_emoji = $(e.target).closest(".user_sidebar_entry").find("img.status_emoji");
+        const $status_emoji = $(e.target).closest(".user_sidebar_entry").find("img.status-emoji");
         if ($status_emoji.length) {
             const animated_url = $status_emoji.data("animated-url");
             if (animated_url) {
@@ -200,7 +200,7 @@ function initialize_right_sidebar() {
     });
 
     $("#user_presences").on("mouseleave", ".user_sidebar_entry", (e) => {
-        const $status_emoji = $(e.target).closest(".user_sidebar_entry").find("img.status_emoji");
+        const $status_emoji = $(e.target).closest(".user_sidebar_entry").find("img.status-emoji");
         if ($status_emoji.length) {
             const still_url = $status_emoji.data("still-url");
             if (still_url) {

--- a/web/src/user_status_ui.js
+++ b/web/src/user_status_ui.js
@@ -118,7 +118,7 @@ function rebuild_status_emoji_selector_ui(selected_emoji_info) {
         selected_emoji = selected_emoji_info;
     }
     const rendered_status_emoji_selector = render_status_emoji_selector({selected_emoji});
-    $("#set-user-status-modal .status_emoji_wrapper").html(rendered_status_emoji_selector);
+    $("#set-user-status-modal .status-emoji-wrapper").html(rendered_status_emoji_selector);
 }
 
 function user_status_post_render() {

--- a/web/src/user_status_ui.js
+++ b/web/src/user_status_ui.js
@@ -18,7 +18,7 @@ export function set_selected_emoji_info(emoji_info) {
     rebuild_status_emoji_selector_ui(selected_emoji_info);
 }
 export function input_field() {
-    return $("#set-user-status-modal input.user_status");
+    return $("#set-user-status-modal input.user-status");
 }
 
 export function submit_button() {
@@ -136,7 +136,7 @@ function user_status_post_render() {
     $("#set-user-status-modal .user-status-value").on("click", (event) => {
         event.stopPropagation();
         const user_status_value = $(event.currentTarget).text().trim();
-        $("input.user_status").val(user_status_value);
+        $("input.user-status").val(user_status_value);
 
         const emoji_info = default_status_messages_and_emoji_info.find(
             (status) => status.status_text === user_status_value,

--- a/web/src/user_status_ui.js
+++ b/web/src/user_status_ui.js
@@ -18,11 +18,11 @@ export function set_selected_emoji_info(emoji_info) {
     rebuild_status_emoji_selector_ui(selected_emoji_info);
 }
 export function input_field() {
-    return $("#set_user_status_modal input.user_status");
+    return $("#set-user-status-modal input.user_status");
 }
 
 export function submit_button() {
-    return $("#set_user_status_modal .dialog_submit_button");
+    return $("#set-user-status-modal .dialog_submit_button");
 }
 
 export function open_user_status_modal() {
@@ -37,7 +37,7 @@ export function open_user_status_modal() {
         html_heading: $t_html({defaultMessage: "Set status"}),
         html_body: rendered_set_status_overlay,
         html_submit_button: $t_html({defaultMessage: "Save"}),
-        id: "set_user_status_modal",
+        id: "set-user-status-modal",
         on_click: submit_new_status,
         post_render: user_status_post_render,
         on_shown() {
@@ -109,7 +109,7 @@ export function clear_message() {
 }
 
 export function user_status_picker_open() {
-    return $("#set_user_status_modal").length !== 0;
+    return $("#set-user-status-modal").length !== 0;
 }
 
 function rebuild_status_emoji_selector_ui(selected_emoji_info) {
@@ -118,7 +118,7 @@ function rebuild_status_emoji_selector_ui(selected_emoji_info) {
         selected_emoji = selected_emoji_info;
     }
     const rendered_status_emoji_selector = render_status_emoji_selector({selected_emoji});
-    $("#set_user_status_modal .status_emoji_wrapper").html(rendered_status_emoji_selector);
+    $("#set-user-status-modal .status_emoji_wrapper").html(rendered_status_emoji_selector);
 }
 
 function user_status_post_render() {
@@ -133,7 +133,7 @@ function user_status_post_render() {
     const $button = submit_button();
     $button.prop("disabled", true);
 
-    $("#set_user_status_modal .user-status-value").on("click", (event) => {
+    $("#set-user-status-modal .user-status-value").on("click", (event) => {
         event.stopPropagation();
         const user_status_value = $(event.currentTarget).text().trim();
         $("input.user_status").val(user_status_value);

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -409,7 +409,7 @@ div.overlay {
         box-shadow: none;
         z-index: 5;
 
-        #set_user_status_modal & {
+        #set-user-status-modal & {
             margin-left: -26px;
             right: 0;
             padding-top: 6px;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -442,7 +442,7 @@
     .new-style .tab-switcher .ind-tab:not(.selected),
     select,
     .pill-container,
-    .user_status_content_wrapper {
+    .user-status-content-wrapper {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
         color: inherit;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -784,7 +784,7 @@ ul {
 .user_info_status_text {
     opacity: 0.8;
 
-    .status_emoji {
+    .status-emoji {
         height: 18px;
         width: 18px;
         /* Override the default 3px left margin for status emoji, which is

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -114,7 +114,7 @@ $user_status_emoji_width: 24px;
 .user-presence-link {
     width: calc(100% - $user_status_emoji_width);
 
-    .status_emoji {
+    .status-emoji {
         top: 9px;
     }
 }
@@ -140,7 +140,7 @@ $user_status_emoji_width: 24px;
             text-overflow: ellipsis;
         }
 
-        .status_emoji {
+        .status-emoji {
             line-height: 20px;
             top: -2px;
         }

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -1,4 +1,4 @@
-#set_user_status_modal {
+#set-user-status-modal {
     /* A narrower width is more attractive for this modal. */
     width: 384px;
 

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -27,7 +27,7 @@
             border-color: inherit;
             cursor: pointer;
 
-            .selected_emoji {
+            .selected-emoji {
                 width: 20px;
                 height: 20px;
                 cursor: pointer;
@@ -39,7 +39,7 @@
             }
 
             /* For custom emojis and smiley icon to take full width. */
-            & img.selected_emoji,
+            & img.selected-emoji,
             .smiley_icon {
                 min-width: 20px;
             }

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -74,7 +74,7 @@
             margin-bottom: 10px;
             line-height: 1.1em;
 
-            .status_emoji {
+            .status-emoji {
                 height: 18px;
                 width: 18px;
                 margin-left: 3px;

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -19,7 +19,7 @@
             }
         }
 
-        .status_emoji_wrapper {
+        .status-emoji-wrapper {
             height: 20px;
             width: 22px;
             padding: 8px 8px 1px;

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -8,7 +8,7 @@
         border-color: hsl(0deg 0% 0% / 60%);
         border-radius: 5px;
 
-        & input.user_status {
+        & input.user-status {
             width: 95%;
             border: none;
             background-color: transparent;

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -40,11 +40,11 @@
 
             /* For custom emojis and smiley icon to take full width. */
             & img.selected-emoji,
-            .smiley_icon {
+            .smiley-icon {
                 min-width: 20px;
             }
 
-            .smiley_icon {
+            .smiley-icon {
                 display: block;
                 font-size: 18px;
                 position: relative;

--- a/web/styles/user_status.css
+++ b/web/styles/user_status.css
@@ -2,7 +2,7 @@
     /* A narrower width is more attractive for this modal. */
     width: 384px;
 
-    .user_status_content_wrapper {
+    .user-status-content-wrapper {
         display: flex;
         border: 1px solid;
         border-color: hsl(0deg 0% 0% / 60%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2314,7 +2314,7 @@ select.invite-as {
     top: 3px;
 }
 
-.status_emoji {
+.status-emoji {
     height: 16px;
     width: 16px;
     /* We are setting minimum width here because when the user's name is very long,

--- a/web/templates/emoji_popover_emoji.hbs
+++ b/web/templates/emoji_popover_emoji.hbs
@@ -1,5 +1,5 @@
 {{#with emoji_dict}}
-<div class="emoji-popover-emoji {{#if ../message_id }}{{#if has_reacted}} reacted {{/if}} reaction {{else if ../is_status_emoji_popover}} status_emoji {{else}} composition {{/if}}" data-emoji-name="{{name}}" tabindex="0" data-emoji-id="{{../type}},{{../section}},{{../index}}">
+<div class="emoji-popover-emoji {{#if ../message_id }}{{#if has_reacted}} reacted {{/if}} reaction {{else if ../is_status_emoji_popover}} status-emoji {{else}} composition {{/if}}" data-emoji-name="{{name}}" tabindex="0" data-emoji-id="{{../type}},{{../section}},{{../index}}">
     {{#if is_realm_emoji}}
     <img src="{{url}}" class="emoji"/>
     {{else}}

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -2,7 +2,7 @@
     <div class="status_emoji_wrapper tippy-zulip-tooltip"  data-tippy-content="{{t 'Select emoji' }}" data-tippy-placement="top" aria-label="{{t 'Select emoji' }}"  tabindex="0" id="selected_emoji">
         {{> status_emoji_selector}}
     </div>
-    <input type="text" class="user_status" placeholder="{{t 'Your status' }}" maxlength="60"/>
+    <input type="text" class="user-status" placeholder="{{t 'Your status' }}" maxlength="60"/>
     <button type="button" class="btn clear_search_button" id="clear_status_message_button" disabled="disabled">
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -1,4 +1,4 @@
-<div class="new-style user_status_content_wrapper">
+<div class="new-style user-status-content-wrapper">
     <div class="status_emoji_wrapper tippy-zulip-tooltip"  data-tippy-content="{{t 'Select emoji' }}" data-tippy-placement="top" aria-label="{{t 'Select emoji' }}"  tabindex="0" id="selected_emoji">
         {{> status_emoji_selector}}
     </div>

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -1,5 +1,5 @@
 <div class="new-style user-status-content-wrapper">
-    <div class="status_emoji_wrapper tippy-zulip-tooltip"  data-tippy-content="{{t 'Select emoji' }}" data-tippy-placement="top" aria-label="{{t 'Select emoji' }}"  tabindex="0" id="selected_emoji">
+    <div class="status-emoji-wrapper tippy-zulip-tooltip"  data-tippy-content="{{t 'Select emoji' }}" data-tippy-placement="top" aria-label="{{t 'Select emoji' }}"  tabindex="0" id="selected_emoji">
         {{> status_emoji_selector}}
     </div>
     <input type="text" class="user-status" placeholder="{{t 'Your status' }}" maxlength="60"/>

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -13,9 +13,9 @@
             {{#if emoji.emoji_alt_code}}
                 <div class="emoji_alt_code">&nbsp;:{{emoji.emoji_name}}:</div>
             {{else if emoji.url}}
-                <img src="{{emoji.url}}" class="emoji status_emoji" />
+                <img src="{{emoji.url}}" class="emoji status-emoji" />
             {{else}}
-                <div class="emoji status_emoji emoji-{{emoji.emoji_code}}"></div>
+                <div class="emoji status-emoji emoji-{{emoji.emoji_code}}"></div>
             {{/if}}
             {{status_text}}
         </button>

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -90,7 +90,7 @@
                         <span class="right preview">
                             {{#if (eq this.code 1)}}
                             <span class="user-name">{{../full_name}}</span>
-                            <div class="emoji status_emoji emoji-1f3e0"></div>
+                            <div class="emoji status-emoji emoji-1f3e0"></div>
                             {{/if}}
                             {{#if (eq this.code 2)}}
                             <div class="user-name-and-status-text">

--- a/web/templates/status_emoji.hbs
+++ b/web/templates/status_emoji.hbs
@@ -2,11 +2,11 @@
 {{#if emoji_alt_code}}
 <span class="emoji_alt_code">&nbsp;:{{emoji_name}}:</span>
 {{else if still_url}}
-<img src="{{still_url}}" class="emoji status_emoji" data-animated-url="{{url}}" data-still-url="{{still_url}}" />
+<img src="{{still_url}}" class="emoji status-emoji" data-animated-url="{{url}}" data-still-url="{{still_url}}" />
 {{else if url}}
 {{!-- note that we have no still_url --}}
-<img src="{{url}}" class="emoji status_emoji" data-animated-url="{{url}}" />
+<img src="{{url}}" class="emoji status-emoji" data-animated-url="{{url}}" />
 {{else if emoji_code}}
-<span class="emoji status_emoji emoji-{{emoji_code}}"></span>
+<span class="emoji status-emoji emoji-{{emoji_code}}"></span>
 {{/if}}
 {{/if}}

--- a/web/templates/status_emoji_selector.hbs
+++ b/web/templates/status_emoji_selector.hbs
@@ -7,5 +7,5 @@
         <div class="emoji selected-emoji emoji-{{selected_emoji.emoji_code}}"></div>
     {{/if}}
 {{else}}
-    <a type="button" class="smiley_icon show fa fa-smile-o"></a>
+    <a type="button" class="smiley-icon show fa fa-smile-o"></a>
 {{/if}}

--- a/web/templates/status_emoji_selector.hbs
+++ b/web/templates/status_emoji_selector.hbs
@@ -2,9 +2,9 @@
     {{#if selected_emoji.emoji_alt_code}}
         <div class="emoji_alt_code">&nbsp;:{{selected_emoji.emoji_name}}:</div>
     {{else if selected_emoji.url}}
-        <img src="{{selected_emoji.url}}" class="emoji selected_emoji" />
+        <img src="{{selected_emoji.url}}" class="emoji selected-emoji" />
     {{else}}
-        <div class="emoji selected_emoji emoji-{{selected_emoji.emoji_code}}"></div>
+        <div class="emoji selected-emoji emoji-{{selected_emoji.emoji_code}}"></div>
     {{/if}}
 {{else}}
     <a type="button" class="smiley_icon show fa fa-smile-o"></a>

--- a/web/templates/user_info_popover_content.hbs
+++ b/web/templates/user_info_popover_content.hbs
@@ -68,9 +68,9 @@
                     {{#if status_emoji_info.emoji_alt_code}}
                         <div class="emoji_alt_code">&nbsp;:{{status_emoji_info.emoji_name}}:</div>
                     {{else if status_emoji_info.url}}
-                        <img src="{{status_emoji_info.url}}" class="emoji status_emoji" />
+                        <img src="{{status_emoji_info.url}}" class="emoji status-emoji" />
                     {{else}}
-                        <div class="emoji status_emoji emoji-{{status_emoji_info.emoji_code}}"></div>
+                        <div class="emoji status-emoji emoji-{{status_emoji_info.emoji_code}}"></div>
                     {{/if}}
                 {{/if}}
                 <span class="status_text">


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This Draft PR, whose [work I previewed on CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/CSS.20selector.20refactoring), provides a look at the scope involved with refactoring CSS selectors with underscores to instead use hyphens (the frontend codebase includes both).

I opted to begin work in the `user_status.css` file, to see where it would take me.

Ordinarily I would have squashed all of these commits (apart from the documentation one). But as this is draft work, I wanted to provide the individual, per-selector commits as standalone records of just how far-flung individual frontend classes are across different CSS, JavaScript, and Handlebars files.

I now see with greater clarity what @andersk was describing in our chat yesterday, about the need for modularity. I still think that complexity is tamed by opting for uniform styles wherever possible.

To that end, there is one selector from `user_status.css` I did not successfully modify: `.status_emoji`, which I was unable to do without the Puppeteer `user-status.test.ts` breaking on waiting for the `.emoji-info-popover` to appear in the DOM.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
