### PR TITLE
search: Improve suggestions for `is:resolved` and `group-pm-with`.

### DIFF
--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -102,6 +102,7 @@ function get_stream_suggestions(last, operators) {
         {operator: "streams"},
         {operator: "is", operand: "private"},
         {operator: "pm-with"},
+        {operator: "group-pm-with"},
     ];
     if (!check_validity(last, operators, valid, invalid)) {
         return [];
@@ -235,7 +236,7 @@ function make_people_getter(last) {
     };
 }
 
-// Possible args for autocomplete_operator: pm-with, sender, from
+// Possible args for autocomplete_operator: pm-with, sender, from, group-pm-with
 function get_person_suggestions(people_getter, last, operators, autocomplete_operator) {
     if (last.operator === "is" && last.operand === "private") {
         // Interpret 'is:private' as equivalent to 'pm-with:'
@@ -251,11 +252,22 @@ function get_person_suggestions(people_getter, last, operators, autocomplete_ope
 
     const valid = ["search", autocomplete_operator];
     let invalid;
-    if (autocomplete_operator === "pm-with") {
-        invalid = [{operator: "pm-with"}, {operator: "stream"}];
-    } else {
-        // If not pm-with, then this must either be 'sender' or 'from'
-        invalid = [{operator: "sender"}, {operator: "from"}];
+
+    switch (autocomplete_operator) {
+        case "group-pm-with":
+            invalid = [{operator: "stream"}, {operator: "is", operand: "resolved"}];
+            break;
+        case "pm-with":
+            invalid = [
+                {operator: "pm-with"},
+                {operator: "stream"},
+                {operator: "is", operand: "resolved"},
+            ];
+            break;
+        case "sender":
+        case "from":
+            invalid = [{operator: "sender"}, {operator: "from"}];
+            break;
     }
 
     if (!check_validity(last, operators, valid, invalid)) {
@@ -338,6 +350,7 @@ function get_topic_suggestions(last, operators) {
     const invalid = [
         {operator: "pm-with"},
         {operator: "is", operand: "private"},
+        {operator: "group-pm-with"},
         {operator: "topic"},
     ];
     if (!check_validity(last, operators, ["stream", "topic", "search"], invalid)) {
@@ -509,6 +522,7 @@ function get_is_filter_suggestions(last, operators) {
             description_html: "direct messages",
             invalid: [
                 {operator: "is", operand: "private"},
+                {operator: "is", operand: "resolved"},
                 {operator: "stream"},
                 {operator: "pm-with"},
                 {operator: "in"},
@@ -537,7 +551,12 @@ function get_is_filter_suggestions(last, operators) {
         {
             search_string: "is:resolved",
             description_html: "topics marked as resolved",
-            invalid: [{operator: "is", operand: "resolved"}],
+            invalid: [
+                {operator: "is", operand: "resolved"},
+                {operator: "is", operand: "private"},
+                {operator: "pm-with"},
+                {operator: "group-pm-with"},
+            ],
         },
     ];
     return get_special_filter_suggestions(last, operators, suggestions);

--- a/web/tests/search_suggestion_future.test.js
+++ b/web/tests/search_suggestion_future.test.js
@@ -538,7 +538,6 @@ test("check_is_suggestions", ({override}) => {
         "is:mentioned",
         "is:alerted",
         "is:unread",
-        "is:resolved",
         "sender:myself@zulip.com",
         "has:link",
         "has:image",


### PR DESCRIPTION
Improves suggestions to not include `is:resolved` for searches that have already specified a narrow with direct messages, since there are no topics for direct messages. And improves suggestions for searches that already have `is:resolved` to not include options that narrow to direct messages.

Improves suggestions to not include `group-pm-with` for searches that have already specified a narrow for stream messages. And improves suggestions for searches that already have `group-pm-with` to not include options that narrow to stream messages.

*Note: This is a prep commit in WIP #25003; it's there so that conflicts are already dealt with in that PR if this is merged.*

---

**Screenshots and screen captures:**

<details>
<summary>Resolved topic search suggestions</summary>

| Before | After |
| --- | --- |
|  ![Screenshot from 2023-04-12 19-46-21](https://user-images.githubusercontent.com/63245456/231542367-2f0a78a9-6fab-4cdc-a694-06fbadc778a4.png) | ![Screenshot from 2023-04-12 19-49-45](https://user-images.githubusercontent.com/63245456/231542568-c7b40a73-6193-42e3-9055-e12ccc6877de.png)
| ![Screenshot from 2023-04-12 19-46-40](https://user-images.githubusercontent.com/63245456/231542822-89b5649b-4149-4acc-ac21-0b32f23e2f52.png) | ![Screenshot from 2023-04-12 19-50-14](https://user-images.githubusercontent.com/63245456/231542832-1e463b8c-19ed-40ca-beb4-d39c2d2b96ac.png)
| ![Screenshot from 2023-04-12 19-46-53](https://user-images.githubusercontent.com/63245456/231542987-cd0b2e78-4c7e-47dd-89be-39b4ecf9d677.png) |![Screenshot from 2023-04-12 19-50-25](https://user-images.githubusercontent.com/63245456/231542992-79ef4bf5-c6c6-4da0-95bb-9ac882dbb619.png)
</details>
<details>
<summary>Direct messages search suggestions</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-04-12 19-48-37](https://user-images.githubusercontent.com/63245456/231543255-d0e8a87d-63c7-4350-aae6-615ebcfe5b5a.png) | ![Screenshot from 2023-04-12 19-51-13](https://user-images.githubusercontent.com/63245456/231543258-f0b54df7-4af0-4750-aecc-e20c4e338fce.png)

</details>
<details>
<summary>Group direct message with search suggestions</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-04-12 19-48-24](https://user-images.githubusercontent.com/63245456/231543665-bb9cf2ef-44bf-43d8-8540-08cf413209df.png) | ![Screenshot from 2023-04-12 19-50-59](https://user-images.githubusercontent.com/63245456/231543670-895e4ae6-6461-4526-8c95-d304d237f202.png)
| ![Screenshot from 2023-04-12 19-47-50](https://user-images.githubusercontent.com/63245456/231543965-7980c69b-3d9e-4aa2-907e-f1081f60341a.png) | ![Screenshot from 2023-04-12 19-50-46](https://user-images.githubusercontent.com/63245456/231544027-f955cf6c-bd93-40ff-9010-fab38fd88b69.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
