### PR TITLE
upgrade-zulip-from-git: Backfill a zulip-git-version as needed.

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -539,6 +539,10 @@ mkdir -p "$deploy_path"/prod-static/serve
 cp -rT "$deploy_path"/prod-static/serve /home/zulip/prod-static
 chown -R zulip:zulip /home/zulip /var/log/zulip /etc/zulip/settings.py
 
+if ! [ -e /home/zulip/deployments/current/zulip-git-version ]; then
+    su zulip -c 'cd /home/zulip/deployments/current && ./scripts/lib/update-git-upstream && ./tools/cache-zulip-git-version'
+fi
+
 if ! [ -e "/home/zulip/prod-static/generated" ]; then
     # If we're installing from a Git checkout, we need to run
     # `tools/update-prod-static` in order to build the static

--- a/scripts/lib/update-git-upstream
+++ b/scripts/lib/update-git-upstream
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu
+
+upstream_url="https://github.com/zulip/zulip.git"
+if ! git remote | grep -qx upstream; then
+    git remote add upstream "$upstream_url"
+else
+    git remote set-url upstream "$upstream_url"
+fi
+
+git fetch --prune --quiet --tags --all

--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -25,8 +25,9 @@ from scripts.lib.zulip_tools import (
 
 config_file = get_config_file()
 deploy_options = get_deploy_options(config_file)
-upstream_url = "https://github.com/zulip/zulip.git"
-remote_url = get_config(config_file, "deployment", "git_repo_url", upstream_url)
+remote_url = get_config(
+    config_file, "deployment", "git_repo_url", "https://github.com/zulip/zulip.git"
+)
 
 assert_running_as_root(strip_lib_from_paths=True)
 
@@ -132,21 +133,7 @@ try:
             preexec_fn=su_to_zulip,
         )
 
-    # Ensure upstream remote is configured; we need this to make `git describe` accurate.
-    remotes = subprocess.check_output(["git", "remote"], preexec_fn=su_to_zulip).split(b"\n")
-    if b"upstream" not in remotes:
-        subprocess.check_call(
-            ["git", "remote", "add", "upstream", upstream_url], preexec_fn=su_to_zulip
-        )
-    else:
-        subprocess.check_call(
-            ["git", "remote", "set-url", "upstream", upstream_url], preexec_fn=su_to_zulip
-        )
-
-    logging.info("Fetching the latest commits")
-    subprocess.check_call(
-        ["git", "fetch", "--prune", "--quiet", "--tags", "--all"], preexec_fn=su_to_zulip
-    )
+    subprocess.check_call(["./scripts/lib/update-git-upstream"], preexec_fn=su_to_zulip)
 
     # Generate the deployment directory via git worktree from our local repository.
     try:

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -108,6 +108,23 @@ def get_deploy_root() -> str:
 
 
 def parse_version_from(deploy_path: str, merge_base: bool = False) -> str:
+    if not os.path.exists(os.path.join(deploy_path, "zulip-git-version")):
+        try:
+            # Pull this tool from _our_ deploy root, since it may not
+            # exist historically, but run it the cwd of the old
+            # deploy, so we set up its remote.
+            subprocess.check_call(
+                [os.path.join(get_deploy_root(), "scripts", "lib", "update-git-upstream")],
+                cwd=deploy_path,
+                preexec_fn=su_to_zulip,
+            )
+            subprocess.check_call(
+                [os.path.join(deploy_path, "tools", "cache-zulip-git-version")],
+                cwd=deploy_path,
+                preexec_fn=su_to_zulip,
+            )
+        except subprocess.CalledProcessError:
+            pass
     try:
         varname = "ZULIP_MERGE_BASE" if merge_base else "ZULIP_VERSION"
         return subprocess.check_output(


### PR DESCRIPTION
Installs which are upgrading to current `main`, and are upgrading for
the very first time from an install which was originally from git,
have a `/home/zulip/deployments/current` which, unlike all later
upgrades, is not a `git worktree` of `/srv/zulip.git`, but rather a
direct `git clone` of some arbitrary URL.  As such, it does not have
an `upstream` remote, nor a cached `zulip-git-version` file.

This makes later attempts to determine the pre-upgrade revision of
git (for pre-deploy hooks) fail, as without a `zulip-git-version`
file, `ZULIP_VERSION` is insufficiently-specific (e.g. `6.1+git`), and
there is no guarantee the necessary tags exist either.

Make fresh git installs set up an `upstream` and run
`./tools/cache-zulip-git-version` going forward; however,
that does not address the issue for deploys which already
exist.  For those, we must configure and fetch a `remote` in the old
checkout, followed by re-generating a cached `zulip-git-version`.

Fixes: #25076.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
