### PR TITLE
emails: Fix email styling regression.

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -87,16 +87,10 @@ table td {
 }
 
 .footer td,
-.footer p,
-.footer span,
-.footer a {
+.footer span {
     color: #5f5ec7;
     font-size: 12px;
     text-align: center;
-}
-
-.footer .content-block p {
-    margin-top: 0;
 }
 
 h1,

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -11,7 +11,6 @@ img {
 }
 
 body {
-    background-color: #f5f9f8;
     font-family: sans-serif;
     font-size: 14px;
     line-height: 1.4;
@@ -40,7 +39,6 @@ table td {
 }
 
 .body {
-    background-color: #f5f9f8;
     width: 100%;
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This issue was introduced after we changed the library we use for
inlining CSS into email HTML. For some reason, the styles in
email.css were not applied earlier but were applied after we
migrated to css-inline. With this commit, we have fixed the
regression in email styles.

Fixes: #25083.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="850" alt="image" src="https://user-images.githubusercontent.com/53193850/231398938-aeb9ad67-f683-450a-9b6b-40a6f7eb382f.png">