### PR TITLE
emails: Add onboarding team to zulip email.

### DIFF
--- a/templates/zerver/emails/onboarding_team_to_zulip.html
+++ b/templates/zerver/emails/onboarding_team_to_zulip.html
@@ -1,0 +1,37 @@
+{% extends "zerver/emails/email_base_default.html" %}
+
+{% block illustration %}
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+
+<p>
+    {% trans %}If you have already decided to use Zulip for your organization, welcome! You can use our <a href="{{ get_organization_started }}">guide for setting up your organization</a> to get started.{% endtrans %}
+</p>
+<p>
+    {% trans %}If you are still deciding between a few different options, here are some tips for successfully evaluating any team chat product:{% endtrans %}
+    <ul>
+        <li>{% trans %}<a href="{{ invite_users }}">Invite others</a> to explore it with you.{% endtrans %} {% trans %}You'll learn how the tool might (or might not) fit your organization when everyone brings their unique perspective. Besides, most of the time using a chat app is spent reading messages, and there's not much to read when you are alone.{% endtrans %} &#128521;</li>
+        <li>{% trans %}Run a week-long trial with your team. Stop using any other chat tools, and fully commit to trying something different. This is the only way to truly get a feel for how a new chat app will impact your team's communication and workflows in the coming months.{% endtrans %}</li>
+    </ul>
+</p>
+<p>
+    {% trans %}Choosing a tool that <a href="{{ why_zulip }}">enables efficient communication</a> is one of the most impactful ways to improve productivity in your organization, and we hope this advice helps you find the best chat app for your team.{% endtrans %}
+</p>
+
+<p>
+    {% if corporate_enabled %}
+        {{macros.contact_us_zulip_cloud(support_email)}}
+    {% else %}
+        {{macros.contact_us_self_hosted(support_email)}}
+    {% endif %}
+</p>
+
+{% endblock %}
+
+{% block manage_preferences %}
+
+<p><a href="{{ unsubscribe_link }}">{% trans %}Unsubscribe from welcome emails for {{ realm_name }}{% endtrans %}</a></p>
+
+{% endblock %}

--- a/templates/zerver/emails/onboarding_team_to_zulip.subject.txt
+++ b/templates/zerver/emails/onboarding_team_to_zulip.subject.txt
@@ -1,0 +1,1 @@
+{{ _("Choosing the chat app for your team") }}

--- a/templates/zerver/emails/onboarding_team_to_zulip.txt
+++ b/templates/zerver/emails/onboarding_team_to_zulip.txt
@@ -1,0 +1,26 @@
+{% trans %}If you have already decided to use Zulip for your organization, welcome! You can use our guide for setting up your organization to get started.{% endtrans %}
+
+<{{ get_organization_started }}>
+
+{% trans %}If you are still deciding between a few different options, here are some tips for successfully evaluating any team chat product:{% endtrans %}
+
+
+- {% trans %}Invite others to explore it with you: {{ invite_users }}.{% endtrans %} {% trans %}You'll learn how the tool might (or might not) fit your organization when everyone brings their unique perspective. Besides, most of the time using a chat app is spent reading messages, and there's not much to read when you are alone.{% endtrans %} ;)
+
+
+- {% trans %}Run a week-long trial with your team. Stop using any other chat tools, and fully commit to trying something different. This is the only way to truly get a feel for how a new chat app will impact your team's communication and workflows in the coming months.{% endtrans %}
+
+
+{% trans %}Choosing a tool that enables efficient communication is one of the most impactful ways to improve productivity in your organization, and we hope this advice helps you find the best chat app for your team.{% endtrans %}
+
+<{{ why_zulip }}>
+
+{% if corporate_enabled %}
+    {% trans %}Do you have questions or feedback to share? Contact us at {{ support_email }} — we'd love to help!{% endtrans %}
+{% else %}
+    {% trans %}If you have any questions, please contact this Zulip server's administrators at {{ support_email }}.{% endtrans %}
+{% endif %}
+
+----
+{% trans %}Unsubscribe from welcome emails for {{ realm_name }}{% endtrans %}:
+{{ unsubscribe_link }}

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -696,6 +696,7 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
         # or comes in while they are dealing with their inbox.
         "onboarding_zulip_topics": timedelta(days=2, hours=-1),
         "onboarding_zulip_guide": timedelta(days=4, hours=-1),
+        "onboarding_team_to_zulip": timedelta(days=6, hours=-1),
     }
 
     user_tz = user.timezone
@@ -707,17 +708,24 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
     # -Do not send emails on Saturday or Sunday
     # -Have at least one weekday between each (potential) email
 
+    # User signed up on Monday
+    if signup_day == 1:
+        # Send onboarding_team_to_zulip on Tuesday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
+
     # User signed up on Tuesday
     if signup_day == 2:
-        # Send onboarding_zulip_topics on Thursday
         # Send onboarding_zulip_guide on Monday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Wednesday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     # User signed up on Wednesday
     if signup_day == 3:
-        # Send onboarding_zulip_topics on Friday
         # Send onboarding_zulip_guide on Tuesday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Thursday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     # User signed up on Thursday
     if signup_day == 4:
@@ -725,6 +733,8 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
         onboarding_emails["onboarding_zulip_topics"] = timedelta(days=4, hours=-1)
         # Send onboarding_zulip_guide on Wednesday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Friday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     # User signed up on Friday
     if signup_day == 5:
@@ -732,6 +742,15 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
         onboarding_emails["onboarding_zulip_topics"] = timedelta(days=4, hours=-1)
         # Send onboarding_zulip_guide on Thursday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Monday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=10, hours=-1)
+
+    # User signed up on Saturday; no adjustments needed
+
+    # User signed up on Sunday
+    if signup_day == 7:
+        # Send onboarding_team_to_zulip on Monday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     return onboarding_emails
 
@@ -893,6 +912,27 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> N
             from_address=from_address,
             context=onboarding_zulip_guide_context,
             delay=onboarding_email_schedule["onboarding_zulip_guide"],
+        )
+
+    # We only send the onboarding_team_to_zulip email to user who created the organization.
+    if realm_creation:
+        onboarding_team_to_zulip_context = common_context(user)
+        onboarding_team_to_zulip_context.update(
+            unsubscribe_link=unsubscribe_link,
+            get_organization_started=realm_url
+            + "/help/getting-your-organization-started-with-zulip",
+            invite_users=realm_url + "/help/invite-users-to-join",
+            why_zulip="https://zulip.com/why-zulip/",
+        )
+
+        send_future_email(
+            "zerver/emails/onboarding_team_to_zulip",
+            user.realm,
+            to_user_ids=[user.id],
+            from_name=from_name,
+            from_address=from_address,
+            context=onboarding_team_to_zulip_context,
+            delay=onboarding_email_schedule["onboarding_team_to_zulip"],
         )
 
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4556,6 +4556,7 @@ EMAIL_TYPES = {
     "account_registered": ScheduledEmail.WELCOME,
     "onboarding_zulip_topics": ScheduledEmail.WELCOME,
     "onboarding_zulip_guide": ScheduledEmail.WELCOME,
+    "onboarding_team_to_zulip": ScheduledEmail.WELCOME,
     "digest": ScheduledEmail.DIGEST,
     "invitation_reminder": ScheduledEmail.INVITATION_REMINDER,
 }

--- a/zerver/tests/test_email_log.py
+++ b/zerver/tests/test_email_log.py
@@ -26,7 +26,7 @@ class EmailLogTest(ZulipTestCase):
             output_log = (
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )
-            self.assertEqual(m.output, [output_log for i in range(17)])
+            self.assertEqual(m.output, [output_log for i in range(18)])
 
     def test_forward_address_details(self) -> None:
         try:

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -402,7 +402,7 @@ class TestDevelopmentEmailsLog(ZulipTestCase):
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )
             # logger.output is a list of all the log messages captured. Verify it is as expected.
-            self.assertEqual(logger.output, [output_log] * 17)
+            self.assertEqual(logger.output, [output_log] * 18)
 
             # Now, lets actually go the URL the above call redirects to, i.e., /emails/
             result = self.client_get(result["Location"])

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -147,7 +147,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     send_account_registered_email(get_user_by_delivery_email("iago@zulip.com", realm))
 
     # Onboarding emails for admin user
-    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm))
+    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm), realm_creation=True)
 
     # Realm reactivation email
     do_send_realm_reactivation_email(realm, acting_user=None)


### PR DESCRIPTION
Adds a 4th onboarding email for users who create a new Zulip organization, which is about the process of choosing the best chat application for their team.

**Notes**:
- There's a prep commit for the test of `get_onboarding_email_schedule`. This refactor makes it significantly easier to test the addition of a new email to the schedule.
- For the text version, I removed the emoji in the first bullet point, and I placed the links in a way that made it easier to read in my opinion.
- I'll note that in order to follow our email scheduling rules, most of the time this email is going out 8 days after the user created the new Zulip organization.

---

**Screenshots and screen captures:**

<details>
<summary>HTML version</summary>

![Screenshot from 2023-04-24 18-09-29](https://user-images.githubusercontent.com/63245456/234054423-4ed3dd3f-7ded-4ce2-9653-3ad605542592.png)
</details>
<details>
<summary>text version</summary>

![Screenshot from 2023-04-24 17-10-44](https://user-images.githubusercontent.com/63245456/234051257-6ebb566a-6334-4ba6-9fb2-d8d07f996bed.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
