### PR TITLE
tooltips: Add tippy tooltip for left sidebar elements.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -133,6 +133,27 @@ export function initialize() {
         },
     });
 
+    // Variant of .tippy-left-sidebar-tooltip configuration. Since
+    // this element doesn't have an always visible label, and
+    // thus hovering it is a way to find out what it does, give
+    // it the faster LONG_HOVER_DELAY.
+    delegate("body", {
+        target: "#show_all_private_messages",
+        placement: "right",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        popperOptions: {
+            modifiers: [
+                {
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: "bottom",
+                    },
+                },
+            ],
+        },
+    });
+
     // The below definitions are for specific tooltips that require
     // custom JavaScript code or configuration.  Note that since the
     // below specify the target directly, elements using those should
@@ -546,15 +567,6 @@ export function initialize() {
             return true;
         },
         delay: LONG_HOVER_DELAY,
-        appendTo: () => document.body,
-    });
-
-    delegate("body", {
-        target: "#show_all_private_messages",
-        placement: "bottom",
-        content: $t({
-            defaultMessage: "All direct messages (P)",
-        }),
         appendTo: () => document.body,
     });
 

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -116,6 +116,23 @@ export function initialize() {
         target: ".tippy-zulip-tooltip",
     });
 
+    delegate("body", {
+        target: ".tippy-left-sidebar-tooltip",
+        placement: "right",
+        delay: EXTRA_LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        popperOptions: {
+            modifiers: [
+                {
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: "bottom",
+                    },
+                },
+            ],
+        },
+    });
+
     // The below definitions are for specific tooltips that require
     // custom JavaScript code or configuration.  Note that since the
     // below specify the target directly, elements using those should

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -77,9 +77,13 @@
                     <h4 class="sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
                 </span>
                 <span class="unread_count"></span>
-                <a id="show_all_private_messages" href="#narrow/is/private">
+                <a id="show_all_private_messages" href="#narrow/is/private" data-tooltip-template-id="show-all-pms-template">
                     <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
                 </a>
+                <template id="show-all-pms-template">
+                    {{t 'All direct messages' }}
+                    {{tooltip_hotkey_hints "P"}}
+                </template>
             </div>
         </div>
         <a class="zoom-out-hide" id="hide_more_private_messages">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -2,7 +2,7 @@
     <div class="narrows_panel">
         <ul id="global_filters" class="filters">
             {{!-- Special-case this link so we don't actually go to page top. --}}
-            <li class="top_left_all_messages top_left_row" title="{{t 'All messages' }} (a)">
+            <li class="top_left_all_messages top_left_row tippy-left-sidebar-tooltip" data-tooltip-template-id="all-message-tooltip-template">
                 <a href="#all_messages" class="home-link">
                     <span class="filter-icon">
                         <i class="fa fa-align-left" aria-hidden="true"></i>
@@ -11,9 +11,13 @@
                     <span>{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
+                <template id="all-message-tooltip-template">
+                    {{t 'All messages' }}
+                    {{tooltip_hotkey_hints "A"}}
+                </template>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_recent_topics top_left_row" title="{{t 'Recent conversations' }} (t)">
+            <li class="top_left_recent_topics top_left_row tippy-left-sidebar-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
                 <a href="#recent">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
@@ -21,6 +25,10 @@
                     {{~!-- squash whitespace --~}}
                     <span>{{t 'Recent conversations' }}</span>
                 </a>
+                <template id="recent-conversations-tooltip-template">
+                    {{t 'Recent conversations' }}
+                    {{tooltip_hotkey_hints "T"}}
+                </template>
             </li>
             <li class="top_left_mentions top_left_row hidden-for-spectators">
                 <a href="#narrow/is/mentioned">
@@ -43,7 +51,7 @@
                 </a>
                 <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_drafts top_left_row hidden-for-spectators" title="{{t 'Drafts' }} (d)">
+            <li class="top_left_drafts top_left_row hidden-for-spectators tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">
                 <a href="#drafts">
                     <span class="filter-icon">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
@@ -52,6 +60,10 @@
                     <span>{{t 'Drafts' }}</span>
                     <span class="unread_count"></span>
                 </a>
+                <template id="drafts-tooltip-template">
+                    {{t 'Drafts' }}
+                    {{tooltip_hotkey_hints "D"}}
+                </template>
                 <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
         </ul>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -22,7 +22,7 @@
                     <span>{{t 'Recent conversations' }}</span>
                 </a>
             </li>
-            <li class="top_left_mentions top_left_row hidden-for-spectators" title="{{t 'Mentions' }}">
+            <li class="top_left_mentions top_left_row hidden-for-spectators">
                 <a href="#narrow/is/mentioned">
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
@@ -32,7 +32,7 @@
                     <span class="unread_count"></span>
                 </a>
             </li>
-            <li class="top_left_starred_messages top_left_row hidden-for-spectators" title="{{t 'Starred messages' }}">
+            <li class="top_left_starred_messages top_left_row hidden-for-spectators">
                 <a href="#narrow/is/starred">
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Added tippy tooltips for all_messages, recent_topics, mentions, drafts, and show_all_private_messages
in the left sidebar by adding a class `.tippy-left-sidebar-tooltip` which adds tooltips with LONG_HOVER_DELAY 
and default placement right with fallback placement equal to bottom.

removed tooltips from Mentions and Starred_messages.

Fixes part of #24311

Fixes: <!-- Issue link, or clear description.-->
#24311
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

All messages:
![image](https://user-images.githubusercontent.com/64723994/229520389-c7e8c90a-157b-4069-8ba4-53f3b807a6d8.png)

![image](https://user-images.githubusercontent.com/64723994/229520266-d9b21717-9469-4537-aec3-0e008f116925.png)

Recent Conversations:
![image](https://user-images.githubusercontent.com/64723994/229520521-789ffdde-a40d-49ae-a121-3765660e2727.png)

Drafts:
![image](https://user-images.githubusercontent.com/64723994/229520926-604b7a0a-79eb-4bdb-9df0-9451d544cf5c.png)

Show all private messages:
![image](https://user-images.githubusercontent.com/64723994/229521169-d44d3de3-de27-4b08-9851-dcc5e36629f0.png)

Fallback placement for mobile devices:
![image](https://user-images.githubusercontent.com/64723994/229522080-2c4bdfe7-34c4-40a6-8bcd-abeeac986a89.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
