### PR TITLE
recent_conversations: Fix unread topics navigation behaviour.

### DIFF
--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -1263,7 +1263,11 @@ export function initialize() {
             const topic = $elt.attr("data-topic-name");
             unread_ops.mark_topic_as_read(stream_id, topic);
         }
-        change_focused_element($elt, "down_arrow");
+        // If `unread` filter is selected, the focused topic row gets removed
+        // and we automatically move one row down.
+        if (!filters.has("unread")) {
+            change_focused_element($elt, "down_arrow");
+        }
     });
 
     $("body").on("keydown", ".on_hover_topic_read", ui_util.convert_enter_to_click);


### PR DESCRIPTION
When marking an unread topic as read with `unread` filter selected, we don't need to move the user a row down, since removing the selected row will automatically move the user down.

Without this, the user goes down twice, which is not intended.

Discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Strange.20behaviour.20when.20marking.20topic.20as.20read