### PR TITLE
left_sidebar: Fix 'more topics' view scroll position.

### DIFF
--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -31,7 +31,7 @@ export function set_count(count) {
     ui_util.update_unread_count_in_dom(get_private_messages_section_header(), count);
 }
 
-function close() {
+export function close() {
     private_messages_collapsed = true;
     $("#toggle_private_messages_section_icon").removeClass("fa-caret-down");
     $("#toggle_private_messages_section_icon").addClass("fa-caret-right");
@@ -100,7 +100,13 @@ export function update_private_messages() {
 }
 
 export function expand() {
+    // Only one thing can be zoomed at a time.
+    if (topic_zoom.is_zoomed_in()) {
+        topic_zoom.zoom_out();
+    }
+
     private_messages_collapsed = false;
+
     $("#toggle_private_messages_section_icon").addClass("fa-caret-down");
     $("#toggle_private_messages_section_icon").removeClass("fa-caret-right");
     update_private_messages();

--- a/web/src/topic_zoom.js
+++ b/web/src/topic_zoom.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import * as pm_list from "./pm_list";
 import * as popovers from "./popovers";
 import * as stream_list from "./stream_list";
 import * as topic_list from "./topic_list";
@@ -15,6 +16,7 @@ function zoom_in() {
     const stream_id = topic_list.active_stream_id();
 
     popovers.hide_all_except_sidebars();
+    pm_list.close();
     topic_list.zoom_in();
     stream_list.zoom_in_topics({
         stream_id,


### PR DESCRIPTION
> I am a GSOC '23 applicant.

'DIRECT MESSAGES' are completely collapsed in the 'more topics' view.

Clicking on 'DIRECT MESSAGES' exits the 'more topics' view and scrolls to it from that state.  
One wouldn't be able to open 'DIRECT MESSAGES' without leaving the 'more topics' view.

Fixes: #25035.

**Screenshots and screen captures:**

<details><summary>Screencast of the left sidebar</summary>
<video src="https://user-images.githubusercontent.com/55971005/230723908-076415dd-c071-48fa-a5a0-6d6000354efc.webm">
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
