### PR TITLE
message_feed: Improve UI for revealing long messages.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -115,7 +115,7 @@ the hotkeys too:
   - click on the star button in the right column
   - use 'Ctrl + S' to star a message
 - Message length
-  - send a long message and see if '[More]' appears
+  - send a long message and see if 'Show more' button appears
   - click on the 'more' or 'collapse' link
   - use i to collapse/expand a message irrespective of message length
 - use 'v' to show all images in the thread

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -113,7 +113,7 @@ export function initialize() {
         }
 
         // Widget for adjusting the height of a message.
-        if ($target.is("div.message_length_controller")) {
+        if ($target.is("button.message_expander") || $target.is("button.message_condenser")) {
             return true;
         }
 

--- a/web/src/condense.js
+++ b/web/src/condense.js
@@ -21,11 +21,13 @@ This library implements two related, similar concepts:
 const _message_content_height_cache = new Map();
 
 function show_more_link($row) {
+    $row.find(".expand_condense_buttons_wrapper").show();
     $row.find(".message_condenser").hide();
     $row.find(".message_expander").show();
 }
 
 function show_condense_link($row) {
+    $row.find(".expand_condense_buttons_wrapper").show();
     $row.find(".message_expander").hide();
     $row.find(".message_condenser").show();
 }
@@ -43,29 +45,31 @@ function uncondense_row($row) {
 }
 
 export function uncollapse($row) {
-    // Uncollapse a message, restoring the condensed message [More] or
-    // [Show less] link if necessary.
+    // Uncollapse a message, restoring the condensed message "Show more" or
+    // "Show less" button if necessary.
     const message = message_lists.current.get(rows.id($row));
     message.collapsed = false;
     message_flags.save_uncollapsed(message);
 
     const process_row = function process_row($row) {
         const $content = $row.find(".message_content");
+        const $expand_condense_buttons_wrapper = $row.find("expand_condense_buttons_wrapper");
         $content.removeClass("collapsed");
 
         if (message.condensed === true) {
             // This message was condensed by the user, so re-show the
-            // [More] link.
+            // "Show more" button.
             condense_row($row);
         } else if (message.condensed === false) {
             // This message was un-condensed by the user, so re-show the
-            // [Show less] link.
+            // "Show less" button.
             uncondense_row($row);
         } else if ($content.hasClass("could-be-condensed")) {
             // By default, condense a long message.
             condense_row($row);
         } else {
-            // This was a short message, no more need for a [More] link.
+            // This was a short message, no more need for a "Show more" button.
+            $expand_condense_buttons_wrapper.hide();
             $row.find(".message_expander").hide();
         }
     };
@@ -78,8 +82,8 @@ export function uncollapse($row) {
 }
 
 export function collapse($row) {
-    // Collapse a message, hiding the condensed message [More] or
-    // [Show less] link if necessary.
+    // Collapse a message, hiding the condensed message 'Show more' or
+    // 'Show less' button if necessary.
     const message = message_lists.current.get(rows.id($row));
     message.collapsed = true;
 
@@ -116,7 +120,7 @@ export function toggle_collapse(message) {
     // This function implements a multi-way toggle, to try to do what
     // the user wants for messages:
     //
-    // * If the message is currently showing any [More] link, either
+    // * If the message is currently showing any "Show more", button either
     //   because it was previously condensed or collapsed, fully display it.
     // * If the message is fully visible, either because it's too short to
     //   condense or because it's already uncondensed, collapse it
@@ -199,6 +203,7 @@ export function condense_and_collapse(elems) {
 
     for (const elem of elems) {
         const $content = $(elem).find(".message_content");
+        const $expand_condense_buttons_wrapper = $(elem).find(".expand_condense_buttons_wrapper");
 
         if ($content.length !== 1) {
             // We could have a "/me did this" message or something
@@ -222,8 +227,10 @@ export function condense_and_collapse(elems) {
         if (long_message) {
             // All long messages are flagged as such.
             $content.addClass("could-be-condensed");
+            $expand_condense_buttons_wrapper.show();
         } else {
             $content.removeClass("could-be-condensed");
+            $expand_condense_buttons_wrapper.hide();
         }
 
         // If message.condensed is defined, then the user has manually
@@ -246,10 +253,11 @@ export function condense_and_collapse(elems) {
             $(elem).find(".message_expander").hide();
         }
 
-        // Completely hide the message and replace it with a [More]
+        // Completely hide the message and replace it with a "Show more"
         // link if the user has collapsed it.
         if (message.collapsed) {
             $content.addClass("collapsed");
+            $expand_condense_buttons_wrapper.show();
             $(elem).find(".message_expander").show();
         }
     }

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -170,7 +170,7 @@ export function handler() {
     }
     resize_page_components();
 
-    // Re-compute and display/remove [More] links to messages
+    // Re-compute and display/remove 'Show more' buttons to messages
     condense.condense_and_collapse($(".message_table .message_row"));
 
     // This function might run onReady (if we're in a narrow window),

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -364,6 +364,13 @@
         background-color: hsl(208deg 17% 29%);
     }
 
+    .private-message .message_length_controller {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(208deg 17% 29%);
+        }
+    }
+
     .active_private_messages_section {
         #private_messages_section,
         #private_messages_list,
@@ -501,6 +508,13 @@
         .emoji-popover-category-tabs
         .emoji-popover-tab-item.active {
         background-color: hsl(0deg 0% 0% / 50%);
+    }
+
+    .message_length_controller {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(212deg 28% 18%);
+        }
     }
 
     .new-style .tab-switcher .ind-tab.selected,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1312,6 +1312,13 @@ td.pointer {
         box-shadow: inset 3px 0 0 -1px hsl(0deg 0% 27%),
             -1px 0 0 0 hsl(0deg 0% 27%);
     }
+
+    .message_length_controller {
+        .message_expander,
+        .message_condenser {
+            background-color: hsl(192deg 20% 95%);
+        }
+    }
 }
 
 .message-header-contents {
@@ -1512,6 +1519,7 @@ div.focused_table {
     display: block;
     position: relative;
     overflow: hidden;
+    mask-image: none;
 
     &:empty {
         display: none;
@@ -1521,12 +1529,26 @@ div.focused_table {
         max-height: 8.5em;
         min-height: 0;
         overflow: hidden;
+        mask-image: linear-gradient(
+            to bottom,
+            hsl(0deg 0% 100%) 60%,
+            hsl(0deg 0% 100% / 0%)
+        );
+        mask-size: cover;
+
+        ~ .message_length_controller {
+            margin: -15px 0 5px;
+        }
     }
 
     &.collapsed {
         max-height: 0;
         min-height: 0;
         overflow: hidden;
+
+        ~ .message_length_controller {
+            margin: -10px 0 5px;
+        }
     }
 }
 
@@ -1661,16 +1683,35 @@ div.focused_table {
     margin-bottom: 10px;
 }
 
+.topic_move_breadcrumb_messages {
+    margin-top: 10px !important;
+}
+
 .message_length_controller {
-    display: none;
-    text-align: center;
-    color: hsl(200deg 100% 40%);
+    display: flex;
+    justify-content: center;
+    height: 25px;
+    position: relative;
+    margin: 5px 0;
 
-    /* to make message-uncollapse easier */
-    margin-top: 10px;
+    .message_expander,
+    .message_condenser {
+        display: none;
+        position: absolute;
+        text-align: center;
+        padding: 1px 10px;
+        color: inherit;
+        background-color: hsl(0deg 0% 100%);
+        border-radius: 4px;
+        border: solid 1px hsl(217deg 64% 59% / 80%);
+        font-size: 13px;
+        font-weight: 400;
+        outline: none;
 
-    &:hover {
-        text-decoration: underline;
+        &:hover {
+            border: solid 1px hsl(217deg 64% 59% / 100%);
+            color: hsl(200deg 100% 40%);
+        }
     }
 }
 

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -56,8 +56,11 @@
 <div class="message_edit">
     <div class="message_edit_form"></div>
 </div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More…]" }}</div>
-<div class="message_condenser message_length_controller" title="{{t 'Show less' }} (-)">[{{t "Show less" }}]</div>
+
+<div class="message_length_controller">
+    <button type="button" class="message_expander" title="{{t 'Show more' }} (-)">{{t "Show more" }}</button>
+    <button type="button" class="message_condenser" title="{{t 'Show less' }} (-)">{{t "Show less" }}</button>
+</div>
 
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>


### PR DESCRIPTION
## Summary

This PR encompasses the following changes:
* Replace the [More...] link with a button that says "Show more".
* Replace the [Show Less...] link with a button that says "Show less".
* In the condensed view, add fading to the bottom of the message to visually communicate that the message is truncated.

Fixes: #19157

## Details

This PR takes `message: Improve the UI for long messages.` #19308  as the base, and tries to improve upon it. It fixes the merge conflicts and also tries to implement the feedbacks on it. The changes are:
* The buttons are now rounded to match other buttons used in the UI, and hover animation is added. It made sense to keep the button borders the same bluish tint as we used the same color in the previous [More] links.

* In condensed view, the fading now starts much lower, allowing for a clearer view of the condensed region.

* The transitions are removed, for the two reasons, 
  * Adding animations could possibly degrade the experience while having to browse through a ton of messages, the little time taken by the animations do add up in the long run, and given that we also support keyboard navigation, we would rather want it to be as snappy as possible.

  * It was problematic to animate the max-height property. The previous PR #19308 used a very high value of max-height (`1000vh`) to enable animations but that lead to a delay in the collapsing part of the animation, since the animation would only start to be visible once the max-height reaches from `1000vh` to the actual length of the expanded message content region. The fix for this would be to to calculate the line height of each message and then dynamically add the max-height and transition properties.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/84973068/230724963-e208a74a-7358-4809-a262-2d3f8c641a7e.png)

![image](https://user-images.githubusercontent.com/84973068/230724348-885bb657-45aa-426c-b4d2-ae11ad24a3af.png)

![working-condense-expand](https://user-images.githubusercontent.com/84973068/230724549-2ace0d0f-3a4a-4456-8262-140eed1977ee.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
