### PR TITLE
UserTopic: Update UserTopic records regardless of the visibility_policy.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -1,4 +1,5 @@
 import datetime
+from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Set
 
 from django.conf import settings
@@ -19,7 +20,7 @@ from zerver.actions.message_send import (
     render_incoming_message,
 )
 from zerver.actions.uploads import check_attachment_reference_change
-from zerver.actions.user_topics import do_set_user_topic_visibility_policy
+from zerver.actions.user_topics import bulk_do_set_user_topic_visibility_policy
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.markdown import MessageRenderingResult, topic_links
 from zerver.lib.markdown import version as markdown_version
@@ -766,41 +767,46 @@ def do_update_message(
         assert stream_being_edited is not None
         assert topic_name is not None or new_stream is not None
 
+        user_profiles_for_visibility_policy: Dict[int, List[UserProfile]] = defaultdict(list)
+        stream_inaccessible_to_user_profiles: List[UserProfile] = []
         for user_topic in get_users_with_user_topic_visibility_policy(
             stream_being_edited.id, orig_topic_name
         ):
-            # TODO: Ideally, this would be a bulk update operation,
-            # because we are doing database operations in a loop here.
-            #
-            # This loop is only acceptable in production because it is
-            # rare for more than a few users to have visibility_policy
-            # set for an individual topic that is being moved; as of this
-            # writing, no individual topic in Zulip Cloud had been
-            # muted by more than 100 users.
-
             if (
                 new_stream is not None
                 and user_topic.user_profile_id in delete_event_notify_user_ids
             ):
-                # If the messages are being moved to a stream the user
-                # cannot access, then we treat this as the
-                # messages/topic being deleted for this user. This is
-                # important for security reasons; we don't want to
-                # give users a UserTopic row in a stream they cannot
-                # access. Remove the user topic rows for such users.
-                do_set_user_topic_visibility_policy(
-                    user_topic.user_profile,
-                    stream_being_edited,
-                    orig_topic_name,
-                    visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
-                )
+                stream_inaccessible_to_user_profiles.append(user_topic.user_profile)
             else:
-                # Otherwise, we move the user topic record for the
-                # user, but removing the old topic visibility_policy
-                # and then creating a new one.
-                new_visibility_policy = user_topic.visibility_policy
-                do_set_user_topic_visibility_policy(
-                    user_topic.user_profile,
+                user_profiles_for_visibility_policy[user_topic.visibility_policy].append(
+                    user_topic.user_profile
+                )
+
+        # If the messages are being moved to a stream the user
+        # cannot access, then we treat this as the
+        # messages/topic being deleted for this user. This is
+        # important for security reasons; we don't want to
+        # give users a UserTopic row in a stream they cannot
+        # access. Remove the user topic rows for such users.
+        bulk_do_set_user_topic_visibility_policy(
+            stream_inaccessible_to_user_profiles,
+            stream_being_edited,
+            orig_topic_name,
+            visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
+        )
+
+        # If the messages are being moved to a stream the user
+        # can access. We move the user topic records for such
+        # users, but removing the old topic visibility_policy
+        # and then creating a new one.
+        for visibility_policy in UserTopic.VisibilityPolicy.values:
+            # Using the dict, we get the user_profiles lists for the original_topic
+            # that corresponds to each visibility_policy.
+            # Perform the remove and create operation for each of
+            # these user_profiles lists.
+            if visibility_policy in user_profiles_for_visibility_policy:
+                bulk_do_set_user_topic_visibility_policy(
+                    user_profiles_for_visibility_policy[visibility_policy],
                     stream_being_edited,
                     orig_topic_name,
                     visibility_policy=UserTopic.VisibilityPolicy.INHERIT,
@@ -811,11 +817,11 @@ def do_update_message(
                     skip_muted_topics_event=True,
                 )
 
-                do_set_user_topic_visibility_policy(
-                    user_topic.user_profile,
+                bulk_do_set_user_topic_visibility_policy(
+                    user_profiles_for_visibility_policy[visibility_policy],
                     new_stream if new_stream is not None else stream_being_edited,
                     topic_name if topic_name is not None else orig_topic_name,
-                    visibility_policy=new_visibility_policy,
+                    visibility_policy=visibility_policy,
                 )
 
     send_event(user_profile.realm, event, users_to_be_notified)

--- a/zerver/actions/user_topics.py
+++ b/zerver/actions/user_topics.py
@@ -1,15 +1,63 @@
 import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from django.utils.timezone import now as timezone_now
 
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.user_topics import (
+    bulk_set_user_topic_visibility_policy_in_database,
     get_topic_mutes,
-    set_user_topic_visibility_policy_in_database,
 )
 from zerver.models import Stream, UserProfile
 from zerver.tornado.django_api import send_event
+
+
+def bulk_do_set_user_topic_visibility_policy(
+    user_profiles: List[UserProfile],
+    stream: Stream,
+    topic: str,
+    *,
+    visibility_policy: int,
+    last_updated: Optional[datetime.datetime] = None,
+    skip_muted_topics_event: bool = False,
+) -> None:
+    if last_updated is None:
+        last_updated = timezone_now()
+
+    user_profiles_with_changed_user_topic_rows = bulk_set_user_topic_visibility_policy_in_database(
+        user_profiles,
+        stream.id,
+        topic,
+        visibility_policy=visibility_policy,
+        recipient_id=stream.recipient_id,
+        last_updated=last_updated,
+    )
+
+    # Users with requests to set the visibility_policy to its current value
+    # or to delete a UserTopic row that doesn't exist shouldn't
+    # send an unnecessary event.
+    if len(user_profiles_with_changed_user_topic_rows) == 0:
+        return
+
+    for user_profile in user_profiles_with_changed_user_topic_rows:
+        # This first muted_topics event is deprecated and will be removed
+        # once clients are migrated to handle the user_topic event type
+        # instead.
+        if not skip_muted_topics_event:
+            muted_topics_event = dict(
+                type="muted_topics", muted_topics=get_topic_mutes(user_profile)
+            )
+            send_event(user_profile.realm, muted_topics_event, [user_profile.id])
+
+        user_topic_event: Dict[str, Any] = {
+            "type": "user_topic",
+            "stream_id": stream.id,
+            "topic_name": topic,
+            "last_updated": datetime_to_timestamp(last_updated),
+            "visibility_policy": visibility_policy,
+        }
+
+        send_event(user_profile.realm, user_topic_event, [user_profile.id])
 
 
 def do_set_user_topic_visibility_policy(
@@ -21,37 +69,14 @@ def do_set_user_topic_visibility_policy(
     last_updated: Optional[datetime.datetime] = None,
     skip_muted_topics_event: bool = False,
 ) -> None:
-    if last_updated is None:
-        last_updated = timezone_now()
-
-    database_changed = set_user_topic_visibility_policy_in_database(
-        user_profile,
-        stream.id,
+    # For conciseness, this function should be used when a single
+    # user_profile is involved. In the case of multiple user profiles,
+    # call 'bulk_do_set_user_topic_visibility_policy' directly.
+    bulk_do_set_user_topic_visibility_policy(
+        [user_profile],
+        stream,
         topic,
         visibility_policy=visibility_policy,
-        recipient_id=stream.recipient_id,
         last_updated=last_updated,
+        skip_muted_topics_event=skip_muted_topics_event,
     )
-
-    # Requests to set the visibility_policy to its current value
-    # or to delete a UserTopic row that doesn't exist shouldn't
-    # send an unnecessary event.
-    if not database_changed:
-        return
-
-    # This first muted_topics event is deprecated and will be removed
-    # once clients are migrated to handle the user_topic event type
-    # instead.
-    if not skip_muted_topics_event:
-        muted_topics_event = dict(type="muted_topics", muted_topics=get_topic_mutes(user_profile))
-        send_event(user_profile.realm, muted_topics_event, [user_profile.id])
-
-    user_topic_event: Dict[str, Any] = {
-        "type": "user_topic",
-        "stream_id": stream.id,
-        "topic_name": topic,
-        "last_updated": datetime_to_timestamp(last_updated),
-        "visibility_policy": visibility_policy,
-    }
-
-    send_event(user_profile.realm, user_topic_event, [user_profile.id])

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -52,7 +52,7 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import DB_TOPIC_NAME, MESSAGE__TOPIC, TOPIC_LINKS, TOPIC_NAME
 from zerver.lib.types import DisplayRecipientT, EditHistoryEvent, UserDisplayRecipient
 from zerver.lib.url_preview.types import UrlEmbedData
-from zerver.lib.user_topics import build_topic_mute_checker, topic_is_muted
+from zerver.lib.user_topics import build_topic_mute_checker, topic_has_visibility_policy
 from zerver.models import (
     MAX_TOPIC_NAME_LENGTH,
     Message,
@@ -64,6 +64,7 @@ from zerver.models import (
     Subscription,
     UserMessage,
     UserProfile,
+    UserTopic,
     get_display_recipient_by_id,
     get_usermessage_by_message_id,
     query_for_ids,
@@ -1293,7 +1294,9 @@ def apply_unread_message_event(
         if (
             stream_id not in state["muted_stream_ids"]
             # This next check hits the database.
-            and not topic_is_muted(user_profile, stream_id, topic)
+            and not topic_has_visibility_policy(
+                user_profile, stream_id, topic, UserTopic.VisibilityPolicy.MUTED
+            )
         ):
             state["unmuted_stream_msgs"].add(message_id)
 

--- a/zerver/lib/user_topics.py
+++ b/zerver/lib/user_topics.py
@@ -239,11 +239,9 @@ def build_topic_mute_checker(user_profile: UserProfile) -> Callable[[int, str], 
     return is_muted
 
 
-def get_users_muting_topic(stream_id: int, topic_name: str) -> QuerySet[UserProfile]:
-    return UserProfile.objects.select_related("realm").filter(
-        id__in=UserTopic.objects.filter(
-            stream_id=stream_id,
-            visibility_policy=UserTopic.VisibilityPolicy.MUTED,
-            topic_name__iexact=topic_name,
-        ).values("user_profile_id")
-    )
+def get_users_with_user_topic_visibility_policy(
+    stream_id: int, topic_name: str
+) -> QuerySet[UserTopic]:
+    return UserTopic.objects.filter(
+        stream_id=stream_id, topic_name__iexact=topic_name
+    ).select_related("user_profile", "user_profile__realm")

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -1765,7 +1765,10 @@ class SingleUserExportTest(ExportFile):
             self.assertEqual(rec["status_text"], "on vacation")
 
         do_set_user_topic_visibility_policy(
-            cordelia, scotland, "bagpipe music", visibility_policy=UserTopic.VisibilityPolicy.MUTED
+            cordelia,
+            scotland,
+            "bagpipe music",
+            visibility_policy=UserTopic.VisibilityPolicy.MUTED,
         )
         do_set_user_topic_visibility_policy(
             othello, scotland, "nessie", visibility_policy=UserTopic.VisibilityPolicy.MUTED

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1357,9 +1357,9 @@ class EditMessageTest(EditMessageTestCase):
         users_to_be_notified = list(map(notify, [hamlet.id, cordelia.id, aaron.id]))
         change_all_topic_name = "Topic 1 edited"
 
-        # This code path adds 19 (10 + 4/user with muted topics + 1) to
+        # This code path adds 21 (10 + 5/user with muted topics + 1) to
         # the number of database queries for moving a topic.
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(21):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,
@@ -1453,7 +1453,7 @@ class EditMessageTest(EditMessageTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(30):
+        with self.assert_database_query_count(32):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -1484,7 +1484,7 @@ class EditMessageTest(EditMessageTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(31):
+        with self.assert_database_query_count(33):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -1517,7 +1517,7 @@ class EditMessageTest(EditMessageTestCase):
         set_topic_visibility_policy(desdemona, muted_topics, UserTopic.VisibilityPolicy.MUTED)
         set_topic_visibility_policy(cordelia, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
-        with self.assert_database_query_count(30):
+        with self.assert_database_query_count(32):
             check_update_message(
                 user_profile=desdemona,
                 message_id=message_id,
@@ -1630,7 +1630,7 @@ class EditMessageTest(EditMessageTestCase):
             users_to_be_notified_via_muted_topics_event.append(user_topic.user_profile_id)
 
         change_all_topic_name = "Topic 1 edited"
-        with self.assert_database_query_count(19):
+        with self.assert_database_query_count(21):
             check_update_message(
                 user_profile=hamlet,
                 message_id=message_id,

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1357,7 +1357,7 @@ class EditMessageTest(EditMessageTestCase):
         users_to_be_notified = list(map(notify, [hamlet.id, cordelia.id, aaron.id]))
         change_all_topic_name = "Topic 1 edited"
 
-        # This code path adds 9 (1 + 4/user with muted topics) + 1 to
+        # This code path adds 19 (10 + 4/user with muted topics + 1) to
         # the number of database queries for moving a topic.
         with self.assert_database_query_count(19):
             check_update_message(

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -46,7 +46,7 @@ from zerver.lib.topic import MATCH_TOPIC, RESOLVED_TOPIC_PREFIX, TOPIC_NAME
 from zerver.lib.types import DisplayRecipientT
 from zerver.lib.upload.base import create_attachment
 from zerver.lib.url_encoding import near_message_url
-from zerver.lib.user_topics import set_topic_mutes
+from zerver.lib.user_topics import set_topic_visibility_policy
 from zerver.models import (
     Attachment,
     Message,
@@ -54,6 +54,7 @@ from zerver.models import (
     Subscription,
     UserMessage,
     UserProfile,
+    UserTopic,
     get_display_recipient,
     get_realm,
     get_stream,
@@ -3132,7 +3133,7 @@ class GetOldMessagesTest(ZulipTestCase):
         muted_topics = [
             ["England", "muted"],
         ]
-        set_topic_mutes(hamlet, muted_topics)
+        set_topic_visibility_policy(hamlet, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
         # send a muted message
         muted_message_id = self.send_stream_message(cordelia, "England", topic_name="muted")
@@ -3399,7 +3400,7 @@ class GetOldMessagesTest(ZulipTestCase):
             ["web stuff", "css"],
             ["bogus", "bogus"],
         ]
-        set_topic_mutes(user_profile, muted_topics)
+        set_topic_visibility_policy(user_profile, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
         query_params = dict(
             anchor="first_unread",
@@ -3440,7 +3441,7 @@ class GetOldMessagesTest(ZulipTestCase):
         muted_topics = [
             ["irrelevant_stream", "irrelevant_topic"],
         ]
-        set_topic_mutes(user_profile, muted_topics)
+        set_topic_visibility_policy(user_profile, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
         # If nothing relevant is muted, then exclude_muting_conditions()
         # should return an empty list.
@@ -3462,7 +3463,7 @@ class GetOldMessagesTest(ZulipTestCase):
             ["Scotland", "golf"],
             ["web stuff", "css"],
         ]
-        set_topic_mutes(user_profile, muted_topics)
+        set_topic_visibility_policy(user_profile, muted_topics, UserTopic.VisibilityPolicy.MUTED)
 
         # And verify that our query will exclude them.
         narrow = [

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -9,7 +9,7 @@ from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.user_topics import (
     get_topic_mutes,
-    topic_is_muted,
+    topic_has_visibility_policy,
 )
 from zerver.models import UserProfile, UserTopic, get_stream
 
@@ -107,7 +107,11 @@ class MutedTopicsTests(ZulipTestCase):
                 self.assert_json_success(result)
 
             self.assertIn((stream.name, "Verona3", mock_date_muted), get_topic_mutes(user))
-            self.assertTrue(topic_is_muted(user, stream.id, "verona3"))
+            self.assertTrue(
+                topic_has_visibility_policy(
+                    user, stream.id, "verona3", UserTopic.VisibilityPolicy.MUTED
+                )
+            )
 
             do_set_user_topic_visibility_policy(
                 user,
@@ -162,7 +166,11 @@ class MutedTopicsTests(ZulipTestCase):
 
             self.assert_json_success(result)
             self.assertNotIn((stream.name, "Verona3", mock_date_muted), get_topic_mutes(user))
-            self.assertFalse(topic_is_muted(user, stream.id, "verona3"))
+            self.assertFalse(
+                topic_has_visibility_policy(
+                    user, stream.id, "verona3", UserTopic.VisibilityPolicy.MUTED
+                )
+            )
 
     def test_muted_topic_add_invalid(self) -> None:
         user = self.example_user("hamlet")


### PR DESCRIPTION
As discussed in #24236 [(comment)](https://github.com/zulip/zulip/pull/24236#discussion_r1117397531)

**The frst commit** updates the `do_update_message` codepath to update the UserTopic records regardless
of visibility policy during the "**move topic**" operation.

This is required before offering new visibility policies in the UI.

Currently, UserTopic records are moved or deleted only for objects with a MUTED visibility policy.

**The second commit** addresses the [TODO comment](https://github.com/zulip/zulip/blob/main/zerver/actions/message_edit.py#L769) to use bulk database operation instead of looping.

[CZO discussion](https://chat.zulip.org/#narrow/stream/3-backend/topic/Unmute.20Topics/near/1527100)

<!-- Describe your pull request here.-->

Fixes: #24574 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
---
To Do:
- [x] Include tests for -- users having UNMUTE visibility_policy during move-topic operation.
- [x] Address the [TODO comment](https://github.com/zulip/zulip/blob/main/zerver/actions/message_edit.py#L769) for bulk update.
- [x] Might have to rework on the current changes after addressing the TODO comment.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
