### PR TITLE
messages: Add spinner for messages sent on slow connections.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -290,6 +290,9 @@ export function send_message(request = create_message_object()) {
 
     if (locally_echoed) {
         clear_compose_box();
+        // Schedule a timer to display a spinner when the message is
+        // taking a longtime to send.
+        setTimeout(() => echo.display_slow_send_loading_spinner(message), 5000);
     }
 }
 

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -453,6 +453,17 @@ function abort_message(message) {
     }
 }
 
+export function display_slow_send_loading_spinner(message) {
+    const $row = $(`div[zid="${message.id}"]`);
+    if (message.locally_echoed && !message.failed_request) {
+        $row.find(".slow-send-spinner").removeClass("hidden");
+        // We don't need to do anything special to ensure this gets
+        // cleaned up if the message is delivered, because the
+        // message's HTML gets replaced once the message is
+        // successfully sent.
+    }
+}
+
 export function initialize() {
     function on_failed_action(selector, callback) {
         $("#main_div").on("click", selector, function (e) {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -220,8 +220,13 @@ export function initialize() {
             const $time_elem = $(instance.reference);
             const $row = $time_elem.closest(".message_row");
             const message = message_lists.current.get(rows.id($row));
+            // Don't show time tooltip for locally echoed message.
+            if (message.locally_echoed) {
+                return false;
+            }
             const time = new Date(message.timestamp * 1000);
             instance.setContent(timerender.get_full_datetime(time));
+            return true;
         },
         onHidden(instance) {
             instance.destroy();

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -97,6 +97,17 @@ $time_column_max_width: 150px;
             }
         }
 
+        .slow-send-spinner {
+            display: none;
+            justify-self: end;
+            margin-right: 10px;
+            text-align: end;
+            grid-row-start: 1;
+            grid-column-start: 4;
+            position: relative;
+            top: $distance_of_text_elements_from_message_box_top;
+        }
+
         .message_content {
             grid-row-start: 1;
             grid-column-start: 2;
@@ -159,6 +170,12 @@ $time_column_max_width: 150px;
                 margin-top: 1px;
             }
 
+            .slow-send-spinner {
+                align-self: center;
+                position: unset;
+                margin-top: 1px;
+            }
+
             .message_edit_notice {
                 align-self: center;
                 top: 2px;
@@ -203,6 +220,7 @@ $time_column_max_width: 150px;
 
                     & ~ .alert-msg,
                     & ~ .message_time,
+                    & ~ .slow-send-spinner,
                     & ~ .message_controls {
                         grid-row: 1 / 3;
                     }
@@ -264,5 +282,10 @@ $time_column_max_width: 150px;
     /* Locally echoed messages. */
     &.local .message_time {
         opacity: 0;
+    }
+
+    /* Show the spinner only for messages that are still locally echoed. */
+    &.local .slow-send-spinner {
+        display: unset !important;
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -929,6 +929,15 @@ td.pointer {
     }
 }
 
+.messagebox-content .slow-send-spinner {
+    display: block;
+    font-size: 12px;
+    text-align: right;
+    opacity: 0.6;
+    color: var(--color-default-text);
+    animation: rotate 1s infinite linear;
+}
+
 /* The way this overrides the menus with a background-color and a high
    z-index is kinda hacky, and requires some annoying color-matching,
    but it works. */

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -31,6 +31,10 @@
     {{timestr}}
 </a>
 
+{{#if msg/locally_echoed}}
+    <span class="fa fa-circle-o-notch slow-send-spinner hidden"></span>
+{{/if}}
+
 {{> message_controls}}
 
 {{#unless status_message}}


### PR DESCRIPTION
At times, it might get confusing for users who are on slow connections if their messages has not been sent even after 5s. Including a spinner that will only show up after 5 seconds has elapsed will keep user informed about their slow connection.

5s is set as minimum time because showing up a spinner before than might be distracting for users on normal connections.

Fixes: #19328.

`zid` has been used to identify the concerned message since it is unique to the message. Another approach we have is to pick the last element in the list. I think using `zid` is a better approach.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![slow](https://user-images.githubusercontent.com/101464851/226104528-e44c66d6-556b-4ebd-a7f4-7bc9f9239838.gif)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
