### PR TITLE
markdown: Fix lists with 3+ digit markers retaining alignment for 2 digits

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -23,15 +23,32 @@
         margin-left: 0;
     }
 
-    /* Ensure ordered lists are nicely centered in 1-line messages */
     & ol {
-        margin: 2px 0 5px 20px;
+        margin: 2px 0 5px;
+
+        & li {
+            display: block;
+        }
+
+        /* Ensure ordered lists are nicely centered in 1-line messages for up to 2
+           digit markers, else the markers take up as much space as needed without
+           being cut off at the beginning */
+        & li::before {
+            content: counter(list-item) ". ";
+            text-align: right;
+            counter-increment: list-item;
+            display: inline-block;
+            min-width: 20px;
+            margin-right: 3px;
+        }
     }
 
-    /* Swap the left and right margins of ordered list for Right-To-Left languages */
-    &.rtl ol {
-        margin-right: 8px;
-        margin-left: 0;
+    /* Invert direction of text alignment and margin of markers in ordered lists
+       for proper centering in Right-To-Left languages */
+    &.rtl ol li::before {
+        text-align: left;
+        margin-left: 3px;
+        margin-right: unset;
     }
 
     /* Reduce top-margin when a paragraph is followed by an ordered or bulleted list */


### PR DESCRIPTION
Until now, lists with 3+ digit markers would have their beginnings cut off to align with 2 digit markers. We fix that by having custom styling for markers where we align markers only uptil 2 digits, and let larger numbers take up more space pushing the list item content forward as required to fit the marker.

Fixes: https://chat.zulip.org/#narrow/stream/9-issues/topic/large.20numbered.20lists

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Left to Right Languages:
![image](https://user-images.githubusercontent.com/68962290/230984544-38d7f032-bd49-4307-8d21-d35ed98e7cc8.png)

- Right to Left Language (example with english but with rtl class)
![image](https://user-images.githubusercontent.com/68962290/230984749-7a8e9495-dae3-4680-b08a-49baa73289a6.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
