### PR TITLE
ts: Convert `emoji.js` to TypeScript.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
 
         /* Basic options */
         "noEmit": true,
-        "target": "ES2020",
+        "target": "ESNext",
         "esModuleInterop": true,
         "moduleResolution": "node",
         "resolveJsonModule": true,

--- a/web/src/emoji.js
+++ b/web/src/emoji.js
@@ -217,29 +217,27 @@ export function get_emoji_details_by_name(emoji_name) {
         throw new Error("Emoji name must be passed.");
     }
 
-    const emoji_info = {emoji_name};
-
     if (active_realm_emojis.has(emoji_name)) {
-        if (emoji_name === "zulip") {
-            emoji_info.reaction_type = "zulip_extra_emoji";
-        } else {
-            emoji_info.reaction_type = "realm_emoji";
-        }
         const emoji_code_info = active_realm_emojis.get(emoji_name);
-        emoji_info.emoji_code = emoji_code_info.id;
-        emoji_info.url = emoji_code_info.emoji_url;
-        if (emoji_code_info.still_url) {
-            emoji_info.still_url = emoji_code_info.still_url;
-        }
-    } else {
-        const codepoint = get_emoji_codepoint(emoji_name);
-        if (codepoint === undefined) {
-            throw new Error("Bad emoji name: " + emoji_name);
-        }
-        emoji_info.reaction_type = "unicode_emoji";
-        emoji_info.emoji_code = codepoint;
+        return {
+            emoji_name,
+            emoji_code: emoji_code_info.id,
+            url: emoji_code_info.emoji_url,
+            still_url: emoji_code_info.still_url,
+            reaction_type: emoji_name === "zulip" ? "zulip_extra_emoji" : "realm_emoji",
+        };
     }
-    return emoji_info;
+
+    const codepoint = get_emoji_codepoint(emoji_name);
+    if (codepoint === undefined) {
+        throw new Error("Bad emoji name: " + emoji_name);
+    }
+
+    return {
+        emoji_name,
+        reaction_type: "unicode_emoji",
+        emoji_code: codepoint,
+    };
 }
 
 export function get_emoji_details_for_rendering(opts) {

--- a/web/tests/emoji.test.js
+++ b/web/tests/emoji.test.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const events = require("./lib/events");
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
+const blueslip = require("./lib/zblueslip");
 
 const emoji_codes = zrequire("../../static/generated/emoji/emoji_codes.json");
 
@@ -12,9 +13,15 @@ const emoji = zrequire("emoji");
 
 const realm_emoji = events.test_realm_emojis;
 
-emoji.initialize({realm_emoji, emoji_codes});
-
 run_test("sanity check", () => {
+    // Invalid emoji data
+    emoji_codes.names = [...emoji_codes.names, "invalid_emoji"];
+    blueslip.expect("error", "No codepoint for emoji name invalid_emoji");
+    emoji.initialize({realm_emoji, emoji_codes});
+
+    // Valid data
+    emoji_codes.names = emoji_codes.names.filter((name) => name !== "invalid_emoji");
+    emoji.initialize({realm_emoji, emoji_codes});
     assert.equal(emoji.get_server_realm_emoji_data(), realm_emoji);
 });
 

--- a/web/tests/emoji.test.js
+++ b/web/tests/emoji.test.js
@@ -76,6 +76,7 @@ run_test("get_emoji_details_by_name", () => {
         reaction_type: "zulip_extra_emoji",
         emoji_code: "zulip",
         url: "/static/generated/emoji/images/emoji/unicode/zulip.png",
+        still_url: null,
     });
 
     // Test adding realm emoji.
@@ -97,6 +98,7 @@ run_test("get_emoji_details_by_name", () => {
         reaction_type: "realm_emoji",
         emoji_code: "102",
         url: "/some/path/to/emoji",
+        still_url: null,
     });
 
     // Test sending without emoji name.

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -358,6 +358,7 @@ test("sending", ({override, override_rewire}) => {
             reaction_type: "zulip_extra_emoji",
             emoji_name: "zulip",
             emoji_code: "zulip",
+            still_url: null,
             url: "/static/generated/emoji/images/emoji/unicode/zulip.png",
         });
     }

--- a/web/tests/reactions.test.js
+++ b/web/tests/reactions.test.js
@@ -891,7 +891,7 @@ test("view.insert_new_reaction (them w/zulip emoji)", ({mock_template}) => {
             class: "message_reaction",
             message_id,
             label: "translated: Bob van Roberts reacted with :zulip:",
-            still_url: undefined,
+            still_url: null,
             reaction_type: clean_reaction_object.reaction_type,
             vote_text: "",
         });


### PR DESCRIPTION
Converted `emoji.js` to TypeScript by adding relevant type definitions, also modified `target` option in our tsconfig to 'ES2022' so that types for object methods like `hasOwn` which is being used in `emoji.js` are included.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
