### PR TITLE
compose validate: Rename and swap return value for overflow verifier.

### DIFF
--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -598,7 +598,7 @@ export function check_overflow_text() {
     return text.length;
 }
 
-export function warn_for_text_overflow_when_tries_to_send() {
+export function validate_message_length() {
     if (compose_state.message_content().length > page_params.max_message_length) {
         $("#compose-textarea").addClass("flash");
         setTimeout(() => $("#compose-textarea").removeClass("flash"), 1500);
@@ -624,7 +624,7 @@ export function validate() {
         );
         return false;
     }
-    if (!warn_for_text_overflow_when_tries_to_send()) {
+    if (!validate_message_length()) {
         return false;
     }
 

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -231,7 +231,7 @@ function handle_keydown(e) {
                 if (should_enter_send(e)) {
                     e.preventDefault();
                     if (
-                        compose_validate.warn_for_text_overflow_when_tries_to_send() &&
+                        compose_validate.validate_message_length() &&
                         !$("#compose-send-button").prop("disabled")
                     ) {
                         $("#compose-send-button").prop("disabled", true);

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -13,7 +13,7 @@ const compose = mock_esm("../src/compose", {
     finish: noop,
 });
 const compose_validate = mock_esm("../src/compose_validate", {
-    warn_for_text_overflow_when_tries_to_send: () => true,
+    validate_message_length: () => true,
 });
 const input_pill = mock_esm("../src/input_pill");
 const message_user_ids = mock_esm("../src/message_user_ids", {


### PR DESCRIPTION
Changed the function to return true when it does something and false when it doesn't, and renamed it to be clearer that it's doing that.
