### PR TITLE
web: Add missing CSS.escape calls

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -73,11 +73,13 @@ export function update_video_chat_button_display() {
 }
 
 export function clear_invites() {
-    $(`#compose_banners .${compose_banner.CLASSNAMES.recipient_not_subscribed}`).remove();
+    $(
+        `#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}`,
+    ).remove();
 }
 
 export function clear_private_stream_alert() {
-    $(`#compose_banners .${compose_banner.CLASSNAMES.private_stream_warning}`).remove();
+    $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.private_stream_warning)}`).remove();
 }
 
 export function clear_preview_area() {
@@ -485,7 +487,7 @@ export function initialize() {
 
     $("#compose_banners").on(
         "click",
-        `.${compose_banner.CLASSNAMES.wildcard_warning} .compose_banner_action_button`,
+        `.${CSS.escape(compose_banner.CLASSNAMES.wildcard_warning)} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
             compose_validate.clear_wildcard_warnings();
@@ -494,10 +496,12 @@ export function initialize() {
         },
     );
 
-    const user_not_subscribed_classname = `.${compose_banner.CLASSNAMES.user_not_subscribed}`;
+    const user_not_subscribed_selector = `.${CSS.escape(
+        compose_banner.CLASSNAMES.user_not_subscribed,
+    )}`;
     $("#compose_banners").on(
         "click",
-        `${user_not_subscribed_classname} .compose_banner_action_button`,
+        `${user_not_subscribed_selector} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
 
@@ -507,13 +511,13 @@ export function initialize() {
             }
             const sub = stream_data.get_sub(stream_name);
             stream_settings_ui.sub_or_unsub(sub);
-            $(user_not_subscribed_classname).remove();
+            $(user_not_subscribed_selector).remove();
         },
     );
 
     $("#compose_banners").on(
         "click",
-        `.${compose_banner.CLASSNAMES.topic_resolved} .compose_banner_action_button`,
+        `.${CSS.escape(compose_banner.CLASSNAMES.topic_resolved)} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
 
@@ -530,7 +534,9 @@ export function initialize() {
 
     $("#compose_banners").on(
         "click",
-        `.${compose_banner.CLASSNAMES.recipient_not_subscribed} .compose_banner_action_button`,
+        `.${CSS.escape(
+            compose_banner.CLASSNAMES.recipient_not_subscribed,
+        )} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
 
@@ -565,7 +571,7 @@ export function initialize() {
     );
 
     for (const classname of Object.values(compose_banner.CLASSNAMES)) {
-        const classname_selector = `.${classname}`;
+        const classname_selector = `.${CSS.escape(classname)}`;
         $("#compose_banners").on(
             "click",
             `${classname_selector} .compose_banner_close_button`,

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -44,7 +44,7 @@ export const CLASSNAMES = {
 
 export function clear_message_sent_banners(): void {
     for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {
-        $(`#compose_banners .${classname}`).remove();
+        $(`#compose_banners .${CSS.escape(classname)}`).remove();
     }
     scroll_to_message_banner_message_id = null;
 }
@@ -57,15 +57,15 @@ function hide_compose_spinner(): void {
 }
 
 export function clear_errors(): void {
-    $(`#compose_banners .${ERROR}`).remove();
+    $(`#compose_banners .${CSS.escape(ERROR)}`).remove();
 }
 
 export function clear_warnings(): void {
-    $(`#compose_banners .${WARNING}`).remove();
+    $(`#compose_banners .${CSS.escape(WARNING)}`).remove();
 }
 
 export function show_error_message(message: string, classname: string, $bad_input?: JQuery): void {
-    $(`#compose_banners .${classname}`).remove();
+    $(`#compose_banners .${CSS.escape(classname)}`).remove();
 
     const new_row = render_compose_banner({
         banner_type: ERROR,
@@ -87,7 +87,7 @@ export function show_error_message(message: string, classname: string, $bad_inpu
 
 export function show_stream_does_not_exist_error(stream_name: string): void {
     // Remove any existing banners with this warning.
-    $(`#compose_banners .${CLASSNAMES.stream_does_not_exist}`).remove();
+    $(`#compose_banners .${CSS.escape(CLASSNAMES.stream_does_not_exist)}`).remove();
 
     const new_row = render_stream_does_not_exist_error({
         banner_type: ERROR,

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -138,7 +138,7 @@ export function warn_if_mentioning_unsubscribed_user(mentioned) {
 
     if (needs_subscribe_warning(user_id, sub.stream_id)) {
         const $existing_invites_area = $(
-            `#compose_banners .${compose_banner.CLASSNAMES.recipient_not_subscribed}`,
+            `#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.recipient_not_subscribed)}`,
         );
 
         const existing_invites = [...$existing_invites_area].map((user_row) =>
@@ -172,7 +172,7 @@ export function warn_if_mentioning_unsubscribed_user(mentioned) {
 // current narrow.
 export function clear_topic_resolved_warning() {
     compose_state.set_recipient_viewed_topic_resolved_banner(false);
-    $(`#compose_banners .${compose_banner.CLASSNAMES.topic_resolved}`).remove();
+    $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.topic_resolved)}`).remove();
 }
 
 export function warn_if_topic_resolved(topic_changed) {
@@ -245,7 +245,7 @@ function show_wildcard_warnings(stream_id) {
     });
 
     // only show one error for any number of @all or @everyone mentions
-    if ($(`#compose_banners .${classname}`).length === 0) {
+    if ($(`#compose_banners .${CSS.escape(classname)}`).length === 0) {
         $compose_banner_area.append(wildcard_template);
     }
 
@@ -254,7 +254,7 @@ function show_wildcard_warnings(stream_id) {
 
 export function clear_wildcard_warnings() {
     const classname = compose_banner.CLASSNAMES.wildcard_warning;
-    $(`#compose_banners .${classname}`).remove();
+    $(`#compose_banners .${CSS.escape(classname)}`).remove();
 }
 
 export function set_user_acknowledged_wildcard_flag(value) {
@@ -400,7 +400,10 @@ export function validation_error(error_type, stream_name) {
             );
             return false;
         case "not-subscribed": {
-            if ($(`#compose_banners .${compose_banner.CLASSNAMES.user_not_subscribed}`).length) {
+            if (
+                $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.user_not_subscribed)}`)
+                    .length
+            ) {
                 return false;
             }
             const sub = stream_data.get_sub(stream_name);
@@ -586,13 +589,13 @@ export function check_overflow_text() {
         $indicator.text(text.length + "/" + max_length);
 
         $("#compose-send-button").prop("disabled", false);
-        $(`#compose_banners .${compose_banner.CLASSNAMES.message_too_long}`).remove();
+        $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.message_too_long)}`).remove();
     } else {
         $indicator.text("");
         $("#compose-textarea").removeClass("over_limit");
 
         $("#compose-send-button").prop("disabled", false);
-        $(`#compose_banners .${compose_banner.CLASSNAMES.message_too_long}`).remove();
+        $(`#compose_banners .${CSS.escape(compose_banner.CLASSNAMES.message_too_long)}`).remove();
     }
 
     return text.length;

--- a/web/src/message_viewport.js
+++ b/web/src/message_viewport.js
@@ -221,8 +221,12 @@ function _visible_divs(
     // We do this explicitly without merges and without recalculating
     // the feed bounds to keep this computation as cheap as possible.
     const visible = [];
-    const $above_pointer = $selected_row.prevAll("div." + div_class).slice(0, num_neighbors);
-    const $below_pointer = $selected_row.nextAll("div." + div_class).slice(0, num_neighbors);
+    const $above_pointer = $selected_row
+        .prevAll(`div.${CSS.escape(div_class)}`)
+        .slice(0, num_neighbors);
+    const $below_pointer = $selected_row
+        .nextAll(`div.${CSS.escape(div_class)}`)
+        .slice(0, num_neighbors);
     add_to_visible(
         $selected_row,
         visible,

--- a/web/src/overlays.js
+++ b/web/src/overlays.js
@@ -125,16 +125,16 @@ export function open_overlay(opts) {
 // on_shown: Callback to run when the modal is shown.
 // on_hide: Callback to run when the modal is triggered to hide.
 // on_hidden: Callback to run when the modal is hidden.
-export function open_modal(selector, conf = {}) {
-    if (selector === undefined) {
-        blueslip.error("Undefined selector was passed into open_modal");
+export function open_modal(modal_id, conf = {}) {
+    if (modal_id === undefined) {
+        blueslip.error("Undefined id was passed into open_modal");
         return;
     }
 
     // Don't accept hash-based selector to enforce modals to have unique ids and
     // since micromodal doesn't accept hash based selectors.
-    if (selector[0] === "#") {
-        blueslip.error("hash-based selector passed in to open_modal: " + selector);
+    if (modal_id[0] === "#") {
+        blueslip.error("hash-based selector passed in to open_modal: " + modal_id);
         return;
     }
 
@@ -156,22 +156,22 @@ export function open_modal(selector, conf = {}) {
             conf.recursive_call_count += 1;
         }
         if (conf.recursive_call_count > 50) {
-            blueslip.error("Modal incorrectly is still open: " + selector);
+            blueslip.error("Modal incorrectly is still open: " + modal_id);
             return;
         }
 
         close_active_modal();
         setTimeout(() => {
-            open_modal(selector, conf);
+            open_modal(modal_id, conf);
         }, 10);
         return;
     }
 
-    blueslip.debug("open modal: " + selector);
+    blueslip.debug("open modal: " + modal_id);
 
     // Micromodal gets elements using the getElementById DOM function
     // which doesn't require the hash. We add it manually here.
-    const id_selector = `#${selector}`;
+    const id_selector = `#${CSS.escape(modal_id)}`;
     const $micromodal = $(id_selector);
 
     $micromodal.find(".modal__container").on("animationend", (event) => {
@@ -213,10 +213,10 @@ export function open_modal(selector, conf = {}) {
         if (document.getSelection().type === "Range") {
             return;
         }
-        close_modal(selector);
+        close_modal(modal_id);
     });
 
-    Micromodal.show(selector, {
+    Micromodal.show(modal_id, {
         disableFocus: true,
         openClass: "modal--opening",
         onShow: conf?.on_show,
@@ -264,9 +264,9 @@ export function close_active() {
 
 // `conf` is an object with the following optional properties:
 // * on_hidden: Callback to run when the modal finishes hiding.
-export function close_modal(selector, conf = {}) {
-    if (selector === undefined) {
-        blueslip.error("Undefined selector was passed into close_modal");
+export function close_modal(modal_id, conf = {}) {
+    if (modal_id === undefined) {
+        blueslip.error("Undefined id was passed into close_modal");
         return;
     }
 
@@ -275,16 +275,16 @@ export function close_modal(selector, conf = {}) {
         return;
     }
 
-    if (active_modal() !== `#${selector}`) {
+    if (active_modal() !== `#${CSS.escape(modal_id)}`) {
         blueslip.error(
-            "Trying to close " + selector + " modal when " + active_modal() + " is open.",
+            "Trying to close " + modal_id + " modal when " + active_modal() + " is open.",
         );
         return;
     }
 
-    blueslip.debug("close modal: " + selector);
+    blueslip.debug("close modal: " + modal_id);
 
-    const id_selector = `#${selector}`;
+    const id_selector = `#${CSS.escape(modal_id)}`;
     const $micromodal = $(id_selector);
 
     // On-hidden hooks should typically be registered in
@@ -298,7 +298,7 @@ export function close_modal(selector, conf = {}) {
         }
     });
 
-    Micromodal.close(selector);
+    Micromodal.close(modal_id);
 }
 
 export function close_active_modal() {

--- a/web/src/portico/header.js
+++ b/web/src/portico/header.js
@@ -64,7 +64,7 @@ $(() => {
             e.preventDefault();
             e.stopPropagation();
             const labelID = $(e.currentTarget).attr("for");
-            $("#" + labelID).trigger("click");
+            $(`#${CSS.escape(labelID)}`).trigger("click");
         }
     });
 

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -267,7 +267,7 @@ export function setup_stream_settings(node) {
         ],
         callback(name, key) {
             $(".stream_section").hide();
-            $("." + key).show();
+            $(`.${CSS.escape(key)}`).show();
             select_tab = key;
         },
     });

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -172,7 +172,7 @@ export function initialize() {
             // Handle dynamic "starred messages" and "edit" widgets.
             const $elem = $(instance.reference);
             const tippy_content = $elem.attr("data-tippy-content");
-            const $template = $("#" + $elem.attr("data-tooltip-template-id"));
+            const $template = $(`#${CSS.escape($elem.attr("data-tooltip-template-id"))}`);
 
             instance.setContent(tippy_content ?? parse_html($template.html()));
         },

--- a/web/src/user_group_edit.js
+++ b/web/src/user_group_edit.js
@@ -155,7 +155,7 @@ export function setup_group_settings(node) {
         ],
         callback(name, key) {
             $(".group_setting_section").hide();
-            $("." + key).show();
+            $(`.${CSS.escape(key)}`).show();
             select_tab = key;
         },
     });

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -241,7 +241,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         ],
         callback(name, key) {
             $(".tabcontent").hide();
-            $("#" + key).show();
+            $(`#${CSS.escape(key)}`).show();
             switch (key) {
                 case "profile-tab":
                     initialize_user_type_fields(user);


### PR DESCRIPTION
When referring to `<div id="my-id" class="my-class">`:

- `my-id` is an id
- `#my-id` is a selector
- `my-class` is a class name
- `.my-class` is a selector

When an id or a class name is interpolated into a selector, it needs to be escaped with `CSS.escape`.

Previously:

- #17200