### PR TITLE
Improvements to groups UI.

### DIFF
--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -253,24 +253,6 @@ export function is_editing_stream(desired_stream_id: number): boolean {
     return stream_id === desired_stream_id;
 }
 
-export function is_editing_group(desired_group_id: number): boolean {
-    const hash_components = window.location.hash.slice(1).split(/\//);
-
-    if (hash_components[0] !== "groups") {
-        return false;
-    }
-
-    if (!hash_components[2]) {
-        return false;
-    }
-
-    // if the string casted to a number is valid, and another component
-    // after exists then it's a stream name/id pair.
-    const group_id = Number.parseFloat(hash_components[1]);
-
-    return group_id === desired_group_id;
-}
-
 export function is_create_new_stream_narrow(): boolean {
     return window.location.hash === "#streams/new";
 }

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -857,8 +857,8 @@ export function dispatch_normal_event(event) {
                     }
                     break;
                 case "remove":
-                    user_group_edit.handle_deleted_group(event.group_id);
                     user_groups.remove(user_groups.get_user_group_from_id(event.group_id));
+                    user_group_edit.handle_deleted_group(event.group_id);
                     break;
                 case "add_members":
                     user_groups.add_members(event.group_id, event.user_ids);

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -862,11 +862,11 @@ export function dispatch_normal_event(event) {
                     break;
                 case "add_members":
                     user_groups.add_members(event.group_id, event.user_ids);
-                    user_group_edit.handle_member_edit_event(event.group_id);
+                    user_group_edit.handle_member_edit_event(event.group_id, event.user_ids);
                     break;
                 case "remove_members":
                     user_groups.remove_members(event.group_id, event.user_ids);
-                    user_group_edit.handle_member_edit_event(event.group_id);
+                    user_group_edit.handle_member_edit_event(event.group_id, event.user_ids);
                     break;
                 case "add_subgroups":
                     user_groups.add_subgroups(event.group_id, event.direct_subgroup_ids);

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -433,6 +433,21 @@ export function initialize() {
         target: "#user_info_popover .status-emoji",
         appendTo: () => document.body,
     });
+
+    delegate("body", {
+        /*
+            The tooltip for new user group button (+) icon button on #groups
+            overlay was not mounted correctly as its sibling element (search bar)
+            is inserted dynamically after handlebar got rendered. So we append the
+            tooltip element to the body itself with target as the + button.
+        */
+        target: "#groups_overlay .create_user_group_plus_button",
+        content: $t({
+            defaultMessage: "Create new user group",
+        }),
+        placement: "bottom",
+        appendTo: () => document.body,
+    });
 }
 
 export function show_copied_confirmation($copy_button, on_hide_callback, timeout_in_ms = 1000) {

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -163,10 +163,32 @@ export function setup_group_settings(node) {
     show_settings_for(node);
 }
 
+export function setup_group_list_tab_hash(tab_key_value) {
+    /*
+        We do not update the hash based on tab switches if
+        a group is currently being edited.
+    */
+    if (user_group_settings_ui.get_active_data().id !== undefined) {
+        return;
+    }
+
+    if (tab_key_value === "all-groups") {
+        browser_history.update("#groups/all");
+    } else if (tab_key_value === "your-groups") {
+        browser_history.update("#groups/your");
+    } else {
+        blueslip.debug(`Unknown tab_key_value: ${tab_key_value} for groups overlay.`);
+    }
+}
+
 function open_right_panel_empty() {
     $(".group-row.active").removeClass("active");
     user_group_settings_ui.show_user_group_settings_pane.nothing_selected();
-    browser_history.update("#groups");
+    const tab_key = $(".user-groups-container")
+        .find("div.ind-tab.selected")
+        .first()
+        .attr("data-tab-key");
+    setup_group_list_tab_hash(tab_key);
 }
 
 export function handle_deleted_group(group_id) {

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -89,7 +89,7 @@ function enable_group_edit_settings(group) {
         return;
     }
     const $edit_container = get_edit_container(group);
-    $edit_container.find("#open_group_info_modal").show();
+    $edit_container.find(".group-header .button-group").show();
     $edit_container.find(".member-list .actions").show();
     user_group_ui_updates.update_add_members_elements(group);
 }
@@ -99,7 +99,7 @@ function disable_group_edit_settings(group) {
         return;
     }
     const $edit_container = get_edit_container(group);
-    $edit_container.find("#open_group_info_modal").hide();
+    $edit_container.find(".group-header .button-group").hide();
     $edit_container.find(".member-list .actions").hide();
     user_group_ui_updates.update_add_members_elements(group);
 }

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -199,10 +199,14 @@ export function is_editing_group(desired_group_id) {
 }
 
 export function handle_deleted_group(group_id) {
-    if (!is_editing_group(group_id)) {
+    if (!overlays.groups_open()) {
         return;
     }
-    open_right_panel_empty();
+
+    if (is_editing_group(group_id)) {
+        open_right_panel_empty();
+    }
+    user_group_settings_ui.redraw_user_group_list();
 }
 
 export function open_group_edit_panel_for_row(group_row) {

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -128,8 +128,7 @@ export function update_settings_pane(group) {
     $edit_container.find(".group-description").text(group.description);
 }
 
-export function show_settings_for(node) {
-    const group = get_user_group_for_target(node);
+export function show_settings_for(group) {
     const html = render_user_group_settings({
         group,
         can_edit: can_edit(group.id),
@@ -146,7 +145,7 @@ export function show_settings_for(node) {
     show_membership_settings(group);
 }
 
-export function setup_group_settings(node) {
+export function setup_group_settings(group) {
     toggler = components.toggle({
         child_wants_focus: true,
         values: [
@@ -160,7 +159,7 @@ export function setup_group_settings(node) {
         },
     });
 
-    show_settings_for(node);
+    show_settings_for(group);
 }
 
 export function setup_group_list_tab_hash(tab_key_value) {
@@ -209,14 +208,17 @@ export function handle_deleted_group(group_id) {
     user_group_settings_ui.redraw_user_group_list();
 }
 
-export function open_group_edit_panel_for_row(group_row) {
-    const group = get_user_group_for_target(group_row);
-
+export function show_group_settings(group) {
     $(".group-row.active").removeClass("active");
     user_group_settings_ui.show_user_group_settings_pane.settings(group);
-    $(group_row).addClass("active");
+    user_group_settings_ui.row_for_group_id(group.id).addClass("active");
     setup_group_edit_hash(group);
-    setup_group_settings(group_row);
+    setup_group_settings(group);
+}
+
+export function open_group_edit_panel_for_row(group_row) {
+    const group = get_user_group_for_target(group_row);
+    show_group_settings(group);
 }
 
 export function initialize() {

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -85,7 +85,7 @@ function show_membership_settings(group) {
 }
 
 function enable_group_edit_settings(group) {
-    if (!hash_util.is_editing_group(group.id)) {
+    if (!is_editing_group(group.id)) {
         return;
     }
     const $edit_container = get_edit_container(group);
@@ -95,7 +95,7 @@ function enable_group_edit_settings(group) {
 }
 
 function disable_group_edit_settings(group) {
-    if (!hash_util.is_editing_group(group.id)) {
+    if (!is_editing_group(group.id)) {
         return;
     }
     const $edit_container = get_edit_container(group);
@@ -191,8 +191,15 @@ function open_right_panel_empty() {
     setup_group_list_tab_hash(tab_key);
 }
 
+export function is_editing_group(desired_group_id) {
+    if (!overlays.groups_open()) {
+        return false;
+    }
+    return user_group_settings_ui.get_active_data().id === desired_group_id;
+}
+
 export function handle_deleted_group(group_id) {
-    if (!hash_util.is_editing_group(group_id)) {
+    if (!is_editing_group(group_id)) {
         return;
     }
     open_right_panel_empty();

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -104,7 +104,7 @@ function disable_group_edit_settings(group) {
     user_group_ui_updates.update_add_members_elements(group);
 }
 
-export function handle_member_edit_event(group_id) {
+export function handle_member_edit_event(group_id, user_ids) {
     if (!overlays.groups_open()) {
         return;
     }
@@ -113,6 +113,31 @@ export function handle_member_edit_event(group_id) {
     // update members list.
     const members = [...group.members];
     user_group_edit_members.update_member_list_widget(group_id, members);
+
+    // update display of group-rows on left panel.
+    // We need this update only if your-groups tab is active
+    // and current user is among the affect users as in that
+    // case the group widget list need to be updated and show
+    // or remove the group-row on the left panel accordingly.
+    const tab_key = user_group_settings_ui.get_active_data().$tabs.first().attr("data-tab-key");
+    if (tab_key === "your-groups" && user_ids.includes(people.my_current_user_id())) {
+        user_group_settings_ui.redraw_user_group_list();
+    }
+
+    // update display of check-mark.
+    if (user_group_settings_ui.is_group_already_present(group)) {
+        const is_member = user_groups.is_user_in_group(group_id, people.my_current_user_id());
+        const $sub_unsub_button = user_group_settings_ui
+            .row_for_group_id(group_id)
+            .find(".sub_unsub_button");
+        if (is_member) {
+            $sub_unsub_button.removeClass("disabled");
+            $sub_unsub_button.addClass("checked");
+        } else {
+            $sub_unsub_button.removeClass("checked");
+            $sub_unsub_button.addClass("disabled");
+        }
+    }
 
     // update_settings buttons.
     if (can_edit(group_id)) {

--- a/web/src/user_group_edit_members.js
+++ b/web/src/user_group_edit_members.js
@@ -51,7 +51,7 @@ function format_member_list_elem(person) {
         user_id: person.user_id,
         is_current_user: person.user_id === page_params.user_id,
         email: person.delivery_email,
-        can_edit_subscribers: user_group_edit.can_edit(current_group_id),
+        can_remove_subscribers: user_group_edit.can_edit(current_group_id),
     });
 }
 

--- a/web/src/user_group_edit_members.js
+++ b/web/src/user_group_edit_members.js
@@ -8,7 +8,6 @@ import * as add_subscribers_pill from "./add_subscribers_pill";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
-import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as ListWidget from "./list_widget";
 import {page_params} from "./page_params";
@@ -37,7 +36,7 @@ function get_potential_members() {
 }
 
 export function update_member_list_widget(group_id, member_ids) {
-    if (!hash_util.is_editing_group(group_id)) {
+    if (!user_group_edit.is_editing_group(group_id)) {
         return;
     }
     const users = people.get_users_from_ids(member_ids);

--- a/web/src/user_group_ui_updates.js
+++ b/web/src/user_group_ui_updates.js
@@ -1,6 +1,5 @@
 import $ from "jquery";
 
-import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
 import * as stream_ui_updates from "./stream_ui_updates";
@@ -13,7 +12,7 @@ export function update_toggler_for_group_setting() {
 }
 
 export function update_add_members_elements(group) {
-    if (!hash_util.is_editing_group(group.id)) {
+    if (!user_group_edit.is_editing_group(group.id)) {
         return;
     }
 

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 
 import render_browse_user_groups_list_item from "../templates/user_group_settings/browse_user_groups_list_item.hbs";
-import render_user_group_settings from "../templates/user_group_settings/user_group_settings.hbs";
 import render_user_group_settings_overlay from "../templates/user_group_settings/user_group_settings_overlay.hbs";
 
 import * as blueslip from "./blueslip";
@@ -137,15 +136,7 @@ export function add_group_to_table(group) {
         return;
     }
 
-    const settings_html = render_user_group_settings({
-        group,
-        can_edit: user_group_edit.can_edit(group.id),
-    });
-
     redraw_user_group_list();
-    scroll_util
-        .get_content_element($("#groups_overlay_container .settings"))
-        .append($(settings_html));
 
     if (user_group_create.get_name() === group.name) {
         // This `user_group_create.get_name()` check tells us whether the

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -71,6 +71,9 @@ export const show_user_group_settings_pane = {
 };
 
 export function do_open_create_user_group() {
+    // Only call this directly for hash changes.
+    // Prefer open_create_user_group().
+    show_right_section();
     user_group_create.create_user_group_clicked();
 }
 

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -217,6 +217,7 @@ export function setup_page(callback) {
                     );
                 },
             },
+            init_sort: ["alphabetic", "name"],
             $simplebar_container: $container,
         });
 

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -50,21 +50,21 @@ export function set_up_click_handlers() {
 
 export const show_user_group_settings_pane = {
     nothing_selected() {
-        $(".settings, #user-group-creation").hide();
+        $("#groups_overlay .settings, #user-group-creation").hide();
         reset_active_group_id();
-        $(".nothing-selected").show();
+        $("#groups_overlay .nothing-selected").show();
         $("#groups_overlay .user-group-info-title").text(
             $t({defaultMessage: "User group settings"}),
         );
     },
     settings(group) {
-        $(".settings, #user-group-creation").hide();
+        $("#groups_overlay .nothing-selected, #user-group-creation").hide();
         $("#groups_overlay .settings").show();
         set_active_group_id(group.id);
         $("#groups_overlay .user-group-info-title").text(group.name);
     },
     create_user_group() {
-        $(".nothing-selected, .settings, #user-group-creation").hide();
+        $("#groups_overlay .nothing-selected, #groups_overlay .settings").hide();
         reset_active_group_id();
         $("#user-group-creation").show();
         $("#groups_overlay .user-group-info-title").text($t({defaultMessage: "Create user group"}));

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -179,6 +179,7 @@ export function update_group(group_id) {
 export function change_state(section) {
     if (section === "new") {
         do_open_create_user_group();
+        redraw_user_group_list();
         return;
     }
 
@@ -271,9 +272,15 @@ export function setup_page(callback) {
         $groups_overlay_container.append(rendered);
 
         const $container = $("#groups_overlay_container .user-groups-list");
-        const user_groups_list = user_groups.get_realm_user_groups();
 
-        group_list_widget = ListWidget.create($container, user_groups_list, {
+        /*
+            As change_state function called after this initial build up
+            redraws left panel based on active tab we avoid building extra dom
+            here as the required group-rows are anyway going to be created
+            immediately after this due to call to change_state. So we call
+            `ListWidget.create` with empty user groups list.
+        */
+        group_list_widget = ListWidget.create($container, [], {
             name: "user-groups-overlay",
             get_item: ListWidget.default_get_item,
             modifier_html(item) {

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -262,6 +262,10 @@ export function setup_page(callback) {
         $groups_overlay_container.empty();
         $groups_overlay_container.append(rendered);
 
+        // Initially as the overlay is build with empty right panel,
+        // active_group_id is undefined.
+        reset_active_group_id();
+
         const $container = $("#groups_overlay_container .user-groups-list");
 
         /*

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -207,7 +207,11 @@ function redraw_left_panel(tab_name) {
             user_groups.get_user_groups_of_user(people.my_current_user_id()),
         );
     }
-    // TODO: If possible persist selection of active group in the left panel.
+}
+
+export function redraw_user_group_list() {
+    const tab_name = get_active_data().$tabs.first().attr("data-tab-key");
+    redraw_left_panel(tab_name);
 }
 
 export function switch_group_tab(tab_name) {

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -129,19 +129,18 @@ export function add_group_to_table(group) {
         can_edit: user_group_edit.can_edit(group.id),
     });
 
-    group_list_widget.replace_list_data(user_groups.get_realm_user_groups());
+    redraw_user_group_list();
     scroll_util
         .get_content_element($("#groups_overlay_container .settings"))
         .append($(settings_html));
 
-    // TODO: Address issue for visibility of newely created group.
     if (user_group_create.get_name() === group.name) {
         // This `user_group_create.get_name()` check tells us whether the
         // group was just created in this browser window; it's a hack
         // to work around the server_events code flow not having a
         // good way to associate with this request because the group
         // ID isn't known yet.
-        row_for_group_id(group.id).trigger("click");
+        user_group_edit.show_group_settings(group);
         user_group_create.reset_name();
     }
 }

--- a/web/src/user_groups_settings_ui.js
+++ b/web/src/user_groups_settings_ui.js
@@ -97,16 +97,29 @@ export function get_active_data() {
     };
 }
 
-export function switch_to_group_row(group_id) {
-    const $group_row = row_for_group_id(group_id);
-    const $container = $(".user-groups-list");
+export function switch_to_group_row(group) {
+    if (is_group_already_present(group)) {
+        /*
+            It is possible that this function may be called at times
+            when group-row for concerned group may not be present this
+            might occur when user manually edits the url for a group
+            that user is not member of and #groups overlay is open with
+            your-groups tab active.
 
-    get_active_data().$row.removeClass("active");
-    $group_row.addClass("active");
+            To handle such cases we perform these steps only if the group
+            is listed in the left panel else we simply open the settings
+            for the concerned group.
+        */
+        const $group_row = row_for_group_id(group.id);
+        const $container = $(".user-groups-list");
 
-    scroll_util.scroll_element_into_container($group_row, $container);
+        get_active_data().$row.removeClass("active");
+        $group_row.addClass("active");
 
-    $group_row.trigger("click");
+        scroll_util.scroll_element_into_container($group_row, $container);
+    }
+
+    user_group_edit.show_group_settings(group);
 }
 
 function show_right_section() {
@@ -189,7 +202,11 @@ export function change_state(section) {
             group_list_toggler.goto("your-groups");
         } else {
             show_right_section();
-            switch_to_group_row(group_id);
+            // We show the list of user groups in the left panel
+            // based on the tab that is active. It is `your-groups`
+            // tab by default.
+            redraw_user_group_list();
+            switch_to_group_row(group);
         }
         return;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -896,6 +896,7 @@
     .stream-row,
     .group-row,
     .subscriptions-container .left .search-container,
+    .user-groups-container .left .search-container,
     .subscriptions-container .left,
     .user-groups-container .left,
     .subscriber-list-box,

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -96,12 +96,6 @@
     }
 }
 
-.create_user_group_button {
-    position: relative;
-    top: 7px;
-    margin: 0 7px 0 0;
-}
-
 #create_user_group_description,
 #create_stream_description {
     width: calc(100% - 15px);
@@ -483,15 +477,6 @@ h4.user_group_setting_subsection_title {
     -webkit-overflow-scrolling: touch;
     height: calc(100% - 85px);
     width: 100%;
-}
-
-.user-groups-list {
-    /*
-        This height rule is temporary for this preparatory commit and
-        will be removed as we add other components widgets in groups list
-        and its styling similar to streams list.
-    */
-    height: calc(100% - 42px) !important;
 }
 
 #clear_search_stream_name,

--- a/web/templates/user_group_settings/user_group_settings.hbs
+++ b/web/templates/user_group_settings/user_group_settings.hbs
@@ -2,7 +2,7 @@
     <div class="tab-container"></div>
     <div class="button-group">
         {{#if can_edit}}
-        <button class="button small rounded btn-danger deactivate" type="button" name="delete_button"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
+        <button class="button small rounded btn-danger deactivate tippy-zulip-tooltip" data-tippy-content="{{t 'Delete group'}}" type="button" name="delete_button"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
         {{/if}}
     </div>
 </div>

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -15,7 +15,7 @@
                     <button type="button" class="btn clear_search_button" id="clear_search_group_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
-                    <div id="add_new_user_group"  class="tippy-zulip-tooltip" data-tippy-content="{{t 'Create new user group' }}" data-tippy-placement="bottom">
+                    <div id="add_new_user_group">
                         <button class="create_user_group_button create_user_group_plus_button">
                             <span>+</span>
                         </button>

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -9,18 +9,20 @@
                 </div>
             </div>
             <div class="left">
-                <div class="input-append group_name_search_section" id="group_filter">
-                    <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
-                      placeholder="{{t 'Filter groups' }}" value=""/>
-                    <button type="button" class="btn clear_search_button" id="clear_search_group_name">
-                        <i class="fa fa-remove" aria-hidden="true"></i>
-                    </button>
+                <div class="search-container">
                     <div id="add_new_user_group">
                         <button class="create_user_group_button create_user_group_plus_button">
                             <span>+</span>
                         </button>
                         <div class="float-clear"></div>
                     </div>
+                </div>
+                <div class="input-append group_name_search_section" id="group_filter">
+                    <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
+                      placeholder="{{t 'Filter groups' }}" value=""/>
+                    <button type="button" class="btn clear_search_button" id="clear_search_group_name">
+                        <i class="fa fa-remove" aria-hidden="true"></i>
+                    </button>
                 </div>
                 <div class="user-groups-list" data-simplebar>
                 </div>


### PR DESCRIPTION
Implments changes suggested in #24443. Following changes are completed:

- [x] Tooltip on `+`.
- [x] Something is wrong with the Actions column in the Members tab.
- [x] Add a "Delete group" tooltip to the trash can button.
- [x] Alphabetize groups by name (ignoring capitalization) in the left sidebar.
- [x] Add "Your groups" / "All groups" tabs in the left panel, equivalent to "Subscribed" / "All streams" (This has some follow-ups that are being addressed.) 

Fixes: Partially addresses #24443.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
