### PR TITLE
templates: Update text on /accounts/find.

### DIFF
--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -9,16 +9,18 @@
 <div class="app find-account-page flex full-page">
     <div class="inline-block new-style">
         <div class="lead">
-            <h1 class="get-started">{{ _("Find your Zulip accounts") }}…</h1>
+            <h1 class="get-started">{{ _("Find your Zulip accounts") }}</h1>
         </div>
 
         <div class="app-main find-account-page-container white-box">
             {% if emails %}
             <div id="results">
                 <p>
-                    Emails sent! You will only receive emails at addresses associated
-                    with Zulip organizations. The addresses entered on the previous page
-                    are listed below:
+                    {% trans %}
+                    Emails sent! You will only receive emails at addresses
+                    associated with Zulip organizations. The addresses entered
+                    on the previous page are listed below:
+                    {% endtrans %}
                 </p>
 
                 <ul>
@@ -33,8 +35,12 @@
             {% else %}
             <div class="find-account-form">
                 <p>
-                    We will send you an email with the sign-in information for
-                    any Zulip organization(s) associated with the addresses you enter below.
+                    {% trans %}
+                    Enter your email address to receive an email with the URLs
+                    for all the Zulip Cloud organizations in which you have
+                    active accounts. If you have also forgotten your password,
+                    you can <a href="/help/change-your-password">reset it</a>.
+                    {% endtrans %}
                 </p>
                 <form class="form-inline" id="find_account" name="email_form"
                   action="{{ current_url() }}" method="post">
@@ -42,7 +48,7 @@
                     <div class="input-box moving-label horizontal">
                         <div class="inline-block relative">
                             <input type="text" autofocus id="emails" name="emails" required />
-                            <label for="emails">{{ _('Email addresses') }}</label>
+                            <label for="emails">{{ _('Email address') }}</label>
                         </div>
                         <button type="submit">{{ _('Find accounts') }}</button>
                     </div>

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -560,7 +560,9 @@ class MultiEmailField(forms.Field):
 
 
 class FindMyTeamForm(forms.Form):
-    emails = MultiEmailField(help_text=_("Add up to 10 comma-separated email addresses."))
+    emails = MultiEmailField(
+        help_text=_("Tip: You can enter multiple email addresses with commas between them.")
+    )
 
     def clean_emails(self) -> List[str]:
         emails = self.cleaned_data["emails"]


### PR DESCRIPTION
- Being more specific about what the user will get.
- Putting less emphasis on entering multiple emails, since most people probably just have one email they need to check.
- Using more intuitive wording and hint that deactivated or deleted accounts won't be included.
- Tagging strings for translation.

Fixes: #24890.

**Screenshots and screen captures:**
- https://zulip.com/accounts/find/

![image](https://user-images.githubusercontent.com/2343554/228700479-4f570f33-ef98-4829-8a0f-fdeb41eb2ead.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>
