### PR TITLE
added copy button to copy email and api key

### DIFF
--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -621,3 +621,6 @@ export function set_up() {
         add_a_new_bot();
     });
 }
+
+new ClipboardJS("#copy_email");
+new ClipboardJS("#copy_api_key");

--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -31,14 +31,21 @@
         </div>
         <div class="email">
             <div class="field">{{t "Bot email" }}</div>
-            <div class="value">{{email}}</div>
+            <div class="value edit-bot-buttons">{{email}}
+                <button type="submit" id="copy_email" class="btn copy_email" data-clipboard-target=".email .value" title="{{t 'Copy email' }}">
+                    <i class="fa fa-clipboard"></i>
+                </button>
+            </div>
         </div>
         {{#if is_active}}
         <div class="api_key">
             <span class="field">{{t "API key" }}</span>
-            <div class="api-key-value-and-button no-select">
+            <div class="api-key-value-and-button no-select edit-bot-buttons">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
                 <span class="value text-select">{{api_key}}</span>
+                <button type="submit" id="copy_api_key" class="btn copy_api_key" data-clipboard-target=".api_key .value" title="{{t 'Copy api key' }}">
+                    <i class="fa fa-clipboard"></i>
+                </button>
                 <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
                     <i class="fa fa-refresh" aria-hidden="true"></i>
                 </button>

--- a/web/tests/settings_bots.test.js
+++ b/web/tests/settings_bots.test.js
@@ -20,6 +20,14 @@ const bot_data_params = {
 };
 
 function ClipboardJS(sel) {
+    assert.equal(sel, "#copy_email");
+}
+
+function ClipboardJS(sel) {
+    assert.equal(sel, "#copy_api_key");
+}
+
+function ClipboardJS(sel) {
     assert.equal(sel, "#copy_zuliprc");
 }
 mock_cjs("clipboard", ClipboardJS);

--- a/web/tests/settings_bots.test.js
+++ b/web/tests/settings_bots.test.js
@@ -20,14 +20,6 @@ const bot_data_params = {
 };
 
 function ClipboardJS(sel) {
-    assert.equal(sel, "#copy_email");
-}
-
-function ClipboardJS(sel) {
-    assert.equal(sel, "#copy_api_key");
-}
-
-function ClipboardJS(sel) {
     assert.equal(sel, "#copy_zuliprc");
 }
 mock_cjs("clipboard", ClipboardJS);


### PR DESCRIPTION
Add "copy" buttons to bot settings #19884

Fixes: added a copy button to copy emails and api-key

In some cases, one needs to copy specific bits of information for a bot in order to set things up. So for this copy button is added.
In the Settings > Bots menu, added a "copy" button in two places:

To the right of the email, to copy the email.
To the right of the API key (left of the button for regenerating the API key), to copy the API key.

Button is visually same as copy zuliprc button but the color is grey.

![image](https://user-images.githubusercontent.com/65345194/227773454-09064cac-ad80-4659-861e-832cc4593ce9.png)


Used the clipboard.js for the copying as it was also used by copy_zuliprc.

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
new button is added to bot section in setting to copy email and api-key
- [x] Highlights technical choices and bugs encountered.
used clipboard.js for copying
- [x] Calls out remaining decisions and concerns.
used same button as copy_zuliprc
- [ ] Automated tests verify logic where appropriate.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
DONE
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.

