### PR TITLE
Fixes part of Issue 25097: using the escape key to exit the calendar view, not the settings view

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -14,9 +14,10 @@ import * as channel from "./channel";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_state from "./compose_state";
-import {media_breakpoints_num} from "./css_variables";
+import { media_breakpoints_num } from "./css_variables";
 import * as dark_theme from "./dark_theme";
 import * as emoji_picker from "./emoji_picker";
+import * as flatpickr from "./flatpickr";
 import * as hash_util from "./hash_util";
 import * as message_edit from "./message_edit";
 import * as message_flags from "./message_flags";
@@ -26,13 +27,14 @@ import * as muted_topics_ui from "./muted_topics_ui";
 import * as narrow from "./narrow";
 import * as navigate from "./navigate";
 import * as notifications from "./notifications";
-import {page_params} from "./page_params";
+import { page_params } from "./page_params";
 import * as pm_list from "./pm_list";
 import * as popovers from "./popovers";
 import * as reactions from "./reactions";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as rows from "./rows";
 import * as server_events from "./server_events";
+import * as settings_account from "./settings_account";
 import * as settings_display from "./settings_display";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as settings_toggle from "./settings_toggle";
@@ -41,7 +43,7 @@ import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
 import * as topic_list from "./topic_list";
 import * as ui_util from "./ui_util";
-import {parse_html} from "./ui_util";
+import { parse_html } from "./ui_util";
 import * as user_profile from "./user_profile";
 import * as util from "./util";
 
@@ -187,7 +189,7 @@ export function initialize() {
         if (page_params.is_spectator) {
             return;
         }
-        compose_actions.respond_to_message({trigger: "message click"});
+        compose_actions.respond_to_message({ trigger: "message click" });
         e.stopPropagation();
         popovers.hide_all();
     };
@@ -414,7 +416,7 @@ export function initialize() {
         }
         e.preventDefault();
         const row_id = get_row_id_for_narrowing(this);
-        narrow.by_recipient(row_id, {trigger: "message header"});
+        narrow.by_recipient(row_id, { trigger: "message header" });
     });
 
     $("#message_feed_container").on("click", ".narrows_by_topic", function (e) {
@@ -423,7 +425,7 @@ export function initialize() {
         }
         e.preventDefault();
         const row_id = get_row_id_for_narrowing(this);
-        narrow.by_topic(row_id, {trigger: "message header"});
+        narrow.by_topic(row_id, { trigger: "message header" });
     });
 
     // SIDEBARS
@@ -461,7 +463,7 @@ export function initialize() {
         .on("click", ".selectable_sidebar_block", (e) => {
             const $li = $(e.target).parents("li");
 
-            activity.narrow_for_user({$li});
+            activity.narrow_for_user({ $li });
 
             e.preventDefault();
             e.stopPropagation();
@@ -514,7 +516,7 @@ export function initialize() {
                 // it will be removed and we need to attach it on an element which will remain in the DOM.
                 const target_node = get_target_node(instance);
                 // We only need to know if any of the `li` elements were removed.
-                const config = {attributes: false, childList: true, subtree};
+                const config = { attributes: false, childList: true, subtree };
                 const callback = function (mutationsList) {
                     for (const mutation of mutationsList) {
                         // Hide instance if reference is in the removed node list.
@@ -600,7 +602,7 @@ export function initialize() {
             return;
         }
         const title_data = recent_topics_ui.get_pm_tooltip_data(user_ids_string);
-        const noop = () => {};
+        const noop = () => { };
         do_render_buddy_list_tooltip($elem, title_data, noop, noop, false, undefined, false);
     });
 
@@ -625,11 +627,34 @@ export function initialize() {
     });
 
     $(".restart_get_events_button").on("click", () => {
-        server_events.restart_get_events({dont_block: true});
+        server_events.restart_get_events({ dont_block: true });
     });
 
     $("#settings_page").on("click", ".collapse-settings-btn", () => {
         settings_toggle.toggle_org_setting_collapse();
+    });
+
+    $("#settings_page").on("click", ".custom_user_field .datepicker", () => {
+        console.log("in our code");
+        const el = document.getElementsByClassName('custom_user_field_value datepicker settings_text_input form-control input');
+        const on_timestamp_selection = (val) => {
+            $("#profile-settings .custom-profile-fields-form")
+                .find(".flatpickr-confirm visible lightTheme")
+                .on("click", function () {
+                    console.log("in our callback");
+                    $(this).parent().find(".custom_user_field_value").val(val);
+                });
+        };
+        flatpickr.show_flatpickr(
+            $(el)[0],
+            on_timestamp_selection,
+            new Date(),
+            {
+                // place the time picker above the icon and center it horizontally
+                position: "above center",
+            },
+        );
+
     });
 
     $("body").on("click", ".reload_link", () => {
@@ -639,11 +664,11 @@ export function initialize() {
     // COMPOSE
 
     $("body").on("click", ".empty_feed_compose_stream", (e) => {
-        compose_actions.start("stream", {trigger: "empty feed message"});
+        compose_actions.start("stream", { trigger: "empty feed message" });
         e.preventDefault();
     });
     $("body").on("click", ".empty_feed_compose_private", (e) => {
-        compose_actions.start("private", {trigger: "empty feed message"});
+        compose_actions.start("private", { trigger: "empty feed message" });
         e.preventDefault();
     });
 
@@ -764,7 +789,7 @@ export function initialize() {
 
                 channel.post({
                     url: "/accounts/webathena_kerberos_login/",
-                    data: {cred: JSON.stringify(r.session)},
+                    data: { cred: JSON.stringify(r.session) },
                     success() {
                         $("#zephyr-mirror-error").removeClass("show");
                     },

--- a/web/tests/settings_data_field.test.js
+++ b/web/tests/settings_data_field.test.js
@@ -1,0 +1,220 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {mock_esm, zrequire} = require("./lib/namespace");
+const {run_test} = require("./lib/test");
+const $ = require("./lib/zjquery");
+const {page_params} = require("./lib/zpage_params");
+
+const loading = mock_esm("../src/loading");
+
+const SHORT_TEXT_ID = 1;
+
+const SELECT_ID = 3;
+const EXTERNAL_ACCOUNT_ID = 7;
+const LONG_TEXT_ID = 2;
+const USER_FIELD_ID = 6;
+
+const SHORT_TEXT_NAME = "Short text";
+const SELECT_NAME = "Select";
+const EXTERNAL_ACCOUNT_NAME = "External account";
+const LONG_TEXT_NAME = "Long text";
+const USER_FIELD_NAME = "Person";
+
+const custom_profile_field_types = {
+    SHORT_TEXT: {
+        id: SHORT_TEXT_ID,
+        name: SHORT_TEXT_NAME,
+    },
+    SELECT: {
+        id: SELECT_ID,
+        name: SELECT_NAME,
+    },
+    EXTERNAL_ACCOUNT: {
+        id: EXTERNAL_ACCOUNT_ID,
+        name: EXTERNAL_ACCOUNT_NAME,
+    },
+    LONG_TEXT: {
+        id: LONG_TEXT_ID,
+        name: LONG_TEXT_NAME,
+    },
+    USER: {
+        id: USER_FIELD_ID,
+        name: USER_FIELD_NAME,
+    },
+};
+
+page_params.custom_profile_field_types = custom_profile_field_types;
+
+mock_esm("sortablejs", {Sortable: {create() {}}});
+
+const settings_profile_fields = zrequire("settings_profile_fields");
+
+function test_populate(opts, template_data) {
+    const fields_data = opts.fields_data;
+
+    page_params.is_admin = opts.is_admin;
+    const $table = $("#admin_profile_fields_table");
+    const $rows = $.create("rows");
+    const $form = $.create("forms");
+    $table.set_find_results("tr.profile-field-row", $rows);
+    $table.set_find_results("tr.profile-field-form", $form);
+
+    $table[0] = "stub";
+
+    $rows.remove = () => {};
+    $form.remove = () => {};
+
+    let num_appends = 0;
+    $table.append = () => {
+        num_appends += 1;
+    };
+
+    loading.destroy_indicator = () => {};
+
+    settings_profile_fields.do_populate_profile_fields(fields_data);
+
+    assert.deepEqual(template_data, opts.expected_template_data);
+    assert.equal(num_appends, fields_data.length);
+}
+
+run_test("populate_profile_fields", ({mock_template}) => {
+    page_params.custom_profile_fields = {};
+    page_params.realm_default_external_accounts = JSON.stringify({});
+
+    $("#admin_profile_fields_table .display_in_profile_summary_false").toggleClass = () => {};
+
+    const template_data = [];
+    mock_template("settings/admin_profile_field_list.hbs", false, (data) => {
+        template_data.push(data);
+        return "eh";
+    });
+
+    const fields_data = [
+        {
+            type: SHORT_TEXT_ID,
+            id: 10,
+            name: "favorite color",
+            hint: "blue?",
+            field_data: "",
+            display_in_profile_summary: false,
+            valid_to_display_in_summary: true,
+        },
+        {
+            type: SELECT_ID,
+            id: 30,
+            name: "meal",
+            hint: "lunch",
+            field_data: JSON.stringify([
+                {
+                    text: "lunch",
+                    order: 0,
+                },
+                {
+                    text: "dinner",
+                    order: 1,
+                },
+            ]),
+            display_in_profile_summary: false,
+            valid_to_display_in_summary: true,
+        },
+        {
+            type: EXTERNAL_ACCOUNT_ID,
+            id: 20,
+            name: "github profile",
+            hint: "username only",
+            field_data: JSON.stringify({
+                subtype: "github",
+            }),
+            display_in_profile_summary: true,
+            valid_to_display_in_summary: true,
+        },
+        {
+            type: EXTERNAL_ACCOUNT_ID,
+            id: 21,
+            name: "zulip profile",
+            hint: "username only",
+            field_data: JSON.stringify({
+                subtype: "custom",
+                url_pattern: "https://chat.zulip.com/%(username)s",
+            }),
+            display_in_profile_summary: true,
+            valid_to_display_in_summary: true,
+        },
+    ];
+    const expected_template_data = [
+        {
+            profile_field: {
+                id: 10,
+                name: "favorite color",
+                hint: "blue?",
+                type: SHORT_TEXT_NAME,
+                choices: [],
+                is_select_field: false,
+                is_external_account_field: false,
+                display_in_profile_summary: false,
+                valid_to_display_in_summary: true,
+            },
+            can_modify: true,
+            realm_default_external_accounts: page_params.realm_default_external_accounts,
+        },
+        {
+            profile_field: {
+                id: 30,
+                name: "meal",
+                hint: "lunch",
+                type: SELECT_NAME,
+                choices: [
+                    {order: 0, value: "0", text: "lunch"},
+                    {order: 1, value: "1", text: "dinner"},
+                ],
+                is_select_field: true,
+                is_external_account_field: false,
+                display_in_profile_summary: false,
+                valid_to_display_in_summary: true,
+            },
+            can_modify: true,
+            realm_default_external_accounts: page_params.realm_default_external_accounts,
+        },
+        {
+            profile_field: {
+                id: 20,
+                name: "github profile",
+                hint: "username only",
+                type: EXTERNAL_ACCOUNT_NAME,
+                choices: [],
+                is_select_field: false,
+                is_external_account_field: true,
+                display_in_profile_summary: true,
+                valid_to_display_in_summary: true,
+            },
+            can_modify: true,
+            realm_default_external_accounts: page_params.realm_default_external_accounts,
+        },
+        {
+            profile_field: {
+                id: 21,
+                name: "zulip profile",
+                hint: "username only",
+                type: EXTERNAL_ACCOUNT_NAME,
+                choices: [],
+                is_select_field: false,
+                is_external_account_field: true,
+                display_in_profile_summary: true,
+                valid_to_display_in_summary: true,
+            },
+            can_modify: true,
+            realm_default_external_accounts: page_params.realm_default_external_accounts,
+        },
+    ];
+
+    test_populate(
+        {
+            fields_data,
+            expected_template_data,
+            is_admin: false,
+        },
+        template_data,
+    );
+});


### PR DESCRIPTION
Please note: the current code is incomplete. For a class assignment, my partner and I needed to submit a PR, whether the code is complete or not, and the deadline is coming up. Please be aware that this code is incomplete and does NOT solve the issue. 

We realized that the issue with the code lies in the fact that when you press "esc" while in settings with the calendar open, it believes it is referring to the settings pop-up, not the calendar pop-up. To resolve this, we wanted to change the code for the calendar pop-up, but unfortunately could not find where this code lies. We searched hard and added console.logs, but did not find it anywhere. We instead decided to make the calendar be a flatpickr so that it would have the appropriate escape and arrow key functionality. The issue, we realized, is that there is a time box which isn't preferred. Another issue is that the flatpickr is not connected to the settings HTML so the date does not pop up after being selected. 

We spent a long time working on this, but unfortunately were unable to complete the task in time for the assignment due date. We apologize profusely for wasting your time and hope that our findings might help another user who works on this issue in the future. 

Fixes: #25097 

![chrome-capture-2023-3-18](https://user-images.githubusercontent.com/94003925/232842526-26fbbdc9-eb60-496d-91b7-74a0de50f4f3.gif)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
