### PR TITLE
Revert "typeahead: Fix bug where typeahead showed momentarily on shif…

### DIFF
--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -439,6 +439,7 @@ import {get_string_diff} from "../../src/util";
   , keydown: function (e) {
     const pseudo_keycode = get_pseudo_keycode(e);
     if (this.trigger_selection(e)) {
+      if (!this.shown) return;
       e.preventDefault();
       this.select(e);
     }
@@ -472,11 +473,6 @@ import {get_string_diff} from "../../src/util";
             this.on_escape();
           }
           break
-
-        // to stop typeahead from showing up momentarily
-        // when shift + tabbing to a field with typeahead
-        case 16: // shift
-          return
 
         default:
           var hideOnEmpty = false


### PR DESCRIPTION
…t + tab."

This reverts commit fa37befe3c40d256afe50e5d5137d2f5a4159214, which broke the topic typeahead after a complete stream name.

Fixes: [issue described here](https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20auto-complete.20bug)

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/68962290/229141739-aa798a31-005f-45b8-a662-6a13fd5885a8.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
