### PR TITLE
compose: Insert two newlines on either side of the quoted message.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -536,25 +536,19 @@ export function quote_and_reply(opts) {
     const message = message_lists.current.selected_message();
     const quoting_placeholder = $t({defaultMessage: "[Quoting…]"});
 
-    if (compose_state.has_message_content()) {
-        // The user already started typing a message,
-        // so we won't re-open the compose box.
-        // (If you did re-open the compose box, you
+    if (!compose_state.has_message_content()) {
+        // The user has not started typing a message,
+        // so we will open the compose box. (If you
+        // did re-open the compose box when the user
+        // has already started typing a message, you
         // are prone to glitches where you select the
         // text, plus it's a complicated codepath that
         // can have other unintended consequences.)
 
-        if ($textarea.caret() !== 0) {
-            // Insert a newline before quoted message if there is
-            // already some content in the compose box and quoted
-            // message is not being inserted at the beginning.
-            $textarea.caret("\n");
-        }
-    } else {
         respond_to_message(opts);
     }
 
-    compose_ui.insert_syntax_and_focus(quoting_placeholder + "\n", $textarea);
+    compose_ui.insert_syntax_and_focus(quoting_placeholder, $textarea, "block");
 
     function replace_content(message) {
         // Final message looks like:

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -30,7 +30,7 @@ export function autosize_textarea($textarea) {
     }
 }
 
-export function smart_insert($textarea, syntax) {
+export function smart_insert_inline($textarea, syntax) {
     function is_space(c) {
         return c === " " || c === "\t" || c === "\n";
     }
@@ -68,11 +68,43 @@ export function smart_insert($textarea, syntax) {
     autosize_textarea($textarea);
 }
 
-export function insert_syntax_and_focus(syntax, $textarea = $("#compose-textarea")) {
+export function smart_insert_block($textarea, syntax) {
+    const pos = $textarea.caret();
+    const before_str = $textarea.val().slice(0, pos);
+    const after_str = $textarea.val().slice(pos);
+
+    // count the number of newlines between the cursor and the content.
+    const newlines_before = before_str.match(/(\n)+$/)?.[0].length ?? 0;
+    const newlines_after = after_str.match(/^(\n)+/)?.[0].length ?? 0;
+
+    if (pos > 0 && newlines_before < 2) {
+        syntax = "\n".repeat(2 - newlines_before) + syntax;
+    }
+
+    if (newlines_after < 2) {
+        syntax = syntax + "\n".repeat(2 - newlines_after);
+    }
+
+    // text-field-edit ensures `$textarea` is focused before inserting
+    // the new syntax.
+    insert($textarea[0], syntax);
+
+    autosize_textarea($textarea);
+}
+
+export function insert_syntax_and_focus(
+    syntax,
+    $textarea = $("#compose-textarea"),
+    display = "inline",
+) {
     // Generic helper for inserting syntax into the main compose box
     // where the cursor was and focusing the area.  Mostly a thin
     // wrapper around smart_insert.
-    smart_insert($textarea, syntax);
+    if (display === "inline") {
+        smart_insert_inline($textarea, syntax);
+    } else if (display === "block") {
+        smart_insert_block($textarea, syntax);
+    }
 }
 
 export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-textarea")) {

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -360,7 +360,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
     override(message_lists.current, "selected_id", () => 100);
 
     override(compose_ui, "insert_syntax_and_focus", (syntax) => {
-        assert.equal(syntax, "translated: [Quoting…]\n");
+        assert.equal(syntax, "translated: [Quoting…]");
     });
 
     const opts = {


### PR DESCRIPTION
Currently, the quoted message is inserted with a newline before and after it. Unless, there is no content before the quoted message, in which case, only a newline is inserted after the quoted message.

This commit changes the behavior to insert two newlines before and after the quoted message, unless there is no content before the quoted message, in which case, newline is inserted only after the quoted message. This is done to make the quoted message stand out from the rest of the message making it easier to read.

This also respects if the user has already inserted more than 2 newlines before or after the quoted message, in which case, no newlines are inserted.

Fixes #23608.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

### Same line
![same-line](https://user-images.githubusercontent.com/84973068/228050026-b02a2cff-0a37-474c-8bde-a2ae3c370c47.gif)

### One new line

![one-new-line](https://user-images.githubusercontent.com/84973068/228050133-330fd90d-3267-41d1-b9cd-f9f2514097bb.gif)

### Multiple Lines

![multiple-lines](https://user-images.githubusercontent.com/84973068/228050173-908e9c90-8639-4d20-b5b2-3a7b49a0f244.gif)

### Without Preceding content

![without-preceding-content](https://user-images.githubusercontent.com/84973068/228050201-e77c7429-c28f-4c74-be6e-6b720518d786.gif)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
