### PR TITLE
account-settings: Pass `page_param` values to dialog widgets for change email and password.

### DIFF
--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -718,25 +718,18 @@ export function set_up() {
         );
     }
 
-    function change_email_post_render() {
-        const $input_elem = $("#change_email_form").find("input[name='email']");
-        const email = $("#change_email_button").text().trim();
-        $input_elem.val(email);
-    }
-
     $("#change_email_button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         if (settings_data.user_can_change_email()) {
             dialog_widget.launch({
                 html_heading: $t_html({defaultMessage: "Change email"}),
-                html_body: render_change_email_modal(),
+                html_body: render_change_email_modal({delivery_email: page_params.delivery_email}),
                 html_submit_button: $t_html({defaultMessage: "Change"}),
                 loading_spinner: true,
                 id: "change_email_modal",
                 form_id: "change_email_form",
                 on_click: do_change_email,
-                post_render: change_email_post_render,
                 on_shown() {
                     $("#change_email_form input").trigger("focus");
                 },

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -588,7 +588,10 @@ export function set_up() {
 
         dialog_widget.launch({
             html_heading: $t_html({defaultMessage: "Change password"}),
-            html_body: render_dialog_change_password(),
+            html_body: render_dialog_change_password({
+                password_min_length: page_params.password_min_length,
+                password_min_guesses: page_params.password_min_guesses,
+            }),
             html_submit_button: $t_html({defaultMessage: "Change"}),
             loading_spinner: true,
             id: "change_password_modal",

--- a/web/templates/change_email_modal.hbs
+++ b/web/templates/change_email_modal.hbs
@@ -1,4 +1,4 @@
 <form id="change_email_form" class="new-style">
     <label for="email">{{t "New email" }}</label>
-    <input type="text" name="email" value="{{ page_params.delivery_email }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+    <input type="text" name="email" value="{{delivery_email}}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
 </form>

--- a/web/templates/dialog_change_password.hbs
+++ b/web/templates/dialog_change_password.hbs
@@ -10,7 +10,7 @@
     <div class="field password-div">
         <label for="new_password" class="title">{{t "New password" }}</label>
         <input type="password" autocomplete="new-password" name="new_password" id="new_password" class="w-200 inline-block" value=""
-          data-min-length="{{ page_params.password_min_length }}" data-min-guesses="{{ page_params.password_min_guesses }}" />
+          data-min-length="{{password_min_length}}" data-min-guesses="{{password_min_guesses}}" />
         <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
         <div class="progress inline-block" id="pw_strength">
             <div class="bar bar-danger fade" style="width: 10%;"></div>


### PR DESCRIPTION
Updates the change password and change email modals so that any `page_params` values referenced in the handlebars template are passed to the `html` parameter in `dialog_widget.launch`. Otherwise the template does not have access to those values.

**Notes**:
- **Change password**:
  - The values that were not getting set were for the password quality bar: `password_min_length` and `password_min_guesses`.
  - The issue was noted [here on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Incorrect.20change.20password.20dialog.20behaviour/near/1528616).
- **Change email**:
  - When I did a `git-grep` search for other instances of `page_params` in `web/templates`, the only other dialog widget modal came up was `change_email_modal.hbs`.
  - This was not noted because the `post_render` callback resets the value of the input to be the same delivery email, but uses the value button text.
    - I looked back through the project history and as far as I can tell this has always been the case (setting the value twice; once in the HTML and again in the modal launch).
    - I did not remove the `post_render` callback in these changes, but it does seem redundant to me if we're also setting the initial value in the handlebars template.
  - Alternatively, we could intentionally set the handelbars template to be an initial empty string value and continue setting it in the `post_render` callback, which we've been doing unintentionally since migrating to use the modal.
    - I'll note that on my computer in both Chrome and Firefox, this ends up with the cursor at the end of the email value when the form launches and is focused on the input field.
    - When it's set initially, the cursor is at the start of the email value.

<details>
<summary>git-grep after these changes</summary>

```console
$ git grep page_params web/templates/
web/templates/settings/account_settings.hbs:                                {{page_params.delivery_email}}
web/templates/settings/account_settings.hbs:                {{#if page_params.two_fa_enabled }}
web/templates/settings/account_settings.hbs:                    {{t "Two factor authentication" }}: {{#if page_params.two_fa_enabled_user }}{{t "Enabled" }}{{else}}{{t "Disabled" }}{{/if}}
web/templates/settings/account_settings.hbs:                    {{#if page_params.realm_email_auth_enabled}}
web/templates/settings/account_settings.hbs:                {{#if page_params.development_environment }}
web/templates/settings/account_settings.hbs:                  hide_tooltip=page_params.realm_enable_read_receipts
web/templates/settings/bot_settings.hbs:        {{#unless page_params.is_guest}}
web/templates/settings/profile_settings.hbs:                                <input id="full_name" name="full_name" type="text" value="{{ page_params.full_name }}" {{#unless user_can_change_name}}disabled="disabled"{{/unless}} maxlength="60" />
web/templates/settings/profile_settings.hbs:                  image = page_params.avatar_url_medium}}
```
</details>

---

**Screenshots and screen captures:**

<details>
<summary>Email change</summary>

### Current main - empty string set
![Screenshot from 2023-03-21 17-41-37](https://user-images.githubusercontent.com/63245456/226681276-43d5b5ea-0f53-4641-acf4-ef5e86860a52.png)

### After changes - email set
![Screenshot from 2023-03-21 17-38-52](https://user-images.githubusercontent.com/63245456/226681234-b697bcdd-ef71-4475-95fd-772d89a853f0.png)
</details>
<details>
<summary>Password change</summary>

### Current main - nothing set for data-min-length or data-min-guesses
![Screenshot from 2023-03-21 17-42-26](https://user-images.githubusercontent.com/63245456/226680872-61282c5a-8a9f-4f61-b3c2-56dc27a5a4c8.png)

### After changes - Defaults set for data-min-length or data-min-guesses
![Screenshot from 2023-03-21 17-42-47](https://user-images.githubusercontent.com/63245456/226680815-9dfa5b15-20b9-4bd6-b31d-2af836ee1161.png)
</details>
<details>
<summary>Screencast of setting new password</summary>

[Screencast from 21-03-23 17:06:09.webm](https://user-images.githubusercontent.com/63245456/226681657-c006dfd6-d077-407a-93c6-69698eb0d938.webm)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
