### PR TITLE
direct_messages: Do not open compose box when navigating to DM conversation.

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -208,11 +208,6 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
     await common.pm_recipient.set(page, "cordelia@zulip.com");
     await page.reload();
 
-    // Reloading into a private messages narrow opens compose box.
-    await page.waitForSelector("#compose-textarea", {visible: true});
-    await page.click("#compose_close");
-
-    console.log("Reloading finished. Opening drafts again now.");
     await page.waitForSelector(drafts_button, {visible: true});
     await page.click(drafts_button);
 

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -24,7 +24,6 @@ import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload_state from "./reload_state";
 import * as resize from "./resize";
-import * as settings_config from "./settings_config";
 import * as spectators from "./spectators";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
@@ -585,16 +584,6 @@ export function quote_and_reply(opts) {
 }
 
 export function on_narrow(opts) {
-    // We use force_close when jumping between PM narrows with the "p" key,
-    // so that we don't have an open compose box that makes it difficult
-    // to cycle quickly through unread messages.
-    if (opts.force_close) {
-        // This closes the compose box if it was already open, and it is
-        // basically a noop otherwise.
-        cancel();
-        return;
-    }
-
     if (opts.trigger === "narrow_to_compose_target") {
         compose_fade.update_message_list();
         return;
@@ -607,36 +596,6 @@ export function on_narrow(opts) {
 
     if (compose_state.has_message_content() || compose_state.is_recipient_edited_manually()) {
         compose_fade.update_message_list();
-        return;
-    }
-
-    if (narrow_state.narrowed_by_pm_reply()) {
-        opts = fill_in_opts_from_current_narrowed_view("private", opts);
-        // Do not open compose box if an invalid recipient is present.
-        if (!opts.private_message_recipient) {
-            if (compose_state.composing()) {
-                cancel();
-            }
-            return;
-        }
-        // Do not open compose box if organization has disabled sending
-        // private messages and recipient is not a bot.
-        if (
-            page_params.realm_private_message_policy ===
-                settings_config.private_message_policy_values.disabled.code &&
-            opts.private_message_recipient
-        ) {
-            const emails = opts.private_message_recipient.split(",");
-            if (emails.length !== 1 || !people.get_by_email(emails[0]).is_bot) {
-                // If we are navigating between private message conversations,
-                // we want the compose box to close for non-bot users.
-                if (compose_state.composing()) {
-                    cancel();
-                }
-                return;
-            }
-        }
-        start("private");
         return;
     }
 

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -899,10 +899,7 @@ export function narrow_to_next_pm_string() {
 
     const filter_expr = [{operator: "pm-with", operand: pm_with}];
 
-    // force_close parameter is true to not auto open compose_box
-    const opts = {
-        force_close: true,
-    };
+    const opts = {};
 
     activate(filter_expr, opts);
 }

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -6,9 +6,6 @@ const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
-const {page_params} = require("./lib/zpage_params");
-
-const settings_config = zrequire("settings_config");
 
 const noop = () => {};
 
@@ -448,32 +445,11 @@ test("on_narrow", ({override, override_rewire}) => {
     let narrowed_by_topic_reply;
     override(narrow_state, "narrowed_by_topic_reply", () => narrowed_by_topic_reply);
 
-    let narrowed_by_pm_reply;
-    override(narrow_state, "narrowed_by_pm_reply", () => narrowed_by_pm_reply);
-
-    const steve = {
-        user_id: 90,
-        email: "steve@example.com",
-        full_name: "Steve Stephenson",
-        is_bot: false,
-    };
-    people.add_active_user(steve);
-
-    const bot = {
-        user_id: 91,
-        email: "bot@example.com",
-        full_name: "Steve's bot",
-        is_bot: true,
-    };
-    people.add_active_user(bot);
-
     let cancel_called = false;
     override_rewire(compose_actions, "cancel", () => {
         cancel_called = true;
     });
-    compose_actions.on_narrow({
-        force_close: true,
-    });
+    compose_actions.on_narrow({});
     assert.ok(cancel_called);
 
     let on_topic_narrow_called = false;
@@ -481,9 +457,7 @@ test("on_narrow", ({override, override_rewire}) => {
         on_topic_narrow_called = true;
     });
     narrowed_by_topic_reply = true;
-    compose_actions.on_narrow({
-        force_close: false,
-    });
+    compose_actions.on_narrow({});
     assert.ok(on_topic_narrow_called);
 
     let update_message_list_called = false;
@@ -492,54 +466,11 @@ test("on_narrow", ({override, override_rewire}) => {
         update_message_list_called = true;
     };
     compose_state.message_content("foo");
-    compose_actions.on_narrow({
-        force_close: false,
-    });
+    compose_actions.on_narrow({});
     assert.ok(update_message_list_called);
 
     compose_state.message_content("");
-    let start_called = false;
-    override_rewire(compose_actions, "start", () => {
-        start_called = true;
-    });
-    narrowed_by_pm_reply = true;
-    page_params.realm_private_message_policy =
-        settings_config.private_message_policy_values.disabled.code;
-    compose_actions.on_narrow({
-        force_close: false,
-        trigger: "not-search",
-        private_message_recipient: "steve@example.com",
-    });
-    assert.ok(!start_called);
-
-    compose_actions.on_narrow({
-        force_close: false,
-        trigger: "not-search",
-        private_message_recipient: "bot@example.com",
-    });
-    assert.ok(start_called);
-
-    page_params.realm_private_message_policy =
-        settings_config.private_message_policy_values.by_anyone.code;
-    compose_actions.on_narrow({
-        force_close: false,
-        trigger: "not-search",
-        private_message_recipient: "not@empty.com",
-    });
-    assert.ok(start_called);
-
-    start_called = false;
-    compose_actions.on_narrow({
-        force_close: false,
-        trigger: "search",
-        private_message_recipient: "",
-    });
-    assert.ok(!start_called);
-
-    narrowed_by_pm_reply = false;
     cancel_called = false;
-    compose_actions.on_narrow({
-        force_close: false,
-    });
+    compose_actions.on_narrow({});
     assert.ok(cancel_called);
 });


### PR DESCRIPTION
Remove `start("private")` call form on_narrow function in compose_actions.js.
Also, removed the if (narrow_state.narrowed_by_pm_reply()) logic that was used to keep compose_box closed in certain cases as now it will remain closed in every case.

Removed force_close option that was passed as opts.force_close to on_narrow that was used to keep compose_box closed while navigating between DMs, not needed it will remain closed now.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#25078
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
No still screenshots showing the change hence attaching the video:

https://user-images.githubusercontent.com/64723994/231818597-e07810c8-ce5c-48bf-8397-3f0fb787cb70.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
