### PR TITLE
run-dev: Add flag to allow JSON requests through HTTPS proxy.

### DIFF
--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -314,11 +314,7 @@ different.
    service nginx reload  # Actually enabled your nginx configuration
    ```
 
-1. Edit `zproject/dev_settings.py` to set
-   `EXTERNAL_URI_SCHEME = "https://"`, so that URLs served by the
-   development environment will be HTTPS.
-
-1. Start the Zulip development environment with the following command:
+1. Start the Zulip development environment in HTTPS mode with the following command:
    ```bash
-   env EXTERNAL_HOST="hostname.example.com" ./tools/run-dev --interface=''
+   env EXTERNAL_HOST="hostname.example.com" ./tools/run-dev --behind-https-proxy --interface=''
    ```

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -57,6 +57,11 @@ parser.add_argument(
     action="store_true",
     help="Enable access logs from tornado proxy server.",
 )
+parser.add_argument(
+    "--behind-https-proxy",
+    action="store_true",
+    help="Start app server in HTTPS mode, using reverse proxy",
+)
 add_provision_check_override_param(parser)
 options = parser.parse_args()
 
@@ -92,6 +97,9 @@ else:
 
 manage_args = [f"--settings={settings_module}"]
 os.environ["DJANGO_SETTINGS_MODULE"] = settings_module
+
+if options.behind_https_proxy:
+    os.environ["BEHIND_HTTPS_PROXY"] = "1"
 
 from scripts.lib.zulip_tools import CYAN, ENDC
 
@@ -323,7 +331,10 @@ def print_listeners() -> None:
     else:
         default_hostname = "localhost"
     external_host = os.getenv("EXTERNAL_HOST", f"{default_hostname}:{proxy_port}")
-    print(f"\nStarting Zulip on:\n\n\t{CYAN}http://{external_host}/{ENDC}\n\nInternal ports:")
+    http_protocol = "https" if options.behind_https_proxy else "http"
+    print(
+        f"\nStarting Zulip on:\n\n\t{CYAN}{http_protocol}://{external_host}/{ENDC}\n\nInternal ports:"
+    )
     ports = [
         (proxy_port, "Development server proxy (connect here)"),
         (django_port, "Django"),

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -62,6 +62,13 @@ AUTHENTICATION_BACKENDS: Tuple[str, ...] = (
 )
 
 EXTERNAL_URI_SCHEME = "http://"
+
+if os.getenv("BEHIND_HTTPS_PROXY"):
+    # URLs served by the development environment will be HTTPS
+    EXTERNAL_URI_SCHEME = "https://"
+    # Trust requests from this host (required due to Nginx proxy)
+    CSRF_TRUSTED_ORIGINS = [EXTERNAL_URI_SCHEME + EXTERNAL_HOST]
+
 EMAIL_GATEWAY_PATTERN = "%s@" + EXTERNAL_HOST_WITHOUT_PORT
 NOTIFICATION_BOT = "notification-bot@zulip.com"
 ERROR_BOT = "error-bot@zulip.com"


### PR DESCRIPTION
**Problem:** Making JSON requests from app running in a remote development environment with an SSL-certified domain currently results in a 403 (CSRF) error.

**What changes:**
Set in the Django dev settings:
```
CSRF_TRUSTED_ORIGINS = [EXTERNAL_URI_SCHEME + EXTERNAL_HOST]
```
Since Django 4.0 it seems that if running the server behind a reverse-proxy such as Nginx, then we require the `CSRF_TRUSTED_ORIGINS` setting containing the exact value for scheme + hostname.

[Reference in the Django docs about `CSRF_TRUSTED_ORIGINS` setting](https://docs.djangoproject.com/en/4.1/ref/settings/#csrf-trusted-origins)



**Screenshot of error as it appears in the network inspector:**
<img width="800" alt="CSRF error with current dev settings if using HTTPS" src="https://user-images.githubusercontent.com/4532677/225682907-5935d8de-b992-459d-8d3a-0070f5b7624d.png">