### PR TITLE
left_sidebar: Prioritize unmuted topics in non-zoomed topic list.

### DIFF
--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -250,6 +250,15 @@ test("get_list_info unreads", ({override}) => {
         return topic_name === "topic 4";
     });
 
+    // muting the stream and unmuting the topic 5
+    // this should make topic 5 at top in items array
+    general.is_muted = true;
+    add_unreads("topic 5", 1);
+    override(user_topics, "is_topic_unmuted", (stream_id, topic_name) => {
+        assert.equal(stream_id, general.stream_id);
+        return topic_name === "topic 5";
+    });
+
     list_info = get_list_info();
     assert.equal(list_info.items.length, 12);
     assert.equal(list_info.more_topics_unreads, 3);
@@ -259,11 +268,11 @@ test("get_list_info unreads", ({override}) => {
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
         [
+            "topic 5",
             "topic 0",
             "topic 1",
             "topic 2",
             "topic 3",
-            "topic 5",
             "topic 6",
             "topic 7",
             "topic 8",


### PR DESCRIPTION
This PR fixes part 4 of the Left sidebar section of https://github.com/zulip/zulip/issues/24243:
- [x] Show unmuted topics within a stream with priority over all muted topics, i.e., you'll see them at the top regardless of age in the default view before you click "more topics", even if muted topics have unreads. This will match what happens if you have some muted topics in a stream where topics are by default "not muted".


Created a new function `choose_topics` that loops through the topics and push filtered topics using `should_show_topic` function to `items` array if not zoomed else just push all topics directly to array.

If stream is muted and not zoomed call the `choose_topics` function twice, first with passing `unmuted_topics` and second time with passing remaining topics. else, call it only once with `topic_names`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#24243
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
https://user-images.githubusercontent.com/64723994/231698353-b1737eb4-cbd8-4c04-9d83-2196427ca812.mp4

example case: In muted stream(ビデオゲーム), Topics 1 to 10 are unmuted, topic 1 doesn't have unread hence it only shows 2-10(9 topics), and topics 14,15,16 are muted(inherit) and has unread hence are also shown(3topics) = 12 topics + 1 active topic(FAILED EXPORT). some other inherit topics have unread messages but are not shown as max_topics_with_unread limit reached.

- **!Zoomed:** 

![image](https://user-images.githubusercontent.com/64723994/233417581-b9e99656-c615-4275-ab24-1d296e99ef00.png)

- **Zoomed:**

![image](https://user-images.githubusercontent.com/64723994/233417882-55d909d4-3540-4b5b-b3eb-a183362ad437.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
