### PR TITLE
popover: Scroll to top of long message when viewing message actions.

### DIFF
--- a/web/src/message_viewport.js
+++ b/web/src/message_viewport.js
@@ -5,6 +5,7 @@ import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as notifications from "./notifications";
 import * as overlays from "./overlays";
+import * as popovers from "./popovers";
 import * as rows from "./rows";
 import * as util from "./util";
 
@@ -386,6 +387,19 @@ export function recenter_view($message, {from_scroll = false, force_center = fal
         set_message_position(message_top, message_height, viewport_info, 1 / 2);
     } else if (is_below) {
         set_message_position(message_top, message_height, viewport_info, 1 / 7);
+    }
+}
+
+export function maybe_scroll_to_show_message_top() {
+    // Sets the top of the message to the top of the viewport.
+    // Only applies if the top of the message is out of view above the visible area.
+    const $selected_message = message_lists.current.selected_row();
+    const viewport_info = message_viewport_info();
+    const message_top = $selected_message.offset().top;
+    const message_height = $selected_message.safeOuterHeight(true);
+    if (message_top < viewport_info.visible_top) {
+        set_message_position(message_top, message_height, viewport_info, 0);
+        popovers.set_suppress_scroll_hide();
     }
 }
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -30,6 +30,7 @@ import {$t, $t_html} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
+import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
 import * as popover_menus_data from "./popover_menus_data";
 import * as popovers from "./popovers";
@@ -186,6 +187,7 @@ export function toggle_message_actions_menu(message) {
         return true;
     }
 
+    message_viewport.maybe_scroll_to_show_message_top();
     const $popover_reference = $(".selected_message .actions_hover .zulip-icon-ellipsis-v-solid");
     message_actions_popover_keyboard_toggle = true;
     $popover_reference.trigger("click");


### PR DESCRIPTION
Previously, when a user scrolls down a long text of message and presses the hotkey for viewing the message actions, the popover menu would continue to open where the message actions button. Thus, the popover menu would be cut short and sometimes off the screen. These changes will scroll the client to the top of the message and ensure that the popover menu is always visible.

This is a rebase of #23830 to continue and push forward the progress on the issue. No additional changes were made from it.

Fixes: #23774.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Before:</summary>

![ezgif com-gif-maker](https://user-images.githubusercontent.com/62449508/230656048-51e0be48-5e1d-4f7e-93a8-6668b83d55ec.gif)
![427e5db32e2754a12807972531cc98ad](https://user-images.githubusercontent.com/62449508/230656702-feb660e0-c960-412e-b113-7eba659b9759.gif)


</details>

<details>
<summary>After:</summary>

![ezgif com-optimize](https://user-images.githubusercontent.com/62449508/230655092-c2f74a5b-1aca-4074-8070-7353da59179c.gif)

![31c70a8a48ac196f0d88df1478227527](https://user-images.githubusercontent.com/62449508/230653612-857d6371-1473-4905-99ee-712b0acd70fc.gif)

</details>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
