### PR TITLE
topic_sidebar: Add unmute topic option in development environment.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -220,6 +220,7 @@ EXEMPT_FILES = make_set(
         "web/src/user_settings.ts",
         "web/src/user_status.js",
         "web/src/user_status_ui.js",
+        "web/src/user_topics.js",
         "web/src/webpack_public_path.js",
         "web/src/zcommand.js",
         "web/src/zform.js",

--- a/web/src/muted_topics_ui.js
+++ b/web/src/muted_topics_ui.js
@@ -1,16 +1,10 @@
 import _ from "lodash";
 
-import render_topic_muted from "../templates/topic_muted.hbs";
-
-import * as channel from "./channel";
-import * as feedback_widget from "./feedback_widget";
-import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as overlays from "./overlays";
 import * as popover_menus from "./popover_menus";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as settings_muted_topics from "./settings_muted_topics";
-import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as unread_ui from "./unread_ui";
 import * as user_topics from "./user_topics";
@@ -44,72 +38,23 @@ export function handle_topic_updates(user_topic) {
     rerender_for_muted_topic(old_muted_topics);
 }
 
-export function mute_topic(stream_id, topic, from_hotkey) {
-    const stream_name = stream_data.maybe_get_stream_name(stream_id);
-    const data = {
-        stream_id,
-        topic,
-        op: "add",
-    };
-
-    channel.patch({
-        url: "/json/users/me/subscriptions/muted_topics",
-        data,
-        success() {
-            if (!from_hotkey) {
-                return;
-            }
-
-            // The following feedback_widget notice helps avoid
-            // confusion when a user who is not familiar with Zulip's
-            // keyboard UI hits "M" in the wrong context and has a
-            // bunch of messages suddenly disappear.  This notice is
-            // only useful when muting from the keyboard, since you
-            // know what you did if you triggered muting with the
-            // mouse.
-            feedback_widget.show({
-                populate($container) {
-                    const rendered_html = render_topic_muted();
-                    $container.html(rendered_html);
-                    $container.find(".stream").text(stream_name);
-                    $container.find(".topic").text(topic);
-                },
-                on_undo() {
-                    unmute_topic(stream_id, topic);
-                },
-                title_text: $t({defaultMessage: "Topic muted"}),
-                undo_button_text: $t({defaultMessage: "Unmute"}),
-            });
-        },
-    });
-}
-
-export function unmute_topic(stream_id, topic) {
-    // Accidentally unmuting a topic isn't as much an issue as accidentally muting
-    // a topic, so we don't show a popup after unmuting.
-    const data = {
-        stream_id,
-        topic,
-        op: "remove",
-    };
-
-    channel.patch({
-        url: "/json/users/me/subscriptions/muted_topics",
-        data,
-        success() {
-            feedback_widget.dismiss();
-        },
-    });
-}
-
 export function toggle_topic_mute(message) {
     const stream_id = message.stream_id;
     const topic = message.topic;
 
     if (user_topics.is_topic_muted(stream_id, topic)) {
-        unmute_topic(stream_id, topic);
+        user_topics.set_user_topic_visibility_policy(
+            stream_id,
+            topic,
+            user_topics.all_visibility_policies.INHERIT,
+        );
     } else if (message.type === "stream") {
-        mute_topic(stream_id, topic, true);
+        user_topics.set_user_topic_visibility_policy(
+            stream_id,
+            topic,
+            user_topics.all_visibility_policies.MUTED,
+            true,
+        );
     }
 }
 
@@ -117,8 +62,16 @@ export function mute_or_unmute_topic($elt, mute) {
     const stream_id = Number.parseInt($elt.attr("data-stream-id"), 10);
     const topic = $elt.attr("data-topic-name");
     if (mute) {
-        mute_topic(stream_id, topic);
+        user_topics.set_user_topic_visibility_policy(
+            stream_id,
+            topic,
+            user_topics.all_visibility_policies.MUTED,
+        );
     } else {
-        unmute_topic(stream_id, topic);
+        user_topics.set_user_topic_visibility_policy(
+            stream_id,
+            topic,
+            user_topics.all_visibility_policies.INHERIT,
+        );
     }
 }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -30,7 +30,6 @@ import {$t, $t_html} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
-import * as muted_topics_ui from "./muted_topics_ui";
 import * as narrow_state from "./narrow_state";
 import * as popover_menus_data from "./popover_menus_data";
 import * as popovers from "./popovers";
@@ -43,6 +42,7 @@ import * as stream_popover from "./stream_popover";
 import {parse_html} from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
+import * as user_topics from "./user_topics";
 
 let message_actions_popover_keyboard_toggle = false;
 
@@ -307,13 +307,39 @@ export function initialize() {
                 return;
             }
 
-            $popper.one("click", ".sidebar-popover-mute-topic", () => {
-                muted_topics_ui.mute_topic(stream_id, topic_name);
+            $popper.one("click", ".sidebar-popover-unmute-topic", () => {
+                user_topics.set_user_topic_visibility_policy(
+                    stream_id,
+                    topic_name,
+                    user_topics.all_visibility_policies.UNMUTED,
+                );
                 instance.hide();
             });
 
-            $popper.one("click", ".sidebar-popover-unmute-topic", () => {
-                muted_topics_ui.unmute_topic(stream_id, topic_name);
+            $popper.one("click", ".sidebar-popover-remove-unmute", () => {
+                user_topics.set_user_topic_visibility_policy(
+                    stream_id,
+                    topic_name,
+                    user_topics.all_visibility_policies.INHERIT,
+                );
+                instance.hide();
+            });
+
+            $popper.one("click", ".sidebar-popover-mute-topic", () => {
+                user_topics.set_user_topic_visibility_policy(
+                    stream_id,
+                    topic_name,
+                    user_topics.all_visibility_policies.MUTED,
+                );
+                instance.hide();
+            });
+
+            $popper.one("click", ".sidebar-popover-remove-mute", () => {
+                user_topics.set_user_topic_visibility_policy(
+                    stream_id,
+                    topic_name,
+                    user_topics.all_visibility_policies.INHERIT,
+                );
                 instance.hide();
             });
 

--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -128,13 +128,17 @@ export function get_actions_popover_content_context(message_id) {
 export function get_topic_popover_content_context({stream_id, topic_name, url}) {
     const sub = sub_store.get(stream_id);
     const topic_muted = user_topics.is_topic_muted(sub.stream_id, topic_name);
+    const topic_unmuted = user_topics.is_topic_unmuted(sub.stream_id, topic_name);
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
     const can_move_topic = settings_data.user_can_move_messages_between_streams();
     return {
         stream_name: sub.name,
         stream_id: sub.stream_id,
+        stream_muted: sub.is_muted,
         topic_name,
         topic_muted,
+        topic_unmuted,
+        development_environment: page_params.development_environment,
         can_move_topic,
         is_realm_admin: page_params.is_admin,
         topic_is_resolved: resolved_topic.is_resolved(topic_name),

--- a/web/src/settings_muted_topics.js
+++ b/web/src/settings_muted_topics.js
@@ -3,7 +3,6 @@ import $ from "jquery";
 import render_muted_topic_ui_row from "../templates/muted_topic_ui_row.hbs";
 
 import * as ListWidget from "./list_widget";
-import * as muted_topics_ui from "./muted_topics_ui";
 import * as ui from "./ui";
 import * as user_topics from "./user_topics";
 
@@ -42,7 +41,11 @@ export function set_up() {
 
         e.stopPropagation();
 
-        muted_topics_ui.unmute_topic(stream_id, topic);
+        user_topics.set_user_topic_visibility_policy(
+            stream_id,
+            topic,
+            user_topics.all_visibility_policies.INHERIT,
+        );
     });
 
     populate_list();

--- a/web/src/user_topics.js
+++ b/web/src/user_topics.js
@@ -1,5 +1,10 @@
+import render_topic_muted from "../templates/topic_muted.hbs";
+
 import * as blueslip from "./blueslip";
+import * as channel from "./channel";
+import * as feedback_widget from "./feedback_widget";
 import {FoldDict} from "./fold_dict";
+import {$t} from "./i18n";
 import {page_params} from "./page_params";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
@@ -56,6 +61,54 @@ export function get_muted_topics() {
         }
     }
     return topics;
+}
+
+export function set_user_topic_visibility_policy(stream_id, topic, visibility_policy, from_hotkey) {
+    const data = {
+        stream_id,
+        topic,
+        visibility_policy,
+    };
+
+    channel.post({
+        url: "/json/user_topics",
+        data,
+        success() {
+            if (visibility_policy === all_visibility_policies.INHERIT) {
+                feedback_widget.dismiss();
+                return;
+            }
+            if (!from_hotkey) {
+                return;
+            }
+
+            // The following feedback_widget notice helps avoid
+            // confusion when a user who is not familiar with Zulip's
+            // keyboard UI hits "M" in the wrong context and has a
+            // bunch of messages suddenly disappear. This notice is
+            // only useful when muting from the keyboard, since you
+            // know what you did if you triggered muting with the
+            // mouse.
+            const stream_name = stream_data.maybe_get_stream_name(stream_id);
+            feedback_widget.show({
+                populate($container) {
+                    const rendered_html = render_topic_muted();
+                    $container.html(rendered_html);
+                    $container.find(".stream").text(stream_name);
+                    $container.find(".topic").text(topic);
+                },
+                on_undo() {
+                    set_user_topic_visibility_policy(
+                        stream_id,
+                        topic,
+                        all_visibility_policies.INHERIT,
+                    );
+                },
+                title_text: $t({defaultMessage: "Topic muted"}),
+                undo_button_text: $t({defaultMessage: "Undo mute"}),
+            });
+        },
+    });
 }
 
 export function set_user_topic(user_topic) {

--- a/web/src/user_topics.js
+++ b/web/src/user_topics.js
@@ -7,7 +7,7 @@ import {get_time_from_date_muted} from "./util";
 
 const muted_topics = new Map();
 
-export const visibility_policy = {
+export const all_visibility_policies = {
     INHERIT: 0,
     MUTED: 1,
     UNMUTED: 2,

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -8,6 +8,26 @@
 
     <hr />
 
+    {{#if development_environment}}
+        {{#if stream_muted}}
+            {{#unless topic_unmuted}}
+                <li class="hidden-for-spectators">
+                    <a tabindex="0" class="sidebar-popover-unmute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+                        <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
+                        {{t "Unmute topic (muted stream)"}}
+                    </a>
+                </li>
+            {{else}}
+                <li class="hidden-for-spectators">
+                    <a tabindex="0" class="sidebar-popover-remove-unmute" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+                        <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
+                        {{t "Mute topic (muted stream)"}}
+                    </a>
+                </li>
+            {{/unless}}
+        {{/if}}
+    {{/if}}
+
     {{#unless topic_muted}}
     <li class="hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-mute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
@@ -17,7 +37,7 @@
     </li>
     {{else}}
     <li class="hidden-for-spectators">
-        <a tabindex="0" class="sidebar-popover-unmute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+        <a tabindex="0" class="sidebar-popover-remove-mute" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
             {{t "Unmute topic"}}
         </a>

--- a/web/tests/message_list_data.test.js
+++ b/web/tests/message_list_data.test.js
@@ -143,7 +143,7 @@ run_test("muting", () => {
         {id: 9, type: "private", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
     ];
 
-    user_topics.add_muted_topic(1, "muted");
+    user_topics.update_user_topics(1, "muted", user_topics.all_visibility_policies.MUTED);
     muted_users.add_muted_user(10);
 
     // `messages_filtered_for_topic_mutes` should skip filtering

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -47,7 +47,11 @@ const muted = {
 stream_data.add_sub(general);
 stream_data.add_sub(muted);
 
-user_topics.add_muted_topic(general.stream_id, "muted topic");
+user_topics.update_user_topics(
+    general.stream_id,
+    "muted topic",
+    user_topics.all_visibility_policies.MUTED,
+);
 
 function test(label, f) {
     run_test(label, (helpers) => {

--- a/web/tests/settings_muted_topics.test.js
+++ b/web/tests/settings_muted_topics.test.js
@@ -7,7 +7,6 @@ const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
 
 const list_widget = mock_esm("../src/list_widget");
-const muted_topics_ui = mock_esm("../src/muted_topics_ui");
 
 const settings_muted_topics = zrequire("settings_muted_topics");
 const stream_data = zrequire("stream_data");
@@ -73,7 +72,7 @@ run_test("settings", ({override}) => {
     };
 
     let unmute_topic_called = false;
-    muted_topics_ui.unmute_topic = (stream_id, topic) => {
+    user_topics.set_user_topic_visibility_policy = (stream_id, topic) => {
         assert.equal(stream_id, frontend.stream_id);
         assert.equal(topic, "js");
         unmute_topic_called = true;

--- a/web/tests/settings_muted_topics.test.js
+++ b/web/tests/settings_muted_topics.test.js
@@ -21,7 +21,12 @@ const frontend = {
 stream_data.add_sub(frontend);
 
 run_test("settings", ({override}) => {
-    user_topics.add_muted_topic(frontend.stream_id, "js", 1577836800);
+    user_topics.update_user_topics(
+        frontend.stream_id,
+        "js",
+        user_topics.all_visibility_policies.MUTED,
+        1577836800,
+    );
     let populate_list_called = false;
     override(list_widget, "create", ($container, list) => {
         assert.deepEqual(list, [

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -233,7 +233,11 @@ test("muting", () => {
     assert.deepEqual(unread.get_msg_ids_for_stream(stream_id), [message.id]);
     test_notifiable_count(counts.home_unread_messages, 0);
 
-    user_topics.add_muted_topic(social.stream_id, "test_muting");
+    user_topics.update_user_topics(
+        social.stream_id,
+        "test_muting",
+        user_topics.all_visibility_policies.MUTED,
+    );
     counts = unread.get_counts();
     assert.equal(counts.stream_count.get(stream_id), 0);
     assert.equal(counts.home_unread_messages, 0);
@@ -470,7 +474,7 @@ test("mentions", () => {
 
     const muted_stream_id = 401;
 
-    user_topics.add_muted_topic(401, "lunch");
+    user_topics.update_user_topics(401, "lunch", user_topics.all_visibility_policies.MUTED);
 
     const already_read_message = {
         id: 14,
@@ -593,7 +597,7 @@ test("mention updates", () => {
 
 test("stream_has_any_unread_mentions", () => {
     const muted_stream_id = 401;
-    user_topics.add_muted_topic(401, "lunch");
+    user_topics.update_user_topics(401, "lunch", user_topics.all_visibility_policies.MUTED);
 
     const mention_me_message = {
         id: 15,

--- a/web/tests/user_topics.test.js
+++ b/web/tests/user_topics.test.js
@@ -56,29 +56,60 @@ test("edge_cases", () => {
 
 test("add_and_remove_mutes", () => {
     assert.ok(!user_topics.is_topic_muted(devel.stream_id, "java"));
-    user_topics.add_muted_topic(devel.stream_id, "java");
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.MUTED);
     assert.ok(user_topics.is_topic_muted(devel.stream_id, "java"));
 
     // test idempotency
-    user_topics.add_muted_topic(devel.stream_id, "java");
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.MUTED);
     assert.ok(user_topics.is_topic_muted(devel.stream_id, "java"));
 
-    user_topics.remove_muted_topic(devel.stream_id, "java");
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.INHERIT);
     assert.ok(!user_topics.is_topic_muted(devel.stream_id, "java"));
 
     // test idempotency
-    user_topics.remove_muted_topic(devel.stream_id, "java");
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.INHERIT);
     assert.ok(!user_topics.is_topic_muted(devel.stream_id, "java"));
 
     // test unknown stream is harmless too
-    user_topics.remove_muted_topic(unknown.stream_id, "java");
+    user_topics.update_user_topics(unknown.stream_id, "java", all_visibility_policies.INHERIT);
     assert.ok(!user_topics.is_topic_muted(unknown.stream_id, "java"));
+});
+
+test("add_and_remove_unmutes", () => {
+    assert.ok(!user_topics.is_topic_unmuted(devel.stream_id, "java"));
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.UNMUTED);
+    assert.ok(user_topics.is_topic_unmuted(devel.stream_id, "java"));
+
+    // test idempotency
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.UNMUTED);
+    assert.ok(user_topics.is_topic_unmuted(devel.stream_id, "java"));
+
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.INHERIT);
+    assert.ok(!user_topics.is_topic_unmuted(devel.stream_id, "java"));
+
+    // test idempotency
+    user_topics.update_user_topics(devel.stream_id, "java", all_visibility_policies.INHERIT);
+    assert.ok(!user_topics.is_topic_unmuted(devel.stream_id, "java"));
+
+    // test unknown stream is harmless too
+    user_topics.update_user_topics(unknown.stream_id, "java", all_visibility_policies.INHERIT);
+    assert.ok(!user_topics.is_topic_unmuted(unknown.stream_id, "java"));
 });
 
 test("get_mutes", () => {
     assert.deepEqual(user_topics.get_muted_topics(), []);
-    user_topics.add_muted_topic(office.stream_id, "gossip", 1577836800);
-    user_topics.add_muted_topic(devel.stream_id, "java", 1577836700);
+    user_topics.update_user_topics(
+        office.stream_id,
+        "gossip",
+        all_visibility_policies.MUTED,
+        1577836800,
+    );
+    user_topics.update_user_topics(
+        devel.stream_id,
+        "java",
+        all_visibility_policies.MUTED,
+        1577836700,
+    );
     const all_muted_topics = user_topics
         .get_muted_topics()
         .sort((a, b) => a.date_muted - b.date_muted);

--- a/web/tests/user_topics.test.js
+++ b/web/tests/user_topics.test.js
@@ -2,7 +2,7 @@
 
 const {strict: assert} = require("assert");
 
-const {visibility_policy} = require("../src/user_topics");
+const {all_visibility_policies} = require("../src/user_topics");
 
 const {zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
@@ -113,19 +113,19 @@ test("set_user_topics", () => {
             stream_id: social.stream_id,
             topic_name: "breakfast",
             last_updated: "1577836800",
-            visibility_policy: visibility_policy.MUTED,
+            visibility_policy: all_visibility_policies.MUTED,
         },
         {
             stream_id: design.stream_id,
             topic_name: "typography",
             last_updated: "1577836800",
-            visibility_policy: visibility_policy.MUTED,
+            visibility_policy: all_visibility_policies.MUTED,
         },
         {
             stream_id: 999, // BOGUS STREAM ID
             topic_name: "random",
             last_updated: "1577836800",
-            visibility_policy: visibility_policy.MUTED,
+            visibility_policy: all_visibility_policies.MUTED,
         },
     ];
 
@@ -152,7 +152,7 @@ test("set_user_topics", () => {
         stream_id: design.stream_id,
         topic_name: "typography",
         last_updated: "1577836800",
-        visibility_policy: visibility_policy.INHERIT,
+        visibility_policy: all_visibility_policies.INHERIT,
     });
     assert.ok(!user_topics.is_topic_muted(design.stream_id, "typography"));
 });
@@ -165,7 +165,7 @@ test("case_insensitivity", () => {
             stream_id: social.stream_id,
             topic_name: "breakfast",
             last_updated: "1577836800",
-            visibility_policy: visibility_policy.MUTED,
+            visibility_policy: all_visibility_policies.MUTED,
         },
     ]);
     assert.ok(user_topics.is_topic_muted(social.stream_id, "breakfast"));


### PR DESCRIPTION
if in development environment, for a topic in muted stream show additional option for unmuting the topic that sets visibility policy to unmute.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#24244 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
setting and removing unmute visibility policy:

https://user-images.githubusercontent.com/64723994/229842881-4ae9ec42-0404-4988-8eef-8419addae6d2.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
