### PR TITLE
unsubscribe-success: Update page for realm name and welcome emails.

### DIFF
--- a/templates/zerver/unsubscribe_success.html
+++ b/templates/zerver/unsubscribe_success.html
@@ -17,18 +17,19 @@
             <div class="white-box">
                 <p>
                     {% trans %}
-                    You've successfully unsubscribed from Zulip {{ subscription_type }} emails.
+                    You've successfully unsubscribed from Zulip {{ subscription_type }} emails for
+                    <a href="{{ realm_uri }}">{{ realm_name }}</a>.
                     {% endtrans %}
                 </p>
 
+                {% if subscription_type != "welcome" %}
                 <p>
                     {% trans %}
-                    You can undo this change or review your
-                    preferences in your
-                    <a href="{{ realm_uri }}/#settings/notifications">Zulip notification
-                    settings</a>.
+                    You can undo this change or review your preferences in your
+                    <a href="{{ realm_uri }}/#settings/notifications">notification settings</a>.
                     {% endtrans %}
                 </p>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Because unsubscribing from welcome emails cannot be undone, it is confusing that the unsubscribe success page suggests that the user can. Makes the second sentence about undoing the unsubscribe action conditional on the `subscription_type` not being "welcome". See first set of screenshots below.

Updates the first sentence to specifically note the Zulip realm that has been updated for the unsubscribe action so that it is clear for which Zulip organization the user's settings have been updated/changed, since the user might have accounts with various Zulip organizations (via Zulip Cloud or self-hosted servers) that use the same email account.

**Notes**:
- Do we want to make the organization name in the first sentence a link to the organization URL? Seems fine for non-welcome emails because there's a link to the user's notification settings tab for the Zulip organization. But the welcome email page doesn't have a link to the organization now.

---

**Screenshots and screen captures:**

<details>
<summary>Welcome emails unsubscribe success page</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-04-11 14-46-38](https://user-images.githubusercontent.com/63245456/231166827-df06d591-3084-4df4-abad-b04730791ae3.png) | ![Screenshot from 2023-04-11 14-39-22](https://user-images.githubusercontent.com/63245456/231166192-a9bb4327-ffbf-4bc2-b991-6b1087103f65.png)
</details>
<details>
<summary>Log-in emails unsubscribe success page</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-04-11 14-47-01](https://user-images.githubusercontent.com/63245456/231166984-6d960627-30ec-4d3d-acde-93246839e564.png) | ![Screenshot from 2023-04-11 14-40-41](https://user-images.githubusercontent.com/63245456/231166160-158132ea-3a32-44b2-ad14-4470a42f97a3.png)
</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
