### PR TITLE
ui_util: Update place_caret_at_end to also work for input fields.

### DIFF
--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -26,6 +26,7 @@ import * as settings_org from "./settings_org";
 import * as settings_ui from "./settings_ui";
 import * as typeahead_helper from "./typeahead_helper";
 import * as ui_report from "./ui_report";
+import * as ui_util from "./ui_util";
 import * as user_pill from "./user_pill";
 import * as user_profile from "./user_profile";
 import {user_settings} from "./user_settings";
@@ -732,7 +733,7 @@ export function set_up() {
                 form_id: "change_email_form",
                 on_click: do_change_email,
                 on_shown() {
-                    $("#change_email_form input").trigger("focus");
+                    ui_util.place_caret_at_end($("#change_email_form input")[0]);
                 },
             });
         }

--- a/web/src/ui_util.ts
+++ b/web/src/ui_util.ts
@@ -9,13 +9,16 @@ import * as keydown_util from "./keydown_util";
 // https://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser
 export function place_caret_at_end(el: HTMLElement): void {
     el.focus();
-
-    const range = document.createRange();
-    range.selectNodeContents(el);
-    range.collapse(false);
-    const sel = window.getSelection();
-    sel?.removeAllRanges();
-    sel?.addRange(range);
+    if (el instanceof HTMLInputElement) {
+        el.setSelectionRange(el.value.length, el.value.length);
+    } else {
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+    }
 }
 
 export function blur_active_element(): void {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Previously `place_caret_at_end` was only used for HTMLElement with
contenteditable="true", updated it to take JQuery element instead of
previous HTMLElement and use logic to place cursor at end as per type
of element passed(i.e HTMLElement or HTMLInputElement).

Updated three previous calls of `place_caret_at_end` to pass
JQuery element instead of HTMLElement.

Also pushed a separate commit that uses this new function for the `New email` Input field.

This is created as a prep PR for #24823 , but can be used for more input field in future.
Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
