### PR TITLE
ts: Migrate landing-page.js to typescript.

### DIFF
--- a/web/src/assets.d.ts
+++ b/web/src/assets.d.ts
@@ -7,3 +7,8 @@ declare module "*.ttf" {
     const url: string;
     export default url;
 }
+
+declare module "*.png" {
+    const value: string;
+    export default value;
+}

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -6,6 +6,24 @@
 declare let zulip_test: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 interface JQuery {
+    /**
+     * Bootstrap carousel planned for removal soon, this type definition should be
+     * removed correpondingly. More information here https://github.com/zulip/zulip/pull/24301
+     */
+    carousel: (
+        option?:
+            | "cycle"
+            | "next"
+            | "pause"
+            | "prev"
+            | number
+            | {
+                  interval: number | false;
+              }
+            | {
+                  pause: "hover" | boolean;
+              },
+    ) => void;
     expectOne(): JQuery;
     tab(action?: string): this; // From web/third/bootstrap
 }

--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -1,8 +1,11 @@
 import $ from "jquery";
 
+import type {Contributor} from "./portico/team";
+
 const t1 = performance.now();
 export const page_params: {
     apps_page_url: string;
+    contributors: Contributor[];
     corporate_enabled: boolean;
     language_list: {
         code: string;

--- a/web/src/portico/landing-page.js
+++ b/web/src/portico/landing-page.js
@@ -196,7 +196,7 @@ $(() => {
 
     if (window.location.pathname === "/team/") {
         const contributors = page_params.contributors;
-        delete page_params.contributors;
+        page_params.contributors = [];
         render_tabs(contributors);
     }
 

--- a/web/src/portico/team.ts
+++ b/web/src/portico/team.ts
@@ -94,9 +94,7 @@ export default function render_tabs(contributors: Contributor[]): void {
     const template = _.template($("#contributors-template").html());
     const count_template = _.template($("#count-template").html());
     const total_count_template = _.template($("#total-count-template").html());
-    const contributors_list = contributors
-        ? contributors.filter((c) => exclude_bot_contributors(c))
-        : [];
+    const contributors_list = contributors.filter((c) => exclude_bot_contributors(c));
     const mapped_contributors_list = contributors_list.map((c) => ({
         name: get_display_name(c),
         github_username: c.github_username,


### PR DESCRIPTION
This PR addresses the migration of file `web/src/portico/landing-page.js` to typescript.

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
