### PR TITLE
invite_users: Restructure "Invite user" modal for improved user

### DIFF
--- a/web/src/invite.js
+++ b/web/src/invite.js
@@ -257,6 +257,13 @@ function open_invite_user_modal(e) {
 
     function invite_user_modal_post_render() {
         $("#invite-user-modal .dialog_submit_button").prop("disabled", true);
+        $("#email_invite_radio").prop("checked", true);
+
+        if (!page_params.is_admin) {
+            $("#generate_multiuse_invite_radio").prop("disabled", true);
+            $("#generate_multiuse_invite_radio_container").addClass("control-label-disabled");
+            $("#generate_multiuse_invite_radio_container").addClass("disabled_setting_tooltip");
+        }
 
         autosize($("#invitee_emails").trigger("focus"));
 
@@ -276,24 +283,19 @@ function open_invite_user_modal(e) {
             toggle_invite_submit_button();
         });
 
-        $("#invite-user-modal").on("change", "#generate_multiuse_invite_radio", () => {
-            $("#invitee_emails").prop("disabled", false);
+        $("#invite-user-modal").on("change", "#email_invite_radio", () => {
+            $("#invitee_emails_container").show();
             $("#invite-user-modal .dialog_submit_button").text($t({defaultMessage: "Invite"}));
             $("#invite-user-modal .dialog_submit_button").data(
                 "loading-text",
                 $t({defaultMessage: "Inviting..."}),
             );
-            $("#multiuse_radio_section").hide();
-            $("#invite-method-choice").show();
             toggle_invite_submit_button();
             reset_error_messages();
         });
 
-        $("#generate_multiuse_invite_button").on("click", () => {
-            $("#generate_multiuse_invite_radio").prop("checked", true);
-            $("#multiuse_radio_section").show();
-            $("#invite-method-choice").hide();
-            $("#invitee_emails").prop("disabled", true);
+        $("#invite-user-modal").on("change", "#generate_multiuse_invite_radio", () => {
+            $("#invitee_emails_container").hide();
             $("#invite-user-modal .dialog_submit_button").text(
                 $t({defaultMessage: "Generate invite link"}),
             );

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -465,6 +465,18 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ["#generate_multiuse_invite_radio_container.disabled_setting_tooltip"],
+        content: $t({
+            defaultMessage:
+                "You do not have permissions to generate invite links in this organization.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    delegate("body", {
         target: "#pm_tooltip_container",
         onShow(instance) {
             if ($(".private_messages_container").hasClass("zoom-in")) {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2354,14 +2354,35 @@ select.invite-as {
     }
 }
 
-#invite-method-choice {
-    margin-top: 2px;
+.invite_type_radio_section {
+    margin: 2px 0 2px 5px;
+    padding: 2px 0;
+
+    & label.radio {
+        display: inline;
+        margin: 5px;
+    }
+
+    & input {
+        float: left;
+        width: auto;
+        cursor: pointer;
+        margin: 5.5px 0 1px;
+
+        &:focus {
+            outline: 1px dotted hsl(0deg 0% 20%);
+            outline: 5px auto -webkit-focus-ring-color;
+            outline-offset: -2px;
+        }
+
+        &:disabled {
+            cursor: not-allowed;
+        }
+    }
 }
 
-#multiuse_radio_section {
-    margin-top: 4px;
-    margin-bottom: -2px;
-    display: none;
+#generate_multiuse_invite_radio_container {
+    width: fit-content;
 }
 
 #custom-invite-expiration-time {

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -3,20 +3,25 @@
     <div class="alert" id="dev_env_msg"></div>
     {{/if}}
     <div class="input-group">
-        <label for="invitee_emails">{{t "Emails (one on each line or comma-separated)" }}</label>
-        <textarea rows="2" id="invitee_emails" name="invitee_emails" class="invitee_emails" placeholder="{{t 'One or more email addresses...' }}"></textarea>
-        {{#if is_admin}}
-        <div id="invite-method-choice">
-            {{t "or" }} <a role="button" tabindex="0" id="generate_multiuse_invite_button">{{t "Generate invite link" }}</a>
+        <label>{{t "How would you like to invite users?" }}</label>
+        <div class="invite_type_radio_section prop-element" id="invite-user">
+            <div id="generate_multiuse_invite_radio_container">
+                <label class="radio generate_multiuse_invite_radio_label">
+                    <input type="radio" id="generate_multiuse_invite_radio" name="invite-user" value="generate-multiuse-invite" />
+                    {{t "Generate invite link" }}
+                </label>
+            </div>
+            <div id="email_invite_radio_container">
+                <label class="radio email_invite_radio_label">
+                    <input type="radio" id="email_invite_radio" name="invite-user" value="email-invite" />
+                    {{t "Send an email" }}
+                </label>
+            </div>
         </div>
-        <div id="multiuse_radio_section" class="new-style">
-            <label class="checkbox display-block" for="generate_multiuse_invite_radio">
-                <input type="checkbox" name="generate_multiuse_invite_radio" id="generate_multiuse_invite_radio"/>
-                <span></span>
-                {{t "Generate invite link" }}
-            </label>
+        <div id="invitee_emails_container">
+            <label for="invitee_emails">{{t "Emails (one on each line or comma-separated)" }}</label>
+            <textarea rows="2" id="invitee_emails" name="invitee_emails" class="invitee_emails" placeholder="{{t 'One or more email addresses...' }}"></textarea>
         </div>
-        {{/if}}
     </div>
     <div class="input-group">
         <label for="expires_in">{{t "Invitation expires after" }}</label>


### PR DESCRIPTION
Fixes: #24692

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

`Have permissions for both options`

<img width="569" alt="Screenshot 2023-03-16 at 5 10 57 PM" src="https://user-images.githubusercontent.com/72064462/225606258-fe2f885f-ce5b-4524-aa14-297352279824.png">

<img width="559" alt="Screenshot 2023-03-16 at 5 11 04 PM" src="https://user-images.githubusercontent.com/72064462/225606252-4383a834-0452-4e5d-97ca-d91f271994bc.png">

`Do not have permissions `

<img width="583" alt="Screenshot 2023-03-16 at 5 10 33 PM" src="https://user-images.githubusercontent.com/72064462/225606263-45c47138-705e-4c94-8f82-52a607391497.png">

<img width="601" alt="Screenshot 2023-03-17 at 12 37 28 AM" src="https://user-images.githubusercontent.com/72064462/225728902-7d2ba2cd-312c-4036-b384-c7880a6aaef9.png">

**Self-review checklist**

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
