### PR TITLE
notifications: Fix blank notification sent when no text specified.

### DIFF
--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -10,6 +10,7 @@ import * as favicon from "./favicon";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
+import * as message_parser from "./message_parser";
 import * as message_store from "./message_store";
 import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
@@ -241,7 +242,16 @@ export function process_notification(notification) {
     const $content = $("<div>").html(message.content);
     ui.replace_emoji_with_text($content);
     spoilers.hide_spoilers_in_notification($content);
-    content = $content.text();
+
+    if (
+        $content.text().trim() === "" &&
+        (message_parser.message_has_image(message) ||
+            message_parser.message_has_attachment(message))
+    ) {
+        content = $t({defaultMessage: "(attached file)"});
+    } else {
+        content = $content.text();
+    }
 
     const topic = message.topic;
 


### PR DESCRIPTION
When we send a message (for which notifications are enabled) in the format `[](file_url)`. A blank notification is sent.
Fixing this by checking if there is no `text` and adding a message in that case.

The below mentioned PR also includes the checking for `user_uploads` to be present in the URL but
I am not sure if that should be required since probably there is going to be an empty text in those cases only.

Inspired from: #8796.
Fixes: #8087.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before (without text)
Message: `[](https://upload.wikimedia.org/wikipedia/commons/4/44/Subhas_Chandra_Bose_NRB.jpg)`
<img width="371" alt="before_wot" src="https://user-images.githubusercontent.com/101464851/229269788-d06bbe7b-cd3d-4743-bc32-a0a7de2d0cbd.png">
After (without text)
Message: `[](https://upload.wikimedia.org/wikipedia/commons/4/44/Subhas_Chandra_Bose_NRB.jpg)`
<img width="377" alt="after_wot" src="https://user-images.githubusercontent.com/101464851/232669216-0d53181b-005c-4539-ba6c-6c5007ee59ce.png">

Before & After (with text)
Message: `[Subhas Chandra Bose](https://upload.wikimedia.org/wikipedia/commons/4/44/Subhas_Chandra_Bose_NRB.jpg)`
<img width="364" alt="with_text" src="https://user-images.githubusercontent.com/101464851/229269836-33d1f20e-dc05-470f-8da1-c02a915bc1ea.png">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
