### PR TITLE
integration: Modify branch names for Bitbucket 3 events.

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -190,6 +190,13 @@ def get_pull_request_event_message(
     else:
         main_message = PULL_REQUEST_OR_ISSUE_MESSAGE_TEMPLATE.format(**kwargs)
 
+    if target_branch and base_branch:
+        branch_info = PULL_REQUEST_BRANCH_INFO_TEMPLATE.format(
+            target=target_branch,
+            base=base_branch,
+        )
+        main_message = f"{main_message} {branch_info}"
+
     if assignees:
         assignees_string = ""
         if len(assignees) == 1:
@@ -209,13 +216,6 @@ def get_pull_request_event_message(
     elif assignee:
         assignee_info = PULL_REQUEST_OR_ISSUE_ASSIGNEE_INFO_TEMPLATE.format(assignee=assignee)
         main_message = f"{main_message} {assignee_info}"
-
-    if target_branch and base_branch:
-        branch_info = PULL_REQUEST_BRANCH_INFO_TEMPLATE.format(
-            target=target_branch,
-            base=base_branch,
-        )
-        main_message = f"{main_message} {branch_info}"
 
     punctuation = ":" if message else "."
     if (

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -116,7 +116,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.check_webhook("issue_commented", expected_topic, expected_message)
 
     def test_bitbucket2_on_pull_request_created_event(self) -> None:
-        expected_message = "Tomasz created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) from `new-branch` to `master` (assigned to Tomasz Kolek):\n\n~~~ quote\ndescription\n~~~"
         self.check_webhook(
             "pull_request_created_or_updated",
             TOPIC_PR_EVENTS,
@@ -125,7 +125,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_created_without_reviewer_username_event(self) -> None:
-        expected_message = "Tomasz created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) from `new-branch` to `master` (assigned to Tomasz Kolek):\n\n~~~ quote\ndescription\n~~~"
         self.check_webhook(
             "pull_request_created_or_updated_without_username",
             TOPIC_PR_EVENTS,
@@ -136,7 +136,7 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_pull_request_created_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "Tomasz created [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz created [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) from `new-branch` to `master` (assigned to Tomasz Kolek):\n\n~~~ quote\ndescription\n~~~"
         self.check_webhook(
             "pull_request_created_or_updated",
             expected_topic,

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -135,7 +135,7 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     def test_pr_opened_with_two_reviewers(self) -> None:
         expected_topic = "sandbox / PR #5 Add Notes Feature"
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #5](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5) from `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)."""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #5](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5) from `master` to `master` (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo))."""
         self.check_webhook(
             "pull_request_opened_with_two_reviewers", expected_topic, expected_message
         )
@@ -144,26 +144,26 @@ class Bitbucket3HookTests(WebhookTestCase):
         expected_topic = "sandbox / PR #5 Add Notes Feature"
         expected_topic = "custom_topic"
         self.url = self.build_webhook_url(topic="custom_topic")
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #5 Add Notes Feature](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5) from `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)."""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #5 Add Notes Feature](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5) from `master` to `master` (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo))."""
         self.check_webhook(
             "pull_request_opened_with_two_reviewers", expected_topic, expected_message
         )
 
     def test_pr_opened_with_multiple_reviewers(self) -> None:
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) from `master` to `master` (assigned to [sougo](http://139.59.64.214:7990/users/sougo), [zura](http://139.59.64.214:7990/users/zura) and [shimura](http://139.59.64.214:7990/users/shimura) for review):\n\n~~~ quote\nAdd a simple text file for further testing purposes.\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) from `master` to `master` (assigned reviewers: [sougo](http://139.59.64.214:7990/users/sougo), [zura](http://139.59.64.214:7990/users/zura) and [shimura](http://139.59.64.214:7990/users/shimura)):\n\n~~~ quote\nAdd a simple text file for further testing purposes.\n~~~"""
         self.check_webhook(
             "pull_request_opened_with_multiple_reviewers", expected_topic, expected_message
         )
 
     def test_pr_modified(self) -> None:
         expected_topic = "sandbox / PR #1 Branch1"
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) from `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) from `branch1` to `master` (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura)):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
         self.check_webhook("pull_request_modified", expected_topic, expected_message)
 
     def test_pr_modified_with_include_title(self) -> None:
         expected_topic = "custom_topic"
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) from `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) from `branch1` to `master` (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura)):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
         self.url = self.build_webhook_url(topic="custom_topic")
         self.check_webhook("pull_request_modified", expected_topic, expected_message)
 

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -158,12 +158,12 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     def test_pr_modified(self) -> None:
         expected_topic = "sandbox / PR #1 Branch1"
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) from `branch1` to `master` (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura)):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura)):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
         self.check_webhook("pull_request_modified", expected_topic, expected_message)
 
     def test_pr_modified_with_include_title(self) -> None:
         expected_topic = "custom_topic"
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) from `branch1` to `master` (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura)):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) (assigned reviewers: [shimura](http://139.59.64.214:7990/users/shimura)):\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
         self.url = self.build_webhook_url(topic="custom_topic")
         self.check_webhook("pull_request_modified", expected_topic, expected_message)
 
@@ -185,7 +185,7 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     def test_pr_merged(self) -> None:
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
-        expected_message = """[zura](http://139.59.64.214:7990/users/zura) merged [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)."""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) merged [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) from `master` to `master`."""
         self.check_webhook("pull_request_merged", expected_topic, expected_message)
 
     # PR reviewer events:

--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -51,7 +51,7 @@ class GiteaHookTests(WebhookTestCase):
 
     def test_pull_request_assigned(self) -> None:
         expected_topic = "test / PR #1906 test 2"
-        expected_message = """kostekIV assigned [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) (assigned to kostekIV) from `d` to `master`."""
+        expected_message = """kostekIV assigned [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) from `d` to `master` (assigned to kostekIV)."""
         self.check_webhook("pull_request__assigned", expected_topic, expected_message)
 
     def test_issues_opened(self) -> None:

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -162,7 +162,7 @@ class GitHubWebhookTest(WebhookTestCase):
 
     def test_pull_request_opened_with_preassigned_assignee_msg(self) -> None:
         expected_topic = "Scheduler / PR #4 Improve README"
-        expected_message = "eeshangarg opened [PR #4](https://github.com/eeshangarg/Scheduler/pull/4) (assigned to eeshangarg) from `eeshangarg:improve-readme-2` to `eeshangarg:master`."
+        expected_message = "eeshangarg opened [PR #4](https://github.com/eeshangarg/Scheduler/pull/4) from `eeshangarg:improve-readme-2` to `eeshangarg:master` (assigned to eeshangarg)."
         self.check_webhook(
             "pull_request__opened_with_preassigned_assignee", expected_topic, expected_message
         )

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -304,7 +304,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_merge_request_created_with_assignee_event_message(self) -> None:
         expected_topic = "my-awesome-project / MR #3 New Merge Request"
-        expected_message = "Tomasz Kolek created [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) (assigned to Tomasz Kolek) from `tomek` to `master`:\n\n~~~ quote\ndescription of merge request\n~~~"
+        expected_message = "Tomasz Kolek created [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) from `tomek` to `master` (assigned to Tomasz Kolek):\n\n~~~ quote\ndescription of merge request\n~~~"
         self.check_webhook(
             "merge_request_hook__merge_request_created_with_assignee",
             expected_topic,
@@ -314,7 +314,7 @@ class GitlabHookTests(WebhookTestCase):
     def test_merge_request_created_with_multiple_assignees_event_message(self) -> None:
         expected_topic = "Demo Project / MR #1 Make a trivial change to the README."
         expected_message = """
-Hemanth V. Alluri created [MR #1](https://gitlab.com/Hypro999/demo-project/-/merge_requests/1) (assigned to Hemanth V. Alluri and Hemanth V. Alluri) from `devel` to `master`:
+Hemanth V. Alluri created [MR #1](https://gitlab.com/Hypro999/demo-project/-/merge_requests/1) from `devel` to `master` (assigned to Hemanth V. Alluri and Hemanth V. Alluri):
 
 ~~~ quote
 A trivial change that should probably be ignored.
@@ -576,7 +576,7 @@ A trivial change that should probably be ignored.
 
     def test_system_merge_request_created_with_assignee_event_message(self) -> None:
         expected_topic = "my-awesome-project / MR #3 New Merge Request"
-        expected_message = "Tomasz Kolek created [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) (assigned to Tomasz Kolek) from `tomek` to `master`:\n\n~~~ quote\ndescription of merge request\n~~~"
+        expected_message = "Tomasz Kolek created [MR #3](https://gitlab.com/tomaszkolek0/my-awesome-project/merge_requests/3) from `tomek` to `master` (assigned to Tomasz Kolek):\n\n~~~ quote\ndescription of merge request\n~~~"
         self.check_webhook(
             "system_hook__merge_request_created_with_assignee", expected_topic, expected_message
         )


### PR DESCRIPTION
This is a follow up to https://github.com/zulip/zulip/pull/24673, we want to modify every webhook events to follow the same pattern and consistency where branch name should only show on opened and merged events.

In this PR there are two prep commits where:
- We move assignee message to the end for git integrations.
- Allow `get_pull_request_event_message` to support reviewers.

In the main changes we have:
- Removed branch names for updated PR events.
- Added branch names for merged PR events.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Will add screenshots and screen captures later.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
