### PR TITLE
timerender: Fix expiration date on invite modal.

### DIFF
--- a/web/src/invite.js
+++ b/web/src/invite.js
@@ -17,9 +17,9 @@ import {$t, $t_html} from "./i18n";
 import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import * as stream_data from "./stream_data";
+import * as timerender from "./timerender";
 import * as ui from "./ui";
 import * as ui_report from "./ui_report";
-import {user_settings} from "./user_settings";
 import * as util from "./util";
 
 let custom_expiration_time_input = 10;
@@ -190,18 +190,10 @@ function valid_to(expires_in) {
         return $t({defaultMessage: "Never expires"});
     }
     const valid_to = add(new Date(), {minutes: time_valid});
-    const options = {
-        year: "numeric",
-        month: "numeric",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: !user_settings.twenty_four_hour_time,
-    };
-    return $t(
-        {defaultMessage: "Expires on {date}"},
-        {date: valid_to.toLocaleTimeString([], options)},
-    );
+    const date = timerender.get_localized_date_or_time_for_format(valid_to, "dayofyear_year");
+    const time = timerender.get_localized_date_or_time_for_format(valid_to, "time");
+
+    return $t({defaultMessage: "Expires on {date} at {time}"}, {date, time});
 }
 
 function get_expiration_time_in_minutes() {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR aims to replace the custom datetime format in the invite modal with one of the standard formats from `timerender.js`.

Related discussion at [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/date.20and.20time)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://user-images.githubusercontent.com/53193850/233572242-caa28e11-7abf-407c-9e72-3bc161674b92.png)
![image](https://user-images.githubusercontent.com/53193850/233572274-2c4c23cb-f0d9-4e6b-ae5d-0631f280cb10.png)
![image](https://user-images.githubusercontent.com/53193850/233572282-0292c8d3-1ff4-468c-83b4-a887249e93e7.png)
![image](https://user-images.githubusercontent.com/53193850/233572300-51f85752-bd9e-40f1-b289-c91fa214e429.png)
