### PR TITLE
popovers: Add "Rename topic" option in topic sidebar popover.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -286,6 +286,7 @@ export function initialize() {
         stream_popover.build_move_topic_to_stream_popover(
             message.stream_id,
             message.topic,
+            false,
             message,
         );
         e.stopPropagation();

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1013,7 +1013,7 @@ export function process_hotkey(e, hotkey) {
                 return false;
             }
 
-            stream_popover.build_move_topic_to_stream_popover(msg.stream_id, msg.topic, msg);
+            stream_popover.build_move_topic_to_stream_popover(msg.stream_id, msg.topic, false, msg);
             return true;
         }
         case "zoom_to_message_near": {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -450,7 +450,12 @@ export function initialize() {
             });
 
             $popper.one("click", ".sidebar-popover-move-topic-messages", () => {
-                stream_popover.build_move_topic_to_stream_popover(stream_id, topic_name);
+                stream_popover.build_move_topic_to_stream_popover(stream_id, topic_name, false);
+                instance.hide();
+            });
+
+            $popper.one("click", ".sidebar-popover-rename-topic-messages", () => {
+                stream_popover.build_move_topic_to_stream_popover(stream_id, topic_name, true);
                 instance.hide();
             });
 
@@ -573,6 +578,7 @@ export function initialize() {
                 stream_popover.build_move_topic_to_stream_popover(
                     message.stream_id,
                     message.topic,
+                    false,
                     message,
                 );
                 e.preventDefault();

--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -131,6 +131,7 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
     const topic_unmuted = user_topics.is_topic_unmuted(sub.stream_id, topic_name);
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
     const can_move_topic = settings_data.user_can_move_messages_between_streams();
+    const can_rename_topic = settings_data.user_can_move_messages_to_another_topic();
     return {
         stream_name: sub.name,
         stream_id: sub.stream_id,
@@ -140,6 +141,7 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
         topic_unmuted,
         development_environment: page_params.development_environment,
         can_move_topic,
+        can_rename_topic,
         is_realm_admin: page_params.is_admin,
         topic_is_resolved: resolved_topic.is_resolved(topic_name),
         color: sub.color,

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -194,8 +194,18 @@ export function build_move_topic_to_stream_popover(current_stream_id, topic_name
         // topic is fetched from the server after clicking submit.
         // Though, this will be changed soon as we are going to make topic
         // edit permission independent of message.
-        args.disable_topic_input = !message_edit.is_topic_editable(message);
-        disable_stream_input = !message_edit.is_stream_editable(message);
+
+        // We potentially got to this function by clicking a button that implied the
+        // user would be able to move their message.  Give a little bit of buffer in
+        // case the button has been around for a bit, e.g. we show the
+        // move_message_button (hovering plus icon) as long as the user would have
+        // been able to click it at the time the mouse entered the message_row. Also
+        // a buffer in case their computer is slow, or stalled for a second, etc
+        // If you change this number also change edit_limit_buffer in
+        // zerver.actions.message_edit.check_update_message
+        const move_limit_buffer = 5;
+        args.disable_topic_input = !message_edit.is_topic_editable(message, move_limit_buffer);
+        disable_stream_input = !message_edit.is_stream_editable(message, move_limit_buffer);
     }
 
     function get_params_from_form() {

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -1,9 +1,14 @@
-{{#unless from_message_actions_popover}}
+{{#unless (or from_message_actions_popover only_topic_edit)}}
 <p>{{#tr}}Move all messages in <strong>{topic_name}</strong>{{/tr}} to:</p>
 {{/unless}}
 <form class="new-style" id="move_topic_form">
+    {{#if only_topic_edit }}
+    <p>{{t "Rename topic to:" }}</p>
+    {{else}}
     <p>{{t "Select a stream below or change topic name." }}</p>
+    {{/if}}
     <div class="topic_stream_edit_header">
+        {{#unless only_topic_edit}}
         <div class="stream_header_colorblock"></div>
         <div class="move-topic-dropdown">
             {{> settings/dropdown_list_widget
@@ -11,6 +16,7 @@
               list_placeholder=(t 'Filter streams')}}
         </div>
         <i class="fa fa-angle-right" aria-hidden="true"></i>
+        {{/unless}}
         <input name="new_topic_name" type="text" class="inline_topic_edit modal_text_input" autocomplete="off" value="{{topic_name}}" {{#if disable_topic_input}}disabled{{/if}} />
         <input name="old_topic_name" type="hidden" class="inline_topic_edit" value="{{topic_name}}" />
         <input name="current_stream_id" type="hidden" value="{{current_stream_id}}" />

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -87,7 +87,7 @@
     </li>
     {{/if}}
 
-    {{#if can_move_topic}}
+    {{#if can_rename_topic}}
     <li>
         <a tabindex="0" class="sidebar-popover-toggle-resolved" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-check" aria-hidden="true"></i>

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -76,6 +76,18 @@
             {{t "Move topic"}}
         </a>
     </li>
+    {{else if can_rename_topic}}
+    <hr />
+
+    <li>
+        <a tabindex="0" class="sidebar-popover-rename-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-pencil" aria-hidden="true"></i>
+            {{t "Rename topic"}}
+        </a>
+    </li>
+    {{/if}}
+
+    {{#if can_move_topic}}
     <li>
         <a tabindex="0" class="sidebar-popover-toggle-resolved" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-check" aria-hidden="true"></i>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to add buffer for disabling the topic and stream inputs in "Move topic" and "Move message" modal.
- Second commit is a prep commit to extract functions to have module level scope.
- Third commit is to add "Rename topic" option in topic sidebar popover.
- Fourth commit is to fix showing resolve option as per topic edit setting.

Fixes: <!-- Issue link, or clear description.--> #19886

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![rename-topic](https://user-images.githubusercontent.com/35494118/232425945-cb98ea8b-270d-4aec-a59b-a6f115efb5b5.gif)
![rename-topic](https://user-images.githubusercontent.com/35494118/232425988-94b7a358-f764-4a00-b66f-45841de53b3d.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
