### PR TITLE
dropdown_list_widget: Show stream icon in the button.

### DIFF
--- a/web/src/dropdown_list_widget.js
+++ b/web/src/dropdown_list_widget.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import _ from "lodash";
 import tippy from "tippy.js";
 
+import render_inline_decorated_stream_name from "../templates/inline_decorated_stream_name.hbs";
 import render_dropdown_list from "../templates/settings/dropdown_list.hbs";
 
 import * as blueslip from "./blueslip";
@@ -63,8 +64,16 @@ export class DropdownListWidget {
             return;
         }
 
-        const text = this.render_text(item.name);
-        $elem.text(text);
+        if (item.stream !== undefined) {
+            const stream = item.stream;
+            const rendered_stream_name_with_privacy_symbol_html =
+                render_inline_decorated_stream_name({stream});
+            $elem.html(rendered_stream_name_with_privacy_symbol_html);
+        } else {
+            const text = this.render_text(item.name);
+            $elem.text(text);
+        }
+
         $elem.removeClass("text-warning");
         $elem.closest(".input-group").find(".dropdown_list_reset_button").show();
     }

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -123,8 +123,8 @@ export function render_stream(stream) {
     }
 
     return render_typeahead_item({
-        primary: stream.name,
         secondary: desc,
+        stream,
         is_unsubscribed: !stream.subscribed,
     });
 }

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -827,7 +827,7 @@ div.overlay {
 
 .stream-privacy-type-icon {
     position: relative;
-    top: 0.06em;
+    top: 0.06rem;
     padding-right: 1px;
 
     &.zulip-icon-globe,

--- a/web/templates/typeahead_list_item.hbs
+++ b/web/templates/typeahead_list_item.hbs
@@ -18,7 +18,11 @@
     <i class="typeahead-image icon fa fa-group no-presence-circle" aria-hidden="true"></i>
 {{/if}}
 <strong>
-    {{~ primary ~}}
+    {{~#if stream}}
+        {{> inline_decorated_stream_name stream=stream }}
+    {{else}}
+        {{~ primary ~}}
+    {{/if}}
 </strong>
 {{~#if has_status}}
 {{> status_emoji status_emoji_info}}

--- a/web/tests/settings_org.test.js
+++ b/web/tests/settings_org.test.js
@@ -769,7 +769,7 @@ test("test get_sorted_options_list", () => {
     assert.deepEqual(settings_org.get_sorted_options_list(option_values_2), expected_option_values);
 });
 
-test("misc", ({override_rewire}) => {
+test("misc", ({override_rewire, mock_template}) => {
     page_params.is_admin = false;
     $("#user-avatar-upload-widget").length = 1;
     $("#user_details_section").length = 1;
@@ -842,7 +842,7 @@ test("misc", ({override_rewire}) => {
     assert.ok(!$("#user-avatar-upload-widget .image_upload_button").hasClass("hide"));
 
     override_rewire(stream_settings_data, "get_streams_for_settings_page", () => [
-        {name: "some_stream", stream_id: 75},
+        {name: "some_stream", stream_id: 75, invite_only: true},
         {name: "some_stream", stream_id: 42},
     ]);
 
@@ -873,8 +873,15 @@ test("misc", ({override_rewire}) => {
     let setting_name = "realm_notifications_stream_id";
     let $elem = $(`#${CSS.escape(setting_name)}_widget #${CSS.escape(setting_name)}_name`);
     $elem.closest = () => $stub_notification_disable_parent;
+    let selected_stream_id = 42;
+    mock_template("inline_decorated_stream_name.hbs", true, (data, html) => {
+        assert.equal(data.stream.stream_id, selected_stream_id);
+        return html;
+    });
+
     settings_org.notifications_stream_widget.render(42);
-    assert.equal($elem.text(), "#some_stream");
+    assert.ok($elem.html().indexOf("some_stream") > 0);
+    assert.ok($elem.html().indexOf("zulip-icon-hashtag") > 0);
     assert.ok(!$elem.hasClass("text-warning"));
 
     settings_org.notifications_stream_widget.render(undefined);
@@ -884,8 +891,10 @@ test("misc", ({override_rewire}) => {
     setting_name = "realm_signup_notifications_stream_id";
     $elem = $(`#${CSS.escape(setting_name)}_widget #${CSS.escape(setting_name)}_name`);
     $elem.closest = () => $stub_notification_disable_parent;
+    selected_stream_id = 75;
     settings_org.signup_notifications_stream_widget.render(75);
-    assert.equal($elem.text(), "#some_stream");
+    assert.ok($elem.html().indexOf("some_stream") > 0);
+    assert.ok($elem.html().indexOf("zulip-icon-lock") > 0);
     assert.ok(!$elem.hasClass("text-warning"));
 
     settings_org.signup_notifications_stream_widget.render(undefined);

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -722,7 +722,7 @@ test("render_stream", ({mock_template}) => {
     };
 
     mock_template("typeahead_list_item.hbs", false, (args) => {
-        assert.equal(args.primary, stream.name);
+        assert.equal(args.stream, stream);
         assert.equal(args.secondary, stream.description);
         rendered = true;
         return "typeahead-item-stub";
@@ -741,7 +741,7 @@ test("render_stream w/long description", ({mock_template}) => {
     };
 
     mock_template("typeahead_list_item.hbs", false, (args) => {
-        assert.equal(args.primary, stream.name);
+        assert.equal(args.stream, stream);
         const short_desc = stream.description.slice(0, 35);
         assert.equal(args.secondary, short_desc + "...");
         rendered = true;


### PR DESCRIPTION
We now show the stream privacy type icon for the option selected in dropdown list widget.

This commit also includes a minor CSS change to make the web-public better aligned in the
dropdown list widget "Move topic" and "Move message" modal. There is no visible change for
other pages and other icons due to this CSS change.

Fixes part of #22355.

<!-- Describe your pull request here.-->

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2023-04-14 13-43-15](https://user-images.githubusercontent.com/35494118/231985768-6dc9ccec-4139-4360-b983-ccdab0b23bf7.png)


![Screenshot from 2023-04-14 13-43-59](https://user-images.githubusercontent.com/35494118/231985842-e6ecb225-2ee7-483a-96d0-53fd4d74b3fc.png)




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
