### PR TITLE
node_cache: Work around pnpm install issue in Docker for Mac

### DIFF
--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -1,6 +1,6 @@
 import os
 
-from scripts.lib.zulip_tools import run
+from scripts.lib.zulip_tools import get_deploy_root, run
 
 DEFAULT_PRODUCTION = False
 
@@ -16,11 +16,16 @@ def setup_node_modules(production: bool = DEFAULT_PRODUCTION) -> None:
     except FileNotFoundError:
         pass
 
-    run(
-        [
-            "/usr/local/bin/pnpm",
-            "install",
-            "--frozen-lockfile",
-            *(["--prod"] if production else []),
-        ]
-    )
+    pnpm_command = ["/usr/local/bin/pnpm", "install", "--frozen-lockfile"]
+    if production:
+        pnpm_command += ["--prod"]
+
+    deploy_root = get_deploy_root()
+    with open("/proc/self/mounts") as mounts:
+        for line in mounts:
+            fields = line.split()
+            if fields[1] == deploy_root and fields[2] in ("fuse.grpcfuse", "fakeowner"):
+                print("Working around https://github.com/pnpm/pnpm/issues/5803")
+                pnpm_command += ["--package-import-method=copy"]
+
+    run(pnpm_command)


### PR DESCRIPTION
On Docker for Mac with the gRPC FUSE or VirtioFS file sharing implementations, we nondeterministically get errors like this from `pnpm install`:

    pnpm: ENOENT: no such file or directory, copyfile '/srv/zulip/.pnpm-store/v3/files/7d/6b44bb658625281b48194e5a3d3a07452bea1f256506dd16f7a21941ef3f0d259e1bcd0cc6202642bf1fd129bc187e6a3921d382d568d312bd83f3023979a0' -> '/srv/zulip/node_modules/.pnpm/regexpu-core@5.3.2/node_modules/_tmp_3227_7f867a9c510832f5f82601784e21e7be/LICENSE-MIT.txt'

    Subcommand of ./lib/provision.py failed with exit status 1: /usr/local/bin/pnpm install --frozen-lockfile
    Actual error output for the subcommand is just above this.

Work around this using `--package-import-method=copy`.