### PR TITLE
message-type: Add support for "direct" as value for `type` parameter.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 174**:
+
+* [`POST /typing`](/api/set-typing-status), [`POST /messages`](/api/send-message):
+  Added `"direct"` as the preferred way to indicate a direct message for the
+  `type` parameter, deprecating the original `"private"`. While `"private"`
+  is still supported for direct messages, clients are encouraged to use to
+  the modern convention with servers that support it, because support for
+  `"private"` will eventually be removed.
+
 **Feature level 173**:
 
 * [`GET /scheduled_messages`](/api/get-scheduled-messages), [`DELETE

--- a/api_docs/send-message.md
+++ b/api_docs/send-message.md
@@ -19,10 +19,10 @@ curl -X POST {{ api_url }}/v1/messages \
     --data-urlencode topic=Castle \
     --data-urlencode 'content=I come not, friends, to steal away your hearts.'
 
-# For private messages
+# For direct messages
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
-    --data-urlencode type=private \
+    --data-urlencode type=direct \
     --data-urlencode 'to=[9]' \
     --data-urlencode 'content=With mirth and laughter let old wrinkles come.'
 ```
@@ -38,7 +38,7 @@ the command-line, providing the message content via STDIN.
 zulip-send --stream Denmark --subject Castle \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 
-# For private messages
+# For direct messages
 zulip-send hamlet@example.com \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 ```

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 173
+API_FEATURE_LEVEL = 174
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1154,7 +1154,7 @@ def check_send_private_message(
 def check_send_message(
     sender: UserProfile,
     client: Client,
-    message_type_name: str,
+    recipient_type_name: str,
     message_to: Union[Sequence[int], Sequence[str]],
     topic_name: Optional[str],
     message_content: str,
@@ -1168,7 +1168,7 @@ def check_send_message(
     *,
     skip_stream_access_check: bool = False,
 ) -> int:
-    addressee = Addressee.legacy_build(sender, message_type_name, message_to, topic_name)
+    addressee = Addressee.legacy_build(sender, recipient_type_name, message_to, topic_name)
     try:
         message = check_message(
             sender,
@@ -1192,7 +1192,7 @@ def check_send_message(
 def check_schedule_message(
     sender: UserProfile,
     client: Client,
-    message_type_name: str,
+    recipient_type_name: str,
     message_to: Union[Sequence[str], Sequence[int]],
     topic_name: Optional[str],
     message_content: str,
@@ -1202,7 +1202,7 @@ def check_schedule_message(
     realm: Optional[Realm] = None,
     forwarder_user_profile: Optional[UserProfile] = None,
 ) -> int:
-    addressee = Addressee.legacy_build(sender, message_type_name, message_to, topic_name)
+    addressee = Addressee.legacy_build(sender, recipient_type_name, message_to, topic_name)
 
     send_request = check_message(
         sender,

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -97,7 +97,7 @@ class Addressee:
     @staticmethod
     def legacy_build(
         sender: UserProfile,
-        message_type_name: str,
+        recipient_type_name: str,
         message_to: Union[Sequence[int], Sequence[str]],
         topic_name: Optional[str],
         realm: Optional[Realm] = None,
@@ -108,7 +108,7 @@ class Addressee:
         if realm is None:
             realm = sender.realm
 
-        if message_type_name == "stream":
+        if recipient_type_name == "stream":
             if len(message_to) > 1:
                 raise JsonableError(_("Cannot send to multiple streams"))
 
@@ -131,7 +131,7 @@ class Addressee:
                 return Addressee.for_stream_id(stream_name_or_id, topic_name)
 
             return Addressee.for_stream_name(stream_name_or_id, topic_name)
-        elif message_type_name == "private":
+        elif recipient_type_name == "private":
             if not message_to:
                 raise JsonableError(_("Message must have recipients"))
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -198,7 +198,7 @@ def send_mm_reply_to_stream(
         check_send_message(
             sender=user_profile,
             client=get_client("Internal"),
-            message_type_name="stream",
+            recipient_type_name="stream",
             message_to=[stream.id],
             topic_name=topic,
             message_content=body,

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -1273,17 +1273,17 @@ def apply_unread_message_event(
 ) -> None:
     message_id = message["id"]
     if message["type"] == "stream":
-        message_type = "stream"
+        recipient_type = "stream"
     elif message["type"] == "private":
         others = [recip for recip in message["display_recipient"] if recip["id"] != user_profile.id]
         if len(others) <= 1:
-            message_type = "private"
+            recipient_type = "private"
         else:
-            message_type = "huddle"
+            recipient_type = "huddle"
     else:
         raise AssertionError("Invalid message type {}".format(message["type"]))
 
-    if message_type == "stream":
+    if recipient_type == "stream":
         stream_id = message["stream_id"]
         topic = message[TOPIC_NAME]
         state["stream_dict"][message_id] = RawUnreadStreamDict(
@@ -1300,7 +1300,7 @@ def apply_unread_message_event(
         ):
             state["unmuted_stream_msgs"].add(message_id)
 
-    elif message_type == "private":
+    elif recipient_type == "private":
         if len(others) == 1:
             other_user_id = others[0]["id"]
         else:

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -191,7 +191,7 @@ def send_response_message(
     that might let someone send arbitrary messages to any stream through this.
     """
 
-    message_type = message_info["type"]
+    recipient_type_name = message_info["type"]
     display_recipient = message_info["display_recipient"]
     try:
         topic_name: Optional[str] = get_topic_from_message_info(message_info)
@@ -207,9 +207,9 @@ def send_response_message(
 
     widget_content = response_data.get("widget_content")
 
-    if message_type == "stream":
+    if recipient_type_name == "stream":
         message_to = [display_recipient]
-    elif message_type == "private":
+    elif recipient_type_name == "private":
         message_to = [recipient["email"] for recipient in display_recipient]
     else:
         raise JsonableError(_("Invalid message type"))
@@ -217,7 +217,7 @@ def send_response_message(
     check_send_message(
         sender=bot_user,
         client=client,
-        message_type_name=message_type,
+        recipient_type_name=recipient_type_name,
         message_to=message_to,
         topic_name=topic_name,
         message_content=content,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3021,6 +3021,16 @@ class ArchivedMessage(AbstractMessage):
 
 
 class Message(AbstractMessage):
+    # Recipient types used when a Message object is provided to
+    # Zulip clients via the API.
+    #
+    # A detail worth noting:
+    # * "direct" was introduced in 2023 with the goal of
+    #   deprecating the original "private" and becoming the
+    #   preferred way to indicate a personal or huddle
+    #   Recipient type via the API.
+    API_RECIPIENT_TYPES = ["direct", "private", "stream"]
+
     search_tsvector = SearchVectorField(null=True)
 
     def topic_name(self) -> str:

--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -113,11 +113,11 @@ add_example("send_message", "/messages:post", 200, async (client, console) => {
     };
     console.log(await client.messages.send(params));
 
-    // Send a private message
+    // Send a direct message
     const user_id = 9;
     params = {
         to: [user_id],
-        type: "private",
+        type: "direct",
         content: "With mirth and laughter let old wrinkles come.",
     };
     console.log(await client.messages.send(params));
@@ -252,7 +252,8 @@ add_example("set_typing_status", "/typing:post", 200, async (client, console) =>
         to: [user_id1, user_id2],
     };
 
-    // The user has started to type in the group PM with Iago and Polonius
+    // The user has started typing in the group direct message
+    // with Iago and Polonius
     console.log(await client.typing.send(typingParams));
     // {code_example|end}
 });

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -954,6 +954,7 @@ def send_message(client: Client) -> int:
         "content": "I come not, friends, to steal away your hearts.",
     }
     result = client.send_message(request)
+
     # {code_example|end}
 
     validate_against_openapi_schema(result, "/messages", "post", "200")
@@ -971,7 +972,7 @@ def send_message(client: Client) -> int:
     ensure_users([10], ["hamlet"])
 
     # {code_example|start}
-    # Send a private message
+    # Send a direct message
     user_id = 10
     request = {
         "type": "private",
@@ -979,6 +980,7 @@ def send_message(client: Client) -> int:
         "content": "With mirth and laughter let old wrinkles come.",
     }
     result = client.send_message(request)
+
     # {code_example|end}
 
     validate_against_openapi_schema(result, "/messages", "post", "200")
@@ -1294,7 +1296,8 @@ def set_typing_status(client: Client) -> None:
     ensure_users([10, 11], ["hamlet", "iago"])
 
     # {code_example|start}
-    # The user has started to type in the group PM with Iago and Polonius
+    # The user has started typing in the group direct message
+    # with Iago and Polonius
     user_id1 = 10
     user_id2 = 11
 
@@ -1309,7 +1312,8 @@ def set_typing_status(client: Client) -> None:
     validate_against_openapi_schema(result, "/typing", "post", "200")
 
     # {code_example|start}
-    # The user has finished typing in the group PM with Iago and Polonius
+    # The user has finished typing in the group direct message
+    # with Iago and Polonius
     user_id1 = 10
     user_id2 = 11
 
@@ -1324,7 +1328,8 @@ def set_typing_status(client: Client) -> None:
     validate_against_openapi_schema(result, "/typing", "post", "200")
 
     # {code_example|start}
-    # The user has started to type in topic "typing status" of stream "Denmark"
+    # The user has started to type in topic "typing status"
+    # of stream "Denmark"
     stream_id = client.get_stream_id("Denmark")["stream_id"]
     topic = "typing status"
 
@@ -1341,7 +1346,8 @@ def set_typing_status(client: Client) -> None:
     validate_against_openapi_schema(result, "/typing", "post", "200")
 
     # {code_example|start}
-    # The user has finished typing in topic "typing status" of stream "Denmark"
+    # The user has finished typing in topic "typing status"
+    # of stream "Denmark"
     stream_id = client.get_stream_id("Denmark")["stream_id"]
     topic = "typing status"
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5502,25 +5502,35 @@ paths:
       summary: Send a message
       tags: ["messages"]
       description: |
-        Send a stream or a private message.
+        Send a [stream message](/help/streams-and-topics) or a
+        [direct message](/help/direct-messages).
       parameters:
         - name: type
           in: query
           description: |
-            The type of message to be sent. `private` for a private message and
-            `stream` for a stream message.
+            The type of message to be sent.
+
+            `"direct"` for a direct message and `"stream"` for a stream message.
+
+            **Changes**: In Zulip 7.0 (feature level 174), `"direct"` was added as
+            the preferred way to request a direct message, deprecating the original
+            `"private"`. While `"private"` is still supported for requesting direct
+            messages, clients are encouraged to use to the modern convention with
+            servers that support it, because support for `"private"` will eventually
+            be removed.
           schema:
             type: string
             enum:
-              - private
+              - direct
               - stream
-          example: private
+              - private
+          example: direct
           required: true
         - name: to
           in: query
           description: |
             For stream messages, either the name or integer ID of the stream. For
-            private messages, either a list containing integer user IDs or a list
+            direct messages, either a list containing integer user IDs or a list
             containing string email addresses.
 
             **Changes**: Support for using user/stream IDs was added in Zulip 2.0.0.
@@ -5624,7 +5634,7 @@ paths:
                             "result": "error",
                           }
                         description: |
-                          A typical failed JSON response for when a private message is sent to a user
+                          A typical failed JSON response for when a direct message is sent to a user
                           that does not exist:
   /messages/{message_id}/history:
     get:
@@ -15056,7 +15066,7 @@ paths:
       summary: Set "typing" status
       tags: ["users"]
       description: |
-        Notify other users whether the current user is typing a message.
+        Notify other users whether the current user is [typing a message](/help/typing-notifications).
 
         Clients implementing Zulip's typing notifications protocol should work as follows:
 
@@ -15100,15 +15110,21 @@ paths:
           description: |
             Type of the message being composed.
 
-            **Changes**: New in Zulip 4.0 (feature level 58). Previously, typing
-            notifications were only for private messages.
+            **Changes**: In Zulip 7.0 (feature level 174), `"direct"` was added
+            as the preferred way to indicate a direct message is being composed,
+            becoming the default value for this parameter and deprecating the
+            original `"private"`.
+
+            New in Zulip 4.0 (feature level 58). Previously, typing notifications
+            were only for direct messages.
           schema:
             type: string
             enum:
-              - private
+              - direct
               - stream
-            default: private
-          example: private
+              - private
+            default: direct
+          example: direct
         - name: op
           in: query
           description: |
@@ -15123,16 +15139,16 @@ paths:
         - name: to
           in: query
           description: |
-            For `"private"` type it is the user_ids of the recipients of the message being typed.
-            Send a JSON-encoded list of user_ids. (Use a list even if there is only one
-            recipient.)
+            For `"direct"` type it is the user IDs of the recipients of the message
+            being typed. Send a JSON-encoded list of user IDs. (Use a list even if
+            there is only one recipient.)
 
             For `"stream"` type it is a single element list containing ID of stream in
             which the message is being typed.
 
             **Changes**: Support for typing notifications for stream messages
             is new in Zulip 4.0 (feature level 58). Previously, typing
-            notifications were only for private messages.
+            notifications were only for direct messages.
 
             Before Zulip 2.0.0, this parameter accepted only a JSON-encoded
             list of email addresses. Support for the email address-based format was
@@ -15149,10 +15165,10 @@ paths:
           in: query
           description: |
             Topic to which message is being typed. Required for the `"stream"` type.
-            Ignored in the case of `"private"` type.
+            Ignored in the case of `"direct"` type.
 
             **Changes**: New in Zulip 4.0 (feature level 58). Previously, typing
-            notifications were only for private messages.
+            notifications were only for direct messages.
           schema:
             type: string
           example: typing notifications

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -324,7 +324,7 @@ class GetEventsTest(ZulipTestCase):
         check_send_message(
             sender=user_profile,
             client=get_client("whatever"),
-            message_type_name="private",
+            recipient_type_name="private",
             message_to=[recipient_email],
             topic_name=None,
             message_content="hello",
@@ -357,7 +357,7 @@ class GetEventsTest(ZulipTestCase):
         check_send_message(
             sender=user_profile,
             client=get_client("whatever"),
-            message_type_name="private",
+            recipient_type_name="private",
             message_to=[recipient_email],
             topic_name=None,
             message_content="hello",

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -586,7 +586,7 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([othello.email]).decode(),
             },
@@ -605,7 +605,7 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([user_profile.email]).decode(),
             },
@@ -628,52 +628,60 @@ class MessagePOSTTest(ZulipTestCase):
 
     def test_personal_message_by_id(self) -> None:
         """
-        Sending a personal message to a valid user ID is successful.
+        Sending a personal message to a valid user ID is successful
+        for both valid strings for `type` parameter.
         """
         self.login("hamlet")
-        result = self.client_post(
-            "/json/messages",
-            {
-                "type": "private",
-                "content": "Test message",
-                "to": orjson.dumps([self.example_user("othello").id]).decode(),
-            },
-        )
-        self.assert_json_success(result)
+        recipient_type_name = ["direct", "private"]
 
-        msg = self.get_last_message()
-        self.assertEqual("Test message", msg.content)
-        self.assertEqual(msg.recipient_id, self.example_user("othello").recipient_id)
+        for type in recipient_type_name:
+            result = self.client_post(
+                "/json/messages",
+                {
+                    "type": type,
+                    "content": "Test message",
+                    "to": orjson.dumps([self.example_user("othello").id]).decode(),
+                },
+            )
+            self.assert_json_success(result)
+
+            msg = self.get_last_message()
+            self.assertEqual("Test message", msg.content)
+            self.assertEqual(msg.recipient_id, self.example_user("othello").recipient_id)
 
     def test_group_personal_message_by_id(self) -> None:
         """
-        Sending a personal message to a valid user ID is successful.
+        Sending a personal message to a valid user ID is successful
+        for both valid strings for `type` parameter.
         """
         self.login("hamlet")
-        result = self.client_post(
-            "/json/messages",
-            {
-                "type": "private",
-                "content": "Test message",
-                "to": orjson.dumps(
-                    [self.example_user("othello").id, self.example_user("cordelia").id]
-                ).decode(),
-            },
-        )
-        self.assert_json_success(result)
+        recipient_type_name = ["direct", "private"]
 
-        msg = self.get_last_message()
-        self.assertEqual("Test message", msg.content)
-        self.assertEqual(
-            msg.recipient_id,
-            get_huddle_recipient(
+        for type in recipient_type_name:
+            result = self.client_post(
+                "/json/messages",
                 {
-                    self.example_user("hamlet").id,
-                    self.example_user("othello").id,
-                    self.example_user("cordelia").id,
-                }
-            ).id,
-        )
+                    "type": type,
+                    "content": "Test message",
+                    "to": orjson.dumps(
+                        [self.example_user("othello").id, self.example_user("cordelia").id]
+                    ).decode(),
+                },
+            )
+            self.assert_json_success(result)
+
+            msg = self.get_last_message()
+            self.assertEqual("Test message", msg.content)
+            self.assertEqual(
+                msg.recipient_id,
+                get_huddle_recipient(
+                    {
+                        self.example_user("hamlet").id,
+                        self.example_user("othello").id,
+                        self.example_user("cordelia").id,
+                    }
+                ).id,
+            )
 
     def test_personal_message_copying_self(self) -> None:
         """
@@ -686,7 +694,7 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([hamlet.id, othello.id]).decode(),
             },
@@ -704,7 +712,7 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": "nonexistent",
             },
@@ -723,7 +731,7 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([othello.id]).decode(),
             },
@@ -733,7 +741,7 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([othello.id, cordelia.id]).decode(),
             },
@@ -754,7 +762,7 @@ class MessagePOSTTest(ZulipTestCase):
                 "to": othello.email,
             },
         )
-        self.assert_json_error(result, "Invalid message type")
+        self.assert_json_error(result, "Invalid type")
 
     def test_empty_message(self) -> None:
         """
@@ -764,7 +772,7 @@ class MessagePOSTTest(ZulipTestCase):
         othello = self.example_user("othello")
         result = self.client_post(
             "/json/messages",
-            {"type": "private", "content": " ", "to": othello.email},
+            {"type": "direct", "content": " ", "to": othello.email},
         )
         self.assert_json_error(result, "Message must not be empty")
 
@@ -824,9 +832,9 @@ class MessagePOSTTest(ZulipTestCase):
         )
         self.assert_json_error(result, "Invalid character in topic, at position 5!")
 
-    def test_invalid_message_type(self) -> None:
+    def test_invalid_recipient_type(self) -> None:
         """
-        Messages other than the type of "private" or "stream" are considered as invalid
+        Messages other than the type of "direct", "private" or "stream" are invalid.
         """
         self.login("hamlet")
         result = self.client_post(
@@ -838,7 +846,7 @@ class MessagePOSTTest(ZulipTestCase):
                 "topic": "Test topic",
             },
         )
-        self.assert_json_error(result, "Invalid message type")
+        self.assert_json_error(result, "Invalid type")
 
     def test_private_message_without_recipients(self) -> None:
         """
@@ -847,7 +855,7 @@ class MessagePOSTTest(ZulipTestCase):
         self.login("hamlet")
         result = self.client_post(
             "/json/messages",
-            {"type": "private", "content": "Test content", "to": ""},
+            {"type": "direct", "content": "Test content", "to": ""},
         )
         self.assert_json_error(result, "Message must have recipients")
 
@@ -859,7 +867,7 @@ class MessagePOSTTest(ZulipTestCase):
             self.mit_user("starnine"),
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",
@@ -879,7 +887,7 @@ class MessagePOSTTest(ZulipTestCase):
             self.mit_user("starnine"),
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",
@@ -898,7 +906,7 @@ class MessagePOSTTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",
@@ -916,7 +924,7 @@ class MessagePOSTTest(ZulipTestCase):
             self.mit_user("starnine"),
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",
@@ -931,7 +939,7 @@ class MessagePOSTTest(ZulipTestCase):
         Sending two mirrored huddles in the row return the same ID
         """
         msg = {
-            "type": "private",
+            "type": "direct",
             "sender": self.mit_email("sipbtest"),
             "content": "Test message",
             "client": "zephyr_mirror",
@@ -1065,7 +1073,7 @@ class MessagePOSTTest(ZulipTestCase):
             self.mit_user("starnine"),
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "client": "zephyr_mirror",
                 "to": self.mit_email("starnine"),
@@ -1079,7 +1087,7 @@ class MessagePOSTTest(ZulipTestCase):
             self.mit_user("starnine"),
             "/api/v1/messages",
             {
-                "type": "not-private",
+                "type": "stream",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",
@@ -1098,7 +1106,7 @@ class MessagePOSTTest(ZulipTestCase):
             self.mit_user("starnine"),
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",
@@ -1120,7 +1128,7 @@ class MessagePOSTTest(ZulipTestCase):
             user,
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",
@@ -1141,7 +1149,7 @@ class MessagePOSTTest(ZulipTestCase):
             user,
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "sender": self.mit_email("sipbtest"),
                 "content": "Test message",
                 "client": "zephyr_mirror",

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2557,7 +2557,7 @@ class TestAddressee(ZulipTestCase):
 
         result = Addressee.legacy_build(
             sender=self.example_user("hamlet"),
-            message_type_name="private",
+            recipient_type_name="private",
             message_to=user_ids,
             topic_name="random_topic",
             realm=realm,
@@ -2576,7 +2576,7 @@ class TestAddressee(ZulipTestCase):
 
         result = Addressee.legacy_build(
             sender=sender,
-            message_type_name="stream",
+            recipient_type_name="stream",
             message_to=[stream.id],
             topic_name="random_topic",
             realm=realm,

--- a/zerver/tests/test_mirror_users.py
+++ b/zerver/tests/test_mirror_users.py
@@ -19,11 +19,13 @@ class MirroredMessageUsersTest(ZulipTestCase):
 
         recipients: List[str] = []
 
-        message_type = "private"
+        recipient_type_name = "private"
         client = get_client("banned_mirror")
 
         with self.assertRaises(InvalidMirrorInputError):
-            create_mirrored_message_users(client, user, recipients, sender.email, message_type)
+            create_mirrored_message_users(
+                client, user, recipients, sender.email, recipient_type_name
+            )
 
     def test_invalid_email(self) -> None:
         invalid_email = "alice AT example.com"
@@ -33,13 +35,15 @@ class MirroredMessageUsersTest(ZulipTestCase):
         user = self.mit_user("starnine")
         sender = user
 
-        message_type = "private"
+        recipient_type_name = "private"
 
         for client_name in ["zephyr_mirror", "irc_mirror", "jabber_mirror"]:
             client = get_client(client_name)
 
             with self.assertRaises(InvalidMirrorInputError):
-                create_mirrored_message_users(client, user, recipients, sender.email, message_type)
+                create_mirrored_message_users(
+                    client, user, recipients, sender.email, recipient_type_name
+                )
 
     @mock.patch(
         "DNS.dnslookup",
@@ -54,11 +58,11 @@ class MirroredMessageUsersTest(ZulipTestCase):
 
         recipients = [user.email, new_user_email]
 
-        message_type = "private"
+        recipient_type_name = "private"
         client = get_client("zephyr_mirror")
 
         mirror_sender = create_mirrored_message_users(
-            client, user, recipients, sender.email, message_type
+            client, user, recipients, sender.email, recipient_type_name
         )
 
         self.assertEqual(mirror_sender, sender)
@@ -82,11 +86,11 @@ class MirroredMessageUsersTest(ZulipTestCase):
 
         recipients = ["stream_name"]
 
-        message_type = "stream"
+        recipient_type_name = "stream"
         client = get_client("zephyr_mirror")
 
         mirror_sender = create_mirrored_message_users(
-            client, user, recipients, sender_email, message_type
+            client, user, recipients, sender_email, recipient_type_name
         )
 
         assert mirror_sender is not None
@@ -105,11 +109,11 @@ class MirroredMessageUsersTest(ZulipTestCase):
             self.nonreg_email("cordelia"),
         ]
 
-        message_type = "private"
+        recipient_type_name = "private"
         client = get_client("irc_mirror")
 
         mirror_sender = create_mirrored_message_users(
-            client, user, recipients, sender.email, message_type
+            client, user, recipients, sender.email, recipient_type_name
         )
 
         self.assertEqual(mirror_sender, sender)
@@ -134,11 +138,11 @@ class MirroredMessageUsersTest(ZulipTestCase):
             self.nonreg_email("cordelia"),
         ]
 
-        message_type = "private"
+        recipient_type_name = "private"
         client = get_client("jabber_mirror")
 
         mirror_sender = create_mirrored_message_users(
-            client, user, recipients, sender.email, message_type
+            client, user, recipients, sender.email, recipient_type_name
         )
 
         self.assertEqual(mirror_sender, sender)

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -132,6 +132,23 @@ class TypingValidateToArgumentsTest(ZulipTestCase):
 
 
 class TypingHappyPathTestPMs(ZulipTestCase):
+    def test_valid_type_and_op_parameters(self) -> None:
+        recipient_type_name = ["direct", "private"]
+        operator_type = ["start", "stop"]
+        sender = self.example_user("hamlet")
+        recipient_user = self.example_user("othello")
+
+        for type in recipient_type_name:
+            for operator in operator_type:
+                params = dict(
+                    to=orjson.dumps([recipient_user.id]).decode(),
+                    op=operator,
+                    type=type,
+                )
+
+                result = self.api_post(sender, "/api/v1/typing", params)
+                self.assert_json_success(result)
+
     def test_start_to_single_recipient(self) -> None:
         sender = self.example_user("hamlet")
         recipient_user = self.example_user("othello")

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -949,7 +949,7 @@ def process_message_event(
 
     sender_id: int = wide_dict["sender_id"]
     message_id: int = wide_dict["id"]
-    message_type: str = wide_dict["type"]
+    recipient_type_name: str = wide_dict["type"]
     sending_client: str = wide_dict["client"]
 
     @lru_cache(maxsize=None)
@@ -970,7 +970,7 @@ def process_message_event(
 
         # If the recipient was offline and the message was a single or group PM to them
         # or they were @-notified potentially notify more immediately
-        private_message = message_type == "private"
+        private_message = recipient_type_name == "private"
         user_notifications_data = UserMessageNotificationsData.from_user_id_sets(
             user_id=user_profile_id,
             flags=flags,


### PR DESCRIPTION
For endpoints with a `type` parameter to indicate whether the message is a stream or direct  message, [`POST /typing`](https://zulip.com/api/set-typing-status) and [`POST /messages`](https://zulip.com/api/send-message), adds support for passing `"direct"` as a value for direct messages.

Maintains support for `"private"` as a deprecated alias for direct messages.

Fixes https://github.com/zulip/zulip/issues/24960.

---

**Notes**:
- For the **Usage examples** in the `POST /messages` documentation:
  - Comments now use 'direct messages' or 'DMs'
  - Updated the curl and javascript examples
  - Did not update the python example for "direct". I wasn't sure if we wanted to update that in tandem with an update to zulip-python-api; see question below.
- I added the validation check for the `type` parameter that was in `POST /typing` to also be in `POST /messages`.
- I did the refactor in the prep commit because any follow-up changes we do can be a bit clearer in that all instances of `message_type_name` now refer to these parameters passed to the view functions from clients. See `git-grep` below.
  - for `POST /messages`, we use "private" for the `message_type` string that's then used for the various function calls.
  - for `POST /typing`, we use "direct" for the default and updated `message_type` string.
- Updates these two API endpoint documentation pages to use "direct messages" or "DMs" and also added links to relevant help center documentation.

<details>
<summary>git-grep of `message_type_name` after changes</summary>

```console
$ git grep message_type_name
zerver/tests/test_message_send.py:        message_type_name = ["direct", "private"]
zerver/tests/test_message_send.py:        for message_type in message_type_name:
zerver/tests/test_message_send.py:        message_type_name = ["direct", "private"]
zerver/tests/test_message_send.py:        for message_type in message_type_name:
zerver/tests/test_typing.py:        message_type_name = ["direct", "private"]
zerver/tests/test_typing.py:        for message_type in message_type_name:
zerver/views/message_send.py:    message_type_name: str = REQ("type", str_validator=check_string_in(VALID_MESSAGE_TYPES)),
zerver/views/message_send.py:    message_type = message_type_name
zerver/views/typing.py:    message_type_name: str = REQ(
zerver/views/typing.py:    message_type = message_type_name

```
</details>

**Questions**:
- In the **Changes** notes, I stated that "private" would be removed in a future release, but I wasn't sure if that's the case?
- I added some TODO notes where `message_type` is set in both view functions, but these might not be something we plan on doing?
- Again, as noted above, we'll likely want to update the [zulip-python-api](https://github.com/zulip/python-zulip-api/blob/02586f1d348dbcab3bc8d30b805fffd48a524e18/zulip/zulip/send.py#L89-L101)?

---

**Screenshots and screen captures:**

<details>
<summary>API changelog update</summary>

![Screenshot from 2023-04-17 16-48-08](https://user-images.githubusercontent.com/63245456/232539073-ca9114d8-f9aa-471e-bd37-2e6ec6c4e8b7.png)
</details>

<details>
<summary>Send a message</summary>

[Current documentation](https://zulip.com/api/send-message)
<details>
<summary>Main endpoint description and usage examples</summary>

![Screenshot from 2023-04-17 16-50-21](https://user-images.githubusercontent.com/63245456/232538394-d2ed3339-3b7c-4f68-89dd-f5398c1f22d7.png)
![Screenshot from 2023-04-17 16-50-32](https://user-images.githubusercontent.com/63245456/232538398-492451a4-471a-4605-bc02-29875decb79a.png)
![Screenshot from 2023-04-17 16-50-40](https://user-images.githubusercontent.com/63245456/232538401-ba956f7a-9b0f-4f5c-b672-a306edb91c6b.png)
![Screenshot from 2023-04-17 16-50-47](https://user-images.githubusercontent.com/63245456/232538415-a9785037-5a4a-4249-8b1d-ef82f095fe85.png)
</details>
<details>
<summary>Parameters and response</summary>

![Screenshot from 2023-04-17 16-50-57](https://user-images.githubusercontent.com/63245456/232538419-25edea0c-d051-4b30-ac9e-ae255836535b.png)
![Screenshot from 2023-04-17 16-51-06](https://user-images.githubusercontent.com/63245456/232538421-708e15bf-1344-4966-a219-9adb0c162fc7.png)
</details>
</details>
<details>
<summary>Set typing status</summary>

[Current documentation](https://zulip.com/api/set-typing-status)
<details>
<summary>Main endpoint description</summary>

![Screenshot from 2023-04-17 16-49-12](https://user-images.githubusercontent.com/63245456/232540431-eb421fa7-c1de-4853-a0b8-f769eee22530.png)
</details>
<details>
<summary>Usage examples</summary>

![Screenshot from 2023-04-17 16-49-30](https://user-images.githubusercontent.com/63245456/232540157-7b0b9d8f-2e16-45dd-b0db-d07446fda0e7.png)
![Screenshot from 2023-04-17 16-49-36](https://user-images.githubusercontent.com/63245456/232540163-f4c557e4-1224-4d22-a2d8-71c265527a3c.png)
![Screenshot from 2023-04-17 16-49-44](https://user-images.githubusercontent.com/63245456/232540167-bd604c45-5ee6-491b-a909-12d114a8499a.png)
</details>
<details>
<summary>Parameters and response</summary>

![Screenshot from 2023-04-17 16-49-54](https://user-images.githubusercontent.com/63245456/232540171-d6a88467-b198-4309-932b-1bf93f9b60ed.png)
![Screenshot from 2023-04-17 16-50-02](https://user-images.githubusercontent.com/63245456/232540176-206d9437-f35a-4a75-b07a-7a9f67b2409d.png)
</details>
</details>
---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
