### PR TITLE
integration: Remove branch names from Gitea edited PR event.

### DIFF
--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -36,7 +36,9 @@ class GiteaHookTests(WebhookTestCase):
 
     def test_pull_request_edited(self) -> None:
         expected_topic = "test / PR #1906 test 2"
-        expected_message = """kostekIV edited [PR #5](https://try.gitea.io/kostekIV/test/pulls/5) from `d` to `master`."""
+        expected_message = (
+            """kostekIV edited [PR #5](https://try.gitea.io/kostekIV/test/pulls/5)."""
+        )
         self.check_webhook("pull_request__edited", expected_topic, expected_message)
 
     def test_pull_request_reopened(self) -> None:

--- a/zerver/webhooks/gitea/view.py
+++ b/zerver/webhooks/gitea/view.py
@@ -28,8 +28,11 @@ def format_pull_request_event(payload: WildValue, include_title: bool = False) -
 
     url = payload["pull_request"]["html_url"].tame(check_string)
     number = payload["pull_request"]["number"].tame(check_int)
-    target_branch = payload["pull_request"]["head"]["ref"].tame(check_string)
-    base_branch = payload["pull_request"]["base"]["ref"].tame(check_string)
+    target_branch = None
+    base_branch = None
+    if action != "edited":
+        target_branch = payload["pull_request"]["head"]["ref"].tame(check_string)
+        base_branch = payload["pull_request"]["base"]["ref"].tame(check_string)
     title = payload["pull_request"]["title"].tame(check_string) if include_title else None
     stringified_assignee = assignee["login"].tame(check_string) if assignee else None
 


### PR DESCRIPTION
This is a follow up to #24673, we want to modify every webhook events to follow the same pattern and consistency where branch name should only show on opened and merged events. This is the final integration to be changed

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/62449508/230682914-e6ed58b8-d4c7-4436-be21-cb2809ff84fe.png)

</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/62449508/230683209-c694c671-6548-4a8e-9af0-649cbcc0b189.png)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
