### PR TITLE
dialog_widget: Add optional parameter `update_submit_on_state_change`.

### DIFF
--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -735,6 +735,7 @@ export function set_up() {
                 on_shown() {
                     ui_util.place_caret_at_end($("#change_email_form input")[0]);
                 },
+                update_submit_disabled_state_on_change: true,
             });
         }
     });


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Add an optional dialog_widget parameter that takes a boolean value. If set to true, it activates the "Confirm" button on a state change of any input field in the modal and also disables it again if the input field value is changed back to the original value.

Implementation: Store all the originalValues of input fields in the modal once it is rendered and add an event listener to all the input fields that listen for input and check if the new value is different from the original value. It activates the "Confirm" button if the new value is different, and makes it disabled if it is the same.

In this PR, I have only used the new option for the email change modal. I will soon create an Issue as a follow-up to this PR, that will use it everywhere else, such as the bot edit modal and move topic modal, as mentioned [here](https://github.com/zulip/zulip/issues/22683#issuecomment-1230805433).

Also, I will fix the cursor to be at the end of the input on focus for the email input field and other input fields where it is needed once I create a focus_on_text_input function, as described [here](https://github.com/zulip/zulip/pull/24823#discussion_r1147433110).

Fixes: <!-- Issue link, or clear description.-->
#22683
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/64723994/228642612-53db87d4-4930-4e85-b1c0-0203d965bc7f.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
