### PR TITLE
Improve compose box behavior when user does not have permission to post in a stream.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -305,6 +305,10 @@ export function start(msg_type, opts) {
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);
 
+    if (msg_type === "stream") {
+        compose_recipient.check_stream_posting_policy_for_compose_box(opts.stream);
+    }
+
     // Reset the `max-height` property of `compose-textarea` so that the
     // compose-box do not cover the last messages of the current stream
     // while writing a long message.

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -3,6 +3,7 @@
 import $ from "jquery";
 import _ from "lodash";
 
+import * as compose_banner from "./compose_banner";
 import * as compose_fade from "./compose_fade";
 import * as compose_state from "./compose_state";
 import * as compose_validate from "./compose_validate";
@@ -100,6 +101,26 @@ export function open_compose_stream_dropup() {
     $("#id_compose_select_stream > .dropdown-toggle").trigger("click");
 }
 
+export function check_stream_posting_policy_for_compose_box(stream_name) {
+    const stream = stream_data.get_sub_by_name(stream_name);
+    if (!stream) {
+        return;
+    }
+    const can_post_messages_in_stream = stream_data.can_post_messages_in_stream(stream);
+    if (!can_post_messages_in_stream) {
+        $(".compose_right_float_container").addClass("disabled-compose-send-button-container");
+        compose_banner.show_error_message(
+            $t({
+                defaultMessage: "You do not have permission to post in this stream.",
+            }),
+            compose_banner.CLASSNAMES.no_post_permissions,
+        );
+    } else {
+        $(".compose_right_float_container").removeClass("disabled-compose-send-button-container");
+        compose_banner.clear_errors();
+    }
+}
+
 export function on_compose_select_stream_update(new_value) {
     const $stream_header_colorblock = $("#compose_stream_selection_dropdown").find(
         ".stream_header_colorblock",
@@ -107,6 +128,8 @@ export function on_compose_select_stream_update(new_value) {
     stream_bar.decorate(new_value, $stream_header_colorblock);
     update_on_recipient_change();
     $("#stream_message_recipient_topic").trigger("focus").trigger("select");
+
+    check_stream_posting_policy_for_compose_box(new_value);
 }
 
 export function update_stream_dropdown_options() {

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -112,7 +112,6 @@ export function on_compose_select_stream_update(new_value) {
 export function update_stream_dropdown_options() {
     const streams_list = stream_data
         .subscribed_subs()
-        .filter((stream) => stream_data.can_post_messages_in_stream(stream))
         .map((stream) => ({
             name: stream.name,
             value: stream.name,
@@ -140,7 +139,6 @@ export function possibly_update_dropdown_selection(old_stream_name, new_stream_n
 export function initialize() {
     const streams_list = stream_data
         .subscribed_subs()
-        .filter((stream) => stream_data.can_post_messages_in_stream(stream))
         .map((stream) => ({
             name: stream.name,
             value: stream.name,

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -639,6 +639,17 @@ export function initialize() {
         placement: "top",
         appendTo: () => document.body,
     });
+
+    delegate("body", {
+        target: [".disabled-compose-send-button-container"],
+        content: $t({
+            defaultMessage: "You do not have permission to post in this stream.",
+        }),
+        appendTo: () => document.body,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
 }
 
 export function show_copied_confirmation($copy_button) {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -703,6 +703,15 @@ input.recipient_box {
     white-space: nowrap;
     margin-top: 2px;
     height: 24px;
+
+    &.disabled-compose-send-button-container {
+        cursor: not-allowed;
+
+        & button {
+            pointer-events: none;
+            background-color: hsl(0deg 0% 65%);
+        }
+    }
 }
 
 a.compose_control_button {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -59,11 +59,6 @@
         border: 1px solid hsl(0deg 0% 0% / 60%);
     }
 
-    .modal__btn:disabled {
-        opacity: 1;
-        background-color: hsl(0deg 0% 83% / 50%);
-    }
-
     .modal__content.simplebar-scrollable-y + .modal__footer {
         border-top: 1px solid hsl(0deg 0% 100% / 20%);
     }
@@ -102,6 +97,12 @@
         .enter_sends_minor {
             color: hsl(0deg 0% 80%);
         }
+    }
+
+    .modal__btn:disabled,
+    .disabled-compose-send-button-container button {
+        opacity: 1;
+        background-color: hsl(0deg 0% 83% / 50%);
     }
 
     & table.table-striped thead.table-sticky-headers th {

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -765,6 +765,7 @@ test_ui("on_events", ({override}) => {
 
 test_ui("create_message_object", ({override, override_rewire}) => {
     mock_stream_header_colorblock();
+    mock_banners();
     override_rewire(stream_bar, "decorate", noop);
     override_rewire(compose_recipient, "update_on_recipient_change", noop);
 

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -131,6 +131,7 @@ test("start", ({override, override_rewire}) => {
     override_rewire(compose_actions, "blur_compose_inputs", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
     override_rewire(compose_recipient, "update_on_recipient_change", () => {});
+    override_rewire(compose_recipient, "check_stream_posting_policy_for_compose_box", () => {});
     stream_bar.decorate = () => {};
     mock_stream_header_colorblock();
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -3,6 +3,7 @@
 const {strict: assert} = require("assert");
 
 const {mock_stream_header_colorblock} = require("./lib/compose");
+const {mock_banners} = require("./lib/compose_banner");
 const {mock_esm, set_global, with_overrides, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
 const $ = require("./lib/zjquery");
@@ -677,6 +678,7 @@ function sorted_names_from(subs) {
 
 test("initialize", ({override, override_rewire, mock_template}) => {
     mock_stream_header_colorblock();
+    mock_banners();
     override_rewire(compose_recipient, "update_on_recipient_change", noop);
     override_rewire(stream_bar, "decorate", noop);
 
@@ -1727,6 +1729,7 @@ test("PM recipients sorted according to stream / topic being viewed", ({override
             stream_id === denmark_stream.stream_id && user_id === cordelia.user_id,
     );
     mock_stream_header_colorblock();
+    mock_banners();
     override_rewire(stream_bar, "decorate", noop);
     override_rewire(compose_recipient, "update_on_recipient_change", noop);
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is to show all accessible streams, including the ones to which user cannot post, in the dropdown.
- Second commit is to show the banner on opening compose box or changing the stream, if user is not allowed to post.

Fixes: <!-- Issue link, or clear description.--> #25219 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![post-banner](https://user-images.githubusercontent.com/35494118/233839898-6f3f8888-b505-4f24-92eb-2ba12bfb960f.png)
![post-banner](https://user-images.githubusercontent.com/35494118/233839908-de405651-2352-4cd6-82f0-592c08209416.gif)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
