### PR TITLE
support: Add option to upgrade an org to Plus plan on /activity/support.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -667,6 +667,17 @@ class TestSupportEndpoint(ZulipTestCase):
                     ["zulip downgraded and voided 1 open invoices"], result
                 )
 
+        with mock.patch("analytics.views.support.switch_realm_from_standard_to_plus_plan") as m:
+            result = self.client_post(
+                "/activity/support",
+                {
+                    "realm_id": f"{iago.realm_id}",
+                    "modify_plan": "upgrade_to_plus",
+                },
+            )
+            m.assert_called_once_with(get_realm("zulip"))
+            self.assert_in_success_response(["zulip upgraded to Plus"], result)
+
     def test_scrub_realm(self) -> None:
         cordelia = self.example_user("cordelia")
         lear_realm = get_realm("lear")

--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -627,7 +627,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 "/activity/support",
                 {
                     "realm_id": f"{iago.realm_id}",
-                    "downgrade_method": "downgrade_at_billing_cycle_end",
+                    "modify_plan": "downgrade_at_billing_cycle_end",
                 },
             )
             m.assert_called_once_with(get_realm("zulip"))
@@ -642,7 +642,7 @@ class TestSupportEndpoint(ZulipTestCase):
                 "/activity/support",
                 {
                     "realm_id": f"{iago.realm_id}",
-                    "downgrade_method": "downgrade_now_without_additional_licenses",
+                    "modify_plan": "downgrade_now_without_additional_licenses",
                 },
             )
             m.assert_called_once_with(get_realm("zulip"))
@@ -658,7 +658,7 @@ class TestSupportEndpoint(ZulipTestCase):
                     "/activity/support",
                     {
                         "realm_id": f"{iago.realm_id}",
-                        "downgrade_method": "downgrade_now_void_open_invoices",
+                        "modify_plan": "downgrade_now_void_open_invoices",
                     },
                 )
                 m1.assert_called_once_with(get_realm("zulip"))

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -54,6 +54,7 @@ if settings.BILLING_ENABLED:
         get_discount_for_realm,
         get_latest_seat_count,
         make_end_of_cycle_updates_if_needed,
+        switch_realm_from_standard_to_plus_plan,
         update_billing_method_of_current_plan,
         update_sponsorship_status,
         void_all_open_invoices,
@@ -125,6 +126,7 @@ VALID_MODIFY_PLAN_METHODS = [
     "downgrade_at_billing_cycle_end",
     "downgrade_now_without_additional_licenses",
     "downgrade_now_void_open_invoices",
+    "upgrade_to_plus",
 ]
 
 VALID_STATUS_VALUES = [
@@ -268,6 +270,9 @@ def support(
                 context[
                     "success_message"
                 ] = f"{realm.string_id} downgraded and voided {voided_invoices_count} open invoices"
+            elif modify_plan == "upgrade_to_plus":
+                switch_realm_from_standard_to_plus_plan(realm)
+                context["success_message"] = f"{realm.string_id} upgraded to Plus"
         elif scrub_realm:
             do_scrub_realm(realm, acting_user=acting_user)
             context["success_message"] = f"{realm.string_id} scrubbed."

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -121,7 +121,7 @@ def get_confirmations(
     return confirmation_dicts
 
 
-VALID_DOWNGRADE_METHODS = [
+VALID_MODIFY_PLAN_METHODS = [
     "downgrade_at_billing_cycle_end",
     "downgrade_now_without_additional_licenses",
     "downgrade_now_void_open_invoices",
@@ -160,8 +160,8 @@ def support(
     ),
     sponsorship_pending: Optional[bool] = REQ(default=None, json_validator=check_bool),
     approve_sponsorship: bool = REQ(default=False, json_validator=check_bool),
-    downgrade_method: Optional[str] = REQ(
-        default=None, str_validator=check_string_in(VALID_DOWNGRADE_METHODS)
+    modify_plan: Optional[str] = REQ(
+        default=None, str_validator=check_string_in(VALID_MODIFY_PLAN_METHODS)
     ),
     scrub_realm: bool = REQ(default=False, json_validator=check_bool),
     query: Optional[str] = REQ("q", default=None),
@@ -251,18 +251,18 @@ def support(
         elif approve_sponsorship:
             do_approve_sponsorship(realm, acting_user=acting_user)
             context["success_message"] = f"Sponsorship approved for {realm.string_id}"
-        elif downgrade_method is not None:
-            if downgrade_method == "downgrade_at_billing_cycle_end":
+        elif modify_plan is not None:
+            if modify_plan == "downgrade_at_billing_cycle_end":
                 downgrade_at_the_end_of_billing_cycle(realm)
                 context[
                     "success_message"
                 ] = f"{realm.string_id} marked for downgrade at the end of billing cycle"
-            elif downgrade_method == "downgrade_now_without_additional_licenses":
+            elif modify_plan == "downgrade_now_without_additional_licenses":
                 downgrade_now_without_creating_additional_invoices(realm)
                 context[
                     "success_message"
                 ] = f"{realm.string_id} downgraded without creating additional invoices"
-            elif downgrade_method == "downgrade_now_void_open_invoices":
+            elif modify_plan == "downgrade_now_void_open_invoices":
                 downgrade_now_without_creating_additional_invoices(realm)
                 voided_invoices_count = void_all_open_invoices(realm)
                 context[

--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -145,6 +145,7 @@
         <option value="downgrade_at_billing_cycle_end">Downgrade at the end of current billing cycle</option>
         <option value="downgrade_now_without_additional_licenses">Downgrade now without creating additional invoices</option>
         <option value="downgrade_now_void_open_invoices">Downgrade now and void open invoices</option>
+        <option value="upgrade_to_plus">Upgrade to the Plus plan</option>
     </select>
     <button type="submit" class="btn btn-default support-submit-button">Modify</button>
 </form>

--- a/templates/analytics/realm_details.html
+++ b/templates/analytics/realm_details.html
@@ -137,16 +137,16 @@
 
 <form method="POST" class="downgrade-plan-form">
     <br />
-    <b>Downgrade plan</b><br />
+    <b>Modify plan</b><br />
     {{ csrf_input }}
     <input type="hidden" name="realm_id" value="{{ realm.id }}" />
-    <select name="downgrade_method" class="downgrade-plan-method-select" required>
+    <select name="modify_plan" class="modify-plan-method-select" required>
         <option disabled value="" selected>-- select --</option>
         <option value="downgrade_at_billing_cycle_end">Downgrade at the end of current billing cycle</option>
         <option value="downgrade_now_without_additional_licenses">Downgrade now without creating additional invoices</option>
         <option value="downgrade_now_void_open_invoices">Downgrade now and void open invoices</option>
     </select>
-    <button type="submit" class="btn btn-default support-submit-button">Downgrade</button>
+    <button type="submit" class="btn btn-default support-submit-button">Modify</button>
 </form>
 
 {% endif %}

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -124,7 +124,7 @@ tr.admin td:first-child {
     top: -75px;
 }
 
-.downgrade-plan-method-select {
+.modify-plan-method-select {
     width: auto;
 }
 


### PR DESCRIPTION
So that we don't need to run the management command to do upgrades