### PR TITLE
tooltips: use tippy tooltips for elements advertising a keyboard shortcut.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -106,6 +106,7 @@
     </div>
 </div>
 
+<div id="tooltip-templates-container"></div>
 <div id="streams_overlay_container"></div>
 <div id="groups_overlay_container"></div>
 <div id="drafts_table"></div>

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -138,6 +138,13 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ".toggle-subscription-tooltip",
+        delay: EXTRA_LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        placement: "bottom",
+    });
+
+    delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
         placement: "right",
         delay: EXTRA_LONG_HOVER_DELAY,

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -4,6 +4,7 @@ import tippy, {delegate} from "tippy.js";
 
 import render_message_inline_image_tooltip from "../templates/message_inline_image_tooltip.hbs";
 import render_narrow_to_compose_recipients_tooltip from "../templates/narrow_to_compose_recipients_tooltip.hbs";
+import render_tooltip_templates from "../templates/tooltip_templates.hbs";
 
 import * as compose_state from "./compose_state";
 import {$t} from "./i18n";
@@ -107,6 +108,8 @@ tippy.setDefaultProps({
 });
 
 export function initialize() {
+    $("#tooltip-templates-container").html(render_tooltip_templates());
+
     // Our default tooltip configuration. For this, one simply needs to:
     // * Set `class="tippy-zulip-tooltip"` on an element for enable this.
     // * Set `data-tippy-content="{{t 'Tooltip content' }}"`, often

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -623,9 +623,6 @@ export function initialize() {
 
     delegate("body", {
         target: ".view_user_card_tooltip",
-        content: $t({
-            defaultMessage: "View user card (u)",
-        }),
         delay: LONG_HOVER_DELAY,
         onShow(instance) {
             if (!document.body.contains(instance.reference)) {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -116,6 +116,27 @@ export function initialize() {
         target: ".tippy-zulip-tooltip",
     });
 
+    // variant of tippy-zulip-tooltip above having delay=LONG_HOVER_DELAY,
+    // default placement="top" with fallback placement="bottom",
+    // and appended to body
+    delegate("body", {
+        target: ".tippy-zulip-delayed-tooltip",
+        // Disable trigger on focus, to avoid displaying on-click.
+        trigger: "mouseenter",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        popperOptions: {
+            modifiers: [
+                {
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: "bottom",
+                    },
+                },
+            ],
+        },
+    });
+
     delegate("body", {
         target: ".tippy-left-sidebar-tooltip",
         placement: "right",

--- a/web/templates/gear_menu.hbs
+++ b/web/templates/gear_menu.hbs
@@ -1,8 +1,12 @@
 <ul class="nav" role="navigation">
     <li class="dropdown actual-dropdown-menu" id="gear-menu">
-        <a id="settings-dropdown" tabindex="0" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{t 'Menu' }} (g)">
+        <a id="settings-dropdown" tabindex="0" role="button" class="dropdown-toggle tippy-zulip-delayed-tooltip" data-target="nada" data-toggle="dropdown" data-tooltip-template-id="gear-menu-tooltip-template">
             <i class="fa fa-cog settings-dropdown-cog" aria-hidden="true"></i>
         </a>
+        <template id="gear-menu-tooltip-template">
+            {{t 'Menu' }}
+            {{tooltip_hotkey_hints "G"}}
+        </template>
         <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
             <li class="org-info org-name">{{realm_name}}</li>
             <li class="org-info org-url">{{realm_url}}</li>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -92,7 +92,7 @@
                 </a>
                 <template id="show-all-pms-template">
                     {{t 'All direct messages' }}
-                    {{tooltip_hotkey_hints "P"}}
+                    {{tooltip_hotkey_hints "Shift" "P"}}
                 </template>
             </div>
         </div>

--- a/web/templates/me_message.hbs
+++ b/web/templates/me_message.hbs
@@ -5,8 +5,8 @@
 
     <span class="sender-status">
         <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">
-            <span class="sender_name_padding view_user_card_tooltip"></span>
-            <span class="view_user_card_tooltip">
+            <span class="sender_name_padding view_user_card_tooltip" data-tooltip-template-id="view-user-card-tooltip-template"></span>
+            <span class="view_user_card_tooltip" data-tooltip-template-id="view-user-card-tooltip-template">
                 {{msg/sender_full_name}}
             </span>
         </span>

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} sender_info_hover inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip" aria-hidden="true">
+<div class="u-{{msg/sender_id}} sender_info_hover inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip" aria-hidden="true" data-tooltip-template-id="view-user-card-tooltip-template">
     <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
 </div>
 {{~! remove whitespace ~}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -7,10 +7,6 @@
             <span class="sender_name_padding view_user_card_tooltip" data-tooltip-template-id="view-user-card-tooltip-template"></span>
             <span class="view_user_card_tooltip" data-tooltip-template-id="view-user-card-tooltip-template">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
         </span>
-        <template id="view-user-card-tooltip-template">
-            {{t 'View user card' }}
-            {{tooltip_hotkey_hints "U"}}
-        </template>
         {{#if sender_is_bot}}
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -4,9 +4,13 @@
     <span>
         {{> message_avatar ~}}
         <span class="sender_info_hover sender_name auto-select" role="button" tabindex="0">
-            <span class="sender_name_padding view_user_card_tooltip"></span>
-            <span class="view_user_card_tooltip">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
+            <span class="sender_name_padding view_user_card_tooltip" data-tooltip-template-id="view-user-card-tooltip-template"></span>
+            <span class="view_user_card_tooltip" data-tooltip-template-id="view-user-card-tooltip-template">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
         </span>
+        <template id="view-user-card-tooltip-template">
+            {{t 'View user card' }}
+            {{tooltip_hotkey_hints "U"}}
+        </template>
         {{#if sender_is_bot}}
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -60,9 +60,17 @@
 <div class="message_edit">
     <div class="message_edit_form"></div>
 </div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More…]" }}</div>
-<div class="message_condenser message_length_controller" title="{{t 'Show less' }} (-)">[{{t "Show less" }}]</div>
+<div class="message_expander message_length_controller tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "[More…]" }}</div>
+<div class="message_condenser message_length_controller tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">[{{t "Show less" }}]</div>
 
+<template id="message-expander-tooltip-template">
+    {{t 'Show more' }}
+    {{tooltip_hotkey_hints "-"}}
+</template>
+<template id="message-condenser-tooltip-template">
+    {{t 'Show less' }}
+    {{tooltip_hotkey_hints "-"}}
+</template>
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>
 {{/unless}}

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -18,4 +18,8 @@
     {{> navbar_icon_and_title }}
 </span>
 {{/if}}
-<span class="search_icon search_closed" role="button"><i class="zulip-icon zulip-icon-search" aria-hidden="true"></i></span>
+<span class="search_icon search_closed"  role="button"><i class="zulip-icon zulip-icon-search tippy-zulip-delayed-tooltip" data-tooltip-template-id="search-query-tooltip-template" aria-hidden="true"></i></span>
+<template id="search-query-tooltip-template">
+    {{t 'Search' }}
+    {{tooltip_hotkey_hints "/"}}
+</template>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -7,7 +7,11 @@
         </div>
         <div class="column-middle" id="navbar-middle">
             <div class="column-middle-inner">
-                <div id="streamlist-toggle" {{#if embedded}}class="hide-streamlist-toggle-visibility"{{/if}} title="{{t 'Stream list' }} (q)">
+                <div id="streamlist-toggle" class="tippy-zulip-delayed-tooltip {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" data-tooltip-template-id="streamlist-toggle-tooltip-template">
+                    <template id="streamlist-toggle-tooltip-template" >
+                        {{t 'View streams' }}
+                        {{tooltip_hotkey_hints "Q"}}
+                    </template>
                     <a id="streamlist-toggle-button" role="button" tabindex="0"><i class="fa fa-reorder" aria-hidden="true"></i>
                         <span id="streamlist-toggle-unreadcount">0</span>
                     </a>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -19,11 +19,11 @@
                     <div id="searchbox">
                         <form id="searchbox_form" class="navbar-search">
                             <div id="search_arrows" class="pill-container input-append">
-                                <span class="search_icon search_open" ><i class="zulip-icon zulip-icon-search"></i></span>
+                                <span class="search_icon search_open"><i class="zulip-icon zulip-icon-search tippy-zulip-delayed-tooltip" data-tooltip-template-id="search-query-tooltip-template"></i></span>
                                 <div contenteditable="true" class="input search-query input-block-level" id="search_query" type="text" placeholder="{{t 'Search' }}"
-                                  autocomplete="off" aria-label="{{t 'Search' }}" title="{{t 'Search' }} (/)">
+                                  autocomplete="off">
                                 </div>
-                                <button class="btn search_close_button" type="button" id="search_exit" aria-label="{{t 'Exit search' }}">
+                                <button class="btn search_close_button tippy-zulip-delayed-tooltip" type="button" id="search_exit" aria-label="{{t 'Exit search' }}" data-tippy-content="Close">
                                     <i class="zulip-icon zulip-icon-close" aria-hidden="true"></i>
                                 </button>
                             </div>
@@ -33,10 +33,10 @@
                     <div id="searchbox_legacy">
                         <form id="searchbox_form" class="navbar-search">
                             <div id="search_arrows" class="input-append">
-                                <span class="search_icon search_open" ><i class="zulip-icon zulip-icon-search"></i></span>
+                                <span class="search_icon search_open"><i class="zulip-icon zulip-icon-search tippy-zulip-delayed-tooltip" data-tooltip-template-id="search-query-tooltip-template"></i></span>
                                 <input class="search-query input-block-level home-page-input" id="search_query" type="text" placeholder="{{t 'Search' }}"
-                                  autocomplete="off" aria-label="{{t 'Search' }}" title="{{t 'Search' }} (/)"/>
-                                <button class="btn search_close_button" type="button" id="search_exit" aria-label="{{t 'Exit search' }}"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>
+                                  autocomplete="off"/>
+                                <button class="btn search_close_button tippy-zulip-delayed-tooltip" type="button" id="search_exit" aria-label="{{t 'Exit search' }}" data-tippy-content="Close"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>
                             </div>
                         </form>
                     </div>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -61,10 +61,14 @@
                     </a>
                 </div>
             </div>
-            <div id="userlist-toggle" title="{{t 'User list' }} (w)" class="hidden-for-spectators">
+            <div id="userlist-toggle" class="hidden-for-spectators tippy-zulip-delayed-tooltip" data-tooltip-template-id="userlist-tooltip-template">
                 <a id="userlist-toggle-button" role="button" tabindex="0"><i class="fa fa-group" aria-hidden="true"></i>
                     <span id="userlist-toggle-unreadcount">0</span>
                 </a>
+                <template id="userlist-tooltip-template">
+                    {{t 'User list' }}
+                    {{tooltip_hotkey_hints "W"}}
+                </template>
             </div>
             <div id="navbar-buttons" {{#if embedded}}class="hide-navbar-buttons-visibility"{{/if}}>
             </div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -3,7 +3,7 @@
     {{#with sub}}
     <div class="button-group">
         <div class="sub_unsub_button_wrapper inline-block">
-            <button class="button small rounded subscribe-button sub_unsub_button {{#if should_display_subscription_button}}tippy-zulip-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}data-tippy-content="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
+            <button class="button small rounded subscribe-button sub_unsub_button {{#if should_display_subscription_button}}toggle-subscription-tooltip{{/if}} {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}} data-tooltip-template-id="toggle-subscription-tooltip-template" {{else}}disabled="disabled"{{/if}}>
                 {{#if subscribed }}
                     {{t "Unsubscribe" }}
                 {{else}}
@@ -11,11 +11,19 @@
                 {{/if}}
             </button>
         </div>
-        <a href="{{preview_url}}" class="button small rounded tippy-zulip-tooltip" id="preview-stream-button" role="button" data-tippy-content="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
+        <template id="toggle-subscription-tooltip-template">
+            {{t 'Toggle subscription' }}
+            {{tooltip_hotkey_hints "Shift" "S"}}
+        </template>
+        <a href="{{preview_url}}" class="button small rounded tippy-zulip-delayed-tooltip" id="preview-stream-button" role="button" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="bottom" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
         {{#if is_realm_admin}}
         <button class="button small rounded btn-danger deactivate tippy-zulip-tooltip" type="button" name="delete_button" data-tippy-content="{{t 'Archive stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
         {{/if}}
     </div>
+    <template id="view-stream-tooltip-template">
+        {{t 'View stream' }}
+        {{tooltip_hotkey_hints "Shift" "V"}}
+    </template>
     {{/with}}
 </div>
 <div class="subscription_settings" data-stream-id="{{sub.stream_id}}">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -12,9 +12,13 @@
                 <div class="search-container">
                     <div id="add_new_subscription">
                         {{#if can_create_streams}}
-                        <button class="create_stream_button create_stream_plus_button tippy-zulip-tooltip" data-tippy-content="{{t 'Create new stream' }} (n)" data-tippy-placement="bottom">
+                        <button class="create_stream_button create_stream_plus_button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
                             <span>+</span>
                         </button>
+                        <template id="create-new-stream-tooltip-template">
+                            {{t 'Create new stream' }}
+                            {{tooltip_hotkey_hints "N"}}
+                        </template>
                         {{/if}}
                         <div class="float-clear"></div>
                     </div>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -1,0 +1,4 @@
+<template id="view-user-card-tooltip-template">
+    {{t 'View user card' }}
+    {{tooltip_hotkey_hints "U"}}
+</template>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
use a modern tippy tooltip style for remaining tooltip elements advertising a keyboard shortcut.

Fixes: <!-- Issue link, or clear description.-->
#24311

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Gear Menu:
![image](https://user-images.githubusercontent.com/64723994/230759114-9667f065-cb56-40d4-8096-14ab726bbcbb.png)
    
    - with fallback placement:
    ![image](https://user-images.githubusercontent.com/64723994/230759126-e1f22cf3-8ce6-499a-9deb-742cc379d66e.png)
    
    - Dark there:
    ![image](https://user-images.githubusercontent.com/64723994/230759140-62b1560b-5f0a-4426-8a13-db8daa6b5e22.png)


- User List:
![image](https://user-images.githubusercontent.com/64723994/230759185-166f1602-b4d1-4505-822c-45c272546deb.png)

![image](https://user-images.githubusercontent.com/64723994/230759246-757f6978-221d-4541-8602-efa63fbef978.png)

- Search_open icon:
  ![image](https://user-images.githubusercontent.com/64723994/232673457-28679673-76fb-4d5e-9b10-85d6760df2aa.png)

- Search_close_button:
  ![image](https://user-images.githubusercontent.com/64723994/232673502-32ee8263-72ed-4f43-bd32-9eb44112493e.png)

- Search_query input field:
  ![image](https://user-images.githubusercontent.com/64723994/232673602-2a6e56d3-8f1f-4c32-b7a4-e3aab1c91211.png)
  
  - on fallback placement:
    ![image](https://user-images.githubusercontent.com/64723994/232673862-75fa90f2-fe3c-447f-85f6-a4536bcac85d.png)

- Search_close icon:
![image](https://user-images.githubusercontent.com/64723994/230759269-459564b2-47db-4dc5-b40f-90979c1b3bb6.png)

- Manage stream settings: 
  - create new stream button: 
     ![image](https://user-images.githubusercontent.com/64723994/232159720-3dbdccbb-8300-4135-8bff-9747597c5d55.png)

  - Toggle subscription:
    ![image](https://user-images.githubusercontent.com/64723994/234315104-5c57fef8-5759-4887-a621-98254e57ce7a.png)

  - View stream:
    ![image](https://user-images.githubusercontent.com/64723994/234315257-7efb302a-3ba4-4b4d-b968-cf91600c5f89.png)

- Message Expander/condenser:
![image](https://user-images.githubusercontent.com/64723994/230759436-9c989ffd-875c-4fa1-a8c1-220b9bc1c2c7.png)

- View user card:
![image](https://user-images.githubusercontent.com/64723994/230759452-f6976aa8-d283-4b6b-b194-fad573678825.png)

![image](https://user-images.githubusercontent.com/64723994/230759457-f182e37c-4651-41d3-b933-37780c08be3f.png)

- Correction of hotkey for `All direct messages` tooltip:
  ![image](https://user-images.githubusercontent.com/64723994/234315715-3f2dff90-1862-4acc-879f-ae5cf59741c7.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
