### PR TITLE
The `tabbed_instructions.js` variable name `language` was confusing 

### DIFF
--- a/web/src/portico/tabbed-instructions.ts
+++ b/web/src/portico/tabbed-instructions.ts
@@ -31,25 +31,25 @@ export function activate_correct_tab($codeSection: JQuery<HTMLElement>): void {
     const $blocks = $codeSection.find(".blocks div");
 
     $li.each(function () {
-        const language = this.dataset.language;
+        const tab_key = this.dataset.tab_key;
         $(this).removeClass("active");
-        if (language === user_os) {
+        if (tab_key === user_os) {
             $(this).addClass("active");
         }
 
-        if (desktop_os.has(user_os) && language === "desktop-web") {
+        if (desktop_os.has(user_os) && tab_key === "desktop-web") {
             $(this).addClass("active");
         }
     });
 
     $blocks.each(function () {
-        const language = this.dataset.language;
+        const tab_key = this.dataset.tab_key;
         $(this).removeClass("active");
-        if (language === user_os) {
+        if (tab_key === user_os) {
             $(this).addClass("active");
         }
 
-        if (desktop_os.has(user_os) && language === "desktop-web") {
+        if (desktop_os.has(user_os) && tab_key === "desktop-web") {
             $(this).addClass("active");
         }
     });
@@ -58,9 +58,9 @@ export function activate_correct_tab($codeSection: JQuery<HTMLElement>): void {
     const $active_list_items = $li.filter(".active");
     if (!$active_list_items.length) {
         $li.first().addClass("active");
-        const language = $li.first()[0].dataset.language;
-        if (language) {
-            $blocks.filter("[data-language=" + language + "]").addClass("active");
+        const tab_key = $li.first()[0].dataset.tab_key;
+        if (tab_key) {
+            $blocks.filter("[data-tab_key=" + tab_key + "]").addClass("active");
         } else {
             blueslip.error("Tabbed instructions widget has no tabs to activate!");
         }

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -27,11 +27,11 @@ NAV_BAR_TEMPLATE = """
 """.strip()
 
 NAV_LIST_ITEM_TEMPLATE = """
-<li data-language="{data_language}" tabindex="0">{label}</li>
+<li data-tab-key="{data_tab_key}" tabindex="0">{label}</li>
 """.strip()
 
 DIV_TAB_CONTENT_TEMPLATE = """
-<div data-language="{data_language}" markdown="1">
+<div data-tab-key="{data_tab_key}" markdown="1">
 {content}
 </div>
 """.strip()
@@ -120,7 +120,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
                 tab_class = "no-tabs"
                 tab_section["tabs"] = [
                     {
-                        "tab_name": "instructions-for-all-platforms",
+                        "tab_key": "instructions-for-all-platforms",
                         "start": tab_section["start_tabs_index"],
                     }
                 ]
@@ -150,7 +150,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
 
             content = "\n".join(lines[start_index:end_index]).strip()
             tab_content_block = DIV_TAB_CONTENT_TEMPLATE.format(
-                data_language=tab["tab_name"],
+                data_tab_key=tab["tab_key"],
                 # Wrapping the content in two newlines is necessary here.
                 # If we don't do this, the inner Markdown does not get
                 # rendered properly.
@@ -162,14 +162,14 @@ class TabbedSectionsPreprocessor(Preprocessor):
     def generate_nav_bar(self, tab_section: Dict[str, Any]) -> str:
         li_elements = []
         for tab in tab_section["tabs"]:
-            tab_name = tab.get("tab_name")
-            tab_label = TAB_SECTION_LABELS.get(tab_name)
+            tab_key = tab.get("tab_key")
+            tab_label = TAB_SECTION_LABELS.get(tab_key)
             if tab_label is None:
                 raise ValueError(
-                    f"Tab '{tab_name}' is not present in TAB_SECTION_LABELS in zerver/lib/markdown/tabbed_sections.py"
+                    f"Tab '{tab_key}' is not present in TAB_SECTION_LABELS in zerver/lib/markdown/tabbed_sections.py"
                 )
 
-            li = NAV_LIST_ITEM_TEMPLATE.format(data_language=tab_name, label=tab_label)
+            li = NAV_LIST_ITEM_TEMPLATE.format(data_tab_key=tab_key, label=tab_label)
             li_elements.append(li)
 
         return NAV_BAR_TEMPLATE.format(tabs="\n".join(li_elements))
@@ -184,7 +184,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
             tab_content_match = TAB_CONTENT_REGEX.search(line)
             if tab_content_match:
                 block.setdefault("tabs", [])
-                tab = {"start": index, "tab_name": tab_content_match.group(1)}
+                tab = {"start": index, "tab_key": tab_content_match.group(1)}
                 block["tabs"].append(tab)
 
             end_match = END_TABBED_SECTION_REGEX.search(line)

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -38,14 +38,14 @@ header
 <p>
   <div class="code-section has-tabs" markdown="1">
     <ul class="nav">
-      <li data-language="ios" tabindex="0">iOS</li>
-      <li data-language="desktop-web" tabindex="0">Desktop/Web</li>
+      <li data-tab-key="ios" tabindex="0">iOS</li>
+      <li data-tab-key="desktop-web" tabindex="0">Desktop/Web</li>
     </ul>
     <div class="blocks">
-      <div data-language="ios" markdown="1"></p>
+      <div data-tab-key="ios" markdown="1"></p>
         <p>iOS instructions</p>
       <p></div>
-      <div data-language="desktop-web" markdown="1"></p>
+      <div data-tab-key="desktop-web" markdown="1"></p>
         <p>Desktop/browser instructions</p>
       <p></div>
     </div>
@@ -56,14 +56,14 @@ header
 <p>
   <div class="code-section has-tabs" markdown="1">
     <ul class="nav">
-      <li data-language="desktop-web" tabindex="0">Desktop/Web</li>
-      <li data-language="android" tabindex="0">Android</li>
+      <li data-tab-key="desktop-web" tabindex="0">Desktop/Web</li>
+      <li data-tab-key="android" tabindex="0">Android</li>
     </ul>
     <div class="blocks">
-      <div data-language="desktop-web" markdown="1"></p>
+      <div data-tab-key="desktop-web" markdown="1"></p>
         <p>Desktop/browser instructions</p>
       <p></div>
-      <div data-language="android" markdown="1"></p>
+      <div data-tab-key="android" markdown="1"></p>
         <p>Android instructions</p>
       <p></div>
     </div>
@@ -74,10 +74,10 @@ header
 <p>
   <div class="code-section no-tabs" markdown="1">
     <ul class="nav">
-      <li data-language="instructions-for-all-platforms" tabindex="0">Instructions for all platforms</li>
+      <li data-tab-key="instructions-for-all-platforms" tabindex="0">Instructions for all platforms</li>
     </ul>
     <div class="blocks">
-      <div data-language="instructions-for-all-platforms" markdown="1"></p>
+      <div data-tab-key="instructions-for-all-platforms" markdown="1"></p>
         <p>Instructions for all platforms</p>
       <p></div>
     </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
the `tabbed_instructions.ts` and ```tabbed_section.py``` variable name ```language``` was misleading. So replaced the ```language``` variable to ```tab_key``` in both the files. Also tabbed_section.py used ```tab_name``` to refer to the same which is also replaced to ```tab_key``` in this commit. 

Fixes: #24669

