### PR TITLE
tooltips: Change `compose-send-button` tooltip dynamically.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -14,6 +14,7 @@ import * as reactions from "./reactions";
 import * as rows from "./rows";
 import * as timerender from "./timerender";
 import {parse_html} from "./ui_util";
+import {user_settings} from "./user_settings";
 
 // For tooltips without data-tippy-content, we use the HTML content of
 // a <template> whose id is given by data-tooltip-template-id.
@@ -63,13 +64,19 @@ function hide_tooltip_if_reference_removed(
     observer.observe(target_node, config);
 }
 
-// We use two delay settings for tooltips. The default "instant"
+// We use three delay settings for tooltips. The default "instant"
 // version has just a tiny bit of delay to create a natural feeling
 // transition, while the "long" version is intended for elements where
 // we want to avoid distracting the user with the tooltip
 // unnecessarily.
 const INSTANT_HOVER_DELAY = [100, 20];
 const LONG_HOVER_DELAY = [750, 20];
+// EXTRA_LONG_HOVER_DELAY is for elements like the compose box send
+// button where the tooltip content is almost exactly the same as the
+// text in the button, and the tooltip exists just to advertise a
+// keyboard shortcut. For these tooltips, it's very important to avoid
+// distracting users unnecessarily.
+const EXTRA_LONG_HOVER_DELAY = [1500, 20];
 
 // We override the defaults set by tippy library here,
 // so make sure to check this too after checking tippyjs
@@ -161,6 +168,19 @@ export function initialize() {
         // This ensures that the upload files tooltip
         // doesn't hide behind the left sidebar.
         appendTo: () => document.body,
+    });
+
+    delegate("body", {
+        target: "#compose-send-button",
+        delay: EXTRA_LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onShow(instance) {
+            if (user_settings.enter_sends) {
+                instance.setContent(parse_html($("#send-enter-tooltip-template").html()));
+            } else {
+                instance.setContent(parse_html($("#send-ctrl-enter-tooltip-template").html()));
+            }
+        },
     });
 
     delegate("body", {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -108,7 +108,7 @@
                             <div id="below-compose-content">
                                 <div class="compose_bottom_top_container">
                                     <div class="compose_right_float_container order-3">
-                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button" title="{{t 'Send' }} (Ctrl + Enter)" tabindex=0>
+                                        <button type="submit" id="compose-send-button" class="button small send_message animated-purple-button">
                                             <img class="loader" alt="" src="" />
                                             <span>{{t 'Send' }}</span>
                                         </button>
@@ -118,6 +118,14 @@
                                         <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
                                             <i class="fa fa-chevron-up"></i>
                                         </button>
+                                        <template id="send-enter-tooltip-template">
+                                            {{t 'Send' }}
+                                            {{tooltip_hotkey_hints "Enter"}}
+                                        </template>
+                                        <template id="send-ctrl-enter-tooltip-template">
+                                            {{t 'Send' }}
+                                            {{tooltip_hotkey_hints "Ctrl" "Enter"}}
+                                        </template>
                                     </div>
                                     {{> compose_control_buttons }}
                                 </div>


### PR DESCRIPTION
Added a tippy tooltip in `tippyjs.js` that delegates to `#compose-send-button`.
The content of tippy tooltip is changed dynamically as per the value of `user_settings.enter_sends`.
`user_settings.enter_sends` returns true if send shortcut is `Enter` and flase if shortcut is `Ctrl + Enter`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#24619
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/64723994/229419202-fc4cfe90-fbaf-4e05-8fc4-361456a87a3c.png)


![image](https://user-images.githubusercontent.com/64723994/229419212-856dfa53-aef7-490a-96ec-2a4de1447850.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
