### PR TITLE
narrow: Support underscore version of "pm-with" and "group-pm-with".

### DIFF
--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -269,6 +269,13 @@ class NarrowBuilder:
             "search": self.by_search,
             "pm-with": self.by_pm_with,
             "group-pm-with": self.by_group_pm_with,
+            # TODO/compatibility: Prior to commit a9b3a9c, the server implementation
+            # for documented search operators with dashes, also implicitly supported
+            # clients sending those same operators with underscores. We can remove
+            # support for the below operators when support for the associated dashed
+            # operator is removed.
+            "pm_with": self.by_pm_with,
+            "group_pm_with": self.by_group_pm_with,
         }
 
     def add_term(self, query: Select, term: Dict[str, Any]) -> Select:

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -521,6 +521,18 @@ class NarrowBuilderTest(ZulipTestCase):
 
         self.assertRaises(BadNarrowOperatorError, _build_query, term)
 
+    # Test that the underscore version of "pm-with" works.
+    def test_add_term_using_underscore_version_of_pm_with_operator(self) -> None:
+        term = dict(operator="pm_with", operand=self.hamlet_email)
+        self._do_add_term_test(
+            term, "WHERE sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s"
+        )
+
+    # Test that the underscore version of "group-pm-with" works.
+    def test_add_term_using_underscore_version_of_group_pm_with_operator(self) -> None:
+        term = dict(operator="group_pm_with", operand=self.othello_email)
+        self._do_add_term_test(term, "WHERE recipient_id IN (__[POSTCOMPILE_recipient_id_1])")
+
     def _do_add_term_test(
         self, term: Dict[str, Any], where_clause: str, params: Optional[Dict[str, Any]] = None
     ) -> None:


### PR DESCRIPTION
Prior to commit a9b3a9c, the server implementation for documented search operators with dashes also implicitly supported clients sending those same operators with underscores. This has been the case sense the server side support for narrow filtering was introduced in commit 3af2bf345a8.

Updates the stricter version of mapping operator strings to `by_*` functions to also include the underscore version of any operators that have dashes. Adds a note that these undocumented versions are tied to the support for the documented versions.

See relevant CZO conversations in [api design](https://chat.zulip.org/#narrow/stream/378-api-design/topic/direct.20message.20search.20operators/near/1530965) and [zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Cannot.20narrow.20to.20.60pm_with.60/near/1530917) streams.

**Notes**:
- As noted above, the original narrow filtering that allowed for dashed and underscore operators to be implicitly the same `by_*` method was from Jan 2013: commit 3af2bf345a89b.
- As far as I can tell, the earliest documentation of the search operators was in Dec 2013: commit d57404683f4. It documents the dashed version of "pm-with".
  - The help documentation (that references the in-app documentation) was added in commits b44c4680f and 208da224e in Dec 2016.
  - The API documentation (that references the help documentation) was added in commit fcf1e3cd88 Aug 2018.
- The "group-pm-with" narrow support was added in commit 5e55fe992d22 in Apr 2017.
- Since the underscore version of these narrows was undocumented (as far as I can tell) and because we're planning on doing an API update to add new operators for direct/private message narrows (see #24806), I didn't feel like an API changelog / documentation update was needed here.
  - Instead I added a `TODO:compatibility` note in the dictionary where the operators are mapped to `by_*` methods to document that the support for these underscore cases is tied to the associated documented dashed operators.
  - I also added explicit and basic testing for these cases in `zerver/tests/test_message_fetch.NarrowBuilderTest`. Confirmed these new tests pass prior to commit a9b3a9c and fail after that commit's changes.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
