### PR TITLE
templates: Update redirects that didn't have CSS formatting.

### DIFF
--- a/templates/zerver/invalid_email.html
+++ b/templates/zerver/invalid_email.html
@@ -5,46 +5,38 @@
 {% endblock %}
 
 {% block portico_content %}
-
-    <h3>{{ _('Invalid email') }}</h3>
-
-    <p>{{ _('Hi there! Thank you for your interest in Zulip.') }}</p>
-
-    {% if invalid_email %}
-    <p>
-        {% trans %}
-        The email address you are trying to sign up with is not valid.
-        Please sign up using a valid email address.
-        {% endtrans %}
-    </p>
-    {% endif %}
-
-    {% if closed_domain %}
-    <p>
-        {% trans %}
-        The organization you are trying to join, {{ realm_name }},
-        only allows users with email addresses within the
-        organization. Please sign up using appropriate email address.
-        {% endtrans %}
-    </p>
-    {% endif %}
-
-    {% if disposable_emails_not_allowed %}
-    <p>
-        {% trans %}The organization you are trying to join,
-        {{realm_name}}, does not allow signups using disposable email
-        addresses. Please sign up using a real email address.
-        {% endtrans %}
-    </p>
-    {% endif %}
-
-    {% if email_contains_plus %}
-    <p>
-        {% trans %}The organization you are trying to join,
-        {{realm_name}}, does not allow signups using emails
-        that contains +. Please sign up using appropriate email address.
-        {% endtrans %}
-    </p>
-    {% endif %}
-
+<div class="app portico-page">
+    <div class="app-main portico-page-container center-block flex full-page account-creation new-style">
+        <div class="inline-block">
+            <div class="get-started">
+                {% if invalid_email %}
+                <h1>{{ _("Invalid email") }}</h1>
+                {% else %}
+                <h1>{{ _("Email not allowed") }}</h1>
+                {% endif %}
+            </div>
+            <div class="white-box">
+                <p>
+                    {% if invalid_email %}
+                        {{ _("The email address you are trying to sign up with is not valid.") }}
+                    {% endif %}
+                    {% if closed_domain %}
+                        {% trans %}The organization you are trying to join, <a href="{{ realm_uri }}">{{ realm_name }}</a>, does not allow signups using emails with your email domain.{% endtrans %}
+                    {% endif %}
+                    {% if disposable_emails_not_allowed %}
+                        {% trans %}The organization you are trying to join, <a href="{{ realm_uri }}">{{ realm_name }}</a>, does not allow signups using disposable email addresses.{% endtrans %}
+                    {% endif %}
+                    {% if email_contains_plus %}
+                        {% trans %}The organization you are trying to join, <a href="{{ realm_uri }}">{{ realm_name }}</a>, does not allow signups using emails that contain "+".{% endtrans %}
+                    {% endif %}
+                    {% if invalid_email %}
+                    {{ _("Please sign up using a valid email address.") }}
+                    {% else %}
+                    {{ _("Please sign up using an allowed email address.") }}
+                    {% endif %}
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/templates/zerver/no_spare_licenses.html
+++ b/templates/zerver/no_spare_licenses.html
@@ -5,16 +5,21 @@
 {% endblock %}
 
 {% block portico_content %}
-<br/>
-<br/>
-<br/>
-
-<h3>{{ _("This organization cannot accept new members right now.") }}</h3>
-
-<p>
-    {% trans %}
-    New members cannot join this organization because all Zulip licenses are currently in use. Please contact the person who
-    invited you and ask them to increase the number of licenses, then try again.
-    {% endtrans %}
-</p>
+<div class="app portico-page">
+    <div class="app-main portico-page-container center-block flex full-page account-creation new-style">
+        <div class="inline-block">
+            <div class="get-started">
+                <h1>{{ _("Organization cannot accept new members right now") }}</h1>
+            </div>
+            <div class="white-box">
+                <p>
+                    {% trans %}New members cannot currently join <a href="{{ realm_uri }}">{{ realm_name }}</a> because all Zulip Cloud licenses are in use.{% endtrans %}
+                </p>
+                <p>
+                    {{ _("Please contact the person who invited you and ask them to increase the number of licenses, then try again.") }}
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/templates/zerver/unsubscribe_link_error.html
+++ b/templates/zerver/unsubscribe_link_error.html
@@ -5,14 +5,21 @@
 {% endblock %}
 
 {% block portico_content %}
-
-<h1>{% trans %}Unknown email unsubscribe request{% endtrans %}</h1>
-
-<p>
-    {% trans %}Hi there! It looks like you tried to unsubscribe from something,
-    but we don't recognize the URL.{% endtrans %}
-</p>
-
-<p>{% trans %}Please double-check that you have the full URL and try again, or <a href="mailto:{{ support_email }}">email us</a> and we'll get this squared away!{% endtrans %}</p>
-
+<div class="app portico-page">
+    <div class="app-main portico-page-container center-block flex full-page account-creation new-style">
+        <div class="inline-block">
+            <div class="get-started">
+                <h1>{{ _("Unknown email unsubscribe request") }}</h1>
+            </div>
+            <div class="white-box">
+                <p>
+                    {{ _("Hi there! It looks like you tried to unsubscribe from something, but we don't recognize the URL.") }}
+                </p>
+                <p>
+                    {% trans %}Please double-check that you have the full URL and try again, or <a href="mailto:{{ support_email }}">email us</a> and we'll get this squared away!{% endtrans %}
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1542,7 +1542,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         self.client_post(url, {"key": registration_key, "from_confirmation": 1, "full_name": "bob"})
         response = self.submit_reg_form_for_user(email, "password", key=registration_key)
         self.assert_in_success_response(
-            ["New members cannot join this organization because all Zulip licenses are"], response
+            ["Organization cannot accept new members right now"], response
         )
 
         guest_prereg_user = PreregistrationUser.objects.create(

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -1094,7 +1094,9 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
 
         result = self.submit_reg_form_for_user("foo@example.com", "password")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response("only allows users with email addresses", result)
+        self.assert_in_response(
+            "does not allow signups using emails with your email domain", result
+        )
 
     def test_disposable_emails_before_closing(self) -> None:
         """
@@ -1119,7 +1121,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
 
         result = self.submit_reg_form_for_user("foo@mailnator.com", "password")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response("Please sign up using a real email address.", result)
+        self.assert_in_response("does not allow signups using disposable email addresses.", result)
 
     def test_invite_with_email_containing_plus_before_closing(self) -> None:
         """
@@ -1145,9 +1147,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
 
         result = self.submit_reg_form_for_user(external_address, "password")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response(
-            "Zulip Dev, does not allow signups using emails\n        that contains +", result
-        )
+        self.assert_in_response('does not allow signups using emails that contain "+".', result)
 
     def test_invalid_email_check_after_confirming_email(self) -> None:
         self.login("hamlet")


### PR DESCRIPTION
Updates 3 templates that had not been updated for the `white-box` style for redirects when there is an error:
- `invalid_email.html`
- `no_spare_licenses.html`
- `unsubscribe_link_error.html`

See relevant [CZO conversation](https://chat.zulip.org/#narrow/stream/9-issues/topic/email.20unsubscribe.20error.20page/near/1550064).

**Notes**:
- Also uses the `account-creation` class to remove any padding on the final `<p>` tag with the `white-box` class, which also makes the font-weight 400.

---

**Screenshots and screen captures:**

<details>
<summary>Unsubscribe link error</summary>

![Screenshot from 2023-04-24 13-29-59](https://user-images.githubusercontent.com/63245456/233999838-615e1612-91a8-4193-9c7c-62b730074727.png)

</details>
<details>
<summary>No Zulip Cloud licenses available</summary>

![Screenshot from 2023-04-24 13-31-07](https://user-images.githubusercontent.com/63245456/233999859-31c537f5-f3fc-4e57-bd33-1ca0e9783cec.png)

</details><details>
<summary>Invalid email - several variants</summary>

**No emails with "+"**:
![Screenshot from 2023-04-24 13-46-11](https://user-images.githubusercontent.com/63245456/233999896-a563921c-b240-41b0-817c-ca63a5f723bf.png)

**No disposable emails**:
![Screenshot from 2023-04-24 13-46-54](https://user-images.githubusercontent.com/63245456/233999928-bd9b1cdb-2087-4fff-ab39-57488c270454.png)

**Limited subdomain emails**:
![Screenshot from 2023-04-24 13-47-17](https://user-images.githubusercontent.com/63245456/234000038-97493ad8-5fe4-4c35-913a-e7f08e86e9f0.png)

**Invalid email**:
![Screenshot from 2023-04-24 13-47-40](https://user-images.githubusercontent.com/63245456/234000061-f3d06371-8cd1-4e98-85aa-252dad27af02.png)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
