### PR TITLE
emails: Remove compiled from .gitignore

### DIFF
--- a/templates/zerver/emails/.gitignore
+++ b/templates/zerver/emails/.gitignore
@@ -1,2 +1,1 @@
-compiled
 custom


### PR DESCRIPTION
It’s unused since commit 2f203f4de1d77c197e472d916857070bcc2d9f54 (#24991).