### PR TITLE
message_row: Fix rewrapping message lines after receiving ack.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -260,4 +260,9 @@ $time_column_max_width: 150px;
             }
         }
     }
+
+    /* Locally echoed messages. */
+    &.local .message_time {
+        opacity: 0;
+    }
 }

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -24,7 +24,7 @@
 
 <span class="alert-msg"></span>
 
-<a href="{{ msg/url }}" class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">
+<a href="{{ msg/url }}" class="message_time{{#if status_message}} status-time{{/if}}">
     {{#unless include_sender}}
     <span class="copy-paste-text">&nbsp;</span>
     {{/unless}}


### PR DESCRIPTION
Since the message time of locally echoed messages were not displayed and their width was restricted by `notvisible` CSS class, it resulted in width available to message text changing after the message was successfully sent and the time was displayed.

To fix this, we just try to set opacity of the message time to 0 for locally echoed messages.

before:
<img width="844" alt="Screenshot 2023-03-17 at 1 16 35 PM" src="https://user-images.githubusercontent.com/25124304/225843739-e426dcf5-0748-4ad0-bf08-97069a6a1bd9.png">


after:
<img width="844" alt="Screenshot 2023-03-17 at 1 09 18 PM" src="https://user-images.githubusercontent.com/25124304/225843553-f1baaf04-1d4f-43e1-a121-77f893bd0a29.png">


discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Line.20wrapping.20messages