### PR TITLE
keyboard_ui: Add shortcut "Shift + V" to view read receipts.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -148,6 +148,8 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Edit message or view message source**: <kbd>E</kbd>
 
+* **View read receipts**: <kbd>Shift</kbd> + <kbd>V</kbd>
+
 * **Move message and (optionally) other messages in the same topic**: <kbd>M</kbd>
 
 * **Star message**: <kbd>Ctrl</kbd> + <kbd>S</kbd>

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -34,6 +34,7 @@ import {page_params} from "./page_params";
 import * as popover_menus from "./popover_menus";
 import * as popovers from "./popovers";
 import * as reactions from "./reactions";
+import * as read_receipts from "./read_receipts";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as search from "./search";
@@ -141,7 +142,7 @@ const keypress_mappings = {
     82: {name: "respond_to_author", message_view_only: true}, // 'R'
     83: {name: "narrow_by_topic", message_view_only: true}, // 'S'
     85: {name: "mark_unread", message_view_only: true}, // 'U'
-    86: {name: "view_selected_stream", message_view_only: false}, // 'V'
+    86: {name: "view_read_receipts_or_view_selected_stream", message_view_only: false}, // 'V'
     97: {name: "all_messages", message_view_only: true}, // 'a'
     99: {name: "compose", message_view_only: true}, // 'c'
     100: {name: "open_drafts", message_view_only: true}, // 'd'
@@ -796,7 +797,12 @@ export function process_hotkey(e, hotkey) {
 
     // Prevent navigation in the background when the overlays are active.
     if (overlays.is_overlay_or_modal_open()) {
-        if (event_name === "view_selected_stream" && overlays.streams_open()) {
+        // Redirect to the stream messages of the selected stream
+        // in the stream settings overlay if it is open.
+        if (
+            event_name === "view_read_receipts_or_view_selected_stream" &&
+            overlays.streams_open()
+        ) {
             stream_settings_ui.view_stream();
             return true;
         }
@@ -999,6 +1005,9 @@ export function process_hotkey(e, hotkey) {
             return true;
         case "mark_unread":
             unread_ops.mark_as_unread_from_here(msg.id);
+            return true;
+        case "view_read_receipts_or_view_selected_stream": // Show read receipts for the selected message
+            read_receipts.show_user_list(msg.id);
             return true;
         case "compose_quote_reply": // > : respond to selected message with quote
             compose_actions.quote_and_reply({trigger: "hotkey"});

--- a/web/templates/actions_popover_content.hbs
+++ b/web/templates/actions_popover_content.hbs
@@ -122,6 +122,7 @@
     <li>
         <a class="view_read_receipts" data-message-id="{{message_id}}" tabindex="0">
             <i class="zulip-icon zulip-icon-readreceipts" aria-label="{{t 'View read receipts' }}"></i> {{t "View read receipts" }}
+            <span class="hotkey-hint">(V)</span>
         </a>
     </li>
     {{/if}}

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -224,6 +224,10 @@
                     <td class="definition">{{t 'Edit selected message or view source' }}</td>
                     <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
+                <tr id="edit-message-hotkey-help">
+                    <td class="definition">{{t 'View read receipts' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
+                </tr>
                 <tr id="move-message-hotkey-help">
                     <td class="definition">{{t 'Move messages or topic' }}</td>
                     <td><span class="hotkey"><kbd>M</kbd></span></td>

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -68,6 +68,7 @@ const popover_menus = mock_esm("../src/popover_menus", {
     get_visible_instance: () => undefined,
 });
 const reactions = mock_esm("../src/reactions");
+const read_receipts = mock_esm("../src/read_receipts");
 const search = mock_esm("../src/search");
 const settings_data = mock_esm("../src/settings_data");
 const stream_list = mock_esm("../src/stream_list");
@@ -359,6 +360,7 @@ run_test("misc", ({override}) => {
     // call get_message_reactions, so we verify just that.
     assert_mapping("=", reactions, "get_message_reactions");
     assert_mapping("-", condense, "toggle_collapse");
+    assert_mapping("V", read_receipts, "show_user_list");
     assert_mapping("r", compose_actions, "respond_to_message");
     assert_mapping("R", compose_actions, "respond_to_message", true);
     assert_mapping("j", navigate, "down");


### PR DESCRIPTION
Fixes part 1 of [#24716](https://github.com/zulip/zulip/issues/24716).

- [x] Implement a keyboard shortcut for "View read receipts". Shift+V has been proposed as an ideal shortcut.

<details>

<summary>Screenshots</summary>

![keyboard shortcut 1](https://user-images.githubusercontent.com/96468766/229361054-cbbe5901-eb65-4b49-bf26-beb6edcfcec2.png)

![keyboard shortcut 2](https://user-images.githubusercontent.com/96468766/229338857-335c0007-5090-4793-9364-db46add9e631.png)

![keyboard shortcut 3](https://user-images.githubusercontent.com/96468766/229339125-c7aca0e2-f3e2-40e0-a152-dfffd9812d13.png)

</details>

<details>

<summary>Screen captures</summary>

![keyboard shortcut](https://user-images.githubusercontent.com/96468766/229361193-0430225a-5ef1-44a4-87c0-d17acf718216.gif)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
