### PR TITLE
integration: Modify branch names for Bitbucket 2 events.

### DIFF
--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -145,7 +145,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_updated_event(self) -> None:
-        expected_message = "Tomasz updated [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz updated [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek):\n\n~~~ quote\ndescription\n~~~"
         self.check_webhook(
             "pull_request_created_or_updated",
             TOPIC_PR_EVENTS,
@@ -192,9 +192,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_fulfilled_event(self) -> None:
-        expected_message = (
-            "Tomasz merged [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
-        )
+        expected_message = "Tomasz merged [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) from `new-branch` to `master`."
         self.check_webhook(
             "pull_request_fulfilled_or_rejected",
             TOPIC_PR_EVENTS,

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -334,11 +334,19 @@ def get_issue_action_body(payload: WildValue, action: str, include_title: bool) 
 
 def get_pull_request_action_body(payload: WildValue, action: str, include_title: bool) -> str:
     pull_request = payload["pullrequest"]
+    target_branch = None
+    base_branch = None
+    if action == "merged":
+        target_branch = pull_request["source"]["branch"]["name"].tame(check_string)
+        base_branch = pull_request["destination"]["branch"]["name"].tame(check_string)
+
     return get_pull_request_event_message(
         get_actor_info(payload),
         action,
         get_pull_request_url(pull_request),
         pull_request["id"].tame(check_int),
+        target_branch=target_branch,
+        base_branch=base_branch,
         title=pull_request["title"].tame(check_string) if include_title else None,
     )
 
@@ -356,8 +364,12 @@ def get_pull_request_created_or_updated_body(
         action,
         get_pull_request_url(pull_request),
         pull_request["id"].tame(check_int),
-        target_branch=pull_request["source"]["branch"]["name"].tame(check_string),
-        base_branch=pull_request["destination"]["branch"]["name"].tame(check_string),
+        target_branch=pull_request["source"]["branch"]["name"].tame(check_string)
+        if action == "created"
+        else None,
+        base_branch=pull_request["destination"]["branch"]["name"].tame(check_string)
+        if action == "created"
+        else None,
         message=pull_request["description"].tame(check_string),
         assignee=assignee,
         title=pull_request["title"].tame(check_string) if include_title else None,


### PR DESCRIPTION
This is a follow up to #24673, we want to modify every webhook events to follow the same pattern and consistency where branch name should only show on opened and merged events.

In the following changes we have:
- Removed branch names for updated PR events.
- Added branch names for merged PR events.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/62449508/227654772-97f40632-7699-4abf-8adf-8c91e1a6c59f.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/62449508/227654656-5debf9d4-e71b-431b-b353-770f56277748.png)

</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
