### PR TITLE
timerender: Revert extra changes to time in recent conversations.

### DIFF
--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -363,7 +363,7 @@ function format_conversation(conversation_data) {
     context.full_last_msg_date_time = timerender.get_full_datetime(time);
     context.conversation_key = get_key_from_message(last_msg);
     context.unread_count = message_to_conversation_unread_count(last_msg);
-    context.last_msg_time = timerender.last_seen_status_from_date(time);
+    context.last_msg_time = timerender.relative_time_string_from_date(time);
     context.is_private = last_msg.type === "private";
     let all_senders;
     let senders;

--- a/web/src/settings_exports.js
+++ b/web/src/settings_exports.js
@@ -46,13 +46,13 @@ export function populate_exports_table(exports) {
             let deleted_timestamp = data.deleted_timestamp;
 
             if (failed_timestamp !== null) {
-                failed_timestamp = timerender.last_seen_status_from_date(
+                failed_timestamp = timerender.relative_time_string_from_date(
                     new Date(failed_timestamp * 1000),
                 );
             }
 
             if (deleted_timestamp !== null) {
-                deleted_timestamp = timerender.last_seen_status_from_date(
+                deleted_timestamp = timerender.relative_time_string_from_date(
                     new Date(deleted_timestamp * 1000),
                 );
             }
@@ -62,7 +62,7 @@ export function populate_exports_table(exports) {
                     id: data.id,
                     acting_user: people.get_full_name(data.acting_user_id),
                     // Convert seconds -> milliseconds
-                    event_time: timerender.last_seen_status_from_date(
+                    event_time: timerender.relative_time_string_from_date(
                         new Date(data.export_time * 1000),
                     ),
                     url: data.export_url,

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -187,6 +187,53 @@ export function render_now(time: Date, today = new Date()): TimeRender {
     };
 }
 
+// Relative time rendering for use in most screens like Recent conversations.
+//
+// Current date is passed as an argument for unit testing
+export function relative_time_string_from_date(
+    last_active_date: Date,
+    current_date = new Date(),
+): string {
+    const minutes = differenceInMinutes(current_date, last_active_date);
+    if (minutes <= 2) {
+        return $t({defaultMessage: "Just now"});
+    }
+    if (minutes < 60) {
+        return $t({defaultMessage: "{minutes} minutes ago"}, {minutes});
+    }
+
+    const days_old = differenceInCalendarDays(current_date, last_active_date);
+    const hours = Math.floor(minutes / 60);
+
+    if (hours < 24) {
+        if (hours === 1) {
+            return $t({defaultMessage: "An hour ago"});
+        }
+        return $t({defaultMessage: "{hours} hours ago"}, {hours});
+    }
+
+    if (days_old === 1) {
+        return $t({defaultMessage: "Yesterday"});
+    }
+
+    if (days_old < 90) {
+        return $t({defaultMessage: "{days_old} days ago"}, {days_old});
+    } else if (
+        days_old > 90 &&
+        days_old < 365 &&
+        last_active_date.getFullYear() === current_date.getFullYear()
+    ) {
+        // Online more than 90 days ago, in the same year
+        return get_localized_date_or_time_for_format(last_active_date, "dayofyear");
+    }
+    return get_localized_date_or_time_for_format(last_active_date, "dayofyear_year");
+}
+
+// Relative time logic variant use in the buddy list, where every
+// string has "Active" init. This is hard to deduplicate with
+// relative_time_string_from_date because of complexities involved in i18n and
+// word order.
+//
 // Current date is passed as an argument for unit testing
 export function last_seen_status_from_date(
     last_active_date: Date,

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -240,9 +240,6 @@ export function last_seen_status_from_date(
     current_date = new Date(),
 ): string {
     const minutes = differenceInMinutes(current_date, last_active_date);
-    if (minutes <= 2) {
-        return $t({defaultMessage: "Active just now"});
-    }
     if (minutes < 60) {
         return $t({defaultMessage: "Active {minutes} minutes ago"}, {minutes});
     }

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -136,7 +136,7 @@ mock_esm("../src/stream_list", {
     handle_narrow_deactivated: noop,
 });
 mock_esm("../src/timerender", {
-    last_seen_status_from_date: () => "Just now",
+    relative_time_string_from_date: () => "Just now",
     get_full_datetime: () => "date at time",
 });
 mock_esm("../src/sub_store", {

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -473,12 +473,6 @@ run_test("last_seen_status_from_date", () => {
         assert.equal(actual_status, expected_status);
     }
 
-    assert_same({seconds: -20}, $t({defaultMessage: "Active just now"}));
-
-    assert_same({minutes: -1}, $t({defaultMessage: "Active just now"}));
-
-    assert_same({minutes: -2}, $t({defaultMessage: "Active just now"}));
-
     assert_same({minutes: -30}, $t({defaultMessage: "Active 30 minutes ago"}));
 
     assert_same({hours: -1}, $t({defaultMessage: "Active an hour ago"}));

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -518,6 +518,61 @@ run_test("last_seen_status_from_date", () => {
     assert_same({hours: -24}, $t({defaultMessage: "Active yesterday"}));
 });
 
+run_test("relative_time_string_from_date", () => {
+    // Set base_date to March 1 2016 12.30 AM (months are zero based)
+    let base_date = new Date(2016, 2, 1, 0, 30);
+
+    function assert_same(duration, expected_status) {
+        const past_date = add(base_date, duration);
+        const actual_status = timerender.relative_time_string_from_date(past_date, base_date);
+        assert.equal(actual_status, expected_status);
+    }
+
+    assert_same({seconds: -20}, $t({defaultMessage: "Just now"}));
+
+    assert_same({minutes: -1}, $t({defaultMessage: "Just now"}));
+
+    assert_same({minutes: -2}, $t({defaultMessage: "Just now"}));
+
+    assert_same({minutes: -30}, $t({defaultMessage: "30 minutes ago"}));
+
+    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
+
+    assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
+
+    assert_same({hours: -20}, $t({defaultMessage: "20 hours ago"}));
+
+    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
+
+    assert_same({hours: -48}, $t({defaultMessage: "2 days ago"}));
+
+    assert_same({days: -2}, $t({defaultMessage: "2 days ago"}));
+
+    assert_same({days: -61}, $t({defaultMessage: "61 days ago"}));
+
+    assert_same({days: -300}, "May 6, 2015");
+
+    assert_same({days: -366}, "Mar 1, 2015");
+
+    assert_same({years: -3}, "Mar 1, 2013");
+
+    // Set base_date to May 1 2016 12.30 AM (months are zero based)
+    base_date = new Date(2016, 4, 1, 0, 30);
+
+    assert_same({days: -91}, "Jan 31");
+
+    // Set base_date to May 1 2016 10.30 PM (months are zero based)
+    base_date = new Date(2016, 4, 2, 23, 30);
+
+    assert_same({hours: -1}, $t({defaultMessage: "An hour ago"}));
+
+    assert_same({hours: -2}, $t({defaultMessage: "2 hours ago"}));
+
+    assert_same({hours: -12}, $t({defaultMessage: "12 hours ago"}));
+
+    assert_same({hours: -24}, $t({defaultMessage: "Yesterday"}));
+});
+
 run_test("set_full_datetime", () => {
     let time = date_2019;
 


### PR DESCRIPTION
Previously after merging #25012, users have reported unneccessary changes to the time in recent conversations. These changes builds on top of the previous changes and removes the unneccessary changes to the time in recent conversastions and makes sure the changes only applies to popovers.

**Note:**
- This PR introduces a new function in `web/src/timerender.ts` called `last_event_from date` which is similar to `last_seen_status_from_date` and is used in call sites that were affect by the previous changes. 
- I have posted general screenshots of these changes. I'm not exactly sure how to change one's time so I'm relying on the testcases to check for the accuracy of these string text.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>

![image](https://user-images.githubusercontent.com/62449508/230735941-fdfac401-1bfc-4981-84d7-505df6440dbe.png)
![image](https://user-images.githubusercontent.com/62449508/230736151-629eae92-eb41-48a0-ad41-1c248a393b62.png)
![image](https://user-images.githubusercontent.com/62449508/230736163-c764ffca-5ab1-4c04-9d31-8b88658a88fd.png)
![image](https://user-images.githubusercontent.com/62449508/230736189-07b34e2e-604f-4383-ac43-146501b96fec.png)


</details>

<details>
<summary>After:</summary>

![image](https://user-images.githubusercontent.com/62449508/230735327-86c12036-8ae9-4b97-b692-fc362788b77f.png)
![image](https://user-images.githubusercontent.com/62449508/230839166-0b118417-2328-4f5a-b614-ee42d7605493.png)
![image](https://user-images.githubusercontent.com/62449508/230839095-d7c143b1-1b95-4c70-8e95-43f5d70dd8fe.png)
![image](https://user-images.githubusercontent.com/62449508/230839233-0adcf23a-eb86-462e-9139-051374d0ee52.png)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
