### PR TITLE
ts migration: Convert `favicon.js` to `favicon.ts`.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -84,7 +84,7 @@ EXEMPT_FILES = make_set(
         "web/src/echo.js",
         "web/src/emoji_picker.js",
         "web/src/emojisets.js",
-        "web/src/favicon.js",
+        "web/src/favicon.ts",
         "web/src/feature_flags.ts",
         "web/src/feedback_widget.js",
         "web/src/flatpickr.js",

--- a/web/src/assets.d.ts
+++ b/web/src/assets.d.ts
@@ -2,3 +2,8 @@ declare module "*.svg" {
     const url: string;
     export default url;
 }
+
+declare module "*.ttf" {
+    const url: string;
+    export default url;
+}


### PR DESCRIPTION
Added type annotations to function parameters, function return values and local variables. Added neccessary `if` statements to enforce the objects having proper type before executing the later operations.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
