### PR TITLE
Take PostgreSQL backups on replicas, if possible

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -836,6 +836,14 @@ based on the `pg_hba.conf` file; if you are using password
 authentication, you can set a `postgresql_replication_password` secret
 for authentication.
 
+#### `skip_backups`
+
+If set to as true value, inhibits the nightly [`wal-g` backups][wal-g] which
+would be taken on all non-replicated hosts and [all warm standby
+replicas](#postgresql-warm-standby). This is generally only set if you have
+multiple warm standby replicas, in order to avoid taking multiple backups, one
+per replica.
+
 #### `ssl_ca_file`
 
 Set to the path to the PEM-encoded certificate authority used to

--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -844,6 +844,13 @@ replicas](#postgresql-warm-standby). This is generally only set if you have
 multiple warm standby replicas, in order to avoid taking multiple backups, one
 per replica.
 
+#### `backups_disk_concurrency`
+
+Number of concurrent disk reads to use when taking backups. Defaults to 1; you
+may wish to increase this if you are taking backups on a replica, so can afford
+to affect other disk I/O, and have an SSD which is good at parallel random
+reads.
+
 #### `ssl_ca_file`
 
 Set to the path to the PEM-encoded certificate authority used to

--- a/puppet/zulip/files/nagios_plugins/zulip_postgresql_backups/check_postgresql_backup
+++ b/puppet/zulip/files/nagios_plugins/zulip_postgresql_backups/check_postgresql_backup
@@ -19,13 +19,39 @@ def report(state: str, msg: str) -> None:
     sys.exit(states[state])
 
 
-if (
-    subprocess.check_output(
-        ["psql", "-v", "ON_ERROR_STOP=1", "postgres", "-t", "-c", "SELECT pg_is_in_recovery()"]
-    ).strip()
-    != b"f"
-):
-    report("OK", "this is not the primary")
+replicas = subprocess.check_output(
+    [
+        "psql",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "postgres",
+        "-t",
+        "-c",
+        "SELECT COUNT(*) FROM pg_stat_replication",
+    ],
+    stdin=subprocess.DEVNULL,
+    text=True,
+).strip()
+if int(replicas) > 0:
+    # We are the primary and we have replicas; we expect that backups
+    # will be taken on one of them.
+    report("OK", "this is the primary, with backups taken on the replicas")
+
+skip_backups = subprocess.run(
+    ["crudini", "--get", "/etc/zulip/zulip.conf", "postgresql", "skip_backups"],
+    capture_output=True,
+    text=True,
+)
+if skip_backups.returncode == 0 and skip_backups.stdout.strip().lower() in [
+    1,
+    "y",
+    "t",
+    "yes",
+    "true",
+    "enable",
+    "enabled",
+]:
+    report("OK", "backups are disabled on this host")
 
 try:
     with open("/var/lib/nagios_state/last_postgresql_backup") as f:

--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import configparser
 import glob
 import logging
 import os
@@ -14,14 +15,32 @@ logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 
-recovery_val = subprocess.check_output(
-    ["psql", "-v", "ON_ERROR_STOP=1", "-t", "-c", "SELECT pg_is_in_recovery()"],
+config_file = configparser.RawConfigParser()
+config_file.read("/etc/zulip/zulip.conf")
+
+
+def get_config(
+    section: str,
+    key: str,
+    default_value: str = "",
+) -> str:
+    if config_file.has_option(section, key):
+        return config_file.get(section, key)
+    return default_value
+
+
+replicas = subprocess.check_output(
+    ["psql", "-v", "ON_ERROR_STOP=1", "-t", "-c", "SELECT COUNT(*) FROM pg_stat_replication"],
+    stdin=subprocess.DEVNULL,
     text=True,
 ).strip()
-# Assertion to check that we're extracting the value correctly.
-assert recovery_val in ["t", "f"]
-if recovery_val == "t":
-    # Only run if we're the primary
+if int(replicas) > 0:
+    # We are the primary and we have replicas; we expect that backups
+    # will be taken on one of them.
+    sys.exit(0)
+
+skip_backups = get_config("postgresql", "skip_backups", "")
+if skip_backups.lower() in [1, "y", "t", "yes", "true", "enable", "enabled"]:
     sys.exit(0)
 
 is_rhel_based = os.path.exists("/etc/redhat-release")

--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -6,7 +6,6 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Dict
 
 import dateutil.parser
 
@@ -41,7 +40,7 @@ with open("/var/lib/nagios_state/last_postgresql_backup", "w") as f:
     f.write(now.isoformat())
     f.write("\n")
 
-backups: Dict[datetime, str] = {}
+backups = {}
 lines = subprocess.check_output(["env-wal-g", "backup-list"], text=True).split("\n")
 for line in lines[1:]:
     if line:

--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -2,12 +2,11 @@
 import glob
 import logging
 import os
-import shlex
 import subprocess
 import sys
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List
+from typing import Dict
 
 import dateutil.parser
 
@@ -16,16 +15,9 @@ logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 
-def run(args: List[str], dry_run: bool = False) -> str:
-    if dry_run:
-        print(f"Would have run: {shlex.join(args)}")
-        return ""
-
-    return subprocess.check_output(args, stdin=subprocess.DEVNULL, text=True)
-
-
-recovery_val = run(
-    ["psql", "-v", "ON_ERROR_STOP=1", "-t", "-c", "SELECT pg_is_in_recovery()"]
+recovery_val = subprocess.check_output(
+    ["psql", "-v", "ON_ERROR_STOP=1", "-t", "-c", "SELECT pg_is_in_recovery()"],
+    text=True,
 ).strip()
 # Assertion to check that we're extracting the value correctly.
 assert recovery_val in ["t", "f"]
@@ -42,7 +34,7 @@ if len(pg_data_paths) != 1:
     print(f"PostgreSQL installation is not unique: {pg_data_paths}")
     sys.exit(1)
 pg_data_path = pg_data_paths[0]
-run(["env-wal-g", "backup-push", pg_data_path])
+subprocess.check_call(["env-wal-g", "backup-push", pg_data_path])
 
 now = datetime.now(tz=timezone.utc)
 with open("/var/lib/nagios_state/last_postgresql_backup", "w") as f:
@@ -50,7 +42,7 @@ with open("/var/lib/nagios_state/last_postgresql_backup", "w") as f:
     f.write("\n")
 
 backups: Dict[datetime, str] = {}
-lines = run(["env-wal-g", "backup-list"]).split("\n")
+lines = subprocess.check_output(["env-wal-g", "backup-list"], text=True).split("\n")
 for line in lines[1:]:
     if line:
         backup_name, date_str, _ = line.split()
@@ -59,7 +51,7 @@ for line in lines[1:]:
 one_month_ago = now - timedelta(days=30)
 for date in sorted(backups.keys(), reverse=True):
     if date < one_month_ago:
-        run(["env-wal-g", "delete", "--confirm", "before", backups[date]])
+        subprocess.check_call(["env-wal-g", "delete", "--confirm", "before", backups[date]])
         # Because we're going from most recent to least recent, we
         # only have to do one delete operation
         break

--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -52,7 +52,11 @@ if len(pg_data_paths) != 1:
     print(f"PostgreSQL installation is not unique: {pg_data_paths}")
     sys.exit(1)
 pg_data_path = pg_data_paths[0]
-subprocess.check_call(["env-wal-g", "backup-push", pg_data_path])
+
+disk_concurrency = get_config("postgresql", "backups_disk_concurrency", "1")
+env = os.environ.copy()
+env["WALG_UPLOAD_DISK_CONCURRENCY"] = disk_concurrency
+subprocess.check_call(["env-wal-g", "backup-push", pg_data_path], env=env)
 
 now = datetime.now(tz=timezone.utc)
 with open("/var/lib/nagios_state/last_postgresql_backup", "w") as f:


### PR DESCRIPTION
I funbled around for a while to try to find a way to have the replicas know about each other, so they could, say, pick the first alphabetic one as the one which would take the backup.

However, the replicas don't have information about each other, and they only only have ACLs to connect to the primary for replication, which doesn't allow arbitrary SQL (to inspect `pg_stat_replication`), only [a limited set of commands](https://www.postgresql.org/docs/current/protocol-replication.html).

At least this errs on the side of too many backups, rather than too few.
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
