### PR TITLE
popover_migration: Migrate stream_popovers to Tippy.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -402,11 +402,6 @@ function handle_popover_events(event_name) {
         return true;
     }
 
-    if (stream_popover.all_messages_popped()) {
-        stream_popover.all_messages_sidebar_menu_handle_keyboard(event_name);
-        return true;
-    }
-
     return false;
 }
 

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -367,11 +367,6 @@ function handle_popover_events(event_name) {
         return true;
     }
 
-    if (popover_menus.actions_popped()) {
-        popovers.actions_menu_handle_keyboard(event_name);
-        return true;
-    }
-
     if (popovers.user_info_manage_menu_popped()) {
         popovers.user_info_popover_manage_menu_handle_keyboard(event_name);
         return true;

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -372,11 +372,6 @@ function handle_popover_events(event_name) {
         return true;
     }
 
-    if (popover_menus.is_starred_messages_visible()) {
-        popover_menus.starred_messages_sidebar_menu_handle_keyboard(event_name);
-        return true;
-    }
-
     if (popovers.user_info_manage_menu_popped()) {
         popovers.user_info_popover_manage_menu_handle_keyboard(event_name);
         return true;

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -357,6 +357,16 @@ export function process_escape_key(e) {
 }
 
 function handle_popover_events(event_name) {
+    const popover_menu_visible_instance = popover_menus.get_visible_instance();
+
+    if (popover_menu_visible_instance) {
+        popover_menus.sidebar_menu_instance_handle_keyboard(
+            popover_menu_visible_instance,
+            event_name,
+        );
+        return true;
+    }
+
     if (popover_menus.actions_popped()) {
         popovers.actions_menu_handle_keyboard(event_name);
         return true;

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -9,6 +9,7 @@ import tippy, {delegate} from "tippy.js";
 import render_actions_popover_content from "../templates/actions_popover_content.hbs";
 import render_compose_control_buttons_popover from "../templates/compose_control_buttons_popover.hbs";
 import render_compose_select_enter_behaviour_popover from "../templates/compose_select_enter_behaviour_popover.hbs";
+import render_drafts_sidebar_actions from "../templates/drafts_sidebar_action.hbs";
 import render_left_sidebar_stream_setting_popover from "../templates/left_sidebar_stream_setting_popover.hbs";
 import render_mobile_message_buttons_popover_content from "../templates/mobile_message_buttons_popover_content.hbs";
 import render_starred_messages_sidebar_actions from "../templates/starred_messages_sidebar_actions.hbs";
@@ -18,6 +19,7 @@ import * as channel from "./channel";
 import * as common from "./common";
 import * as compose_actions from "./compose_actions";
 import * as condense from "./condense";
+import * as drafts from "./drafts";
 import * as emoji_picker from "./emoji_picker";
 import * as giphy from "./giphy";
 import {$t} from "./i18n";
@@ -48,6 +50,7 @@ let compose_control_buttons_popover_instance;
 const popover_instances = {
     compose_control_buttons: null,
     starred_messages: null,
+    drafts: null,
 };
 
 export function sidebar_menu_instance_handle_keyboard(instance, key) {
@@ -95,6 +98,8 @@ const default_popover_props = {
        is a popover styling similar to Bootstrap.  We've also customized
        its CSS to support Zulip's dark theme. */
     theme: "light-border",
+    // The maxWidth has been set to "none" to avoid the default value of 300px.
+    maxWidth: "none",
     touch: true,
     /* Don't use allow-HTML here since it is unsafe. Instead, use `parse_html`
        to generate the required html */
@@ -533,6 +538,30 @@ export function initialize() {
         onHidden(instance) {
             instance.destroy();
             popover_instances.starred_messages = undefined;
+        },
+    });
+
+    // Drafts popover
+    tippy_no_propagation(".drafts-sidebar-menu-icon", {
+        ...left_sidebar_tippy_options,
+        onMount(instance) {
+            const $popper = $(instance.popper);
+            $popper.addClass("drafts-popover");
+            popover_instances.drafts = instance;
+
+            $popper.one("click", "#delete_all_drafts_sidebar", () => {
+                drafts.confirm_delete_all_drafts();
+                instance.hide();
+            });
+        },
+        onShow(instance) {
+            popovers.hide_all_except_sidebars();
+
+            instance.setContent(parse_html(render_drafts_sidebar_actions({})));
+        },
+        onHidden(instance) {
+            instance.destroy();
+            popover_instances.drafts = undefined;
         },
     });
 }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -40,7 +40,6 @@ import {parse_html} from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
 
-let compose_mobile_button_popover_displayed = false;
 export let compose_enter_sends_popover_displayed = false;
 let message_actions_popover_keyboard_toggle = false;
 
@@ -53,6 +52,7 @@ const popover_instances = {
     all_messages: null,
     message_actions: null,
     stream_settings: null,
+    compose_mobile_button: null,
 };
 
 export function sidebar_menu_instance_handle_keyboard(instance, key) {
@@ -119,7 +119,6 @@ const left_sidebar_tippy_options = {
 
 export function any_active() {
     return (
-        compose_mobile_button_popover_displayed ||
         compose_control_buttons_popover_instance ||
         compose_enter_sends_popover_displayed ||
         get_visible_instance()
@@ -222,6 +221,7 @@ export function initialize() {
         target: ".compose_mobile_button",
         placement: "top",
         onShow(instance) {
+            popover_instances.compose_mobile_button = instance;
             on_show_prep(instance);
             instance.setContent(
                 parse_html(
@@ -230,7 +230,6 @@ export function initialize() {
                     }),
                 ),
             );
-            compose_mobile_button_popover_displayed = true;
         },
         onMount(instance) {
             const $popper = $(instance.popper);
@@ -249,7 +248,7 @@ export function initialize() {
             // Destroy instance so that event handlers
             // are destroyed too.
             instance.destroy();
-            compose_mobile_button_popover_displayed = false;
+            popover_instances.compose_control_button = undefined;
         },
     });
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -40,7 +40,6 @@ import {parse_html} from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
 
-let left_sidebar_stream_setting_popover_displayed = false;
 let compose_mobile_button_popover_displayed = false;
 export let compose_enter_sends_popover_displayed = false;
 let message_actions_popover_keyboard_toggle = false;
@@ -53,6 +52,7 @@ const popover_instances = {
     drafts: null,
     all_messages: null,
     message_actions: null,
+    stream_settings: null,
 };
 
 export function sidebar_menu_instance_handle_keyboard(instance, key) {
@@ -119,7 +119,6 @@ const left_sidebar_tippy_options = {
 
 export function any_active() {
     return (
-        left_sidebar_stream_setting_popover_displayed ||
         compose_mobile_button_popover_displayed ||
         compose_control_buttons_popover_instance ||
         compose_enter_sends_popover_displayed ||
@@ -191,6 +190,7 @@ export function toggle_message_actions_menu(message) {
 export function initialize() {
     tippy_no_propagation("#streams_inline_icon", {
         onShow(instance) {
+            popover_instances.stream_settings = instance;
             const can_create_streams =
                 settings_data.user_can_create_private_streams() ||
                 settings_data.user_can_create_public_streams() ||
@@ -206,12 +206,11 @@ export function initialize() {
             }
 
             instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
-            left_sidebar_stream_setting_popover_displayed = true;
             return true;
         },
         onHidden(instance) {
             instance.destroy();
-            left_sidebar_stream_setting_popover_displayed = false;
+            popover_instances.stream_settings = undefined;
         },
     });
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -96,6 +96,20 @@ const default_popover_props = {
        to generate the required html */
 };
 
+const left_sidebar_tippy_options = {
+    placement: "right",
+    popperOptions: {
+        modifiers: [
+            {
+                name: "flip",
+                options: {
+                    fallbackPlacements: "bottom",
+                },
+            },
+        ],
+    },
+};
+
 export function any_active() {
     return (
         left_sidebar_stream_setting_popover_displayed ||
@@ -478,24 +492,7 @@ export function initialize() {
 
     // Starred messages popover
     tippy_no_propagation(".starred-messages-sidebar-menu-icon", {
-        placement: "right",
-        maxWidth: "none",
-        popperOptions: {
-            modifiers: [
-                {
-                    name: "flip",
-                    options: {
-                        fallbackPlacements: "bottom",
-                    },
-                },
-                {
-                    name: "preventOverflow",
-                    options: {
-                        padding: 40,
-                    },
-                },
-            ],
-        },
+        ...left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);
             starred_messages_popover_instance = instance;

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -7,6 +7,7 @@ import $ from "jquery";
 import tippy, {delegate} from "tippy.js";
 
 import render_actions_popover_content from "../templates/actions_popover_content.hbs";
+import render_all_messages_sidebar_actions from "../templates/all_messages_sidebar_actions.hbs";
 import render_compose_control_buttons_popover from "../templates/compose_control_buttons_popover.hbs";
 import render_compose_select_enter_behaviour_popover from "../templates/compose_select_enter_behaviour_popover.hbs";
 import render_drafts_sidebar_actions from "../templates/drafts_sidebar_action.hbs";
@@ -51,6 +52,7 @@ const popover_instances = {
     compose_control_buttons: null,
     starred_messages: null,
     drafts: null,
+    all_messages: null,
 };
 
 export function sidebar_menu_instance_handle_keyboard(instance, key) {
@@ -562,6 +564,29 @@ export function initialize() {
         onHidden(instance) {
             instance.destroy();
             popover_instances.drafts = undefined;
+        },
+    });
+
+    // All messages popover
+    tippy_no_propagation(".all-messages-sidebar-menu-icon", {
+        ...left_sidebar_tippy_options,
+        onMount(instance) {
+            const $popper = $(instance.popper);
+            $popper.addClass("all-messages-popover");
+            popover_instances.all_messages = instance;
+
+            $popper.one("click", "#mark_all_messages_as_read", () => {
+                unread_ops.confirm_mark_all_as_read();
+                instance.hide();
+            });
+        },
+        onShow(instance) {
+            popovers.hide_all_except_sidebars();
+            instance.setContent(parse_html(render_all_messages_sidebar_actions()));
+        },
+        onHidden(instance) {
+            instance.destroy();
+            popover_instances.all_messages = undefined;
         },
     });
 }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -43,7 +43,6 @@ import {user_settings} from "./user_settings";
 let left_sidebar_stream_setting_popover_displayed = false;
 let compose_mobile_button_popover_displayed = false;
 export let compose_enter_sends_popover_displayed = false;
-let message_actions_popover_displayed = false;
 let message_actions_popover_keyboard_toggle = false;
 
 let compose_control_buttons_popover_instance;
@@ -53,6 +52,7 @@ const popover_instances = {
     starred_messages: null,
     drafts: null,
     all_messages: null,
+    message_actions: null,
 };
 
 export function sidebar_menu_instance_handle_keyboard(instance, key) {
@@ -62,10 +62,6 @@ export function sidebar_menu_instance_handle_keyboard(instance, key) {
 
 export function get_visible_instance() {
     return Object.values(popover_instances).find(Boolean);
-}
-
-export function actions_popped() {
-    return message_actions_popover_displayed;
 }
 
 export function get_compose_control_buttons_popover() {
@@ -127,7 +123,6 @@ export function any_active() {
         compose_mobile_button_popover_displayed ||
         compose_control_buttons_popover_instance ||
         compose_enter_sends_popover_displayed ||
-        message_actions_popover_displayed ||
         get_visible_instance()
     );
 }
@@ -349,13 +344,13 @@ export function initialize() {
             const args = popover_menus_data.get_actions_popover_content_context(message_id);
             instance.setContent(parse_html(render_actions_popover_content(args)));
             $row.addClass("has_popover has_actions_popover");
-            message_actions_popover_displayed = true;
         },
         onMount(instance) {
             if (message_actions_popover_keyboard_toggle) {
                 popovers.focus_first_action_popover_item();
+                message_actions_popover_keyboard_toggle = false;
             }
-            message_actions_popover_keyboard_toggle = false;
+            popover_instances.message_actions = instance;
 
             // We want click events to propagate to `instance` so that
             // instance.hide gets called.
@@ -496,7 +491,7 @@ export function initialize() {
             const $row = $(instance.reference).closest(".message_row");
             $row.removeClass("has_popover has_actions_popover");
             instance.destroy();
-            message_actions_popover_displayed = false;
+            popover_instances.message_actions = undefined;
             message_actions_popover_keyboard_toggle = false;
         },
     });

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -46,6 +46,20 @@ let message_actions_popover_keyboard_toggle = false;
 let compose_control_buttons_popover_instance;
 let starred_messages_popover_instance;
 
+const popover_instances = {
+    compose_control_buttons: null,
+    starred_messages: null,
+};
+
+export function sidebar_menu_instance_handle_keyboard(instance, key) {
+    const items = get_popover_items_for_instance(instance);
+    popovers.popover_items_handle_keyboard(key, items);
+}
+
+export function get_visible_instance() {
+    return Object.values(popover_instances).find(Boolean);
+}
+
 export function actions_popped() {
     return message_actions_popover_displayed;
 }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -40,7 +40,6 @@ import {parse_html} from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
 
-export let compose_enter_sends_popover_displayed = false;
 let message_actions_popover_keyboard_toggle = false;
 
 const popover_instances = {
@@ -51,6 +50,7 @@ const popover_instances = {
     message_actions: null,
     stream_settings: null,
     compose_mobile_button: null,
+    compose_enter_sends: null,
 };
 
 export function sidebar_menu_instance_handle_keyboard(instance, key) {
@@ -68,6 +68,10 @@ export function get_compose_control_buttons_popover() {
 
 export function get_starred_messages_popover() {
     return popover_instances.starred_messages;
+}
+
+export function is_compose_enter_sends_popover_displayed() {
+    return popover_instances.compose_enter_sends?.state.isVisible;
 }
 
 function get_popover_items_for_instance(instance) {
@@ -116,7 +120,7 @@ const left_sidebar_tippy_options = {
 };
 
 export function any_active() {
-    return compose_enter_sends_popover_displayed || get_visible_instance();
+    return Boolean(get_visible_instance());
 }
 
 function on_show_prep(instance) {
@@ -279,9 +283,9 @@ export function initialize() {
                     }),
                 ),
             );
-            compose_enter_sends_popover_displayed = true;
         },
         onMount(instance) {
+            popover_instances.compose_enter_sends = instance;
             common.adjust_mac_kbd_tags(".enter_sends_choices kbd");
 
             $(instance.popper).one("click", ".enter_sends_choice", (e) => {
@@ -307,7 +311,7 @@ export function initialize() {
         },
         onHidden(instance) {
             instance.destroy();
-            compose_enter_sends_popover_displayed = false;
+            popover_instances.compose_enter_sends = undefined;
         },
     });
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -43,8 +43,6 @@ import {user_settings} from "./user_settings";
 export let compose_enter_sends_popover_displayed = false;
 let message_actions_popover_keyboard_toggle = false;
 
-let compose_control_buttons_popover_instance;
-
 const popover_instances = {
     compose_control_buttons: null,
     starred_messages: null,
@@ -65,7 +63,7 @@ export function get_visible_instance() {
 }
 
 export function get_compose_control_buttons_popover() {
-    return compose_control_buttons_popover_instance;
+    return popover_instances.compose_control_buttons;
 }
 
 export function get_starred_messages_popover() {
@@ -118,11 +116,7 @@ const left_sidebar_tippy_options = {
 };
 
 export function any_active() {
-    return (
-        compose_control_buttons_popover_instance ||
-        compose_enter_sends_popover_displayed ||
-        get_visible_instance()
-    );
+    return compose_enter_sends_popover_displayed || get_visible_instance();
 }
 
 function on_show_prep(instance) {
@@ -265,12 +259,12 @@ export function initialize() {
                     }),
                 ),
             );
-            compose_control_buttons_popover_instance = instance;
+            popover_instances.compose_control_buttons = instance;
             popovers.hide_all_except_sidebars();
         },
         onHidden(instance) {
             instance.destroy();
-            compose_control_buttons_popover_instance = undefined;
+            popover_instances.compose_control_buttons = undefined;
         },
     });
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -44,7 +44,6 @@ let message_actions_popover_displayed = false;
 let message_actions_popover_keyboard_toggle = false;
 
 let compose_control_buttons_popover_instance;
-let starred_messages_popover_instance;
 
 const popover_instances = {
     compose_control_buttons: null,
@@ -64,16 +63,12 @@ export function actions_popped() {
     return message_actions_popover_displayed;
 }
 
-export function is_starred_messages_visible() {
-    return starred_messages_popover_instance?.state.isVisible;
-}
-
 export function get_compose_control_buttons_popover() {
     return compose_control_buttons_popover_instance;
 }
 
 export function get_starred_messages_popover() {
-    return starred_messages_popover_instance;
+    return popover_instances.starred_messages;
 }
 
 function get_popover_items_for_instance(instance) {
@@ -88,11 +83,6 @@ function get_popover_items_for_instance(instance) {
     }
 
     return $current_elem.find("li:not(.divider):visible a");
-}
-
-export function starred_messages_sidebar_menu_handle_keyboard(key) {
-    const items = get_popover_items_for_instance(starred_messages_popover_instance);
-    popovers.popover_items_handle_keyboard(key, items);
 }
 
 const default_popover_props = {
@@ -131,7 +121,7 @@ export function any_active() {
         compose_control_buttons_popover_instance ||
         compose_enter_sends_popover_displayed ||
         message_actions_popover_displayed ||
-        is_starred_messages_visible()
+        get_visible_instance()
     );
 }
 
@@ -509,7 +499,7 @@ export function initialize() {
         ...left_sidebar_tippy_options,
         onMount(instance) {
             const $popper = $(instance.popper);
-            starred_messages_popover_instance = instance;
+            popover_instances.starred_messages = instance;
 
             $popper.one("click", "#unstar_all_messages", () => {
                 starred_messages_ui.confirm_unstar_all_messages();
@@ -542,7 +532,7 @@ export function initialize() {
         },
         onHidden(instance) {
             instance.destroy();
-            starred_messages_popover_instance = undefined;
+            popover_instances.starred_messages = undefined;
         },
     });
 }

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1141,7 +1141,6 @@ export function hide_all_except_sidebars(opts) {
     giphy.hide_giphy_popover();
     stream_popover.hide_stream_popover();
     stream_popover.hide_topic_popover();
-    stream_popover.hide_all_messages_popover();
     hide_all_user_info_popovers();
     hide_playground_links_popover();
 

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -558,11 +558,6 @@ export function focus_first_action_popover_item() {
     focus_first_popover_item($items);
 }
 
-export function actions_menu_handle_keyboard(key) {
-    const $items = get_action_menu_menu_items();
-    popover_items_handle_keyboard(key, $items);
-}
-
 export function message_info_popped() {
     return $current_message_info_popover_elem !== undefined;
 }

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1142,7 +1142,6 @@ export function hide_all_except_sidebars(opts) {
     stream_popover.hide_stream_popover();
     stream_popover.hide_topic_popover();
     stream_popover.hide_all_messages_popover();
-    stream_popover.hide_drafts_popover();
     hide_all_user_info_popovers();
     hide_playground_links_popover();
 

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -4,7 +4,6 @@ import $ from "jquery";
 import * as resolved_topic from "../shared/src/resolved_topic";
 import render_all_messages_sidebar_actions from "../templates/all_messages_sidebar_actions.hbs";
 import render_delete_topic_modal from "../templates/confirm_dialog/confirm_delete_topic.hbs";
-import render_drafts_sidebar_actions from "../templates/drafts_sidebar_action.hbs";
 import render_move_topic_to_stream from "../templates/move_topic_to_stream.hbs";
 import render_stream_sidebar_actions from "../templates/stream_sidebar_actions.hbs";
 import render_topic_sidebar_actions from "../templates/topic_sidebar_actions.hbs";
@@ -15,7 +14,6 @@ import * as compose_actions from "./compose_actions";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
-import * as drafts from "./drafts";
 import {DropdownListWidget} from "./dropdown_list_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
@@ -42,7 +40,6 @@ import * as user_topics from "./user_topics";
 let current_stream_sidebar_elem;
 let current_topic_sidebar_elem;
 let all_messages_sidebar_elem;
-let drafts_sidebar_elem;
 let stream_widget;
 let $stream_header_colorblock;
 
@@ -111,10 +108,6 @@ export function all_messages_popped() {
     return all_messages_sidebar_elem !== undefined;
 }
 
-export function drafts_popped() {
-    return drafts_sidebar_elem !== undefined;
-}
-
 export function hide_stream_popover() {
     if (stream_popped()) {
         $(current_stream_sidebar_elem).popover("destroy");
@@ -136,14 +129,6 @@ export function hide_all_messages_popover() {
         $(all_messages_sidebar_elem).popover("destroy");
         hide_left_sidebar_menu_icon();
         all_messages_sidebar_elem = undefined;
-    }
-}
-
-export function hide_drafts_popover() {
-    if (drafts_popped()) {
-        $(drafts_sidebar_elem).popover("destroy");
-        hide_left_sidebar_menu_icon();
-        drafts_sidebar_elem = undefined;
     }
 }
 
@@ -323,30 +308,6 @@ function build_all_messages_popover(e) {
 
     $(elt).popover("show");
     all_messages_sidebar_elem = elt;
-    show_left_sidebar_menu_icon(elt);
-    e.stopPropagation();
-}
-
-function build_drafts_popover(e) {
-    const elt = e.target;
-
-    if (drafts_popped() && drafts_sidebar_elem === elt) {
-        hide_drafts_popover();
-        e.stopPropagation();
-        return;
-    }
-
-    popovers.hide_all_except_sidebars();
-    const content = render_drafts_sidebar_actions({});
-    $(elt).popover({
-        content,
-        html: true,
-        trigger: "manual",
-        fixed: true,
-    });
-
-    $(elt).popover("show");
-    drafts_sidebar_elem = elt;
     show_left_sidebar_menu_icon(elt);
     e.stopPropagation();
 }
@@ -573,8 +534,6 @@ export function register_click_handlers() {
 
     $("#global_filters").on("click", ".all-messages-sidebar-menu-icon", build_all_messages_popover);
 
-    $("#global_filters").on("click", ".drafts-sidebar-menu-icon", build_drafts_popover);
-
     $("body").on("click keypress", ".move-topic-dropdown .list_item", (e) => {
         // We want the dropdown to collapse once any of the list item is pressed
         // and thus don't want to kill the natural bubbling of event.
@@ -625,12 +584,6 @@ export function register_stream_handlers() {
         hide_all_messages_popover();
         e.stopPropagation();
         unread_ops.confirm_mark_all_as_read();
-    });
-
-    $("body").on("click", "#delete_all_drafts_sidebar", (e) => {
-        hide_drafts_popover();
-        e.stopPropagation();
-        drafts.confirm_delete_all_drafts();
     });
 
     // Unstar all messages in topic

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -2,7 +2,6 @@ import ClipboardJS from "clipboard";
 import $ from "jquery";
 
 import * as resolved_topic from "../shared/src/resolved_topic";
-import render_all_messages_sidebar_actions from "../templates/all_messages_sidebar_actions.hbs";
 import render_delete_topic_modal from "../templates/confirm_dialog/confirm_delete_topic.hbs";
 import render_move_topic_to_stream from "../templates/move_topic_to_stream.hbs";
 import render_stream_sidebar_actions from "../templates/stream_sidebar_actions.hbs";
@@ -39,7 +38,6 @@ import * as user_topics from "./user_topics";
 // module.  Both are popped up from the left sidebar.
 let current_stream_sidebar_elem;
 let current_topic_sidebar_elem;
-let all_messages_sidebar_elem;
 let stream_widget;
 let $stream_header_colorblock;
 
@@ -77,11 +75,6 @@ export function topic_sidebar_menu_handle_keyboard(key) {
     popovers.popover_items_handle_keyboard(key, items);
 }
 
-export function all_messages_sidebar_menu_handle_keyboard(key) {
-    const items = get_popover_menu_items(all_messages_sidebar_elem);
-    popovers.popover_items_handle_keyboard(key, items);
-}
-
 function elem_to_stream_id($elem) {
     const stream_id = Number.parseInt($elem.attr("data-stream-id"), 10);
 
@@ -104,10 +97,6 @@ export function topic_popped() {
     return current_topic_sidebar_elem !== undefined;
 }
 
-export function all_messages_popped() {
-    return all_messages_sidebar_elem !== undefined;
-}
-
 export function hide_stream_popover() {
     if (stream_popped()) {
         $(current_stream_sidebar_elem).popover("destroy");
@@ -121,14 +110,6 @@ export function hide_topic_popover() {
         $(current_topic_sidebar_elem).popover("destroy");
         hide_left_sidebar_menu_icon();
         current_topic_sidebar_elem = undefined;
-    }
-}
-
-export function hide_all_messages_popover() {
-    if (all_messages_popped()) {
-        $(all_messages_sidebar_elem).popover("destroy");
-        hide_left_sidebar_menu_icon();
-        all_messages_sidebar_elem = undefined;
     }
 }
 
@@ -284,32 +265,6 @@ function build_topic_popover(opts) {
 
     current_topic_sidebar_elem = elt;
     show_left_sidebar_menu_icon(elt);
-}
-
-function build_all_messages_popover(e) {
-    const elt = e.target;
-
-    if (all_messages_popped() && all_messages_sidebar_elem === elt) {
-        hide_all_messages_popover();
-        e.stopPropagation();
-        return;
-    }
-
-    popovers.hide_all_except_sidebars();
-
-    const content = render_all_messages_sidebar_actions();
-
-    $(elt).popover({
-        content,
-        html: true,
-        trigger: "manual",
-        fixed: true,
-    });
-
-    $(elt).popover("show");
-    all_messages_sidebar_elem = elt;
-    show_left_sidebar_menu_icon(elt);
-    e.stopPropagation();
 }
 
 export function build_move_topic_to_stream_popover(current_stream_id, topic_name, message) {
@@ -532,8 +487,6 @@ export function register_click_handlers() {
         build_topic_link_clipboard(url);
     });
 
-    $("#global_filters").on("click", ".all-messages-sidebar-menu-icon", build_all_messages_popover);
-
     $("body").on("click keypress", ".move-topic-dropdown .list_item", (e) => {
         // We want the dropdown to collapse once any of the list item is pressed
         // and thus don't want to kill the natural bubbling of event.
@@ -577,13 +530,6 @@ export function register_stream_handlers() {
         hide_stream_popover();
         unread_ops.mark_stream_as_read(sub.stream_id);
         e.stopPropagation();
-    });
-
-    // Mark all messages as read
-    $("body").on("click", "#mark_all_messages_as_read", (e) => {
-        hide_all_messages_popover();
-        e.stopPropagation();
-        unread_ops.confirm_mark_all_as_read();
     });
 
     // Unstar all messages in topic

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -289,7 +289,7 @@ export function initialize() {
         content: $t({defaultMessage: "Change send shortcut"}),
         onShow() {
             // Don't show tooltip if the popover is displayed.
-            if (popover_menus.compose_enter_sends_popover_displayed) {
+            if (popover_menus.is_compose_enter_sends_popover_displayed()) {
                 return false;
             }
             return true;

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -86,7 +86,6 @@ mock_esm("../src/recent_topics_util", {
 const stream_popover = mock_esm("../src/stream_popover", {
     stream_popped: () => false,
     topic_popped: () => false,
-    all_messages_popped: () => false,
 });
 
 message_lists.current = {

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -67,7 +67,6 @@ const popovers = mock_esm("../src/popovers", {
 const popover_menus = mock_esm("../src/popover_menus", {
     actions_popped: () => false,
     get_visible_instance: () => undefined,
-    is_starred_messages_visible: () => false,
 });
 const reactions = mock_esm("../src/reactions");
 const search = mock_esm("../src/search");

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -65,7 +65,6 @@ const popovers = mock_esm("../src/popovers", {
     user_info_popped: () => false,
 });
 const popover_menus = mock_esm("../src/popover_menus", {
-    actions_popped: () => false,
     get_visible_instance: () => undefined,
 });
 const reactions = mock_esm("../src/reactions");

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -66,6 +66,7 @@ const popovers = mock_esm("../src/popovers", {
 });
 const popover_menus = mock_esm("../src/popover_menus", {
     actions_popped: () => false,
+    get_visible_instance: () => undefined,
     is_starred_messages_visible: () => false,
 });
 const reactions = mock_esm("../src/reactions");

--- a/web/tests/popovers.test.js
+++ b/web/tests/popovers.test.js
@@ -32,7 +32,6 @@ const message_lists = mock_esm("../src/message_lists", {
 mock_esm("../src/stream_popover", {
     hide_stream_popover: noop,
     hide_topic_popover: noop,
-    hide_all_messages_popover: noop,
     hide_drafts_popover: noop,
     hide_streamlist_sidebar: noop,
 });


### PR DESCRIPTION
This PR is an essential step towards achieving our goal to migrate Popovers from Bootstrap Popovers to the new `popover_menus.js` framework.