### PR TITLE
unmute_topic: Show all unmuted topics within muted streams in `All messages` narrow.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -11,6 +11,7 @@ import {page_params} from "./page_params";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
 import * as unread from "./unread";
+import * as user_topics from "./user_topics";
 import * as util from "./util";
 
 function zephyr_stream_name_match(message, operand) {
@@ -56,6 +57,9 @@ function zephyr_topic_name_match(message, operand) {
 }
 
 function message_in_home(message) {
+    // The home view contains messages not sent to muted streams, with
+    // additional logic for unmuted topics, mentions, and
+    // single-stream windows.
     if (
         message.type === "private" ||
         message.mentioned ||
@@ -65,8 +69,10 @@ function message_in_home(message) {
         return true;
     }
 
-    // We don't display muted streams in 'All messages' view
-    return !stream_data.is_muted(message.stream_id);
+    return (
+        !stream_data.is_muted(message.stream_id) ||
+        user_topics.is_topic_unmuted(message.stream_id, message.topic)
+    );
 }
 
 function message_matches_search_term(message, operator, operand) {

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -1,6 +1,7 @@
 import autosize from "autosize";
 import $ from "jquery";
 
+import {all_messages_data} from "./all_messages_data";
 import * as blueslip from "./blueslip";
 import {MessageListData} from "./message_list_data";
 import {MessageListView} from "./message_list_view";
@@ -426,6 +427,20 @@ export class MessageList {
     }
 
     update_muting_and_rerender() {
+        // For the home message list, we need to re-initialize
+        // _all_items for stream muting/topic unmuting from
+        // all_messages_data, since otherwise unmuting a previously
+        // muted stream won't work.
+        //
+        // TODO: The zhome conditional is a bit awkward, but a check
+        // for whether the filter excludes muted streams wouldn't be
+        // correct, because other narrows can't pull from
+        // all_messages.
+        if (this.table_name === "zhome") {
+            this.data.clear();
+            this.data.add_messages(all_messages_data.all_messages());
+        }
+
         this.data.update_items_for_muting();
         // We need to rerender whether or not the narrow hides muted
         // topics, because we need to update recipient bars for topics

--- a/web/src/stream_muting.js
+++ b/web/src/stream_muting.js
@@ -1,11 +1,4 @@
-import {all_messages_data} from "./all_messages_data";
 import * as message_lists from "./message_lists";
-import * as message_scroll from "./message_scroll";
-import * as message_util from "./message_util";
-import * as message_viewport from "./message_viewport";
-import * as narrow_state from "./narrow_state";
-import * as navigate from "./navigate";
-import * as overlays from "./overlays";
 import * as settings_notifications from "./settings_notifications";
 import * as stream_edit from "./stream_edit";
 import * as stream_list from "./stream_list";
@@ -14,57 +7,14 @@ import * as unread_ui from "./unread_ui";
 export function update_is_muted(sub, value) {
     sub.is_muted = value;
 
-    setTimeout(() => {
-        let msg_offset;
-        let saved_ypos;
-        // Save our current scroll position
-        if (overlays.is_active() || overlays.is_modal_open()) {
-            saved_ypos = message_viewport.scrollTop();
-        } else if (
-            narrow_state.is_message_feed_visible() &&
-            message_lists.current === message_lists.home &&
-            message_lists.current.selected_row().offset() !== null
-        ) {
-            msg_offset = message_lists.current.selected_row().offset().top;
-        }
+    // TODO: In theory, other message lists whose behavior depends on
+    // stream muting might need to be live-updated as well, but the
+    // current _all_items design doesn't have a way to support that.
+    message_lists.home.update_muting_and_rerender();
 
-        message_lists.home.clear({clear_selected_id: false});
-
-        // Recreate the message_lists.home with the newly filtered all_messages_data
-        message_util.add_old_messages(all_messages_data.all_messages(), message_lists.home);
-
-        // Ensure we're still at the same scroll position
-        if (overlays.is_overlay_or_modal_open()) {
-            message_viewport.scrollTop(saved_ypos);
-        } else if (
-            narrow_state.is_message_feed_visible() &&
-            message_lists.current === message_lists.home
-        ) {
-            // We pass use_closest to handle the case where the
-            // currently selected message is being hidden from the
-            // home view
-            message_lists.home.select_id(message_lists.home.selected_id(), {
-                use_closest: true,
-                empty_ok: true,
-                mark_read: false,
-            });
-            if (message_lists.current.selected_id() !== -1) {
-                message_lists.current.view.set_message_offset(msg_offset);
-            }
-        }
-
-        // In case we added messages to what's visible in the home
-        // view, we need to re-scroll to make sure the pointer is
-        // still visible. We don't want the auto-scroll handler to
-        // move our pointer to the old scroll location before we have
-        // a chance to update it.
-        navigate.plan_scroll_to_selected();
-        message_scroll.suppress_selection_update_on_next_scroll();
-
-        // Since muted streams aren't counted in visible unread
-        // counts, we need to update the rendering of them.
-        unread_ui.update_unread_counts();
-    }, 0);
+    // Since muted streams aren't counted in visible unread
+    // counts, we need to update the rendering of them.
+    unread_ui.update_unread_counts();
 
     settings_notifications.update_muted_stream_state(sub);
     stream_edit.update_muting_rendering(sub);


### PR DESCRIPTION
- [x] Show all unmuted topics within muted streams in `All messages` narrow.

------------------------------------------------------------------------

Fixes: #24243

- This PR fixes point 6 of #24243. 

--------------------------------------------------------------

**Screenshots and screen captures:**


<details>
<summary>All Messages</summary>
<br>

![demo_hello](https://user-images.githubusercontent.com/66828942/232172262-09c2939d-4dc5-472f-936f-ec4f41f8fbb4.gif)


</details>

------------------------------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
