### PR TITLE
help: Document edit or delete a message mobile feature.

### DIFF
--- a/help/edit-or-delete-a-message.md
+++ b/help/edit-or-delete-a-message.md
@@ -77,6 +77,12 @@ least confusing option for other users.
     **Note:** If you don't see the **pencil** (<i class="fa fa-pencil"></i>) icon,
     you are not permitted to edit this message.
 
+{tab|mobile}
+
+{!message-long-press-menu.md!}
+
+1. Tap **Delete message** to delete the content of the message.
+
 {end_tabs}
 
 ### Delete a message completely

--- a/help/edit-or-delete-a-message.md
+++ b/help/edit-or-delete-a-message.md
@@ -17,15 +17,31 @@ content.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!message-actions.md!}
 
 1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon.
 
-1. Edit the message, and click **Save**.
+1. Edit the content of the message.
+
+1. Click **Save**.
 
 !!! warn ""
     **Note:** If you don't see the **pencil** (<i class="fa fa-pencil"></i>) icon,
     you are not permitted to edit this message.
+
+{tab|mobile}
+
+{!message-long-press-menu.md!}
+
+1. Tap **Edit message**.
+
+1. Edit the content of the message.
+
+1. Approve by tapping the **checkmark**
+   (<img src="/static/images/help/mobile-check-circle-icon.svg" alt="checkmark" class="mobile-icon"/>)
+   button in the bottom right corner of the app.
 
 {end_tabs}
 

--- a/help/edit-or-delete-a-message.md
+++ b/help/edit-or-delete-a-message.md
@@ -61,6 +61,24 @@ message is still accessible via Zulip's [edit
 history](/help/view-a-messages-edit-history) feature.  This can be the
 least confusing option for other users.
 
+{start_tabs}
+
+{tab|desktop-web}
+
+{!message-actions.md!}
+
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon.
+
+1. Delete the content of the message.
+
+1. Click **Save**.
+
+!!! warn ""
+    **Note:** If you don't see the **pencil** (<i class="fa fa-pencil"></i>) icon,
+    you are not permitted to edit this message.
+
+{end_tabs}
+
 ### Delete a message completely
 
 For cases where someone accidentally shared secret information publicly


### PR DESCRIPTION
-  Documents "Edit message" mobile feature.
- Adds instructions block to "Delete a message" on Desktop/Web.
- Documents "Delete message" mobile feature.

**Question:**
For clarity, should we also add a `Desktop/Web` tab to the instructions block for [deleting a message completely](https://zulip.com/help/edit-or-delete-a-message#delete-a-message-completely)?

**Screenshots and screen captures:**

- https://zulip.com/help/edit-or-delete-a-message#edit-a-message

![image](https://user-images.githubusercontent.com/2343554/231006324-cca70940-5e40-4692-aefe-410a9d3be80e.png)

![image](https://user-images.githubusercontent.com/2343554/231006411-da8e3184-78be-4548-a0a5-c3698244acff.png)

- https://zulip.com/help/edit-or-delete-a-message#delete-a-message

![image](https://user-images.githubusercontent.com/2343554/231006451-de99493c-cdfd-4247-8ff1-39313ed55117.png)

![image](https://user-images.githubusercontent.com/2343554/231006510-a2cb89e7-5a30-48b3-b59a-6d44db8273ec.png)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>