### PR TITLE
Review 23929

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -29,6 +29,7 @@ import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
+import {show_copied_confirmation} from "./tippyjs";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as util from "./util";
@@ -397,14 +398,13 @@ function create_copy_to_clipboard_handler($row, source, message_id) {
             document.querySelector(`#edit_form_${CSS.escape(message_id)} .message_edit_content`),
     });
 
-    clipboard.on("success", () => {
-        end_message_row_edit($row);
-        $row.find(".alert-msg").text($t({defaultMessage: "Copied!"}));
-        $row.find(".alert-msg").css("display", "block");
-        $row.find(".alert-msg").delay(1000).fadeOut(300);
-        if ($(".tooltip").is(":visible")) {
-            $(".tooltip").hide();
-        }
+    clipboard.on("success", (e) => {
+        e.clearSelection();
+        source._tippy.setContent($t({defaultMessage: "Copied!"}));
+        show_copied_confirmation(source);
+        setTimeout(() => {
+            end_message_row_edit($row);
+        }, "2000");
     });
 }
 

--- a/web/src/rendered_markdown.js
+++ b/web/src/rendered_markdown.js
@@ -13,6 +13,7 @@ import * as realm_playground from "./realm_playground";
 import * as rtl from "./rtl";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
+import {show_copied_confirmation} from "./tippyjs";
 import * as user_groups from "./user_groups";
 import {user_settings} from "./user_settings";
 
@@ -227,10 +228,13 @@ export const update_elements = ($content) => {
         }
         const $copy_button = $(copy_code_button());
         $pre.prepend($copy_button);
-        new ClipboardJS($copy_button[0], {
+        const clipboard = new ClipboardJS($copy_button[0], {
             text(copy_element) {
                 return $(copy_element).siblings("code").text();
             },
+        });
+        clipboard.on("success", () => {
+            show_copied_confirmation($copy_button[0]);
         });
     });
 

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -469,3 +469,22 @@ export function initialize() {
         appendTo: () => document.body,
     });
 }
+
+export function show_copied_confirmation($copy_button) {
+    // Display a tooltip to notify the user the message or code was copied.
+    const instance = tippy($copy_button, {
+        placement: "top",
+        appendTo: () => document.body,
+        onUntrigger() {
+            remove_instance();
+        },
+    });
+    instance.setContent($t({defaultMessage: "Copied!"}));
+    instance.show();
+    function remove_instance() {
+        if (!instance.state.isDestroyed) {
+            instance.destroy();
+        }
+    }
+    setTimeout(remove_instance, 3000);
+}

--- a/web/tests/rendered_markdown.test.js
+++ b/web/tests/rendered_markdown.test.js
@@ -13,11 +13,15 @@ class Clipboard {
     constructor(...args) {
         clipboard_args = args;
     }
+    on(success, show_copied_confirmation) {
+        show_copied_confirmation();
+    }
 }
 
 mock_cjs("clipboard", Clipboard);
 
 const realm_playground = mock_esm("../src/realm_playground");
+const tippyjs = mock_esm("../src/tippyjs");
 user_settings.emojiset = "apple";
 
 const rm = zrequire("rendered_markdown");
@@ -428,6 +432,8 @@ run_test("code playground none", ({override, mock_template}) => {
         return undefined;
     });
 
+    override(tippyjs, "show_copied_confirmation", () => {});
+
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, false);
     assert.deepEqual(prepends, [$copy_code]);
     assert_clipboard_setup();
@@ -441,6 +447,8 @@ run_test("code playground single", ({override, mock_template}) => {
         assert.equal(language, "javascript");
         return [{name: "Some Javascript Playground"}];
     });
+
+    override(tippyjs, "show_copied_confirmation", () => {});
 
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
     assert.deepEqual(prepends, [$view_code, $copy_code]);
@@ -459,6 +467,8 @@ run_test("code playground multiple", ({override, mock_template}) => {
         assert.equal(language, "javascript");
         return ["whatever", "whatever"];
     });
+
+    override(tippyjs, "show_copied_confirmation", () => {});
 
     const {prepends, $copy_code, $view_code} = test_code_playground(mock_template, true);
     assert.deepEqual(prepends, [$view_code, $copy_code]);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/12359771/225930971-fd3d63e8-84b4-4c46-8aa4-f60be6b65b92.mov

This is just a rebase of the work done by @Deekshith-S-Shetty.

Sometimes the page still reloads after clearing the selection highlighting, but I couldn't reproduce this consistently.

I tried changing `e.clearSelection();` to the following:

```javascript
if (window.getSelection) {
  if (window.getSelection().empty) {  // Chrome
    window.getSelection().empty();
  } else if (window.getSelection().removeAllRanges) {  // Firefox
    window.getSelection().removeAllRanges();
  }
} else if (document.selection) {  // IE?
  document.selection.empty();
}
```
This worked without a reload in Chrome and Safari, but it didn't remove highlighting in Firefox.  Therefore I restored the original code and retested.  It seems to be working right now.

I searched for information regarding `e.clearSelection();` causing page reloads, but couldn't find anything.  The page reload may be unrelated, and my manual testing results may have been a coincidence.


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ x] Visual appearance of the changes.
- [x ] Responsiveness and internationalization.
- [ x] Strings and tooltips.
- [x ] End-to-end functionality of buttons, interactions and flows.
- [x ] Corner cases, error conditions, and easily imagined bugs.
</details>
