### PR TITLE
compose: Disable send button while uploads are in progress.

### DIFF
--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -19,6 +19,7 @@ import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
+import * as upload from "./upload";
 import * as util from "./util";
 
 let user_acknowledged_wildcard = false;
@@ -618,6 +619,13 @@ function validate_private_message() {
     return true;
 }
 
+export function should_enable_send_button() {
+    const text = compose_state.message_content();
+    const max_length = page_params.max_message_length;
+
+    return !(text.length > max_length) && !upload.get_upload_status();
+}
+
 export function check_overflow_text() {
     // This function is called when typing every character in the
     // compose box, so it's important that it not doing anything
@@ -652,9 +660,10 @@ export function check_overflow_text() {
     } else {
         $indicator.text("");
         $("#compose-textarea").removeClass("over_limit");
-
-        $("#compose-send-button").prop("disabled", false);
         $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.message_too_long)}`).remove();
+        if (should_enable_send_button()) {
+            $("#compose-send-button").prop("disabled", false);
+        }
     }
 
     return text.length;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -565,6 +565,11 @@ input.recipient_box {
     }
 }
 
+#compose-send-button[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .enter_sends_choices {
     .enter_sends_choice {
         display: flex;

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -58,6 +58,8 @@ const echo = zrequire("echo");
 const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 
+upload.get_upload_status = () => false;
+
 function reset_jquery() {
     // Avoid leaks.
     $.clear_all_elements();

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -18,7 +18,11 @@ mock_esm("@uppy/core", {
     },
 });
 mock_esm("@uppy/xhr-upload", {default: class XHRUpload {}});
-
+mock_esm("../src/compose_validate", {
+    should_enable_send_button() {
+        return true;
+    },
+});
 const compose_actions = mock_esm("../src/compose_actions");
 mock_esm("../src/csrf", {csrf_token: "csrf_token"});
 
@@ -164,6 +168,11 @@ test("get_item", () => {
 });
 
 test("show_error_message", ({mock_template}) => {
+    const uppy = {
+        getFiles() {
+            return 0;
+        },
+    };
     $("#compose_banners .upload_banner .moving_bar").css = () => {};
     $("#compose_banners .upload_banner").length = 0;
 
@@ -176,7 +185,7 @@ test("show_error_message", ({mock_template}) => {
 
     $("#compose-send-button").prop("disabled", true);
 
-    upload.show_error_message({mode: "compose"}, "Error message");
+    upload.show_error_message(uppy, {mode: "compose"}, "Error message");
     assert.equal($("#compose-send-button").prop("disabled"), false);
     assert.ok(banner_shown);
 
@@ -185,12 +194,13 @@ test("show_error_message", ({mock_template}) => {
         assert.equal(data.banner_text, "translated: An unknown error occurred.");
         banner_shown = true;
     });
-    upload.show_error_message({mode: "compose"});
+    upload.show_error_message(uppy, {mode: "compose"});
 });
 
 test("upload_files", async ({mock_template, override_rewire}) => {
     $("#compose_banners .upload_banner").remove = () => {};
     $("#compose_banners .upload_banner .moving_bar").css = () => {};
+    $("#compose-send-button").css = () => {};
     $("#compose_banners .upload_banner").length = 0;
 
     let files = [
@@ -212,6 +222,9 @@ test("upload_files", async ({mock_template, override_rewire}) => {
         },
         removeFile() {
             remove_file_called = true;
+        },
+        getFiles() {
+            return 0;
         },
     };
     let hide_upload_banner_called = false;
@@ -499,6 +512,9 @@ test("uppy_events", ({override_rewire, mock_template}) => {
                     },
                 ],
             }),
+            getFiles() {
+                return 0;
+            },
         };
     };
     upload.setup_upload({mode: "compose"});


### PR DESCRIPTION
Previously, the send button wasn't actually disabled when there is an upload in progress since the changes to the button would be undone by other input handlers. These changes will ensure that the send button is disabled throughout the entire upload process.

Fixes: #21135.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>

![f2ac0df43298c409d581b18edca1e6c3](https://user-images.githubusercontent.com/62449508/228113836-ed554f0c-50e4-43e4-b948-99e81f2390b6.gif)
![8da28234886c30b0df251ef9af728985](https://user-images.githubusercontent.com/62449508/228120074-c2481726-2095-4224-a6ce-c5903720a200.gif)


</details>

<details>
<summary>After:</summary>

![c6562e92d51da59eafd6749c495059ec](https://user-images.githubusercontent.com/62449508/228119667-78d8cbed-859f-4a51-bb9c-4cbd84df4612.gif)


![640d0df8ad7800bbfa386c4b291f9a3c](https://user-images.githubusercontent.com/62449508/228119312-e85ba4d9-21c8-4f0c-888b-1ade7f1dcfd9.gif)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
