### PR TITLE
tippy: Prevent second appearance of tooltips due to topic menu popover.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -501,6 +501,23 @@ export function initialize() {
             defaultMessage: "View user card (u)",
         }),
         delay: LONG_HOVER_DELAY,
+        onShow(instance) {
+            if (!document.body.contains(instance.reference)) {
+                return false;
+            }
+            const $elem = $(instance.reference);
+            const target = $elem.parents(".message_row.include-sender").get(0);
+            const config = {attributes: true, childList: false, subtree: false};
+            const nodes_to_check_for_removal = [$elem.get(0)];
+            hide_tooltip_if_reference_removed(target, config, instance, nodes_to_check_for_removal);
+            return true;
+        },
+        onHidden(instance) {
+            instance.destroy();
+            if (observer) {
+                observer.disconnect();
+            }
+        },
         appendTo: () => document.body,
     });
 }

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -246,7 +246,6 @@ export function initialize() {
     // box or it is not limited by the parent container.
     delegate("body", {
         target: [
-            ".recipient_bar_icon",
             "#streams_header .sidebar-title",
             "#userlist-title",
             "#user_filter_icon",
@@ -257,6 +256,32 @@ export function initialize() {
             "#add_streams_tooltip",
             "#filter_streams_tooltip",
         ],
+        appendTo: () => document.body,
+    });
+
+    delegate("body", {
+        target: ".recipient_bar_icon",
+        onShow(instance) {
+            if (!document.body.contains(instance.reference)) {
+                return false;
+            }
+            const $elem = $(instance.reference);
+
+            const config = {attributes: false, childList: true, subtree: true};
+            const target = $elem.parents(".message_header.message_header_stream.right_part").get(0);
+            const nodes_to_check_for_removal = [
+                $elem.parents(".recipient_bar_controls").get(0),
+                $elem.get(0),
+            ];
+            hide_tooltip_if_reference_removed(target, config, instance, nodes_to_check_for_removal);
+            return true;
+        },
+        onHidden(instance) {
+            instance.destroy();
+            if (observer) {
+                observer.disconnect();
+            }
+        },
         appendTo: () => document.body,
     });
 


### PR DESCRIPTION
**Issue:**

> With the recent migration of the topic_menu popover to Tippy, some tooltips have been impacted. If we click on a popover menu and then click on any button where the area is above the tooltip icon, two tooltips appear. The first one is expected to appear over the reference element, but the second tooltip appears on the top left corner of the screen because the associated reference element is hidden.

------------------------------------

**Changes:**

- [x] Prevent appearance of second `view_user_card` tooltip.
- [x] Prevent second appearance of tooltips for recipient bar icons.

------------------------------------

### Screenshots and screen captures:

**Before:**

<details>
<summary>View User Card tooltip:</summary>
<br>

![view_user](https://user-images.githubusercontent.com/66828942/232349749-b0f5b686-0d8b-46ff-8d19-38a73c36a9d7.gif)

</details>

<details>
<summary>Recipient bar icons:</summary>
<br>

![before_topic-tooltip](https://user-images.githubusercontent.com/66828942/232349778-cce634f5-d725-4d73-9427-8a6618255c3b.gif)


</details>

-------------------------------

**After:**

<details>
<summary>View User Card tooltip:</summary>
<br>

![after_view](https://user-images.githubusercontent.com/66828942/232349851-90e684b8-a8ee-4286-bc35-2fd5c75c46dd.gif)


</details>

<details>
<summary>Recipient bar icons:</summary>
<br>

![recipient_after](https://user-images.githubusercontent.com/66828942/232349917-7a17a7e5-da50-4e38-ad61-dfb00fdc8a85.gif)


</details>

-----------------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
