### PR TITLE
fixed lock icon in settings

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -5,7 +5,7 @@ This page the release history for the Zulip server. See also the
 
 ## Zulip 6.x series
 
-### 6.0 -- unreleased
+### 6.0-rc1 -- 2022-11-02
 
 This section is an incomplete draft of the release notes for the next
 major release, and is only updated occasionally. See the [commit

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 import os
 
-ZULIP_VERSION = "6.0-dev+git"
+ZULIP_VERSION = "6.0-rc1"
 
 # Add information on number of commits and commit hash to version, if available
 zulip_git_version_file = os.path.join(


### PR DESCRIPTION
I tried to fix the lock icons that should disappear when user have the permissions. In the previous version, the lock icon is shown regardless of the user's permission status. So, the ideal condition is the lock icon must appear when the user have no permission to edit these settings, and the icon should update as soon as the permission changed. Similar about issue #24786.

 Added`show_uploaded_files_section: page_params.max_file_upload_size_mib > 0,`, `show_bot_settings_lock: settings_bots.can_create_new_bots(), show_user_group_settings_lock: settings_data.user_can_edit_user_groups(),show_bot_settings_lock: settings_bots.can_create_new_group_users()`
