### PR TITLE
tooltips: Fix text overflowing.

### DIFF
--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -4,7 +4,7 @@
      * for tooltips here.
      */
     font-family: "Source Sans 3", sans-serif !important;
-    word-wrap: break-word;
+    overflow-wrap: anywhere;
     /* Contains stylistic variant of upper-case character "I" in Source Sans 3 */
     font-feature-settings: "ss01" on;
 


### PR DESCRIPTION
This PR fixes the text overflowing in tooltips. 

**Screenshots:**
Before: 
![image](https://user-images.githubusercontent.com/53193850/231839839-a3454a98-d189-42ee-8e0f-1f16182dcaab.png)
![image](https://user-images.githubusercontent.com/53193850/231840494-f467e986-f528-4606-a433-ae4d10581ce4.png)


After: 
![image](https://user-images.githubusercontent.com/53193850/231839872-ca546aa9-bf24-49ed-bc4a-24c746165dee.png)
![image](https://user-images.githubusercontent.com/53193850/231840507-dfdd8c5c-5705-4981-9d2d-2e8044fe3cd2.png)



[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/screenshot.20URL.20overflows.20tippy)
