### PR TITLE
settings: Replace extraneous pointer cursors on text with text cursor.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -11,6 +11,10 @@ label {
     }
 }
 
+label:not([for]) {
+    cursor: text;
+}
+
 label,
 h4,
 h3,

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -7,7 +7,7 @@
                 <div class="alert-notification" id="account-settings-status"></div>
                 <form class="grid">
                     <div class="input-group">
-                        <label class="inline-block title">{{t "Email" }}</label>
+                        <label class="inline-block title" for="change_email_button">{{t "Email" }}</label>
                         <div id="change_email_button_container" class="inline-block {{#unless user_can_change_email}}disabled_setting_tooltip{{/unless}}">
                             <button id="change_email_button" type="button" class="button btn-link small rounded inline-block" {{#unless user_can_change_email}}disabled="disabled"{{/unless}}>
                                 {{page_params.delivery_email}}
@@ -27,7 +27,7 @@
                 <form class="password-change-form grid">
                     {{#if page_params.realm_email_auth_enabled}}
                     <div>
-                        <label class="inline-block title">{{t "Password" }}</label>
+                        <label class="inline-block title" for="change_password">{{t "Password" }}</label>
                         <div class="input-group inline-block" id="pw_change_link">
                             <button id="change_password" type="button" class="change_password_button btn-link small button rounded inline-block" data-dismiss="modal">********<i class="fa fa-pencil"></i></button>
                         </div>

--- a/web/templates/settings/account_settings.hbs
+++ b/web/templates/settings/account_settings.hbs
@@ -84,7 +84,7 @@
                   prefix="user_"}}
             </div>
             <div class="input-group">
-                <label for="email_address_visibility" class="dropdown-title">{{t "Who can access your email address" }}
+                <label for="user_email_address_visibility" class="dropdown-title">{{t "Who can access your email address" }}
                     {{> ../help_link_widget link="/help/configure-email-visibility" }}
                 </label>
                 <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -1,7 +1,7 @@
 <form id="create_bot_form" class="new-style">
     <div class="new-bot-form">
         <div class="input-group">
-            <label for="bot_type">
+            <label for="create_bot_type">
                 {{t "Bot type" }}
                 <i class="fa fa-question-circle settings-info-icon bot_type_tooltip tippy-zulip-tooltip" aria-hidden="true" data-tippy-content='{{t "Incoming webhooks can only send messages." }}'></i>
             </label>
@@ -28,7 +28,7 @@
             <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
         </div>
         <div class="input-group">
-            <label for="bot_short_name">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
+            <label for="create_bot_short_name">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
             <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part modal_text_input"
               placeholder="{{t 'cookie' }}" value="" />
             -bot@{{ realm_bot_domain }}

--- a/web/templates/settings/api_key_modal.hbs
+++ b/web/templates/settings/api_key_modal.hbs
@@ -13,7 +13,7 @@
                     <div id="api_key_form">
                         <p>{{t "Please re-enter your password to confirm your identity." }}</p>
                         <div class="password-div">
-                            <label for="password">{{t "Your password" }}</label>
+                            <label for="get_api_key_password">{{t "Your password" }}</label>
                             <input type="password" autocomplete="off" name="password" id="get_api_key_password" class="modal_text_input" value="" />
                             <i class="fa fa-eye-slash password_visibility_toggle tippy-zulip-tooltip" role="button"></i>
                         </div>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -4,9 +4,9 @@
     <div class="field_hint">{{ field.hint }}</div>
     <div class="field">
         {{#if is_long_text_field}}
-        <textarea maxlength="500" class="custom_user_field_value settings_textarea">{{ field_value.value }}</textarea>
+        <textarea id="{{field.name}}" maxlength="500" class="custom_user_field_value settings_textarea">{{ field_value.value }}</textarea>
         {{else if is_select_field}}
-        <select class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style">
+        <select id="{{field.name}}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_select{{else}}settings_select{{/if}} bootstrap-focus-style">
             <option value=""></option>
             {{#each field_choices}}
                 <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
@@ -17,15 +17,15 @@
             <div class="input" contenteditable="true"></div>
         </div>
         {{else if is_date_field }}
-        <input class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" data-field-id="{{ field.id }}" type="text"
+        <input id="{{field.name}}" class="custom_user_field_value datepicker {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" data-field-id="{{ field.id }}" type="text"
           value="{{ field_value.value }}" />
         <span class="remove_date"><i class="fa fa-close"></i></span>
         {{else if is_url_field }}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
+        <input id="{{field.name}}"class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="2048" />
         {{else if is_pronouns_field}}
-        <input class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        <input id="{{field.name}}" class="custom_user_field_value pronouns_type_field {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{else}}
-        <input class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        <input id="{{field.name}}" class="custom_user_field_value {{#if for_manage_user_modal}}modal_text_input{{else}}settings_text_input{{/if}}" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
         {{/if}}
     </div>
 </div>

--- a/web/templates/settings/custom_user_profile_field.hbs
+++ b/web/templates/settings/custom_user_profile_field.hbs
@@ -1,5 +1,5 @@
 <div class="custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
-    <label class="inline-block" for="{{ field.name }}" class="title">{{ field.name }}</label>
+    <label for="{{field.name}}" class="inline-block title">{{ field.name }}</label>
     <div class="alert-notification custom-field-status"></div>
     <div class="field_hint">{{ field.hint }}</div>
     <div class="field">

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -11,7 +11,7 @@
                 <div class="settings-section-title">{{t "Add new default stream" }}</div>
                 <div class="inline-block" id="default_stream_inputs">
                     <label for="default_stream_name">{{t "Stream name" }}</label>
-                    <input class="create_default_stream settings_text_input" type="text" placeholder="{{t 'Stream name' }}" name="stream_name" autocomplete="off" />
+                    <input class="create_default_stream settings_text_input" type="text" placeholder="{{t 'Stream name' }}" name="stream_name" autocomplete="off" id="create_default_stream" />
                 </div>
                 <div class="inline-block">
                     <button type="submit" id="do_submit_stream" class="button rounded sea-green">{{t "Add stream" }}</button>

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -14,7 +14,7 @@
         {{/unless}}
 
         <div class="input-group">
-            <label for="twenty_four_hour_time" class="dropdown-title">{{ settings_label.twenty_four_hour_time }}</label>
+            <label for="{{prefix}}twenty_four_hour_time" class="dropdown-title">{{ settings_label.twenty_four_hour_time }}</label>
             <select name="twenty_four_hour_time" class="setting_twenty_four_hour_time prop-element settings_select bootstrap-focus-style" id="{{prefix}}twenty_four_hour_time" data-setting-widget-type="string">
                 {{#each twenty_four_hour_time_values}}
                     <option value='{{ this.value }}'>{{ this.description }}</option>
@@ -22,7 +22,7 @@
             </select>
         </div>
         <div class="input-group">
-            <label for="color_scheme" class="dropdown-title">{{t "Theme" }}</label>
+            <label for="{{prefix}}color_scheme" class="dropdown-title">{{t "Theme" }}</label>
             <select name="color_scheme" class="setting_color_scheme prop-element settings_select bootstrap-focus-style" id="{{prefix}}color_scheme" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=color_scheme_values}}
             </select>
@@ -117,7 +117,7 @@
         </div>
 
         <div class="input-group thinner setting-next-is-related">
-            <label for="default_view" class="dropdown-title">{{t "Default view" }}
+            <label for="{{prefix}}default_view" class="dropdown-title">{{t "Default view" }}
                 {{> ../help_link_widget link="/help/configure-default-view" }}
             </label>
             <select name="default_view" class="setting_default_view prop-element settings_select bootstrap-focus-style" id="{{prefix}}default_view" data-setting-widget-type="string">
@@ -132,7 +132,7 @@
           prefix=prefix}}
 
         <div class="input-group">
-            <label for="demote_inactive_streams" class="dropdown-title">{{t "Demote inactive streams" }}
+            <label for="{{prefix}}demote_inactive_streams" class="dropdown-title">{{t "Demote inactive streams" }}
                 {{> ../help_link_widget link="/help/manage-inactive-streams" }}
             </label>
             <select name="demote_inactive_streams" class="setting_demote_inactive_streams prop-element settings_select bootstrap-focus-style" id="{{prefix}}demote_inactive_streams"  data-setting-widget-type="number">

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -68,7 +68,7 @@
               prefix=../prefix}}
         {{/each}}
 
-        <label for="notification_sound">
+        <label for="{{prefix}}notification_sound">
             {{t "Notification sound" }}
         </label>
 
@@ -88,7 +88,7 @@
         </div>
 
         <div class="input-group">
-            <label for="desktop_icon_count_display" class="dropdown-title">{{ settings_label.desktop_icon_count_display }}</label>
+            <label for="{{prefix}}desktop_icon_count_display" class="dropdown-title">{{ settings_label.desktop_icon_count_display }}</label>
             <select name="desktop_icon_count_display" class="setting_desktop_icon_count_display prop-element settings_select bootstrap-focus-style" id="{{prefix}}desktop_icon_count_display" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=desktop_icon_count_display_values}}
             </select>
@@ -125,7 +125,7 @@
 
         <div class="input-group time-limit-setting">
 
-            <label for="email_notifications_batching_period">
+            <label for="{{prefix}}email_notifications_batching_period_seconds">
                 {{t "Delay before sending message notification emails" }}
             </label>
             <select name="email_notifications_batching_period_seconds" class="setting_email_notifications_batching_period_seconds prop-element settings_select bootstrap-focus-style" id="{{prefix}}email_notifications_batching_period_seconds" data-setting-widget-type="time-limit">
@@ -134,7 +134,7 @@
                 {{/each}}
             </select>
             <div class="dependent-settings-block">
-                <label for="email_notification_batching_period_edit_minutes" class="inline-block">
+                <label for="{{prefix}}email_notification_batching_period_edit_minutes" class="inline-block">
                     {{t 'Delay period (minutes)' }}:
                 </label>
                 <input type="text"
@@ -147,7 +147,7 @@
         </div>
 
         <div class="input-group">
-            <label for="realm_name_in_email_notifications_policy" class="dropdown-title">{{ settings_label.realm_name_in_email_notifications_policy }}</label>
+            <label for="{{prefix}}realm_name_in_email_notifications_policy" class="dropdown-title">{{ settings_label.realm_name_in_email_notifications_policy }}</label>
             <select name="realm_name_in_email_notifications_policy" class="setting_realm_name_in_email_notifications_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}realm_name_in_email_notifications_policy" data-setting-widget-type="number">
                 {{> dropdown_options_widget option_values=realm_name_in_email_notifications_policy_values}}
             </select>

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -16,7 +16,7 @@
                       prefix="id_"
                       is_checked=realm_invite_required
                       label=admin_settings_label.realm_invite_required}}
-                    <label for="realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}
+                    <label for="id_realm_invite_to_realm_policy" class="dropdown-title">{{t "Who can invite users to this organization" }}
                     </label>
                     <select name="realm_invite_to_realm_policy" id="id_realm_invite_to_realm_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_realm_policy_values}}
@@ -24,7 +24,7 @@
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_org_join_restrictions" class="dropdown-title">{{t "Restrict email domains of new users?" }}</label>
+                    <label for="id_realm_org_join_restrictions" class="dropdown-title">{{t "Restrict email domains of new users?" }}</label>
                     <select name="realm_org_join_restrictions" id="id_realm_org_join_restrictions" class="prop-element settings_select bootstrap-focus-style">
                         <option value="no_restriction">{{t "No restrictions" }}</option>
                         <option value="no_disposable_email">{{t "Don’t allow disposable email addresses" }}</option>
@@ -38,7 +38,7 @@
                     </div>
                 </div>
                 <div class="input-group time-limit-setting">
-                    <label for="realm_waiting_period_threshold" class="dropdown-title">
+                    <label for="id_realm_waiting_period_threshold" class="dropdown-title">
                         {{t "Waiting period before new members turn into full members" }}
                         {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
@@ -90,7 +90,7 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_create_public_stream_policy" class="dropdown-title">{{t "Who can create public streams" }}</label>
+                    <label for="id_realm_create_public_stream_policy" class="dropdown-title">{{t "Who can create public streams" }}</label>
                     <select name="realm_create_public_stream_policy" id="id_realm_create_public_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
@@ -104,25 +104,25 @@
                   is_disabled=disable_enable_spectator_access_setting
                   help_link="/help/public-access-option"}}
                 <div class="input-group realm_create_web_public_stream_policy">
-                    <label for="realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public streams" }}</label>
+                    <label for="id_realm_create_web_public_stream_policy" class="dropdown-title">{{t "Who can create web-public streams" }}</label>
                     <select name="realm_create_web_public_stream_policy" id="id_realm_create_web_public_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=create_web_public_stream_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_create_private_stream_policy" class="dropdown-title">{{t "Who can create private streams" }}</label>
+                    <label for="id_realm_create_private_stream_policy" class="dropdown-title">{{t "Who can create private streams" }}</label>
                     <select name="realm_create_private_stream_policy" id="id_realm_create_private_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
+                    <label for="id_realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_wildcard_mention_policy" class="dropdown-title">{{t "Who can use @all/@everyone mentions in large streams" }}
+                    <label for="id_realm_wildcard_mention_policy" class="dropdown-title">{{t "Who can use @all/@everyone mentions in large streams" }}
                         {{> ../help_link_widget link="/help/restrict-wildcard-mentions" }}
                     </label>
                     <select name="realm_wildcard_mention_policy" id="id_realm_wildcard_mention_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
@@ -153,7 +153,7 @@
                   label=admin_settings_label.realm_allow_edit_history}}
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_edit_limit_seconds" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
+                    <label for="id_realm_message_content_edit_limit_seconds" class="dropdown-title">{{t "Time limit for editing messages" }}</label>
                     <select name="realm_message_content_edit_limit_seconds" id="id_realm_message_content_edit_limit_seconds" class="prop-element settings_select bootstrap-focus-style" {{#unless realm_allow_message_editing}}disabled{{/unless}} data-setting-widget-type="time-limit">
                         {{#each msg_edit_limit_dropdown_values}}
                             <option value="{{value}}">{{text}}</option>
@@ -182,15 +182,15 @@
                 {{> settings_save_discard_widget section_name="moving-msgs" }}
             </div>
             <div class="input-group">
-                <label for="realm_edit_topic_policy" class="dropdown-title">{{t "Who can move messages to another topic" }}</label>
+                <label for="id_realm_edit_topic_policy" class="dropdown-title">{{t "Who can move messages to another topic" }}</label>
                 <select name="realm_edit_topic_policy" id="id_realm_edit_topic_policy" class="prop-element move-message-policy-setting settings_select bootstrap-focus-style" data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=edit_topic_policy_values}}
                 </select>
             </div>
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_within_stream_limit_seconds" class="dropdown-title">{{t "Time limit for editing topics" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
-                <select name="realm_move_messages_within_stream_limit_seconds" id="id_realm_move_messages_within_stream_limit_seconds" class="prop-element settings_select" data-setting-widget-type="time-limit">
+                <label for="id_realm_move_messages_within_stream_limit_seconds" class="dropdown-title">{{t "Time limit for editing topics" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <select name="realm_move_messages_within_stream_limit_seconds" id="id_realm_move_messages_within_stream_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
                     {{/each}}
@@ -207,7 +207,7 @@
             </div>
 
             <div class="input-group">
-                <label for="realm_move_messages_between_streams_policy">{{t "Who can move messages to another stream" }}
+                <label for="id_realm_move_messages_between_streams_policy">{{t "Who can move messages to another stream" }}
                 </label>
                 <select name="realm_move_messages_between_streams_policy" class="setting-widget prop-element bootstrap-focus-style move-message-policy-setting settings_select" id="id_realm_move_messages_between_streams_policy" data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=move_messages_between_streams_policy_values}}
@@ -215,7 +215,7 @@
             </div>
 
             <div class="input-group time-limit-setting">
-                <label for="realm_move_messages_between_streams_limit_seconds" class="dropdown-title">{{t "Time limit for moving messages between streams" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
+                <label for="id_realm_move_messages_between_streams_limit_seconds" class="dropdown-title">{{t "Time limit for moving messages between streams" }} <i>({{t "does not apply to moderators and administrators" }})</i></label>
                 <select name="realm_move_messages_between_streams_limit_seconds" id="id_realm_move_messages_between_streams_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
                     {{#each msg_move_limit_dropdown_values}}
                         <option value="{{value}}">{{text}}</option>
@@ -245,7 +245,7 @@
                     {{t "Administrators can delete any message." }}
                 </label>
                 <div class="input-group">
-                    <label for="realm_delete_own_message_policy" class="dropdown-title">
+                    <label for="id_realm_delete_own_message_policy" class="dropdown-title">
                         {{t "Who can delete their own messages" }}
                     </label>
                     <select name="realm_delete_own_message_policy" id="id_realm_delete_own_message_policy" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="number">
@@ -254,7 +254,7 @@
                 </div>
 
                 <div class="input-group time-limit-setting">
-                    <label for="realm_message_content_delete_limit_seconds" class="dropdown-title">
+                    <label for="id_realm_message_content_delete_limit_seconds" class="dropdown-title">
                         {{t "Time limit for deleting messages" }} <i>({{t "does not apply to administrators" }})</i>
                     </label>
                     <select name="realm_message_content_delete_limit_seconds" id="id_realm_message_content_delete_limit_seconds" class="prop-element bootstrap-focus-style settings_select" data-setting-widget-type="time-limit">
@@ -283,28 +283,28 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_bot_creation_policy">{{t "Who can add bots" }}</label>
+                    <label for="id_realm_bot_creation_policy">{{t "Who can add bots" }}</label>
                     <select name="realm_bot_creation_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_bot_creation_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=bot_creation_policy_values}}
                     </select>
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_user_group_edit_policy" class="dropdown-title">{{t "Who can create and manage user groups" }}</label>
+                    <label for="id_realm_user_group_edit_policy" class="dropdown-title">{{t "Who can create and manage user groups" }}</label>
                     <select name="realm_user_group_edit_policy" id="id_realm_user_group_edit_policy" class="prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_add_custom_emoji_policy" class="dropdown-title">{{t "Who can add custom emoji" }}</label>
+                    <label for="id_realm_add_custom_emoji_policy" class="dropdown-title">{{t "Who can add custom emoji" }}</label>
                     <select name="realm_add_custom_emoji_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_add_custom_emoji_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=common_policy_values}}
                     </select>
                 </div>
 
                 <div class="input-group">
-                    <label for="realm_private_message_policy">{{t "Who can use direct messages" }} ({{t "beta" }})
+                    <label for="id_realm_private_message_policy">{{t "Who can use direct messages" }} ({{t "beta" }})
                         {{> ../help_link_widget link="/help/restrict-direct-messages" }}
                     </label>
                     <select name="realm_private_message_policy" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_private_message_policy" data-setting-widget-type="number">

--- a/web/templates/settings/organization_profile_admin.hbs
+++ b/web/templates/settings/organization_profile_admin.hbs
@@ -18,7 +18,7 @@
                       value="{{ realm_name }}" maxlength="40" />
                 </div>
                 <div class="input-group admin-realm">
-                    <label for="realm_org_type" class="dropdown-title">{{t "Organization type" }}
+                    <label for="id_realm_org_type" class="dropdown-title">{{t "Organization type" }}
                         {{> ../help_link_widget link="/help/organization-type" }}
                     </label>
                     <select name="realm_org_type" class="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_org_type" data-setting-widget-type="number">
@@ -33,7 +33,7 @@
                   label=admin_settings_label.realm_want_advertise_in_communities_directory
                   help_link="/help/communities-directory"}}
                 <div class="input-group admin-realm">
-                    <label for="realm_description">{{t "Organization description" }}</label>
+                    <label for="id_realm_description">{{t "Organization description" }}</label>
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element settings_textarea"
                       maxlength="1000" data-setting-widget-type="string">{{ realm_description }}</textarea>
                 </div>

--- a/web/templates/settings/organization_settings_admin.hbs
+++ b/web/templates/settings/organization_settings_admin.hbs
@@ -102,7 +102,7 @@
             </div>
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
-                    <label for="realm_video_chat_provider" class="dropdown-title">
+                    <label for="id_realm_video_chat_provider" class="dropdown-title">
                         {{t 'Video call provider' }}
                     </label>
                     <select name="realm_video_chat_provider" class ="setting-widget prop-element settings_select bootstrap-focus-style" id="id_realm_video_chat_provider" data-setting-widget-type="number">
@@ -112,7 +112,7 @@
                     </select>
                 </div>
                 <div class="input-group">
-                    <label for="realm_giphy_rating" class="dropdown-title">
+                    <label for="id_realm_giphy_rating" class="dropdown-title">
                         {{t 'GIPHY integration' }}
                         {{> ../help_link_widget link=giphy_help_link }}
                     </label>

--- a/web/templates/settings/organization_user_settings_defaults.hbs
+++ b/web/templates/settings/organization_user_settings_defaults.hbs
@@ -30,7 +30,7 @@
           help_link="/help/read-receipts"}}
 
         <div class="input-group">
-            <label for="email_address_visibility" class="dropdown-title">{{t "Who can access user's email address" }}
+            <label for="realm_email_address_visibility" class="dropdown-title">{{t "Who can access user's email address" }}
                 {{> ../help_link_widget link="/help/configure-email-visibility" }}
             </label>
             <select name="email_address_visibility" class="email_address_visibility prop-element settings_select bootstrap-focus-style" data-setting-widget-type="number"

--- a/web/templates/settings/profile_settings.hbs
+++ b/web/templates/settings/profile_settings.hbs
@@ -17,7 +17,7 @@
 
                 <form class="timezone-setting-form">
                     <div class="input-group grid">
-                        <label for="timezone" class="dropdown-title inline-block">{{t "Time zone" }}</label>
+                        <label for="user_timezone" class="dropdown-title inline-block">{{t "Time zone" }}</label>
                         <div class="alert-notification timezone-setting-status"></div>
                         <div class="timezone-input">
                             <select name="timezone" id="user_timezone" class="bootstrap-focus-style settings_select">

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -35,7 +35,7 @@
                 </div>
             </section>
             <section class="block">
-                <label for="people_to_add">
+                <label>
                     <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
                 </label>
                 <div id="stream_subscription_error" class="stream_creation_error"></div>

--- a/web/templates/stream_settings/stream_types.hbs
+++ b/web/templates/stream_settings/stream_types.hbs
@@ -17,7 +17,7 @@
 </div>
 
 <div class="input-group">
-    <label class="dropdown-title">{{t 'Who can post to the stream?'}}
+    <label class="dropdown-title" for="id_stream_post_policy">{{t 'Who can post to the stream?'}}
         {{> ../help_link_widget link="/help/stream-sending-policy" }}
     </label>
     <select name="stream-post-policy" class="stream_post_policy_setting prop-element settings_select bootstrap-focus-style" id="id_stream_post_policy" data-setting-widget-type="number">
@@ -41,7 +41,7 @@
 {{#if (or is_owner is_stream_edit)}}
 <div>
     <div class="input-group inline-block message-retention-setting-group time-limit-setting">
-        <label class="dropdown-title">{{t "Message retention period" }}
+        <label class="dropdown-title" for="id_message_retention_days">{{t "Message retention period" }}
             {{> ../help_link_widget link="/help/message-retention-policy" }}
         </label>
 


### PR DESCRIPTION
- [x] Replace extraneous pointer cursors on text with text cursor, where the label is not associated with any input element.
- [x] Fix interaction between label and input element to focus on input/select fields on clicking on label.

--------------------------
Fixes: #21769

-----------------------------------

**Screenshots and screen captures:**

|Before | After |
|----------|----------|
| ![before](https://user-images.githubusercontent.com/66828942/231064365-7dae41b4-ea78-4f66-a727-81ad42970361.gif) | ![interaction](https://user-images.githubusercontent.com/66828942/231064395-c4b4862e-9764-4fbc-92dd-45fca0fd1aaa.gif)|
| ![text-before](https://user-images.githubusercontent.com/66828942/231064446-7ca2536a-0d8d-47e4-bb7c-a7096f330430.gif) | ![text](https://user-images.githubusercontent.com/66828942/231064473-c34e75ca-9831-481d-bbbf-ec8645945416.gif) |


-------------------------------------

Comment for reviewer:

- In the Personal Settings > Profile section, we have multiple input and select elements with a single label for all of them. With the new approach of fixing the `for` and `id` attributes, everything works fine and as expected, except for the `birthday` and `mentor` inputs. These inputs have a div element that doesn't show any interaction with the label.


![birthday](https://user-images.githubusercontent.com/66828942/231180197-3ac104ee-3a4b-4b65-b616-cef37b4b59d4.gif)

--------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
