### PR TITLE
webhooks: Add body to PR Review Event message for GitHub Integration.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -240,13 +240,13 @@ class GitHubWebhookTest(WebhookTestCase):
         self.check_webhook("status__with_target_url", TOPIC_REPO, expected_message)
 
     def test_pull_request_review_msg(self) -> None:
-        expected_message = "baxterthehacker submitted [PR review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884)."
+        expected_message = "baxterthehacker submitted [PR review](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n~~~ quote\nLooks great!\n~~~"
         self.check_webhook("pull_request_review", TOPIC_PR, expected_message)
 
     def test_pull_request_review_msg_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "baxterthehacker submitted [PR review for #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884)."
+        expected_message = "baxterthehacker submitted [PR review for #1 Update the README with new information](https://github.com/baxterthehacker/public-repo/pull/1#pullrequestreview-2626884):\n\n~~~ quote\nLooks great!\n~~~"
         self.check_webhook("pull_request_review", expected_topic, expected_message)
 
     def test_pull_request_review_comment_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -490,6 +490,7 @@ def get_pull_request_review_body(helper: Helper) -> str:
         url=payload["review"]["html_url"].tame(check_string),
         type="PR review",
         title=title if include_title else None,
+        message=payload["review"]["body"].tame(check_string),
     )
 
 


### PR DESCRIPTION
This PR adds the `body` to the PR Review Event message for GitHub Integration. 

To do this the following had to be done:

- The function that generates the message for the PR Review Event did not have `body` as a parameter, so it had to be added.
- The `body` parameter that was passed must be included in the message generated by the aforementioned function.
- The actual `body` of the event had to be passed to the function as an argument.

**Update:**

To do the above mentioned just the following had to be done:
- Passing the `body` of the event as the `message` argument to the function that generates the message.

<hr></hr>

**Screenshots:**

<details>
<summary>Without Custom Topic:</summary>
<br/>
Before:

![image](https://user-images.githubusercontent.com/35286603/229568188-df79a733-7a83-42a4-ba93-3bce52f7d25d.png)

After:
![Without Custom Topic](https://user-images.githubusercontent.com/35286603/229566748-c0c9a08e-c4d5-443b-b653-80eec3af6f7f.png)

</details>

<details>
<summary>With Custom Topic:</summary>
<br/>
Before:

![image](https://user-images.githubusercontent.com/35286603/229568663-eb7ba0f7-c5da-4e0e-9348-6c26f829538c.png)

After:
![With Custom Topic](https://user-images.githubusercontent.com/35286603/229567078-96f449cc-6e5e-4eea-929a-1601afd8db8b.png)

</details>

<hr></hr>

Fixes: #24676 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [X] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
