### PR TITLE
integration: Modify branch names for Gitlab MR events.

### DIFF
--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -369,7 +369,7 @@ A trivial change that should probably be ignored.
 
     def test_merge_request_updated_event_message(self) -> None:
         expected_topic = "my-awesome-project / MR #3 New Merge Request"
-        expected_message = "Tomasz Kolek updated [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) (assigned to Tomasz Kolek) from `tomek` to `master`:\n\n~~~ quote\nupdated desc\n~~~"
+        expected_message = "Tomasz Kolek updated [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) (assigned to Tomasz Kolek):\n\n~~~ quote\nupdated desc\n~~~"
         self.check_webhook(
             "merge_request_hook__merge_request_updated", expected_topic, expected_message
         )
@@ -383,7 +383,7 @@ A trivial change that should probably be ignored.
 
     def test_merge_request_merged_event_message(self) -> None:
         expected_topic = "my-awesome-project / MR #3 New Merge Request"
-        expected_message = "Tomasz Kolek merged [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3)."
+        expected_message = "Tomasz Kolek merged [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) from `tomek` to `master`."
 
         self.check_webhook(
             "merge_request_hook__merge_request_merged", expected_topic, expected_message
@@ -589,7 +589,7 @@ A trivial change that should probably be ignored.
 
     def test_system_merge_request_merged_event_message(self) -> None:
         expected_topic = "my-awesome-project / MR #3 New Merge Request"
-        expected_message = "Tomasz Kolek merged [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3)."
+        expected_message = "Tomasz Kolek merged [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) from `tomek` to `master`."
 
         self.check_webhook("system_hook__merge_request_merged", expected_topic, expected_message)
 

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -132,11 +132,19 @@ def get_merge_request_updated_event_body(payload: WildValue, include_title: bool
 
 def get_merge_request_event_body(payload: WildValue, action: str, include_title: bool) -> str:
     pull_request = payload["object_attributes"]
+    target_branch = None
+    base_branch = None
+    if action == "merged":
+        target_branch = pull_request["source_branch"].tame(check_string)
+        base_branch = pull_request["target_branch"].tame(check_string)
+
     return get_pull_request_event_message(
         get_issue_user_name(payload),
         action,
         pull_request["url"].tame(check_string),
         pull_request["iid"].tame(check_int),
+        target_branch=target_branch,
+        base_branch=base_branch,
         type="MR",
         title=payload["object_attributes"]["title"].tame(check_string) if include_title else None,
     )
@@ -151,8 +159,8 @@ def get_merge_request_open_or_updated_body(
         action,
         pull_request["url"].tame(check_string),
         pull_request["iid"].tame(check_int),
-        pull_request["source_branch"].tame(check_string),
-        pull_request["target_branch"].tame(check_string),
+        pull_request["source_branch"].tame(check_string) if action == "created" else None,
+        pull_request["target_branch"].tame(check_string) if action == "created" else None,
         pull_request["description"].tame(check_string),
         assignees=replace_assignees_username_with_name(get_assignees(payload)),
         type="MR",


### PR DESCRIPTION
This is a follow up to #24673, we want to modify every webhook events to follow the same pattern and consistency where branch name should only show on opened and merged events.

In the following changes we have:
- Removed branch names for updated MR events.
- Added branch names for merged MR events.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/62449508/227318246-45326cf9-ac7d-446f-9670-dabdb198ee0d.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/62449508/227317863-dbcce228-7421-453a-b791-917693d80ed5.png)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
