### PR TITLE
[WIP] help: Cover unmuting topics in /help/mute-a-topic.

### DIFF
--- a/help/include/mute-unmute-intro.md
+++ b/help/include/mute-unmute-intro.md
@@ -1,5 +1,5 @@
-To avoid receiving notifications messages you are not interested in, Zulip lets
-you mute topics and streams. Muting a stream effectively mutes all topics in
+Zulip lets you mute topics and streams to avoid receiving notifications messages
+you are not interested in. Muting a stream effectively mutes all topics in
 that stream. You can also manually **mute** a topic in an unmuted stream, or
 **unmute** a topic in a muted stream.
 

--- a/help/include/mute-unmute-intro.md
+++ b/help/include/mute-unmute-intro.md
@@ -1,0 +1,24 @@
+To avoid receiving notifications messages you are not interested in, Zulip lets
+you mute topics and streams. Muting a stream effectively mutes all topics in
+that stream. You can also manually **mute** a topic in an unmuted stream, or
+**unmute** a topic in a muted stream.
+
+Muting has the following effects:
+
+- Messages in muted topics do not generate notifications (including [alert
+  word](/help/dm-mention-alert-notifications#alert-words) notifications), unless
+  you are [mentioned](/help/mention-a-user-or-group).
+- Messages in muted topics do not appear in the [**All messages**
+  view](/help/all-messages).
+- Muted topics appear in the [**Recent conversations**
+  view](/help/recent-conversations) only if the **Include muted** filter is
+  enabled.
+- Unread messages in muted topics do not contribute to stream unread counts.
+- In the left sidebar, muted topics and streams are grayed out. They are also
+  sorted to the bottom of their stream (for topics) or stream section (for
+  streams).
+
+!!! warn ""
+
+    **Note**: Some parts of the Zulip experience may start to degrade
+    if you receive more than a few hundred muted messages a day.

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -128,8 +128,8 @@
 ## Notifications
 * [Stream notifications](/help/stream-notifications)
 * [DMs, mentions, and alerts](/help/dm-mention-alert-notifications)
-* [Mute a stream](/help/mute-a-stream)
-* [Mute a topic](/help/mute-a-topic)
+* [Mute or unmute a stream](/help/mute-a-stream)
+* [Mute or unmute a topic](/help/mute-a-topic)
 * [Mute a user](/help/mute-a-user)
 * [Email notifications](/help/email-notifications)
 * [Desktop notifications](/help/desktop-notifications)

--- a/help/mute-a-stream.md
+++ b/help/mute-a-stream.md
@@ -1,17 +1,6 @@
-# Mute a stream
+# Mute or unmute a stream
 
-Messages from muted streams do not show up in **All messages** or generate
-notifications, unless you are
-[mentioned](/help/mention-a-user-or-group). Messages from muted streams
-do not generate [alert word](/help/dm-mention-alert-notifications#alert-words) notifications.
-
-Muted streams still appear in the left sidebar, but they are grayed out and
-sorted to the bottom of their section.
-
-!!! warn ""
-
-    **Note**: Some parts of the Zulip experience may start to degrade
-    if you receive more than a few hundred muted messages a day.
+{!mute-unmute-intro.md!}
 
 ## Mute a stream
 

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -1,10 +1,6 @@
-# Mute a topic
+# Mute or unmute a topic
 
-Messages from muted topics do not show up in either **All messages**
-or **Recent conversations**, nor do they generate notifications (including
-[alert word](/help/dm-mention-alert-notifications#alert-words)
-notifications), unless you are [mentioned](/help/mention-a-user-or-group).
-They also do not contribute to stream unread counts.
+{!mute-unmute-intro.md!}
 
 ## Mute a topic
 
@@ -18,7 +14,8 @@ They also do not contribute to stream unread counts.
 
 !!! tip ""
 
-    You can also click the **mute** (<i class="zulip-icon zulip-icon-mute"></i>) icon in the message recipient bar to mute the topic.
+    You can also click the **mute** (<i class="zulip-icon zulip-icon-mute"></i>) icon
+    in the message recipient bar or in **Recent conversations**.
 
 {tab|mobile}
 
@@ -30,16 +27,41 @@ They also do not contribute to stream unread counts.
 
 {end_tabs}
 
-## Browse and unmute previously muted topics
+## Unmute a topic
 
 {start_tabs}
 
 {tab|desktop-web}
 
-{settings_tab|muted-topics}
+{!topic-actions.md!}
 
-1. In the **Actions** column, click **Unmute** next to each topic you want
-   to unmute.
+1. Select **Unmute topic**.
+
+!!! tip ""
+
+    You can also click the **unmute** (<i class="zulip-icon zulip-icon-unmute"></i>) icon
+    in the message recipient bar or in **Recent conversations**.
+
+{tab|mobile}
+
+{!topic-long-press-menu.md!}
+
+1. Tap **Unmute topic**.
+
+{!topic-long-press-menu-tip.md!}
+
+{end_tabs}
+
+## Manage configured topics
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|topics}
+
+1. Configure notifications for each topic by selecting the desired option from
+   the dropdown in the **Status** column.
 
 {tab|mobile}
 
@@ -47,7 +69,7 @@ They also do not contribute to stream unread counts.
    (<img src="/static/images/help/mobile-hash-icon.svg" alt="hash" class="mobile-icon"/>)
    tab at the bottom of the app.
 
-1. Select a stream containing topics you want to unmute.
+1. Select a stream containing topics you want to configure.
 
 1. Tap the **Topics list**
    (<img src="/static/images/help/mobile-list-icon.svg" alt="list" class="mobile-icon"/>)
@@ -55,7 +77,7 @@ They also do not contribute to stream unread counts.
 
 {!topic-long-press-menu.md!}
 
-1. Tap **Unmute topic**.
+1. Tap **Mute topic** or **Unmute topic**.
 
 !!! tip ""
 
@@ -65,6 +87,6 @@ They also do not contribute to stream unread counts.
 
 ## Related articles
 
-* [Mute a stream](/help/mute-a-stream)
+* [Mute or unmute a stream](/help/mute-a-stream)
 
 * [Mute a user](/help/mute-a-user)

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -29,7 +29,7 @@ link_mapping = {
     "your-bots": ["Personal settings", "Bots", "/#settings/your-bots"],
     "alert-words": ["Personal settings", "Alert words", "/#settings/alert-words"],
     "uploaded-files": ["Personal settings", "Uploaded files", "/#settings/uploaded-files"],
-    "muted-topics": ["Personal settings", "Muted topics", "/#settings/muted-topics"],
+    "topics": ["Personal settings", "Topics", "/#settings/topics"],
     "muted-users": ["Personal settings", "Muted users", "/#settings/muted-users"],
     "organization-profile": [
         "Organization settings",


### PR DESCRIPTION
Updates made in connection with the new "Unmute topic" feature. Posting for initial review in case we want to revise the approach, but known remaining todo items are:

- [ ] Update links to use the new page names ("Mute or unmute a topic", "Mute or unmute a stream")
- [ ] Add missing "unmute topic" icon.
- [ ] Update commit message and squash commits.

Blockers for merging:

- [ ] Unmute topic feature
- [ ] #25127
- [ ] https://github.com/zulip/zulip-mobile/issues/5691

Current page: https://zulip.com/help/mute-a-topic

The intro changes also update the intro for https://zulip.com/help/mute-a-stream to match.

<details>
<summary>
Intro screenshot
</summary>

<img width="775" alt="Screen Shot 2023-04-20 at 10 36 48 PM" src="https://user-images.githubusercontent.com/2090066/233549264-d1c571e6-4699-421f-befc-5afba40bef58.png">

</details>


<details>
<summary>
Instructions screenshots
</summary>

![Screen Shot 2023-04-20 at 1 47 43 PM](https://user-images.githubusercontent.com/2090066/233488797-ea13a8b3-6c60-4aef-ad93-c641160931a9.png)


![Screen Shot 2023-04-20 at 1 48 00 PM](https://user-images.githubusercontent.com/2090066/233488795-545e5b6a-e932-434a-bd17-8fdbda6df159.png)

</details>

