### PR TITLE
Backport "recent_senders: Fix twice sent user ids in PM to self case." (#24437)

### DIFF
--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -347,4 +347,14 @@ test("process_pms", () => {
         participants: [],
         non_participants: [],
     });
+
+    rs.process_private_message({
+        to_user_ids: "1",
+        sender_id: sender1,
+        id: 4,
+    });
+    assert.deepEqual(rs.get_pm_recent_senders("1"), {
+        participants: [1],
+        non_participants: [],
+    });
 });

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -26,10 +26,8 @@ function make_stream_message({stream_id, topic, sender_id}) {
 mock_esm("../../static/js/message_store", {
     get: (message_id) => messages.get(message_id),
 });
-mock_esm("../../static/js/people", {
-    my_current_user_id: () => 1,
-});
-
+const people = zrequire("people");
+people.initialize_current_user(1);
 const rs = zrequire("recent_senders");
 zrequire("message_util.js");
 

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -232,6 +232,19 @@ export function user_ids_string_to_ids_array(user_ids_string) {
     return ids;
 }
 
+export function get_participants_from_user_ids_string(user_ids_string) {
+    let user_ids = user_ids_string_to_ids_array(user_ids_string);
+    // Convert to set to ensure there are no duplicate ids.
+    user_ids = new Set(user_ids);
+    // For group PMs or 1:1 private messages, the user_ids_string
+    // contains just the other user, so we need to add ourselves if not
+    // already present. For PM to self, the current user is already present,
+    // in user_ids_string, so we don't need to add it which is take care of
+    // by user_ids being a `Set`.
+    user_ids.add(my_user_id);
+    return user_ids;
+}
+
 export function emails_strings_to_user_ids_array(emails_string) {
     const user_ids_string = emails_strings_to_user_ids_string(emails_string);
     if (user_ids_string === undefined) {

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -225,22 +225,11 @@ export function process_private_message({to_user_ids, sender_id, id}) {
 }
 
 export function get_pm_recent_senders(user_ids_string) {
-    const user_ids = user_ids_string.split(",").map((id) => Number.parseInt(id, 10));
+    const user_ids = [...people.get_participants_from_user_ids_string(user_ids_string)];
     const sender_dict = pm_senders.get(user_ids_string);
     const pm_senders_info = {participants: [], non_participants: []};
     if (!sender_dict) {
         return pm_senders_info;
-    }
-
-    if (!(user_ids.length === 1 && user_ids[0] === people.my_current_user_id())) {
-        // For group PMs or 1:1 private messages, the user_ids_string
-        // contains just the other user, so we need to add ourselves if not
-        // already present. For PM to self, the current user is already present,
-        // in user_ids_string, so we don't need to add it.
-        //
-        // TODO: Replace this logic with a people.js common function for parsing
-        // user_ids_string and returning the set of user_ids, self included.
-        user_ids.push(people.my_current_user_id());
     }
 
     function compare_pm_user_ids_by_recency(user_id1, user_id2) {

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -232,14 +232,23 @@ export function get_pm_recent_senders(user_ids_string) {
         return pm_senders_info;
     }
 
+    if (!(user_ids.length === 1 && user_ids[0] === people.my_current_user_id())) {
+        // For group PMs or 1:1 private messages, the user_ids_string
+        // contains just the other user, so we need to add ourselves if not
+        // already present. For PM to self, the current user is already present,
+        // in user_ids_string, so we don't need to add it.
+        //
+        // TODO: Replace this logic with a people.js common function for parsing
+        // user_ids_string and returning the set of user_ids, self included.
+        user_ids.push(people.my_current_user_id());
+    }
+
     function compare_pm_user_ids_by_recency(user_id1, user_id2) {
         const max_id1 = sender_dict.get(user_id1)?.max_id() || -1;
         const max_id2 = sender_dict.get(user_id2)?.max_id() || -1;
         return max_id2 - max_id1;
     }
 
-    // Add current user to user_ids.
-    user_ids.push(people.my_current_user_id());
     pm_senders_info.non_participants = user_ids.filter((user_id) => {
         if (sender_dict.get(user_id)) {
             pm_senders_info.participants.push(user_id);


### PR DESCRIPTION
This is a very visible looking bug, if one happens to come across it.