### PR TITLE
support: Fix scrubbing realms if string_id is a number.

### DIFF
--- a/web/src/analytics/support.ts
+++ b/web/src/analytics/support.ts
@@ -7,7 +7,7 @@ $(() => {
         e.preventDefault();
         const message =
             "Confirm the string_id of the realm you want to scrub.\n\n WARNING! This action is irreversible!";
-        const actual_string_id = $(this).data("string-id");
+        const actual_string_id = $(this).attr("data-string-id");
         // eslint-disable-next-line no-alert
         const confirmed_string_id = window.prompt(message);
         if (confirmed_string_id === actual_string_id) {

--- a/web/tests/support.test.js
+++ b/web/tests/support.test.js
@@ -24,8 +24,8 @@ run_test("scrub_realm", () => {
     const click_handler = $("body").get_on_handler("click", ".scrub-realm-button");
 
     const $fake_this = $.create("fake-.scrub-realm-button");
-    $fake_this.data = (name) => {
-        assert.equal(name, "string-id");
+    $fake_this.attr = (name) => {
+        assert.equal(name, "data-string-id");
         return "zulip";
     };
 


### PR DESCRIPTION
This took longer to debug then I'd like to admit :neutral_face: 

This bug made it impossible to scrub realms where the string_id was a number, e.g. 123.zulipchat.com because
confirmed_string_id === actual_string_id comparison failed due to one being a string and the other a number.

Per http://api.jquery.com/data/#data-html5:
Every attempt is made to convert the attribute's string value to a JavaScript value (this includes booleans, numbers, objects, arrays, and null).
To retrieve a data-* attribute value as an unconverted string, use the attr() method.
