### PR TITLE
message_edit: Show modal if user cannot resolve topics.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -5,6 +5,7 @@ import * as resolved_topic from "../shared/src/resolved_topic";
 import render_delete_message_modal from "../templates/confirm_dialog/confirm_delete_message.hbs";
 import render_confirm_moving_messages_modal from "../templates/confirm_dialog/confirm_moving_messages.hbs";
 import render_message_edit_form from "../templates/message_edit_form.hbs";
+import render_resolve_topic_time_limit_error_modal from "../templates/resolve_topic_time_limit_error_modal.hbs";
 import render_topic_edit_form from "../templates/topic_edit_form.hbs";
 
 import * as blueslip from "./blueslip";
@@ -30,6 +31,7 @@ import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
+import * as timerender from "./timerender";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as util from "./util";
@@ -603,9 +605,94 @@ export function start($row, edit_box_open_callback) {
     });
 }
 
+function get_resolve_topic_time_limit_error_string(time_limit, time_limit_unit, topic_is_resolved) {
+    if (topic_is_resolved) {
+        if (time_limit_unit === "minute") {
+            return $t(
+                {
+                    defaultMessage:
+                        "You do not have permission to unresolve topics with messages older than {N, plural, one {# minute} other {# minutes}} in this organization.",
+                },
+                {N: time_limit},
+            );
+        } else if (time_limit_unit === "hour") {
+            return $t(
+                {
+                    defaultMessage:
+                        "You do not have permission to unresolve topics with messages older than {N, plural, one {# hour} other {# hours}} in this organization.",
+                },
+                {N: time_limit},
+            );
+        }
+        return $t(
+            {
+                defaultMessage:
+                    "You do not have permission to unresolve topics with messages older than {N, plural, one {# day} other {# days}} in this organization.",
+            },
+            {N: time_limit},
+        );
+    }
+
+    if (time_limit_unit === "minute") {
+        return $t(
+            {
+                defaultMessage:
+                    "You do not have permission to resolve topics with messages older than {N, plural, one {# minute} other {# minutes}} in this organization.",
+            },
+            {N: time_limit},
+        );
+    } else if (time_limit_unit === "hour") {
+        return $t(
+            {
+                defaultMessage:
+                    "You do not have permission to resolve topics with messages older than {N, plural, one {# hour} other {# hours}} in this organization.",
+            },
+            {N: time_limit},
+        );
+    }
+    return $t(
+        {
+            defaultMessage:
+                "You do not have permission to resolve topics with messages older than {N, plural, one {# day} other {# days}} in this organization.",
+        },
+        {N: time_limit},
+    );
+}
+
+function handle_resolve_topic_failure_due_to_time_limit(topic_is_resolved) {
+    const time_limit_for_resolving_topic = timerender.get_time_limit_setting_in_appropriate_unit(
+        page_params.realm_move_messages_within_stream_limit_seconds,
+    );
+    const resolve_topic_time_limit_error_string = get_resolve_topic_time_limit_error_string(
+        time_limit_for_resolving_topic.value,
+        time_limit_for_resolving_topic.unit,
+        topic_is_resolved,
+    );
+
+    const html_body = render_resolve_topic_time_limit_error_modal({
+        topic_is_resolved,
+        resolve_topic_time_limit_error_string,
+    });
+    let modal_heading;
+    if (topic_is_resolved) {
+        modal_heading = $t_html({defaultMessage: "Could not unresolve topic"});
+    } else {
+        modal_heading = $t_html({defaultMessage: "Could not resolve topic"});
+    }
+    dialog_widget.launch({
+        html_heading: modal_heading,
+        html_body,
+        html_submit_button: $t_html({defaultMessage: "Close"}),
+        on_click() {},
+        single_footer_button: true,
+        focus_submit_on_open: true,
+    });
+}
+
 export function toggle_resolve_topic(message_id, old_topic_name) {
     let new_topic_name;
-    if (resolved_topic.is_resolved(old_topic_name)) {
+    const topic_is_resolved = resolved_topic.is_resolved(old_topic_name);
+    if (topic_is_resolved) {
         new_topic_name = resolved_topic.unresolve_name(old_topic_name);
     } else {
         new_topic_name = resolved_topic.resolve_name(old_topic_name);
@@ -621,6 +708,11 @@ export function toggle_resolve_topic(message_id, old_topic_name) {
     channel.patch({
         url: "/json/messages/" + message_id,
         data: request,
+        error(xhr) {
+            if (xhr.responseJSON.code === "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED") {
+                handle_resolve_topic_failure_due_to_time_limit(topic_is_resolved);
+            }
+        },
     });
 }
 

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -455,3 +455,25 @@ export function get_full_datetime(time: Date): string {
 
     return $t({defaultMessage: "{date} at {time}"}, {date: date_string, time: time_string});
 }
+
+type TimeLimitSetting = {
+    value: number;
+    unit: string;
+};
+
+export function get_time_limit_setting_in_appropriate_unit(
+    time_limit_in_seconds: number,
+): TimeLimitSetting {
+    const time_limit_in_minutes = Math.floor(time_limit_in_seconds / 60);
+    if (time_limit_in_minutes < 60) {
+        return {value: time_limit_in_minutes, unit: "minute"};
+    }
+
+    const time_limit_in_hours = Math.floor(time_limit_in_minutes / 60);
+    if (time_limit_in_hours < 24) {
+        return {value: time_limit_in_hours, unit: "hour"};
+    }
+
+    const time_limit_in_days = Math.floor(time_limit_in_hours / 24);
+    return {value: time_limit_in_days, unit: "day"};
+}

--- a/web/templates/resolve_topic_time_limit_error_modal.hbs
+++ b/web/templates/resolve_topic_time_limit_error_modal.hbs
@@ -1,0 +1,8 @@
+<p>
+    {{resolve_topic_time_limit_error_string}}
+    {{#if topic_is_resolved}}
+        {{t "Contact a moderator to unresolve this topic."}}
+    {{else}}
+        {{t "Contact a moderator to resolve this topic." }}
+    {{/if}}
+</p>


### PR DESCRIPTION
We show a modal if user is not allowed to resolve or unresolve topics due to time limit.
The modal just contains the text mentioning user cannot resolve topic without stating the count
of messages that are withing the time limit as we do not recommend partial resolving of topics.

<!-- Describe your pull request here.-->
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![resolve-unresolve-topic](https://user-images.githubusercontent.com/35494118/231414912-2daccc1e-75c9-4f17-943e-ccb8a26e1709.gif)


![Screenshot from 2023-04-12 14-53-51](https://user-images.githubusercontent.com/35494118/231414962-66b8e49c-4507-41f7-b1ac-a68f1c063b30.png)

![Screenshot from 2023-04-12 14-54-25](https://user-images.githubusercontent.com/35494118/231415021-05d7ba67-c860-4001-99ae-8c3ca4657ed2.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
