### PR TITLE
webpack: Disable webpack-dev-server overlay for runtime errors

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -216,6 +216,11 @@ export default (
             }),
         ],
         devServer: {
+            client: {
+                overlay: {
+                    runtimeErrors: false,
+                },
+            },
             devMiddleware: {
                 publicPath: "/webpack/",
                 stats: {


### PR DESCRIPTION
[webpack-dev-server 4.12.0](https://github.com/webpack/webpack-dev-server/releases/tag/v4.12.0) introduced a global handler that shows a full-screen overlay for all runtime errors, but it’s redundant with our `blueslip_stacktrace` handler and less functional at this time.