### PR TITLE
Fix focus behavior for dropdown list widgets.

### DIFF
--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -127,7 +127,8 @@ input::-ms-reveal {
     }
 }
 
-select.bootstrap-focus-style {
+select.bootstrap-focus-style,
+button.dropdown-toggle {
     &:focus {
         outline: 1px dotted hsl(0deg 0% 20%);
         outline: 5px auto -webkit-focus-ring-color;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1584,6 +1584,10 @@ $option_title_width: 180px;
                     hsl(200deg 100% 35%)
                 );
             }
+
+            &:focus {
+                text-decoration: none;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to change the focus outline on dropdown button.
- Second commit is to remove underline for the focussed option.

Fixes: <!-- Issue link, or clear description.--> https://chat.zulip.org/#narrow/stream/6-frontend/topic/dropdown.20keyboard.20behavior/near/1550252

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![dropdown-widget-focus](https://user-images.githubusercontent.com/35494118/232961495-6d7178b5-da47-42e9-870a-b4eeeda28571.png)
![Screenshot from 2023-04-19 09-08-26](https://user-images.githubusercontent.com/35494118/232961621-1636b8b6-4bdb-4c2d-81f6-614a381835e9.png)
![dropdown-focus](https://user-images.githubusercontent.com/35494118/232961660-393b852a-b20d-40d2-8ce9-8a819c62e8fc.gif)






<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
