### PR TITLE
user groups: Minor fixes in CSS common to #groups and #streams overlay.

### DIFF
--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -201,6 +201,7 @@ export function initialize() {
         const template_data = {
             group_name: user_group.name,
             group_description: user_group.description,
+            max_user_group_name_length: user_group_settings_ui.max_user_group_name_length,
         };
         const change_user_group_info_modal = render_change_user_group_info_modal(template_data);
         dialog_widget.launch({

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -19,6 +19,11 @@ import * as user_groups from "./user_groups";
 
 let group_list_widget;
 
+// Ideally this should be included in page params.
+// Like we have page_params.max_stream_name_length` and
+// `page_params.max_stream_description_length` for streams.
+export const max_user_group_name_length = 100;
+
 export function set_up_click_handlers() {
     $("#groups_overlay").on("click", ".left #clear_search_group_name", (e) => {
         const $input = $("#groups_overlay .left #search_group_name");
@@ -177,6 +182,7 @@ export function setup_page(callback) {
     function populate_and_fill() {
         const template_data = {
             can_create_or_edit_user_groups: settings_data.user_can_edit_user_groups(),
+            max_user_group_name_length,
         };
 
         const rendered = render_user_group_settings_overlay(template_data);

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -47,6 +47,8 @@
     font-size: 1.375rem;
     font-weight: 600;
     line-height: 1.25;
+    overflow: hidden;
+    word-wrap: break-word;
 
     /* help_link_widget margin for the fa-circle-o. */
     .help_link_widget {

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -407,8 +407,9 @@ h4.user_group_setting_subsection_title {
                 display: none;
                 font-size: 1.5em;
                 line-height: 1;
-                margin: 9px 0;
+                margin: 9px;
                 font-weight: 600;
+                word-break: break-all;
 
                 .large-icon {
                     display: inline-block;
@@ -767,7 +768,7 @@ h4.user_group_setting_subsection_title {
         .button-group {
             padding-top: 5px;
             margin-left: auto;
-            margin-right: 15px;
+            margin-right: 18px;
 
             .subscribe-button,
             #preview-stream-button,
@@ -794,18 +795,23 @@ h4.user_group_setting_subsection_title {
             margin-left: -3px;
             margin-top: -5px;
             white-space: nowrap;
+            max-width: 90%;
+            flex: auto;
+            min-width: 0;
+            overflow-x: clip;
+            text-overflow: ellipsis;
 
             .group-name,
             .sub-stream-name {
                 display: block;
-                max-width: 100%;
+                width: 100%;
                 overflow: hidden;
                 text-overflow: ellipsis;
             }
         }
 
         .button-group {
-            margin-left: 1rem;
+            margin-left: auto;
 
             .deactivate {
                 margin-right: 3px;
@@ -843,7 +849,7 @@ h4.user_group_setting_subsection_title {
         .group_change_property_info,
         .stream_change_property_info {
             vertical-align: top;
-            margin: -5px 0 0;
+            margin: 0 5px 0 0;
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -788,7 +788,6 @@ h4.user_group_setting_subsection_title {
 
         .group-name-wrapper,
         .stream-name {
-            display: inline-block;
             position: relative;
             font-size: 1.5em;
             font-weight: 600;

--- a/web/templates/user_group_settings/change_user_group_info_modal.hbs
+++ b/web/templates/user_group_settings/change_user_group_info_modal.hbs
@@ -2,7 +2,7 @@
     <label for="change_user_group_name">
         {{t 'User group name' }}
     </label>
-    <input type="text" id="change_user_group_name" class="modal_text_input" value="{{ group_name }}" />
+    <input type="text" id="change_user_group_name" class="modal_text_input" value="{{ group_name }}" maxlength="{{max_user_group_name_length}}" />
 </div>
 <div>
     <label for="change_user_group_description">

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -9,7 +9,7 @@
                     {{t "User group name" }}
                 </label>
                 <input type="text" name="user_group_name" id="create_user_group_name" class="settings_text_input"
-                  placeholder="{{t 'User group name' }}" value="" autocomplete="off" />
+                  placeholder="{{t 'User group name' }}" value="" autocomplete="off" maxlength="{{ max_user_group_name_length }}"/>
                 <div id="user_group_name_error" class="user_group_creation_error"></div>
             </section>
             <section class="block">


### PR DESCRIPTION
This PR does following improvements in #streams and #groups overlay.
* Adds word break in the title in the right pane to handle long stream and group names.
* Handle long group/stream names in group/stream name edit dialog box header.
* Fix positioning of edit (pencil) button to the right end and provide maximum available space for stream/group name.

Follow-up for: #24514 (and edit for #24583, originally worked by @Ddharmani3).

<!-- Describe your pull request here.-->
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Long stream name title on right pane:
![image](https://user-images.githubusercontent.com/63504956/226007881-40b4ee64-068a-4d55-948b-6ef787c292c4.png)
Long group name title in right pane:
![image](https://user-images.githubusercontent.com/63504956/226009004-77ccc3e8-d4d2-4935-80c1-7774169a8a7e.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
