### PR TITLE
message_body: Remove link from message time when locally echoed. 

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -279,12 +279,12 @@ $time_column_max_width: 150px;
     }
 
     /* Locally echoed messages. */
-    &.local .message_time {
+    &.locally-echoed .message_time {
         opacity: 0;
     }
 
     /* Show the spinner only for messages that are still locally echoed. */
-    &.local .slow-send-spinner {
+    &.locally-echoed .slow-send-spinner {
         display: unset !important;
     }
 }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -281,10 +281,13 @@ $time_column_max_width: 150px;
     /* Locally echoed messages. */
     &.locally-echoed .message_time {
         opacity: 0;
+        /* Don't show pointer when message_time doesn't has a link. */
+        cursor: default;
     }
 
     /* Show the spinner only for messages that are still locally echoed. */
     &.locally-echoed .slow-send-spinner {
         display: unset !important;
+        cursor: default;
     }
 }

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -24,7 +24,7 @@
 
 <span class="alert-msg"></span>
 
-<a href="{{ msg/url }}" class="message_time{{#if status_message}} status-time{{/if}}">
+<a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message_time{{#if status_message}} status-time{{/if}}">
     {{#unless include_sender}}
     <span class="copy-paste-text">&nbsp;</span>
     {{/unless}}

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -1,5 +1,5 @@
 <div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}"
-  class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#include_sender}} include-sender{{/include_sender}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row"
+  class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#include_sender}} include-sender{{/include_sender}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}locally-echoed{{/if}} selectable_row"
   role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     {{#if want_date_divider}}


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/25069

Since the locally echoed link of message doesn't work, it is
better to remove it.