### PR TITLE
i18n: Update `makemessages` for `trimmed` and `notrimmed` flags in jinja2 templates.

### DIFF
--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -299,6 +299,10 @@ Files: zerver/lib/ccache.py
 Copyright: 2013 David Benjamin and Alan Huang
 License: Expat
 
+Files: zerver/management/commands/makemessages.py
+Copyright: 2012-2013 Andrey Antukh <niwi@niwi.be>
+License: BSD-3-Clause
+
 Files: zerver/lib/markdown/fenced_code.py
 Copyright: 2006-2008 Waylan Limberg
 License: BSD-3-Clause

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -138,7 +138,9 @@ class Command(makemessages.Command):
             template.endblock_re.pattern + r"|" + r"""^-?\s*endtrans\s*-?$"""
         )
         template.block_re = re.compile(
-            template.block_re.pattern + r"|" + r"""^-?\s*trans(?:\s+(?!'|")(?=.*?=.*?)|\s*-?$)"""
+            template.block_re.pattern
+            + r"|"
+            + r"""^-?\s*trans(?:\s+(?:no)?trimmed)?(?:\s+(?!'|")(?=.*?=.*?)|\s*-?$)"""
         )
         template.plural_re = re.compile(
             template.plural_re.pattern + r"|" + r"""^-?\s*pluralize(?:\s+.+|-?$)"""

--- a/zproject/jinja2/__init__.py
+++ b/zproject/jinja2/__init__.py
@@ -44,5 +44,6 @@ def environment(**options: Any) -> Environment:
 
     env.policies["json.dumps_function"] = json_dumps
     env.policies["json.dumps_kwargs"] = {}
+    env.policies["ext.i18n.trimmed"] = True
 
     return env


### PR DESCRIPTION
The upstream project that the `makemessages` management command in Zulip was taken from implemented support for applying trimmed to all `{% trans %}` tags when the jinja2 policy is set to `True` for `ext.i18n.trimmed`.
    
Implements a modified version of those upstream changes to the `makemessages` management command.
    
Commits referenced for implementation:
https://github.com/niwinz/django-jinja/pull/285/commits/ade847b3e5e4140809e7ea5a46c51ae175af3d31
https://github.com/niwinz/django-jinja/pull/273/commits/9f76ce3966b66c77f9f71f6aedf247bd28bf268e

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/58-translation/topic/line.20breaks.20in.20txt.20vs.20html.20email.20strings/near/1534410)

---

**`./manage.py makemessages --locale=es`**:

<details>
<summary>Example of subset of impacted strings - without existing translations</summary>

```diff
@@ -258,67 +265,55 @@ msgstr ""
 #: templates/404.html:22
 #, python-format
 msgid ""
-"\n"
-"                        If this error is unexpected, you can\n"
-"                        <a href=\"mailto:%(support_email)s\">contact support</a>.\n"
-"                        "
+"If this error is unexpected, you can <a href=\"mailto:%(support_email)s"
+"\">contact support</a>."
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:21 zerver/middleware.py:494
+#: templates/500.html:4 templates/500.html:21 zerver/middleware.py:489
 msgid "Internal server error"
 msgstr "Error interno del servidor"
 
 #: templates/500.html:23
 msgid ""
-"\n"
-"                        Your Zulip chat cannot be loaded because the server is experiencing technical difficulties.\n"
-"                        "
+"Your Zulip chat cannot be loaded because the server is experiencing "
+"technical difficulties."
 msgstr ""
 
 #: templates/500.html:28
-msgid ""
-"\n"
-"                        This page will reload automatically when service is restored.\n"
-"                        "
+msgid "This page will reload automatically when service is restored."
 msgstr ""
 
 #: templates/500.html:32
 #, python-format
 msgid ""
-"\n"
-"                            In the meantime, you can <a href=\"mailto:%(support_email)s\">contact Zulip support</a>.\n"
-"                            "
+"In the meantime, you can <a href=\"mailto:%(support_email)s\">contact Zulip "
+"support</a>."
 msgstr ""
```
</details>

**`./manage.py makemessages --locale=de`**:

<details>
<summary>Example of subset of impacted strings - with existing translations</summary>

```diff
 #: templates/404.html:22
-#, python-format
-msgid ""
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "                        If this error is unexpected, you can\n"
+#| "                        <a href=\"mailto:%(support_email)s\">contact "
+#| "support</a>.\n"
+#| "                        "
+msgid ""
+"If this error is unexpected, you can <a href=\"mailto:%(support_email)s"
+"\">contact support</a>."
+msgstr ""
 "\n"
-"                        If this error is unexpected, you can\n"
-"                        <a href=\"mailto:%(support_email)s\">contact support</a>.\n"
+"                       Sollte dieser Fehler unerwartet kommen, bitte\n"
+"                        <a href=\"mailto:%(support_email)s\">den Support "
+"kontaktieren</a>.\n"
 "                        "
-msgstr "\n                       Sollte dieser Fehler unerwartet kommen, bitte\n                        <a href=\"mailto:%(support_email)s\">den Support kontaktieren</a>.\n                        "
 
-#: templates/500.html:4 templates/500.html:21 zerver/middleware.py:494
+#: templates/500.html:4 templates/500.html:21 zerver/middleware.py:489
 msgid "Internal server error"
 msgstr "Interner Serverfehler"
 
 #: templates/500.html:23
-msgid ""
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                        Your Zulip chat cannot be loaded because the "
+#| "server is experiencing technical difficulties.\n"
+#| "                        "
+msgid ""
+"Your Zulip chat cannot be loaded because the server is experiencing "
+"technical difficulties."
+msgstr ""
 "\n"
-"                        Your Zulip chat cannot be loaded because the server is experiencing technical difficulties.\n"
+"                        Dein Zulip-Chat kann nicht geladen werden, da der "
+"Server technische Schwierigkeiten hat.\n"
 "                        "
-msgstr "\n                        Dein Zulip-Chat kann nicht geladen werden, da der Server technische Schwierigkeiten hat.\n                        "
 
 #: templates/500.html:28
-msgid ""
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "                        This page will reload automatically when service "
+#| "is restored.\n"
+#| "                        "
+msgid "This page will reload automatically when service is restored."
+msgstr ""
 "\n"
-"                        This page will reload automatically when service is restored.\n"
+"                        Diese Seite wird automatisch neu geladen, wenn der "
+"Dienst wieder verfügbar ist.\n"
 "                        "
-msgstr "\n                        Diese Seite wird automatisch neu geladen, wenn der Dienst wieder verfügbar ist.\n                        "
 
 #: templates/500.html:32
-#, python-format
-msgid ""
 "                        "
-msgstr "\n                        Diese Seite wird automatisch neu geladen, wenn der Dienst wieder verfügbar ist.\n                        "
 
 #: templates/500.html:32
-#, python-format
-msgid ""
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "                            In the meantime, you can <a href=\"mailto:"
+#| "%(support_email)s\">contact Zulip support</a>.\n"
+#| "                            "
+msgid ""
+"In the meantime, you can <a href=\"mailto:%(support_email)s\">contact Zulip "
+"support</a>."
+msgstr ""
 "\n"
-"                            In the meantime, you can <a href=\"mailto:%(support_email)s\">contact Zulip support</a>.\n"
+"                            Inzwischen kannst du den <a href=\"mailto:"
+"%(support_email)s\">Zulip-Support kontaktieren</a>.\n"
 "                            "
-msgstr "\n                            Inzwischen kannst du den <a href=\"mailto:%(support_email)s\">Zulip-Support kontaktieren</a>.\n                            "
```
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
