### PR TITLE
Add mark messages as read for -is:private narrow.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -502,6 +502,22 @@ export class Filter {
         if (_.isEqual(term_types, ["is-private"])) {
             return true;
         }
+        // -is:private excludes private messages from all messages
+        if (_.isEqual(term_types, ["not-is-private"])) {
+            return true;
+        }
+
+        // Excluding private messages from stream and topic does not
+        // accomplish anything, but we are still letting them mark
+        // mark messages as read to be consistent with our design.
+
+        if (_.isEqual(term_types, ["stream", "not-is-private"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["topic", "not-is-private"])) {
+            return true;
+        }
 
         if (_.isEqual(term_types, ["is-mentioned"])) {
             return true;
@@ -543,8 +559,10 @@ export class Filter {
     is_common_narrow() {
         // can_mark_messages_read tests the following filters:
         // stream, stream + topic,
-        // is: private, pm-with:,
-        // is: mentioned, is: resolved
+        // is: private, -is: private,
+        // stream + -is:private, topic + -is:private
+        // pm-with:, is: mentioned,
+        // is: resolved
         if (this.can_mark_messages_read()) {
             return true;
         }

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -195,6 +195,15 @@ test("basics", () => {
     assert.ok(filter.can_apply_locally());
     assert.ok(!filter.is_personal_filter());
 
+    operators = [{operator: "is", operand: "private", negated: true}];
+    filter = new Filter(operators);
+    assert.ok(!filter.contains_only_private_messages());
+    assert.ok(filter.can_mark_messages_read());
+    assert.ok(filter.supports_collapsing_recipients());
+    assert.ok(!filter.has_operator("search"));
+    assert.ok(filter.can_apply_locally());
+    assert.ok(!filter.is_personal_filter());
+
     operators = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(operators);
     assert.ok(!filter.contains_only_private_messages());


### PR DESCRIPTION
Fixes #25113.

-is:private search view now marks message as read. Combining -is:private with stream and topic will also mark messages as read.