### PR TITLE
[6.x] setup-apt-repo: Fix GPG check of groonga-apt-source-*.deb.

### DIFF
--- a/scripts/setup/apt-repos/zulip/custom.sh
+++ b/scripts/setup/apt-repos/zulip/custom.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
+    pgroonga_apt_sign_key=$(readlink -f "$LIST_PATH/pgroonga-packages.groonga.org.asc")
+
     remove_pgroonga_apt_tmp_dir() {
         rm -rf "$pgroonga_apt_tmp_dir"
     }
@@ -10,7 +13,6 @@ if [[ ! -e /usr/share/doc/groonga-apt-source/copyright ]]; then
     {
         cd "$pgroonga_apt_tmp_dir" || exit 1
         tmp_gpg_home=.gnupg
-        pgroonga_apt_sign_key="$LIST_PATH/pgroonga-packages.groonga.org.asc"
         gpg --homedir="$tmp_gpg_home" --import "$pgroonga_apt_sign_key"
         # Find fingerprint of the first key.
         pgroonga_apt_sign_key_fingerprint=$(


### PR DESCRIPTION
Backport to 6.x:

- #25005