### PR TITLE
popovers: Fix tooltip partially hidden by recipient bar when selected.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1360,10 +1360,6 @@ td.pointer {
 }
 
 .selected_message {
-    .messagebox {
-        z-index: 1;
-    }
-
     .messagebox-content {
         box-shadow: inset 0 0 0 2px hsl(215, 47%, 50%),
             0 0 0 1px hsl(215, 47%, 50%);
@@ -1477,10 +1473,6 @@ div.message_table {
     position: relative;
     border-left: 1px solid hsla(0, 0%, 0%, 0.1);
     border-right: 1px solid hsla(0, 0%, 0%, 0.1);
-
-    &.selected_message {
-        z-index: 2;
-    }
 
     .date_row {
         /* We only want padding for the date rows between recipient blocks */


### PR DESCRIPTION
Previously, when a user view the message source of a message at the very top with the blue box around, the tooltip for the button will be partially hidden by the recipient bar. Since the z-index works as intented for messages without the blue box, this change will remove those styles when the message is selected with the blue box.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/62449508/226146568-733e6691-2a47-4af3-b886-7093e0eac326.png)
![image](https://user-images.githubusercontent.com/62449508/226146577-0515e021-d6e0-49cd-a468-e45eafd998c0.png)


</details>
<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/62449508/226146515-b10960bf-5603-444f-8381-175271720297.png)
![image](https://user-images.githubusercontent.com/62449508/226146599-86d58158-2a0f-4738-bace-25ef666b9e3c.png)

</details>



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
