### PR TITLE
OpenAPI testsuite reporting endpoint as not in urls.py #24982

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -936,7 +936,6 @@ def get_api_key_fetch_authenticate_failure(return_data: Dict[str, bool]) -> Json
 
 
 @csrf_exempt
-@require_post
 @has_request_variables
 def jwt_fetch_api_key(
     request: HttpRequest,
@@ -975,7 +974,6 @@ def jwt_fetch_api_key(
 
 
 @csrf_exempt
-@require_post
 @has_request_variables
 def api_fetch_api_key(
     request: HttpRequest, username: str = REQ(), password: str = REQ()

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -512,6 +512,7 @@ v1_api_and_json_patterns = [
     # export/realm -> zerver.views.realm_export
     rest_path("export/realm", POST=export_realm, GET=get_realm_exports),
     rest_path("export/realm/<int:export_id>", DELETE=delete_realm_export),
+    rest_path("jwt/fetch_api_key", POST=(jwt_fetch_api_key, {"intentionally_undocumented"})),
 ]
 
 integrations_view = IntegrationView.as_view()
@@ -755,11 +756,6 @@ urls += [
 urls += [path("", include("social_django.urls", namespace="social"))]
 urls += [path("saml/metadata.xml", saml_sp_metadata)]
 
-#  This view accepts a JWT containing an email and returns an API key
-#  and the details for a single user.
-urls += [
-    path("api/v1/jwt/fetch_api_key", jwt_fetch_api_key),
-]
 
 # SCIM2
 


### PR DESCRIPTION
Added the `jwt/fetch_api_key` method to `v1_api_and_json_patterns` array as suggested in the [ticket](https://github.com/zulip/zulip/issues/24982) description.