### PR TITLE
Unread message display fixes.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -529,32 +529,6 @@
         border-color: hsl(0deg 0% 0% / 20%);
     }
 
-    .recipient_row {
-        .message_row.unread {
-            .date_row {
-                background-color: hsl(212deg 28% 18%);
-            }
-        }
-
-        .private-message.unread {
-            .date_row {
-                background-color: hsl(208deg 17% 29%);
-            }
-        }
-
-        .message_row.unread ~ .message_row.unread {
-            .date_row {
-                background-color: transparent;
-            }
-        }
-
-        .private-message.unread ~ .private-message.unread {
-            .date_row {
-                background-color: hsl(208deg 17% 29%);
-            }
-        }
-    }
-
     .spectator_narrow_login_button,
     .top-navbar-border {
         border-color: hsl(0deg 0% 0% / 60%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1408,7 +1408,7 @@ td.pointer {
     }
 }
 
-.private-message {
+.message_row.private-message {
     background-color: var(--color-background-private-message-content);
 
     .alert-msg {
@@ -1568,6 +1568,7 @@ div.message_table {
     .date_row {
         /* We only want padding for the date rows between recipient blocks */
         padding-bottom: 0;
+        background-color: var(--color-background);
 
         & span {
             font-size: calc(12em / 14);
@@ -2979,13 +2980,6 @@ select.invite-as {
         .date_row {
             position: relative;
             z-index: 3;
-            background-color: hsl(0deg 0% 100%);
-        }
-    }
-
-    .private-message.unread {
-        .date_row {
-            background-color: hsl(192deg 20% 95%);
         }
     }
 
@@ -2995,13 +2989,6 @@ select.invite-as {
         .date_row {
             position: unset;
             z-index: 0;
-            background-color: transparent;
-        }
-    }
-
-    .private-message.unread ~ .private-message.unread {
-        .date_row {
-            background-color: hsl(192deg 20% 95%);
         }
     }
 }


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/date.20row.20unread.20marker.20bug.2E

before:
![image](https://user-images.githubusercontent.com/25124304/232190727-8bd20c16-6375-4d61-8b40-bc54f70c7ff7.png)

after:
<img width="740" alt="Screenshot 2023-04-15 at 11 46 51 AM" src="https://user-images.githubusercontent.com/25124304/232190709-7879d83f-b467-4fce-adb7-0c917d34ed9c.png">


Reproducer for date row bug:
> I figured out what causes the date row colors bug we were talking about! We have a bunch of CSS for unread messages (some with dark theme or private message added to the selectors), such as this:
`.message_row.unread .date_row`
And so if the first message on a given day in a private message thread is unread, you get the wrong background color.