### PR TITLE
help: Document new "Rename topic" option.

### DIFF
--- a/help/rename-a-topic.md
+++ b/help/rename-a-topic.md
@@ -19,7 +19,9 @@ Organizations can [configure](/help/restrict-moving-messages) which
 
 {start_tabs}
 
-1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon in the message recipient bar.
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon in the message
+   recipient bar. If you do not see the **pencil** (<i class="fa
+   fa-pencil"></i>) icon, you do not have permission to rename this topic.
 
 1. Edit the topic name.
 
@@ -27,18 +29,19 @@ Organizations can [configure](/help/restrict-moving-messages) which
 
 {end_tabs}
 
-
 ### Via the left sidebar (alternate method)
 
 {start_tabs}
 
 {!topic-actions.md!}
 
-1. Select **Move topic**.
+1. Select **Move topic** or **Rename topic**. If you do not see either option,
+   you do not have permission to rename this topic.
 
 1. Edit the topic name.
 
-1. _(optional)_  Select the destination stream for the topic from the streams dropdown list.
+1. _(optional)_  If using the **Move topic** menu, select the destination stream
+   for the topic from the streams dropdown list.
 
 1. Toggle whether automated notices should be sent.
 


### PR DESCRIPTION
Documents option introduced in #25149.

Note: The "If you do not see this option,..." phrasing and placement for the note is consistent with https://zulip.com/help/move-content-to-another-topic and related pages.

Current page: https://zulip.com/help/rename-a-topic

Updated instructions:

<img width="807" alt="Screen Shot 2023-04-19 at 4 40 18 PM" src="https://user-images.githubusercontent.com/2090066/233222533-852c7f38-bb0f-41b6-b46f-cec338337b34.png">


