### PR TITLE
multiuse-invites-backend: Add edit feature for multiuse invites

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 173**
+
+* `GET /invites`: Added the `stream_ids` field to be returned for all
+  multiuse invite objects.
+
 **Feature level 172**
 
 * [`PATCH /messages/{message_id}`](/api/update-message): Topic editing

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -22,6 +22,8 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 173**
 
+* `PATCH /invites/multiuse`: Added support for editing multiuse invites
+  to users as admin with regards to role and associated streams.
 * `GET /invites`: Added the `stream_ids` field to be returned for all
   multiuse invite objects.
 

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 172
+API_FEATURE_LEVEL = 173
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -476,6 +476,20 @@ def do_revoke_multi_use_invite(multiuse_invite: MultiuseInvite) -> None:
     notify_invites_changed(realm)
 
 
+def do_edit_multiuse_invite_link(
+    multiuse_invite: MultiuseInvite,
+    invited_as: int,
+    streams: Sequence[Stream],
+) -> None:
+    # The `streams` and `invited_as` fields of a `multiuse_invite` can be edited.
+    multiuse_invite.streams.set(streams)
+    multiuse_invite.invited_as = invited_as
+    multiuse_invite.save()
+
+    realm = multiuse_invite.referred_by.realm
+    notify_invites_changed(realm)
+
+
 def do_resend_user_invite_email(prereg_user: PreregistrationUser) -> int:
     # These are two structurally for the caller's code path.
     assert prereg_user.referred_by is not None

--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -388,6 +388,7 @@ def do_get_invites_controlled_by_user(user_profile: UserProfile) -> List[Dict[st
                 ),
                 invited_as=invite.invited_as,
                 is_multiuse=True,
+                stream_ids=list(invite.streams.values_list("id", flat=True)),
             )
         )
     return invites

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1628,8 +1628,11 @@ class InvitationsTestCase(InviteUserBase):
         othello = self.example_user("othello")
 
         streams = []
+        stream_ids = []
         for stream_name in ["Denmark", "Scotland"]:
-            streams.append(get_stream(stream_name, user_profile.realm))
+            stream = get_stream(stream_name, user_profile.realm)
+            streams.append(stream)
+            stream_ids.append(stream.id)
 
         invite_expires_in_minutes = 2 * 24 * 60
         do_invite_users(
@@ -1664,7 +1667,10 @@ class InvitationsTestCase(InviteUserBase):
         )
 
         do_create_multiuse_invite_link(
-            hamlet, PreregistrationUser.INVITE_AS["MEMBER"], invite_expires_in_minutes
+            hamlet,
+            PreregistrationUser.INVITE_AS["MEMBER"],
+            invite_expires_in_minutes,
+            streams,
         )
 
         result = self.client_get("/json/invites")
@@ -1676,6 +1682,7 @@ class InvitationsTestCase(InviteUserBase):
         self.assertEqual(invites[0]["email"], "TestOne@zulip.com")
         self.assertTrue(invites[1]["is_multiuse"])
         self.assertEqual(invites[1]["invited_by_user_id"], hamlet.id)
+        self.assertEqual(set(invites[1]["stream_ids"]), set(stream_ids))
 
     def test_get_never_expiring_invitations(self) -> None:
         self.login("iago")

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -57,6 +57,7 @@ from zerver.views.events_register import events_register_backend
 from zerver.views.home import accounts_accept_terms, desktop_home, home
 from zerver.views.hotspots import mark_hotspot_as_read
 from zerver.views.invite import (
+    edit_multiuse_invite,
     generate_multiuse_invite_backend,
     get_user_invites,
     invite_users_backend,
@@ -313,7 +314,11 @@ v1_api_and_json_patterns = [
     # invites/multiuse -> zerver.views.invite
     rest_path("invites/multiuse", POST=generate_multiuse_invite_backend),
     # invites/multiuse -> zerver.views.invite
-    rest_path("invites/multiuse/<int:invite_id>", DELETE=revoke_multiuse_invite),
+    rest_path(
+        "invites/multiuse/<int:invite_id>",
+        DELETE=revoke_multiuse_invite,
+        PATCH=edit_multiuse_invite,
+    ),
     # mark messages as read (in bulk)
     rest_path("mark_all_as_read", POST=mark_all_as_read),
     rest_path("mark_stream_as_read", POST=mark_stream_as_read),


### PR DESCRIPTION
> I am a GSoC '23 applicant

This pull request adds changes in backend only to support the feature to allow the editing of multiuse invites.

Partially fixes: GH-22099

### Implementation Path
1. `do_get_invites_controlled_by_user` now also returns a list of `stream_ids` for every invite. This is useful to show the user the current config on the edit-modal.
2. Added a PATCH handler for `invites/multiuse/<int:invite_id>`

### Unresolved threads from the child PR
- [ ] [Who is allowed to edit invites to owners?](https://github.com/zulip/zulip/pull/24666#discussion_r1149208158)
- [ ] [Does this template formatting help with readability?](https://github.com/zulip/zulip/pull/24666#discussion_r1147515965)
- [ ] [Should we allow creating/edit of multiuse invites when the `Who can invite users to this organization` is set to `NOBODY`](https://github.com/zulip/zulip/pull/24666#discussion_r1144620756)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.
- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
