### PR TITLE
help: Update 'Include organization name in subject line' documentation.

### DIFF
--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -54,18 +54,21 @@ To configure the delay for message notification emails:
 
 ### Include organization name in subject line
 
-If you belong to multiple Zulip organizations, it can be helpful to have the
-name of the organization in the subject line of your message notification emails.
+You can configure whether the name of your Zulip organization is included in the
+subject of message notification emails.
+
+Zulip offers a convenient **Automatic** configuration option, which includes the
+name of the organization in the subject only if you have accounts in multiple
+Zulip Cloud organizations, or in multiple organizations on the same Zulip server.
 
 {start_tabs}
 
 {settings_tab|notifications}
 
-1. Under **Email message notifications**, toggle
+1. Under **Email message notifications**, configure
    **Include organization name in subject of message notification emails**.
 
 {end_tabs}
-
 
 ### Hide message content
 


### PR DESCRIPTION
Document new "Automatic" configuration option (implemented in https://github.com/zulip/zulip/pull/24075).

Current section: https://zulip.com/help/email-notifications#include-organization-name-in-subject-line

Updated:
<img width="751" alt="Screen Shot 2023-03-15 at 5 00 20 PM" src="https://user-images.githubusercontent.com/2090066/225472574-44887629-5f9a-4ad7-b98b-0aeb9fcdcf28.png">


Questions for review:
1. Should we change the name of the heading? I struggled to find something that's better and decently succinct, so I left it as-is.
2. It's a bit in the weeds about Zulip Cloud / self-hosted servers. I'd be OK with dropping some of those details, but I went for having it actually be accurate, e.g., for users who have a Zulip Cloud account and a self-hosted Zulip account.
