### PR TITLE
popover_menus: Change the selector `.enter_sends` for opening tippyjs popover.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -272,7 +272,7 @@ export function initialize() {
         },
     });
 
-    tippy_no_propagation(".enter_sends", {
+    tippy_no_propagation(".open_enter_sends_dialog", {
         placement: "top",
         onShow(instance) {
             on_show_prep(instance);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -597,7 +597,7 @@ input.recipient_box {
     }
 }
 
-.enter_sends {
+.open_enter_sends_dialog {
     font-size: 12px;
     height: 14px;
     padding-left: 4px;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -64,7 +64,7 @@
         box-shadow: inset 0 1px 0 hsl(0deg 0% 0% / 20%);
     }
 
-    .enter_sends,
+    .open_enter_sends_dialog,
     .enter_sends_choices {
         color: hsl(236deg 33% 90%);
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -117,7 +117,7 @@
                                 </div>
                                 <div class="compose_bottom_bottom_container">
                                     <span id="compose_limit_indicator"></span>
-                                    <div class="enter_sends">
+                                    <div class="open_enter_sends_dialog">
                                         <span class="enter_sends_true">
                                             {{#tr}}
                                                 <z-shortcut></z-shortcut> to send


### PR DESCRIPTION
Changed the `.enter_sends` selector for launching tippyjs popover from `compose.hbs` because it was colliding with `.enter_sends` selector present in `organization_user_settings_defaults.hbs`.

Before this change when an admin tried to change user realm default setting of `enter_sends` it was opening a tippyjs popover despite being a checkbox and it was hitting `/json/settings` endpoint instead of `/json/realm/user_setting_defaults`.

Discussion - [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Changing.20.60enter_sends.60.20realm.20default.20settings.20bug)
<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

**Before(A tippyjs popover)**
![before](https://user-images.githubusercontent.com/84276404/229306274-ac65ee02-552c-46ed-a864-dbf2cd1564fe.png)

**After(A simple checkbox)**
![after](https://user-images.githubusercontent.com/84276404/229306319-2cbae061-0a60-496f-8ac1-6c05879859e1.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
