### PR TITLE
help: Fix links to production docs.

### DIFF
--- a/help/change-organization-url.md
+++ b/help/change-organization-url.md
@@ -30,7 +30,7 @@ using the `change_realm_subdomain` [management command][management-commands].
 In addition to configuring Zulip as detailed here, you also need to
 generate [SSL certificates][ssl-certificates] for your new domain.
 
-[ssl-certificates]: https://zulip.readthedocs.io/en/latest/production/ssl-certificates.html
+[ssl-certificates]: https://zulip.readthedocs.io/en/stable/production/ssl-certificates.html
 [zulip-settings]: https://zulip.readthedocs.io/en/stable/production/settings.html
 [zulip-multiple-organizations]: https://zulip.readthedocs.io/en/stable/production/multiple-organizations.html
-[management-commands]: https://zulip.readthedocs.io/en/latest/production/management-commands.html#other-useful-manage-py-commands
+[management-commands]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#other-useful-manage-py-commands

--- a/help/configure-authentication-methods.md
+++ b/help/configure-authentication-methods.md
@@ -12,7 +12,7 @@ self-hosted Zulip organizations only. SAML authentication is supported
 by Zulip Cloud but requires contacting support@zulip.com to configure it.
 
 **Note:** If you are running your own server,
-[read this](https://zulip.readthedocs.io/en/latest/production/authentication-methods.html)
+[read this](https://zulip.readthedocs.io/en/stable/production/authentication-methods.html)
 first. Server configuration is needed for several of the authentication
 methods listed above.
 
@@ -30,5 +30,5 @@ methods listed above.
 
 ## Related articles
 
-* [Configuring authentication methods](https://zulip.readthedocs.io/en/latest/production/authentication-methods.html)
+* [Configuring authentication methods](https://zulip.readthedocs.io/en/stable/production/authentication-methods.html)
   for server administrators (self-hosted only)

--- a/help/configure-multi-language-search.md
+++ b/help/configure-multi-language-search.md
@@ -9,7 +9,7 @@ custom set of English stop words to improve the quality of the search results.
 Self-hosted Zulip organizations can instead set up an experimental
 [PGroonga](https://pgroonga.github.io/) integration that provides full-text
 search for all languages simultaneously, including Japanese and Chinese. See
-[here](https://zulip.readthedocs.io/en/latest/subsystems/full-text-search.html#multi-language-full-text-search)
+[here](https://zulip.readthedocs.io/en/stable/subsystems/full-text-search.html#multi-language-full-text-search)
 for setup instructions.
 
 ## Related articles

--- a/help/custom-profile-fields.md
+++ b/help/custom-profile-fields.md
@@ -90,4 +90,4 @@ checkboxes will be disabled.
 * [Edit your profile](/help/edit-your-profile)
 * [View someone's profile](/help/view-someones-profile)
 
-[authentication-production]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html
+[authentication-production]: https://zulip.readthedocs.io/en/stable/production/authentication-methods.html

--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -20,7 +20,7 @@ replying to message notification emails, unless you are connecting to
 a self-hosted Zulip server whose system administrator has not
 configured the [incoming email gateway][incoming-email-gateway].
 
-[incoming-email-gateway]: https://zulip.readthedocs.io/en/latest/production/email-gateway.html
+[incoming-email-gateway]: https://zulip.readthedocs.io/en/stable/production/email-gateway.html
 
 ### Delay before sending emails
 

--- a/help/gdpr-compliance.md
+++ b/help/gdpr-compliance.md
@@ -54,7 +54,7 @@ The [on-premises section](#gdpr-compliance-on-premises) of this page
 discusses how the Zulip on-premises software works in relation to GDPR
 compliance.
 
-[mobile-push]: https://zulip.readthedocs.io/en/latest/production/mobile-push-notifications.html
+[mobile-push]: https://zulip.readthedocs.io/en/stable/production/mobile-push-notifications.html
 
 ## Zulip Cloud's subprocessors
 
@@ -143,5 +143,5 @@ access, logging, and backups, etc.  If you need detailed guidance, we
 recommend contacting support@zulip.com; our paid support contracts
 include assistance with understanding GDPR compliance with Zulip.
 
-[management-commands]: https://zulip.readthedocs.io/en/latest/production/management-commands.html
-[export-and-import-tool]: https://zulip.readthedocs.io/en/latest/production/export-and-import.html
+[management-commands]: https://zulip.readthedocs.io/en/stable/production/management-commands.html
+[export-and-import-tool]: https://zulip.readthedocs.io/en/stable/production/export-and-import.html

--- a/help/getting-your-organization-started-with-zulip.md
+++ b/help/getting-your-organization-started-with-zulip.md
@@ -28,7 +28,7 @@ tools ([cloud][export-cloud], [self-hosted][export-self-hosted])
 ensure you can always move from our hosting to yours (and back).
 
 [export-cloud]: /help/export-your-organization
-[export-self-hosted]: https://zulip.readthedocs.io/en/latest/production/export-and-import.html
+[export-self-hosted]: https://zulip.readthedocs.io/en/stable/production/export-and-import.html
 
 ### Advantages of Zulip Cloud
 

--- a/help/high-contrast-mode.md
+++ b/help/high-contrast-mode.md
@@ -11,4 +11,4 @@ W3C's Web Content Accessibility Guidelines.
 
 ## Related articles
 
-* [Accessibility in Zulip](https://zulip.readthedocs.io/en/latest/subsystems/accessibility.html)
+* [Accessibility in Zulip](https://zulip.readthedocs.io/en/stable/subsystems/accessibility.html)

--- a/help/import-from-gitter.md
+++ b/help/import-from-gitter.md
@@ -131,7 +131,7 @@ keep in mind about the import process:
 
 - Message edit history is not imported.
 
-[grant-admin-access]: https://zulip.readthedocs.io/en/latest/production/management-commands.html#grant-administrator-access)
+[grant-admin-access]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#grant-administrator-access)
 [gitter-api-user-data]: https://developer.gitter.im/docs/user-resource
 
 ## Get your organization started with Zulip

--- a/help/import-from-gitter.md
+++ b/help/import-from-gitter.md
@@ -131,7 +131,7 @@ keep in mind about the import process:
 
 - Message edit history is not imported.
 
-[grant-admin-access]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#grant-administrator-access)
+[grant-admin-access]: https://zulip.readthedocs.io/en/stable/production/management-commands.html#other-useful-manage-py-commands
 [gitter-api-user-data]: https://developer.gitter.im/docs/user-resource
 
 ## Get your organization started with Zulip

--- a/help/include/advantages-of-self-hosting-zulip.md
+++ b/help/include/advantages-of-self-hosting-zulip.md
@@ -20,7 +20,7 @@
 Learn more about [self-hosting Zulip](https://zulip.com/self-hosting/).
 
 [zulip-github]: https://github.com/zulip/zulip#readme
-[install-zulip]: https://zulip.readthedocs.io/en/latest/production/install.html
+[install-zulip]: https://zulip.readthedocs.io/en/stable/production/install.html
 [back-up-zulip]: https://zulip.readthedocs.io/en/stable/production/export-and-import.html#backups
 [maintain-zulip]: https://zulip.readthedocs.io/en/stable/production/upgrade-or-modify.html
-[modify-zulip]: https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html#modifying-zulip
+[modify-zulip]: https://zulip.readthedocs.io/en/stable/production/upgrade-or-modify.html#modifying-zulip

--- a/help/include/translation-project-info.md
+++ b/help/include/translation-project-info.md
@@ -6,4 +6,4 @@ If you'd like to help by contributing as a translator, see the
 [Zulip translation guidelines][translating-zulip] to get started.
 
 [transifex-zulip]: https://www.transifex.com/zulip/zulip/
-[translating-zulip]: https://zulip.readthedocs.io/en/latest/translating/translating.html
+[translating-zulip]: https://zulip.readthedocs.io/en/stable/translating/translating.html

--- a/help/logging-in.md
+++ b/help/logging-in.md
@@ -54,7 +54,7 @@ Here are some ways to find the URL for your Zulip organization.
 
 * On [Zulip Cloud](https://zulip.com/plans/) and other Zulip servers updated to
   [Zulip 6.0 or
-  higher](https://zulip.readthedocs.io/en/latest/overview/changelog.html#zulip-6-x-series),
+  higher](https://zulip.readthedocs.io/en/stable/overview/changelog.html#zulip-6-x-series),
   click the **gear** (<i class="fa fa-cog"></i>) icon in the upper right
   corner of the web or desktop app. Your organization's log in URL is shown in the top
   section of the menu.

--- a/help/message-a-stream-by-email.md
+++ b/help/message-a-stream-by-email.md
@@ -5,7 +5,7 @@
     This feature is not available on self-hosted Zulip servers where
     the [incoming email gateway][email-gateway] has not been
     configured by a system administrator.
-    [email-gateway]: https://zulip.readthedocs.io/en/latest/production/email-gateway.html
+    [email-gateway]: https://zulip.readthedocs.io/en/stable/production/email-gateway.html
 
 You can send emails to Zulip streams. This can be useful:
 

--- a/help/public-access-option.md
+++ b/help/public-access-option.md
@@ -33,7 +33,7 @@ communities such as open-source projects and research communities.
 
 !!! warn ""
     Self-hosted Zulip servers must enable support for web-public streams in their
-    [server settings](https://zulip.readthedocs.io/en/latest/production/settings.html)
+    [server settings](https://zulip.readthedocs.io/en/stable/production/settings.html)
     by setting `WEB_PUBLIC_STREAMS_ENABLED = True` prior to proceeding.
 
 {start_tabs}

--- a/help/restrict-name-and-email-changes.md
+++ b/help/restrict-name-and-email-changes.md
@@ -51,4 +51,4 @@ to manage user emails.
 {end_tabs}
 
 [change-email]: /help/change-your-email-address
-[ldap-sync-data]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#synchronizing-data
+[ldap-sync-data]: https://zulip.readthedocs.io/en/stable/production/authentication-methods.html#synchronizing-data

--- a/help/restrict-profile-picture-changes.md
+++ b/help/restrict-profile-picture-changes.md
@@ -24,4 +24,4 @@ profile pictures from LDAP][ldap-sync-avatars] or a similar directory.
 {end_tabs}
 
 [change-avatar]: /help/change-your-profile-picture
-[ldap-sync-avatars]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#synchronizing-avatars
+[ldap-sync-avatars]: https://zulip.readthedocs.io/en/stable/production/authentication-methods.html#synchronizing-avatars

--- a/help/setting-up-zulip-for-a-class.md
+++ b/help/setting-up-zulip-for-a-class.md
@@ -44,7 +44,7 @@ ensure you can always move from our hosting to yours (and back).
 
 [install-self-hosted]: https://zulip.readthedocs.io/en/stable/production/install.html
 [export-cloud]: /help/export-your-organization
-[export-self-hosted]: https://zulip.readthedocs.io/en/latest/production/export-and-import.html
+[export-self-hosted]: https://zulip.readthedocs.io/en/stable/production/export-and-import.html
 
 ### Advantages of Zulip Cloud
 
@@ -69,7 +69,7 @@ ensure you can always move from our hosting to yours (and back).
   European Union), self-hosting is the option for you.
 * Customize Zulip for all your needs.
 
-[install-zulip]: https://zulip.readthedocs.io/en/latest/production/install.html
+[install-zulip]: https://zulip.readthedocs.io/en/stable/production/install.html
 [back-up-zulip]: https://zulip.readthedocs.io/en/stable/production/export-and-import.html#backups
 [maintain-zulip]: https://zulip.readthedocs.io/en/stable/production/upgrade-or-modify.html
 

--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -48,5 +48,5 @@ supported by zulip are:
 
 {end_tabs}
 
-[big-blue-button-configuration]: https://zulip.readthedocs.io/en/latest/production/video-calls.html#big-blue-button
-[zoom-configuration]: https://zulip.readthedocs.io/en/latest/production/video-calls.html#zoom
+[big-blue-button-configuration]: https://zulip.readthedocs.io/en/stable/production/video-calls.html#big-blue-button
+[zoom-configuration]: https://zulip.readthedocs.io/en/stable/production/video-calls.html#zoom

--- a/help/start-a-call.md
+++ b/help/start-a-call.md
@@ -48,5 +48,5 @@ supported by zulip are:
 
 {end_tabs}
 
-[big-blue-button-configuration]: https://zulip.readthedocs.io/en/stable/production/video-calls.html#big-blue-button
+[big-blue-button-configuration]: https://zulip.readthedocs.io/en/stable/production/video-calls.html#bigbluebutton
 [zoom-configuration]: https://zulip.readthedocs.io/en/stable/production/video-calls.html#zoom

--- a/help/support-zulip-project.md
+++ b/help/support-zulip-project.md
@@ -72,22 +72,22 @@ Collective](https://opencollective.com/zulip).
 ## Help improve Zulip
 
 * [**Report
-  issues**](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#reporting-issues),
+  issues**](https://zulip.readthedocs.io/en/stable/contributing/contributing.html#reporting-issues),
   including both feature requests and bug reports. Many improvements to the
   Zulip app start with a user's suggestion.
 
 * [**Give
-  feedback**](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#user-feedback)
+  feedback**](https://zulip.readthedocs.io/en/stable/contributing/contributing.html#user-feedback)
   if you are evaluating or using Zulip.
 
-* [**Translate**](https://zulip.readthedocs.io/en/latest/translating/translating.html)
+* [**Translate**](https://zulip.readthedocs.io/en/stable/translating/translating.html)
   Zulip into your language. Zulip has been translated into over 25 languages by
   an amazing group of volunteers, and you can help expand, improve, and
   maintain the translation for your language, or start working on a language
   that hasn't been covered yet.
 
 * [**Contribute
-  code**](https://zulip.readthedocs.io/en/latest/contributing/contributing.html)
+  code**](https://zulip.readthedocs.io/en/stable/contributing/contributing.html)
   to the Zulip open-source project. To make it easy for contributors from a
   variety of backgrounds to get started, we have invested into making Zulip’s
   code uniquely readable, well tested, and easy to modify.

--- a/help/view-zulip-version.md
+++ b/help/view-zulip-version.md
@@ -10,8 +10,8 @@ web app your organization is using.
 Zulip Cloud organizations are always updated to the latest version of Zulip.
 
 [upgrade-zulip]:
-    https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html
-[changelog]: https://zulip.readthedocs.io/en/latest/overview/changelog.html
+    https://zulip.readthedocs.io/en/stable/production/upgrade-or-modify.html
+[changelog]: https://zulip.readthedocs.io/en/stable/overview/changelog.html
 
 ### View Zulip server and web app version
 
@@ -46,4 +46,4 @@ web app.
 
 * [Desktop installation guides](/help/desktop-app-install-guide)
 * [Upgrading Zulip][upgrade-zulip]
-* [Zulip release lifecycle](https://zulip.readthedocs.io/en/latest/overview/release-lifecycle.html)
+* [Zulip release lifecycle](https://zulip.readthedocs.io/en/stable/overview/release-lifecycle.html)

--- a/help/zulip-cloud-or-self-hosting.md
+++ b/help/zulip-cloud-or-self-hosting.md
@@ -26,4 +26,4 @@ ensure you can always move from our hosting to yours (and back).
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 
 [export-cloud]: /help/export-your-organization
-[export-self-hosted]: https://zulip.readthedocs.io/en/latest/production/export-and-import.html
+[export-self-hosted]: https://zulip.readthedocs.io/en/stable/production/export-and-import.html


### PR DESCRIPTION
We should normally be linking to the `stable` version of production documentation instead of `latest`, unless the page/section isn't there yet.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Links.
</details>