### PR TITLE
docs: Remove now-unnecessary reactivate_realm step after import.

### DIFF
--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -359,7 +359,7 @@ cd ~
 tar -xf /path/to/export/file/zulip-export-zcmpxfm6.tar.gz
 cd /home/zulip/deployments/current
 ./manage.py import '' ~/zulip-export-zcmpxfm6
-# ./scripts/start-server
+./scripts/start-server
 ```
 
 This could take several minutes to run depending on how much data you're
@@ -377,6 +377,7 @@ root domain. Replace the last two lines above with the following, after replacin
 
 ```bash
 ./manage.py import <subdomain> ~/zulip-export-zcmpxfm6
+./scripts/start-server
 ```
 
 ### Logging in

--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -360,7 +360,6 @@ tar -xf /path/to/export/file/zulip-export-zcmpxfm6.tar.gz
 cd /home/zulip/deployments/current
 ./manage.py import '' ~/zulip-export-zcmpxfm6
 # ./scripts/start-server
-# ./manage.py reactivate_realm -r ''  # Reactivates the organization
 ```
 
 This could take several minutes to run depending on how much data you're
@@ -373,12 +372,11 @@ importing.
 The commands above create an imported organization on the root domain
 (`EXTERNAL_HOST`) of the Zulip installation. You can also import into a
 custom subdomain, e.g. if you already have an existing organization on the
-root domain. Replace the last three lines above with the following, after replacing
+root domain. Replace the last two lines above with the following, after replacing
 `<subdomain>` with the desired subdomain.
 
 ```bash
 ./manage.py import <subdomain> ~/zulip-export-zcmpxfm6
-./manage.py reactivate_realm -r <subdomain>  # Reactivates the organization
 ```
 
 ### Logging in

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -115,6 +115,14 @@ if (
 ):
     action = "start"
     verbing = "Starting"
+elif action == "start":
+    existing_services = list_supervisor_processes([*workers, "zulip-django", "zulip-tornado:*"])
+    running_services = list_supervisor_processes(
+        [*workers, "zulip-django", "zulip-tornado:*"], only_running=True
+    )
+    if existing_services == running_services:
+        logging.info("Zulip is already started; nothing to do!")
+        sys.exit(0)
 
 
 def restart_or_start(service: str) -> None:

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -127,8 +127,13 @@ elif action == "start":
 
 def restart_or_start(service: str) -> None:
     our_verb = action
-    if our_verb == "restart" and len(list_supervisor_processes([service], only_running=True)) == 0:
+    existing_services = list_supervisor_processes([service])
+    running_services = list_supervisor_processes([service], only_running=True)
+    if our_verb == "restart" and len(running_services) == 0:
         our_verb = "start"
+    elif our_verb == "start" and existing_services == running_services:
+        logging.info("%s already started!", service)
+        return
     subprocess.check_call(["supervisorctl", our_verb, service])
 
 
@@ -202,9 +207,11 @@ if has_application_server():
 # If we were doing this non-gracefully, or starting as opposed to
 # restarting, we need to turn the workers (back) on.  There's no
 # advantage to doing this not-all-at-once.
-if (action == "start" or args.less_graceful) and len(workers) > 0:
-    logging.info("Starting workers")
-    subprocess.check_call(["supervisorctl", "start", *workers])
+if action == "start" or args.less_graceful:
+    workers = list_supervisor_processes(workers, only_running=False)
+    if workers:
+        logging.info("Starting workers")
+        subprocess.check_call(["supervisorctl", "start", *workers])
 
 logging.info("Done!")
 print(OKGREEN + f"Zulip {action}ed successfully!" + ENDC)


### PR DESCRIPTION
113a8c4782bc made this step unnecessary.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
