### PR TITLE
Use new lock and hash icons in stream modals and add icons to stream options in dropdown_list_widget.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -417,6 +417,7 @@ export function get_available_streams_for_moving_messages(current_stream_id) {
         .map((stream) => ({
             name: stream.name,
             value: stream.stream_id.toString(),
+            stream,
         }))
         .sort((a, b) => {
             if (a.name.toLowerCase() < b.name.toLowerCase()) {

--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -1011,6 +1011,7 @@ export function init_dropdown_widgets() {
         data: streams.map((x) => ({
             name: x.name,
             value: x.stream_id.toString(),
+            stream: x,
         })),
         on_update() {
             save_discard_widget_status_handler($("#org-notifications"));

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -833,13 +833,18 @@ div.overlay {
         font-size: 0.75em;
     }
 
-    &.fa-lock {
+    &.zulip-icon-lock {
+        position: relative;
+        top: 0.06em;
         padding-right: 1px;
-        font-size: 0.865em;
+        font-size: 0.8em;
     }
 
-    &.hashtag:empty::after {
-        font-size: 1em;
+    &.zulip-icon-hashtag {
+        position: relative;
+        top: 0.06em;
+        padding-right: 1px;
+        font-size: 0.75em;
     }
 }
 

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -828,7 +828,7 @@ div.overlay {
 .stream-privacy-type-icon {
     &.zulip-icon-globe {
         position: relative;
-        top: 1px;
+        top: 0.06em;
         padding-right: 1px;
         font-size: 0.75em;
     }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -826,25 +826,17 @@ div.overlay {
 }
 
 .stream-privacy-type-icon {
-    &.zulip-icon-globe {
-        position: relative;
-        top: 0.06em;
-        padding-right: 1px;
+    position: relative;
+    top: 0.06em;
+    padding-right: 1px;
+
+    &.zulip-icon-globe,
+    &.zulip-icon-hashtag {
         font-size: 0.75em;
     }
 
     &.zulip-icon-lock {
-        position: relative;
-        top: 0.06em;
-        padding-right: 1px;
         font-size: 0.8em;
-    }
-
-    &.zulip-icon-hashtag {
-        position: relative;
-        top: 0.06em;
-        padding-right: 1px;
-        font-size: 0.75em;
     }
 }
 

--- a/web/templates/inline_decorated_stream_name.hbs
+++ b/web/templates/inline_decorated_stream_name.hbs
@@ -1,8 +1,8 @@
 {{! This controls whether the swatch next to streams in the left sidebar has a lock icon. }}
 {{#if stream.invite_only }}
-<i class="fa fa-lock stream-privacy-type-icon" aria-hidden="true"></i>{{stream.name ~}}
+<i class="zulip-icon zulip-icon-lock stream-privacy-type-icon" aria-hidden="true"></i>{{stream.name ~}}
 {{ else if stream.is_web_public }}
 <i class="zulip-icon zulip-icon-globe stream-privacy-type-icon" aria-hidden="true"></i>{{stream.name ~}}
 {{ else }}
-<span class="hashtag stream-privacy-type-icon"></span>{{stream.name ~}}
+<i class="zulip-icon zulip-icon-hashtag stream-privacy-type-icon"></i>{{stream.name ~}}
 {{/if}}

--- a/web/templates/settings/dropdown_list.hbs
+++ b/web/templates/settings/dropdown_list.hbs
@@ -1,7 +1,11 @@
 {{#with item}}
 <li class="list_item" role="presentation" data-value="{{value}}">
     <a role="menuitem" tabindex="0">
-        {{name}}
+        {{#if stream}}
+            {{> ../inline_decorated_stream_name stream=stream}}
+        {{else}}
+            {{name}}
+        {{/if}}
     </a>
 </li>
 {{/with}}


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to use new lock and hash icons in `inline_decorated_stream_name` template.
- Second commit is to add stream-privacy icons in dropdown_list_widget.

Fixes part of #22355 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Using new icons -
![private-big](https://user-images.githubusercontent.com/35494118/231497306-7b210e63-52f5-4733-ab63-8eee0f5af1c2.png)
![private-small](https://user-images.githubusercontent.com/35494118/231497342-488bcbff-6e89-4d46-a0e1-a79f9d97bfb6.png)
![public-big](https://user-images.githubusercontent.com/35494118/231497366-1a33476b-de67-46d7-9e9b-eab9e14c187e.png)
![public-small](https://user-images.githubusercontent.com/35494118/231497380-90d7261a-895a-45ec-9070-2d6dd4d5f277.png)

Icons in dropdown list widgets
![privacy-icons-dropdown](https://user-images.githubusercontent.com/35494118/231497504-ed370265-9b24-41a3-8b03-41c0592a8aeb.png)
![move-topic-dropdown-privacy-icon](https://user-images.githubusercontent.com/35494118/231497545-b7702c7a-b19a-4191-b57e-566ad3855e75.png)
![dropdown-privacy-icons](https://user-images.githubusercontent.com/35494118/231497568-32ab69cf-1e02-450d-b8eb-3a40175c428b.gif)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
