### PR TITLE
navbar: Fix alignment of `search_close` icon on device width < `$sm_min`.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1886,7 +1886,7 @@ div.focused_table {
         padding: 10px 15px 0 0;
 
         @media (width < $sm_min) {
-            padding: 5px 15px 0 0;
+            padding: 0 15px 0 0;
         }
     }
 
@@ -2758,7 +2758,7 @@ select.invite-as {
     /* Usually the styling is applied directly to the icon, but here
     the icon is `position: static`, so we can't. */
     .search_closed {
-        top: 4px;
+        top: 5px;
     }
 
     #streamlist-toggle,


### PR DESCRIPTION
This commit fixes the alignment of the `search_close` icon on devices with a width less than $sm_min (576px) by removing a top padding of 5px and adjusting the position to the top 5px from the previous 4px.

This fixes the vertical alignment of search_close icon.

<!-- Describe your pull request here.-->

<!-- Fixes:  --><!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
![image](https://user-images.githubusercontent.com/64723994/230764387-859d52d9-0442-4c04-a48d-db8fb419b8ba.png)

After:
![image](https://user-images.githubusercontent.com/64723994/230764398-877f40f4-6fe4-47d9-8053-db4ab575a21e.png)

![image](https://user-images.githubusercontent.com/64723994/230764411-5b6a225f-49b9-4277-93a2-8a3270ced8ab.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
