### PR TITLE
portico: Use jQuery better to select the first integration.

### DIFF
--- a/web/src/portico/integrations.js
+++ b/web/src/portico/integrations.js
@@ -308,14 +308,7 @@ function toggle_categories_dropdown() {
 function integration_events() {
     $('#integration-search input[type="text"]').on("keypress", (e) => {
         if (e.key === "Enter" && e.target.value !== "") {
-            for (const integration_element of $(".integration-lozenges").children()) {
-                const $integration = $(integration_element).find(".integration-lozenge");
-
-                if ($integration.css("display") !== "none") {
-                    $integration.closest("a")[0].click();
-                    break;
-                }
-            }
+            $(".integration-lozenges .integration-lozenge:visible")[0]?.closest("a").click();
         }
     });
 


### PR DESCRIPTION
The `.integration-lozenges` children may contain
non-`.integration-lozenge` elements; if there were no matching integrations, attempting to fetch the css `display` property of those failed.

Switch to using jQuery to find the full set of visible lozenges directly; this does the right thing if there are no such elements.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
