### PR TITLE
help: Add new "Writing messages" section, and improve message formatting intro and text emphasis documentation.

### DIFF
--- a/help/format-your-message-using-markdown.md
+++ b/help/format-your-message-using-markdown.md
@@ -13,7 +13,7 @@ is a convenient [**message formatting
 reference**](#message-formatting-reference) in the Zulip app that you can use
 whenever you need a reminder of the formatting syntax below.
 
-* [Emphasis](#emphasis)
+* [Text emphasis](#text-emphasis)
 * [Lists](#lists)
 * [Links and images](#links)
 * [Code blocks](#code)
@@ -28,15 +28,14 @@ whenever you need a reminder of the formatting syntax below.
 * [To-do lists](#to-do-lists)
 * [Paragraphs and lines](#paragraphs-and-lines)
 
-## Emphasis
+## Text emphasis
 
-```
-**bold**, *italic*, and ~~strikethrough~~ text
-***~~All three at once~~***
-```
+{!emphasis.md!}
 
-![Markdown emphasis](/static/images/help/markdown-emphasis.png)
-
+!!! tip ""
+    You can also use buttons or keyboard shortcuts (<kbd>Ctrl</kbd> +
+    <kbd>B</kbd> or <kbd>Ctrl</kbd> + <kbd>I</kbd>) to make text bold or italic.
+    [Learn more](/help/text-emphasis).
 
 ## Lists
 

--- a/help/format-your-message-using-markdown.md
+++ b/help/format-your-message-using-markdown.md
@@ -3,10 +3,15 @@
 [//]: # (All screenshots here require line-height: 22px and font-size: 16px in .message-content.)
 [//]: # (Requires some additional fiddling for the LaTeX picture, inline code span, and maybe a few others.)
 
-Zulip uses a variant of Markdown to allow you to easily format your
-messages. There is a convenient [**message formatting
-reference**](#message-formatting-reference) in the Zulip app that you
-can use whenever you need a reminder of the formatting syntax below.
+Zulip uses Markdown to allow you to easily format your messages. Even if you've
+never heard of Markdown, you are probably familiar with basic Markdown
+formatting, such as using `*` at the start of a line in a bulleted list, or
+around text to indicate emphasis.
+
+This page provides an overview of all the formatting available in Zulip. There
+is a convenient [**message formatting
+reference**](#message-formatting-reference) in the Zulip app that you can use
+whenever you need a reminder of the formatting syntax below.
 
 * [Emphasis](#emphasis)
 * [Lists](#lists)

--- a/help/include/edit-organization-profile.md
+++ b/help/include/edit-organization-profile.md
@@ -1,6 +1,6 @@
 !!! tip ""
 
-    The **organization description** supports [full Markdown syntax][markdown-syntax],
+    The **organization description** supports [full Markdown formatting][markdown-formatting],
     including **bold**/*italic*, links, lists, and more.
 
 !!! tip ""
@@ -21,4 +21,4 @@
 
 {end_tabs}
 
-[markdown-syntax]: /help/format-your-message-using-markdown
+[markdown-formatting]: /help/format-your-message-using-markdown

--- a/help/include/emphasis.md
+++ b/help/include/emphasis.md
@@ -1,0 +1,12 @@
+In Zulip, you can make text bold or italic, or cross it out with strikethrough.
+
+### What you type
+
+```
+**bold**, *italic*, and ~~strikethrough~~ text
+***~~All three at once~~***
+```
+
+### What it looks like
+
+![Markdown emphasis](/static/images/help/markdown-emphasis.png)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -55,17 +55,9 @@
 * [Enable full width display](/help/enable-full-width-display)
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
 
-## Sending messages
-* [Open the compose box](/help/open-the-compose-box)
-* [Mastering the compose box](/help/mastering-the-compose-box)
-* [Resize the compose box](/help/resize-the-compose-box)
+## Writing messages
 * [Message formatting](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)
-* [Typing notifications](/help/typing-notifications)
-* [Preview messages before sending](/help/preview-your-message-before-sending)
-* [Verify a message was sent](/help/verify-your-message-was-successfully-sent)
-* [Edit or delete a message](/help/edit-or-delete-a-message)
-* [Message drafts](/help/view-and-edit-your-message-drafts)
 * [Emoji and emoticons](/help/emoji-and-emoticons)
 * [Start a video call](/help/start-a-call)
 * [Share and upload files](/help/share-and-upload-files)
@@ -73,6 +65,16 @@
 * [Code blocks](/help/code-blocks)
 * [Add GIFs in your message](/help/animated-gifs-from-giphy)
 * [Create a poll](/help/create-a-poll)
+
+## Sending messages
+* [Open the compose box](/help/open-the-compose-box)
+* [Mastering the compose box](/help/mastering-the-compose-box)
+* [Resize the compose box](/help/resize-the-compose-box)
+* [Typing notifications](/help/typing-notifications)
+* [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Verify a message was sent](/help/verify-your-message-was-successfully-sent)
+* [Edit or delete a message](/help/edit-or-delete-a-message)
+* [Message drafts](/help/view-and-edit-your-message-drafts)
 * [Message a stream by email](/help/message-a-stream-by-email)
 
 ## Reading messages

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -58,13 +58,13 @@
 ## Writing messages
 * [Message formatting](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)
-* [Emoji and emoticons](/help/emoji-and-emoticons)
-* [Start a video call](/help/start-a-call)
-* [Share and upload files](/help/share-and-upload-files)
 * [Quote and reply](/help/quote-and-reply)
-* [Code blocks](/help/code-blocks)
+* [Emoji and emoticons](/help/emoji-and-emoticons)
+* [Share and upload files](/help/share-and-upload-files)
 * [Add GIFs in your message](/help/animated-gifs-from-giphy)
+* [Code blocks](/help/code-blocks)
 * [Create a poll](/help/create-a-poll)
+* [Start a video call](/help/start-a-call)
 
 ## Sending messages
 * [Open the compose box](/help/open-the-compose-box)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -62,6 +62,7 @@
 * [Emoji and emoticons](/help/emoji-and-emoticons)
 * [Share and upload files](/help/share-and-upload-files)
 * [Add GIFs in your message](/help/animated-gifs-from-giphy)
+* [Text emphasis](/help/text-emphasis)
 * [Code blocks](/help/code-blocks)
 * [Create a poll](/help/create-a-poll)
 * [Start a video call](/help/start-a-call)

--- a/help/text-emphasis.md
+++ b/help/text-emphasis.md
@@ -1,0 +1,77 @@
+# Text emphasis
+
+{!emphasis.md!}
+
+## Making text bold
+
+{start_tabs}
+
+{tab|via-markdown}
+
+{!start-composing.md!}
+
+1. Surround your text with double asterisks (`**`) to make it bold.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>B</kbd> to insert bold formatting.
+
+{tab|via-compose-box-buttons}
+
+{!start-composing.md!}
+
+1. Select the text you want to format.
+
+1. Click the **Bold** (<i class="fa fa-bold"></i>) icon at the
+   bottom of the compose box.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>B</kbd> to insert bold formatting.
+
+{end_tabs}
+
+## Making text italic
+
+{start_tabs}
+
+{tab|via-markdown}
+
+{!start-composing.md!}
+
+1. Surround your text with single asterisks (`*`) to make it italic.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>I</kbd> to insert italic formatting.
+
+{tab|via-compose-box-buttons}
+
+{!start-composing.md!}
+
+1. Select the text you want to format.
+
+1. Click the **Italic** (<i class="fa fa-italic"></i>) icon at the
+   bottom of the compose box.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Ctrl</kbd> + <kbd>I</kbd> to insert italic formatting.
+
+{end_tabs}
+
+## Applying strikethrough formatting
+
+{start_tabs}
+
+{!start-composing.md!}
+
+1. Surround your text with two tildes (`~~`) to apply strikethrough formatting.
+
+{end_tabs}
+
+## Related articles
+
+* [Message formatting](/help/format-your-message-using-markdown)
+* [Preview messages before sending](/help/preview-your-message-before-sending)
+* [Resize the compose box](/help/resize-the-compose-box)

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -93,6 +93,8 @@ TAB_SECTION_LABELS = {
     "user": "User",
     "bot": "Bot",
     "on-sign-up": "On sign-up",
+    "via-markdown": "Via Markdown",
+    "via-compose-box-buttons": "Via compose box buttons",
 }
 
 


### PR DESCRIPTION
This is a slightly edited version of the first 3 commits in #24694. Should be ready for integration.

<details>
<summary>
Sidebar sections
</summary>
<img width="296" alt="Screen Shot 2023-03-15 at 4 15 31 PM" src="https://user-images.githubusercontent.com/2090066/225464982-1cd8abfe-8730-4de9-9d37-f501b53d04b1.png">

</details>

<details>
<summary>
Message formatting (intro + first section)
</summary>

<img width="1039" alt="Screen Shot 2023-03-15 at 4 13 23 PM" src="https://user-images.githubusercontent.com/2090066/225465005-735b0e3a-c228-4159-ba47-f23c7da9af30.png">

</details>

<details>
<summary>
Text emphasis page
</summary>

<img width="834" alt="Screen Shot 2023-03-15 at 4 13 10 PM" src="https://user-images.githubusercontent.com/2090066/225465025-0a9ded0b-4453-4897-9aa1-d23260a267f6.png">

</details>

