### PR TITLE
TS migration: Convert `localstorage.js` to `localstorage.ts`.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -103,7 +103,7 @@ EXEMPT_FILES = make_set(
         "web/src/list_widget.js",
         "web/src/loading.ts",
         "web/src/local_message.js",
-        "web/src/localstorage.js",
+        "web/src/localstorage.ts",
         "web/src/message_edit.js",
         "web/src/message_edit_history.js",
         "web/src/message_events.js",

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -91,7 +91,7 @@ test("profile_incomplete_alert", () => {
 
 test("server_upgrade_alert hide_duration_expired", ({override}) => {
     const ls = localstorage();
-    const start_time = new Date(1620327447050); // Thursday 06/5/2021 07:02:27 AM (UTC+0)
+    const start_time = 1620327447050; // Thursday 06/5/2021 07:02:27 AM (UTC+0)
 
     override(Date, "now", () => start_time);
     assert.equal(ls.get("lastUpgradeNagDismissalTime"), undefined);
@@ -99,7 +99,7 @@ test("server_upgrade_alert hide_duration_expired", ({override}) => {
     navbar_alerts.dismiss_upgrade_nag(ls);
     assert.equal(navbar_alerts.should_show_server_upgrade_notification(ls), false);
 
-    override(Date, "now", () => addDays(start_time, 8)); // Friday 14/5/2021 07:02:27 AM (UTC+0)
+    override(Date, "now", () => addDays(start_time, 8).getTime()); // Friday 14/5/2021 07:02:27 AM (UTC+0)
     assert.equal(navbar_alerts.should_show_server_upgrade_notification(ls), true);
     navbar_alerts.dismiss_upgrade_nag(ls);
     assert.equal(navbar_alerts.should_show_server_upgrade_notification(ls), false);


### PR DESCRIPTION
Added function parameter types, return type, and types of local varaibles. 
Added a `null` check for `raw_data` before `JSON.parse`.
Created a type `FormDataObject` and  an export type `LocalStorage`   to
imporve conciseness and clearity. Type `LocalStorage` is `export` because
it might be used in other files based on an observation that many files
has imported `localstorage`.

One thing to note is that the return type of a member function `setExpiry` 
in type `LocalStorage` is currently `object`, rather than a more specific type.
This is because I am not able to infer what the type `this` is in the `setExpiry`
funtion body.  

I checked a six-year-ago commit 8b22b94ab1613f523be01572787a13e3d49c50fd which created the original js file 
`localstorage.js`. Seems there was few clues on why the decision was made.


<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
