### PR TITLE
portico-header: Fix navbar user dropdown not working.

### DIFF
--- a/web/src/portico/header.ts
+++ b/web/src/portico/header.ts
@@ -80,4 +80,21 @@ $(() => {
             document.body.classList.remove("_full-height-no-scroll");
         }
     });
+
+    /* Used by navbar of non-corporate URLs. */
+    $(".portico-header li.logout").on("click", () => {
+        $("#logout_form").trigger("submit");
+        return false;
+    });
+
+    $(".dropdown").on("click", (e) => {
+        const $this = $(e.target);
+        const dropdown_is_shown = $this.closest(".dropdown").hasClass("show");
+
+        if (!dropdown_is_shown) {
+            $this.closest(".dropdown").addClass("show");
+        } else if (dropdown_is_shown) {
+            $this.closest(".dropdown").removeClass("show");
+        }
+    });
 });

--- a/web/src/portico/header.ts
+++ b/web/src/portico/header.ts
@@ -87,14 +87,14 @@ $(() => {
         return false;
     });
 
-    $(".dropdown").on("click", (e) => {
-        const $this = $(e.target);
-        const dropdown_is_shown = $this.closest(".dropdown").hasClass("show");
+    $(".portico-header .dropdown").on("click", (e) => {
+        const $user_dropdown = $(e.target).closest(".dropdown");
+        const dropdown_is_shown = $user_dropdown.hasClass("show");
 
         if (!dropdown_is_shown) {
-            $this.closest(".dropdown").addClass("show");
+            $user_dropdown.addClass("show");
         } else if (dropdown_is_shown) {
-            $this.closest(".dropdown").removeClass("show");
+            $user_dropdown.removeClass("show");
         }
     });
 });


### PR DESCRIPTION
As part of #24678, this code was accidentally removed. We just add it back to fix the broken user profile dropdown in the navbar of non corporate pages.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/logo.20dropdown.20on.20non-app.20pages