### PR TITLE
typeahead: Fix bug where typeahead showed momentarily on shift + tab.

### DIFF
--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -199,6 +199,14 @@ import {get_string_diff} from "../../src/util";
   }
 
   , show: function () {
+      var header_text = this.header();
+      if (header_text) {
+        this.$header.find('span#typeahead-header-text').html(header_text);
+        this.$header.show();
+      } else {
+        this.$header.hide();
+      }
+
       var pos;
 
       if (this.fixed) {
@@ -229,14 +237,6 @@ import {get_string_diff} from "../../src/util";
         top: top_pos
        , left: pos.left
       })
-
-      var header_text = this.header();
-      if (header_text) {
-        this.$header.find('span#typeahead-header-text').html(header_text);
-        this.$header.show();
-      } else {
-        this.$header.hide();
-      }
 
       this.$container.show()
       this.shown = true

--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -439,7 +439,6 @@ import {get_string_diff} from "../../src/util";
   , keydown: function (e) {
     const pseudo_keycode = get_pseudo_keycode(e);
     if (this.trigger_selection(e)) {
-      if (!this.shown) return;
       e.preventDefault();
       this.select(e);
     }
@@ -473,6 +472,11 @@ import {get_string_diff} from "../../src/util";
             this.on_escape();
           }
           break
+
+        // to stop typeahead from showing up momentarily
+        // when shift + tabbing to a field with typeahead
+        case 16: // shift
+          return
 
         default:
           var hideOnEmpty = false


### PR DESCRIPTION
Break on `keyup` for case of `shift` key, instead of letting it trigger the typeahead.

This is a PR continuing on #24181. It was previously reverted due to a regression and it has now been fixed with #24812.

Fixes: #24152.

**Note:** Currently in main, we are calling `lookup` whenever we are letting go of the shift key to help fix the position of the typeahead. With the shift key being disabled in the changes, this becomes a problem as the typeahead fails to fix its position and will hover higher than usual. Thus, we will call `lookup` whenever we partially complete with `>` instead.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>

![f5a72a0c5fe2b137fc81dde61dd47179](https://user-images.githubusercontent.com/62449508/227443181-1e7d5adc-01b9-4a8d-926b-d7ccafec2023.gif)
</details>
<details>
<summary>After:</summary>

![7361d279d6046cc2147f70943e13ecfe](https://user-images.githubusercontent.com/62449508/227424192-16732b76-8649-41ec-a5d0-917188fe20d5.gif)
</details>
<details>
<summary>Compose box:</summary>

![60d9ecd7cd1d3f21e1acaabfd6209bc3](https://user-images.githubusercontent.com/62449508/227442637-d284bbb2-cd9d-4145-b1e2-1e714bfb4a27.gif)
![7fe00276ac8e3b53698aec244e7b3bdf](https://user-images.githubusercontent.com/62449508/227442843-8e941cdb-5395-4078-864d-bfe41fac8ed4.gif)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
