### PR TITLE
tippy: Fix compose close button tooltip logic. 

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -460,12 +460,12 @@ export function initialize() {
         // Change compose close button tooltip as per condition.
         // We save compose text in draft only if its length is > 2.
         if (compose_text_length > 2) {
-            $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip_template");
-        } else {
             $("#compose_close").attr(
                 "data-tooltip-template-id",
                 "compose_close_and_save_tooltip_template",
             );
+        } else {
+            $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip_template");
         }
     });
 

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -133,6 +133,7 @@ export function autosize_message_content() {
 }
 
 export function expand_compose_box() {
+    $("#compose_close").attr("data-tooltip-template-id", "compose_close_tooltip_template");
     $("#compose_close").show();
     $("#compose_controls").hide();
     $(".message_comp").show();


### PR DESCRIPTION
**Issue**: There are two different tooltips for compose close button in compose box. One is when there is no text in the inputbox that says `Cancel compose` and if there is text in the inputbox then it says `Cancel compose and save draft` however the logic of these two tooltips was reversed.

----------------------------------------

- [x] Change the default tooltip of compose_close_button everytime the compose box opens.
- [x] If there are more than two input in textarea change the tooltip to `Cancel compose and save draft`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
--------------------------------------------------------

CZO: [Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/compose.20close.20button.20tooltip.20logic)

------------------------------------
**Screenshots and screen captures:**

<details>
<summary>Before:</summary>
<br>

![compose_close_button](https://user-images.githubusercontent.com/66828942/229380567-7b49c141-dccb-4f7e-9a2a-1bb2e4ee323d.gif)

</details>

<details>
<summary>After:</summary>
<br>

![compose](https://user-images.githubusercontent.com/66828942/229380622-e89359d6-7a80-4ec7-a535-e802f7848f0e.gif)


</details>

--------------------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
