### PR TITLE
integration: Refactor functions to use keyword arugments.

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -163,6 +163,7 @@ def get_remove_branch_event_message(user_name: str, branch_name: str) -> str:
 
 
 def get_pull_request_event_message(
+    *,
     user_name: str,
     action: str,
     url: str,
@@ -244,10 +245,10 @@ def get_issue_event_message(
     title: Optional[str] = None,
 ) -> str:
     return get_pull_request_event_message(
-        user_name,
-        action,
-        url,
-        number,
+        user_name=user_name,
+        action=action,
+        url=url,
+        number=number,
         message=message,
         assignee=assignee,
         assignees=assignees,

--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -235,6 +235,7 @@ def get_pull_request_event_message(
 
 
 def get_issue_event_message(
+    *,
     user_name: str,
     action: str,
     url: str,

--- a/zerver/webhooks/azuredevops/view.py
+++ b/zerver/webhooks/azuredevops/view.py
@@ -19,10 +19,10 @@ from zerver.models import UserProfile
 
 def get_code_pull_request_updated_body(payload: WildValue) -> str:
     return get_pull_request_event_message(
-        get_code_pull_request_user_name(payload),
-        "updated",
-        get_code_pull_request_url(payload),
-        get_code_pull_request_id(payload),
+        user_name=get_code_pull_request_user_name(payload),
+        action="updated",
+        url=get_code_pull_request_url(payload),
+        number=get_code_pull_request_id(payload),
         message=payload["detailedMessage"]["markdown"].tame(check_string),
         title=get_code_pull_request_title(payload),
     )
@@ -30,10 +30,10 @@ def get_code_pull_request_updated_body(payload: WildValue) -> str:
 
 def get_code_pull_request_merged_body(payload: WildValue) -> str:
     return get_pull_request_event_message(
-        get_code_pull_request_user_name(payload),
-        "merged",
-        get_code_pull_request_url(payload),
-        get_code_pull_request_id(payload),
+        user_name=get_code_pull_request_user_name(payload),
+        action="merged",
+        url=get_code_pull_request_url(payload),
+        number=get_code_pull_request_id(payload),
         target_branch=payload["resource"]["sourceRefName"]
         .tame(check_string)
         .replace("refs/heads/", ""),
@@ -50,13 +50,17 @@ def get_code_pull_request_opened_body(payload: WildValue) -> str:
     else:
         description = None
     return get_pull_request_event_message(
-        get_code_pull_request_user_name(payload),
-        "created",
-        get_code_pull_request_url(payload),
-        get_code_pull_request_id(payload),
-        payload["resource"]["sourceRefName"].tame(check_string).replace("refs/heads/", ""),
-        payload["resource"]["targetRefName"].tame(check_string).replace("refs/heads/", ""),
-        description,
+        user_name=get_code_pull_request_user_name(payload),
+        action="created",
+        url=get_code_pull_request_url(payload),
+        number=get_code_pull_request_id(payload),
+        target_branch=payload["resource"]["sourceRefName"]
+        .tame(check_string)
+        .replace("refs/heads/", ""),
+        base_branch=payload["resource"]["targetRefName"]
+        .tame(check_string)
+        .replace("refs/heads/", ""),
+        message=description,
         title=get_code_pull_request_title(payload),
     )
 

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -322,12 +322,12 @@ def get_issue_action_body(payload: WildValue, action: str, include_title: bool) 
         message = issue["content"]["raw"].tame(check_string)
 
     return get_issue_event_message(
-        get_actor_info(payload),
-        action,
-        issue["links"]["html"]["href"].tame(check_string),
-        issue["id"].tame(check_int),
-        message,
-        assignee,
+        user_name=get_actor_info(payload),
+        action=action,
+        url=issue["links"]["html"]["href"].tame(check_string),
+        number=issue["id"].tame(check_int),
+        message=message,
+        assignee=assignee,
         title=issue["title"].tame(check_string) if include_title else None,
     )
 

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -341,10 +341,10 @@ def get_pull_request_action_body(payload: WildValue, action: str, include_title:
         base_branch = pull_request["destination"]["branch"]["name"].tame(check_string)
 
     return get_pull_request_event_message(
-        get_actor_info(payload),
-        action,
-        get_pull_request_url(pull_request),
-        pull_request["id"].tame(check_int),
+        user_name=get_actor_info(payload),
+        action=action,
+        url=get_pull_request_url(pull_request),
+        number=pull_request["id"].tame(check_int),
         target_branch=target_branch,
         base_branch=base_branch,
         title=pull_request["title"].tame(check_string) if include_title else None,
@@ -360,10 +360,10 @@ def get_pull_request_created_or_updated_body(
         assignee = get_user_info(pull_request["reviewers"][0])
 
     return get_pull_request_event_message(
-        get_actor_info(payload),
-        action,
-        get_pull_request_url(pull_request),
-        pull_request["id"].tame(check_int),
+        user_name=get_actor_info(payload),
+        action=action,
+        url=get_pull_request_url(pull_request),
+        number=pull_request["id"].tame(check_int),
         target_branch=pull_request["source"]["branch"]["name"].tame(check_string)
         if action == "created"
         else None,
@@ -404,10 +404,10 @@ def get_pull_request_comment_action_body(
 ) -> str:
     action += " on"
     return get_pull_request_event_message(
-        get_actor_info(payload),
-        action,
-        payload["pullrequest"]["links"]["html"]["href"].tame(check_string),
-        payload["pullrequest"]["id"].tame(check_int),
+        user_name=get_actor_info(payload),
+        action=action,
+        url=payload["pullrequest"]["links"]["html"]["href"].tame(check_string),
+        number=payload["pullrequest"]["id"].tame(check_int),
         message=payload["comment"]["content"]["raw"].tame(check_string),
         title=payload["pullrequest"]["title"].tame(check_string) if include_title else None,
     )

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -80,9 +80,9 @@ def get_opened_or_update_pull_request_body(helper: Helper) -> str:
         base_branch = pull_request["base"]["label"].tame(check_string)
 
     return get_pull_request_event_message(
-        get_sender_name(payload),
-        action,
-        pull_request["html_url"].tame(check_string),
+        user_name=get_sender_name(payload),
+        action=action,
+        url=pull_request["html_url"].tame(check_string),
         target_branch=target_branch,
         base_branch=base_branch,
         message=description,
@@ -101,9 +101,9 @@ def get_assigned_or_unassigned_pull_request_body(helper: Helper) -> str:
         stringified_assignee = assignee["login"].tame(check_string)
 
     base_message = get_pull_request_event_message(
-        get_sender_name(payload),
-        payload["action"].tame(check_string),
-        pull_request["html_url"].tame(check_string),
+        user_name=get_sender_name(payload),
+        action=payload["action"].tame(check_string),
+        url=pull_request["html_url"].tame(check_string),
         number=pull_request["number"].tame(check_int),
         title=pull_request["title"].tame(check_string) if include_title else None,
     )
@@ -118,9 +118,9 @@ def get_closed_pull_request_body(helper: Helper) -> str:
     pull_request = payload["pull_request"]
     action = "merged" if pull_request["merged"].tame(check_bool) else "closed without merge"
     return get_pull_request_event_message(
-        get_sender_name(payload),
-        action,
-        pull_request["html_url"].tame(check_string),
+        user_name=get_sender_name(payload),
+        action=action,
+        url=pull_request["html_url"].tame(check_string),
         number=pull_request["number"].tame(check_int),
         title=pull_request["title"].tame(check_string) if include_title else None,
     )
@@ -485,9 +485,9 @@ def get_pull_request_review_body(helper: Helper) -> str:
         payload["pull_request"]["title"].tame(check_string),
     )
     return get_pull_request_event_message(
-        get_sender_name(payload),
-        "submitted",
-        payload["review"]["html_url"].tame(check_string),
+        user_name=get_sender_name(payload),
+        action="submitted",
+        url=payload["review"]["html_url"].tame(check_string),
         type="PR review",
         title=title if include_title else None,
     )
@@ -507,9 +507,9 @@ def get_pull_request_review_comment_body(helper: Helper) -> str:
     )
 
     return get_pull_request_event_message(
-        get_sender_name(payload),
-        action,
-        payload["comment"]["html_url"].tame(check_string),
+        user_name=get_sender_name(payload),
+        action=action,
+        url=payload["comment"]["html_url"].tame(check_string),
         message=message,
         type="PR review comment",
         title=title if include_title else None,

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -161,11 +161,11 @@ def get_issue_body(helper: Helper) -> str:
     issue = payload["issue"]
     assignee = issue["assignee"]
     return get_issue_event_message(
-        get_sender_name(payload),
-        action,
-        issue["html_url"].tame(check_string),
-        issue["number"].tame(check_int),
-        issue["body"].tame(check_none_or(check_string)),
+        user_name=get_sender_name(payload),
+        action=action,
+        url=issue["html_url"].tame(check_string),
+        number=issue["number"].tame(check_int),
+        message=issue["body"].tame(check_none_or(check_string)),
         assignee=assignee["login"].tame(check_string) if assignee else None,
         title=issue["title"].tame(check_string) if include_title else None,
     )
@@ -185,11 +185,11 @@ def get_issue_comment_body(helper: Helper) -> str:
     action += "({}) on".format(comment["html_url"].tame(check_string))
 
     return get_issue_event_message(
-        get_sender_name(payload),
-        action,
-        issue["html_url"].tame(check_string),
-        issue["number"].tame(check_int),
-        comment["body"].tame(check_string),
+        user_name=get_sender_name(payload),
+        action=action,
+        url=issue["html_url"].tame(check_string),
+        number=issue["number"].tame(check_int),
+        message=comment["body"].tame(check_string),
         title=issue["title"].tame(check_string) if include_title else None,
     )
 

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -95,11 +95,11 @@ def get_issue_created_event_body(payload: WildValue, include_title: bool) -> str
         stringified_description = None
 
     return get_issue_event_message(
-        get_issue_user_name(payload),
-        "created",
-        get_object_url(payload),
-        payload["object_attributes"]["iid"].tame(check_int),
-        stringified_description,
+        user_name=get_issue_user_name(payload),
+        action="created",
+        url=get_object_url(payload),
+        number=payload["object_attributes"]["iid"].tame(check_int),
+        message=stringified_description,
         assignees=replace_assignees_username_with_name(get_assignees(payload)),
         title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
     )
@@ -107,10 +107,10 @@ def get_issue_created_event_body(payload: WildValue, include_title: bool) -> str
 
 def get_issue_event_body(payload: WildValue, action: str, include_title: bool) -> str:
     return get_issue_event_message(
-        get_issue_user_name(payload),
-        action,
-        get_object_url(payload),
-        payload["object_attributes"]["iid"].tame(check_int),
+        user_name=get_issue_user_name(payload),
+        action=action,
+        url=get_object_url(payload),
+        number=payload["object_attributes"]["iid"].tame(check_int),
         title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
     )
 
@@ -159,8 +159,12 @@ def get_merge_request_open_or_updated_body(
         action=action,
         url=pull_request["url"].tame(check_string),
         number=pull_request["iid"].tame(check_int),
-        target_branch=pull_request["source_branch"].tame(check_string) if action == "created" else None,
-        base_branch=pull_request["target_branch"].tame(check_string) if action == "created" else None,
+        target_branch=pull_request["source_branch"].tame(check_string)
+        if action == "created"
+        else None,
+        base_branch=pull_request["target_branch"].tame(check_string)
+        if action == "created"
+        else None,
         message=pull_request["description"].tame(check_string),
         assignees=replace_assignees_username_with_name(get_assignees(payload)),
         type="MR",

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -139,10 +139,10 @@ def get_merge_request_event_body(payload: WildValue, action: str, include_title:
         base_branch = pull_request["target_branch"].tame(check_string)
 
     return get_pull_request_event_message(
-        get_issue_user_name(payload),
-        action,
-        pull_request["url"].tame(check_string),
-        pull_request["iid"].tame(check_int),
+        user_name=get_issue_user_name(payload),
+        action=action,
+        url=pull_request["url"].tame(check_string),
+        number=pull_request["iid"].tame(check_int),
         target_branch=target_branch,
         base_branch=base_branch,
         type="MR",
@@ -155,13 +155,13 @@ def get_merge_request_open_or_updated_body(
 ) -> str:
     pull_request = payload["object_attributes"]
     return get_pull_request_event_message(
-        get_issue_user_name(payload),
-        action,
-        pull_request["url"].tame(check_string),
-        pull_request["iid"].tame(check_int),
-        pull_request["source_branch"].tame(check_string) if action == "created" else None,
-        pull_request["target_branch"].tame(check_string) if action == "created" else None,
-        pull_request["description"].tame(check_string),
+        user_name=get_issue_user_name(payload),
+        action=action,
+        url=pull_request["url"].tame(check_string),
+        number=pull_request["iid"].tame(check_int),
+        target_branch=pull_request["source_branch"].tame(check_string) if action == "created" else None,
+        base_branch=pull_request["target_branch"].tame(check_string) if action == "created" else None,
+        message=pull_request["description"].tame(check_string),
         assignees=replace_assignees_username_with_name(get_assignees(payload)),
         type="MR",
         title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
@@ -218,10 +218,10 @@ def get_commented_merge_request_event_body(payload: WildValue, include_title: bo
     )
 
     return get_pull_request_event_message(
-        get_issue_user_name(payload),
-        action,
-        url,
-        payload["merge_request"]["iid"].tame(check_int),
+        user_name=get_issue_user_name(payload),
+        action=action,
+        url=url,
+        number=payload["merge_request"]["iid"].tame(check_int),
         message=comment["note"].tame(check_string),
         type="MR",
         title=payload["merge_request"]["title"].tame(check_string) if include_title else None,
@@ -237,10 +237,10 @@ def get_commented_issue_event_body(payload: WildValue, include_title: bool) -> s
     )
 
     return get_pull_request_event_message(
-        get_issue_user_name(payload),
-        action,
-        url,
-        payload["issue"]["iid"].tame(check_int),
+        user_name=get_issue_user_name(payload),
+        action=action,
+        url=url,
+        number=payload["issue"]["iid"].tame(check_int),
         message=comment["note"].tame(check_string),
         type="issue",
         title=payload["issue"]["title"].tame(check_string) if include_title else None,
@@ -256,10 +256,10 @@ def get_commented_snippet_event_body(payload: WildValue, include_title: bool) ->
     )
 
     return get_pull_request_event_message(
-        get_issue_user_name(payload),
-        action,
-        url,
-        payload["snippet"]["id"].tame(check_int),
+        user_name=get_issue_user_name(payload),
+        action=action,
+        url=url,
+        number=payload["snippet"]["id"].tame(check_int),
         message=comment["note"].tame(check_string),
         type="snippet",
         title=payload["snippet"]["title"].tame(check_string) if include_title else None,

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -100,11 +100,11 @@ def format_issues_event(payload: WildValue, include_title: bool = False) -> str:
     issue_nr = payload["issue"]["number"].tame(check_int)
     assignee = payload["issue"]["assignee"]
     return get_issue_event_message(
-        payload["sender"]["login"].tame(check_string),
-        payload["action"].tame(check_string),
-        get_issue_url(payload["repository"]["html_url"].tame(check_string), issue_nr),
-        issue_nr,
-        payload["issue"]["body"].tame(check_string),
+        user_name=payload["sender"]["login"].tame(check_string),
+        action=payload["action"].tame(check_string),
+        url=get_issue_url(payload["repository"]["html_url"].tame(check_string), issue_nr),
+        number=issue_nr,
+        message=payload["issue"]["body"].tame(check_string),
         assignee=assignee["login"].tame(check_string) if assignee else None,
         title=payload["issue"]["title"].tame(check_string) if include_title else None,
     )
@@ -122,13 +122,13 @@ def format_issue_comment_event(payload: WildValue, include_title: bool = False) 
     action += "({}) on".format(comment["html_url"].tame(check_string))
 
     return get_issue_event_message(
-        payload["sender"]["login"].tame(check_string),
-        action,
-        get_issue_url(
+        user_name=payload["sender"]["login"].tame(check_string),
+        action=action,
+        url=get_issue_url(
             payload["repository"]["html_url"].tame(check_string), issue["number"].tame(check_int)
         ),
-        issue["number"].tame(check_int),
-        comment["body"].tame(check_string),
+        number=issue["number"].tame(check_int),
+        message=comment["body"].tame(check_string),
         title=issue["title"].tame(check_string) if include_title else None,
     )
 


### PR DESCRIPTION
Previously, some call sites for the function provided optional arguments as positional arguments. These changes will allow the
arguments to be passed as keyword arguments to the function and fix up the call sites of the function to pass keyword arguments instead.

List of functions refactored:
- get_pull_request_event_message
- get_issue_event_message

Notes:
- `user_name`, `action`, `url` are required arguments. I noticed that some of these were passed as keyword arguments, so I decided to change those as well for consistency.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/GitHub.20bot.20wording/near/1525687)

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
