### PR TITLE
messages: Fix sender name hover.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -258,11 +258,17 @@ $time_column_max_width: 150px;
                     line-height: normal;
                     outline: none;
                     margin-top: $sender_name_distance_below_flex_center;
+                }
 
-                    .sender_name_padding {
-                        /* Add padding to align user name with the content */
-                        padding-left: $avatar_column_width;
-                    }
+                .sender_name_padding {
+                    /* Add padding to align user name with the content. This region is
+                       important to ensure that the hover region for the sender name
+                       and avatar are continuous with each other. */
+                    padding-left: $avatar_column_width;
+                }
+
+                .sender_name-in-status .sender_name_padding {
+                    margin-left: -$avatar_column_width;
                 }
             }
 

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -249,6 +249,11 @@ $time_column_max_width: 150px;
                 }
 
                 .sender_name {
+                    margin-top: $sender_name_distance_below_flex_center;
+                }
+
+                .sender_name,
+                .sender_name-in-status {
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
@@ -257,7 +262,6 @@ $time_column_max_width: 150px;
                        from start and end vertically in all languages. */
                     line-height: normal;
                     outline: none;
-                    margin-top: $sender_name_distance_below_flex_center;
                 }
 
                 .sender_name_padding {

--- a/web/templates/me_message.hbs
+++ b/web/templates/me_message.hbs
@@ -5,6 +5,7 @@
 
     <span class="sender-status">
         <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">
+            <span class="sender_name_padding view_user_card_tooltip"></span>
             <span class="view_user_card_tooltip">
                 {{msg/sender_full_name}}
             </span>

--- a/web/templates/me_message.hbs
+++ b/web/templates/me_message.hbs
@@ -1,8 +1,6 @@
 <span class="message_sender no-select is_me_message">
-    <span class="sender_info_hover">
-        <span>
-            {{> message_avatar}}
-        </span>
+    <span>
+        {{> message_avatar}}
     </span>
 
     <span class="sender-status">

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip" aria-hidden="true">
+<div class="u-{{msg/sender_id}} sender_info_hover inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}} view_user_card_tooltip" aria-hidden="true">
     <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
 </div>
 {{~! remove whitespace ~}}

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -1,9 +1,9 @@
 {{#unless status_message}}
-<span class="message_sender sender_info_hover no-select">
+<span class="message_sender no-select">
     {{#if include_sender}}
     <span>
         {{> message_avatar ~}}
-        <span class="sender_name auto-select" role="button" tabindex="0">
+        <span class="sender_info_hover sender_name auto-select" role="button" tabindex="0">
             <span class="sender_name_padding view_user_card_tooltip"></span>
             <span class="view_user_card_tooltip">{{msg/sender_full_name}}{{> status_emoji msg/status_emoji_info}}</span>
         </span>


### PR DESCRIPTION
Previously, the hover effect on the sender name in the message list would apply to the entire row, which was causing unexpected behavior. This commit updates the CSS to only apply the hover effect to the sender name itself, which resolves the issue.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#25276

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://user-images.githubusercontent.com/64723994/234387401-385c9448-5c1b-478b-ae23-80c27ab5a945.mp4

Unable to add still screenshot as screenshot don't capture mouse position.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
