### PR TITLE
search: Add title to the search bar when in "sender:" narrow.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -535,6 +535,11 @@ export class Filter {
             return true;
         }
 
+        // Also check if a real user exists with the provided email.
+        if (_.isEqual(term_types, ["sender"]) && people.get_by_email(this.operands("sender")[0])) {
+            return true;
+        }
+
         if (_.isEqual(term_types, [])) {
             // All view
             return true;
@@ -745,6 +750,20 @@ export class Filter {
                     return $t({defaultMessage: "Alerted messages"});
                 case "is-unread":
                     return $t({defaultMessage: "Unread messages"});
+                case "sender": {
+                    const user = people.get_by_email(this.operands("sender")[0]);
+                    if (user) {
+                        if (people.is_my_user_id(user.user_id)) {
+                            return $t({defaultMessage: "Messages sent by you"});
+                        }
+                        return $t(
+                            {defaultMessage: "Messages sent by {sender}"},
+                            {
+                                sender: user.full_name,
+                            },
+                        );
+                    }
+                }
             }
         }
         /* istanbul ignore next */

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1514,6 +1514,7 @@ test("navbar_helpers", () => {
         test_redirect_url_with_search(test_case);
     }
 
+    const sender = [{operator: "sender", operand: joe.email}];
     const in_home = [{operator: "in", operand: "home"}];
     const in_all = [{operator: "in", operand: "all"}];
     const is_starred = [{operator: "is", operand: "starred"}];
@@ -1555,6 +1556,13 @@ test("navbar_helpers", () => {
     ];
 
     const test_cases = [
+        {
+            operator: sender,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Messages sent by " + joe.full_name,
+            redirect_url_with_search: "/#narrow/sender/" + joe.user_id + "-joe",
+        },
         {
             operator: is_starred,
             is_common_narrow: true,

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -801,7 +801,7 @@ run_test("narrow_compute_title", ({override}) => {
     assert.equal(narrow.compute_narrow_title(filter), "translated: Search results");
 
     filter = new Filter([{operator: "sender", operand: "me"}]);
-    assert.equal(narrow.compute_narrow_title(filter), "translated: Search results");
+    assert.equal(narrow.compute_narrow_title(filter), "translated: Messages sent by you");
 
     // Stream narrows
     const sub = {


### PR DESCRIPTION
Zulip's "all messages sent by X" views are useful but they can be
really confusing for someone who doesn't realize or has forgotten
they're in that view.

Adding a proper title in the search bar that indicate this state
of their view will be helpful.

For example, when we're in a view that shows all messages of
"Lakshay Mittal". The title will indicate,

"Messages sent by Lakshay Mittal"

Fixes: #18690.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
**For searching other's messages**
<img width="873" alt="image" src="https://user-images.githubusercontent.com/101464851/236759463-9d1c74f3-4450-4795-adbe-8d2b9f5f122d.png">
**For searching your messages**
<img width="872" alt="ss" src="https://github.com/zulip/zulip/assets/101464851/603ff28c-443a-4d33-896d-631c672132d7">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
