### PR TITLE
Reword user activity info from "Last active:" to "Active".

### DIFF
--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -108,10 +108,9 @@ export function user_last_seen_time_status(user_id) {
     }
 
     const last_active_date = presence.last_active_date(user_id);
-    let last_seen;
     if (page_params.realm_is_zephyr_mirror_realm) {
         // We don't send presence data to clients in Zephyr mirroring realms
-        last_seen = $t({defaultMessage: "Unknown"});
+        return $t({defaultMessage: "Activity unknown"});
     } else if (last_active_date === undefined) {
         // There are situations where the client has incomplete presence
         // history on a user.  This can happen when users are deactivated,
@@ -120,11 +119,9 @@ export function user_last_seen_time_status(user_id) {
         //
         // We give this vague status for such users; we will get to
         // delete this code when we finish rewriting the presence API.
-        last_seen = $t({defaultMessage: "More than 2 weeks ago"});
-    } else {
-        last_seen = timerender.last_seen_status_from_date(last_active_date);
+        return $t({defaultMessage: "Active more than 2 weeks ago"});
     }
-    return $t({defaultMessage: "Last active: {last_seen}"}, {last_seen});
+    return timerender.last_seen_status_from_date(last_active_date);
 }
 
 export function info_for(user_id) {

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -194,10 +194,10 @@ export function last_seen_status_from_date(
 ): string {
     const minutes = differenceInMinutes(current_date, last_active_date);
     if (minutes <= 2) {
-        return $t({defaultMessage: "Just now"});
+        return $t({defaultMessage: "Active just now"});
     }
     if (minutes < 60) {
-        return $t({defaultMessage: "{minutes} minutes ago"}, {minutes});
+        return $t({defaultMessage: "Active {minutes} minutes ago"}, {minutes});
     }
 
     const days_old = differenceInCalendarDays(current_date, last_active_date);
@@ -205,17 +205,17 @@ export function last_seen_status_from_date(
 
     if (hours < 24) {
         if (hours === 1) {
-            return $t({defaultMessage: "An hour ago"});
+            return $t({defaultMessage: "Active an hour ago"});
         }
-        return $t({defaultMessage: "{hours} hours ago"}, {hours});
+        return $t({defaultMessage: "Active {hours} hours ago"}, {hours});
     }
 
     if (days_old === 1) {
-        return $t({defaultMessage: "Yesterday"});
+        return $t({defaultMessage: "Active yesterday"});
     }
 
     if (days_old < 90) {
-        return $t({defaultMessage: "{days_old} days ago"}, {days_old});
+        return $t({defaultMessage: "Active {days_old} days ago"}, {days_old});
     } else if (
         days_old > 90 &&
         days_old < 365 &&
@@ -223,7 +223,7 @@ export function last_seen_status_from_date(
     ) {
         // Online more than 90 days ago, in the same year
         return $t(
-            {defaultMessage: "{last_active_date}"},
+            {defaultMessage: "Active {last_active_date}"},
             {
                 last_active_date: get_localized_date_or_time_for_format(
                     last_active_date,
@@ -233,7 +233,7 @@ export function last_seen_status_from_date(
         );
     }
     return $t(
-        {defaultMessage: "{last_active_date}"},
+        {defaultMessage: "Active {last_active_date}"},
         {
             last_active_date: get_localized_date_or_time_for_format(
                 last_active_date,

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -321,7 +321,7 @@ test("title_data", () => {
 
     expected_data = {
         first_line: "Old User",
-        second_line: "translated: Last active: translated: More than 2 weeks ago",
+        second_line: "translated: Active more than 2 weeks ago",
         third_line: "",
         show_you: false,
     };
@@ -459,24 +459,24 @@ test("user_last_seen_time_status", ({override}) => {
     page_params.realm_is_zephyr_mirror_realm = true;
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Last active: translated: Unknown",
+        "translated: Activity unknown",
     );
     page_params.realm_is_zephyr_mirror_realm = false;
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Last active: translated: More than 2 weeks ago",
+        "translated: Active more than 2 weeks ago",
     );
 
     presence.presence_info.set(old_user.user_id, {last_active: 1526137743});
 
     override(timerender, "last_seen_status_from_date", (date) => {
         assert.deepEqual(date, new Date(1526137743000));
-        return "May 12";
+        return "translated: Active May 12";
     });
 
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Last active: May 12",
+        "translated: Active May 12",
     );
 
     set_presence(selma.user_id, "idle");

--- a/web/tests/popovers.test.js
+++ b/web/tests/popovers.test.js
@@ -175,8 +175,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
             user_time: undefined,
             user_type: $t({defaultMessage: "Member"}),
             user_circle_class: "user_circle_empty",
-            user_last_seen_time_status:
-                "translated: Last active: translated: More than 2 weeks ago",
+            user_last_seen_time_status: "translated: Active more than 2 weeks ago",
             pm_with_url: "#narrow/pm-with/42-Alice-Smith",
             sent_by_uri: "#narrow/sender/42-Alice-Smith",
             private_message_class: "respond_personal_button",

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -471,49 +471,49 @@ run_test("last_seen_status_from_date", () => {
         assert.equal(actual_status, expected_status);
     }
 
-    assert_same({seconds: -20}, $t({defaultMessage: "Just now"}));
+    assert_same({seconds: -20}, $t({defaultMessage: "Active just now"}));
 
-    assert_same({minutes: -1}, $t({defaultMessage: "Just now"}));
+    assert_same({minutes: -1}, $t({defaultMessage: "Active just now"}));
 
-    assert_same({minutes: -2}, $t({defaultMessage: "Just now"}));
+    assert_same({minutes: -2}, $t({defaultMessage: "Active just now"}));
 
-    assert_same({minutes: -30}, $t({defaultMessage: "30 minutes ago"}));
+    assert_same({minutes: -30}, $t({defaultMessage: "Active 30 minutes ago"}));
 
-    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "Active an hour ago"}));
 
-    assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
+    assert_same({hours: -2}, $t({defaultMessage: "Active 2 hours ago"}));
 
-    assert_same({hours: -20}, $t({defaultMessage: "20 hours ago"}));
+    assert_same({hours: -20}, $t({defaultMessage: "Active 20 hours ago"}));
 
-    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -24}, $t({defaultMessage: "Active yesterday"}));
 
-    assert_same({hours: -48}, $t({defaultMessage: "2 days ago"}));
+    assert_same({hours: -48}, $t({defaultMessage: "Active 2 days ago"}));
 
-    assert_same({days: -2}, $t({defaultMessage: "2 days ago"}));
+    assert_same({days: -2}, $t({defaultMessage: "Active 2 days ago"}));
 
-    assert_same({days: -61}, $t({defaultMessage: "61 days ago"}));
+    assert_same({days: -61}, $t({defaultMessage: "Active 61 days ago"}));
 
-    assert_same({days: -300}, $t({defaultMessage: "May 6, 2015"}));
+    assert_same({days: -300}, $t({defaultMessage: "Active May 6, 2015"}));
 
-    assert_same({days: -366}, $t({defaultMessage: "Mar 1, 2015"}));
+    assert_same({days: -366}, $t({defaultMessage: "Active Mar 1, 2015"}));
 
-    assert_same({years: -3}, $t({defaultMessage: "Mar 1, 2013"}));
+    assert_same({years: -3}, $t({defaultMessage: "Active Mar 1, 2013"}));
 
     // Set base_date to May 1 2016 12.30 AM (months are zero based)
     base_date = new Date(2016, 4, 1, 0, 30);
 
-    assert_same({days: -91}, $t({defaultMessage: "Jan 31"}));
+    assert_same({days: -91}, $t({defaultMessage: "Active Jan 31"}));
 
     // Set base_date to May 1 2016 10.30 PM (months are zero based)
     base_date = new Date(2016, 4, 2, 23, 30);
 
-    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "Active an hour ago"}));
 
-    assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
+    assert_same({hours: -2}, $t({defaultMessage: "Active 2 hours ago"}));
 
-    assert_same({hours: -12}, $t({defaultMessage: "12 hours ago"}));
+    assert_same({hours: -12}, $t({defaultMessage: "Active 12 hours ago"}));
 
-    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
+    assert_same({hours: -24}, $t({defaultMessage: "Active yesterday"}));
 });
 
 run_test("set_full_datetime", () => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #22758

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2023-04-06 11-32-11](https://user-images.githubusercontent.com/99073049/230294941-049ced20-ab4f-4597-923c-2c7994a0d809.png)
![Screenshot from 2023-04-06 11-32-32](https://user-images.githubusercontent.com/99073049/230294956-7545410f-f4b2-4a39-8858-dd0e007a0721.png)
![Screenshot from 2023-04-06 11-50-03](https://user-images.githubusercontent.com/99073049/230294960-cfe084bf-6483-44dd-b743-82e77f9f2672.png)
![Screenshot from 2023-04-06 11-51-14](https://user-images.githubusercontent.com/99073049/230294966-e8ecf31b-63a0-4318-9e48-6aa105960cd7.png)
![Screenshot from 2023-04-06 11-51-54](https://user-images.githubusercontent.com/99073049/230294971-1e2c1109-493b-4af9-9588-c1a84f0bd354.png)
![Screenshot from 2023-04-06 11-53-09](https://user-images.githubusercontent.com/99073049/230294976-37f2ba5d-73d8-4d28-b177-552ed7855f6e.png)
![Screenshot from 2023-04-06 11-53-53](https://user-images.githubusercontent.com/99073049/230294980-c9a2cf8f-8c0b-4243-9eb2-28f306aa23c8.png)
![Screenshot from 2023-04-06 11-55-19](https://user-images.githubusercontent.com/99073049/230294983-056a8e93-f327-4f4b-8364-18b9faf7cbc8.png)
![Screenshot from 2023-04-06 12-05-20](https://user-images.githubusercontent.com/99073049/230294988-698072de-e8eb-43ce-8a3e-e3fe7255730d.png)
![Screenshot from 2023-04-06 12-08-27](https://user-images.githubusercontent.com/99073049/230294992-98c771ad-fdc9-46b1-a574-e6f93e6aaed5.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
