### PR TITLE
click_handlers: Allow messages being edited/viewed to be clicked.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -177,12 +177,12 @@ export function initialize() {
         const $row = $(this).closest(".message_row");
         const id = rows.id($row);
 
+        message_lists.current.select_id(id);
+
         if (message_edit.is_editing(id)) {
             // Clicks on a message being edited shouldn't trigger a reply.
             return;
         }
-
-        message_lists.current.select_id(id);
 
         if (page_params.is_spectator) {
             return;


### PR DESCRIPTION
If a user is editing a message or viewing the message source, they'll notice that clicking on the messsage doesn't move the blue box to it while the keyboard works just fine. We want to allow the message to be selected while not triggering the reply function.

**Note:**
Since we don't want to open the compose box when clicking the messages being edited/viewed, clicking on the message won't trigger the message fading effect like how other messages do when in stream views.
<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>View source UI</summary> 

![d9efad019422bcaaf08604e50f8028dc](https://user-images.githubusercontent.com/62449508/233865674-a329542c-488d-4ad7-893c-7625d9c80978.gif)

</details>

<details>
<summary>Edit message UI</summary> 

![7e24e7fa2561a343fb9d260e555ad840](https://user-images.githubusercontent.com/62449508/233865831-62d6c99a-57d1-4a0b-be2e-10652b92ea64.gif)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
