### PR TITLE
emojiset: Promise reject calls want an error, not an event.

### DIFF
--- a/web/src/emojisets.js
+++ b/web/src/emojisets.js
@@ -30,7 +30,12 @@ export async function select(name) {
     await new Promise((resolve, reject) => {
         const sheet = new Image();
         sheet.addEventListener("load", resolve);
-        sheet.addEventListener("error", reject);
+        sheet.addEventListener("error", () => {
+            // Unfortunately, the "event" we get doesn't have any
+            // useful information on it, as it's not the window-level
+            // error handler.
+            reject(new Error("Failed to load emojiset " + name + " from " + sheet.src));
+        });
         sheet.src = new_emojiset.sheet;
     });
     if (current_emojiset) {


### PR DESCRIPTION
This improves the error message captured, from the mildly inscrutable "Non-Error promise rejection captured with keys: currentTarget, isTrusted, target, type".

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
