### PR TITLE
recent_topics_row: Remove unused dataset attributes from template

### DIFF
--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -387,8 +387,6 @@ function format_conversation(conversation_data) {
         // display / hide them according to filters instead of
         // doing complete re-render.
         context.topic_muted = Boolean(user_topics.is_topic_muted(context.stream_id, context.topic));
-        const stream_muted = stream_data.is_muted(context.stream_id);
-        context.muted = context.topic_muted || stream_muted;
         context.mention_in_unread = unread.topic_has_any_unread_mentions(
             context.stream_id,
             context.topic,
@@ -476,7 +474,6 @@ function format_conversation(conversation_data) {
     context.other_sender_names_html = displayed_other_names
         .map((name) => _.escape(name))
         .join("<br />");
-    context.participated = conversation_data.participated;
     context.last_msg_url = hash_util.by_conversation_and_time_url(last_msg);
 
     return context;

--- a/web/templates/recent_topic_row.hbs
+++ b/web/templates/recent_topic_row.hbs
@@ -1,4 +1,4 @@
-<tr id="recent_conversation:{{conversation_key}}" class="{{#if unread_count}}unread_topic{{/if}} {{#if is_private}}private_conversation_row{{/if}}" data-unread-count="{{unread_count}}" data-muted="{{muted}}" data-participated="{{participated}}" data-private="{{is_private}}">
+<tr id="recent_conversation:{{conversation_key}}" class="{{#if unread_count}}unread_topic{{/if}} {{#if is_private}}private_conversation_row{{/if}}">
     <td class="recent_topic_stream">
         <div class="flex_container flex_container_pm">
             <div class="left_part recent_topics_focusable">

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -286,7 +286,7 @@ function generate_topic_data(topic_info_array) {
     $.clear_all_elements();
     const data = [];
 
-    for (const [stream_id, topic, unread_count, muted, participated] of topic_info_array) {
+    for (const [stream_id, topic, unread_count, muted] of topic_info_array) {
         data.push({
             other_senders_count: 0,
             other_sender_names_html: "",
@@ -306,9 +306,7 @@ function generate_topic_data(topic_info_array) {
             topic_url: "https://www.example.com",
             unread_count,
             mention_in_unread: false,
-            muted,
             topic_muted: muted,
-            participated,
         });
     }
     return data;
@@ -407,7 +405,7 @@ test("test_filter_all", ({mock_template}) => {
     });
 
     // topic is not muted
-    row_data = generate_topic_data([[1, "topic-1", 0, false, true]]);
+    row_data = generate_topic_data([[1, "topic-1", 0, false]]);
     i = row_data.length;
     rt.clear_for_tests();
     stub_out_filter_buttons();
@@ -420,7 +418,7 @@ test("test_filter_all", ({mock_template}) => {
         {last_msg_id: 1, participated: true, type: "stream"},
     ];
 
-    row_data = [...row_data, ...generate_topic_data([[1, "topic-7", 1, true, true]])];
+    row_data = [...row_data, ...generate_topic_data([[1, "topic-7", 1, true]])];
     i = row_data.length;
     // topic is muted (=== hidden)
     stub_out_filter_buttons();
@@ -428,7 +426,7 @@ test("test_filter_all", ({mock_template}) => {
 
     // Test search
     expected.search_val = "topic-1";
-    row_data = generate_topic_data([[1, "topic-1", 0, false, true]]);
+    row_data = generate_topic_data([[1, "topic-1", 0, false]]);
     i = row_data.length;
     rt.set_default_focus();
     $(".home-page-input").trigger("focus");
@@ -462,15 +460,15 @@ test("test_filter_unread", ({mock_template}) => {
     let i = 0;
 
     const row_data = generate_topic_data([
-        // stream_id, topic, unread_count,  muted, participated
-        [4, "topic-10", 1, false, true],
-        [1, "topic-7", 1, true, true],
-        [1, "topic-6", 1, false, true],
-        [1, "topic-5", 1, false, true],
-        [1, "topic-4", 1, false, false],
-        [1, "topic-3", 1, false, false],
-        [1, "topic-2", 1, false, true],
-        [1, "topic-1", 0, false, true],
+        // stream_id, topic, unread_count,  muted
+        [4, "topic-10", 1, false],
+        [1, "topic-7", 1, true],
+        [1, "topic-6", 1, false],
+        [1, "topic-5", 1, false],
+        [1, "topic-4", 1, false],
+        [1, "topic-3", 1, false],
+        [1, "topic-2", 1, false],
+        [1, "topic-1", 0, false],
     ]);
 
     mock_template("recent_topic_row.hbs", false, (data) => {
@@ -582,15 +580,15 @@ test("test_filter_participated", ({mock_template}) => {
     });
 
     const row_data = generate_topic_data([
-        // stream_id, topic, unread_count,  muted, participated
-        [4, "topic-10", 1, false, true],
-        [1, "topic-7", 1, true, true],
-        [1, "topic-6", 1, false, true],
-        [1, "topic-5", 1, false, true],
-        [1, "topic-4", 1, false, false],
-        [1, "topic-3", 1, false, false],
-        [1, "topic-2", 1, false, true],
-        [1, "topic-1", 0, false, true],
+        // stream_id, topic, unread_count,  muted
+        [4, "topic-10", 1, false],
+        [1, "topic-7", 1, true],
+        [1, "topic-6", 1, false],
+        [1, "topic-5", 1, false],
+        [1, "topic-4", 1, false],
+        [1, "topic-3", 1, false],
+        [1, "topic-2", 1, false],
+        [1, "topic-1", 0, false],
     ]);
     let i = 0;
 
@@ -692,7 +690,7 @@ test("test_update_unread_count", () => {
     rt.process_messages(messages);
 
     // update a message
-    generate_topic_data([[1, "topic-7", 1, false, true]]);
+    generate_topic_data([[1, "topic-7", 1, false]]);
     rt.update_topic_unread_count(messages[9]);
 });
 
@@ -713,7 +711,7 @@ test("basic assertions", ({mock_template, override_rewire}) => {
     let all_topics = rt_data.get();
 
     // update a message
-    generate_topic_data([[1, "topic-7", 1, false, true]]);
+    generate_topic_data([[1, "topic-7", 1, false]]);
     stub_out_filter_buttons();
     expected_data_to_replace_in_list_widget = [
         {
@@ -822,7 +820,7 @@ test("basic assertions", ({mock_template, override_rewire}) => {
 
     // update_topic_is_muted now relies on external libraries completely
     // so we don't need to check anythere here.
-    generate_topic_data([[1, topic1, 0, false, true]]);
+    generate_topic_data([[1, topic1, 0, false]]);
     $(".home-page-input").trigger("focus");
     assert.equal(rt.update_topic_is_muted(stream1, topic1), true);
     // a topic gets muted which we are not tracking


### PR DESCRIPTION
Commit 084cbd4ff7fdd25bbe37fc122c79dd15933e966d (#15064) removed the `.data()` calls that inspected these.

Needed for

- #24810