### PR TITLE
Focus topic input in "Move messages" and "Move topic" modals.

### DIFF
--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -325,7 +325,7 @@ export function build_move_topic_to_stream_popover(
     }
 
     function set_stream_topic_typeahead() {
-        const $topic_input = $("#move_topic_form .inline_topic_edit");
+        const $topic_input = $("#move_topic_form .move_messages_edit_topic");
         const new_stream_id = Number(stream_widget.value(), 10);
         const new_stream_name = sub_store.get(new_stream_id).name;
         $topic_input.data("typeahead").unlisten();
@@ -340,7 +340,7 @@ export function build_move_topic_to_stream_popover(
     function move_topic_post_render() {
         $("#move_topic_modal .dialog_submit_button").prop("disabled", true);
 
-        const $topic_input = $("#move_topic_form .inline_topic_edit");
+        const $topic_input = $("#move_topic_form .move_messages_edit_topic");
         composebox_typeahead.initialize_topic_edit_typeahead(
             $topic_input,
             current_stream_name,
@@ -376,7 +376,7 @@ export function build_move_topic_to_stream_popover(
         stream_widget.setup();
 
         $("#select_stream_widget .dropdown-toggle").prop("disabled", disable_stream_input);
-        $("#move_topic_modal .inline_topic_edit").on("input", () => {
+        $("#move_topic_modal .move_messages_edit_topic").on("input", () => {
             update_submit_button_disabled_state(stream_widget.value());
         });
     }

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -22,6 +22,7 @@ import * as stream_data from "./stream_data";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as ui_report from "./ui_report";
+import * as ui_util from "./ui_util";
 import * as unread_ops from "./unread_ops";
 // We handle stream popovers and topic popovers in this
 // module.  Both are popped up from the left sidebar.
@@ -381,6 +382,14 @@ export function build_move_topic_to_stream_popover(
         });
     }
 
+    function focus_on_move_modal_render() {
+        if (!disable_stream_input && args.disable_topic_input) {
+            $("#select_stream_widget .button").trigger("focus");
+        } else {
+            ui_util.place_caret_at_end($(".move_messages_edit_topic")[0]);
+        }
+    }
+
     dialog_widget.launch({
         html_heading: modal_heading,
         html_body: render_move_topic_to_stream(args),
@@ -388,6 +397,7 @@ export function build_move_topic_to_stream_popover(
         id: "move_topic_modal",
         on_click: move_topic,
         loading_spinner: true,
+        on_shown: focus_on_move_modal_render,
         post_render: move_topic_post_render,
     });
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -816,7 +816,7 @@ ul {
 
     .dropdown-list-widget,
     .stream_header_colorblock,
-    .inline_topic_edit {
+    .move_messages_edit_topic {
         margin-bottom: 10px;
     }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1678,7 +1678,7 @@ div.focused_table {
     }
 }
 
-#inline_topic_edit {
+.inline_topic_edit {
     margin-bottom: 5px;
     width: 206px;
 
@@ -1702,7 +1702,7 @@ div.focused_table {
     justify-content: flex-start;
 }
 
-#inline_topic_edit:focus,
+.inline_topic_edit:focus,
 #message_edit_topic:focus {
     outline: none;
 }

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -17,8 +17,8 @@
         </div>
         <i class="fa fa-angle-right" aria-hidden="true"></i>
         {{/unless}}
-        <input name="new_topic_name" type="text" class="inline_topic_edit modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
-        <input name="old_topic_name" type="hidden" class="inline_topic_edit" value="{{topic_name}}" />
+        <input name="new_topic_name" type="text" class="move_messages_edit_topic modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
+        <input name="old_topic_name" type="hidden" class="move_messages_edit_topic" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />
         {{#if from_message_actions_popover}}
         <select class="message_edit_topic_propagate modal_select bootstrap-focus-style">

--- a/web/templates/topic_edit_form.hbs
+++ b/web/templates/topic_edit_form.hbs
@@ -1,7 +1,7 @@
 {{! Client-side Handlebars template for rendering the topic edit form. }}
 
 <form id="topic_edit_form">
-    <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
+    <input type="text" value="" class="inline_topic_edit header-v"
       autocomplete="off" maxlength="{{ max_topic_length }}" />
     <button type="button" class="topic_edit_save small_square_button animated-purple-button"><i class="fa fa-check" aria-hidden="true"></i></button>
     <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
In move_topic modal, Renamed inline_topic_edit to move_messages_edit_topic to be more specific selector as inline_topic_edit is also used in message header.

If user has permissions to move the message(s) to a different stream and can't edit topic name then focus stream input; else, focus topic input on "Move messages" and "Move topic" modals render by `ui_util.place_caret_at_end($(".move_messages_edit_topic")[0])` to position the cursor at end on focus.

Fixes: #24805

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/64723994/227015227-8809e01d-6264-4d93-b0c9-f828bbea3092.mp4


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
