### PR TITLE
user_topics: Rerender unmuted topics in Recent conversations.

### DIFF
--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -618,7 +618,7 @@ export function inplace_rerender(topic_key) {
     return true;
 }
 
-export function update_topic_is_muted(stream_id, topic) {
+export function update_topic_visibility_policy(stream_id, topic) {
     const key = get_topic_key(stream_id, topic);
     if (!topics.has(key)) {
         // we receive mute request for a topic we are

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -919,13 +919,13 @@ test("basic assertions", ({mock_template, override_rewire}) => {
         "1:topic-7,1:topic-3,4:topic-10,1:topic-6,1:topic-5,1:topic-4,1:topic-2,1:topic-1,6,7,8",
     );
 
-    // update_topic_is_muted now relies on external libraries completely
+    // update_topic_visibility_policy now relies on external libraries completely
     // so we don't need to check anythere here.
     generate_topic_data([[1, topic1, 0, false]]);
     $(".home-page-input").trigger("focus");
-    assert.equal(rt.update_topic_is_muted(stream1, topic1), true);
+    assert.equal(rt.update_topic_visibility_policy(stream1, topic1), true);
     // a topic gets muted which we are not tracking
-    assert.equal(rt.update_topic_is_muted(stream1, "topic-10"), false);
+    assert.equal(rt.update_topic_visibility_policy(stream1, "topic-10"), false);
 });
 
 test("test_reify_local_echo_message", ({mock_template}) => {


### PR DESCRIPTION
This is a prep PR for #25140 and this enables to update of the visibility policy of the topic in a muted stream by clicking on unmute icon in Recent conversations in real-time without any page reload.

Renamed and updated get_muted_topics to `get_user_topics_for_visibility_policy()` to work for all visibility policies by taking visibility policy as a parameter to get topics having that visibility policy.

Added rerender_for_unmuted_topic function similar to rerender_for_muted_topic function that updates unmuted topics in Recent conversations.

Renamed update_topic_is_muted to update_topic_visibility_policy as it now updates unmuted topics as well.

**Feedback Required:**
Should I merge `rerender_for_unmuted_topic` and `rerender_for_muted_topic` and convert them into one general function?

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
