### PR TITLE
copy_message_button: Use `div` HTML tag instead of `button`.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -592,10 +592,18 @@ li,
 }
 
 .copy_message {
+    float: right;
     position: relative;
-    top: 27px;
-    left: -10px;
-    margin-top: -24px;
+    cursor: pointer;
+    top: 30px;
+    /* To make sure the svg doesn't occupy any vertical space. */
+    margin-top: -30px;
+    right: 2px;
+    padding-top: 2px;
+
+    #clipboard_image {
+        margin: 0;
+    }
 }
 
 #copy_generated_invite_link {

--- a/web/templates/copy_message_button.hbs
+++ b/web/templates/copy_message_button.hbs
@@ -1,3 +1,3 @@
-<button class="btn pull-right copy_button_base copy_message tippy-zulip-tooltip" data-tippy-content="{{t 'Copy and close' }}" aria-label="{{t 'Copy and close' }}" >
+<div class="copy_button_base copy_message tippy-zulip-tooltip" data-tippy-content="{{t 'Copy and close' }}" aria-label="{{t 'Copy and close' }}" role="button">
     {{> copy_to_clipboard_svg }}
-</button>
+</div>


### PR DESCRIPTION
For some reason, browser is treating clicking on the button as submitting the form, which results in the page getting redirected to the same page with an additional empty query `?` in the URL.

discussion: https://chat.zulip.org/#narrow/stream/49-development-help/topic/Copied!.20Tippy.20tooltip.20.2321036
