### PR TITLE
markdown: Change search and alert word highlight colors.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -932,6 +932,10 @@
     }
 
     .rendered_markdown {
+        .alert-word {
+            background-color: hsl(22deg 70% 35%);
+        }
+
         .user-mention,
         .user-group-mention {
             background: linear-gradient(
@@ -1343,7 +1347,7 @@
 
     /* Search highlight used in both topics and rendered_markdown */
     .highlight {
-        background-color: hsl(51deg 100% 64% / 42%);
+        background-color: hsl(51deg 100% 23%);
     }
 
     .sub-unsub-message span::before,

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -178,7 +178,7 @@
     }
 
     .alert-word {
-        background-color: hsl(102deg 85% 57% / 50%);
+        background-color: hsl(18deg 100% 84%);
     }
 
     /* Timestamps */
@@ -686,5 +686,5 @@
 
 /* Search highlight used in both topics and rendered_markdown */
 .highlight {
-    background-color: hsl(51deg 94% 74%);
+    background-color: hsl(51deg 100% 79%);
 }


### PR DESCRIPTION
As part of the redesign project, this highlight colors are changed:

Light theme:
Search highlight yellow: #FFEF95 - `hsl(51deg 100% 79%)`
Alert highlight orange: #FFC6AE - `hsl(18deg 100% 84%)`

Dark theme:
Search highlight yellow: #756400 - `hsl(51deg 100% 23%)`
Alert highlight orange: 	#98491b - `hsl(22deg 70% 35%)`

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#24922

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Search Highlight:
![image](https://user-images.githubusercontent.com/64723994/229045231-9151f7ba-dca2-4b12-a417-aac6aed8649c.png) 

Dark Theme:
![image](https://user-images.githubusercontent.com/64723994/229045259-32bdecfe-2c15-4fe8-b3d4-40de5fe48fb0.png)


Alert Word: 
![image](https://user-images.githubusercontent.com/64723994/229045297-59f3fba8-f639-4fbd-8b03-161fd98d37d5.png)
Dark Theme:
![image](https://user-images.githubusercontent.com/64723994/229576413-0e860060-ee91-48ef-81bb-3d66ad047092.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
