### PR TITLE
send_later: Move some options to a modal.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -886,9 +886,10 @@
         color: inherit;
     }
 
-    .send_later_popover_header,
-    .selected_send_later_time {
-        color: hsl(236deg 33% 90%);
+    #send_later_modal .send_later_input_group .send_later_date_input {
+        opacity: 0.8;
+        color: hsl(0deg 0% 100%);
+        background-color: hsl(0deg 0% 0% / 20%);
     }
 
     .nav-list > li > a,

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -861,14 +861,24 @@ ul {
     & hr {
         margin: 5px 0;
     }
+}
 
-    .send_later_popover_header {
-        text-align: center;
-        font-weight: bold;
+#send_later_modal {
+    .modal__content {
+        padding-bottom: 16px;
     }
 
-    .selected_send_later_time {
-        text-align: center;
-        margin-top: 3px;
+    .send_later_input_group {
+        display: flex;
+
+        .send_later_date_input {
+            width: 100%;
+            cursor: pointer;
+            background: hsl(0deg 0% 100%);
+
+            &:focus {
+                box-shadow: none;
+            }
+        }
     }
 }

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -1,0 +1,39 @@
+<div class="micromodal" id="send_later_modal" aria-hidden="true">
+    <div class="modal__overlay" tabindex="-1">
+        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="send_later_modal_label">
+            <header class="modal__header">
+                <h1 class="modal__title" id="send_later_modal_label">
+                    {{t "Schedule message" }}
+                </h1>
+                <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
+            </header>
+            <main class="modal__content">
+                <div class="send_later_input_group">
+                    <input class="send_later_date_input" type="text" placeholder="{{t 'Select Date and time' }}" readonly="readonly"
+                      {{#if formatted_send_later_time }}value="{{formatted_send_later_time}}"{{/if}} />
+                </div>
+                <div class="send_later_options">
+                    <ul class="nav nav-list">
+                        {{#if formatted_send_later_time }}
+                        <li>
+                            <a id="clear_compose_schedule_state" tabindex="0">{{t "Now" }}</a>
+                        </li>
+                        {{/if}}
+                        {{#if possible_send_later_today}}
+                            {{#each possible_send_later_today}}
+                                <li>
+                                    <a id="{{@key}}" class="send_later_today" tabindex="0">{{this.text}}</a>
+                                </li>
+                            {{/each}}
+                        {{/if}}
+                        {{#each send_later_tomorrow}}
+                            <li>
+                                <a id="{{@key}}" class="send_later_tomorrow" tabindex="0">{{this.text}}</a>
+                            </li>
+                        {{/each}}
+                    </ul>
+                </div>
+            </main>
+        </div>
+    </div>
+</div>

--- a/web/templates/send_later_popover.hbs
+++ b/web/templates/send_later_popover.hbs
@@ -1,36 +1,9 @@
 <ul id="send_later_popover" class="nav nav-list">
-    <li class="send_later_popover_header">
-        {{t "Schedule message" }}
-    </li>
-    {{#if formatted_send_later_time }}
-    <li class="selected_send_later_time">
-        {{ formatted_send_later_time }}
+    <li>
+        <a class="open_send_later_modal" tabindex="0">{{t "Schedule message" }}</a>
     </li>
     <hr />
     <li>
-        <a id="clear_compose_schedule_state">{{t "Now" }}</a>
-    </li>
-    {{/if}}
-    <hr />
-    {{#if possible_send_later_today}}
-        {{#each possible_send_later_today}}
-            <li>
-                <a id="{{@key}}" class="send_later_today">{{this.text}}</a>
-            </li>
-        {{/each}}
-        <hr />
-    {{/if}}
-    {{#each send_later_tomorrow}}
-        <li>
-            <a id="{{@key}}" class="send_later_tomorrow">{{this.text}}</a>
-        </li>
-    {{/each}}
-    <hr />
-    <li>
-        <a id="send-later-custom-input">{{send_later_custom.text}}</a>
-    </li>
-    <hr />
-    <li>
-        <a href="#scheduled">{{t "View scheduled messages" }}</a>
+        <a href="#scheduled" tabindex="0">{{t "View scheduled messages" }}</a>
     </li>
 </ul>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/Scheduled.20message.20time.20selection.20popover
<img width="1019" alt="Screenshot 2023-04-25 at 12 00 31 AM" src="https://user-images.githubusercontent.com/25124304/234085036-b42029a8-bb15-4add-a65b-d1bb2e547299.png">
<img width="1019" alt="Screenshot 2023-04-25 at 12 01 55 AM" src="https://user-images.githubusercontent.com/25124304/234085023-e736edcc-ff7d-4e2b-bbc1-b2f75e20bed0.png">
<img width="1019" alt="Screenshot 2023-04-25 at 12 01 38 AM" src="https://user-images.githubusercontent.com/25124304/234085041-43acc850-84c4-4604-bc74-24ff4bb4df93.png">
<img width="1019" alt="Screenshot 2023-04-25 at 12 09 33 AM" src="https://user-images.githubusercontent.com/25124304/234086516-8a14fcea-29bd-473c-a9d7-de1bca369354.png">
<img width="1019" alt="Screenshot 2023-04-25 at 12 11 11 AM" src="https://user-images.githubusercontent.com/25124304/234086825-b4a985af-025f-42da-9988-9d148f2aeb30.png">
