### PR TITLE
js: Break cyclic dependency between `reload` and `server_events`.

### DIFF
--- a/web/src/reload.js
+++ b/web/src/reload.js
@@ -14,11 +14,23 @@ import * as message_lists from "./message_lists";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as reload_state from "./reload_state";
-import * as server_events from "./server_events";
 import * as ui_report from "./ui_report";
 import * as util from "./util";
 
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
+
+const reload_hooks = [];
+
+export function add_reload_hook(hook) {
+    reload_hooks.push(hook);
+}
+
+function call_reload_hooks() {
+    for (const hook of reload_hooks) {
+        hook();
+    }
+}
+
 function preserve_state(send_after_reload, save_pointer, save_narrow, save_compose) {
     if (!localstorage.supported()) {
         // If local storage is not supported by the browser, we can't
@@ -255,7 +267,7 @@ function do_reload_app(send_after_reload, save_pointer, save_narrow, save_compos
     util.call_function_periodically(retry_reload, 30000);
 
     try {
-        server_events.cleanup_event_queue();
+        call_reload_hooks();
     } catch (error) {
         blueslip.error("Failed to clean up before reloading", undefined, error);
     }

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -269,6 +269,7 @@ export function home_view_loaded() {
 }
 
 export function initialize() {
+    reload.add_reload_hook(cleanup_event_queue);
     watchdog.on_unsuspend(() => {
         // Immediately poll for new events on unsuspend
         blueslip.log("Restarting get_events due to unsuspend");
@@ -278,7 +279,7 @@ export function initialize() {
     get_events();
 }
 
-export function cleanup_event_queue() {
+function cleanup_event_queue() {
     // Submit a request to the server to clean up our event queue
     if (page_params.event_queue_expired === true || page_params.no_event_queue === true) {
         return;


### PR DESCRIPTION
`reload.js` and `server_events.js` was forming a 2-way cyclic import. To break the cycle, I passed `server_events.cleanup_event_queue` to reload module via its initialization function in `ui_init` and stored this function in a global variable to be later used by `reload` module without having us import `server_events` and hence breaks the cycle.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
