### PR TITLE
Fixes #D1288: Clicking enter when adding custom emoji removes image/gif

### DIFF
--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -153,11 +153,18 @@ export function launch(conf: WidgetConfig): void {
     const $submit_button = $dialog.find(".dialog_submit_button");
 
     // This is used to link the submit button with the form, if present, in the modal.
-    // This makes it so that submitting this form by pressing Enter on an input element
+    // This makes it so that submitting this form by pressing Enter on valid input elements
     // triggers a click on the submit button.
-    if (conf.form_id) {
-        $submit_button.attr("form", conf.form_id);
-    }
+    $dialog.on("keydown", (e) => {
+        if (
+            e.key === "Enter" &&
+            $("#emoji_name").val() !== "" &&
+            $("#emoji_file_input").val() !== ""
+        ) {
+            e.preventDefault();
+            $submit_button.trigger("click");
+        }
+    });
 
     // Set up handlers.
     $submit_button.on("click", (e) => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Issue [#D1288](https://github.com/zulip/zulip/issues/24972) states that there is a bug with pressing enter key while adding a custom emoji. While adding a custom emoji, pressing enter key does not trigger submitting and it removes the current uploaded file from the modal. 

Fixes: <!-- Issue link, or clear description.--> [#D1288](https://github.com/zulip/zulip/issues/24972) 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
_At waits I am pressing enter key_
Before Implementation: 
![ezgif-3-0a419413c2](https://user-images.githubusercontent.com/94247411/229355744-b5ff0f40-41e0-4b5a-a6f6-78ca9136a9a2.gif)

After Implementation: 
![ezgif-4-19cde57212](https://user-images.githubusercontent.com/94247411/229355780-3c93a1d4-0afa-4d50-b140-83a6174df9e1.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
