### PR TITLE
help: Clarify alert words documentation.

### DIFF
--- a/help/dm-mention-alert-notifications.md
+++ b/help/dm-mention-alert-notifications.md
@@ -54,8 +54,13 @@ mentions](/help/restrict-wildcard-mentions) in large streams.
 
 ## Alert words
 
-Zulip lets you to specify **alert words or phrases** that notify you whenever
-the alert word is included in a message. Alert words are case-insensitive.
+Zulip lets you to specify **alert words or phrases** that send you a desktop
+notification whenever the alert word is included in a message. Alert words are
+case-insensitive.
+
+!!! tip ""
+
+    Alert words in messages you receive while the alert is enabled will be highlighted.
 
 ### Add an alert word or phrase
 

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -87,7 +87,9 @@ Zulip offers the following filters based on the location of the message.
 ### Search your important messages
 
 * `is:alerted`: Search messages that contain your [alert
-  words](/help/dm-mention-alert-notifications#alert-words).
+  words](/help/dm-mention-alert-notifications#alert-words). Messages are
+  included in the search results based on the alerts you had configured when you
+  received the message.
 * `is:mentioned`: Search messages where you were
   [mentioned](/help/mention-a-user-or-group).
 * `is:starred`: Search your [starred messages](/help/star-a-message).


### PR DESCRIPTION
Based on [CZO discussion](https://chat.zulip.org/#narrow/stream/19-documentation/topic/Alert-word.20clarification/near/1523289).

I decided it wasn't worth explaining some minor details:
- How message editing affects results. (All search results are affected by message editing.)
- The precise, incidental logic for how old alert words are/are not highlighted.


## Screenshots

Before: https://zulip.com/help/dm-mention-alert-notifications

After:
![Screen Shot 2023-03-21 at 2 01 50 PM](https://user-images.githubusercontent.com/2090066/226741610-f52d92f0-6d90-4e23-9b8b-2286a10370ee.png)

----

Before: https://zulip.com/help/search-for-messages#search-your-important-messages

After: 
![Screen Shot 2023-03-21 at 2 06 58 PM](https://user-images.githubusercontent.com/2090066/226741600-9a4b654e-c6db-4a58-9bb0-c1ae5307469f.png)

