### PR TITLE
help: Document mark messages as read via recent conversations.

### DIFF
--- a/help/include/open-recent-conversations.md
+++ b/help/include/open-recent-conversations.md
@@ -1,0 +1,1 @@
+1. Click **Recent conversations** in the left sidebar.

--- a/help/include/reading-topics.md
+++ b/help/include/reading-topics.md
@@ -2,8 +2,7 @@
 
 {tab|via-recent-conversations}
 
-1. Open **Recent conversations** from the left sidebar or by pressing the
-   <kbd>Esc</kbd> key.
+{!open-recent-conversations.md!}
 
 1. Click on the name of a topic in the **Topic** column.
 

--- a/help/include/recent-conversations.md
+++ b/help/include/recent-conversations.md
@@ -4,8 +4,7 @@ messages sent while you were away.
 
 {start_tabs}
 
-1. Open **Recent conversations** from the left sidebar or by pressing the
-   <kbd>Esc</kbd> key.
+{!open-recent-conversations.md!}
 
 1. The filters at the top help you quickly find relevant conversations.
    For example, select **Participated** to narrow to the topics you

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -48,7 +48,7 @@ stream or topic as read**.
 
 {start_tabs}
 
-{tab|desktop-web}
+{tab|via-left-sidebar}
 
 1. Hover over a stream, topic, or **All messages** in the left sidebar.
 
@@ -61,6 +61,13 @@ stream or topic as read**.
     You can also mark all messages in your current view as read by
     jumping to the bottom with the **Scroll to bottom**
     (<i class="fa fa-chevron-down"></i>) button or the <kbd>End</kbd> shortcut.
+
+{tab|via-recent-conversations}
+
+{!open-recent-conversations.md!}
+
+1. Click on an unread messages counter in the **Topic** column to mark all
+   messages in that topic as read.
 
 {tab|mobile}
 


### PR DESCRIPTION
- Documents feature as a new tab under [Mark all messages as read](https://zulip.com/help/marking-messages-as-read#mark-all-messages-as-read).
- Moves how to open Recent Conversations to include block.

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/2343554/227395679-d96b413b-5421-4d70-b6f9-b4adfb27c686.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
</details>