### PR TITLE
user_info_popover: Add close button to all user-info-popovers.

### DIFF
--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -807,6 +807,11 @@ export function register_click_handlers() {
         e.stopPropagation();
     });
 
+    $("body").on("click", ".exit_user_info_popover", (e) => {
+        hide_all_user_info_popovers();
+        e.stopPropagation();
+    });
+
     $("body").on("click", ".info_popover_actions .narrow_to_private_messages", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const email = people.get_by_user_id(user_id).email;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -347,6 +347,36 @@ ul {
         outline: 10px solid hsl(0deg 0% 100%);
     }
 
+    .popover-avatar-background {
+        background-color: hsl(0deg 0% 0%);
+        height: 100%;
+        width: 100%;
+        opacity: 0.6;
+        display: none;
+    }
+
+    .exit_user_info_popover {
+        color: hsl(0deg 0% 100%);
+        cursor: pointer;
+        display: none;
+        position: absolute;
+        font-size: 2rem;
+        top: 0;
+        right: 10px;
+    }
+
+    &:hover,
+    &:active {
+        .popover-avatar-background {
+            display: block;
+        }
+
+        .exit_user_info_popover {
+            display: block;
+            opacity: 1;
+        }
+    }
+
     .popover-inner {
         width: 240px;
     }

--- a/web/templates/user_info_popover_title.hbs
+++ b/web/templates/user_info_popover_title.hbs
@@ -1,2 +1,4 @@
 <div class="popover-avatar{{#if user_is_guest}} guest-avatar{{/if}}" style="background-image: url('{{user_avatar}}');" >
+    <div class="popover-avatar-background"></div>
+    <span class="exit_user_info_popover">&times;</span>
 </div>


### PR DESCRIPTION
This commit adds a close button to all the user-info-popovers:
* user-info-popover
* message-info-popover
* user_popover 

With this new change, now if we hover over the image, there is an overlay effect. because of which the image gets dim and the close button appears, on clicking the close button, the popover closes.

-------------------------------------------------

Fixes: [CZO Thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/Close.20profile.20modal)

------------------------------------------
**Screenshots and screen captures:**

<details>
<summary>Demo:</summary>
<br>

![user_info_popover](https://user-images.githubusercontent.com/66828942/234256030-a96a6a6f-ffe0-45a2-819c-2e1cd390a30c.gif)

</details>

<details>
<summary>All messages narrow > user-info-popover</summary>
<br>

![Screenshot from 2023-04-25 16-29-58](https://user-images.githubusercontent.com/66828942/234257862-89a640f7-1ba5-4e86-8533-f5fb83730212.png)


</details>

------------------------------------
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
