### PR TITLE
stream_settings: Fix bugs with `#stream-creation .modal-footer`.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -685,12 +685,15 @@ h4.user_group_setting_subsection_title {
         outline: none;
         -webkit-overflow-scrolling: touch;
 
+        .stream-creation-simplebar-container {
+            /*
+                45px (.subscriptions-header) +  44px (.display-type) + 60px (.modal-footer)
+            */
+            height: calc(95vh - 149px);
+        }
+
         .user-group-creation-body,
         .stream-creation-body {
-            /*
-                45px (.subscriptions-header) +  44px (.display-type) + 60px (.modal-footer) + 15px (padding for .simplebar-content)
-            */
-            height: calc(95vh - 164px);
             padding: 15px 15px 0;
         }
 
@@ -699,6 +702,12 @@ h4.user_group_setting_subsection_title {
             bottom: 0;
             width: calc(100% - 27px);
             padding-top: 9px;
+        }
+
+        @media (width > $md_min) {
+            .modal-footer {
+                border-radius: 0 0 6px;
+            }
         }
 
         .add_all_users_to_user_group,

--- a/web/templates/stream_settings/stream_creation_form.hbs
+++ b/web/templates/stream_settings/stream_creation_form.hbs
@@ -1,46 +1,48 @@
 <div class="hide" id="stream-creation" tabindex="-1" role="dialog"
   aria-label="{{t 'Stream creation' }}">
     <form id="stream_creation_form">
-        <div class="alert stream_create_info"></div>
-        <div id="stream_creating_indicator"></div>
-        <div class="stream-creation-body" data-simplebar>
-            <section class="block">
-                <label for="create_stream_name">
-                    {{t "Stream name" }}
-                </label>
-                <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
-                  placeholder="{{t 'Stream name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
-                <div id="stream_name_error" class="stream_creation_error"></div>
-            </section>
-            <section class="block">
-                <label for="create_stream_description">
-                    {{t "Stream description" }}
-                    {{> ../help_link_widget link="/help/change-the-stream-description" }}
-                </label>
-                <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"
-                  placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
-            </section>
-            {{#if ask_to_announce_stream}}
-                <div id="announce-new-stream">
-                    {{>announce_stream_checkbox }}
-                </div>
-            {{/if}}
-            <section class="block" id="make-invite-only">
-                <div class="stream-types">
-                    <h3 class="stream_setting_subsection_title">{{t "Stream permissions" }}</h3>
-                    {{> stream_types
-                      stream_post_policy=stream_post_policy_values.everyone.code
-                      is_stream_edit=false
-                      can_remove_subscribers_setting_widget_name="new_stream_can_remove_subscribers_group_id" }}
-                </div>
-            </section>
-            <section class="block">
-                <label for="people_to_add">
-                    <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
-                </label>
-                <div id="stream_subscription_error" class="stream_creation_error"></div>
-                <div class="controls" id="people_to_add"></div>
-            </section>
+        <div class="stream-creation-simplebar-container" data-simplebar>
+            <div class="alert stream_create_info"></div>
+            <div id="stream_creating_indicator"></div>
+            <div class="stream-creation-body">
+                <section class="block">
+                    <label for="create_stream_name">
+                        {{t "Stream name" }}
+                    </label>
+                    <input type="text" name="stream_name" id="create_stream_name" class="settings_text_input"
+                      placeholder="{{t 'Stream name' }}" value="" autocomplete="off" maxlength="{{ max_stream_name_length }}" />
+                    <div id="stream_name_error" class="stream_creation_error"></div>
+                </section>
+                <section class="block">
+                    <label for="create_stream_description">
+                        {{t "Stream description" }}
+                        {{> ../help_link_widget link="/help/change-the-stream-description" }}
+                    </label>
+                    <input type="text" name="stream_description" id="create_stream_description" class="settings_text_input"
+                      placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_stream_description_length }}" />
+                </section>
+                {{#if ask_to_announce_stream}}
+                    <div id="announce-new-stream">
+                        {{>announce_stream_checkbox }}
+                    </div>
+                {{/if}}
+                <section class="block" id="make-invite-only">
+                    <div class="stream-types">
+                        <h3 class="stream_setting_subsection_title">{{t "Stream permissions" }}</h3>
+                        {{> stream_types
+                          stream_post_policy=stream_post_policy_values.everyone.code
+                          is_stream_edit=false
+                          can_remove_subscribers_setting_widget_name="new_stream_can_remove_subscribers_group_id" }}
+                    </div>
+                </section>
+                <section class="block">
+                    <label for="people_to_add">
+                        <h4 class="stream_setting_subsection_title">{{t "Choose subscribers" }}</h4>
+                    </label>
+                    <div id="stream_subscription_error" class="stream_creation_error"></div>
+                    <div class="controls" id="people_to_add"></div>
+                </section>
+            </div>
         </div>
         <div class="modal-footer">
             <button class="button small white rounded" data-dismiss="modal">{{t "Cancel" }}</button>


### PR DESCRIPTION
CZO Discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/bug.20in.20create.20stream.20UI

This commit addresses `#stream-creation .modal-footer` becoming transparent after an error in creating a stream due to overlapping with `.stream-creation-body`. Instead of adding `data-simplebar` on `.stream-creation-body`, added it to a new div
`stream-creation-simplebar-container` which contains 3 divs:
`stream_create_info, stream_creating_indicator and stream-creation-body`.

This solved the issue as now the `stream_create_info` error banner won't shift down the simple bar container (which previously resulted in overlapping) since now  `stream_create_info` is now also part of the simple bar container.

Additionally, fixed the `border-radius` of the modal footer on the bottom left side for device width > $md_min.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
https://user-images.githubusercontent.com/64723994/234381711-8b57e016-d444-4c3b-94ae-a30e0c378ec9.mp4


After:
![image](https://user-images.githubusercontent.com/64723994/234381046-54df54b8-7c1f-4ec5-93a4-3ad29dd213ea.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
