### PR TITLE
template: Fix padding in `unsubscribe_success.html`.

### DIFF
--- a/templates/zerver/unsubscribe_success.html
+++ b/templates/zerver/unsubscribe_success.html
@@ -7,7 +7,7 @@
 {% block portico_content %}
 
 <div class="app portico-page">
-    <div class="app-main portico-page-container center-block flex full-page new-style">
+    <div class="app-main portico-page-container center-block flex full-page account-creation new-style">
         <div class="inline-block">
 
             <div class="get-started">


### PR DESCRIPTION
Removes the bottom padding in the last `<p>` tag with content in `unsubscribe_success.html`.

Follow-up to #25074.

**Notes**:
- Another option was to add the `account-creation` class, which also removes the padding from the final `<p>` tag. But that also impacts the font-weight. Added example screenshots of that below for comparison.

---

**Screenshots and screen captures:**

<details>
<summary>Before and after changes</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-04-14 12-29-58](https://user-images.githubusercontent.com/63245456/232790420-19c269fb-c31b-4a40-a436-f6b88cf4f1bd.png) | ![Screenshot from 2023-04-18 13-01-40](https://user-images.githubusercontent.com/63245456/232790510-69e09421-930c-419b-8fd7-5a20d173529a.png)
| ![Screenshot from 2023-04-14 12-30-56](https://user-images.githubusercontent.com/63245456/232790423-28a23f32-f385-4b4d-b5ad-75abd51a5874.png) | ![Screenshot from 2023-04-18 13-01-35](https://user-images.githubusercontent.com/63245456/232790981-a8243a9d-3d97-4cb4-9577-708573f7c5f4.png)
</details>
<details>
<summary>Version with adding existing `account-creation` CSS class</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-04-14 12-29-58](https://user-images.githubusercontent.com/63245456/232790420-19c269fb-c31b-4a40-a436-f6b88cf4f1bd.png) | ![Screenshot from 2023-04-18 15-25-45](https://user-images.githubusercontent.com/63245456/232791629-fc754dfb-0b18-4967-a7f5-38e67badeed7.png)
| ![Screenshot from 2023-04-14 12-30-56](https://user-images.githubusercontent.com/63245456/232790423-28a23f32-f385-4b4d-b5ad-75abd51a5874.png) | ![Screenshot from 2023-04-18 15-25-51](https://user-images.githubusercontent.com/63245456/232791918-e66abfb7-916a-4c3c-9fd8-1f7f2a9e85d3.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
