### PR TITLE
compose: Remove empty message warning border after closing.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -231,7 +231,6 @@ EXEMPT_FILES = make_set(
         "web/src/zulip.js",
         "web/src/zulip_test.js",
         "web/tests/lib/mdiff.js",
-        "web/tests/lib/zjquery_element.js",
     ]
 )
 

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -118,6 +118,7 @@ function clear_box() {
     clear_textarea();
     compose_validate.check_overflow_text();
     $("#compose-textarea").removeData("draft-id");
+    $("#compose-textarea").toggleClass("invalid", false);
     compose_ui.autosize_textarea($("#compose-textarea"));
     compose_banner.clear_errors();
     compose_banner.clear_warnings();


### PR DESCRIPTION
This PR adds the code to remove the `invalid` class (which is responsible for showing the error border on the compose box) from the compose text area when the compose box is closed. 

Before this, if someone clicks on "Send" on an empty compose box then a red border will appear indicating that there is no message but when the compose box was re-opened the border was still there, this PR fixes that.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/empty.20message.20indicator.20not.20clearing/near/1555466)

**Screenshots and screen captures:**

Before:

[Before_1.webm](https://user-images.githubusercontent.com/35286603/234382349-2517e077-4f28-448b-969f-d09a5c879008.webm)

After:

[After_1.webm](https://user-images.githubusercontent.com/35286603/234382340-84c18b26-b5a3-442a-8abd-239f9e7d9fed.webm)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [X] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
