### PR TITLE
message_list_view: Change date of sticky header more carefully.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1511,10 +1511,14 @@ export class MessageListView {
         } else {
             $sticky_header.addClass("sticky_header");
             const sticky_header_props = $sticky_header[0].getBoundingClientRect();
+            /* date separator starts to be hidden at this height difference. */
+            const date_separator_padding = 7;
+            const sticky_header_bottom = sticky_header_props.top + sticky_header_props.height;
+            const possible_new_date_separator_start = sticky_header_bottom - date_separator_padding;
             /* Get `message_row` under the sticky header. */
             const elements_below_sticky_header = document.elementsFromPoint(
                 sticky_header_props.left,
-                sticky_header_props.top,
+                possible_new_date_separator_start,
             );
             $message_row = $(
                 elements_below_sticky_header.filter((element) =>


### PR DESCRIPTION
If the sticky recipient bar hides the date separator completely, the recipient bar needs to show the correct date for the message next to it, otherwise the user will see the wrong date for the message.

To fix this, we show the date on the date separator as soon as the sticky message header starts to overlap with the date separator.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/old.20date.20in.20sticky.20recipient.20bar

before:
<img width="473" alt="image" src="https://user-images.githubusercontent.com/25124304/232632268-1d092f03-e892-4267-96a6-ead0fc0d8d03.png">

after:
<img width="469" alt="image" src="https://user-images.githubusercontent.com/25124304/232632113-91824565-0f84-45b4-b827-3bf71f197c05.png">

<img width="477" alt="image" src="https://user-images.githubusercontent.com/25124304/232632083-074ae8dd-8344-43f0-a7e2-2b22504a1ad9.png">
