### PR TITLE
Change recipient bar colors and PM background colors.

### DIFF
--- a/web/src/stream_color.js
+++ b/web/src/stream_color.js
@@ -48,7 +48,7 @@ export function get_recipient_bar_color(color) {
     const using_dark_theme = settings_data.using_dark_theme();
     color = get_stream_privacy_icon_color(color);
     return colord(using_dark_theme ? "#000000" : "#ffffff")
-        .mix(color, using_dark_theme ? 0.5 : 0.4)
+        .mix(color, using_dark_theme ? 0.43 : 0.35)
         .toHex();
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -72,9 +72,9 @@ body,
 %dark-theme {
     --color-default-text: hsl(0deg 0% 100%);
     --color-date: hsl(0deg 0% 100% / 75%);
-    --color-background-private-message-header: hsl(46deg 25% 20%);
+    --color-background-private-message-header: hsl(46deg 15% 20%);
     --color-text-private-message-header: hsl(0deg 0% 100%);
-    --color-background-private-message-content: hsl(46deg 25% 14%);
+    --color-background-private-message-content: hsl(46deg 10% 15%);
     --color-text-message-header: hsl(0deg 0% 100%);
     --color-message-header-icon-non-interactive: hsl(0deg 0% 100% / 30%);
     --color-message-header-icon-interactive: hsl(0deg 0% 100%);


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/431-redesign-project/topic/redesign.20tweaks.20.2325247

Fixes `Recipient bar color correction` and  `Dark mode DM background` parts of #25247


# Recipient bar color correction


before:

<img width="1019" alt="Screenshot 2023-04-25 at 12 56 42 AM" src="https://user-images.githubusercontent.com/25124304/234096149-3300e6fc-d09a-4c4b-9f82-ba2dfec7568f.png">



after:


<img width="1019" alt="Screenshot 2023-04-25 at 12 54 05 AM" src="https://user-images.githubusercontent.com/25124304/234095654-c71e1f8a-46f7-4fbd-91bd-2225fdec807e.png">


# Dark mode DM background

before:
<img width="1019" alt="Screenshot 2023-04-25 at 12 55 23 AM" src="https://user-images.githubusercontent.com/25124304/234095880-5ffa881c-df65-45aa-b795-c3f00fd1c7d0.png">


after:


<img width="1019" alt="Screenshot 2023-04-25 at 12 54 56 AM" src="https://user-images.githubusercontent.com/25124304/234095790-2e9193fe-8bd9-46dd-9e8b-d38bf9b90e7f.png">
