### PR TITLE
Revert "Reword user activity info from "Last active:" to "Active"."

### DIFF
--- a/web/src/buddy_data.js
+++ b/web/src/buddy_data.js
@@ -108,9 +108,10 @@ export function user_last_seen_time_status(user_id) {
     }
 
     const last_active_date = presence.last_active_date(user_id);
+    let last_seen;
     if (page_params.realm_is_zephyr_mirror_realm) {
         // We don't send presence data to clients in Zephyr mirroring realms
-        return $t({defaultMessage: "Activity unknown"});
+        last_seen = $t({defaultMessage: "Unknown"});
     } else if (last_active_date === undefined) {
         // There are situations where the client has incomplete presence
         // history on a user.  This can happen when users are deactivated,
@@ -119,9 +120,11 @@ export function user_last_seen_time_status(user_id) {
         //
         // We give this vague status for such users; we will get to
         // delete this code when we finish rewriting the presence API.
-        return $t({defaultMessage: "Active more than 2 weeks ago"});
+        last_seen = $t({defaultMessage: "More than 2 weeks ago"});
+    } else {
+        last_seen = timerender.last_seen_status_from_date(last_active_date);
     }
-    return timerender.last_seen_status_from_date(last_active_date);
+    return $t({defaultMessage: "Last active: {last_seen}"}, {last_seen});
 }
 
 export function info_for(user_id) {

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -194,10 +194,10 @@ export function last_seen_status_from_date(
 ): string {
     const minutes = differenceInMinutes(current_date, last_active_date);
     if (minutes <= 2) {
-        return $t({defaultMessage: "Active just now"});
+        return $t({defaultMessage: "Just now"});
     }
     if (minutes < 60) {
-        return $t({defaultMessage: "Active {minutes} minutes ago"}, {minutes});
+        return $t({defaultMessage: "{minutes} minutes ago"}, {minutes});
     }
 
     const days_old = differenceInCalendarDays(current_date, last_active_date);
@@ -205,17 +205,17 @@ export function last_seen_status_from_date(
 
     if (hours < 24) {
         if (hours === 1) {
-            return $t({defaultMessage: "Active an hour ago"});
+            return $t({defaultMessage: "An hour ago"});
         }
-        return $t({defaultMessage: "Active {hours} hours ago"}, {hours});
+        return $t({defaultMessage: "{hours} hours ago"}, {hours});
     }
 
     if (days_old === 1) {
-        return $t({defaultMessage: "Active yesterday"});
+        return $t({defaultMessage: "Yesterday"});
     }
 
     if (days_old < 90) {
-        return $t({defaultMessage: "Active {days_old} days ago"}, {days_old});
+        return $t({defaultMessage: "{days_old} days ago"}, {days_old});
     } else if (
         days_old > 90 &&
         days_old < 365 &&
@@ -223,7 +223,7 @@ export function last_seen_status_from_date(
     ) {
         // Online more than 90 days ago, in the same year
         return $t(
-            {defaultMessage: "Active {last_active_date}"},
+            {defaultMessage: "{last_active_date}"},
             {
                 last_active_date: get_localized_date_or_time_for_format(
                     last_active_date,
@@ -233,7 +233,7 @@ export function last_seen_status_from_date(
         );
     }
     return $t(
-        {defaultMessage: "Active {last_active_date}"},
+        {defaultMessage: "{last_active_date}"},
         {
             last_active_date: get_localized_date_or_time_for_format(
                 last_active_date,

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -321,7 +321,7 @@ test("title_data", () => {
 
     expected_data = {
         first_line: "Old User",
-        second_line: "translated: Active more than 2 weeks ago",
+        second_line: "translated: Last active: translated: More than 2 weeks ago",
         third_line: "",
         show_you: false,
     };
@@ -459,24 +459,24 @@ test("user_last_seen_time_status", ({override}) => {
     page_params.realm_is_zephyr_mirror_realm = true;
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Activity unknown",
+        "translated: Last active: translated: Unknown",
     );
     page_params.realm_is_zephyr_mirror_realm = false;
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Active more than 2 weeks ago",
+        "translated: Last active: translated: More than 2 weeks ago",
     );
 
     presence.presence_info.set(old_user.user_id, {last_active: 1526137743});
 
     override(timerender, "last_seen_status_from_date", (date) => {
         assert.deepEqual(date, new Date(1526137743000));
-        return "translated: Active May 12";
+        return "May 12";
     });
 
     assert.equal(
         buddy_data.user_last_seen_time_status(old_user.user_id),
-        "translated: Active May 12",
+        "translated: Last active: May 12",
     );
 
     set_presence(selma.user_id, "idle");

--- a/web/tests/popovers.test.js
+++ b/web/tests/popovers.test.js
@@ -175,7 +175,8 @@ test_ui("sender_hover", ({override, mock_template}) => {
             user_time: undefined,
             user_type: $t({defaultMessage: "Member"}),
             user_circle_class: "user_circle_empty",
-            user_last_seen_time_status: "translated: Active more than 2 weeks ago",
+            user_last_seen_time_status:
+                "translated: Last active: translated: More than 2 weeks ago",
             pm_with_url: "#narrow/pm-with/42-Alice-Smith",
             sent_by_uri: "#narrow/sender/42-Alice-Smith",
             private_message_class: "respond_personal_button",

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -471,49 +471,49 @@ run_test("last_seen_status_from_date", () => {
         assert.equal(actual_status, expected_status);
     }
 
-    assert_same({seconds: -20}, $t({defaultMessage: "Active just now"}));
+    assert_same({seconds: -20}, $t({defaultMessage: "Just now"}));
 
-    assert_same({minutes: -1}, $t({defaultMessage: "Active just now"}));
+    assert_same({minutes: -1}, $t({defaultMessage: "Just now"}));
 
-    assert_same({minutes: -2}, $t({defaultMessage: "Active just now"}));
+    assert_same({minutes: -2}, $t({defaultMessage: "Just now"}));
 
-    assert_same({minutes: -30}, $t({defaultMessage: "Active 30 minutes ago"}));
+    assert_same({minutes: -30}, $t({defaultMessage: "30 minutes ago"}));
 
-    assert_same({hours: -1}, $t({defaultMessage: "Active an hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
 
-    assert_same({hours: -2}, $t({defaultMessage: "Active 2 hours ago"}));
+    assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
 
-    assert_same({hours: -20}, $t({defaultMessage: "Active 20 hours ago"}));
+    assert_same({hours: -20}, $t({defaultMessage: "20 hours ago"}));
 
-    assert_same({hours: -24}, $t({defaultMessage: "Active yesterday"}));
+    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
 
-    assert_same({hours: -48}, $t({defaultMessage: "Active 2 days ago"}));
+    assert_same({hours: -48}, $t({defaultMessage: "2 days ago"}));
 
-    assert_same({days: -2}, $t({defaultMessage: "Active 2 days ago"}));
+    assert_same({days: -2}, $t({defaultMessage: "2 days ago"}));
 
-    assert_same({days: -61}, $t({defaultMessage: "Active 61 days ago"}));
+    assert_same({days: -61}, $t({defaultMessage: "61 days ago"}));
 
-    assert_same({days: -300}, $t({defaultMessage: "Active May 6, 2015"}));
+    assert_same({days: -300}, $t({defaultMessage: "May 6, 2015"}));
 
-    assert_same({days: -366}, $t({defaultMessage: "Active Mar 1, 2015"}));
+    assert_same({days: -366}, $t({defaultMessage: "Mar 1, 2015"}));
 
-    assert_same({years: -3}, $t({defaultMessage: "Active Mar 1, 2013"}));
+    assert_same({years: -3}, $t({defaultMessage: "Mar 1, 2013"}));
 
     // Set base_date to May 1 2016 12.30 AM (months are zero based)
     base_date = new Date(2016, 4, 1, 0, 30);
 
-    assert_same({days: -91}, $t({defaultMessage: "Active Jan 31"}));
+    assert_same({days: -91}, $t({defaultMessage: "Jan 31"}));
 
     // Set base_date to May 1 2016 10.30 PM (months are zero based)
     base_date = new Date(2016, 4, 2, 23, 30);
 
-    assert_same({hours: -1}, $t({defaultMessage: "Active an hour ago"}));
+    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
 
-    assert_same({hours: -2}, $t({defaultMessage: "Active 2 hours ago"}));
+    assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
 
-    assert_same({hours: -12}, $t({defaultMessage: "Active 12 hours ago"}));
+    assert_same({hours: -12}, $t({defaultMessage: "12 hours ago"}));
 
-    assert_same({hours: -24}, $t({defaultMessage: "Active yesterday"}));
+    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
 });
 
 run_test("set_full_datetime", () => {


### PR DESCRIPTION
This PR reverts zulip/zulip#25012 as it had unwanted byproduct. 

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Recent.20conversation.20time.20bug)

Screenshots:
![image](https://user-images.githubusercontent.com/62449508/230694861-76be4538-11b3-4ee1-8637-d72c085667cc.png)

