### PR TITLE
narrow: Use dict to map operator to `by_*` method in `NarrowBuilder`.

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -256,6 +256,20 @@ class NarrowBuilder:
         self.msg_id_column = msg_id_column
         self.realm = realm
         self.is_web_public_query = is_web_public_query
+        self.by_method_map = {
+            "has": self.by_has,
+            "in": self.by_in,
+            "is": self.by_is,
+            "stream": self.by_stream,
+            "streams": self.by_streams,
+            "topic": self.by_topic,
+            "sender": self.by_sender,
+            "near": self.by_near,
+            "id": self.by_id,
+            "search": self.by_search,
+            "pm-with": self.by_pm_with,
+            "group-pm-with": self.by_group_pm_with,
+        }
 
     def add_term(self, query: Select, term: Dict[str, Any]) -> Select:
         """
@@ -278,9 +292,9 @@ class NarrowBuilder:
 
         negated = term.get("negated", False)
 
-        method_name = "by_" + operator.replace("-", "_")
-        method = getattr(self, method_name, None)
-        if method is None:
+        if operator in self.by_method_map:
+            method = self.by_method_map[operator]
+        else:
             raise BadNarrowOperatorError("unknown operator " + operator)
 
         if negated:


### PR DESCRIPTION
Updates the logic for identifying the method to use to extend the query for the given term from a narrow to use a dictionary that maps the operator string to the `by_*` method in the `NarrowBuilder` class.

Previously, the `by_*` method was determined by building a string based on the operator string and replacing dashes with underscores.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/378-api-design/topic/direct.20message.20search.20operators/near/1516515)

---

**Notes**:
- I went with adding the dict on the class instance in the `__init__` method, so that the method is bound to `self` and any changes to the method names immediately are reflected in the mapped values.
  - An alternative would be to create the dict as a constant in the `NarrowBuilder` class with strings that match the `by_*` methods, and to use `getattr` in `add_term` to get the method. If the method name was changed, automated tests would catch the broken mapped string.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
