### PR TITLE
api-docs: Clean up documentation of API events with `message_type`.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1868,38 +1868,40 @@ paths:
                                 message_ids:
                                   type: array
                                   description: |
-                                    The `message_ids` property will be present for clients that support
-                                    the `bulk_message_deletion` client capability.
+                                    Only present for clients that support the `bulk_message_deletion`
+                                    [client capability][client-capabilities].
 
-                                    An containing the IDs of the newly deleted messages.
+                                    A list containing the IDs of the newly deleted messages.
+
+                                    [client-capabilities]: /api/register-queue#parameter-client_capabilities
                                   items:
                                     type: integer
                                 message_id:
                                   type: integer
                                   description: |
-                                    The `message_id` property will be present for clients that do not support
-                                    the `bulk_message_deletion` client capability.
+                                    Only present for clients that do not support the `bulk_message_deletion`
+                                    [client capability][client-capabilities].
 
                                     The ID of the newly deleted message.
+
+                                    [client-capabilities]: /api/register-queue#parameter-client_capabilities
                                 message_type:
                                   type: string
                                   description: |
-                                    The type of message. Either 'stream' or 'private'. The other keys
-                                    present in the event, necessary to update various frontend data structures
-                                    that might be tracking the message, depend on the message type.
+                                    The type of message. Either `"stream"` or `"private"`.
                                   enum:
                                     - private
                                     - stream
                                 stream_id:
                                   type: integer
                                   description: |
-                                    Only present for stream messages.
+                                    Only present if `message_type` is `"stream"`.
 
                                     The ID of the stream to which the message was sent.
                                 topic:
                                   type: string
                                   description: |
-                                    Only present for stream messages.
+                                    Only present if `message_type` is `"stream"`.
 
                                     The topic to which the message was sent.
                               example:
@@ -2397,12 +2399,15 @@ paths:
                                 message being typed, with the additional rule that typing
                                 notifications for stream messages are only sent to clients
                                 that included `stream_typing_notifications` in their
-                                `client_capabilities` when registering the event queue.
+                                [client capabilities][client-capabilities] when registering
+                                the event queue.
+
+                                See [POST /typing](/api/set-typing-status) endpoint for more details.
 
                                 **Changes**: Typing notifications for stream messages are new in
                                 Zulip 4.0 (feature level 58).
 
-                                See the [typing endpoint docs](/api/set-typing-status) for more details.
+                                [client-capabilities]: /api/register-queue#parameter-client_capabilities
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -2418,11 +2423,10 @@ paths:
                                 message_type:
                                   type: string
                                   description: |
-                                    Type of message being composed. Must be "stream" or "private",
-                                    as with sending a message.
+                                    Type of message being composed. Must be `"stream"` or `"private"`.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    all typing notifications were implicitly private `private`.
+                                    all typing notifications were implicitly private messages.
                                   enum:
                                     - private
                                     - stream
@@ -2430,7 +2434,7 @@ paths:
                                   additionalProperties: false
                                   type: object
                                   description: |
-                                    Object describing the "sender" (i.e. the user who is typing a message).
+                                    Object describing the user who is typing the message.
                                   properties:
                                     user_id:
                                       type: integer
@@ -2443,12 +2447,12 @@ paths:
                                 recipients:
                                   type: array
                                   description: |
-                                    Only present if `message_type` is `private`.
+                                    Only present if `message_type` is `"private"`.
 
-                                    Array of dictionaries describing the set of users who would be recipients
-                                    of the message being typed. Each dictionary contains details on one
-                                    one of the recipients users; the sending user is guaranteed to appear
-                                    among the recipients.
+                                    Array of dictionaries describing the set of users who would be
+                                    recipients of the message being typed. Each dictionary contains
+                                    details about one of the recipients. The sending user is guaranteed
+                                    to appear among the recipients.
                                   items:
                                     type: object
                                     additionalProperties: false
@@ -2466,7 +2470,7 @@ paths:
                                 stream_id:
                                   type: integer
                                   description: |
-                                    Only present if `message_type` is `stream`.
+                                    Only present if `message_type` is `"stream"`.
 
                                     The unique ID of the stream to which message is being typed.
 
@@ -2475,7 +2479,7 @@ paths:
                                 topic:
                                   type: string
                                   description: |
-                                    Only present if `message_type` is `stream`.
+                                    Only present if `message_type` is `"stream"`.
 
                                     Topic within the stream where the message is being typed.
 
@@ -2485,6 +2489,7 @@ paths:
                                 {
                                   "type": "typing",
                                   "op": "start",
+                                  "message_type": "private",
                                   "sender":
                                     {
                                       "user_id": 10,
@@ -2512,12 +2517,15 @@ paths:
                                 that was previously being typed, with the additional rule
                                 that typing notifications for stream messages are only sent to
                                 clients that included `stream_typing_notifications` in their
-                                `client_capabilities` when registering the event queue.
+                                [client capabilities][client-capabilities] when registering
+                                the event queue.
+
+                                See [POST /typing](/api/set-typing-status) endpoint for more details.
 
                                 **Changes**: Typing notifications for stream messages are new in
                                 Zulip 4.0 (feature level 58).
 
-                                See the [typing endpoint docs](/api/set-typing-status) for more details.
+                                [client-capabilities]: /api/register-queue#parameter-client_capabilities
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -2533,11 +2541,10 @@ paths:
                                 message_type:
                                   type: string
                                   description: |
-                                    Type of message being composed. Must be "stream" or "private",
-                                    as with sending a message.
+                                    Type of message being composed. Must be `"stream"` or `"private"`.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    all typing notifications were implicitly private `private`.
+                                    all typing notifications were implicitly private messages.
                                   enum:
                                     - private
                                     - stream
@@ -2545,8 +2552,7 @@ paths:
                                   additionalProperties: false
                                   type: object
                                   description: |
-                                    Object describing the "sender" (i.e. the user who was previously
-                                    typing a message).
+                                    Object describing the user who was previously typing the message.
                                   properties:
                                     user_id:
                                       type: integer
@@ -2559,12 +2565,12 @@ paths:
                                 recipients:
                                   type: array
                                   description: |
-                                    Only present for typing notifications for (group) private messages.
+                                    Only present if `message_type` is `"private"`.
 
-                                    Array of dictionaries describing the set of users who would be recipients
-                                    of the message that stopped being typed. Each dictionary contains
-                                    details on one one of the recipients users; the sending user is
-                                    guaranteed to appear among the recipients.
+                                    Array of dictionaries describing the set of users who would be
+                                    recipients of the message that was previously being typed. Each
+                                    dictionary contains details about one of the recipients. The
+                                    sending user is guaranteed to appear among the recipients.
                                   items:
                                     type: object
                                     additionalProperties: false
@@ -2582,7 +2588,7 @@ paths:
                                 stream_id:
                                   type: integer
                                   description: |
-                                    Only present if `message_type` is `stream`.
+                                    Only present if `message_type` is `"stream"`.
 
                                     The unique ID of the stream to which message is being typed.
 
@@ -2591,7 +2597,7 @@ paths:
                                 topic:
                                   type: string
                                   description: |
-                                    Only present if `message_type` is `stream`.
+                                    Only present if `message_type` is `"stream"`.
 
                                     Topic within the stream where the message is being typed.
 
@@ -2601,6 +2607,7 @@ paths:
                                 {
                                   "type": "typing",
                                   "op": "stop",
+                                  "message_type": "private",
                                   "sender":
                                     {
                                       "user_id": 10,


### PR DESCRIPTION
Cleans up the API documentation for get events with a `message_type` value: `delete_message`, `typing op:start` and `typing op:stop`.

Noted when working on #25154.

**Screenshots and screen captures:**

<details>
<summary>Delete message event</summary>

[Current documentation](https://zulip.com/api/get-events#delete_message)
![Screenshot from 2023-04-19 13-52-50](https://user-images.githubusercontent.com/63245456/233068463-2127dc84-ba31-4f84-bf31-9f6eb794815d.png)
</details>
<details>
<summary>Typing op:start event</summary>

[Current documentation](https://zulip.com/api/get-events#typing-start)
![Screenshot from 2023-04-19 13-54-47](https://user-images.githubusercontent.com/63245456/233068566-bbebb518-a461-4f37-aa02-4396ccd85531.png)
![Screenshot from 2023-04-19 13-55-02](https://user-images.githubusercontent.com/63245456/233068574-87341318-dcc0-4796-98a4-67a3af67fc7d.png)

</details>
<details>
<summary>Typing op:stop event</summary>

[Current documentation](https://zulip.com/api/get-events#typing-stop)
![Screenshot from 2023-04-19 13-53-47](https://user-images.githubusercontent.com/63245456/233068525-e5106527-d483-4205-a148-f0c38ea2a5f3.png)
![Screenshot from 2023-04-19 13-54-15](https://user-images.githubusercontent.com/63245456/233068538-4b9f07e4-1b78-4e72-b04c-fd5510eca5bc.png)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
