### PR TITLE
ts: Migrate google_analytics.js and help.js to typescript.

### DIFF
--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -11,6 +11,7 @@ export const page_params: {
         percent_translated: number | undefined;
     }[];
     development_environment: boolean;
+    google_analytics_id: string | undefined;
     is_admin: boolean;
     is_guest: boolean;
     is_moderator: boolean;

--- a/web/src/portico/google-analytics.ts
+++ b/web/src/portico/google-analytics.ts
@@ -2,11 +2,15 @@ import {gtag, install} from "ga-gtag";
 
 import {page_params} from "../page_params";
 
-export let config;
+type Info = {
+    page_path: string;
+};
+
+export let config: (info: Info) => void;
 
 if (page_params.google_analytics_id !== undefined) {
     install(page_params.google_analytics_id);
     config = (info) => gtag("config", page_params.google_analytics_id, info);
 } else {
-    config = () => {};
+    config = () => undefined;
 }

--- a/web/src/types/ga-gtag/index.d.ts
+++ b/web/src/types/ga-gtag/index.d.ts
@@ -1,0 +1,22 @@
+/**
+ * npm module name:- "ga-gtag"
+ * version:-  "^1.0.1"
+ */
+
+/**
+ * This can be improved using zulip specific information
+ * on fields that can be passed with this object into the
+ * `install` function.
+ */
+declare type AdditionalConfigInfo = Record<string, unknown>;
+
+export declare const install: (
+    trackingId: string,
+    additionalConfigInfo?: AdditionalConfigInfo,
+) => void;
+/**
+ * Improvements can be made using zulip specific information
+ * on values that can be passed as arguments in this function.
+ */
+export declare const gtag: (...args: unknown[]) => void;
+export default gtag;


### PR DESCRIPTION
This PR addresses the migration of files `web/src/portico/google_analytics.js` and `web/src/portico/help.js` to typescript.

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
