### PR TITLE
fixes #24750 : Pronouns testing options covered under the taskbar in profile settings

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1412,7 +1412,9 @@ $option_title_width: 180px;
 #profile-settings,
 #edit-user-form {
     .custom_user_field {
-        padding-bottom: 20px;
+        padding-bottom: 50px;
+        position: relative;
+        top: -15px;
 
         .field_hint {
             color: hsl(0, 0%, 67%);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes:  https://github.com/zulip/zulip/issues/24750 <!-- Issue link, or clear description.-->
**steps performed to fix the issue:** increased the `padding-bottom` and adjusted the `position` of the div container so that select options fits inside it. 
**outcome:** the pronouns testing option "they/them" which was hidden under the taskbar is visible.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Issue:**
on windows
<img width="324" alt="zulip-issue1-2" src="https://user-images.githubusercontent.com/122230731/227458154-723d37c2-f23c-43db-a484-144f03cf3afc.png">

https://user-images.githubusercontent.com/122230731/228728521-a1ec9501-8cf1-4bbc-804a-d1cc8b1c1eca.mp4






on linux/ubuntu
![linuxissue](https://user-images.githubusercontent.com/122230731/227530479-993aa50e-b478-44cb-8fd7-f7d2304f61dd.png)

full Screen
![zulipIssueFullScreen](https://user-images.githubusercontent.com/122230731/228727762-3f70ac6e-c1e8-43f7-9963-1ed4a3f377d7.png)



**after fixing:** 

![issuefixed1](https://user-images.githubusercontent.com/122230731/227244295-7cc80f67-4947-4bc0-bcc3-1cd7b51a3393.png)

Full Screen
![zulipfix1](https://user-images.githubusercontent.com/122230731/228727906-4796c44c-8589-4f1e-b2cb-e2f38c058cd9.png)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
