### PR TITLE
ts : convert `settings_ui.js` to `settings_ui.ts` in `web/src`

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -172,7 +172,7 @@ EXEMPT_FILES = make_set(
         "web/src/settings_sections.js",
         "web/src/settings_streams.js",
         "web/src/settings_toggle.js",
-        "web/src/settings_ui.js",
+        "web/src/settings_ui.ts",
         "web/src/settings_user_groups_legacy.js",
         "web/src/settings_users.js",
         "web/src/setup.js",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -78,3 +78,13 @@ export type AjaxRequestHandler = (args: {
     success?(response_data: unknown, textStatus: string, jqXHR: JQuery.jqXHR): void;
     error?(xhr: JQuery.jqXHR, error_type: string, xhn: string): void;
 }) => void;
+
+// TODO/ typescript: Move this to settings_ui
+export type DoSettingsChangeOptions = {
+    success_msg_html?: string;
+    failure_msg_html?: string;
+    success_continuation?: (data: unknown) => void;
+    error_continuation?: (xhr: JQuery.jqXHR) => void;
+    sticky: boolean;
+    $error_msg_element?: JQuery;
+};


### PR DESCRIPTION
This PR converts `src/setting_ui`  to typescript

In making that possible,I added `interface DoSettingsChangeOptions` which contains all the return types of  `function check_duplicate_ids` to specify the strict return types.

> I also added `type unknown` to `data` and `response data`  as we initially don't know the type of  the data.




**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [X] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [X] Corner cases, error conditions, and easily imagined bugs.
</details>
