### PR TITLE
topic_sidebar_actions: Revamp topic mute/unmute UI in sidebar actions menu.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -139,7 +139,6 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
         topic_name,
         topic_muted,
         topic_unmuted,
-        development_environment: page_params.development_environment,
         can_move_topic,
         can_rename_topic,
         is_realm_admin: page_params.is_admin,

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -8,41 +8,39 @@
 
     <hr />
 
-    {{#if development_environment}}
-        {{#if stream_muted}}
-            {{#unless topic_unmuted}}
-                <li class="hidden-for-spectators">
-                    <a tabindex="0" class="sidebar-popover-unmute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-                        <i class="zulip-icon zulip-icon-unmute" aria-hidden="true"></i>
-                        {{t "Unmute topic (muted stream)"}}
-                    </a>
-                </li>
-            {{else}}
-                <li class="hidden-for-spectators">
-                    <a tabindex="0" class="sidebar-popover-remove-unmute" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-                        <i class="zulip-icon zulip-icon-unmute" aria-hidden="true"></i>
-                        {{t "Mute topic (muted stream)"}}
-                    </a>
-                </li>
-            {{/unless}}
-        {{/if}}
-    {{/if}}
-
-    {{#unless topic_muted}}
-    <li class="hidden-for-spectators">
-        <a tabindex="0" class="sidebar-popover-mute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
-            {{t "Mute topic"}}
-        </a>
-    </li>
+    {{#if stream_muted}}
+        {{#unless topic_unmuted}}
+            <li class="hidden-for-spectators">
+                <a tabindex="0" class="sidebar-popover-unmute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+                    <i class="zulip-icon zulip-icon-unmute" aria-hidden="true"></i>
+                    {{t "Unmute topic"}}
+                </a>
+            </li>
+        {{else}}
+            <li class="hidden-for-spectators">
+                <a tabindex="0" class="sidebar-popover-remove-unmute" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+                    <i class="zulip-icon zulip-icon-unmute" aria-hidden="true"></i>
+                    {{t "Mute topic"}}
+                </a>
+            </li>
+        {{/unless}}
     {{else}}
-    <li class="hidden-for-spectators">
-        <a tabindex="0" class="sidebar-popover-remove-mute" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
-            {{t "Unmute topic"}}
-        </a>
-    </li>
-    {{/unless}}
+        {{#unless topic_muted}}
+        <li class="hidden-for-spectators">
+            <a tabindex="0" class="sidebar-popover-mute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+                <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
+                {{t "Mute topic"}}
+            </a>
+        </li>
+        {{else}}
+        <li class="hidden-for-spectators">
+            <a tabindex="0" class="sidebar-popover-remove-mute" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+                <i class="zulip-icon zulip-icon-mute" aria-hidden="true"></i>
+                {{t "Unmute topic"}}
+            </a>
+        </li>
+        {{/unless}}
+    {{/if}}
 
     {{#if has_starred_messages}}
     <li class="hidden-for-spectators">


### PR DESCRIPTION
This PR solves the First part under Left sidebar section of #24243:
For topics in muted streams, replace the "Mute topic" option in the three-dot topic menu with an "Unmute topic" option, which should make the topic unmuted. For unmuted topics in muted streams, show the regular "Mute topic" option, which should specifically mark the topic as muted, as usual.

Fixes part of #24243

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Topic in an unmuted stream(same as before):

![image](https://user-images.githubusercontent.com/64723994/231257527-0ff964cb-1baf-46aa-8f72-28fe918438aa.png)

- Muted topic in an unmuted stream(same as before):

![image](https://user-images.githubusercontent.com/64723994/231258426-fe206169-bb5c-408c-8007-afe4da896b2b.png)


- Topic in a muted stream[New behaviour]:

![image](https://user-images.githubusercontent.com/64723994/234399274-26a1f3fc-d93b-4e1d-987f-5ffe0949772e.png)

- Unmuted topic in a muted stream[New behaviour]:

![image](https://user-images.githubusercontent.com/64723994/234399344-940a350f-9cfb-4d26-866f-f6323579b56d.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
