### PR TITLE
hotkey: Clear message sent success banners too on escape keypress.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -310,6 +310,7 @@ export function process_escape_key(e) {
 
             // Check for errors in compose box; close errors if they exist
             if ($(".compose_banner").length) {
+                compose_banner.clear_message_sent_banners();
                 compose_banner.clear_errors();
                 compose_banner.clear_warnings();
                 return true;


### PR DESCRIPTION
Without this, if there was a success compose banner and user pressed escape key, no banners were hidden, and the same behaviour was repeated without compose ever closing.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/esc.20after.20creating.20scheduled.20msg