### PR TITLE
streams: Fix notice appears even when the panel is not empty.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -490,8 +490,8 @@ export function dispatch_normal_event(event) {
                         const is_narrowed_to_stream = narrow_state.is_for_stream_id(
                             stream.stream_id,
                         );
-                        stream_settings_ui.remove_stream(stream.stream_id);
                         stream_data.delete_sub(stream.stream_id);
+                        stream_settings_ui.remove_stream(stream.stream_id);
                         if (was_subscribed) {
                             stream_list.remove_sidebar_row(stream.stream_id);
                         }

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -451,11 +451,20 @@ export function render_left_panel_superset() {
 }
 
 export function update_empty_left_panel_message() {
-    // Check if we have any subscribed streams to decide whether to
+    // Check if we have any streams in panel to decide whether to
     // display a notice.
-    const has_subscribed_streams = stream_data.subscribed_subs().length > 0;
-
-    if (has_subscribed_streams) {
+    let has_streams;
+    if (is_subscribed_stream_tab_active()) {
+        // We don't remove stream row from UI on unsubscribe, To handle
+        // this case here we are also checking DOM if there are streams
+        // displayed in panel or not.
+        has_streams =
+            stream_data.subscribed_subs().length ||
+            $("#manage_streams_container .stream-row:not(.notdisplayed)").length;
+    } else {
+        has_streams = stream_data.get_unsorted_subs().length;
+    }
+    if (has_streams) {
         $(".no-streams-to-show").hide();
         return;
     }


### PR DESCRIPTION
This fixes regression in 55bd3220b6ea8ebb694d87400c27ce95e2f38054, Where notice gets rendered even when there are streams shown in panel. Now the check var to render message conditionally checks for both `subscribed` and `all streams` tabs. We are avoiding the fully use of DOM in this context because if the filter results in no stream, then also it will display a notice. Also this commits swaps order of calling `stream_data.delete_sub()` and `stream_settings_ui.remove_stream()` functions in server_events_dispatch because `update_empty_left_panel_message` uses stream_data, which was giving outdated data.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
***Before***
<img width="1440" alt="Screenshot 2023-04-19 at 3 44 04 AM" src="https://user-images.githubusercontent.com/71015892/232916930-b42c8d44-cd19-46f7-8c63-b610ea3a66fc.png">
<img width="1440" alt="Screenshot 2023-04-19 at 3 44 10 AM" src="https://user-images.githubusercontent.com/71015892/232916940-d77fbb6c-106e-49e8-96cf-e1d847cf5631.png">

***After***
<img width="1440" alt="Screenshot 2023-04-19 at 3 41 58 AM" src="https://user-images.githubusercontent.com/71015892/232917023-6974755c-b6c5-417c-acbf-779c17717626.png">
<img width="1440" alt="Screenshot 2023-04-19 at 3 42 06 AM" src="https://user-images.githubusercontent.com/71015892/232917030-19b14b6a-d837-478b-96f2-bcd6321c62e5.png">

https://user-images.githubusercontent.com/71015892/232916113-f516349c-b899-45e5-9ec7-2e8b6e309046.mov


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
