### PR TITLE
fix: Hide buttons in message header bar while editing topic #24888

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -294,18 +294,24 @@ export function initialize() {
     $("body").on("click", ".always_visible_topic_edit,.on_hover_topic_edit", function (e) {
         const $recipient_row = $(this).closest(".recipient_row");
         message_edit.start_inline_topic_edit($recipient_row);
+        $(".zulip-icon-mute").hide();
+        $(".mark-as-resolved").hide();
         e.stopPropagation();
         popovers.hide_all();
     });
     $("body").on("click", ".topic_edit_save", function (e) {
         const $recipient_row = $(this).closest(".recipient_row");
         message_edit.save_inline_topic_edit($recipient_row);
+        $(".zulip-icon-mute").show();
+        $(".mark-as-resolved").show();
         e.stopPropagation();
         popovers.hide_all();
     });
     $("body").on("click", ".topic_edit_cancel", function (e) {
         const $recipient_row = $(this).closest(".recipient_row");
         message_edit.end_inline_topic_edit($recipient_row);
+        $(".zulip-icon-mute").show();
+        $(".mark-as-resolved").show();
         e.stopPropagation();
         popovers.hide_all();
     });
@@ -768,7 +774,7 @@ export function initialize() {
                 });
             },
         );
-        $("#settings-dropdown").dropdown("toggle");
+        //$("#settings-dropdown").dropdown("toggle");
         e.preventDefault();
         e.stopPropagation();
     });

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -774,7 +774,7 @@ export function initialize() {
                 });
             },
         );
-        //$("#settings-dropdown").dropdown("toggle");
+        $("#settings-dropdown").dropdown("toggle");
         e.preventDefault();
         e.stopPropagation();
     });

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -372,6 +372,8 @@ function handle_inline_topic_edit_keydown(e) {
     } else if (e.key === "Escape") {
         // Handle Esc
         end_if_focused_on_inline_topic_edit();
+        $(".zulip-icon-mute").show();
+        $(".mark-as-resolved").show();
         e.stopPropagation();
         e.preventDefault();
     }

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -59,7 +59,7 @@
                     {{#if topic_is_resolved}}
                         <i class="fa fa-check on_hover_topic_unresolve recipient_bar_icon hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as unresolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as unresolved' }}"></i>
                     {{else}}
-                        <i class="fa fa-check on_hover_topic_resolve recipient_bar_icon hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as resolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as resolved' }}"></i>
+                        <i class="fa fa-check on_hover_topic_resolve recipient_bar_icon hidden-for-spectators mark-as-resolved" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as resolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as resolved' }}"></i>
                     {{/if}}
                 {{/if}}
 


### PR DESCRIPTION
While editing a topic, other buttons in the header unnecessary for this action temporary disappear, until the user cancels or accepts the operation.

Fixes: Hide buttons in message header bar while editing topic #24888

https://user-images.githubusercontent.com/92218971/228526776-3ffddabb-7840-46c5-8242-9b93681fd614.mov

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>