### PR TITLE
python: Update tuple handling pattern; returned by a delete() query.

### DIFF
--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -322,14 +322,14 @@ def delete_messages(msg_ids: List[int]) -> None:
 
 
 def delete_expired_attachments(realm: Realm) -> None:
-    attachments_deleted, _ = Attachment.objects.filter(
+    (num_deleted, ignored) = Attachment.objects.filter(
         messages__isnull=True,
         realm_id=realm.id,
         id__in=ArchivedAttachment.objects.filter(realm_id=realm.id),
     ).delete()
 
-    if attachments_deleted > 0:
-        logger.info("Cleaned up %s attachments for realm %s", attachments_deleted, realm.string_id)
+    if num_deleted > 0:
+        logger.info("Cleaned up %s attachments for realm %s", num_deleted, realm.string_id)
 
 
 def move_related_objects_to_archive(msg_ids: List[int]) -> None:

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -194,10 +194,10 @@ def unregister_remote_push_device(
     validate_bouncer_token_request(token, token_kind)
     user_identity = UserPushIdentityCompat(user_id=user_id, user_uuid=user_uuid)
 
-    deleted = RemotePushDeviceToken.objects.filter(
+    (num_deleted, ignored) = RemotePushDeviceToken.objects.filter(
         user_identity.filter_q(), token=token, kind=token_kind, server=server
     ).delete()
-    if deleted[0] == 0:
+    if num_deleted == 0:
         raise JsonableError(err_("Token does not exist"))
 
     return json_success(request)


### PR DESCRIPTION
This is a follow-up PR to #24690 -- [(related comment)](https://github.com/zulip/zulip/pull/24690#discussion_r1139158417)

[Tim Abbott said](https://github.com/zulip/zulip/pull/24690#discussion_r1137916411):

> I prefer (num_deleted, ignored) = UserTopic.objects... as a pattern if something returns a tuple.

This commit updates the pattern for dealing with tuples returned by the delete() query.

The `(num_deleted, ignored) = ModelName.objects.filter().delete()` pattern is preferred due to better readability.

<!-- Describe your pull request here.-->

Fixes: follow-up PR to #24690 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
