### PR TITLE
tooltip: Change placement of tooltip according to the popover menu.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -203,11 +203,37 @@ export function initialize() {
             }
 
             instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
+            //  When showing the popover menu, we want the
+            // "Add streams" and the "Filter streams" tooltip
+            //  to appear below the "Add streams" icon.
+            const add_streams_tooltip = $("#add_streams_tooltip").get(0);
+            add_streams_tooltip._tippy?.setProps({
+                placement: "bottom",
+            });
+            const filter_streams_tooltip = $("#filter_streams_tooltip").get(0);
+            // If `filter_streams_tooltip` is not triggered yet, this will set its initial placement.
+            filter_streams_tooltip.dataset.tippyPlacement = "bottom";
+            filter_streams_tooltip._tippy?.setProps({
+                placement: "bottom",
+            });
             return true;
         },
         onHidden(instance) {
             instance.destroy();
             popover_instances.stream_settings = undefined;
+            //  After the popover menu is closed, we want the
+            //  "Add streams" and the "Filter streams" tooltip
+            //  to appear at it's original position that is
+            //  above the "Add streams" icon.
+            const add_streams_tooltip = $("#add_streams_tooltip").get(0);
+            add_streams_tooltip._tippy?.setProps({
+                placement: "top",
+            });
+            const filter_streams_tooltip = $("#filter_streams_tooltip").get(0);
+            filter_streams_tooltip.dataset.tippyPlacement = "top";
+            filter_streams_tooltip._tippy?.setProps({
+                placement: "top",
+            });
         },
     });
 

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -220,6 +220,7 @@ export function initialize() {
             "#scroll-to-bottom-button-clickable-area",
             ".code_external_link",
             ".spectator_narrow_login_button",
+            "#stream-specific-notify-table .unmute_stream",
         ],
         appendTo: () => document.body,
     });
@@ -231,11 +232,6 @@ export function initialize() {
         onHidden(instance) {
             instance.destroy();
         },
-    });
-
-    delegate("body", {
-        target: "#stream-specific-notify-table .unmute_stream",
-        appendTo: () => document.body,
     });
 
     delegate("body", {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -221,6 +221,8 @@ export function initialize() {
             ".code_external_link",
             ".spectator_narrow_login_button",
             "#stream-specific-notify-table .unmute_stream",
+            "#add_streams_tooltip",
+            "#filter_streams_tooltip",
         ],
         appendTo: () => document.body,
     });

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -82,10 +82,10 @@
 
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
-                <span class="tippy-zulip-tooltip streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
+                <span id="add_streams_tooltip" class="tippy-zulip-tooltip streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
                     <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
-                <i class="streams_filter_icon fa fa-filter tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
+                <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -82,10 +82,10 @@
 
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-tooltip-template-id="filter-streams-tooltip-template">{{t 'STREAMS' }}</h4>
-                <span id="add_streams_tooltip" class="tippy-zulip-tooltip streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
+                <span id="add_streams_tooltip" class="streams_inline_icon_wrapper hidden-for-spectators" data-tippy-content="{{t 'Add streams' }}">
                     <i id="streams_inline_icon" class='fa fa-plus' aria-hidden="true" ></i>
                 </span>
-                <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
+                <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">


### PR DESCRIPTION
This PR changes the placement of `Add streams` tooltip and `Filter streams` tooltip to `bottom` when the `Add streams` popover menu is opened and changes its back to `top` when the popover menu is closed.

Also adds an `id` attribute to both the tooltip elements to get access to them for changing their placement.

Discussion: [CZO Link](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Add.20streams.22.20tooltip.20behind.20menu) 

Fixes: #20675 

<hr>

**Screenshots and screen captures:**

<details>
<summary> GIF Showing the new behavior in Dark Theme </summary>

![Tippy Fix](https://user-images.githubusercontent.com/35286603/224767887-06ef32e2-cd23-41d4-af78-23a9b0ac1f84.gif)

</details>

<details>
<summary> GIF Showing the new behavior in Light Theme </summary>

![Light Theme Fix](https://user-images.githubusercontent.com/35286603/226999537-c4fb5fe8-e46b-463d-8923-b8fe85435e00.gif)


</details>

<details>
<summary>git grep results </summary>

`git grep 'add_streams_tooltip'`:
![image](https://user-images.githubusercontent.com/35286603/224770678-167d76c0-abb2-47e2-99be-3459ec94fddf.png)

`git grep 'filter_streams_tooltip'`:
![image](https://user-images.githubusercontent.com/35286603/224770616-64eaee44-7ee1-4a28-bed0-f4775d279269.png)

</details>

<hr>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [X] Responsiveness and internationalization.
- [X] Strings and tooltips.
- [X] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>