### PR TITLE
Fixing the 'Save Changes' button inconsistency with owner dropdown menu

### DIFF
--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -430,7 +430,10 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
             default_text: $t({defaultMessage: "No owner"}),
             value: owner_id,
             on_update(value) {
-                $("#edit_bot_modal .dialog_submit_button").prop("disabled", value === null);
+                const new_Owner_ID = Number.parseInt(value, 10);
+                if (new_Owner_ID !== owner_id) {
+                    $("#edit_bot_modal .dialog_submit_button").prop("disabled", value === null);
+                }
             },
         };
         // Note: Rendering this is quite expensive in


### PR DESCRIPTION
Description: 

In the current version, if a user were to edit a bot, and click on the dropdown to change the owner but clicks on the same owner, the 'Save Changes' button will become enabled. This is obviously wrong because no changes have been made, but the bot settings is implying that a change has been made. There are 2 things to keep note when fixing this issue:

1) If the 'Save Changes' button is currently disabled, and a user clicks on the owner dropdown and selects the same owner, it should remain disabled - since no change has been made. 

2) If the 'Save Changes' button is currently enabled because other edits have been made for this bot, and a user clicks on the owner dropdown and selects the same owner, the 'Save Changes' button should remain enabled.

Fixes #24568

Added changes to make sure the save changes button remains disabled if the user clicks on the current bot owner from the dropdown menu. However, if there have already been changes in the bot settings, this change is making sure to not disable the Save Changes button.

Demo of my fixed changes:

https://user-images.githubusercontent.com/16692028/230746382-0cde8b02-730b-4924-95cf-71219e5e0a5b.mov
