### PR TITLE
Improve UI for lock icon in settings

### DIFF
--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -159,7 +159,6 @@ export function initialize() {
         show_user_group_settings_lock: settings_data.user_can_edit_user_groups(),
         show_uploaded_files_section: page_params.max_file_upload_size_mib > 0,
         show_emoji_settings_lock: !settings_data.user_can_add_custom_emoji(),
-            //!page_params.is_admin && page_params.realm_add_emoji_by_admins_only,
     });
     $("#settings_overlay_container").append(rendered_settings_overlay);
 }

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -155,9 +155,11 @@ export function initialize() {
         is_owner: page_params.is_owner,
         is_admin: page_params.is_admin,
         is_guest: page_params.is_guest,
+        show_bot_settings_lock: settings_bots.can_create_new_bots(),
+        show_user_group_settings_lock: settings_data.user_can_edit_user_groups(),
         show_uploaded_files_section: page_params.max_file_upload_size_mib > 0,
-        show_emoji_settings_lock:
-            !page_params.is_admin && page_params.realm_add_emoji_by_admins_only,
+        show_emoji_settings_lock: !settings_data.user_can_add_custom_emoji(),
+            //!page_params.is_admin && page_params.realm_add_emoji_by_admins_only,
     });
     $("#settings_overlay_container").append(rendered_settings_overlay);
 }

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -103,6 +103,9 @@
                     <li tabindex="0" data-section="user-groups-admin">
                         <i class="icon fa fa-group" aria-hidden="true"></i>
                         <div class="text">{{t "User groups" }}</div>
+                        {{#unless show_user_group_settings_lock}}
+                        <i class="locked fa fa-lock" title="{{t 'Only organization administrators can edit these settings.' }}"></i>
+                        {{/unless}}
                     </li>
                     {{/unless}}
                     {{#unless is_guest}}
@@ -127,7 +130,7 @@
                     <li tabindex="0" data-section="bot-list-admin">
                         <i class="icon fa fa-github" aria-hidden="true"></i>
                         <div class="text">{{t "Bots" }}</div>
-                        {{#unless is_admin}}
+                        {{#unless show_bot_settings_lock}}
                         <i class="locked fa fa-lock" title="{{t 'Only organization administrators can edit these settings.' }}"></i>
                         {{/unless}}
                     </li>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
The PR fixes the lock icon for User Groups, Add Emoji, and Bots in the organization settings overlay. I've added two new variables for user groups(show_user_group_settings_lock) and bots(show_bot_settings_lock) and assigned them values based on already defined functions for the same. And I've updated the emoji(show_emoji_settings_lock) variable and assigned it a relevant function value in the settings.js file.

Fixes: <!-- Issue link, or clear description.--> #24393 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Screenshots:

- Example 1: Owner sets the Org Permissions to allow only bots editing for normal users. (Note: the Result section is a screenshot from a 'Normal user' profile and the Setting section is from an 'Owner' profile)

Setting: 
<img width="1440" alt="only bots -setting" src="https://user-images.githubusercontent.com/39451634/229292791-cb4f5c0b-05a3-45d3-8d53-59165f0e097b.png">

Result: 
<img width="1440" alt="preview1" src="https://user-images.githubusercontent.com/39451634/229292795-dadf9a0f-86e5-41c9-89a1-3f7354ab19d4.png">



- Example 2: Owner allows all three permissions for all users, i.e. Bots, Custom Emoji and User Groups.

Setting: 
<img width="1440" alt="allow all - setting" src="https://user-images.githubusercontent.com/39451634/229292797-96d24a3b-f96f-4273-b58c-384be2cb9053.png">

Result: 
<img width="1440" alt="preview2" src="https://user-images.githubusercontent.com/39451634/229292803-e5e0bbdb-8f84-41a0-8602-49a668cb3926.png">




Screen Capture:

In the recording first I allow a normal user to be able to edit only user groups and bots and then I reverse the situation. Also, it might look like when there is a lock on custom emoji we still see the add new emoji button, but that button does not work, and an insufficient privileges error is thrown.

[https://drive.google.com/file/d/1h0qUGXmebAk5ldfkSPk_LrAi6ZNRB4QW/view?usp=sharing](url)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
