### PR TITLE
help: Document `=` keyboard shortcut.

### DIFF
--- a/help/emoji-reactions.md
+++ b/help/emoji-reactions.md
@@ -51,6 +51,11 @@ message.
     To make it easy to see which reactions you have added, they are
     highlighted in a different color.
 
+!!! keyboard_tip ""
+
+    You can also toggle the first emoji reaction on the selected message by
+    using the <kbd>=</kbd> shortcut.
+
 {tab|mobile}
 
 1. Click on an existing emoji reaction to add or remove your reaction.

--- a/help/emoji-reactions.md
+++ b/help/emoji-reactions.md
@@ -26,8 +26,15 @@ message.
    with your mouse.
 
 !!! tip ""
+
     To add multiple reactions without closing the emoji picker, hold the
     <kbd>Shift</kbd> key while selecting emoji.
+
+!!! keyboard_tip ""
+
+    You can react to the selected message with <img alt=":thumbs_up:"
+    class="emoji" src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
+    title="thumbs up"/> by using the <kbd>+</kbd> shortcut.
 
 {tab|mobile}
 

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -156,6 +156,8 @@ in the Zulip app to add more to your repertoire as needed.
   src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
   title="thumbs up"/>**: <kbd>+</kbd>
 
+* **Toggle first emoji reaction**: <kbd>=</kbd>
+
 * **Mark as unread from selected message**: <kbd>Shift</kbd> + <kbd>U</kbd>
 
 * **Collapse/show message**: <kbd>-</kbd>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -243,6 +243,10 @@
                     <td><span class="hotkey"><kbd>+</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'Toggle first emoji reaction on selected message' }}</td>
+                    <td><span class="hotkey"><kbd>=</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Mark as unread from selected message' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>U</kbd></span></td>
                 </tr>


### PR DESCRIPTION
- Documents the new shortcut in the `?` menu, [Keyboard Shortcuts](https://zulip.com/help/keyboard-shortcuts) page, and [Emoji Reactions](https://zulip.com/help/emoji-reactions) page.
- Adds `keyboard_tip` about `+` keyboard shortcut.

Follow up to [#24266](https://github.com/zulip/zulip/pull/24266#issuecomment-1468820987).

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/2343554/227390859-3ee2811f-7e1a-4d84-8412-d670562e9311.png)

![image](https://user-images.githubusercontent.com/2343554/227397793-b3d04dfd-281b-4cbb-b29a-3d13231177fa.png)

![image](https://user-images.githubusercontent.com/2343554/227397449-83e1b035-d6ba-4111-a1df-d4683440ed4b.png)

![image](https://user-images.githubusercontent.com/2343554/227397484-0004f2d5-a3b4-4d42-89fd-9fbbe183f627.png)
