### PR TITLE
test: Replace occurences of `uri` with `url`.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1039,7 +1039,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.client.cookies = result.cookies
 
         # Next, the browser requests result["Location"], and gets
-        # redirected back to the registered redirect uri.
+        # redirected back to the registered redirect url.
 
         # We register callbacks for the key URLs on Identity Provider that
         # auth completion URL will call
@@ -1114,8 +1114,8 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.assertEqual(data["redirect_to"], "/user_uploads/image")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
         self.assertIn(
             f"INFO:{self.logger_string}:Authentication attempt from 127.0.0.1: subdomain=zulip;username=hamlet@zulip.com;outcome=success",
@@ -1138,8 +1138,8 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.assertEqual(data["redirect_to"], "/user_uploads/image")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
     def test_social_auth_deactivated_user(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -1360,8 +1360,8 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
         hamlet = self.example_user("hamlet")
         # Name wasn't changed at all
         self.assertEqual(hamlet.full_name, "King Hamlet")
@@ -1386,8 +1386,8 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
         result = self.client_get(result["Location"])
 
@@ -1673,8 +1673,8 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
         result = self.client_get(result["Location"])
         self.assertEqual(result.status_code, 200)
@@ -1697,8 +1697,8 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase, ABC):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
         result = self.client_get(result["Location"])
         self.assertEqual(result.status_code, 200)
@@ -2674,10 +2674,10 @@ class SAMLAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
-        self.client_get(uri)
+        self.client_get(url)
         self.assert_logged_in_user_id(self.example_user("hamlet").id)
 
     def test_choose_subdomain_invalid_subdomain_specified(self) -> None:
@@ -2709,10 +2709,10 @@ class SAMLAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
-        self.client_get(uri)
+        self.client_get(url)
         self.assert_logged_in_user_id(self.example_user("hamlet").id)
 
     def test_idp_initiated_signin_subdomain_implicit_no_relaystate_param(self) -> None:
@@ -2730,10 +2730,10 @@ class SAMLAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
-        self.client_get(uri)
+        self.client_get(url)
         self.assert_logged_in_user_id(self.example_user("hamlet").id)
 
     def test_idp_initiated_signin_subdomain_implicit_invalid(self) -> None:
@@ -3745,8 +3745,8 @@ class GitHubAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["redirect_to"], "/user_uploads/image")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
     def test_github_oauth2_success_single_email(self) -> None:
         # If the user has a single email associated with its GitHub account,
@@ -3770,8 +3770,8 @@ class GitHubAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["redirect_to"], "/user_uploads/image")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
     def test_github_oauth2_login_only_one_account_exists(self) -> None:
         # In a login flow, if only one of the user's verified emails
@@ -3799,8 +3799,8 @@ class GitHubAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["redirect_to"], "/user_uploads/image")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
     def test_github_oauth2_login_multiple_accounts_exist(self) -> None:
         # In the login flow, if multiple of the user's verified emails
@@ -3828,8 +3828,8 @@ class GitHubAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["redirect_to"], "/user_uploads/image")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
     def test_github_oauth2_login_no_account_exists(self) -> None:
         # In the login flow, if the user has multiple verified emails,
@@ -3889,8 +3889,8 @@ class GitHubAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["redirect_to"], "/user_uploads/image")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
     def test_github_oauth2_signup_choose_new_email_to_register(self) -> None:
         # In the sign up flow, if the user has multiple verified
@@ -3972,8 +3972,8 @@ class GitHubAuthBackendTest(SocialAuthBase):
         self.assertEqual(data["subdomain"], "zulip")
         self.assertEqual(result.status_code, 302)
         parsed_url = urllib.parse.urlparse(result["Location"])
-        uri = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
-        self.assertTrue(uri.startswith("http://zulip.testserver/accounts/login/subdomain/"))
+        url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
+        self.assertTrue(url.startswith("http://zulip.testserver/accounts/login/subdomain/"))
 
     def test_github_oauth2_email_not_associated(self) -> None:
         account_data_dict = self.get_account_data_dict(
@@ -4091,7 +4091,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
             ],
         )
 
-    def test_social_auth_mobile_realm_uri(self) -> None:
+    def test_social_auth_mobile_realm_url(self) -> None:
         mobile_flow_otp = "1234abcd" * 8
         account_data_dict = self.get_account_data_dict(email=self.email, name="Full Name")
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2432,17 +2432,17 @@ class NormalActionsTest(BaseAction):
         self.login("hamlet")
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
-        uri = None
+        url = None
 
         def do_upload() -> None:
-            nonlocal uri
+            nonlocal url
             result = self.client_post("/json/user_uploads", {"file": fp})
 
             response_dict = self.assert_json_success(result)
             self.assertIn("uri", response_dict)
-            uri = response_dict["uri"]
+            url = response_dict["uri"]
             base = "/user_uploads/"
-            self.assertEqual(base, uri[: len(base)])
+            self.assertEqual(base, url[: len(base)])
 
         events = self.verify_action(lambda: do_upload(), num_events=1, state_change_expected=False)
 
@@ -2455,8 +2455,8 @@ class NormalActionsTest(BaseAction):
 
         hamlet = self.example_user("hamlet")
         self.subscribe(hamlet, "Denmark")
-        assert uri is not None
-        body = f"First message ...[zulip.txt](http://{hamlet.realm.host}" + uri + ")"
+        assert url is not None
+        body = f"First message ...[zulip.txt](http://{hamlet.realm.host}" + url + ")"
         events = self.verify_action(
             lambda: self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test"),
             num_events=2,

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1480,7 +1480,7 @@ class MarkdownTest(ZulipTestCase):
             ],
         )
 
-        # Test URI escaping
+        # Test URL escaping
         RealmFilter(
             realm=realm,
             pattern=r"url-(?P<id>[0-9]+)",

--- a/zerver/tests/test_outgoing_http.py
+++ b/zerver/tests/test_outgoing_http.py
@@ -18,12 +18,12 @@ class RequestMockWithProxySupport(responses.RequestsMock):
         **kwargs: Any,
     ) -> requests.Response:
         if "proxies" in kwargs and request.url:
-            proxy_uri = requests.utils.select_proxy(request.url, kwargs["proxies"])
-            if proxy_uri is not None:
+            proxy_url = requests.utils.select_proxy(request.url, kwargs["proxies"])
+            if proxy_url is not None:
                 request = requests.Request(
                     method="GET",
-                    url=f"{proxy_uri}/",
-                    headers=adapter.proxy_headers(proxy_uri),
+                    url=f"{proxy_url}/",
+                    headers=adapter.proxy_headers(proxy_url),
                 ).prepare()
         return super()._on_request(adapter, request, **kwargs)
 

--- a/zerver/tests/test_realm_linkifiers.py
+++ b/zerver/tests/test_realm_linkifiers.py
@@ -125,7 +125,7 @@ class RealmFilterTest(ZulipTestCase):
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_success(result)
 
-        data["pattern"] = r"ZUL-URI-(?P<id>\d+)"
+        data["pattern"] = r"ZUL-URL-(?P<id>\d+)"
         data["url_format_string"] = "https://example.com/%ba/%(id)s"
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_success(result)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1035,13 +1035,13 @@ class StreamAdminTest(ZulipTestCase):
         fp.name = "zulip.txt"
 
         result = self.client_post("/json/user_uploads", {"file": fp})
-        uri = self.assert_json_success(result)["uri"]
+        url = self.assert_json_success(result)["uri"]
 
         owner = self.example_user("desdemona")
         realm = owner.realm
         stream = self.make_stream("test_stream", realm=realm)
         self.subscribe(owner, "test_stream")
-        body = f"First message ...[zulip.txt](http://{realm.host}" + uri + ")"
+        body = f"First message ...[zulip.txt](http://{realm.host}" + url + ")"
         msg_id = self.send_stream_message(owner, "test_stream", body, "test")
         attachment = Attachment.objects.get(messages__id=msg_id)
 

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -17,33 +17,33 @@ class ThumbnailTest(ZulipTestCase):
         self.assert_json_success(result)
         json = orjson.loads(result.content)
         self.assertIn("uri", json)
-        uri = json["uri"]
+        url = json["uri"]
         base = "/user_uploads/"
-        self.assertEqual(base, uri[: len(base)])
+        self.assertEqual(base, url[: len(base)])
 
-        result = self.client_get("/thumbnail", {"url": uri[1:], "size": "full"})
+        result = self.client_get("/thumbnail", {"url": url[1:], "size": "full"})
         self.assertEqual(result.status_code, 302, result)
-        self.assertEqual(uri, result["Location"])
+        self.assertEqual(url, result["Location"])
 
         self.login("iago")
-        result = self.client_get("/thumbnail", {"url": uri[1:], "size": "full"})
+        result = self.client_get("/thumbnail", {"url": url[1:], "size": "full"})
         self.assertEqual(result.status_code, 403, result)
         self.assert_in_response("You are not authorized to view this file.", result)
 
-        uri = "https://www.google.com/images/srpr/logo4w.png"
-        result = self.client_get("/thumbnail", {"url": uri, "size": "full"})
+        url = "https://www.google.com/images/srpr/logo4w.png"
+        result = self.client_get("/thumbnail", {"url": url, "size": "full"})
         self.assertEqual(result.status_code, 302, result)
         base = "https://external-content.zulipcdn.net/external_content/56c362a24201593891955ff526b3b412c0f9fcd2/68747470733a2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67"
         self.assertEqual(base, result["Location"])
 
-        uri = "http://www.google.com/images/srpr/logo4w.png"
-        result = self.client_get("/thumbnail", {"url": uri, "size": "full"})
+        url = "http://www.google.com/images/srpr/logo4w.png"
+        result = self.client_get("/thumbnail", {"url": url, "size": "full"})
         self.assertEqual(result.status_code, 302, result)
         base = "https://external-content.zulipcdn.net/external_content/7b6552b60c635e41e8f6daeb36d88afc4eabde79/687474703a2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67"
         self.assertEqual(base, result["Location"])
 
-        uri = "//www.google.com/images/srpr/logo4w.png"
-        result = self.client_get("/thumbnail", {"url": uri, "size": "full"})
+        url = "//www.google.com/images/srpr/logo4w.png"
+        result = self.client_get("/thumbnail", {"url": url, "size": "full"})
         self.assertEqual(result.status_code, 302, result)
         base = "https://external-content.zulipcdn.net/external_content/676530cf4b101d56f56cc4a37c6ef4d4fd9b0c03/2f2f7777772e676f6f676c652e636f6d2f696d616765732f737270722f6c6f676f34772e706e67"
         self.assertEqual(base, result["Location"])
@@ -57,34 +57,34 @@ class ThumbnailTest(ZulipTestCase):
         result = self.client_post("/json/user_uploads", {"file": fp})
         self.assert_json_success(result)
         json = orjson.loads(result.content)
-        uri = json["uri"]
+        url = json["uri"]
 
         add_ratelimit_rule(86400, 1000, domain="spectator_attachment_access_by_file")
         # Deny file access for non-web-public stream
         self.subscribe(self.example_user("hamlet"), "Denmark")
         host = self.example_user("hamlet").realm.host
-        body = f"First message ...[zulip.txt](http://{host}" + uri + ")"
+        body = f"First message ...[zulip.txt](http://{host}" + url + ")"
         self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
 
         self.logout()
-        response = self.client_get("/thumbnail", {"url": uri[1:], "size": "full"})
+        response = self.client_get("/thumbnail", {"url": url[1:], "size": "full"})
         self.assertEqual(response.status_code, 403)
 
         # Allow file access for web-public stream
         self.login("hamlet")
         self.make_stream("web-public-stream", is_web_public=True)
         self.subscribe(self.example_user("hamlet"), "web-public-stream")
-        body = f"First message ...[zulip.txt](http://{host}" + uri + ")"
+        body = f"First message ...[zulip.txt](http://{host}" + url + ")"
         self.send_stream_message(self.example_user("hamlet"), "web-public-stream", body, "test")
 
         self.logout()
-        response = self.client_get("/thumbnail", {"url": uri[1:], "size": "full"})
+        response = self.client_get("/thumbnail", {"url": url[1:], "size": "full"})
         self.assertEqual(response.status_code, 302)
         remove_ratelimit_rule(86400, 1000, domain="spectator_attachment_access_by_file")
 
         # Deny file access since rate limited
         add_ratelimit_rule(86400, 0, domain="spectator_attachment_access_by_file")
-        response = self.client_get("/thumbnail", {"url": uri[1:], "size": "full"})
+        response = self.client_get("/thumbnail", {"url": url[1:], "size": "full"})
         self.assertEqual(response.status_code, 403)
         remove_ratelimit_rule(86400, 0, domain="spectator_attachment_access_by_file")
 

--- a/zerver/tests/test_upload_local.py
+++ b/zerver/tests/test_upload_local.py
@@ -42,13 +42,13 @@ from zerver.models import (
 class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
     def test_upload_message_attachment(self) -> None:
         user_profile = self.example_user("hamlet")
-        uri = upload_message_attachment(
+        url = upload_message_attachment(
             "dummy.txt", len(b"zulip!"), "text/plain", b"zulip!", user_profile
         )
 
         base = "/user_uploads/"
-        self.assertEqual(base, uri[: len(base)])
-        path_id = re.sub("/user_uploads/", "", uri)
+        self.assertEqual(base, url[: len(base)])
+        path_id = re.sub("/user_uploads/", "", url)
         assert settings.LOCAL_UPLOADS_DIR is not None
         assert settings.LOCAL_FILES_DIR is not None
         file_path = os.path.join(settings.LOCAL_FILES_DIR, path_id)
@@ -59,11 +59,11 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
 
     def test_save_attachment_contents(self) -> None:
         user_profile = self.example_user("hamlet")
-        uri = upload_message_attachment(
+        url = upload_message_attachment(
             "dummy.txt", len(b"zulip!"), "text/plain", b"zulip!", user_profile
         )
 
-        path_id = re.sub("/user_uploads/", "", uri)
+        path_id = re.sub("/user_uploads/", "", url)
         output = BytesIO()
         save_attachment_contents(path_id, output)
         self.assertEqual(output.getvalue(), b"zulip!")
@@ -79,11 +79,11 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         user_profile = get_system_bot(settings.EMAIL_GATEWAY_BOT, internal_realm.id)
         self.assertEqual(user_profile.realm, internal_realm)
 
-        uri = upload_message_attachment(
+        url = upload_message_attachment(
             "dummy.txt", len(b"zulip!"), "text/plain", b"zulip!", user_profile, zulip_realm
         )
         # Ensure the correct realm id of the target realm is used instead of the bot's realm.
-        self.assertTrue(uri.startswith(f"/user_uploads/{zulip_realm.id}/"))
+        self.assertTrue(url.startswith(f"/user_uploads/{zulip_realm.id}/"))
 
     def test_delete_message_attachment(self) -> None:
         self.login("hamlet")
@@ -108,12 +108,12 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
         user_profile = self.example_user("hamlet")
         path_ids = []
         for n in range(1, 1005):
-            uri = upload_message_attachment(
+            url = upload_message_attachment(
                 "dummy.txt", len(b"zulip!"), "text/plain", b"zulip!", user_profile
             )
             base = "/user_uploads/"
-            self.assertEqual(base, uri[: len(base)])
-            path_id = re.sub("/user_uploads/", "", uri)
+            self.assertEqual(base, url[: len(base)])
+            path_id = re.sub("/user_uploads/", "", url)
             path_ids.append(path_id)
             file_path = os.path.join(settings.LOCAL_FILES_DIR, path_id)
             self.assertTrue(os.path.isfile(file_path))
@@ -256,14 +256,14 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
             f.write("dummy")
 
         assert settings.LOCAL_AVATARS_DIR is not None
-        uri = upload_export_tarball(user_profile.realm, tarball_path)
+        url = upload_export_tarball(user_profile.realm, tarball_path)
         self.assertTrue(os.path.isfile(os.path.join(settings.LOCAL_AVATARS_DIR, tarball_path)))
 
-        result = re.search(re.compile(r"([A-Za-z0-9\-_]{24})"), uri)
+        result = re.search(re.compile(r"([A-Za-z0-9\-_]{24})"), url)
         if result is not None:
             random_name = result.group(1)
         expected_url = f"http://zulip.testserver/user_avatars/exports/{user_profile.realm_id}/{random_name}/tarball.tar.gz"
-        self.assertEqual(expected_url, uri)
+        self.assertEqual(expected_url, url)
 
         # Delete the tarball.
         with self.assertLogs(level="WARNING") as warn_log:
@@ -272,5 +272,5 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
             warn_log.output,
             ["WARNING:root:not_a_file does not exist. Its entry in the database will be removed."],
         )
-        path_id = urllib.parse.urlparse(uri).path
+        path_id = urllib.parse.urlparse(url).path
         self.assertEqual(delete_export_tarball(path_id), path_id)


### PR DESCRIPTION
In #23380 we want to change all occurences of `uri` with `url` in order to fill in the conventions. The roadmap for this task can start with easily changing those occurences in comments, local variables, function names and their callers. Among the codebase, I start by fixing it in all test (.py) files. Later on, maybe or maybe not in this PR, we can do the similar changes in comments, fix local variables and function names in other files in the codebase. 

Quoted from original issues #23380:

> The one thing that will hard will be this line: `zerver/lib/events.py:        state["realm_uri"] = realm.uri`, which is an API change; we should save that for last (as it'll likely require adding a new realm_url, leaving the old name available for mobile clients and other API tools that we don't want to break compatibility for), after we've renamed all the smaller uses that don't require this API change.

After these, we should focus on changing the `uri` occurences appeared along with `realm` (quoted), which indicates an API change.  




In short, this commit, for all the tests files, replaces all occurences of `uri` with `url` appeared in comments, local variablles, function names and their callers.



<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
