### PR TITLE
test_classes: Rename and refactor 'tornado_redirected_to_list'.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1692,10 +1692,10 @@ Output:
         )
 
     @contextmanager
-    def tornado_redirected_to_list(
-        self, lst: List[Mapping[str, Any]], expected_num_events: int
-    ) -> Iterator[None]:
-        lst.clear()
+    def capture_send_event_calls(
+        self, expected_num_events: int
+    ) -> Iterator[List[Mapping[str, Any]]]:
+        lst: List[Mapping[str, Any]] = []
 
         # process_notification takes a single parameter called 'notice'.
         # lst.append takes a single argument called 'object'.
@@ -1711,7 +1711,7 @@ Output:
             # never be sent in tests, and we would be unable to verify them. Hence, we use
             # this helper to make sure the `send_event` calls actually run.
             with self.captureOnCommitCallbacks(execute=True):
-                yield
+                yield lst
 
         self.assert_length(lst, expected_num_events)
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -1,6 +1,6 @@
 import filecmp
 import os
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -163,8 +163,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         hamlet = self.example_user("hamlet")
         self.login("hamlet")
         self.assert_num_bots_equal(0)
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=4):
+        with self.capture_send_event_calls(expected_num_events=4) as events:
             result = self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -330,8 +329,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         self.login_user(user)
         self.assert_num_bots_equal(0)
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=4):
+        with self.capture_send_event_calls(expected_num_events=4) as events:
             result = self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -384,8 +382,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         request_data = {
             "principals": '["' + iago.email + '"]',
         }
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=3):
+        with self.capture_send_event_calls(expected_num_events=3) as events:
             result = self.common_subscribe_to_streams(hamlet, ["Rome"], request_data)
             self.assert_json_success(result)
 
@@ -401,8 +398,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_request_data = {
             "principals": '["hambot-bot@zulip.testserver"]',
         }
-        events_bot: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events_bot, expected_num_events=2):
+        with self.capture_send_event_calls(expected_num_events=2) as events_bot:
             result = self.common_subscribe_to_streams(hamlet, ["Rome"], bot_request_data)
             self.assert_json_success(result)
 
@@ -428,8 +424,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
 
         self.assert_num_bots_equal(0)
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=4):
+        with self.capture_send_event_calls(expected_num_events=4) as events:
             result = self.create_bot(default_sending_stream="Denmark")
         self.assert_num_bots_equal(1)
         self.assertEqual(result["default_sending_stream"], "Denmark")
@@ -512,8 +507,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         )
 
         self.assert_num_bots_equal(0)
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=4):
+        with self.capture_send_event_calls(expected_num_events=4) as events:
             result = self.create_bot(default_events_register_stream="Denmark")
         self.assert_num_bots_equal(1)
         self.assertEqual(result["default_events_register_stream"], "Denmark")

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Callable, Dict, List, Mapping, Optional
+from typing import Any, Callable, Dict, List, Optional
 from unittest import mock
 from urllib.parse import urlsplit
 
@@ -1367,8 +1367,7 @@ class TestUserPresenceUpdatesDisabled(ZulipTestCase):
     # force_send_update is passed.
     @override_settings(USER_LIMIT_FOR_SENDING_PRESENCE_UPDATE_EVENTS=3)
     def test_presence_events_disabled_on_larger_realm(self) -> None:
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1):
             do_update_user_presence(
                 self.example_user("cordelia"),
                 get_client("website"),
@@ -1377,7 +1376,7 @@ class TestUserPresenceUpdatesDisabled(ZulipTestCase):
                 force_send_update=True,
             )
 
-        with self.tornado_redirected_to_list(events, expected_num_events=0):
+        with self.capture_send_event_calls(expected_num_events=0):
             do_update_user_presence(
                 self.example_user("hamlet"),
                 get_client("website"),

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -309,7 +309,7 @@ class BaseAction(ZulipTestCase):
 
         # We want even those `send_event` calls which have been hooked to
         # `transaction.on_commit` to execute in tests.
-        # See the comment in `ZulipTestCase.tornado_redirected_to_list`.
+        # See the comment in `ZulipTestCase.capture_send_event_calls`.
         with self.captureOnCommitCallbacks(execute=True):
             action()
 

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Any, List, Mapping
 from unittest import mock
 
 import orjson
@@ -230,11 +229,8 @@ class TestFullStack(ZulipTestCase):
 
         params = dict(status_text="on vacation")
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(cordelia, "/api/v1/users/me/status", params)
 
         self.assert_json_success(result)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -3871,7 +3871,7 @@ class DeleteMessageTest(ZulipTestCase):
         self.send_stream_message(hamlet, "Denmark")
         message = self.get_last_message()
 
-        with self.tornado_redirected_to_list([], expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1):
             with mock.patch("zerver.actions.message_edit.send_event") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits."

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Mapping, Set
+from typing import TYPE_CHECKING, Any, List, Set
 from unittest import mock
 
 import orjson
@@ -322,8 +322,7 @@ class UnreadCountTests(ZulipTestCase):
             self.example_user("hamlet"), "Denmark", "hello"
         )
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.client_post(
                 "/json/mark_stream_as_read",
                 {
@@ -392,8 +391,7 @@ class UnreadCountTests(ZulipTestCase):
         unrelated_message_id = self.send_stream_message(
             self.example_user("hamlet"), "Denmark", "hello", "Denmark2"
         )
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.client_post(
                 "/json/mark_topic_as_read",
                 {
@@ -1683,11 +1681,8 @@ class MarkUnreadTest(ZulipTestCase):
             "flag": "read",
         }
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(receiver, "/api/v1/messages/flags", params)
 
         self.assert_json_success(result)
@@ -1756,11 +1751,8 @@ class MarkUnreadTest(ZulipTestCase):
             "flag": "read",
         }
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(receiver, "/api/v1/messages/flags", params)
 
         self.assert_json_success(result)
@@ -1829,11 +1821,8 @@ class MarkUnreadTest(ZulipTestCase):
             "flag": "read",
         }
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(receiver, "/api/v1/messages/flags", params)
 
         self.assert_json_success(result)
@@ -1958,8 +1947,7 @@ class MarkUnreadTest(ZulipTestCase):
         # ones that already have UserMessage rows are already unread,
         # and the others don't have UserMessage rows and cannot be
         # marked as unread without first subscribing.
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=0):
+        with self.capture_send_event_calls(expected_num_events=0) as events:
             result = self.client_post(
                 "/json/messages/flags",
                 {"messages": orjson.dumps(message_ids).decode(), "op": "remove", "flag": "read"},
@@ -1984,7 +1972,7 @@ class MarkUnreadTest(ZulipTestCase):
         # have UserMessage rows will be ignored.
         message_ids = before_subscribe_stream_message_ids + message_ids
         self.login("hamlet")
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.client_post(
                 "/json/messages/flags",
                 {"messages": orjson.dumps(message_ids).decode(), "op": "add", "flag": "read"},
@@ -2018,7 +2006,7 @@ class MarkUnreadTest(ZulipTestCase):
         # This also create new 'historical' UserMessage rows for the
         # messages in subscribed streams that didn't have them
         # previously.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.client_post(
                 "/json/messages/flags",
                 {"messages": orjson.dumps(message_ids).decode(), "op": "remove", "flag": "read"},
@@ -2090,11 +2078,8 @@ class MarkUnreadTest(ZulipTestCase):
             "flag": "read",
         }
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(receiver, "/api/v1/messages/flags", params)
 
         self.assert_json_success(result)
@@ -2160,11 +2145,8 @@ class MarkUnreadTest(ZulipTestCase):
             "flag": "read",
         }
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(receiver, "/api/v1/messages/flags", params)
 
         self.assert_json_success(result)
@@ -2231,11 +2213,8 @@ class MarkUnreadTest(ZulipTestCase):
             "flag": "read",
         }
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(receiver, "/api/v1/messages/flags", params)
 
         self.assert_json_success(result)
@@ -2297,11 +2276,8 @@ class MarkUnreadTest(ZulipTestCase):
             "flag": "read",
         }
 
-        events: List[Mapping[str, Any]] = []
-
-        # Use the tornado_redirected_to_list context manager to capture
-        # events.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        # Use the capture_send_event_calls context manager to capture events.
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(receiver, "/api/v1/messages/flags", params)
 
         self.assert_json_success(result)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -1,7 +1,7 @@
 import datetime
 import sys
 from email.headerregistry import Address
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Union
 from unittest import mock
 
 import orjson
@@ -1682,8 +1682,7 @@ class StreamMessagesTest(ZulipTestCase):
         )
 
     def _send_stream_message(self, user: UserProfile, stream_name: str, content: str) -> Set[int]:
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             self.send_stream_message(
                 user,
                 stream_name,

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping
+from typing import TYPE_CHECKING, Any, Dict, List
 from unittest import mock
 
 import orjson
@@ -443,8 +443,7 @@ class ReactionEventTest(ZulipTestCase):
             "emoji_name": "smile",
         }
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(
                 reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info
             )
@@ -490,8 +489,7 @@ class ReactionEventTest(ZulipTestCase):
         add = self.api_post(reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info)
         self.assert_json_success(add)
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_delete(
                 reaction_sender, f"/api/v1/messages/{pm_id}/reactions", reaction_info
             )
@@ -528,8 +526,7 @@ class ReactionEventTest(ZulipTestCase):
 
         # Hamlet and Polonius joined after the message was sent, and
         # so only Iago should receive the event.
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
@@ -548,7 +545,7 @@ class ReactionEventTest(ZulipTestCase):
         message_after_id = self.send_stream_message(
             iago, "test_reactions_stream", "after subscription history private"
         )
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_after_id}/reactions", reaction_info
             )
@@ -573,7 +570,7 @@ class ReactionEventTest(ZulipTestCase):
         # Since stream history is public to subscribers, reacting to
         # message_before_id should notify all subscribers:
         # Iago and Hamlet.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
@@ -597,7 +594,7 @@ class ReactionEventTest(ZulipTestCase):
         )
         # For is_web_public streams, events even on old messages
         # should go to all subscribers, including guests like polonius.
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(
                 iago, f"/api/v1/messages/{message_before_id}/reactions", reaction_info
             )
@@ -617,7 +614,7 @@ class ReactionEventTest(ZulipTestCase):
             hamlet,
             "hello to single receiver",
         )
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(
                 hamlet, f"/api/v1/messages/{private_message_id}/reactions", reaction_info
             )
@@ -633,7 +630,7 @@ class ReactionEventTest(ZulipTestCase):
             [polonius, iago],
             "hello message to multiple receiver",
         )
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_post(
                 polonius, f"/api/v1/messages/{huddle_message_id}/reactions", reaction_info
             )
@@ -1062,8 +1059,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
             "emoji_code": "1f354",
             "reaction_type": "unicode_emoji",
         }
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             with mock.patch("zerver.actions.reactions.send_event") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits!"
@@ -1106,8 +1102,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
         )
         self.assert_json_success(add)
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.api_delete(
                 reaction_sender,
                 f"/api/v1/messages/{pm_id}/reactions",
@@ -1147,7 +1142,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
             reaction_type="whatever",
         )
 
-        with self.tornado_redirected_to_list([], expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1):
             with mock.patch("zerver.actions.reactions.send_event") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits."

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import re
 from datetime import timedelta
-from typing import Any, Dict, List, Mapping, Union
+from typing import Any, Dict, List, Union
 from unittest import mock
 
 import orjson
@@ -136,8 +136,7 @@ class RealmTest(ZulipTestCase):
     def test_update_realm_name_events(self) -> None:
         realm = get_realm("zulip")
         new_name = "Puliz"
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             do_set_realm_property(realm, "name", new_name, acting_user=None)
         event = events[0]["event"]
         self.assertEqual(
@@ -153,8 +152,7 @@ class RealmTest(ZulipTestCase):
     def test_update_realm_description_events(self) -> None:
         realm = get_realm("zulip")
         new_description = "zulip dev group"
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             do_set_realm_property(realm, "description", new_description, acting_user=None)
         event = events[0]["event"]
         self.assertEqual(
@@ -171,8 +169,7 @@ class RealmTest(ZulipTestCase):
         self.login("iago")
         new_description = "zulip dev group"
         data = dict(description=new_description)
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.client_patch("/json/realm", data)
             self.assert_json_success(result)
             realm = get_realm("zulip")

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List
 from unittest import mock
 
 from zerver.actions.submessage import do_add_submessage
@@ -151,8 +151,7 @@ class TestBasics(ZulipTestCase):
             msg_type="whatever",
             content='{"name": "alice", "salary": 20}',
         )
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1) as events:
             result = self.client_post("/json/submessage", payload)
         self.assert_json_success(result)
 
@@ -195,7 +194,7 @@ class TestBasics(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         message_id = self.send_stream_message(hamlet, "Denmark")
 
-        with self.tornado_redirected_to_list([], expected_num_events=1):
+        with self.capture_send_event_calls(expected_num_events=1):
             with mock.patch("zerver.actions.submessage.send_event") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits."

--- a/zerver/tests/test_user_status.py
+++ b/zerver/tests/test_user_status.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict
 
 import orjson
 
@@ -118,8 +118,7 @@ class UserStatusTest(ZulipTestCase):
     def update_status_and_assert_event(
         self, payload: Dict[str, Any], expected_event: Dict[str, Any], num_events: int = 1
     ) -> None:
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=num_events):
+        with self.capture_send_event_calls(expected_num_events=num_events) as events:
             result = self.client_post("/json/users/me/status", payload)
         self.assert_json_success(result)
         self.assertEqual(events[0]["event"], expected_event)

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List
 
 import time_machine
 from django.utils.timezone import now as timezone_now
@@ -323,8 +323,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         mock_date_muted = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=2):
+        with self.capture_send_event_calls(expected_num_events=2) as events:
             with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
                 result = self.api_post(user, url, data)
                 self.assert_json_success(result)
@@ -390,8 +389,7 @@ class MutedTopicsTests(ZulipTestCase):
 
         mock_date_mute_removed = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=2):
+        with self.capture_send_event_calls(expected_num_events=2) as events:
             with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
                 result = self.api_post(user, url, data)
                 self.assert_json_success(result)
@@ -518,8 +516,7 @@ class UnmutedTopicsTests(ZulipTestCase):
 
         mock_date_unmuted = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=2):
+        with self.capture_send_event_calls(expected_num_events=2) as events:
             with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
                 result = self.api_post(user, url, data)
                 self.assert_json_success(result)
@@ -585,8 +582,7 @@ class UnmutedTopicsTests(ZulipTestCase):
 
         mock_date_unmute_removed = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
 
-        events: List[Mapping[str, Any]] = []
-        with self.tornado_redirected_to_list(events, expected_num_events=2):
+        with self.capture_send_event_calls(expected_num_events=2) as events:
             with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc), tick=False):
                 result = self.api_post(user, url, data)
                 self.assert_json_success(result)


### PR DESCRIPTION
This PR renames the `tornado_redirected_to_list` context manager to `capture_send_event_calls` to improve readability.

It also refactors the function to yield a list of events instead of passing in a list data structure as a parameter and appending events to it.

Previously:
```
with self.tornado_redirected_to_list(events, expected_num_events=1):
     do_something()
     ...
self.assertEqual(events[0], {...})
```

Now:
```
with self.capture_send_event_calls(expected_num_events=1) as events:
     do_something()
     ...
self.assertEqual(events[0], {...})
```

[**CZO Discussion**](https://chat.zulip.org/#narrow/stream/3-backend/topic/tornado_redirected_to_list/near/1540847)

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
