### PR TITLE
compose: Add banner for unmuting the muted topic a message is sent to.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -39,6 +39,7 @@ import * as transmit from "./transmit";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import {user_settings} from "./user_settings";
+import * as user_topics from "./user_topics";
 import * as util from "./util";
 import * as zcommand from "./zcommand";
 
@@ -512,6 +513,28 @@ export function initialize() {
                 message_edit.toggle_resolve_topic(message_id, topic_name);
                 compose_validate.clear_topic_resolved_warning(true);
             });
+        },
+    );
+
+    $("#compose_banners").on(
+        "click",
+        `.${CSS.escape(
+            compose_banner.CLASSNAMES.unmute_topic_notification,
+        )} .compose_banner_action_button`,
+        (event) => {
+            event.preventDefault();
+
+            const $target = $(event.target).parents(".compose_banner");
+            const stream_id = Number.parseInt($target.attr("data-stream-id"), 10);
+            const topic_name = $target.attr("data-topic-name");
+
+            user_topics.set_user_topic_visibility_policy(
+                stream_id,
+                topic_name,
+                user_topics.all_visibility_policies.UNMUTED,
+                false,
+                true,
+            );
         },
     );
 

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -65,6 +65,10 @@ export function clear_warnings(): void {
     $(`#compose_banners .${CSS.escape(WARNING)}`).remove();
 }
 
+export function clear_all(): void {
+    $(`#compose_banners`).empty();
+}
+
 export function show_error_message(message: string, classname: string, $bad_input?: JQuery): void {
     $(`#compose_banners .${CSS.escape(classname)}`).remove();
 

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -17,9 +17,15 @@ const MESSAGE_SENT_CLASSNAMES = {
     narrow_to_recipient: "narrow_to_recipient",
     scheduled_message_banner: "scheduled_message_banner",
 };
+// Technically, unmute_topic_notification is a message sent banner, but
+// it has distinct behavior / look - it has an associated action button,
+// does not disappear on scroll - so we don't include it here, as it needs
+// to be handled separately.
 
 export const CLASSNAMES = {
     ...MESSAGE_SENT_CLASSNAMES,
+    // unmute topic notifications are styled like warnings but have distinct behaviour
+    unmute_topic_notification: "unmute_topic_notification warning-style",
     // warnings
     topic_resolved: "topic_resolved",
     recipient_not_subscribed: "recipient_not_subscribed",
@@ -43,9 +49,12 @@ export const CLASSNAMES = {
     user_not_subscribed: "user_not_subscribed",
 };
 
-export function clear_message_sent_banners(): void {
+export function clear_message_sent_banners(include_unmute_banner = true): void {
     for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {
         $(`#compose_banners .${CSS.escape(classname)}`).remove();
+    }
+    if (include_unmute_banner) {
+        clear_unmute_topic_notifications();
     }
     scroll_to_message_banner_message_id = null;
 }
@@ -63,6 +72,10 @@ export function clear_errors(): void {
 
 export function clear_warnings(): void {
     $(`#compose_banners .${CSS.escape(WARNING)}`).remove();
+}
+
+export function clear_unmute_topic_notifications(): void {
+    $(`#compose_banners .${CLASSNAMES.unmute_topic_notification.replaceAll(" ", ".")}`).remove();
 }
 
 export function clear_all(): void {

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -310,9 +310,7 @@ export function process_escape_key(e) {
 
             // Check for errors in compose box; close errors if they exist
             if ($(".compose_banner").length) {
-                compose_banner.clear_message_sent_banners();
-                compose_banner.clear_errors();
-                compose_banner.clear_warnings();
+                compose_banner.clear_all();
                 return true;
             }
 

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -198,7 +198,7 @@ export function scroll_finished() {
             compose_banner.scroll_to_message_banner_message_id,
         );
         if ($message_row.length > 0 && !message_viewport.is_message_below_viewport($message_row)) {
-            compose_banner.clear_message_sent_banners();
+            compose_banner.clear_message_sent_banners(false);
         }
     }
 

--- a/web/src/user_topics.js
+++ b/web/src/user_topics.js
@@ -2,6 +2,7 @@ import render_topic_muted from "../templates/topic_muted.hbs";
 
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
+import * as compose_banner from "./compose_banner";
 import * as feedback_widget from "./feedback_widget";
 import {FoldDict} from "./fold_dict";
 import {$t} from "./i18n";
@@ -75,7 +76,13 @@ export function get_user_topics_for_visibility_policy(visibility_policy) {
     return topics;
 }
 
-export function set_user_topic_visibility_policy(stream_id, topic, visibility_policy, from_hotkey) {
+export function set_user_topic_visibility_policy(
+    stream_id,
+    topic,
+    visibility_policy,
+    from_hotkey,
+    from_banner,
+) {
     const data = {
         stream_id,
         topic,
@@ -88,6 +95,10 @@ export function set_user_topic_visibility_policy(stream_id, topic, visibility_po
         success() {
             if (visibility_policy === all_visibility_policies.INHERIT) {
                 feedback_widget.dismiss();
+                return;
+            }
+            if (from_banner) {
+                compose_banner.clear_unmute_topic_notifications();
                 return;
             }
             if (!from_hotkey) {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -323,7 +323,11 @@
         }
     }
 
-    &.warning {
+    /* warning and warning-style classes have the same CSS; this is since
+    the warning class has some associated javascript which we do not want
+    for some of the banners, for which we use the warning-style class. */
+    &.warning,
+    &.warning-style {
         background-color: hsl(50deg 75% 92%);
         border-color: hsl(38deg 44% 27% / 40%);
         color: hsl(38deg 44% 27%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -226,7 +226,8 @@
             }
         }
 
-        &.warning {
+        &.warning,
+        &.warning-style {
             background-color: hsl(53deg 100% 11%);
             border-color: hsl(38deg 44% 60% / 40%);
             color: hsl(50deg 45% 80%);

--- a/web/templates/compose_banner/unmute_topic_banner.hbs
+++ b/web/templates/compose_banner/unmute_topic_banner.hbs
@@ -1,0 +1,10 @@
+{{#> compose_banner }}
+    <p>
+        {{#if (eq muted_narrow "stream")}}
+            {{#tr}}Your message was sent to a stream you have muted.{{/tr}}
+        {{else if (eq muted_narrow "topic")}}
+            {{#tr}}Your message was sent to a topic you have muted.{{/tr}}
+        {{/if}}
+        {{#tr}}You will not receive notifications about new messages.{{/tr}}
+    </p>
+{{/compose_banner}}

--- a/web/tests/lib/compose_banner.js
+++ b/web/tests/lib/compose_banner.js
@@ -8,7 +8,7 @@ exports.mock_banners = () => {
     // zjquery doesn't support `remove`, which is used when clearing the compose box.
     // TODO: improve how we test this so that we don't have to mock things like this.
     for (const classname of Object.values(compose_banner.CLASSNAMES)) {
-        $(`#compose_banners .${classname}`).remove = () => {};
+        $(`#compose_banners .${classname.replaceAll(" ", ".")}`).remove = () => {};
     }
     $("#compose_banners .warning").remove = () => {};
     $("#compose_banners .error").remove = () => {};


### PR DESCRIPTION
We add a new banner informing the user if and when they send a message to a muted topic / stream. It also has a button to unmute the topic.
    
Fixes: #24246.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/68962290/233202655-71ed5cab-8407-4455-879c-3ecc6c0c64a0.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
