### PR TITLE
upgrade-zulip-from-git: CWD will be the cache directory.

### DIFF
--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -16,6 +16,7 @@ from scripts.lib.zulip_tools import (
     get_config,
     get_config_file,
     get_deploy_options,
+    get_deploy_root,
     get_deployment_lock,
     make_deploy_path,
     overwrite_symlink,
@@ -133,7 +134,9 @@ try:
             preexec_fn=su_to_zulip,
         )
 
-    subprocess.check_call(["./scripts/lib/update-git-upstream"], preexec_fn=su_to_zulip)
+    subprocess.check_call(
+        [os.path.join(get_deploy_root(), "scripts/lib/update-git-upstream")], preexec_fn=su_to_zulip
+    )
 
     # Generate the deployment directory via git worktree from our local repository.
     try:


### PR DESCRIPTION
96e42b8e811f broke this when it split out the steps to reset the upstream.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
