### PR TITLE
css: Use new color for unread marker.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1194,7 +1194,7 @@ td.pointer {
 
             .unread-marker-fill {
                 border-radius: 0 0 0 7px;
-                height: calc(100% - 2px);
+                height: calc(100% - 3px);
             }
 
             .messagebox {
@@ -1445,7 +1445,7 @@ td.pointer {
 }
 
 .unread-marker-fill {
-    border-left: 2px solid hsl(107deg 74% 29%);
+    border-left: 1px solid hsl(217deg 100% 60%);
     height: 100%;
 }
 


### PR DESCRIPTION
This also reduces the width of the unread marker by 1px.

Fixes part 6 of #22059

before:
<img width="677" alt="image" src="https://user-images.githubusercontent.com/25124304/232227536-5714396e-9bef-4507-974f-e7a3e920c2dd.png">
<img width="680" alt="image" src="https://user-images.githubusercontent.com/25124304/232227546-14357a93-aaba-4e64-917c-ec3bc59f19fe.png">


after:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/25124304/232227504-6a2a0634-f5e2-4c26-a9c3-5867f7d886f1.png">
<img width="685" alt="image" src="https://user-images.githubusercontent.com/25124304/232227511-2455a001-9f09-47b3-b1b1-90fbcfc0665d.png">


2px variant (works better for me):
<img width="684" alt="image" src="https://user-images.githubusercontent.com/25124304/232227587-c1e8cd5d-b022-406f-b202-d12ed800b31c.png">
<img width="671" alt="image" src="https://user-images.githubusercontent.com/25124304/232227597-733a67b1-c9f7-45df-af46-646d73aca186.png">
