### PR TITLE
topic_sidebar: Add tab switcher to filter topics by state.

### DIFF
--- a/web/src/components.ts
+++ b/web/src/components.ts
@@ -137,6 +137,7 @@ export function toggle(opts: {
         // Skip disabled tabs and go to the next one.
         maybe_go_left,
         maybe_go_right,
+        meta,
 
         disable_tab(name: string) {
             const value = opts.values.find((o) => o.key === name);

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -332,10 +332,11 @@ export function zoom_in_topics(options) {
 
         if (stream_id_for_elt($elt) === stream_id) {
             $elt.show();
-            // Add search box for topics list.
+            // Add search section for topics list.
             $elt.children("div.bottom_left_row").append(render_filter_topics());
             $("#filter-topic-input").trigger("focus");
             $("#clear_search_topic_button").hide();
+            $(".filter-topics .resolved-toggle").append(topic_list.init_resolved_toggle().get());
         } else {
             $elt.hide();
         }
@@ -353,7 +354,8 @@ export function zoom_out_topics() {
 
     $("#streams_list").expectOne().removeClass("zoom-in").addClass("zoom-out");
     $("#stream_filters li.narrow-filter").show();
-    // Remove search box for topics list from DOM.
+    // Remove search session for topics list from DOM.
+    topic_list.remove_resolved_toggle();
     $(".filter-topics").remove();
 }
 

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -21,6 +21,7 @@ import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_list_sort from "./stream_list_sort";
 import * as stream_popover from "./stream_popover";
+import * as stream_topic_history from "./stream_topic_history";
 import * as sub_store from "./sub_store";
 import * as topic_list from "./topic_list";
 import * as topic_zoom from "./topic_zoom";
@@ -333,7 +334,12 @@ export function zoom_in_topics(options) {
         if (stream_id_for_elt($elt) === stream_id) {
             $elt.show();
             // Add search section for topics list.
-            $elt.children("div.bottom_left_row").append(render_filter_topics());
+            // Show the topic tab switcher only for the streams that have at least one resolved topic.
+            const stream_has_resolved_topics =
+                stream_topic_history.stream_has_resolved_topics(stream_id);
+            $elt.children("div.bottom_left_row").append(
+                render_filter_topics({stream_has_resolved_topics}),
+            );
             $("#filter-topic-input").trigger("focus");
             $("#clear_search_topic_button").hide();
             $(".filter-topics .resolved-toggle").append(topic_list.init_resolved_toggle().get());

--- a/web/src/stream_topic_history.js
+++ b/web/src/stream_topic_history.js
@@ -1,3 +1,5 @@
+import * as resolved_topics from "../shared/src/resolved_topic";
+
 import {all_messages_data} from "./all_messages_data";
 import {FoldDict} from "./fold_dict";
 import * as message_util from "./message_util";
@@ -72,6 +74,16 @@ export function stream_has_topics(stream_id) {
     return history.has_topics();
 }
 
+export function stream_has_resolved_topics(stream_id) {
+    if (!stream_dict.has(stream_id)) {
+        return false;
+    }
+
+    const history = stream_dict.get(stream_id);
+
+    return history.has_resolved_topics();
+}
+
 export class PerStreamHistory {
     /*
         For a given stream, this structure has a dictionary of topics.
@@ -108,6 +120,10 @@ export class PerStreamHistory {
 
     constructor(stream_id) {
         this.stream_id = stream_id;
+    }
+
+    has_resolved_topics() {
+        return [...this.topics._items.keys()].some((topic) => resolved_topics.is_resolved(topic));
     }
 
     has_topics() {

--- a/web/src/topic_list.js
+++ b/web/src/topic_list.js
@@ -8,6 +8,7 @@ import render_topic_list_item from "../templates/topic_list_item.hbs";
 import * as blueslip from "./blueslip";
 import * as components from "./components";
 import {$t} from "./i18n";
+import * as keydown_util from "./keydown_util";
 import * as popover_menus from "./popover_menus";
 import * as scroll_util from "./scroll_util";
 import * as stream_topic_history from "./stream_topic_history";
@@ -31,8 +32,17 @@ let zoomed = false;
 let resolved_toggle;
 let topics_state = "all";
 
+function set_key_handlers(toggler) {
+    keydown_util.handle({
+        $elem: toggler.meta.$ind_tab,
+        handlers: {
+            Tab: toggler.maybe_go_right,
+        },
+    });
+}
+
 export function init_resolved_toggle() {
-    resolved_toggle = components.toggle({
+    const opts = {
         child_wants_focus: true,
         values: [
             {label: $t({defaultMessage: "All"}), key: "all"},
@@ -44,7 +54,9 @@ export function init_resolved_toggle() {
             topics_state = key;
             active_widgets.get(active_stream_id()).build();
         },
-    });
+    };
+    resolved_toggle = components.toggle(opts);
+    set_key_handlers(resolved_toggle);
     return resolved_toggle;
 }
 

--- a/web/src/topic_list.js
+++ b/web/src/topic_list.js
@@ -6,6 +6,8 @@ import render_more_topics_spinner from "../templates/more_topics_spinner.hbs";
 import render_topic_list_item from "../templates/topic_list_item.hbs";
 
 import * as blueslip from "./blueslip";
+import * as components from "./components";
+import {$t} from "./i18n";
 import * as popover_menus from "./popover_menus";
 import * as scroll_util from "./scroll_util";
 import * as stream_topic_history from "./stream_topic_history";
@@ -25,6 +27,37 @@ const active_widgets = new Map();
 
 // We know whether we're zoomed or not.
 let zoomed = false;
+
+let resolved_toggle;
+let topics_state = "all";
+
+export function init_resolved_toggle() {
+    resolved_toggle = components.toggle({
+        child_wants_focus: true,
+        values: [
+            {label: $t({defaultMessage: "All"}), key: "all"},
+            {label: $t({defaultMessage: "Unresolved"}), key: "unresolved"},
+            {label: $t({defaultMessage: "Resolved"}), key: "resolved"},
+        ],
+        selected: 0,
+        callback(_value, key) {
+            topics_state = key;
+            active_widgets.get(active_stream_id()).build();
+        },
+    });
+    return resolved_toggle;
+}
+
+export function remove_resolved_toggle() {
+    if (resolved_toggle !== undefined) {
+        resolved_toggle.get().remove();
+        resolved_toggle = undefined;
+    }
+}
+
+export function get_resolved_filter_value() {
+    return topics_state;
+}
 
 export function update() {
     for (const widget of active_widgets.values()) {
@@ -132,6 +165,7 @@ export class TopicListWidget {
             this.my_stream_id,
             zoomed,
             get_topic_search_term(),
+            topics_state,
         );
 
         const num_possible_topics = list_info.num_possible_topics;

--- a/web/src/topic_list_data.js
+++ b/web/src/topic_list_data.js
@@ -103,7 +103,8 @@ function choose_topics(stream_id, topic_names, zoomed, topic_choice_state) {
     }
 }
 
-export function get_list_info(stream_id, zoomed, search_term) {
+export function get_list_info(stream_id, zoomed, search_term, topics_state) {
+    const isTopicsStateResolved = topics_state === "resolved";
     const topic_choice_state = {
         items: [],
         topics_selected: 0,
@@ -120,6 +121,11 @@ export function get_list_info(stream_id, zoomed, search_term) {
     let topic_names = stream_topic_history.get_recent_topic_names(stream_id);
     if (zoomed) {
         topic_names = util.filter_by_word_prefix_match(topic_names, search_term, (item) => item);
+        if (topics_state !== "all") {
+            topic_names = topic_names.filter(
+                (name) => resolved_topic.is_resolved(name) === isTopicsStateResolved,
+            );
+        }
     }
 
     if (stream_muted && !zoomed) {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -106,18 +106,30 @@ li.show-more-topics {
     padding: 0;
     font-weight: normal;
 
-    .input-append.topic_search_section {
+    .filter-topics {
         padding: 2px 0 2px calc($topic_indent - $topic_resolve_width);
         margin-bottom: 3px;
         margin-left: 3px;
 
-        & input {
-            width: calc(100% - 50px);
+        .input-append {
+            margin-bottom: 0;
         }
 
         .clear_search_button {
             margin-left: -1px;
         }
+    }
+
+    .input-append.topic_search_section input {
+        width: calc(100% - 30px);
+    }
+
+    .tab-switcher {
+        width: calc(100% - 17px);
+        margin-left: 0;
+        display: flex;
+        font-size: 75%;
+        margin-top: 5px;
     }
 
     & li {

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,6 +1,9 @@
-<div class="input-append topic_search_section filter-topics">
-    <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
-    <button type="button" class="btn clear_search_button" id="clear_search_topic_button">
-        <i class="fa fa-remove" aria-hidden="true"></i>
-    </button>
+<div class="filter-topics">
+    <div class="input-append topic_search_section">
+        <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
+        <button type="button" class="btn clear_search_button" id="clear_search_topic_button">
+            <i class="fa fa-remove" aria-hidden="true"></i>
+        </button>
+    </div>
+    <div class="resolved-toggle new-style"></div>
 </div>

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -5,5 +5,7 @@
             <i class="fa fa-remove" aria-hidden="true"></i>
         </button>
     </div>
+    {{#if stream_has_resolved_topics}}
     <div class="resolved-toggle new-style"></div>
+    {{/if}}
 </div>

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -380,13 +380,24 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     stream_list.initialize_stream_cursor();
 
     mock_template("filter_topics.hbs", false, () => "filter-topics-stub");
+    topic_list.init_resolved_toggle = () => ({
+        get() {
+            return "resolved_toggle_stub";
+        },
+    });
+
     let filter_topics_appended = false;
+    let resolved_toggle_appended = false;
     $stream_li1.children = () => ({
         append(html) {
             assert.equal(html, "filter-topics-stub");
             filter_topics_appended = true;
         },
     });
+    $(".filter-topics .resolved-toggle").append = (html) => {
+        assert.equal(html, "resolved_toggle_stub");
+        resolved_toggle_appended = true;
+    };
     stream_list.zoom_in_topics({stream_id: 42});
 
     assert.ok(!$label1.visible());
@@ -396,6 +407,7 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     assert.ok(!$stream_li2.visible());
     assert.ok($("#streams_list").hasClass("zoom-in"));
     assert.ok(filter_topics_appended);
+    assert.ok(resolved_toggle_appended);
 
     $("#stream_filters li.narrow-filter").show = () => {
         $stream_li1.show();
@@ -406,6 +418,9 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     $(".filter-topics").remove = () => {
         filter_topics_appended = false;
     };
+    topic_list.remove_resolved_toggle = () => {
+        resolved_toggle_appended = false;
+    };
     stream_list.zoom_out_topics({$stream_li: $stream_li1});
 
     assert.ok($label1.visible());
@@ -415,6 +430,7 @@ test_ui("zoom_in_and_zoom_out", ({mock_template}) => {
     assert.ok($stream_li2.visible());
     assert.ok($("#streams_list").hasClass("zoom-out"));
     assert.ok(!filter_topics_appended);
+    assert.ok(!resolved_toggle_appended);
 });
 
 test_ui("narrowing", ({mock_template}) => {

--- a/web/tests/stream_topic_history.test.js
+++ b/web/tests/stream_topic_history.test.js
@@ -297,6 +297,26 @@ test("test_stream_has_topics", () => {
     assert.equal(stream_topic_history.stream_has_topics(stream_id), true);
 });
 
+test("test_stream_has_resolved_topics", () => {
+    const stream_id = 89;
+
+    assert.equal(stream_topic_history.stream_has_resolved_topics(stream_id), false);
+
+    stream_topic_history.find_or_create(stream_id);
+
+    // This was a bug before--just creating a bucket does not
+    // mean we have actual topics.
+    assert.equal(stream_topic_history.stream_has_resolved_topics(stream_id), false);
+
+    stream_topic_history.add_message({
+        stream_id,
+        message_id: 889,
+        topic_name: "✔ whatever",
+    });
+
+    assert.equal(stream_topic_history.stream_has_resolved_topics(stream_id), true);
+});
+
 test("server_history_end_to_end", () => {
     stream_topic_history.reset();
 

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -39,11 +39,11 @@ const general = {
 
 stream_data.add_sub(general);
 
-function get_list_info(zoom, search) {
+function get_list_info(zoom, type, search) {
     const stream_id = general.stream_id;
     const zoomed = zoom === undefined ? false : zoom;
     const search_term = search === undefined ? "" : search;
-    return topic_list_data.get_list_info(stream_id, zoomed, search_term);
+    return topic_list_data.get_list_info(stream_id, zoomed, search_term, type);
 }
 
 function test(label, f) {
@@ -120,11 +120,20 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     // If we zoom in, our results are based on topic filter.
     // If topic search input is empty, we show all 10 topics.
     const zoomed = true;
-    list_info = get_list_info(zoomed);
+    list_info = get_list_info(zoomed, "all");
+
     assert.equal(list_info.items.length, 10);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
     assert.equal(list_info.num_possible_topics, 10);
+
+    list_info = get_list_info(zoomed, "resolved");
+    assert.equal(list_info.items.length, 5);
+    assert.equal(list_info.num_possible_topics, 5);
+
+    list_info = get_list_info(zoomed, "unresolved");
+    assert.equal(list_info.items.length, 5);
+    assert.equal(list_info.num_possible_topics, 5);
 
     add_topic_message("After Brooklyn", 1008);
     add_topic_message("Catering", 1009);
@@ -132,11 +141,22 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
     // When topic search input is not empty, we show topics
     // based on the search term.
     const search_term = "b,c";
-    list_info = get_list_info(zoomed, search_term);
+    list_info = get_list_info(zoomed, "all", search_term);
     assert.equal(list_info.items.length, 2);
+    add_topic_message("✔ Catering1", 1010);
+    // when topic search is open then we list topics based on search term.
+    list_info = get_list_info(zoomed, "all", "b,c");
+    assert.equal(list_info.items.length, 3);
     assert.equal(list_info.more_topics_unreads, 0);
     assert.equal(list_info.more_topics_have_unread_mention_messages, false);
-    assert.equal(list_info.num_possible_topics, 2);
+    assert.equal(list_info.num_possible_topics, 3);
+
+    // search term + resolved/unresolved
+    list_info = get_list_info(zoomed, "resolved", "b,c");
+    assert.equal(list_info.items.length, 1);
+
+    list_info = get_list_info(zoomed, "unresolved", "b,c");
+    assert.equal(list_info.items.length, 2);
 });
 
 test("get_list_info unreads", ({override}) => {


### PR DESCRIPTION
- [x]  Add a tab switcher to filter the topic based on their state.
- [x] If the topic list is already filtered with the search input, then only the filtered list of topics is further filtered based on the selected tab
- [x] Show the tab switcher only if there is atleast one resolved topic within a stream

-------------------------------------

Fixes: #24200

------------------------------------

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>

![Screenshot from 2023-04-08 01-46-10](https://user-images.githubusercontent.com/66828942/230673255-c177923b-b502-4882-b178-b0eceb8625a1.png)

</details>

<details>
<summary>After:</summary>

![Screenshot from 2023-04-07 23-00-28](https://user-images.githubusercontent.com/66828942/230673403-84990d69-8ea9-46e8-a89d-5b5b598bfe39.png)

<br>

- **Demo**:

![mmm](https://user-images.githubusercontent.com/66828942/230673486-c70f212c-e32a-43f2-bd5f-ffc8b951896f.gif)

<br>

![demo_with](https://user-images.githubusercontent.com/66828942/233802171-422bce03-dd1b-40c7-9768-0b1ac7f52444.gif)


<br>

- **Demo with Input**:

![input](https://user-images.githubusercontent.com/66828942/230673616-1d1a1e62-765f-4db1-ae07-08c2594d4d82.gif)


</details>

<details>
<summary>internationalization:</summary>

| English | Russian |
|------------|-------------|
| ![Screenshot from 2023-04-07 23-00-28](https://user-images.githubusercontent.com/66828942/230673915-67e159ee-a0fa-4a36-bc8c-8d6c52cafb14.png) | ![Screenshot from 2023-04-07 23-02-58](https://user-images.githubusercontent.com/66828942/230673931-daeb73c8-d20e-4c1a-90c9-76f3b0def06a.png) |


</details>

-------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
