### PR TITLE
ts : Convert src/user_group_pill.js to typescript

### DIFF
--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -78,3 +78,18 @@ export type AjaxRequestHandler = (args: {
     success?(response_data: unknown, textStatus: string, jqXHR: JQuery.jqXHR): void;
     error?(xhr: JQuery.jqXHR, error_type: string, xhn: string): void;
 }) => void;
+
+// TODO/typescript: export type to user_group_pill
+export type PillItem = {
+    type: string;
+    id: number;
+    display_value: string;
+    group_name: string;
+};
+
+// TODO/typescript: export type to input_pill_create
+export type PillWidget = {
+    appendValidatedData: (item: PillItem) => void;
+    clear_text: () => void;
+    items: () => PillItem[];
+};

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -1,10 +1,15 @@
+import type {PillItem, PillWidget} from "./types";
 import * as user_groups from "./user_groups";
+import type {UserGroup} from "./user_groups";
 
-function display_pill(group) {
-    return group.name + ": " + group.members.size + " users";
+function display_pill(group: UserGroup): string {
+    return `${group.name}: ${group.members.size} users`;
 }
 
-export function create_item_from_group_name(group_name, current_items) {
+export function create_item_from_group_name(
+    group_name: string,
+    current_items: PillItem[],
+): PillItem | undefined {
     group_name = group_name.trim();
     const group = user_groups.get_user_group_from_name(group_name);
     if (!group) {
@@ -16,7 +21,7 @@ export function create_item_from_group_name(group_name, current_items) {
         return undefined;
     }
 
-    const item = {
+    const item: PillItem = {
         type: "user_group",
         display_value: display_pill(group),
         id: group.id,
@@ -26,18 +31,18 @@ export function create_item_from_group_name(group_name, current_items) {
     return item;
 }
 
-export function get_group_name_from_item(item) {
+export function get_group_name_from_item(item: PillItem): string {
     return item.group_name;
 }
 
-function get_user_ids_from_user_groups(items) {
+function get_user_ids_from_user_groups(items: PillItem[]): number[] {
     const group_ids = items.map((item) => item.id).filter(Boolean);
     return group_ids.flatMap((group_id) => [
         ...user_groups.get_user_group_from_id(group_id).members,
     ]);
 }
 
-export function get_user_ids(pill_widget) {
+export function get_user_ids(pill_widget: {items: () => PillItem[]}): number[] {
     const items = pill_widget.items();
     let user_ids = get_user_ids_from_user_groups(items);
     user_ids = [...new Set(user_ids)];
@@ -47,18 +52,19 @@ export function get_user_ids(pill_widget) {
     return user_ids;
 }
 
-export function append_user_group(group, pill_widget) {
+export function append_user_group(group: UserGroup, pill_widget: PillWidget): void {
     if (group !== undefined && group !== null) {
         pill_widget.appendValidatedData({
             type: "user_group",
             display_value: display_pill(group),
             id: group.id,
+            group_name: "",
         });
         pill_widget.clear_text();
     }
 }
 
-export function get_group_ids(pill_widget) {
+export function get_group_ids(pill_widget: PillWidget): number[] {
     const items = pill_widget.items();
     let group_ids = items.map((item) => item.id);
     group_ids = group_ids.filter(Boolean);
@@ -66,13 +72,13 @@ export function get_group_ids(pill_widget) {
     return group_ids;
 }
 
-export function filter_taken_groups(items, pill_widget) {
+export function filter_taken_groups(items: UserGroup[], pill_widget: PillWidget): UserGroup[] {
     const taken_group_ids = get_group_ids(pill_widget);
     items = items.filter((item) => !taken_group_ids.includes(item.id));
     return items;
 }
 
-export function typeahead_source(pill_widget) {
+export function typeahead_source(pill_widget: PillWidget): UserGroup[] {
     const groups = user_groups.get_realm_user_groups();
     return filter_taken_groups(groups, pill_widget);
 }

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -4,7 +4,7 @@ import * as group_permission_settings from "./group_permission_settings";
 import * as settings_config from "./settings_config";
 import type {User, UserGroupUpdateEvent} from "./types";
 
-type UserGroup = {
+export type UserGroup = {
     description: string;
     id: number;
     name: string;


### PR DESCRIPTION
This PR converts `src/user_group_pill` to typescript.

To make the migration successful, it was necessarily to first define the types of the `user_group` object  defined as `type UserGroup` which is imported from `src/user_group` to enhance maximum type safety. 

In addition to that, return types of all functions in the module have been typed correctly.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
