### PR TITLE
portico: Remove Senior Frontend Engineer position from `/jobs` page.

### DIFF
--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -28,11 +28,16 @@
             <div class="padded-content markdown">
                 <h1>Open positions</h1>
                 <p>
+                    We are not actively recruiting for any roles at this time.
+                    However, if you are an experienced engineer, and you believe
+                    that your background would be a great fit for Zulip, please
+                    email us at <a
+                    href="mailto:jobs@zulip.com">jobs@zulip.com</a> with your
+                    cover letter and resume.
+                </p>
+                <p>
                     All openings are remote, or partially in-person in our San Francisco, CA office.
                 </p>
-                <ul>
-                    <li><a href="#frontend">Senior Frontend Engineer</a></li>
-                </ul>
             </div>
         </div>
     </div>
@@ -109,120 +114,6 @@
                     efficiently tune out the rest, no matter whether you're there in real
                     time, coming online after a morning hard at work, or returning from a
                     vacation away from it.
-                </p>
-            </div>
-        </div>
-    </div>
-
-    <div class="open-positions">
-        <div class="main">
-            <div class="padded-content markdown">
-                <h1>Open positions</h1>
-
-                To apply for an open position, please send your <b>resume</b>
-                and a brief <b>cover letter</b> (which can be in the body of
-                your email) to
-                <a href="mailto:jobs@zulip.com">jobs@zulip.com</a>. Your cover
-                letter should explain what makes you excited about working at
-                Zulip in the role you're applying for. Applications without a
-                cover letter will not be considered.
-
-                <h2 id="frontend">Senior Frontend Engineer</h2>
-                <p>
-                    We’re looking for an engineer to join our small
-                    core team and help define the future of team chat.
-                </p>
-                <p>
-                    This job is remote, or partially in-person in our San Francisco, CA office.
-                </p>
-                <h3>We'd especially like to get to know you if:</h3>
-                <ul>
-                    <li>
-                        <strong>You love giving a code review, and love receiving one.</strong>
-                        We’re an open-source project welcoming contributions from people with
-                        a wide range of experience.
-                    </li>
-                    <li>
-                        <strong>You communicate with clarity and precision.</strong>
-                        You’ll be doing this a lot in code, comments, code reviews, and chat
-                        conversations. We care about this almost as much as your technical
-                        skills.
-                    </li>
-                    <li>
-                        <strong>You can empathize with the many different types of users</strong>
-                        who rely on Zulip, and see the product from their perspective — and do
-                        the same thing for the project's contributors.
-                    </li>
-                </ul>
-
-                <h3>You will:</h3>
-                <ul>
-                    <li>
-                        Work directly with Zulip’s product and design leads to drive work on a major initiative to <a
-                        href="https://github.com/zulip/zulip/labels/redesign">
-                        redesign</a> Zulip’s core surfaces.
-                    </li>
-                    <li>
-                        Design new features and subsystems, write design
-                        proposals for discussion, and build them.
-                    </li>
-                    <li>
-                        Diagnose and fix bugs small and large and across several
-                        layers of our stack, including spelunking in third-party
-                        dependencies to find the best possible solution.
-                    </li>
-                    <li>
-                        Share your expertise (both newly-acquired and
-                        longstanding) with the rest of the team, through short-
-                        and long-form written communication.
-                    </li>
-                    <li>
-                        Write primarily JavaScript, HTML, CSS, and occasionally
-                        Python.
-                    </li>
-                </ul>
-
-                <h3>Extra credit for any of the following:</h3>
-                <ul>
-                    <li>
-                        You have extensive software engineering experience, with
-                        deep expertise in frontend development.
-                    </li>
-                    <li>
-                        You have significant experience as a technical lead for
-                        your team, including designing systems and collaborating
-                        to get them built, coaching people in writing
-                        high-quality code, and other aspects of technical
-                        leadership.
-                    </li>
-                    <li>
-                        You have experience making complex changes to an
-                        actively developed codebase, such as carefully removing
-                        legacy dependencies, or executing a major refactoring
-                        project.
-                    </li>
-                    <li>
-                        You have the UI design skills to spot where a UI can be
-                        improved; better yet, to design a better one.
-                    </li>
-                    <li>
-                        You have contributed to open-source projects; better
-                        yet, maintained a project and helped many people
-                        contribute to it.
-                    </li>
-                </ul>
-                <p>
-                    Learn more about <a href="/jobs/#how-we-work">how we
-                    work</a>, or apply by sending your resume and a brief cover
-                    letter explaining what makes you excited about this role to
-                    <a href="mailto:jobs@zulip.com">jobs@zulip.com</a>.
-                </p>
-                <br />
-                <hr />
-
-                <h2>How to apply for a job</h2>
-                <p>
-                    You can email us at <a href="mailto:jobs@zulip.com">jobs@zulip.com</a> with your resume.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Also add a note about reaching out to us, since there are no open positions remaining at this time.

I decided not to update PAGE_DESCRIPTION and the page subtitle (which say we're hiring), since we are still open to opportunistic hires, and this way there will be fewer places to change again next time we open a position.

![Screen Shot 2023-04-19 at 12 00 41 PM](https://user-images.githubusercontent.com/2090066/233174597-7c925047-5f35-4b8a-bf5b-da6adb10f254.png)
