### PR TITLE
i18n: Fix email translations.

### DIFF
--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -205,6 +205,16 @@ class Realm(models.Model):
 To ensure we always internationalize our JSON error messages, the
 Zulip linter (`tools/lint`) attempts to verify correct usage.
 
+### Translations in emails
+
+Translations for strings containing links or other HTML elements in
+emails involve some extra technical complexity, because inlining CSS
+mutates those strings to insert `style=` attributes. See
+`inline_email_css.py` and the comment attached to
+`inline_strings_for_language` for details on this problem and how we
+solve it in a way that doesn't require manual effort either for
+developers or translators.
+
 ## Frontend translations
 
 We use the [FormatJS][] library for frontend translations when dealing

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -244,7 +244,11 @@ python_rules = RuleList(
         },
         {
             "pattern": "msgid|MSGID",
-            "exclude": {"tools/check-capitalization"},
+            "exclude": {
+                "tools/check-capitalization",
+                "zerver/management/commands/compilemessages.py",
+                "scripts/setup/inline_email_css.py",
+            },
             "description": 'Avoid using "msgid" as a variable name; use "message_id" instead.',
         },
         {


### PR DESCRIPTION
Сorrected translations for strings in emails that contained <a> tags. This issue arose because Transifex doesn't have inlined CSS, but inlining is necessary to properly display emails. As a result of inlining, there were differences in the strings.

To resolve this, I've identified all the strings that require inlining, inline them, and saved them in `.mo` files.