### PR TITLE
compose: Ensure compose box is focused after inserting any content.

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -61,10 +61,7 @@ export function smart_insert_inline($textarea, syntax) {
         syntax += " ";
     }
 
-    // text-field-edit ensures `$textarea` is focused before inserting
-    // the new syntax.
     insert($textarea[0], syntax);
-
     autosize_textarea($textarea);
 }
 
@@ -111,10 +108,7 @@ export function smart_insert_block($textarea, syntax) {
     const new_lines_needed_after_count = 2 - new_lines_after_count;
     syntax = syntax + "\n".repeat(new_lines_needed_after_count);
 
-    // text-field-edit ensures `$textarea` is focused before inserting
-    // the new syntax.
     insert($textarea[0], syntax);
-
     autosize_textarea($textarea);
 }
 
@@ -126,6 +120,17 @@ export function insert_syntax_and_focus(
     // Generic helper for inserting syntax into the main compose box
     // where the cursor was and focusing the area.  Mostly a thin
     // wrapper around smart_insert_inline and smart_inline_block.
+    //
+    // We focus the textarea first. In theory, we could let the
+    // `insert` function of text-area-edit take care of this, since it
+    // will focus the target element before manipulating it.
+    //
+    // But it unfortunately will blur it afterwards if the original
+    // focus was something else, which is not behavior we want, so we
+    // just focus the textarea in question ourselves before calling
+    // it.
+    $textarea.trigger("focus");
+
     if (mode === "inline") {
         smart_insert_inline($textarea, syntax);
     } else if (mode === "block") {


### PR DESCRIPTION
At the end of `insert_syntax_and_focus`, we now explicitly focus the textarea after inserting the content so that the function does exactly as expected.

This fixes the bug where the compose box would not be focused after inserting video call links, emojis from the picker and GIPHY gifs.

Fixes: https://chat.zulip.org/#narrow/stream/9-issues/topic/cursor.20disappears.20when.20video.20call.20is.20inserted

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
https://user-images.githubusercontent.com/68962290/230952074-a0438451-fb2b-4ebb-a8ae-70fa471438d2.mp4


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
