### PR TITLE
ci: Enable XML coverage report to fix Codecov uploads

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Run backend tests
         run: |
           source tools/ci/activate-venv
-          ./tools/test-backend --coverage --include-webhooks --no-cov-cleanup --ban-console-output
+          ./tools/test-backend --coverage --xml-report --no-html-report --include-webhooks --no-cov-cleanup --ban-console-output
 
       - name: Run mypy
         run: |


### PR DESCRIPTION
This was broken by commit 534754442a804af97004c23fb1d54a15c579ae93 (#22039).