### PR TITLE
ts: Convert `input_pill` to TypeScript and break import cycle.

### DIFF
--- a/web/src/emoji.ts
+++ b/web/src/emoji.ts
@@ -54,7 +54,7 @@ type EmojiDict = {
 };
 
 // Details needed by template to render an emoji.
-type EmojiRenderingDetails = {
+export type EmojiRenderingDetails = {
     emoji_name: string;
     reaction_type: string;
     emoji_code: string | number;

--- a/web/src/input_pill.js
+++ b/web/src/input_pill.js
@@ -385,8 +385,8 @@ export function create(opts) {
         appendValue: funcs.appendPill.bind(funcs),
         appendValidatedData: funcs.appendValidatedData.bind(funcs),
 
-        getByElement: funcs.getByElement,
-        items: funcs.items,
+        getByElement: funcs.getByElement.bind(funcs),
+        items: funcs.items.bind(funcs),
 
         onPillCreate(callback) {
             store.onPillCreate = callback;
@@ -401,9 +401,9 @@ export function create(opts) {
         },
 
         clear: funcs.removeAllPills.bind(funcs),
-        clear_text: funcs.clear_text,
-        is_pending: funcs.is_pending,
-        _get_pills_for_testing: funcs._get_pills_for_testing,
+        clear_text: funcs.clear_text.bind(funcs),
+        is_pending: funcs.is_pending.bind(funcs),
+        _get_pills_for_testing: funcs._get_pills_for_testing.bind(funcs),
     };
 
     return prototype;

--- a/web/src/input_pill.js
+++ b/web/src/input_pill.js
@@ -5,7 +5,6 @@ import $ from "jquery";
 import render_input_pill from "../templates/input_pill.hbs";
 
 import * as blueslip from "./blueslip";
-import * as compose_recipient from "./compose_recipient";
 import * as keydown_util from "./keydown_util";
 import * as ui_util from "./ui_util";
 
@@ -163,6 +162,11 @@ export function create(opts) {
                 if (typeof store.removePillFunction === "function") {
                     store.removePillFunction(pill);
                 }
+
+                // This is needed to run the "change" event handler registered in
+                // compose_recipient.js, which calls the `update_on_recipient_change` to update
+                // the compose_fade state.
+                store.$input.trigger("change");
 
                 return pill;
             }
@@ -358,8 +362,6 @@ export function create(opts) {
 
             funcs.removePill($pill[0]);
             $next.trigger("focus");
-
-            compose_recipient.update_on_recipient_change();
         });
 
         store.$parent.on("click", function (e) {

--- a/web/src/input_pill.js
+++ b/web/src/input_pill.js
@@ -89,12 +89,6 @@ export function create(opts) {
                 return;
             }
 
-            const payload = {
-                item,
-            };
-
-            store.pills.push(payload);
-
             const has_image = item.img_src !== undefined;
 
             const opts = {
@@ -120,7 +114,12 @@ export function create(opts) {
             }
 
             const pill_html = render_input_pill(opts);
-            payload.$element = $(pill_html);
+            const payload = {
+                item,
+                $element: $(pill_html),
+            };
+
+            store.pills.push(payload);
             store.$input.before(payload.$element);
         },
 

--- a/web/tests/input_pill.test.js
+++ b/web/tests/input_pill.test.js
@@ -161,11 +161,10 @@ run_test("copy from pill", ({mock_template}) => {
 
     let copied_text;
 
-    const $pill_stub = {
-        [0]: "<pill-stub RED>",
-    };
+    const $pill_stub = "<pill-stub RED>";
 
     const e = {
+        currentTarget: $pill_stub,
         originalEvent: {
             clipboardData: {
                 setData(format, text) {
@@ -176,8 +175,6 @@ run_test("copy from pill", ({mock_template}) => {
         },
         preventDefault: noop,
     };
-
-    $container.set_find_results(":focus", $pill_stub);
 
     copy_handler(e);
 


### PR DESCRIPTION
This PR contains two commits:
1) Breaks a fairly simple import cycle between `compose.js` and `input_pill.js`.
2) Migrates the `input_pill` module to TypeScript and leverages TypeScript generics to make it a generic module.

Fixes: #25022 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
