### PR TITLE
linkifier: Use Reserved Expansion for template conversion.

### DIFF
--- a/zerver/migrations/0441_backfill_realmfilter_url_template.py
+++ b/zerver/migrations/0441_backfill_realmfilter_url_template.py
@@ -25,7 +25,7 @@ def transform_to_url_template_syntax(
     for linkifier in linkifiers:
         converted_template = linkifier.url_format_string.translate(escape_table)
         # Replace format string variables with the RFC 6570 URI Template syntax
-        converted_template = var_pattern.sub(r"\1{\2}", converted_template).replace("%%", "%")
+        converted_template = var_pattern.sub(r"\1{+\2}", converted_template).replace("%%", "%")
         if not uri_template.validate(converted_template):
             raise RuntimeError(
                 f'Failed to convert url format "{var_pattern}". The converted template "{converted_template}" is invalid.'

--- a/zerver/tests/test_migrations.py
+++ b/zerver/tests/test_migrations.py
@@ -103,8 +103,8 @@ class LinkifierURLFormatString(MigrationsTestCase):
             "https://example.com/%(foo",
             "https://example.com/%(foo)",
             "https://example.com/%(foo)s",
-            "https://example.com/{foo}",
-            "https://example.com/{foo}{bar}",
+            "https://example.com/{+foo}",
+            "https://example.com/{+foo}{+bar}",
         ]
 
         for linkifier_id, expected in zip(self.linkifier_ids, expected_urls):


### PR DESCRIPTION
When transitioning from URL format string to URL template, we have a migration that backfills the linkifiers by generating RFC 6570 URL templates. Such templates would automatically escape the reserved keywords using Simple String Expansions (denoted as `{groupname}` in the templates).

This breaks linkifiers that intended to have characters like "/" in the match groups.

One example of the offensing template is:

https://zulip.readthedocs.io/en/latest/{article}

where the article can be "outreach/mentoring.html".

Though that is likely a rare use case, we change the migrataion to use Reserved Expansions (`{+groupname}`) during the conversion. It behaves more like the previous URL format string, which does not URL-encode the expanded variables.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
