### PR TITLE
unmute_topic: Show all unmuted topics within muted streams in `Recent conversations`. 

### DIFF
--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -541,9 +541,11 @@ export function filters_should_hide_topic(topic_data) {
     }
 
     if (!filters.has("include_muted") && topic_data.type === "stream") {
+        // We want to show the unmuted topics within muted streams in the recent topics.
+        const topic_unmuted = Boolean(user_topics.is_topic_unmuted(msg.stream_id, msg.topic));
         const topic_muted = Boolean(user_topics.is_topic_muted(msg.stream_id, msg.topic));
         const stream_muted = stream_data.is_muted(msg.stream_id);
-        if (topic_muted || stream_muted) {
+        if (topic_muted || (stream_muted && !topic_unmuted)) {
             return true;
         }
     }

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -107,6 +107,7 @@ mock_esm("../src/user_topics", {
         }
         return false;
     },
+    is_topic_unmuted: () => false,
 });
 const narrow = mock_esm("../src/narrow", {
     update_narrow_title: noop,


### PR DESCRIPTION
- [x] Show all unmuted topics within muted streams in `Recent conversations` narrow.

-----------------------------------

Fixes part of #24243 
- This PR fixes the 5th point of #24243

-----------------------------

**Screenshots and screen captures:**

<details>
<summary>Recent Conversations</summary>
<br>

![recent_conversation](https://user-images.githubusercontent.com/66828942/231963711-62bf8544-2116-4320-8fa5-d9dd946f6d87.gif)

</details>

-------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
