### PR TITLE
Fix send later tooltip being cutoff by the new design of compose box deployed on CZO.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -567,4 +567,11 @@ export function initialize() {
         },
         appendTo: () => document.body,
     });
+
+    delegate("body", {
+        target: "#send_later",
+        delay: LONG_HOVER_DELAY,
+        placement: "top",
+        appendTo: () => document.body,
+    });
 }

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -309,6 +309,7 @@ export function initialize() {
 
     delegate("body", {
         target: ".narrow_to_compose_recipients",
+        delay: LONG_HOVER_DELAY,
         appendTo: () => document.body,
         content() {
             const narrow_filter = narrow_state.filter();

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -115,7 +115,7 @@
                                         <button id="compose-schedule-confirm-button" class="button small hide animated-purple-button" tabindex=0>
                                             <span>{{t 'Schedule' }}</span>
                                         </button>
-                                        <button class="animated-purple-button message-control-button tippy-zulip-tooltip" data-tippy-content="{{t 'Send later' }}" id="send_later" tabindex=0 type="button">
+                                        <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
                                             <i class="fa fa-chevron-up"></i>
                                         </button>
                                     </div>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/25124304/232914269-987c1586-03e2-42a1-912a-469ad9d277f4.png)
after (remove padding on right side of compose to reproduce it):
<img width="930" alt="Screenshot 2023-04-19 at 3 21 05 AM" src="https://user-images.githubusercontent.com/25124304/232914305-284f1d1b-3458-48d9-bffe-139cbe7cfce3.png">


Also, we adding delay when showing send later and narrow to topic tooltips.