### PR TITLE
message_list_view: Don't select message if the list is not current.

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -394,16 +394,6 @@ export class MessageList {
         $recipient_row.find(".always_visible_topic_edit").show();
     }
 
-    show_message_as_read(message, options) {
-        const $row = this.get_row(message.id);
-        if (options.from === "pointer" || options.from === "server") {
-            $row.find(".unread_marker").addClass("fast_fade");
-        } else {
-            $row.find(".unread_marker").addClass("slow_fade");
-        }
-        $row.removeClass("unread");
-    }
-
     reselect_selected_id() {
         const selected_id = this.data.selected_id();
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1587,4 +1587,13 @@ export class MessageListView {
         }
         $row.removeClass("unread");
     }
+
+    show_messages_as_unread(message_ids) {
+        const $table = rows.get_table(this.table_name);
+        const $rows_to_show_as_unread = $table.find(".message_row").filter((index, $row) => {
+            const message_id = Number.parseFloat($row.getAttribute("zid"));
+            return message_ids.includes(message_id);
+        });
+        $rows_to_show_as_unread.addClass("unread");
+    }
 }

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1577,4 +1577,14 @@ export class MessageListView {
             stream_color.update_stream_recipient_color($stream_header);
         }
     }
+
+    show_message_as_read(message, options) {
+        const $row = this.get_row(message.id);
+        if (options.from === "pointer" || options.from === "server") {
+            $row.find(".unread_marker").addClass("fast_fade");
+        } else {
+            $row.find(".unread_marker").addClass("slow_fade");
+        }
+        $row.removeClass("unread");
+    }
 }

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1250,8 +1250,9 @@ export class MessageListView {
         this._post_process($rendered_msg);
         $row.replaceWith($rendered_msg);
 
-        if (was_selected) {
-            this.list.select_id(message_container.msg.id);
+        // If this list not currently displayed, we don't need to select the message.
+        if (was_selected && this.list === message_lists.current) {
+            this.list.reselect_selected_id(message_container.msg.id);
         }
     }
 

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -150,7 +150,7 @@ export function mark_all_as_read(args = {}) {
 
 function process_newly_read_message(message, options) {
     for (const msg_list of message_lists.all_rendered_message_lists()) {
-        msg_list.show_message_as_read(message, options);
+        msg_list.view.show_message_as_read(message, options);
     }
     notifications.close_notification(message);
     recent_topics_ui.update_topic_unread_count(message);

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -10,7 +10,6 @@ import {$t_html} from "./i18n";
 import * as loading from "./loading";
 import * as message_flags from "./message_flags";
 import * as message_lists from "./message_lists";
-import * as message_live_update from "./message_live_update";
 import * as message_store from "./message_store";
 import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
@@ -331,22 +330,11 @@ export function process_unread_messages_event({message_ids, message_details}) {
         });
     }
 
-    /*
-        A batch of messages marked as unread can be 1000+ messages, so
-        we do want to do a bulk operation for these UI updates.
+    // Update UI for the messages marked as unread.
+    for (const list of message_lists.all_rendered_message_lists()) {
+        list.view.show_messages_as_unread(message_ids);
+    }
 
-        We use a big-hammer approach now to updating the message view.
-        This is relatively harmless, since the only time we are called is
-        when the user herself marks her message as unread.  But we
-        do eventually want to be more surgical here, especially once we
-        have a final scheme for how best to structure the HTML within
-        the message to indicate read-vs.-unread.  Currently we use a
-        green border, but that may change.
-
-        The main downside of doing a full rerender is that it can be
-        user-visible in the form of users' avatars flickering.
-    */
-    message_live_update.rerender_messages_view_by_message_ids(message_ids);
     recent_topics_ui.complete_rerender();
 
     if (

--- a/web/tests/example7.test.js
+++ b/web/tests/example7.test.js
@@ -55,8 +55,8 @@ const message_viewport = mock_esm("../src/message_viewport");
 const notifications = mock_esm("../src/notifications");
 const unread_ui = mock_esm("../src/unread_ui");
 
-message_lists.current = {};
-message_lists.home = {};
+message_lists.current = {view: {}};
+message_lists.home = {view: {}};
 message_lists.all_rendered_message_lists = () => [message_lists.home, message_lists.current];
 
 const message_store = zrequire("message_store");
@@ -107,8 +107,8 @@ run_test("unread_ops", ({override}) => {
     override(message_lists.current, "all_messages", () => test_messages);
 
     // Ignore these interactions for now:
-    override(message_lists.current, "show_message_as_read", () => {});
-    override(message_lists.home, "show_message_as_read", () => {});
+    override(message_lists.current.view, "show_message_as_read", () => {});
+    override(message_lists.home.view, "show_message_as_read", () => {});
     override(notifications, "close_notification", () => {});
     override(unread_ui, "update_unread_counts", () => {});
     override(unread_ui, "notify_messages_remain_unread", () => {});


### PR DESCRIPTION
Not having this check caused `Mark as unread from here` to not work for message which was selected when the list was rendered since we marked it as read again via `this.list.select_id` after marking it as unread.

Steps for reproducer:
* Narrow to a topic / PM with plenty of messages.
* Mark some messages as unread in that narrow.
* Reload the page.
* Now the message which was selected will remain "read" even upon marking it as unread.

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/unable.20to.20mark.20message.20as.20read

![unread_bug](https://user-images.githubusercontent.com/25124304/232604338-94bb7d6d-5bff-4571-b581-656ab3ca06a9.gif)
