### PR TITLE
ts: Convert `overlays.js` and `dialog_widget.js` to TypeScript.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -139,7 +139,7 @@ js_rules = RuleList(
                 "web/src/portico",
                 "web/src/lightbox.js",
                 "web/src/ui_report.ts",
-                "web/src/dialog_widget.js",
+                "web/src/dialog_widget.ts",
                 "web/tests/",
             },
             "description": "Setting HTML content with jQuery .html() can lead to XSS security bugs.  Consider .text() or using rendered_foo as a variable name if content comes from Handlebars and thus is already sanitized.",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -78,7 +78,7 @@ EXEMPT_FILES = make_set(
         "web/src/debug.js",
         "web/src/deprecated_feature_notice.js",
         "web/src/desktop_integration.js",
-        "web/src/dialog_widget.js",
+        "web/src/dialog_widget.ts",
         "web/src/drafts.js",
         "web/src/dropdown_list_widget.js",
         "web/src/echo.js",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -123,7 +123,7 @@ EXEMPT_FILES = make_set(
         "web/src/navbar_alerts.js",
         "web/src/navigate.js",
         "web/src/notifications.js",
-        "web/src/overlays.js",
+        "web/src/overlays.ts",
         "web/src/padded_widget.ts",
         "web/src/page_params.ts",
         "web/src/pm_list.js",

--- a/web/src/channel.js
+++ b/web/src/channel.js
@@ -112,6 +112,9 @@ function call(args) {
     return $.ajax(args);
 }
 
+// TODO: When this file is converted to TypeScript, deduplicate the
+// AjaxRequest type defined in dialog_widget.js.
+
 export function get(options) {
     const args = {type: "GET", dataType: "json", ...options};
     return call(args);


### PR DESCRIPTION
Converts `overlays.js` to TypeScript. Also converts `dialog_widget.js` to TypeScript (Thanks to @Ddharmani3).

This is a prep PR for #24426.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
