### PR TITLE
compose: Remove vertical shifts in compose when toggling preview mode.

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -656,6 +656,18 @@
     }
 }
 
+.preview_content.rendered_markdown {
+    /*  Ensure that the first child and last child
+    don't have blank area at the top and bottom respectively. */
+    & :first-child {
+        margin-top: 0;
+    }
+
+    & :last-child {
+        margin-bottom: 0;
+    }
+}
+
 .codehilite {
     display: block !important;
     border: none !important;


### PR DESCRIPTION
The vertical shifts in message body was due to the `<p>` tags it gets when converted to markdown. Removing the top margin from the first `<p>` child and bottom margin from the last `<p>` child resolves this issue as due to those default margins in `<p>` tags there was vertical shifts in message body.

This is a rebase and fixup of #21685 to continue and push forward the progress on the issue. No additional changes were made from it aside from fixing up the nested selectors to start with a symbol rather than a letter.

Fixes: #21276.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Normal text:</summary>

| Before |
| --- |
|![07207a213cf0bd49e758aa4364363252](https://user-images.githubusercontent.com/62449508/229419432-c3386672-cd6d-4a13-b64c-c5bffe389674.gif)
![d8a2f1f7e69a4e65fedfadcd1cddd446](https://user-images.githubusercontent.com/62449508/229419634-67b34d37-6e9c-4646-85a4-ab8999aa9801.gif)

| After |
| --- |
![b4258b27d84b9103a6f3fc2cb89cbe35](https://user-images.githubusercontent.com/62449508/229420014-e57275bb-0560-4936-b3ff-9cae183b6cb6.gif)
![b00a4c2086447d3a5a0ec9ff8076ad28](https://user-images.githubusercontent.com/62449508/229419813-34bbb3f6-5646-4f96-9abe-d27613150cd3.gif)

</details>

<details>
<summary>List:</summary>

| Before |
| --- |
![3d69d73a45cf826e18ae3130d464a076](https://user-images.githubusercontent.com/62449508/230516368-637d8dda-f5cd-4074-b104-953a41acae02.gif)
![690a8d9c55726d43bf30b3af7efa37b7](https://user-images.githubusercontent.com/62449508/230517009-fd2faea9-90d2-4ee3-9d99-ee925035b756.gif)


| After |
| --- |
![b9c93e751294157d8b40e24ca493c8be](https://user-images.githubusercontent.com/62449508/230516175-55b883eb-1e0b-41c5-ae08-1bb3c08bc297.gif)
![02b0aeaee292a1cd5f8a974c4631e5ed](https://user-images.githubusercontent.com/62449508/230516825-c3772079-f4f7-48b3-a865-59a1f6dcb96d.gif)

</details>
<details>

<summary>Numbered List:</summary>

| Before |
| --- |
![81268ed9b76801cb2e0b76090cc35a0e](https://user-images.githubusercontent.com/62449508/230517312-b1f7d7bd-c6bb-49e5-8956-bccbf8e6221e.gif)


| After |
| --- |
![e54dfa7be0e756ea43ffdb7a21b5bdd0](https://user-images.githubusercontent.com/62449508/230517449-19a875f0-1ec3-4783-8c8f-53d135f26230.gif)

</details>

<details>

<summary>Extra changes:</summary>

| Before |
| --- |
![e6b88e0131236009bb7c02c31faa2a9e](https://user-images.githubusercontent.com/62449508/230518387-d9d0cd88-6ea8-4df2-ad88-6a0abe3c4d22.gif)


| After |
| --- |
![3447415795430fdedec33df0d09f7d5e](https://user-images.githubusercontent.com/62449508/230518278-fe959520-ae85-47cf-b2b9-3d298cb7f133.gif)


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
