### PR TITLE
urls: Move jwt_fetch_api_key endpoint to v1_api_mobile_patterns.

### DIFF
--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -275,6 +275,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         "/rest-error-handling",
         # Zulip outgoing webhook payload
         "/zulip-outgoing-webhook",
+        "/jwt/fetch_api_key",
     }
 
     # Endpoints where the documentation is currently failing our

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -725,6 +725,9 @@ v1_api_mobile_patterns = [
     # API key - as we consider access to the API key sensitive
     # and just having a logged-in session should be insufficient.
     rest_path("users/me/api_key/regenerate", POST=regenerate_api_key),
+    #  This view accepts a JWT containing an email and returns an API key
+    #  and the details for a single user.
+    path("jwt/fetch_api_key", jwt_fetch_api_key),
 ]
 
 # View for uploading messages from email mirror
@@ -755,11 +758,6 @@ urls += [
 urls += [path("", include("social_django.urls", namespace="social"))]
 urls += [path("saml/metadata.xml", saml_sp_metadata)]
 
-#  This view accepts a JWT containing an email and returns an API key
-#  and the details for a single user.
-urls += [
-    path("api/v1/jwt/fetch_api_key", jwt_fetch_api_key),
-]
 
 # SCIM2
 


### PR DESCRIPTION
urls: Move `jwt_fetch_api_key` endpoint to `v1_api_mobile_patterns`.

Moves `jwt_fetch_api_key` endpoint to `v1_api_mobile_patterns` so
that `tools/test-api` detects it as an API endpoint that is pending
documentation.

Fixes #24982.