### PR TITLE
Fix class of custom profile field inputs and width of url type custom field inputs.

### DIFF
--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -261,6 +261,7 @@ export function append_custom_profile_fields(element_id, user_id) {
             is_pronouns_field: field.type === all_field_types.PRONOUNS.id,
             is_select_field,
             field_choices,
+            for_manage_user_modal: element_id === "#edit-user-form .custom-profile-field-form",
         });
         $(element_id).append(html);
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -382,7 +382,9 @@ td .button {
 }
 
 .settings_text_input {
-    width: 206px;
+    /* 311px + 2 * 6px (padding) + 2 * 1px (border) = 325px (min width of select
+    elements in settings) */
+    width: 311px;
 }
 
 #admin-user-list,

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -618,6 +618,10 @@ input[type="checkbox"] {
     .person_picker {
         min-width: 311px;
     }
+
+    & textarea {
+        width: 311px;
+    }
 }
 
 .control-label-disabled {
@@ -1425,8 +1429,6 @@ $option_title_width: 180px;
         }
 
         & textarea {
-            width: max(206px, 25vw);
-            max-width: 320px;
             height: 80px;
         }
 
@@ -1470,8 +1472,15 @@ $option_title_width: 180px;
     }
 }
 
-#edit-user-form .person_picker {
-    min-width: 206px;
+#edit-user-form {
+    .person_picker {
+        min-width: 206px;
+    }
+
+    & textarea {
+        width: max(206px, 25vw);
+        max-width: 320px;
+    }
 }
 
 .dropdown-list-widget {
@@ -1851,7 +1860,6 @@ $option_title_width: 180px;
         margin-top: 5px;
     }
 
-    #settings_page,
     #edit-user-form {
         .custom_user_field textarea {
             width: calc(100% - 25px);

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -614,6 +614,10 @@ input[type="checkbox"] {
         margin-left: 5px;
         border: none;
     }
+
+    .person_picker {
+        min-width: 311px;
+    }
 }
 
 .control-label-disabled {
@@ -1446,10 +1450,6 @@ $option_title_width: 180px;
         .datepicker {
             cursor: default;
         }
-
-        .person_picker {
-            min-width: 206px;
-        }
     }
 
     #show_my_user_profile_modal {
@@ -1468,6 +1468,10 @@ $option_title_width: 180px;
         /* Override undesired Bootstrap default. */
         margin-bottom: 0;
     }
+}
+
+#edit-user-form .person_picker {
+    min-width: 206px;
 }
 
 .dropdown-list-widget {

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -3,17 +3,17 @@
         <input type="hidden" name="is_full_name" value="true" />
         <div class="input-group name_change_container">
             <label for="edit_user_full_name">{{t "Full name" }}</label>
-            <input type="text" autocomplete="off" name="full_name" id="edit_user_full_name" value="{{ full_name }}" />
+            <input type="text" autocomplete="off" name="full_name" id="edit_user_full_name" class="modal_text_input" value="{{ full_name }}" />
         </div>
         {{#if email}}
         <div class="input-group email_change_container">
             <label for="email">{{t "Email" }}</label>
-            <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
+            <input type="text" autocomplete="off" name="email" class="modal_text_input" value="{{ email }}" readonly/>
         </div>
         {{/if}}
         <div class="input-group user_id_container">
             <label for="user_id">{{t "User ID" }}</label>
-            <input type="text" autocomplete="off" name="user_id" value="{{ user_id }}" readonly/>
+            <input type="text" autocomplete="off" name="user_id" class="modal_text_input" value="{{ user_id }}" readonly/>
         </div>
         <div class="input-group">
             <label class="input-label" for="user-role-select">{{t 'User role' }}

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -17,15 +17,15 @@
             <div class="input" contenteditable="true"></div>
         </div>
         {{else if is_date_field }}
-        <input class="custom_user_field_value datepicker modal_text_input" data-field-id="{{ field.id }}" type="text"
+        <input class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" data-field-id="{{ field.id }}" type="text"
           value="{{ field_value.value }}" />
         <span class="remove_date"><i class="fa fa-close"></i></span>
         {{else if is_url_field }}
-        <input class="custom_user_field_value modal_text_input" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
+        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
         {{else if is_pronouns_field}}
-        <input class="custom_user_field_value pronouns_type_field modal_text_input" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{else}}
-        <input class="custom_user_field_value modal_text_input" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{/if}}
     </div>
 </div>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -6,7 +6,7 @@
         {{#if is_long_text_field}}
         <textarea maxlength="500" class="custom_user_field_value settings_textarea">{{ field_value.value }}</textarea>
         {{else if is_select_field}}
-        <select class="custom_user_field_value settings_select modal_select bootstrap-focus-style">
+        <select class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style">
             <option value=""></option>
             {{#each field_choices}}
                 <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to increase the width of url type custom field inputs.
- Second commit is to add `modal_text_inputs` class to remaining inputs in "Manage user" modal.
- Third and fourth commits are to update the class for input and select elements.

Discussion - https://github.com/zulip/zulip/pull/24881#issuecomment-1486244879
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
For profile section-

![Screenshot from 2023-03-28 17-11-18](https://user-images.githubusercontent.com/35494118/228228736-8cbd7729-6343-4762-8c33-c37129ee4997.png)

For "Manage user" modal -

![Screenshot from 2023-03-28 17-12-16](https://user-images.githubusercontent.com/35494118/228228761-5c000b65-c2eb-42f1-be03-cea934b5bf3d.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
