### PR TITLE
bots: Replace / remove the display presence dot for bots with the zulip-bot icon.

### DIFF
--- a/web/src/pm_list_data.js
+++ b/web/src/pm_list_data.js
@@ -46,6 +46,7 @@ export function get_conversations() {
 
         let user_circle_class;
         let status_emoji_info;
+        let is_bot = false;
 
         if (!is_group) {
             const user_id = Number.parseInt(user_ids_string, 10);
@@ -53,10 +54,8 @@ export function get_conversations() {
             const recipient_user_obj = people.get_by_user_id(user_id);
 
             if (recipient_user_obj.is_bot) {
-                // Bots do not have status emoji, and are modeled as
-                // always present. We may want to use this space for a
-                // bot icon in the future.
-                user_circle_class = "user_circle_green";
+                // We display the bot icon rather than a user circle for bots.
+                is_bot = true;
             } else {
                 status_emoji_info = user_status.get_status_emoji(user_id);
             }
@@ -72,6 +71,7 @@ export function get_conversations() {
             status_emoji_info,
             user_circle_class,
             is_group,
+            is_bot,
         };
         display_objects.push(display_object);
     }

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -429,9 +429,8 @@ function format_conversation(conversation_data) {
             const user_id = Number.parseInt(last_msg.to_user_ids, 10);
             const user = people.get_by_user_id(user_id);
             if (user.is_bot) {
-                // Bots do not have status emoji, and are modeled as
-                // always present.
-                context.user_circle_class = "user_circle_green";
+                // We display the bot icon rather than a user circle for bots.
+                context.is_bot = true;
             } else {
                 context.user_circle_class = buddy_data.get_user_circle_class(user_id);
             }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -579,6 +579,10 @@ li.topic-list-item {
         position: relative;
         top: 0;
     }
+
+    .zulip-icon.zulip-icon-bot {
+        padding: 3px 0;
+    }
 }
 
 .zero-pm-unreads .pm-box,

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -256,6 +256,10 @@ li.show-more-topics {
 
             .pm_left_col {
                 min-width: $left_col_size;
+
+                & span:not(.user_circle) {
+                    opacity: 0.7;
+                }
             }
         }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -69,6 +69,10 @@
 .popover_user_name_row {
     display: flex;
     align-items: center;
+
+    .zulip-icon.zulip-icon-bot {
+        padding-left: 5px;
+    }
 }
 
 .user_info_popover_action_buttons {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -429,9 +429,16 @@ ul {
     }
 
     .user_profile_edit_button {
-        margin-left: 10px;
         width: 25px;
         text-align: center;
+    }
+
+    .user_profile_name {
+        margin-right: 10px;
+    }
+
+    .zulip-icon.zulip-icon-bot {
+        padding: 3px 0 0;
     }
 
     #user_profile_edit_button_icon {

--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -408,9 +408,9 @@
                 width: 14px;
                 height: 14px;
 
-                .fa-group {
+                .fa-group,
+                .zulip-icon.zulip-icon-bot {
                     font-size: 0.8rem;
-                    /* color: hsl(105, 2%, 50%); */
                     opacity: 0.6;
                 }
 

--- a/web/templates/pm_list_item.hbs
+++ b/web/templates/pm_list_item.hbs
@@ -4,6 +4,8 @@
         <div class="pm_left_col">
             {{#if is_group}}
             <span class="fa fa-group"></span>
+            {{else if is_bot}}
+            <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
             {{else}}
             <span class="{{user_circle_class}} user_circle"></span>
             {{/if}}

--- a/web/templates/recent_topic_row.hbs
+++ b/web/templates/recent_topic_row.hbs
@@ -18,6 +18,8 @@
                 <span class="pm_status_icon {{#unless is_group}}show-tooltip{{/unless}}" data-tippy-placement="top" data-user-ids-string="{{user_ids_string}}">
                     {{#if is_group}}
                     <span class="fa fa-group"></span>
+                    {{else if is_bot}}
+                    <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
                     {{else}}
                     <span class="{{user_circle_class}} user_circle"></span>
                     {{/if}}

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -2,9 +2,11 @@
     <div class="modal__overlay" tabindex="-1">
         <div class="modal__container new-style" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
             <div class="modal__header">
+                {{#unless is_bot}}
                 <div class="tippy-zulip-tooltip" data-tippy-content="{{last_seen}}">
                     <span class="{{user_circle_class}} user_circle user_profile_presence"></span>
                 </div>
+                {{/unless}}
                 <h1 class="modal__title user_profile_name_heading" id="name">
                     <span class="user_profile_name">{{full_name}}</span>
                     {{#if is_bot}}

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -91,6 +91,7 @@ test("get_conversations", ({override}) => {
 
     const expected_data = [
         {
+            is_bot: false,
             is_active: false,
             is_group: false,
             is_zero: false,
@@ -112,6 +113,7 @@ test("get_conversations", ({override}) => {
             url: "#narrow/pm-with/101,102-group",
             user_circle_class: undefined,
             is_group: true,
+            is_bot: false,
             status_emoji_info: undefined,
         },
     ];
@@ -149,8 +151,9 @@ test("get_conversations bot", ({override}) => {
             is_active: false,
             url: "#narrow/pm-with/314-Outgoing-webhook",
             status_emoji_info: undefined,
-            user_circle_class: "user_circle_green",
+            user_circle_class: "user_circle_empty",
             is_group: false,
+            is_bot: true,
         },
         {
             recipients: "Alice, Bob",
@@ -162,6 +165,7 @@ test("get_conversations bot", ({override}) => {
             user_circle_class: undefined,
             status_emoji_info: undefined,
             is_group: true,
+            is_bot: false,
         },
     ];
 


### PR DESCRIPTION
- [x] Remove the display presence dot for bots in user-profile-popover.
- [x] Fix the gap between user-name and zulip-bot-icon in user-profile-popover and user-card.
- [x] Replace the display presence dot for bots  with zulip-bot-icon in left-sidebar (pm-list) and recent conversations.
- [x]  Fixed the opacity of the group-icon and bot-icon in the PM-list to match the consistency of the left-sidebar.

--------------------------------------------

Fixes: #25066 
CZO: [Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Visual.20indicator.20discrepancy/near/1539650)

-------------------------------

**Screenshots and screen captures:**

| Before: | After: |
|------------|----------|
| ![Screenshot from 2023-04-11 18-30-09](https://user-images.githubusercontent.com/66828942/231173369-802912ec-703b-4762-861c-d4c4131c6d8f.png) | ![Screenshot from 2023-04-11 22-47-07](https://user-images.githubusercontent.com/66828942/231244271-c8aa0cc8-2c3d-425b-a25a-c2aa5cd2e235.png) |
| ![Screenshot from 2023-04-18 04-46-35](https://user-images.githubusercontent.com/66828942/232630595-b5835d4f-9ecc-4afc-9224-ee8e15a05e78.png) |![Screenshot from 2023-04-18 06-03-58](https://user-images.githubusercontent.com/66828942/232639225-72da2963-686f-4020-9c36-4f335ec2712b.png)|
![Screenshot from 2023-04-18 04-46-45](https://user-images.githubusercontent.com/66828942/232631019-b8e39c71-d0e1-4d07-8b30-eca15b108a66.png) |![Screenshot from 2023-04-18 04-42-08](https://user-images.githubusercontent.com/66828942/232631026-149bb74a-e246-4f7e-8979-e2b5530badbe.png) |
![Screenshot from 2023-04-18 04-47-00](https://user-images.githubusercontent.com/66828942/232631232-05d89e67-9211-4974-8c18-b485b00e10a4.png) | ![Screenshot from 2023-04-18 04-50-40](https://user-images.githubusercontent.com/66828942/232631426-b5f2e3ec-0086-4062-a34f-ebd66a2ae0ca.png) |



---------------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
