### PR TITLE
puppet: Decrease default nginx worker_connections.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -726,6 +726,16 @@ SSL/TLS termination.
 Set to the port number if you [prefer to listen on a port other than
 443](#using-an-alternate-port).
 
+#### `nginx_worker_connections`
+
+Adjust the [`worker_connections`][nginx_worker_connections] setting in
+the nginx server. This defaults to 10000; increasing it allows more
+concurrent connections per CPU core, at the cost of more memory
+consumed by NGINX. This number, times the number of CPU cores, should
+be more than twice the concurrent number of users.
+
+[nginx_worker_connections]: http://nginx.org/en/docs/ngx_core_module.html#worker_connections
+
 #### `queue_workers_multiprocess`
 
 By default, Zulip automatically detects whether the system has enough

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -44,6 +44,7 @@ class zulip::nginx {
   } else {
       $ca_crt = '/etc/pki/tls/certs/ca-bundle.crt'
   }
+  $worker_connections = zulipconf('application_server', 'nginx_worker_connections', 10000)
   file { '/etc/nginx/nginx.conf':
     ensure  => file,
     require => Package[$zulip::common::nginx, 'ca-certificates'],

--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -6,7 +6,7 @@ include /etc/nginx/modules-enabled/*.conf;
 
 worker_rlimit_nofile 1000000;
 events {
-    worker_connections 1000000;
+    worker_connections <%= @worker_connections %>;
 
     use epoll;
 


### PR DESCRIPTION
Increasing worker_connections has a memory cost, unlike the rest of the changes in 1c76036c61d8; setting it to 1 million caused nginx to consume several GB of memory.

Reduce the default down to 10k, and allow deploys to configure it up if necessary.  `worker_rlimit_nofile` is left at 1M, since it has no impact on memory consumption.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
