### PR TITLE
UI redesign: more-less message interaction.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -115,7 +115,7 @@ the hotkeys too:
   - click on the star button in the right column
   - use 'Ctrl + S' to star a message
 - Message length
-  - send a long message and see if '[More]' appears
+  - send a long message and see if 'Show more' button appears
   - click on the 'more' or 'collapse' link
   - use i to collapse/expand a message irrespective of message length
 - use 'v' to show all images in the thread

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -113,7 +113,7 @@ export function initialize() {
         }
 
         // Widget for adjusting the height of a message.
-        if ($target.is("div.message_length_controller")) {
+        if ($target.is("button.message_expander") || $target.is("button.message_condenser")) {
             return true;
         }
 

--- a/web/src/condense.js
+++ b/web/src/condense.js
@@ -43,8 +43,8 @@ function uncondense_row($row) {
 }
 
 export function uncollapse($row) {
-    // Uncollapse a message, restoring the condensed message [More] or
-    // [Show less] link if necessary.
+    // Uncollapse a message, restoring the condensed message "Show more" or
+    // "Show less" button if necessary.
     const message = message_lists.current.get(rows.id($row));
     message.collapsed = false;
     message_flags.save_uncollapsed(message);
@@ -55,11 +55,11 @@ export function uncollapse($row) {
 
         if (message.condensed === true) {
             // This message was condensed by the user, so re-show the
-            // [More] link.
+            // "Show more" button.
             condense_row($row);
         } else if (message.condensed === false) {
             // This message was un-condensed by the user, so re-show the
-            // [Show less] link.
+            // "Show less" button.
             uncondense_row($row);
         } else if ($content.hasClass("could-be-condensed")) {
             // By default, condense a long message.
@@ -116,7 +116,7 @@ export function toggle_collapse(message) {
     // This function implements a multi-way toggle, to try to do what
     // the user wants for messages:
     //
-    // * If the message is currently showing any [More] link, either
+    // * If the message is currently showing any "Show more" button, either
     //   because it was previously condensed or collapsed, fully display it.
     // * If the message is fully visible, either because it's too short to
     //   condense or because it's already uncondensed, collapse it
@@ -246,8 +246,8 @@ export function condense_and_collapse(elems) {
             $(elem).find(".message_expander").hide();
         }
 
-        // Completely hide the message and replace it with a [More]
-        // link if the user has collapsed it.
+        // Completely hide the message and replace it with a "Show more"
+        // button if the user has collapsed it.
         if (message.collapsed) {
             $content.addClass("collapsed");
             $(elem).find(".message_expander").show();

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -170,7 +170,7 @@ export function handler() {
     }
     resize_page_components();
 
-    // Re-compute and display/remove [More] links to messages
+    // Re-compute and display/remove 'Show more' buttons to messages
     condense.condense_and_collapse($(".message_table .message_row"));
 
     // This function might run onReady (if we're in a narrow window),

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -482,6 +482,29 @@
         background-color: hsl(0deg 0% 0% / 50%);
     }
 
+    .messagebox {
+        &:hover {
+            .message_expander {
+                background-color: hsl(240deg 44% 56% / 15%);
+            }
+        }
+    }
+
+    .message_length_controller {
+        .message_length_toggle {
+            color: hsl(240deg 30% 65% / 100%);
+            background: transparent;
+
+            &:hover {
+                background-color: hsl(240deg 44% 56% / 25%);
+            }
+
+            &:active {
+                background-color: hsl(240deg 44% 56% / 15%);
+            }
+        }
+    }
+
     .new-style .tab-switcher .ind-tab.selected,
     div.message_content thead,
     .table-striped thead th,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1106,6 +1106,13 @@ td.pointer {
             visibility: visible;
         }
     }
+
+    &:hover {
+        .message_expander {
+            color: hsl(240deg 47% 54% / 100%);
+            background-color: hsl(240deg 44% 56% / 8%);
+        }
+    }
 }
 
 .message_header {
@@ -1602,6 +1609,12 @@ div.focused_table {
         max-height: 8.5em;
         min-height: 0;
         overflow: hidden;
+        mask-image: linear-gradient(
+            to top,
+            hsl(0deg 0% 100% / 0%) 0%,
+            hsl(0deg 0% 100%) 50px
+        );
+        mask-size: cover;
     }
 
     &.collapsed {
@@ -1743,15 +1756,30 @@ div.focused_table {
 }
 
 .message_length_controller {
-    display: none;
-    text-align: center;
-    color: hsl(200deg 100% 40%);
+    .message_length_toggle {
+        display: none;
+        text-align: center;
+        width: 100%;
+        height: 24px;
+        margin-bottom: 3px;
+        color: hsl(240deg 20% 50%);
+        background: hsla(0deg 0% 100% / 0%);
+        border-radius: 4px;
+        border: none;
+        font-size: 14px;
+        font-weight: 400;
+        outline: none;
+        text-transform: uppercase;
 
-    /* to make message-uncollapse easier */
-    margin-top: 10px;
+        &:hover {
+            color: hsl(240deg 52% 53% / 100%);
+            background-color: hsl(240deg 44% 56% / 15%);
+        }
 
-    &:hover {
-        text-decoration: underline;
+        &:active {
+            color: hsl(240deg 52% 53% / 100%);
+            background-color: hsl(240deg 44% 56% / 20%);
+        }
     }
 }
 

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -60,8 +60,11 @@
 <div class="message_edit">
     <div class="message_edit_form"></div>
 </div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More…]" }}</div>
-<div class="message_condenser message_length_controller" title="{{t 'Show less' }} (-)">[{{t "Show less" }}]</div>
+
+<div class="message_length_controller">
+    <button type="button" class="message_expander message_length_toggle" title="{{t 'Show more' }} (-)">{{t "Show more" }}</button>
+    <button type="button" class="message_condenser message_length_toggle" title="{{t 'Show less' }} (-)">{{t "Show less" }}</button>
+</div>
 
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>


### PR DESCRIPTION
This commit encompasses the following changes:
* Replace the [More...] link with a button titled "Show more".
* Replace the [Show Less...] link with a button titled "Show less".
* Add various on-hover interactions to the buttons.
* In the condensed view, add fading to the bottom of the message to visually communicate that the message is truncated.

Fixes #22801.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![light](https://user-images.githubusercontent.com/84973068/231951781-7ac42de4-a3e3-473d-9148-1cde4f0c6f25.gif)

![dark](https://user-images.githubusercontent.com/84973068/231951831-deebfcc7-5b9e-41a4-a136-461cc571d242.gif)

| Change | Light mode | Dark mode |
|--------|--------|--------|
| Interaction | ![light](https://user-images.githubusercontent.com/84973068/231951781-7ac42de4-a3e3-473d-9148-1cde4f0c6f25.gif) | ![dark](https://user-images.githubusercontent.com/84973068/231951831-deebfcc7-5b9e-41a4-a136-461cc571d242.gif) |
| Normal message | ![Image20230414112727](https://user-images.githubusercontent.com/84973068/231954694-1da50966-1382-4070-8c75-e33fa3290dec.png) | ![Image20230414112719](https://user-images.githubusercontent.com/84973068/231955101-76439ed0-0dcf-4435-a414-1c7c65957620.png) |
| Direct message | ![Image20230414112734](https://user-images.githubusercontent.com/84973068/231954638-df323732-78e0-4d8a-8f5a-088f58eca7ac.png) | ![Image20230414112659](https://user-images.githubusercontent.com/84973068/231955729-113e0786-1f01-4dc2-943d-f02473d4d433.png) |
| Mention | ![Image20230414112705](https://user-images.githubusercontent.com/84973068/231955663-d64465cf-c91f-43da-bf5a-fae5c43ec599.png) | ![Image20230414112712](https://user-images.githubusercontent.com/84973068/231955575-b7c97493-330f-4207-ac6c-7849dcd61ecd.png) | 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
