### PR TITLE
ci: Run `pnpm dedupe --check`

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -195,6 +195,10 @@ jobs:
           source tools/ci/activate-venv
           ./tools/test-js-with-puppeteer
 
+      - name: Check pnpm dedupe
+        if: ${{ matrix.include_frontend_tests }}
+        run: pnpm dedupe --check
+
       - name: Check for untracked files
         run: |
           source tools/ci/activate-venv


### PR DESCRIPTION
New in pnpm 8.3.0, this replaces the yarn-deduplicate check that was removed in commit 3a27b12a7dc9580e565946d3252720cbdce08934 (#24731).

Sample failure:

```console
$ pnpm dedupe --check
 WARN  deprecated json-schema-ref-parser@9.0.9: Please switch to @apidevtools/json-schema-ref-parser
 WARN  deprecated uuid@2.0.3: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
 WARN  deprecated mumath@3.3.4: Redundant dependency in your project.
 WARN  deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs

 ERR_PNPM_DEDUPE_CHECK_ISSUES  Dedupe --check found changes to the lockfile

Packages
/@formatjs/icu-messageformat-parser/2.3.1
└── tslib 2.4.0 → 2.5.0

/@formatjs/icu-skeleton-parser/1.3.18
└── tslib 2.4.0 → 2.5.0

/@formatjs/ts-transformer/3.13.0
└── tslib 2.4.0 → 2.5.0

/css-tree/2.2.1
└── source-map-js 1.0.1 → 1.0.2

/css-tree/2.3.1
└── source-map-js 1.0.1 → 1.0.2


Run pnpm dedupe to apply the changes above.
```