### PR TITLE
ts: Migrate settings_ui.js to typescript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -171,7 +171,7 @@ EXEMPT_FILES = make_set(
         "web/src/settings_sections.js",
         "web/src/settings_streams.js",
         "web/src/settings_toggle.js",
-        "web/src/settings_ui.js",
+        "web/src/settings_ui.ts",
         "web/src/settings_user_groups_legacy.js",
         "web/src/settings_users.js",
         "web/src/setup.js",

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -6,7 +6,7 @@ import {$t, $t_html} from "./i18n";
 import * as loading from "./loading";
 import * as ui_report from "./ui_report";
 
-export function display_checkmark($elem) {
+export function display_checkmark($elem: JQuery): void {
     const check_mark = document.createElement("img");
     check_mark.src = checkbox_image;
     $elem.prepend(check_mark);
@@ -23,29 +23,40 @@ export const strings = {
 // UI.  Intended to replace the old system that was built around
 // direct calls to `ui_report`.
 export function do_settings_change(
-    request_method,
-    url,
-    data,
-    status_element,
+    request_method: (
+        options: Pick<JQuery.AjaxSettings, "error" | "success" | "url"> & {data: unknown},
+    ) => JQuery.jqXHR | undefined,
+    url: string,
+    data: unknown,
+    status_element: JQuery,
     {
-        success_msg_html = strings.success_html,
-        failure_msg_html = strings.failure_html,
-        success_continuation,
         error_continuation,
+        failure_msg_html = strings.failure_html,
         sticky = false,
+        success_continuation,
+        success_msg_html = strings.success_html,
         $error_msg_element,
+    }: {
+        error_continuation?(xhr: JQuery.jqXHR): void;
+        failure_msg_html?: string;
+        sticky?: boolean;
+        success_continuation?(response_data: unknown): void;
+        success_msg_html?: string;
+        $error_msg_element?: JQuery;
+        error_continuation?(xhr: JQuery.jqXHR): void;
+        success_continuation?(response_data: unknown): void;
     } = {},
-) {
+): void {
     const $spinner = $(status_element).expectOne();
     $spinner.fadeTo(0, 1);
     loading.make_indicator($spinner, {text: strings.saving});
     const remove_after = sticky ? undefined : 1000;
     const appear_after = 500;
 
-    request_method({
+    void request_method({
         url,
         data,
-        success(response_data) {
+        success(response_data: unknown) {
             setTimeout(() => {
                 ui_report.success(success_msg_html, $spinner, remove_after);
                 display_checkmark($spinner);
@@ -76,11 +87,11 @@ export function do_settings_change(
 // * disable_on_uncheck is boolean, true if sub setting should be disabled
 //   when main setting unchecked.
 export function disable_sub_setting_onchange(
-    is_checked,
-    sub_setting_id,
-    disable_on_uncheck,
-    include_label,
-) {
+    is_checked: boolean,
+    sub_setting_id: string,
+    disable_on_uncheck: boolean,
+    include_label: boolean = false,
+): void {
     if ((is_checked && disable_on_uncheck) || (!is_checked && !disable_on_uncheck)) {
         $(`#${CSS.escape(sub_setting_id)}`).prop("disabled", false);
         if (include_label) {

--- a/web/src/settings_ui.ts
+++ b/web/src/settings_ui.ts
@@ -30,17 +30,15 @@ export function do_settings_change(
     data: unknown,
     status_element: JQuery,
     {
-        error_continuation,
         failure_msg_html = strings.failure_html,
         sticky = false,
-        success_continuation,
         success_msg_html = strings.success_html,
         $error_msg_element,
+        error_continuation,
+        success_continuation,
     }: {
-        error_continuation?(xhr: JQuery.jqXHR): void;
         failure_msg_html?: string;
         sticky?: boolean;
-        success_continuation?(response_data: unknown): void;
         success_msg_html?: string;
         $error_msg_element?: JQuery;
         error_continuation?(xhr: JQuery.jqXHR): void;
@@ -90,7 +88,7 @@ export function disable_sub_setting_onchange(
     is_checked: boolean,
     sub_setting_id: string,
     disable_on_uncheck: boolean,
-    include_label: boolean = false,
+    include_label = false,
 ): void {
     if ((is_checked && disable_on_uncheck) || (!is_checked && !disable_on_uncheck)) {
         $(`#${CSS.escape(sub_setting_id)}`).prop("disabled", false);


### PR DESCRIPTION
This PR addresses the migration of file `web/src/settings_ui.js` to typescript.

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
