### PR TITLE
narrow: Resolve the dependency between `narrow` and `stream_list`.

### DIFF
--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -11,6 +11,7 @@ import * as info_overlay from "./info_overlay";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow from "./narrow";
+import * as narrow_hooks from "./narrow_hooks";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -412,4 +413,6 @@ export function initialize() {
         hashchanged(false, e.originalEvent);
     });
     hashchanged(true);
+    narrow_hooks.register_hashchange_activate_hook(handle_narrow_activated);
+    narrow_hooks.register_hashchange_deactivate_hook(handle_narrow_deactivated);
 }

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -11,7 +11,7 @@ import * as compose_state from "./compose_state";
 import * as condense from "./condense";
 import {Filter} from "./filter";
 import * as hash_util from "./hash_util";
-import * as hashchange from "./hashchange";
+//import * as hashchange from "./hashchange";
 import {$t} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_fetch from "./message_fetch";
@@ -23,8 +23,9 @@ import * as message_scroll from "./message_scroll";
 import * as message_store from "./message_store";
 import * as message_view_header from "./message_view_header";
 import * as narrow_banner from "./narrow_banner";
+import * as narrow_hooks from "./narrow_hooks";
 import * as narrow_state from "./narrow_state";
-import * as notifications from "./notifications";
+// import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pm_list from "./pm_list";
@@ -36,7 +37,7 @@ import * as search_pill from "./search_pill";
 import * as search_pill_widget from "./search_pill_widget";
 import * as spectators from "./spectators";
 import * as stream_data from "./stream_data";
-import * as stream_list from "./stream_list";
+//import * as stream_list from "./stream_list";
 import * as top_left_corner from "./top_left_corner";
 import * as topic_generator from "./topic_generator";
 import * as typing_events from "./typing_events";
@@ -169,7 +170,8 @@ export function compute_narrow_title(filter) {
 export let narrow_title = "home";
 export function update_narrow_title(filter) {
     narrow_title = compute_narrow_title(filter);
-    notifications.redraw_title();
+    // notifications.redraw_title(); //todo hook
+    narrow_hooks.call_notification_hook();
 }
 
 export function reset_ui_state() {
@@ -410,7 +412,7 @@ export function activate(raw_operators, opts) {
     reset_ui_state();
 
     if (coming_from_recent_topics) {
-        recent_topics_ui.hide();
+        recent_topics_ui.hide(); // todo hook
     } else {
         // If recent topics was not visible, then we are switching
         // from another message list view. Save the scroll position in
@@ -563,7 +565,8 @@ export function activate(raw_operators, opts) {
     // Disabled when the URL fragment was the source
     // of this narrow.
     if (opts.change_hash) {
-        hashchange.save_narrow(operators);
+        //hashchange.save_narrow(operators); // todo hook
+        narrow_hooks.call_hashchange_activate_hook(operators);
     }
 
     if (page_params.search_pills_enabled && opts.trigger !== "search") {
@@ -582,7 +585,7 @@ export function activate(raw_operators, opts) {
     }
     compose_closed_ui.update_reply_recipient_label();
 
-    search.update_button_visibility();
+    search.update_button_visibility(); // todo hook
 
     compose_actions.on_narrow(opts);
 
@@ -590,7 +593,8 @@ export function activate(raw_operators, opts) {
 
     top_left_corner.handle_narrow_activated(current_filter);
     pm_list.handle_narrow_activated(current_filter);
-    stream_list.handle_narrow_activated(current_filter);
+    narrow_hooks.call_stream_list_activate_hook(current_filter);
+    //stream_list.handle_narrow_activated(current_filter); // todo hook
     typing_events.render_notifications_for_narrow();
     message_view_header.initialize();
 
@@ -1009,7 +1013,8 @@ function handle_post_narrow_deactivate_processes() {
 
     top_left_corner.handle_narrow_deactivated();
     pm_list.handle_narrow_deactivated();
-    stream_list.handle_narrow_deactivated();
+    narrow_hooks.call_stream_list_deactivate_hook();
+    //stream_list.handle_narrow_deactivated(); // todo hook
     compose_closed_ui.update_buttons_for_stream();
     message_edit.handle_narrow_deactivated();
     widgetize.set_widgets_for_list();
@@ -1035,7 +1040,7 @@ export function deactivate(coming_from_recent_topics = false) {
       message_list_data structure caching system that happens to have
       message_lists.home in it.
      */
-    search.clear_search_form();
+    search.clear_search_form(); // todo hook
     // Both All messages and Recent topics have `undefined` filter.
     // Return if already in the All message narrow.
     if (narrow_state.filter() === undefined && !coming_from_recent_topics) {
@@ -1067,8 +1072,8 @@ export function deactivate(coming_from_recent_topics = false) {
 
     reset_ui_state();
     handle_middle_pane_transition();
-    hashchange.save_narrow();
-
+    //hashchange.save_narrow(); // todo hook
+    narrow_hooks.call_hashchange_deactivate_hook();
     if (message_lists.current.selected_id() !== -1) {
         const preserve_pre_narrowing_screen_position =
             message_lists.current.selected_row().length > 0 &&

--- a/web/src/narrow_hooks.ts
+++ b/web/src/narrow_hooks.ts
@@ -1,0 +1,68 @@
+type Hook = () => void;
+type Hook_ = (param: any) => void;
+
+let notification_hook : Hook[] = []                 //1
+let hashchange_activate_hook : Hook_[] = []          //2
+let hashchange_deactivate_hook : Hook[] = []        //3
+let stream_list_activate_hook : Hook_[] = []          //4
+let stream_list_deactivate_hook : Hook[] = []        //5
+
+
+//1 notification - redraw_title
+export function register_notification_hook(func: Hook) :void {
+    notification_hook.push(func);
+}
+
+export function call_notification_hook() : void {
+    for (let func of notification_hook) {
+        func();
+    }
+}
+
+
+//2 hashchange - save_narrow
+export function register_hashchange_activate_hook(func: Hook) :void {
+    hashchange_activate_hook.push(func);
+}
+
+export function call_hashchange_activate_hook(param: any) : void {
+    for (let func of hashchange_activate_hook) {
+        func(param);
+    }
+}
+
+
+//3 hashchange - save_narrow
+export function register_hashchange_deactivate_hook(func: Hook) :void {
+    hashchange_deactivate_hook.push(func);
+}
+
+export function call_hashchange_deactivate_hook() : void {
+    for (let func of hashchange_deactivate_hook) {
+        func();
+    }
+}
+
+
+//4 stream_list - handle_narrow_activated
+export function register_stream_list_activate_hook(func: Hook) :void {
+    stream_list_activate_hook.push(func);
+}
+
+export function call_stream_list_activate_hook(param: any) : void {
+    for (let func of stream_list_activate_hook) {
+        func(param);
+    }
+}
+
+
+//5 stream_list - handle_narrow_deactivated
+export function register_stream_list_deactivate_hook(func: Hook) :void {
+    stream_list_deactivate_hook.push(func);
+}
+
+export function call_stream_list_deactivate_hook() : void {
+    for (let func of stream_list_deactivate_hook) {
+        func();
+    }
+}

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -12,6 +12,7 @@ import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as narrow from "./narrow";
+import * as narrow_hooks from "./narrow_hooks";
 import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
 import {page_params} from "./page_params";
@@ -96,6 +97,7 @@ export function initialize() {
         $("#realm-default-notification-sound-audio"),
         realm_user_settings_defaults,
     );
+    narrow_hooks.register_notification_hook(redraw_title);
 }
 
 export function update_notification_sound_source(container_elem, settings_object) {

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -13,6 +13,7 @@ import {$t} from "./i18n";
 import * as keydown_util from "./keydown_util";
 import {ListCursor} from "./list_cursor";
 import * as narrow from "./narrow";
+import * as narrow_hooks from "./narrow_hooks";
 import * as narrow_state from "./narrow_state";
 import * as pm_list from "./pm_list";
 import * as popovers from "./popovers";
@@ -593,6 +594,8 @@ export function initialize() {
     build_stream_list();
     update_subscribe_to_more_streams_link();
     set_event_handlers();
+    narrow_hooks.register_stream_list_activate_hook(handle_narrow_activated);
+    narrow_hooks.register_stream_list_deactivate_hook(handle_narrow_deactivated);
 }
 
 export function set_event_handlers() {


### PR DESCRIPTION
`narrow.js` and `stream_list.js` forms 2-way cyclic import. To break the cycle, I made `stream_list.initialize()` register  callback functions `handle_narrow_activated` and `handle_narrow_deactivated` that `narrow.js` will use.

On the top of `narrow.js`, a register function is created for receiving the callback function. A gobal variable named similarly to the callback function is created as well. The global variable
`stream_list_handle_narrow_activated` stores the callback and removes the dependency on calling `handle_narrow_activated` in `stream_list.js`. Same for `stream_list_handle_narrow_deactivated` and
`handle_narrow_deactivated`.

This technique is inspired by the dependency breaking method used in #24628.

~~**Current limitation**~~
~~The CI fails at the test case `narrow_activate.test.js` because the mocked `stream_list` and their mocked functions (such as ``) does not call `initialized()`. Therefore, the callback function in `narrow.js` is not registered and thus the test case fails. I tried to `zrequire('stream_list')` and remove `mock_esm("../src/stream_list")` but then the test case shows~~

```
Error:
        Please use mock_template if your test needs to render subscribe_to_more_streams.hbs

        We use mock_template in our unit tests to verify that the
        JS code is calling the template with the proper data. And
        then we use the results of mock_template to supply the JS
        code with either the actual HTML from the template or some
        kind of zjquery stub.
```


~~Since I'm not sure whether following the error message to  mock templates of `stream_list` in `narrow_activate.test.js` is a best practice, so I pause here and would like to pick up later when I get inspired.~~


<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
