### PR TITLE
search: Fix display of suggestion box when search bar empty.

### DIFF
--- a/web/src/search.js
+++ b/web/src/search.js
@@ -93,6 +93,9 @@ export function initialize() {
         fixed: true,
         items: search_suggestion.max_num_of_search_results,
         helpOnEmptyStrings: true,
+        // With search pills, the contenteditable input will be empty
+        // even if some pills are present.
+        hideOnEmpty: page_params.search_pills_enabled,
         naturalSearch: true,
         highlighter(item) {
             const obj = search_map.get(item);

--- a/web/third/bootstrap-typeahead/typeahead.js
+++ b/web/third/bootstrap-typeahead/typeahead.js
@@ -476,8 +476,13 @@ import {get_string_diff} from "../../src/util";
 
         default:
           var hideOnEmpty = false
-          if (e.keyCode === 8 && this.options.helpOnEmptyStrings) { // backspace
-            hideOnEmpty = true
+          // backspace
+          if (e.keyCode === 8 && this.options.helpOnEmptyStrings) {
+            // Support for inputs to set the hideOnEmpty option explicitly to false
+            // to display typeahead after hitting backspace to clear the input.
+            if (typeof(this.options.hideOnEmpty) === undefined || this.options.hideOnEmpty) {
+              hideOnEmpty = true;
+            }
           }
           this.lookup(hideOnEmpty)
       }


### PR DESCRIPTION
When search bar is empty and we've reached that state by using the `backspace` key. There are no suggestions as there are when you select an empty search bar.

The cause of this was an explicit prevention of this suggestion box in `typeahead.js` so that the
`backspace` key is free to interact with the other elements.

The fix here is to add an optional `hideOnEmpty` option so that if we want this suggestion box to appear we can set this option to `false` and this behavior will be prevented.

Fixes: #25062

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![bar](https://user-images.githubusercontent.com/101464851/232197555-1d003294-6c67-4026-9160-7c339284cdee.gif)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
