### PR TITLE
integration: Remove branch names from Gogs edited PR event.

### DIFF
--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -85,7 +85,7 @@ class GogsHookTests(WebhookTestCase):
 
     def test_pull_request_edited(self) -> None:
         expected_topic = "test / PR #1349 Test"
-        expected_message = """kostekIV edited [PR #2](https://try.gogs.io/kostekIV/test/pulls/2) from `c` to `master`."""
+        expected_message = """kostekIV edited [PR #2](https://try.gogs.io/kostekIV/test/pulls/2)."""
         self.check_webhook("pull_request__edited", expected_topic, expected_message)
 
     def test_pull_request_assigned(self) -> None:

--- a/zerver/webhooks/gogs/view.py
+++ b/zerver/webhooks/gogs/view.py
@@ -81,8 +81,11 @@ def format_pull_request_event(payload: WildValue, include_title: bool = False) -
         action = payload["action"].tame(check_string)
     url = payload["pull_request"]["html_url"].tame(check_string)
     number = payload["pull_request"]["number"].tame(check_int)
-    target_branch = payload["pull_request"]["head_branch"].tame(check_string)
-    base_branch = payload["pull_request"]["base_branch"].tame(check_string)
+    target_branch = None
+    base_branch = None
+    if action != "edited":
+        target_branch = payload["pull_request"]["head_branch"].tame(check_string)
+        base_branch = payload["pull_request"]["base_branch"].tame(check_string)
     title = payload["pull_request"]["title"].tame(check_string) if include_title else None
 
     return get_pull_request_event_message(


### PR DESCRIPTION
This is a follow up to #24673, we want to modify every webhook events to follow the same pattern and consistency where branch name should only show on opened and merged events.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/62449508/229371029-d976709a-9815-4cb8-b548-efb89215d2cb.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/62449508/229371003-f1a8b669-899b-415b-9e4f-146c43c2ffad.png)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
