### PR TITLE
Adding two newline before and after uploading image and "quote and reply" feature

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -554,7 +554,7 @@ export function quote_and_reply(opts) {
         respond_to_message(opts);
     }
 
-    compose_ui.insert_syntax_and_focus(quoting_placeholder + "\n", $textarea);
+    compose_ui.insert_syntax_and_focus(quoting_placeholder + "\n", $textarea, true);
 
     function replace_content(message) {
         // Final message looks like:

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -30,7 +30,7 @@ export function autosize_textarea($textarea) {
     }
 }
 
-export function smart_insert($textarea, syntax) {
+export function smart_insert($textarea, syntax, block_format) {
     function is_space(c) {
         return c === " " || c === "\t" || c === "\n";
     }
@@ -39,26 +39,52 @@ export function smart_insert($textarea, syntax) {
     const before_str = $textarea.val().slice(0, pos);
     const after_str = $textarea.val().slice(pos);
 
-    if (
-        pos > 0 &&
-        // If there isn't space either at the end of the content
-        // before the insert or (unlikely) at the start of the syntax,
-        // add one.
-        !is_space(before_str.slice(-1)) &&
-        !is_space(syntax[0])
-    ) {
-        syntax = " " + syntax;
-    }
+    // For inserting newlines above and below the syntax, if the option is true.
+    if (block_format === true) {
+        if (
+            pos > 0 &&
+            // If there are non-whitespace characters before the syntax then insert
+            // two newline characters before the syntax.
+            !is_space(before_str.slice(-1)) &&
+            !is_space(syntax[0])
+        ) {
+            syntax = "\n\n" + syntax;
+        }
+        // If there is now content after the syntax, or if the first character after
+        // syntax is not a newline character, then append two newline characters to
+        // the syntax. Otherwise, append only a single newline character to the string.
+        if (
+            !(
+                (after_str.length > 0 && is_space(after_str[0])) ||
+                (syntax.length > 0 && is_space(syntax.slice(-1)))
+            )
+        ) {
+            syntax += "\n\n";
+        } else {
+            syntax += "\n";
+        }
+    } else {
+        if (
+            pos > 0 &&
+            // If there isn't space either at the end of the content
+            // before the insert or (unlikely) at the start of the syntax,
+            // add one.
+            !is_space(before_str.slice(-1)) &&
+            !is_space(syntax[0])
+        ) {
+            syntax = " " + syntax;
+        }
 
-    // If there isn't whitespace either at the end of the syntax or the
-    // start of the content after the syntax, add one.
-    if (
-        !(
-            (after_str.length > 0 && is_space(after_str[0])) ||
-            (syntax.length > 0 && is_space(syntax.slice(-1)))
-        )
-    ) {
-        syntax += " ";
+        // If there isn't whitespace either at the end of the syntax or the
+        // start of the content after the syntax, add one.
+        if (
+            !(
+                (after_str.length > 0 && is_space(after_str[0])) ||
+                (syntax.length > 0 && is_space(syntax.slice(-1)))
+            )
+        ) {
+            syntax += " ";
+        }
     }
 
     // text-field-edit ensures `$textarea` is focused before inserting
@@ -68,11 +94,15 @@ export function smart_insert($textarea, syntax) {
     autosize_textarea($textarea);
 }
 
-export function insert_syntax_and_focus(syntax, $textarea = $("#compose-textarea")) {
+export function insert_syntax_and_focus(
+    syntax,
+    $textarea = $("#compose-textarea"),
+    block_format = false,
+) {
     // Generic helper for inserting syntax into the main compose box
     // where the cursor was and focusing the area.  Mostly a thin
     // wrapper around smart_insert.
-    smart_insert($textarea, syntax);
+    smart_insert($textarea, syntax, block_format);
 }
 
 export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-textarea")) {

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -183,6 +183,7 @@ export async function upload_files(uppy, config, files) {
             compose_ui.insert_syntax_and_focus(
                 get_translated_status(file),
                 get_item("textarea", config),
+                true,
             );
             compose_ui.autosize_textarea(get_item("textarea", config));
             uppy.addFile({

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -297,7 +297,7 @@ run_test("quote_and_reply", ({override, override_rewire}) => {
     $("#compose-textarea")[0] = "compose-textarea";
     override(text_field_edit, "insert", (elt, syntax) => {
         assert.equal(elt, "compose-textarea");
-        assert.equal(syntax, "translated: [Quoting…]\n");
+        assert.equal(syntax, "translated: [Quoting…]\n\n");
     });
 
     function set_compose_content_with_caret(content) {


### PR DESCRIPTION
Currently, only one line is added before and after quoted message and pasting images in compose area. For more breathing room around these, two newlines are inserted which would pad the inserted text with a whole empty line

Fixes: [#11389](https://github.com/zulip/zulip/issues/11389) and [#23608](https://github.com/zulip/zulip/issues/23608)

Before:-
![before- quote and reply](https://user-images.githubusercontent.com/97045316/225522536-f833077c-5d89-4ed0-947f-307afe0bf65f.png)

After:

https://user-images.githubusercontent.com/97045316/225522607-2ffffa01-0279-4350-8360-ee635578e75f.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
