### PR TITLE
dropdown_list_widget: Fix fading transition during focus.

### DIFF
--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -133,5 +133,6 @@ button.dropdown-toggle {
         outline: 1px dotted hsl(0deg 0% 20%);
         outline: 5px auto -webkit-focus-ring-color;
         outline-offset: -2px;
+        transition: none;
     }
 }


### PR DESCRIPTION
This commit sets the transition to "none" for the dropdown list widget element during focus to remove a weird fade-in effect. We have to set this to none as the existing CSS sets transition for all button elements inside ".new-style" div. This commit adds the CSS for select element too, as both are using same CSS, but since there was no transition effect for select elements before as well, we can do this change safely.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->https://github.com/zulip/zulip/pull/25175#issuecomment-1515177026

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![dropdown-widget-transition](https://user-images.githubusercontent.com/35494118/233324122-f1800fe9-dbce-4780-8595-d33e90cf4aaf.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
