### PR TITLE
web: Remove inappropriate $ prefix from HTML variables

### DIFF
--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -234,7 +234,7 @@ function show_wildcard_warnings(stream_id) {
 
     const $compose_banner_area = $("#compose_banners");
     const classname = compose_banner.CLASSNAMES.wildcard_warning;
-    const $wildcard_template = render_wildcard_warning({
+    const wildcard_template = render_wildcard_warning({
         banner_type: compose_banner.WARNING,
         subscriber_count,
         stream_name: compose_state.stream_name(),
@@ -246,7 +246,7 @@ function show_wildcard_warnings(stream_id) {
 
     // only show one error for any number of @all or @everyone mentions
     if ($(`#compose_banners .${classname}`).length === 0) {
-        $compose_banner_area.append($wildcard_template);
+        $compose_banner_area.append(wildcard_template);
     }
 
     user_acknowledged_wildcard = false;

--- a/web/src/narrow_error.js
+++ b/web/src/narrow_error.js
@@ -5,6 +5,6 @@ export function narrow_error(narrow_banner_data) {
     const html = narrow_banner_data.html;
     const search_data = narrow_banner_data.search_data;
 
-    const $empty_feed_notice = render_empty_feed_notice({title, html, search_data});
-    return $empty_feed_notice;
+    const empty_feed_notice = render_empty_feed_notice({title, html, search_data});
+    return empty_feed_notice;
 }

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -122,11 +122,11 @@ function show_upload_banner(config, banner_type, banner_text) {
         get_item("upload_banner_message", config).text(banner_text);
         return;
     }
-    const $new_banner = render_upload_banner({
+    const new_banner = render_upload_banner({
         banner_type,
         banner_text,
     });
-    get_item("banner_container", config).append($new_banner);
+    get_item("banner_container", config).append(new_banner);
 }
 
 export function show_error_message(


### PR DESCRIPTION
Only jQuery object variables should be prefixed with `$`.