### PR TITLE
bots: Avoid multiple active bots with the same name.

### DIFF
--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -245,6 +245,7 @@ def check_change_bot_full_name(
     check_bot_name_available(
         realm_id=user_profile.realm_id,
         full_name=new_full_name,
+        is_activation=False,
     )
     do_change_full_name(user_profile, new_full_name, acting_user)
 

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -61,7 +61,7 @@ def check_full_name(full_name_raw: str) -> str:
 # name (e.g. you can get there by reactivating a deactivated bot after
 # making a new bot with the same name).  This is just a check designed
 # to make it unlikely to happen by accident.
-def check_bot_name_available(realm_id: int, full_name: str) -> None:
+def check_bot_name_available(realm_id: int, full_name: str, *, is_activation: bool) -> None:
     dup_exists = UserProfile.objects.filter(
         realm_id=realm_id,
         full_name=full_name.strip(),
@@ -69,7 +69,12 @@ def check_bot_name_available(realm_id: int, full_name: str) -> None:
     ).exists()
 
     if dup_exists:
-        raise JsonableError(_("Name is already in use!"))
+        if is_activation:
+            raise JsonableError(
+                f"There is already an active bot named {full_name} in this organization. To reactivate this bot, you must rename or deactivate the other one first."
+            )
+        else:
+            raise JsonableError(_("Name is already in use!"))
 
 
 def check_short_name(short_name_raw: str) -> str:

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -681,6 +681,36 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "No such user")
         self.assert_num_bots_equal(1)
 
+    def test_activate_bot_with_duplicate_name(self) -> None:
+        self.login("iago")
+        # Create a bot and then deactivate it
+        original_name = "The Bot of Hamlet"
+        bot_info = {
+            "full_name": original_name,
+            "short_name": "hambot",
+        }
+        result = self.client_post("/json/bots", bot_info)
+        self.assert_json_success(result)
+        bot_email = "hambot-bot@zulip.testserver"
+        bot = self.get_bot_user(bot_email)
+        do_deactivate_user(bot, False, acting_user=None)
+        self.assertFalse(
+            UserProfile.objects.filter(is_bot=True, id=bot.id, is_active=True).exists()
+        )
+
+        # Create another bot with the same name
+        bot_info2 = {
+            "full_name": original_name,
+            "short_name": "hambot2",
+        }
+        result = self.client_post("/json/bots", bot_info2)
+        self.assert_json_success(result)
+        result = self.client_post(f"/json/users/{bot.id}/reactivate")
+        self.assert_json_error(
+            result,
+            "There is already an active bot named The Bot of Hamlet in this organization. To reactivate this bot, you must rename or deactivate the other one first.",
+        )
+
     def test_bot_permissions(self) -> None:
         self.login("hamlet")
         self.assert_num_bots_equal(0)

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -182,6 +182,7 @@ def reactivate_user_backend(
     if target.is_bot:
         assert target.bot_type is not None
         check_bot_creation_policy(user_profile, target.bot_type)
+        check_bot_name_available(user_profile.realm_id, target.full_name, is_activation=True)
     do_reactivate_user(target, acting_user=user_profile)
     return json_success(request)
 
@@ -514,6 +515,7 @@ def add_bot_backend(
     check_bot_name_available(
         realm_id=user_profile.realm_id,
         full_name=full_name,
+        is_activation=False,
     )
 
     check_bot_creation_policy(user_profile, bot_type)


### PR DESCRIPTION
Creating a bot with a name that is already in use will raise an error. However, by deactivating the existing bot, creating a new bot with the same name, and then reactivating the original bot, it is possible to have multiple bots with the same name.

To fix this, we check if the bot name is already in use in the active bots list by using `check_bot_name_available()` function present inside `users.py`.  If it is, an error will be raised, prompting either the name of the existing bot to be changed or the bot to be deactivated.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Previous behavior:

![multi_bots](https://user-images.githubusercontent.com/96344003/228062487-76b0b35a-abc1-41c4-ae18-ed04a3b4282d.png)

New behavior:

![multi_bots_fix](https://user-images.githubusercontent.com/96344003/228063307-8c2cdd2d-10dd-422c-a4e0-603f9667a5db.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
