### PR TITLE
ts : convert alert words to typescript

### DIFF
--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -4,23 +4,33 @@ import * as people from "./people";
 
 // For simplicity, we use a list for our internal
 // data, since that matches what the server sends us.
-let my_alert_words = [];
+let my_alert_words:string[] = [];
 
-export function set_words(words) {
+
+interface AlertWord {
+    word: string;
+}
+
+interface Message {
+    alerted: boolean;
+    content: string;
+}
+
+export function set_words(words:string[]) :void{
     my_alert_words = words;
 }
 
-export function get_word_list() {
+export function get_word_list() :AlertWord[] {
     // Returns a array of objects
     // (with each alert_word as value and 'word' as key to the object.)
-    const words = [];
+    const words:AlertWord[] = [];
     for (const word of my_alert_words) {
         words.push({word});
     }
     return words;
 }
 
-export function has_alert_word(word) {
+export function has_alert_word(word: string) : boolean {
     return my_alert_words.includes(word);
 }
 
@@ -33,7 +43,7 @@ const alert_regex_replacements = new Map([
     ["'", "(?:'|&#39;)"],
 ]);
 
-export function process_message(message) {
+export function process_message(message: Message) :void{
     // Parsing for alert words is expensive, so we rely on the host
     // to tell us there any alert words to even look for.
     if (!message.alerted) {
@@ -41,7 +51,7 @@ export function process_message(message) {
     }
 
     for (const word of my_alert_words) {
-        const clean = _.escapeRegExp(word).replace(/["&'<>]/g, (c) =>
+        const clean:string = _.escapeRegExp(word).replace(/["&'<>]/g, (c: string) =>
             alert_regex_replacements.get(c),
         );
         const before_punctuation = "\\s|^|>|[\\(\\\".,';\\[]";
@@ -50,7 +60,7 @@ export function process_message(message) {
         const regex = new RegExp(`(${before_punctuation})(${clean})(${after_punctuation})`, "ig");
         message.content = message.content.replace(
             regex,
-            (match, before, word, after, offset, content) => {
+            (match:string, before:string, word:string, after:string, offset:number, content:string):string => {
                 // Logic for ensuring that we don't muck up rendered HTML.
                 const pre_match = content.slice(0, offset);
                 // We want to find the position of the `<` and `>` only in the
@@ -69,7 +79,12 @@ export function process_message(message) {
     }
 }
 
-export function notifies(message) {
+interface Notifies {
+    sender_email: string;
+    alerted: boolean;
+}
+
+export function notifies(message:Notifies) :boolean {
     // We exclude ourselves from notifications when we type one of our own
     // alert words into a message, just because that can be annoying for
     // certain types of workflows where everybody on your team, including
@@ -77,6 +92,6 @@ export function notifies(message) {
     return !people.is_current_user(message.sender_email) && message.alerted;
 }
 
-export const initialize = (params) => {
+export const initialize = (params: { alert_words: string[]; }) :void => {
     my_alert_words = params.alert_words;
 };

--- a/web/src/alert_words.ts
+++ b/web/src/alert_words.ts
@@ -1,11 +1,11 @@
 import _ from "lodash";
 
+//@ts-ignore
 import * as people from "./people";
 
 // For simplicity, we use a list for our internal
 // data, since that matches what the server sends us.
-let my_alert_words:string[] = [];
-
+let my_alert_words: string[] = [];
 
 interface AlertWord {
     word: string;
@@ -16,21 +16,21 @@ interface Message {
     content: string;
 }
 
-export function set_words(words:string[]) :void{
+export function set_words(words: string[]): void {
     my_alert_words = words;
 }
 
-export function get_word_list() :AlertWord[] {
+export function get_word_list(): AlertWord[] {
     // Returns a array of objects
     // (with each alert_word as value and 'word' as key to the object.)
-    const words:AlertWord[] = [];
+    const words: AlertWord[] = [];
     for (const word of my_alert_words) {
         words.push({word});
     }
     return words;
 }
 
-export function has_alert_word(word: string) : boolean {
+export function has_alert_word(word: string): boolean {
     return my_alert_words.includes(word);
 }
 
@@ -43,7 +43,7 @@ const alert_regex_replacements = new Map([
     ["'", "(?:'|&#39;)"],
 ]);
 
-export function process_message(message: Message) :void{
+export function process_message(message: Message): void {
     // Parsing for alert words is expensive, so we rely on the host
     // to tell us there any alert words to even look for.
     if (!message.alerted) {
@@ -51,8 +51,9 @@ export function process_message(message: Message) :void{
     }
 
     for (const word of my_alert_words) {
-        const clean:string = _.escapeRegExp(word).replace(/["&'<>]/g, (c: string) =>
-            alert_regex_replacements.get(c),
+        const clean: string | undefined = _.escapeRegExp(word).replace(
+            /["&'<>]/g,
+            (c: string | undefined) => alert_regex_replacements.get(c!),
         );
         const before_punctuation = "\\s|^|>|[\\(\\\".,';\\[]";
         const after_punctuation = "(?=\\s)|$|<|[\\)\\\"\\?!:.,';\\]!]";
@@ -60,7 +61,14 @@ export function process_message(message: Message) :void{
         const regex = new RegExp(`(${before_punctuation})(${clean})(${after_punctuation})`, "ig");
         message.content = message.content.replace(
             regex,
-            (match:string, before:string, word:string, after:string, offset:number, content:string):string => {
+            (
+                match: string,
+                before: string,
+                word: string,
+                after: string,
+                offset: number,
+                content: string,
+            ): string => {
                 // Logic for ensuring that we don't muck up rendered HTML.
                 const pre_match = content.slice(0, offset);
                 // We want to find the position of the `<` and `>` only in the
@@ -84,7 +92,7 @@ interface Notifies {
     alerted: boolean;
 }
 
-export function notifies(message:Notifies) :boolean {
+export function notifies(message: Notifies): boolean {
     // We exclude ourselves from notifications when we type one of our own
     // alert words into a message, just because that can be annoying for
     // certain types of workflows where everybody on your team, including
@@ -92,6 +100,6 @@ export function notifies(message:Notifies) :boolean {
     return !people.is_current_user(message.sender_email) && message.alerted;
 }
 
-export const initialize = (params: { alert_words: string[]; }) :void => {
+export const initialize = (params: {alert_words: string[]}): void => {
     my_alert_words = params.alert_words;
 };


### PR DESCRIPTION
This PR converts `alert_words` to TypeScript and Its still work in progress

To convert `alert_words` to typescript it was necessary to type check all the variables in alert_words and type narrow them to the required types

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
