### PR TITLE
compose: Clear search filter when opening new stream picker in compose box.

### DIFF
--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -94,7 +94,10 @@ export function open_compose_stream_dropup() {
     if ($("#id_compose_select_stream").hasClass("open")) {
         return;
     }
-    $("#id_compose_select_stream > .dropdown-toggle").dropdown("toggle");
+    // We trigger a click rather than directly toggling the element;
+    // this is important to ensure the filter text gets cleared when
+    // reopening the widget after previous use.
+    $("#id_compose_select_stream > .dropdown-toggle").trigger("click");
 }
 
 export function on_compose_select_stream_update(new_value) {


### PR DESCRIPTION
We should trigger click event to open up the dropdown popup instead of using `.dropdown("toggle")` because we want to clear the search state when opening up the popup and the logic for that is registered in `on-click` handler defined in `dropdown_list_widget`.

Fixes: #25218

Before:

https://user-images.githubusercontent.com/84276404/233763252-ac779afa-1bdb-4a87-8177-d729d74543df.mp4

After:

https://user-images.githubusercontent.com/84276404/233763291-8c957f48-77c2-4d49-96dc-9e26149a1c36.mp4

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
