### PR TITLE
compose: Hide spinner and re-enable submit button after send.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -264,6 +264,13 @@ export function send_message(request = create_message_object()) {
                 compose_banner.CLASSNAMES.generic_compose_error,
                 $("#compose-textarea"),
             );
+            // For messages that were not locally echoed, we're
+            // responsible for hiding the compose spinner to restore
+            // the compose box so one can send a next message.
+            //
+            // (Restoring this state is handled by clear_compose_box
+            // for locally echoed messages.)
+            compose_ui.hide_compose_spinner();
             return;
         }
 

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -234,7 +234,6 @@ function handle_keydown(e) {
                         compose_validate.warn_for_text_overflow_when_tries_to_send() &&
                         !$("#compose-send-button").prop("disabled")
                     ) {
-                        $("#compose-send-button").prop("disabled", true);
                         compose.finish();
                     }
                     return;


### PR DESCRIPTION
This was previously working for the happy case of messages that send, but both re-enabling the submit button and hiding the loading spinner were not happening in a place that would consistently reset the state for any kind of send attempt. These changes fixes that. More details on the bug that inspired this change, and what was happening on CZO: https://chat.zulip.org/#narrow/stream/9-issues/topic/compose.20error.20handling.20bug/near/1525852

