### PR TITLE
added copy button to copy email and api key

### DIFF
--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -603,6 +603,9 @@ export function set_up() {
         },
     });
 
+    new ClipboardJS("#copy_email");
+    new ClipboardJS("#copy_api_key");
+
     $("#bots_lists_navbar .active-bots-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -603,9 +603,6 @@ export function set_up() {
         },
     });
 
-    new ClipboardJS("#copy_email");
-    new ClipboardJS("#copy_api_key");
-
     $("#bots_lists_navbar .active-bots-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -624,3 +621,7 @@ export function set_up() {
         add_a_new_bot();
     });
 }
+
+
+new ClipboardJS("#copy_api_key");
+new ClipboardJS("#copy_email");

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -33,7 +33,7 @@
             <div class="field">{{t "Bot email" }}</div>
             <div class="value edit-bot-buttons">{{email}}
                 <button type="submit" id="copy_email" class="btn copy_email" data-clipboard-target=".email .value" title="{{t 'Copy email' }}">
-                    <i class="fa fa-clipboard copy"></i>
+                    <i class="fa fa-clipboard"></i>
                 </button>
             </div>
         </div>
@@ -44,7 +44,7 @@
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
                 <button type="submit" id="copy_api_key" class="btn copy_api_key" data-clipboard-target=".api_key .value" title="{{t 'Copy api key' }}">
-                    <i class="fa fa-clipboard copy"></i>
+                    <i class="fa fa-clipboard"></i>
                 </button>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-refresh" aria-hidden="true"></i>

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -31,14 +31,21 @@
         </div>
         <div class="email">
             <div class="field">{{t "Bot email" }}</div>
-            <div class="value">{{email}}</div>
+            <div class="value edit-bot-buttons">{{email}}
+                <button type="submit" id="copy_email" class="btn copy_email" data-clipboard-target=".email .value" title="{{t 'Copy email' }}">
+                    <i class="fa fa-clipboard copy"></i>
+                </button>
+            </div>
         </div>
         {{#if is_active}}
         <div class="api_key">
             <span class="field">{{t "API key" }}</span>
-            <div class="api-key-value-and-button no-select">
+            <div class="api-key-value-and-button no-select edit-bot-buttons">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
+                <button type="submit" id="copy_api_key" class="btn copy_api_key" data-clipboard-target=".api_key .value" title="{{t 'Copy api key' }}">
+                    <i class="fa fa-clipboard copy"></i>
+                </button>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-refresh" aria-hidden="true"></i>
                 </button>


### PR DESCRIPTION
Add "copy" buttons to bot settings #19884

Fixes: added a copy button to copy emails and api-key.

In some cases, one needs to copy specific bits of information for a bot in order to set things up. So for this copy button is added.
In the Settings > Bots menu, added a "copy" button in two places:

To the right of the email, to copy the email.
To the right of the API key (left of the button for regenerating the API key), to copy the API key.

Button is visually same as copy zuliprc button but the color is grey.

![image](https://user-images.githubusercontent.com/65345194/227747576-9991f119-4eb0-498c-9192-6637c5de522b.png)


Used the clipboard.js for the copying as it was also used by copy_zuliprc.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
new button is added to bot section in setting to copy email and api-key
- [x] Highlights technical choices and bugs encountered.
used clipboard.js for copying
- [x] Calls out remaining decisions and concerns.
used same button as copy_zuliprc 
- [ ] Automated tests verify logic where appropriate.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
DONE
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

