### PR TITLE
dialog_widget: Refactor `AjaxRequest` type and moved it to `types.ts`.

### DIFF
--- a/web/src/channel.js
+++ b/web/src/channel.js
@@ -112,9 +112,6 @@ function call(args) {
     return $.ajax(args);
 }
 
-// TODO: When this file is converted to TypeScript, deduplicate the
-// AjaxRequest type defined in dialog_widget.js.
-
 export function get(options) {
     const args = {type: "GET", dataType: "json", ...options};
     return call(args);

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -5,6 +5,7 @@ import render_dialog_widget from "../templates/dialog_widget.hbs";
 import {$t_html} from "./i18n";
 import * as loading from "./loading";
 import * as overlays from "./overlays";
+import type {AjaxRequestHandler} from "./types";
 import * as ui_report from "./ui_report";
 
 /*
@@ -61,24 +62,10 @@ type WidgetConfig = {
     loading_spinner?: boolean;
 };
 
-// TODO: This type should probably be exported from channel.ts once
-// that's converted to TypeScript.
-type AjaxRequest = ({
-    url,
-    data = {},
-    success,
-    error,
-}: {
-    url: string;
-    data?: Record<string, never>;
-    success(response_data?: string): void;
-    error(xhr?: JQuery.jqXHR): void;
-}) => void;
-
 type RequestOpts = {
     failure_msg_html?: string;
-    success_continuation?: (response_data?: string) => void;
-    error_continuation?: (xhr?: JQuery.jqXHR) => void;
+    success_continuation?: Parameters<AjaxRequestHandler>[0]["success"];
+    error_continuation?: Parameters<AjaxRequestHandler>[0]["error"];
 };
 
 export function hide_dialog_spinner(): void {
@@ -190,9 +177,9 @@ export function launch(conf: WidgetConfig): void {
 }
 
 export function submit_api_request(
-    request_method: AjaxRequest,
+    request_method: AjaxRequestHandler,
     url: string,
-    data = {},
+    data: Parameters<AjaxRequestHandler>[0]["data"] = {},
     {
         failure_msg_html = $t_html({defaultMessage: "Failed"}),
         success_continuation,
@@ -203,17 +190,17 @@ export function submit_api_request(
     request_method({
         url,
         data,
-        success(response_data?: string) {
+        success(response_data, textStatus, jqXHR) {
             close_modal();
             if (success_continuation !== undefined) {
-                success_continuation(response_data);
+                success_continuation(response_data, textStatus, jqXHR);
             }
         },
-        error(xhr?: JQuery.jqXHR) {
+        error(xhr, error_type, xhn) {
             ui_report.error(failure_msg_html, xhr, $("#dialog_error"));
             hide_dialog_spinner();
             if (error_continuation !== undefined) {
-                error_continuation(xhr);
+                error_continuation(xhr, error_type, xhn);
             }
         },
     });

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -69,3 +69,12 @@ export type UpdateMessageEvent = {
 // TODO/typescript: Move the User and Stream placeholder
 // types to their appropriate modules.
 export type User = Record<string, never>;
+
+// TODO/typescript: Move this to channel
+export type AjaxRequestHandler = (args: {
+    url: string;
+    data?: Record<string, unknown> | string | unknown[];
+    ignoreReload?: boolean;
+    success?(response_data: unknown, textStatus: string, jqXHR: JQuery.jqXHR): void;
+    error?(xhr: JQuery.jqXHR, error_type: string, xhn: string): void;
+}) => void;


### PR DESCRIPTION
Follow-up PR for #24909 

Changed `AjaxRequest` name to a clearer one `AjaxRequestHandler`, also moved this type to `types.ts` with a comment to move it into `channel.js` once it migrates to typescript.

Took reference from jQuery docs: https://api.jquery.com/Jquery.ajax/ for correct types for `success` and `error` callbacks.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
