### PR TITLE
left_sidebar: Implement new unread_count logic and font styling for muted streams.

### DIFF
--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -37,17 +37,23 @@ export function update_count_in_dom(
     $stream_li,
     stream_counts,
     stream_has_any_unread_mention_messages,
+    stream_has_any_unmuted_unread_mention,
 ) {
     // The subscription_block properly excludes the topic list,
     // and it also has sensitive margins related to whether the
     // count is there or not.
     const $subscription_block = $stream_li.find(".subscription_block");
 
-    ui_util.update_unread_count_in_dom($subscription_block, count);
     ui_util.update_unread_mention_info_in_dom(
         $subscription_block,
         stream_has_any_unread_mention_messages,
     );
+
+    if (stream_has_any_unmuted_unread_mention) {
+        $subscription_block.addClass("has-unmuted-mentions");
+    } else {
+        $subscription_block.removeClass("has-unmuted-mentions");
+    }
 
     // Here we set the count and compute the values of two classes:
     // .stream-with-count is used for the layout CSS to know whether
@@ -388,7 +394,15 @@ class StreamSidebarRow {
         const stream_has_any_unread_mention_messages = unread.stream_has_any_unread_mentions(
             this.sub.stream_id,
         );
-        update_count_in_dom(this.$list_item, count, stream_has_any_unread_mention_messages);
+        const stream_has_any_unmuted_unread_mention = unread.stream_has_any_unmuted_mentions(
+            this.sub.stream_id,
+        );
+        update_count_in_dom(
+            this.$list_item,
+            count,
+            stream_has_any_unread_mention_messages,
+            stream_has_any_unmuted_unread_mention,
+        );
     }
 }
 
@@ -425,7 +439,12 @@ export function redraw_stream_privacy(sub) {
     $div.html(html);
 }
 
-function set_stream_unread_count(stream_id, count, stream_has_any_unread_mention_messages) {
+function set_stream_unread_count(
+    stream_id,
+    count,
+    stream_has_any_unread_mention_messages,
+    stream_has_any_unmuted_unread_mention,
+) {
     const $stream_li = get_stream_li(stream_id);
     if (!$stream_li) {
         // This can happen for legitimate reasons, but we warn
@@ -433,7 +452,12 @@ function set_stream_unread_count(stream_id, count, stream_has_any_unread_mention
         blueslip.warn("stream id no longer in sidebar: " + stream_id);
         return;
     }
-    update_count_in_dom($stream_li, count, stream_has_any_unread_mention_messages);
+    update_count_in_dom(
+        $stream_li,
+        count,
+        stream_has_any_unread_mention_messages,
+        stream_has_any_unmuted_unread_mention,
+    );
 }
 
 export function update_streams_sidebar(force_rerender) {
@@ -467,7 +491,14 @@ export function update_dom_with_unread_counts(counts) {
     for (const [stream_id, count] of counts.stream_count) {
         const stream_has_any_unread_mention_messages =
             counts.streams_with_mentions.includes(stream_id);
-        set_stream_unread_count(stream_id, count, stream_has_any_unread_mention_messages);
+        const stream_has_any_unmuted_unread_mention =
+            counts.streams_with_unmuted_mentions.includes(stream_id);
+        set_stream_unread_count(
+            stream_id,
+            count,
+            stream_has_any_unread_mention_messages,
+            stream_has_any_unmuted_unread_mention,
+        );
     }
 }
 

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -33,7 +33,11 @@ export let stream_cursor;
 
 let has_scrolled = false;
 
-export function update_count_in_dom($stream_li, count, stream_has_any_unread_mention_messages) {
+export function update_count_in_dom(
+    $stream_li,
+    stream_counts,
+    stream_has_any_unread_mention_messages,
+) {
     // The subscription_block properly excludes the topic list,
     // and it also has sensitive margins related to whether the
     // count is there or not.
@@ -45,10 +49,38 @@ export function update_count_in_dom($stream_li, count, stream_has_any_unread_men
         stream_has_any_unread_mention_messages,
     );
 
-    if (count === 0) {
+    // Here we set the count and compute the values of two classes:
+    // .stream-with-count is used for the layout CSS to know whether
+    // to leave space for the unread count, and has-unmuted-unreads is
+    // used in muted streams to set the fading correctly to indicate
+    // those are unread
+    if (stream_counts.unmuted_count > 0 && !stream_counts.stream_is_muted) {
+        // Normal stream, has unmuted unreads; display normally.
+        ui_util.update_unread_count_in_dom($subscription_block, stream_counts.unmuted_count);
+        $subscription_block.addClass("stream-with-count");
+        $subscription_block.removeClass("has-unmuted-unreads");
+    } else if (stream_counts.unmuted_count > 0 && stream_counts.stream_is_muted) {
+        // Muted stream, has unmuted unreads.
+        ui_util.update_unread_count_in_dom($subscription_block, stream_counts.unmuted_count);
+        $subscription_block.addClass("stream-with-count");
+        $subscription_block.addClass("has-unmuted-unreads");
+    } else if (stream_counts.muted_count > 0 && stream_counts.stream_is_muted) {
+        // Muted stream, only muted unreads.
+        ui_util.update_unread_count_in_dom($subscription_block, stream_counts.muted_count);
+        $subscription_block.addClass("stream-with-count");
+        $subscription_block.removeClass("has-unmuted-unreads");
+    } else if (stream_counts.muted_count > 0 && !stream_counts.stream_is_muted) {
+        // Normal stream, only muted unreads: display nothing. The
+        // current thinking is displaying those counts with muted
+        // styling would be more distracting than helpful.
+        ui_util.update_unread_count_in_dom($subscription_block, 0);
+        $subscription_block.removeClass("has-unmuted-unreads");
         $subscription_block.removeClass("stream-with-count");
     } else {
-        $subscription_block.addClass("stream-with-count");
+        // No unreads: display nothing.
+        ui_util.update_unread_count_in_dom($subscription_block, 0);
+        $subscription_block.removeClass("has-unmuted-unreads");
+        $subscription_block.removeClass("stream-with-count");
     }
 }
 

--- a/web/src/topic_list_data.js
+++ b/web/src/topic_list_data.js
@@ -16,6 +16,7 @@ function choose_topics(stream_id, topic_names, zoomed, topic_choice_state) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
         const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
+        const is_topic_unmuted = user_topics.is_topic_unmuted(stream_id, topic_name);
         const [topic_resolved_prefix, topic_display_name] =
             resolved_topic.display_parts(topic_name);
         // Important: Topics are lower-case in this set.
@@ -90,6 +91,7 @@ function choose_topics(stream_id, topic_names, zoomed, topic_choice_state) {
             unread: num_unread,
             is_zero: num_unread === 0,
             is_muted: is_topic_muted,
+            is_unmuted: is_topic_unmuted,
             is_active_topic,
             url: hash_util.by_stream_topic_url(stream_id, topic_name),
             contains_unread_mention,

--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -438,6 +438,21 @@ class UnreadTopicCounter {
         return streams_with_mentions;
     }
 
+    get_streams_with_unmuted_mentions() {
+        const streams_with_unmuted_mentions = new Set();
+        // Collect the set of streams containing at least one mention
+        // in an unmuted topic within a muted stream.
+        for (const message_id of unread_mentions_counter) {
+            const stream_id = this.bucketer.reverse_lookup.get(message_id);
+            const stream_bucketer = this.bucketer.get_bucket(stream_id);
+            const topic = stream_bucketer.reverse_lookup.get(message_id);
+            if (user_topics.is_topic_unmuted(stream_id, topic)) {
+                streams_with_unmuted_mentions.add(stream_id);
+            }
+        }
+        return streams_with_unmuted_mentions;
+    }
+
     topic_has_any_unread(stream_id, topic) {
         const per_stream_bucketer = this.bucketer.get_bucket(stream_id);
 
@@ -730,9 +745,11 @@ export function get_counts() {
     // This sets stream_count, topic_count, and home_unread_messages
     const topic_res = unread_topic_counter.get_counts();
     const streams_with_mentions = unread_topic_counter.get_streams_with_unread_mentions();
+    const streams_with_unmuted_mentions = unread_topic_counter.get_streams_with_unmuted_mentions();
     res.home_unread_messages = topic_res.stream_unread_messages;
     res.stream_count = topic_res.stream_count;
     res.streams_with_mentions = [...streams_with_mentions];
+    res.streams_with_unmuted_mentions = [...streams_with_unmuted_mentions];
 
     const pm_res = unread_pm_counter.get_counts();
     res.pm_count = pm_res.pm_dict;
@@ -783,6 +800,13 @@ export function stream_has_any_unread_mentions(stream_id) {
     // This function is somewhat inefficient and thus should not be
     // called in loops, since runs in O(total unread mentions) time.
     const streams_with_mentions = unread_topic_counter.get_streams_with_unread_mentions();
+    return streams_with_mentions.has(stream_id);
+}
+
+export function stream_has_any_unmuted_mentions(stream_id) {
+    // This function is somewhat inefficient and thus should not be
+    // called in loops, since runs in O(total unread mentions) time.
+    const streams_with_mentions = unread_topic_counter.get_streams_with_unmuted_mentions();
     return streams_with_mentions.has(stream_id);
 }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -32,6 +32,10 @@
             color: inherit;
         }
 
+        .has-unmuted-mentions .unread_mention_info {
+            color: hsl(236deg 33% 90%);
+        }
+
         & li.muted_topic,
         li.out_of_home_view {
             color: hsl(236deg 33% 90%/50%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -37,6 +37,10 @@
             color: hsl(236deg 33% 90%/50%);
         }
 
+        & li.unmuted_topic {
+            color: hsl(236deg 33% 90%);
+        }
+
         & li.out_of_home_view {
             &:hover {
                 color: hsl(236deg 33% 90%/ 75%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -25,8 +25,23 @@
         }
     }
 
-    & ul.filters a:hover {
-        color: inherit;
+    & ul.filters {
+        color: hsl(236deg 33% 90%);
+
+        & a:hover {
+            color: inherit;
+        }
+
+        & li.muted_topic,
+        li.out_of_home_view {
+            color: hsl(236deg 33% 90%/50%);
+        }
+
+        & li.out_of_home_view {
+            &:hover {
+                color: hsl(236deg 33% 90%/ 75%);
+            }
+        }
     }
 
     /************************* MODAL DARK THEME *******************/

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -346,6 +346,12 @@ ul.filters {
             opacity: 0.5;
         }
 
+        .has-unmuted-unreads {
+            .unread_count {
+                opacity: 1;
+            }
+        }
+
         & li.unmuted_topic {
             color: hsl(0deg 0% 20%);
 
@@ -365,6 +371,12 @@ ul.filters {
 
             .unread_count {
                 opacity: 0.75;
+            }
+
+            .has-unmuted-unreads {
+                .unread_count {
+                    opacity: 1;
+                }
             }
         }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -346,6 +346,13 @@ ul.filters {
             opacity: 0.5;
         }
 
+        & li.unmuted_topic {
+            color: hsl(0deg 0% 20%);
+
+            .unread_count {
+                opacity: 1;
+            }
+        }
     }
 
     & li.out_of_home_view {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -338,6 +338,10 @@ ul.filters {
     li.out_of_home_view {
         color: hsl(0deg 0% 20% / 50%);
 
+        .has-unmuted-mentions .unread_mention_info {
+            color: hsl(0deg 0% 20%);
+        }
+
         .stream-privacy {
             opacity: 0.5;
         }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -323,6 +323,7 @@ li.show-more-topics {
 ul.filters {
     list-style-type: none;
     margin-left: 0;
+    color: hsl(0deg 0% 20% / 100%);
 
     & a {
         color: inherit;
@@ -335,12 +336,29 @@ ul.filters {
 
     & li.muted_topic,
     li.out_of_home_view {
-        opacity: 0.5;
+        color: hsl(0deg 0% 20% / 50%);
+
+        .stream-privacy {
+            opacity: 0.5;
+        }
+
+        & .unread_count {
+            opacity: 0.5;
+        }
+
     }
 
     & li.out_of_home_view {
         &:hover {
-            opacity: 0.75;
+            color: hsla(0deg 0% 20% / 75%);
+
+            .stream-privacy {
+                opacity: 0.75;
+            }
+
+            .unread_count {
+                opacity: 0.75;
+            }
         }
 
         & li.muted_topic {

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -1,4 +1,4 @@
-<li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
+<li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} {{#if is_unmuted}}unmuted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
         <span class="sidebar-topic-check">
             {{topic_resolved_prefix}}

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -15,6 +15,7 @@ page_params.realm_users = [];
 // We use this with override.
 let num_unread_for_stream;
 let stream_has_any_unread_mentions;
+let stream_has_any_unmuted_mentions;
 const noop = () => {};
 
 mock_esm("../src/narrow_state", {
@@ -35,6 +36,7 @@ mock_esm("../src/unread", {
         muted_count: 0,
     }),
     stream_has_any_unread_mentions: () => stream_has_any_unread_mentions,
+    stream_has_any_unmuted_mentions: () => stream_has_any_unmuted_mentions,
 });
 
 const {Filter} = zrequire("../src/filter");

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -29,7 +29,11 @@ const scroll_util = mock_esm("../src/scroll_util", {
 });
 mock_esm("../src/ui", {get_scroll_element: ($element) => $element});
 mock_esm("../src/unread", {
-    num_unread_for_stream: () => num_unread_for_stream,
+    num_unread_for_stream: () => ({
+        unmuted_count: num_unread_for_stream,
+        stream_is_muted: false,
+        muted_count: 0,
+    }),
     stream_has_any_unread_mentions: () => stream_has_any_unread_mentions,
 });
 

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -19,6 +19,9 @@ const user_topics = mock_esm("../src/user_topics", {
     is_topic_muted() {
         return false;
     },
+    is_topic_unmuted() {
+        return false;
+    },
 });
 const narrow_state = mock_esm("../src/narrow_state", {
     topic() {},
@@ -91,6 +94,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         contains_unread_mention: false,
         is_active_topic: false,
         is_muted: false,
+        is_unmuted: false,
         is_zero: true,
         topic_display_name: "topic 9",
         topic_name: "✔ topic 9",
@@ -103,6 +107,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         contains_unread_mention: false,
         is_active_topic: false,
         is_muted: false,
+        is_unmuted: false,
         is_zero: true,
         topic_display_name: "topic 8",
         topic_name: "topic 8",

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -227,9 +227,9 @@ test("muting", () => {
 
     unread.process_loaded_messages([message]);
     let counts = unread.get_counts();
-    assert.equal(counts.stream_count.get(stream_id), 1);
+    assert.equal(counts.stream_count.get(stream_id).unmuted_count, 1);
     assert.equal(counts.home_unread_messages, 1);
-    assert.equal(unread.num_unread_for_stream(stream_id), 1);
+    assert.equal(unread.num_unread_for_stream(stream_id).unmuted_count, 1);
     assert.deepEqual(unread.get_msg_ids_for_stream(stream_id), [message.id]);
     test_notifiable_count(counts.home_unread_messages, 0);
 
@@ -239,9 +239,9 @@ test("muting", () => {
         user_topics.all_visibility_policies.MUTED,
     );
     counts = unread.get_counts();
-    assert.equal(counts.stream_count.get(stream_id), 0);
+    assert.equal(counts.stream_count.get(stream_id).unmuted_count, 0);
     assert.equal(counts.home_unread_messages, 0);
-    assert.equal(unread.num_unread_for_stream(stream_id), 0);
+    assert.equal(unread.num_unread_for_stream(stream_id).unmuted_count, 0);
     assert.deepEqual(unread.get_msg_ids_for_stream(stream_id), []);
     test_notifiable_count(counts.home_unread_messages, 0);
 
@@ -345,7 +345,7 @@ test("home_messages", () => {
 
     counts = unread.get_counts();
     assert.equal(counts.home_unread_messages, 1);
-    assert.equal(counts.stream_count.get(stream_id), 1);
+    assert.equal(counts.stream_count.get(stream_id).unmuted_count, 1);
     test_notifiable_count(counts.home_unread_messages, 0);
     unread.mark_as_read(message.id);
     counts = unread.get_counts();


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR fixes parts 2 and 3 of the Left sidebar section of #24243: 
- [x] Display unmuted topics in regular font (not faded).
- [x] If there are unread messages in an unmuted topic within a muted stream, replace the unread counter for the stream with a counter that just adds up all the unread messages in unmuted topics in the stream. The counter should be shown in regular color (not faded). When there are no unread messages in unmuted topics, we should show the stream counter as we currently do.

Commit 1[fbd1befa9c1202b89b7cc6f1b8a9841debc9772e]: Changed CSS for fading the muted stream. This will allow us to add
feature in the next commits in this PR to set the opacity of unread_count to 1 while keeping it at 0.5/0.75. 

Commit 2[8a05d9ba119cda6319dc44d7cbf38b62c60b7f92]: If unread messages of unmuted topics in muted stream>0, show stream_unmute_count in .unread_count and show it in regular font(not faded).

Commit 3[4cce16dcf6942118095a3f30b4836f1d0eed542b]: Add class unmuted_topic to li.bottom_left_row element if the topic is unmuted. Add relevant CSS for .unmuted_topic to display unmuted topics in regular font.

Note: In commit 2 8a05d9ba119cda6319dc44d7cbf38b62c60b7f92, the unread messages count of unmuted topics is being added to the `all_messages` unread counter. But, unread messages of unmuted topics are currently not shown in the `all_messages` view. It will be implemented in a separate PR for #24243 by @palashb01 soon.

Fixes: <!-- Issue link, or clear description.-->
#24243
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- The screenshot of a muted_stream has unread messages in the unmuted topic(`#support` stream) vs muted_stream has unread messages in normal topic(`#ビデオゲーム` stream):

![image](https://user-images.githubusercontent.com/64723994/231559605-8f5ad978-acc1-4857-8115-b044f70ce208.png)

- Muted stream showing unread count as the sum of unread messages in unmuted topics(not faded):

![image](https://user-images.githubusercontent.com/64723994/231560184-264a0bce-5e9b-4bd7-ac85-e4cc7e8850e7.png)

- Above ss when the stream is hovered:

![image](https://user-images.githubusercontent.com/64723994/231560380-086aeef2-7319-4c76-873e-b923e19b076c.png)

- Dark theme:

![image](https://user-images.githubusercontent.com/64723994/231560555-bfeb0717-1667-4932-88d2-976b8c6757c2.png)

- Dark theme with hover:

![image](https://user-images.githubusercontent.com/64723994/231560638-94b0dcbd-f2cd-4481-a05f-a1f0b9ff5d8b.png)

- Updated PR:
  - if a muted stream has an unread mention but no unread message in an unmuted topic:
  ![image](https://user-images.githubusercontent.com/64723994/231676038-bf92a5de-6c73-4922-99fc-3b1f26ca727e.png)

  - if a muted stream has an unread mention in a normal topic and also has unread messages in an unmuted topic:
    ![image](https://user-images.githubusercontent.com/64723994/231677262-e26c884f-77a5-472e-91f4-a0ad195d7655.png)
  
  - if a muted stream has unread mention in both unmuted and normal topic:
    ![image](https://user-images.githubusercontent.com/64723994/231677601-01e824a2-6d7d-4767-a76f-79746e00564f.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
