### PR TITLE
help: Update /help/require-topics.

### DIFF
--- a/help/require-topics.md
+++ b/help/require-topics.md
@@ -1,6 +1,7 @@
 # Require topics in stream messages
 
-Administrators can configure whether stream messages must have a
+If a user sends a message without a topic, the message's topic is displayed as
+**(no topic)**. Administrators can configure whether stream messages must have a
 specified topic.
 
 ## Require topics in stream messages
@@ -18,11 +19,6 @@ specified topic.
 
 {end_tabs}
 
-## Stream messages without a topic
+## Related articles
 
-If a user sends a message without a topic, the message's topic is
-displayed as **(no topic)**.
-
-Any user can [add a topic](/help/rename-a-topic) to messages without a topic.
-They can do so regardless of whether they can [edit topics in
-general](/help/restrict-moving-messages).
+* [Streams and topics](/help/streams-and-topics)


### PR DESCRIPTION
After #21739, there is no longer a special permissions exception for adding a topic to messages without one.

Current page: https://zulip.com/help/require-topics

Updated:

![Screen Shot 2023-04-19 at 5 25 25 PM](https://user-images.githubusercontent.com/2090066/233227129-478c516a-e3f4-4875-819c-4b7f6d8d6ea7.png)

