### PR TITLE
api-docs: Update docs to reference max lengths in register response.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5572,7 +5572,9 @@ paths:
             The topic of the message. Only required for stream messages
             (`type="stream"`), ignored otherwise.
 
-            Maximum length of 60 characters.
+            Clients should use the `max_topic_length` returned by the
+            [`POST /register`](/api/register-queue) endpoint to determine
+            the maximum topic length
 
             **Changes**: New in Zulip 2.0.0. Previous Zulip releases encoded
             this as `subject`, which is currently a deprecated alias.
@@ -6655,7 +6657,10 @@ paths:
           in: query
           description: |
             The topic to move the message(s) to, to request changing the topic.
-            Maximum length of 60 characters.
+
+            Clients should use the `max_topic_length` returned by the
+            [`POST /register`](/api/register-queue) endpoint to determine
+            the maximum topic length
 
             Should only be sent when changing the topic, and will throw an error
             if the target message is not a stream message.
@@ -8029,11 +8034,19 @@ paths:
                       type: string
                       description: |
                         The name of the stream.
+
+                        Clients should use the `max_stream_name_length` returned by the
+                        [`POST /register`](/api/register-queue) endpoint to determine
+                        the maximum stream name length.
                     description:
                       type: string
                       description: |
                         The [description](/help/change-the-stream-description)
                         to use for a new stream being created, in text/markdown format.
+
+                        Clients should use the `max_stream_description_length` returned
+                        by the [`POST /register`](/api/register-queue) endpoint to
+                        determine the maximum stream description length.
                   required:
                     - name
                   example:
@@ -10503,36 +10516,36 @@ paths:
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The maximum allowed length for a stream name. Clients should use
-                          these properties rather than hardcoding field sizes, as they may
-                          change in a future Zulip release.
+                          The maximum allowed length for a stream name, in Unicode code
+                          points. Clients should use this property rather than hardcoding
+                          field sizes.
 
                           **Changes**: New in Zulip 4.0 (feature level 53). Previously,
                           this required `stream` in `fetch_event_types`, was called
-                          `stream_name_max_length`, and always had value 60.
+                          `stream_name_max_length`, and always had a value of 60.
                       max_stream_description_length:
                         type: integer
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The maximum allowed length for a stream description. Clients should use
-                          these properties rather than hardcoding field sizes, as they may
-                          change in a future Zulip release.
+                          The maximum allowed length for a stream description, in Unicode
+                          code points. Clients should use this property rather than hardcoding
+                          field sizes.
 
                           **Changes**: New in Zulip 4.0 (feature level 53). Previously,
                           this required `stream` in `fetch_event_types`, was called
-                          `stream_description_max_length`, and always had value 1024.
+                          `stream_description_max_length`, and always had a value of 1024.
                       max_topic_length:
                         type: integer
                         description: |
                           Present if `realm` is present in `fetch_event_types`.
 
-                          The maximum allowed length for a topic. Clients should use
-                          these properties rather than hardcoding field sizes, as they may
-                          change in a future Zulip release.
+                          The maximum allowed length for a topic, in Unicode code points.
+                          Clients should use this property rather than hardcoding field
+                          sizes.
 
                           **Changes**: New in Zulip 4.0 (feature level 53). Previously,
-                          this always had value 60.
+                          this property always had a value of 60.
                       max_message_length:
                         type: integer
                         description: |
@@ -14986,8 +14999,12 @@ paths:
         - name: description
           in: query
           description: |
-            The new description for the stream. Limited Zulip markdown is allowed in this
-            field.
+            The new [description](/help/change-the-stream-description) for
+            the stream, in text/markdown format.
+
+            Clients should use the `max_stream_description_length` returned
+            by the [`POST /register`](/api/register-queue) endpoint to
+            determine the maximum stream description length.
 
             **Changes**: Removed unnecessary JSON-encoding of this parameter in
             Zulip 4.0 (feature level 64).
@@ -15000,6 +15017,10 @@ paths:
           in: query
           description: |
             The new name for the stream.
+
+            Clients should use the `max_stream_name_length` returned by the
+            [`POST /register`](/api/register-queue) endpoint to determine
+            the maximum stream name length.
 
             **Changes**: Removed unnecessary JSON-encoding of this parameter in
             Zulip 4.0 (feature level 64).


### PR DESCRIPTION
Updates areas in the API documentation that reference the maximum length of a stream message topic to note the `max_topic_length`.

Updates areas in the API documentation that reference the maximum length of a stream name to note the `max_stream_name_length` and areas that reference the maximum length of a stream description to note the `max_stream_description_length`.

All of these maximum values are sent by the `POST /register` response.

See relevant CZO conversations:
- [#api documentation > direct message search operators](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/direct.20message.20search.20operators/near/1552433)
- [#api documentation > max size](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/max.20message.20size/near/1508146)

**Notes**:
- In #24401, we landed on documenting the units for the message length as "Unicode code points". I used that same language for these properties as well. Previously, either "characters" or nothing was used to denote the unit for the integer value.

---

**Screenshots and screen captures:**

<details>
<summary>Register queue - max_X_length.</summary>

[Current documentation](https://zulip.com/api/register-queue)
![Screenshot from 2023-04-21 16-10-14](https://user-images.githubusercontent.com/63245456/233660527-7e87a36b-6446-4b84-aff9-939f95dacadb.png)
</details>
<details>
<summary>Send a message</summary>

[Current documentation](https://zulip.com/api/send-message#parameter-topic)
![Screenshot from 2023-04-21 16-09-12](https://user-images.githubusercontent.com/63245456/233666102-1cf6b7b3-569e-4998-95b1-b6bcc1f3c63c.png)

</details>
<details>
<summary>Edit a message</summary>

[Current documentation](https://zulip.com/api/update-message#parameter-topic)
![Screenshot from 2023-04-21 16-09-02](https://user-images.githubusercontent.com/63245456/233666079-19c2bc64-7699-4e67-93fe-5ecd7f53e9a8.png)

</details>
<details>
<summary>Subscribe to a stream</summary>

[Current documentation](https://zulip.com/api/subscribe#parameter-subscriptions)
![Screenshot from 2023-04-21 16-09-38](https://user-images.githubusercontent.com/63245456/233666215-c82ba91b-1f33-4407-afe4-ba362873fa77.png)

</details>
<details>
<summary>Update a stream</summary>

[Current documentation](https://zulip.com/api/update-stream#parameters)
![Screenshot from 2023-04-21 16-09-25](https://user-images.githubusercontent.com/63245456/233666180-23a367d5-6dc6-4773-91c4-0d59d5e3c604.png)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
