### PR TITLE
Push bouncer: Deduplicate device registrations

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -547,6 +547,9 @@ def add_push_device_token(
         post_data = {
             "server_uuid": settings.ZULIP_ORG_ID,
             "user_uuid": str(user_profile.uuid),
+            # user_id is sent so that the bouncer can delete any pre-existing registrations
+            # for this user+device to avoid duplication upon adding the uuid registration.
+            "user_id": str(user_profile.id),
             "token": token_str,
             "token_kind": kind,
         }

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -336,6 +336,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
         token = "aaaa"
         android_tokens = []
+        uuid_android_tokens = []
         for i in ["aa", "bb"]:
             android_tokens.append(
                 RemotePushDeviceToken.objects.create(
@@ -345,6 +346,19 @@ class PushBouncerNotificationTest(BouncerTestCase):
                     server=server,
                 )
             )
+
+            # Create a duplicate, newer uuid-based registration for the same user to verify
+            # the bouncer will handle that correctly, without triggering a duplicate notification,
+            # and will delete the old, legacy registration.
+            uuid_android_tokens.append(
+                RemotePushDeviceToken.objects.create(
+                    kind=RemotePushDeviceToken.GCM,
+                    token=hex_to_b64(token + i),
+                    user_uuid=str(hamlet.uuid),
+                    server=server,
+                )
+            )
+
         apple_token = RemotePushDeviceToken.objects.create(
             kind=RemotePushDeviceToken.APNS,
             token=hex_to_b64(token),
@@ -354,6 +368,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         many_ids = ",".join(str(i) for i in range(1, 250))
         payload = {
             "user_id": hamlet.id,
+            "user_uuid": str(hamlet.uuid),
             "gcm_payload": {"event": "remove", "zulip_message_ids": many_ids},
             "apns_payload": {
                 "badge": 0,
@@ -383,12 +398,14 @@ class PushBouncerNotificationTest(BouncerTestCase):
             logger.output,
             [
                 "INFO:zilencer.views:"
-                f"Sending mobile push notifications for remote user 6cde5f7a-1f7e-4978-9716-49f69ebfc9fe:<id:{hamlet.id}>: "
-                "2 via FCM devices, 1 via APNs devices"
+                f"Deduplicating push registrations for server id:{server.id} user id:{hamlet.id} uuid:{str(hamlet.uuid)} and tokens:{sorted([t.token for t in android_tokens[:]])}",
+                "INFO:zilencer.views:"
+                f"Sending mobile push notifications for remote user 6cde5f7a-1f7e-4978-9716-49f69ebfc9fe:<id:{hamlet.id}><uuid:{str(hamlet.uuid)}>: "
+                "2 via FCM devices, 1 via APNs devices",
             ],
         )
 
-        user_identity = UserPushIdentityCompat(user_id=hamlet.id)
+        user_identity = UserPushIdentityCompat(user_id=hamlet.id, user_uuid=str(hamlet.uuid))
         apple_push.assert_called_once_with(
             user_identity,
             [apple_token],
@@ -405,7 +422,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         )
         android_push.assert_called_once_with(
             user_identity,
-            list(reversed(android_tokens)),
+            list(reversed(uuid_android_tokens)),
             {"event": "remove", "zulip_message_ids": ",".join(str(i) for i in range(50, 250))},
             {},
             remote=server,


### PR DESCRIPTION
Fixes #24969

Implements the solution discussed in the issue description and  https://chat.zulip.org/#narrow/stream/48-mobile/topic/iOS.20duplicate.20notifications