### PR TITLE
popovers: Add Manage / View user groups to profile popover.

### DIFF
--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -18,6 +18,7 @@ import * as people from "./people";
 import * as popovers from "./popovers";
 import * as settings_account from "./settings_account";
 import * as settings_bots from "./settings_bots";
+import * as settings_data from "./settings_data";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
@@ -197,6 +198,8 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         user_avatar: people.medium_avatar_url_for_person(user),
         is_me: people.is_current_user(user.email),
         is_bot: user.is_bot,
+        is_guest: page_params.is_guest,
+        can_edit_user_groups: settings_data.user_can_edit_user_groups(),
         date_joined: timerender.get_localized_date_or_time_for_format(
             parseISO(user.date_joined),
             "dayofyear_year",
@@ -359,6 +362,10 @@ export function register_click_handlers() {
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */
     $("body").on("click", "#user-profile-modal #name .user_profile_edit_button", () => {
+        hide_user_profile();
+    });
+
+    $("body").on("click", "#user-profile-modal .manage_user_group", () => {
         hide_user_profile();
     });
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -501,6 +501,12 @@ ul {
         }
     }
 
+    #user-profile-groups-tab {
+        .manage_user_group {
+            padding: 0 2px 6px;
+        }
+    }
+
     .stream-list-top-section {
         display: flex;
 

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -104,6 +104,17 @@
                     </div>
 
                     <div class="tabcontent" id="user-profile-groups-tab">
+                        {{#unless is_guest}}
+                        <div class="manage_user_group">
+                            <a href="#organization/user-groups-admin">
+                                {{#if can_edit_user_groups}}
+                                {{t "View and edit user groups" }}
+                                {{else}}
+                                {{t "View user groups" }}
+                                {{/if}}
+                            </a>
+                        </div>
+                        {{/unless}}
                         <div class="subscription-group-list">
                             <table class="user-group-list" data-empty="{{t 'No user group subscriptions.'}}"></table>
                         </div>


### PR DESCRIPTION
Fixes: #18880.

This adds a link in the `User groups` tab of the User profile modal which goes to Organization settings > User groups, making it convenient to visit User groups settings through User profile modal.

For those who have organization rights to view and edit user groups, `View and edit user groups`, will be displayed, otherwise `View user groups` will be displayed.

This PR is a continuation of [#18962](https://github.com/zulip/zulip/pull/18962).

<details>

<summary>Screenshots</summary>

1) If the user has organization permissions to view and edit groups - 

![Screenshot_20230420_032733](https://user-images.githubusercontent.com/96468766/233209222-4eedb5d4-cdca-4c66-a3bf-1cde9bffc8db.png)

2) If the user has organization permissions to **only view groups** - 

![Screenshot_20230420_032848](https://user-images.githubusercontent.com/96468766/233209231-720037d4-e5ee-4625-9360-af751d68971f.png)

</details>

<details>

<summary>Screen captures</summary>

![user groups 1](https://user-images.githubusercontent.com/96468766/233209333-5d3e8dfd-a8ca-4eed-893c-d7b7f0aa8287.gif)

![user groups 2](https://user-images.githubusercontent.com/96468766/233209342-42a9aead-ec36-4c76-99e7-ff1890ce2568.gif)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
