### PR TITLE
time_picker: Set minutes to zero in global time picker.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -31,6 +31,7 @@ import * as stream_data from "./stream_data";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as subscriber_api from "./subscriber_api";
+import {get_timestamp_for_flatpickr} from "./timerender";
 import * as transmit from "./transmit";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
@@ -702,7 +703,7 @@ export function initialize() {
             flatpickr.show_flatpickr(
                 $(compose_click_target)[0],
                 on_timestamp_selection,
-                new Date(),
+                get_timestamp_for_flatpickr(),
                 {
                     // place the time picker above the icon and center it horizontally
                     position: "above center",

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -355,9 +355,10 @@ export function get_timestamp_for_flatpickr(timestring: string): Date {
         // we use it to initialize the flatpickr instance.
         timestamp = parseISO(timestring);
     } finally {
-        // Otherwise, default to showing the current time.
+        // Otherwise, default to showing the current time to the hour.
         if (!timestamp || !isValid(timestamp)) {
             timestamp = new Date();
+            timestamp.setMinutes(0, 0);
         }
     }
     return timestamp;

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -369,8 +369,10 @@ run_test("get_timestamp_for_flatpickr", () => {
     // Freeze time for testing.
     MockDate.set(date_2017.getTime());
 
-    // Invalid timestamps should show current time.
-    assert.equal(func("random str").valueOf(), Date.now());
+    // Invalid timestamps should show current time on the hour.
+    const date_without_minutes = new Date();
+    date_without_minutes.setMinutes(0, 0);
+    assert.equal(func("random str").valueOf(), date_without_minutes.getTime());
 
     // Valid ISO timestamps should return the timestamp.
     assert.equal(func(date_2017.toISOString()).valueOf(), date_2017.getTime());


### PR DESCRIPTION
Usually when a user uses the time picker, they're most likely going to set the time to the hour rather than the current minute. These changes will set the minutes to zero whenever we are opening the global time picker.

This is a rebase of #23895 with a couple changes to shorten the amount of changes required.

**Notes:**
There are two ways to opening the global time picker, either through the compose button or the typeahead system with `<time:`

- When we click on the compose button, we can just set the time to the hour. 
- When we open the global time picker through the typeahead system, there are two situations:
  - When there isn't a vaild timestamp, we should set the time to the hour.
  - When there is a valid timestmap already, the user probably wants to use that timestamp and may have triggered the typeahead by accident or may just require a minor change. In any case, we probably should keep the minutes here rather than setting it to 0. 

Fixes: #23874.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
