### PR TITLE
message_display: Fix interaction between collapsed and muted messages.

### DIFF
--- a/web/src/condense.js
+++ b/web/src/condense.js
@@ -126,6 +126,11 @@ export function toggle_collapse(message) {
         return;
     }
 
+    const message_container = message_lists.current.view.message_containers.get(message.id);
+    if (message_container.is_hidden && !message.collapsed) {
+        return;
+    }
+
     const $content = $row.find(".message_content");
     const is_condensable = $content.hasClass("could-be-condensed");
     const is_condensed = $content.hasClass("condensed");

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -331,6 +331,7 @@ export class MessageListView {
             2. Hide reactions on that message.
             3. Do not give a background color to that message even if it mentions the
                current user.
+            4. Disable collapse operation on that message.
 
             Further, is a hidden message was just revealed, we make sure to show
             the sender.

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -397,11 +397,14 @@ export function initialize() {
                 const message_id = $(e.currentTarget).data("message-id");
                 const $row = message_lists.current.get_row(message_id);
                 const message = message_lists.current.get(rows.id($row));
+                const message_container = message_lists.current.view.message_containers.get(
+                    message.id,
+                );
                 if ($row) {
-                    if (message.collapsed) {
-                        condense.uncollapse($row);
-                    } else {
+                    if (!message_container.is_hidden && !message.collapsed) {
                         condense.collapse($row);
+                    } else {
+                        condense.uncollapse($row);
                     }
                 }
                 e.preventDefault();


### PR DESCRIPTION
Fixes: #24109

We hide the messages of a muted user in the message feed display. So ideally, we do not want a user to be able to collapse hidden messages, since we only display the text describing the reason for hiding the message.

This commit fixes the behaviour of being able to collapse hidden messages by checking if the selected message container is hidden. If it is, condense.collapse() will not be called when manually selecting the "Collapse message" option from the message popover or condense.toggle() when using the keyboard shortcut to collapse the selected message.

The behaviour returns to normal once the message is revealed or the user who sent the message is unmuted.

**Screen captures:**

![collapse 1](https://user-images.githubusercontent.com/96468766/229483639-2e820673-9548-46bc-b9f5-e350ab563b97.gif)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
