### PR TITLE
update to use direct instead of private as the message type

### DIFF
--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_send_receive_time
@@ -151,7 +151,7 @@ time_start = time.time()
 send_zulip(
     zulip_sender,
     {
-        "type": "private",
+        "type": "direct",
         "content": msg_to_send,
         "subject": "time to send",
         "to": recipient.email,

--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -134,7 +134,7 @@ async function test_narrow_to_private_messages_with_cordelia(page: Page): Promis
 async function test_send_multirecipient_pm_from_cordelia_pm_narrow(page: Page): Promise<void> {
     const recipients = ["cordelia@zulip.com", "othello@zulip.com"];
     const multiple_recipients_pm = "A huddle to check spaces";
-    await common.send_message(page, "private", {
+    await common.send_message(page, "direct", {
         recipient: recipients.join(", "),
         outside_view: true,
         content: multiple_recipients_pm,

--- a/web/e2e-tests/edit.test.ts
+++ b/web/e2e-tests/edit.test.ts
@@ -75,7 +75,7 @@ async function test_edit_message_with_slash_me(page: Page): Promise<void> {
 }
 
 async function test_edit_private_message(page: Page): Promise<void> {
-    await common.send_message(page, "private", {
+    await common.send_message(page, "direct", {
         recipient: "cordelia@zulip.com",
         content: "test editing pm",
     });

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -407,7 +407,7 @@ export async function select_item_via_dropdown(
 // Wait for any previous send to finish, then send a message.
 export async function send_message(
     page: Page,
-    type: "stream" | "private",
+    type: "stream" | "direct",
     params: Message,
 ): Promise<void> {
     // If a message is outside the view, we do not need
@@ -420,7 +420,7 @@ export async function send_message(
 
     if (type === "stream") {
         await page.keyboard.press("KeyC");
-    } else if (type === "private") {
+    } else if (type === "direct") {
         await page.keyboard.press("KeyX");
         const recipients = params.recipient!.split(", ");
         for (const recipient of recipients) {
@@ -462,7 +462,7 @@ export async function send_message(
 
 export async function send_multiple_messages(page: Page, msgs: Message[]): Promise<void> {
     for (const msg of msgs) {
-        await send_message(page, msg.stream !== undefined ? "stream" : "private", msg);
+        await send_message(page, msg.stream !== undefined ? "stream" : "direct", msg);
     }
 }
 

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -670,7 +670,7 @@ export function initialize() {
         e.preventDefault();
     });
     $("body").on("click", ".empty_feed_compose_private", (e) => {
-        compose_actions.start("private", {trigger: "empty feed message"});
+        compose_actions.start("direct", {trigger: "empty feed message"});
         e.preventDefault();
     });
 

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -134,7 +134,7 @@ export function create_message_object() {
     };
     message.topic = "";
 
-    if (message.type === "private") {
+    if (message.type === "direct") {
         // TODO: this should be collapsed with the code in composebox_typeahead.js
         const recipient = compose_state.private_message_recipient();
         const emails = util.extract_pm_recipients(recipient);
@@ -204,7 +204,7 @@ export function send_message_success(local_id, message_id, locally_echoed) {
 
 export function send_message(request = create_message_object()) {
     compose_state.set_recipient_edited_manually(false);
-    if (request.type === "private") {
+    if (request.type === "direct") {
         request.to = JSON.stringify(request.to);
     } else {
         request.to = JSON.stringify([request.to]);

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -54,7 +54,7 @@ function get_focus_area(msg_type, opts) {
         return "#stream_message_recipient_topic";
     } else if (
         (msg_type === "stream" && opts.stream) ||
-        (msg_type === "private" && opts.private_message_recipient)
+        (msg_type === "direct" && opts.private_message_recipient)
     ) {
         if (opts.trigger === "new topic button") {
             return "#stream_message_recipient_topic";
@@ -201,7 +201,7 @@ function same_recipient_as_before(msg_type, opts) {
         ((msg_type === "stream" &&
             opts.stream === compose_state.stream_name() &&
             opts.topic === compose_state.topic()) ||
-            (msg_type === "private" &&
+            (msg_type === "direct" &&
                 opts.private_message_recipient === compose_state.private_message_recipient()))
     );
 }
@@ -381,7 +381,7 @@ export function respond_to_message(opts) {
             // home view.
             msg_type = "stream";
             if (narrow_state.narrowed_by_pm_reply()) {
-                msg_type = "private";
+                msg_type = "direct";
             }
 
             const new_opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
@@ -397,8 +397,8 @@ export function respond_to_message(opts) {
     // Important note: A reply_type of 'personal' is for the R hotkey
     // (replying to a message's sender with a private message).  All
     // other replies can just copy message.type.
-    if (opts.reply_type === "personal" || message.type === "private") {
-        msg_type = "private";
+    if (opts.reply_type === "personal" || message.type === "direct") {
+        msg_type = "direct";
     } else {
         msg_type = message.type;
     }
@@ -565,7 +565,7 @@ export function on_narrow(opts) {
     }
 
     if (narrow_state.narrowed_by_pm_reply()) {
-        opts = fill_in_opts_from_current_narrowed_view("private", opts);
+        opts = fill_in_opts_from_current_narrowed_view("direct", opts);
         // Do not open compose box if an invalid recipient is present.
         if (!opts.private_message_recipient) {
             if (compose_state.composing()) {
@@ -590,7 +590,7 @@ export function on_narrow(opts) {
                 return;
             }
         }
-        start("private");
+        start("direct");
         return;
     }
 

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -33,7 +33,7 @@ export function get_recipient_label(message) {
                 const user_ids_dicts = user_ids.map((user_id) => ({id: user_id}));
                 message = {
                     display_reply_to: message_store.get_pm_full_names({
-                        type: "private",
+                        type: "direct",
                         display_recipient: user_ids_dicts,
                     }),
                 };
@@ -167,7 +167,7 @@ export function initialize() {
     });
 
     $("body").on("click", ".compose_private_button", () => {
-        compose_actions.start("private", {trigger: "new private message"});
+        compose_actions.start("direct", {trigger: "new private message"});
     });
 
     $("body").on("click", ".compose_reply_button", () => {

--- a/web/src/compose_fade_helper.js
+++ b/web/src/compose_fade_helper.js
@@ -61,5 +61,5 @@ export function want_normal_display() {
         }
     }
 
-    return focused_recipient.type === "private" && focused_recipient.reply_to === "";
+    return focused_recipient.type === "direct" && focused_recipient.reply_to === "";
 }

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -55,7 +55,7 @@ export function update_narrow_to_recipient_visibility() {
             $(".narrow_to_compose_recipients").toggleClass("invisible", false);
             return;
         }
-    } else if (message_type === "private") {
+    } else if (message_type === "direct") {
         const recipients = compose_state.private_message_recipient();
         if (
             recipients &&

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -631,7 +631,7 @@ export function validate() {
         return false;
     }
 
-    if (compose_state.get_message_type() === "private") {
+    if (compose_state.get_message_type() === "direct") {
         return validate_private_message();
     }
     return validate_stream_message();

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -338,7 +338,7 @@ export function tokenize_compose_str(s) {
 export function broadcast_mentions() {
     const wildcard_mention_array = ["all", "everyone"];
     let wildcard_string = "";
-    if (compose_state.get_message_type() === "private") {
+    if (compose_state.get_message_type() === "direct") {
         wildcard_string = $t({defaultMessage: "Notify recipients"});
     } else {
         wildcard_string = $t({defaultMessage: "Notify stream"});

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -193,7 +193,7 @@ export function snapshot_message() {
         type: compose_state.get_message_type(),
         content: compose_state.message_content(),
     };
-    if (message.type === "private") {
+    if (message.type === "direct") {
         const recipient = compose_state.private_message_recipient();
         message.reply_to = recipient;
         message.private_message_recipient = recipient;
@@ -503,7 +503,7 @@ function current_recipient_data() {
             topic: compose_state.topic(),
             private_recipients: undefined,
         };
-    } else if (compose_state.get_message_type() === "private") {
+    } else if (compose_state.get_message_type() === "direct") {
         return {
             stream_name: undefined,
             topic: undefined,
@@ -537,7 +537,7 @@ function filter_drafts_by_compose_box_and_recipient(drafts) {
         }
         // Match by private message recipient.
         else if (
-            draft.type === "private" &&
+            draft.type === "direct" &&
             private_recipients &&
             _.isEqual(
                 draft.private_message_recipient

--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -61,7 +61,7 @@ function message_in_home(message) {
     // additional logic for unmuted topics, mentions, and
     // single-stream windows.
     if (
-        message.type === "private" ||
+        message.type === "direct" ||
         message.mentioned ||
         (page_params.narrow_stream !== undefined &&
             message.stream.toLowerCase() === page_params.narrow_stream.toLowerCase())
@@ -92,7 +92,7 @@ function message_matches_search_term(message, operator, operand) {
         case "is":
             switch (operand) {
                 case "dm":
-                    return message.type === "private";
+                    return message.type === "direct";
                 case "starred":
                     return message.starred;
                 case "mentioned":
@@ -163,7 +163,7 @@ function message_matches_search_term(message, operator, operand) {
 
         case "dm": {
             // TODO: use user_ids, not emails here
-            if (message.type !== "private") {
+            if (message.type !== "direct") {
                 return false;
             }
             const operand_ids = people.pm_with_operand_ids(operand);
@@ -238,7 +238,7 @@ export class Filter {
         switch (operator) {
             case "is":
                 // "is:private" was renamed to "is:dm"
-                if (operand === "private") {
+                if (operand === "direct") {
                     operand = "dm";
                 }
                 break;
@@ -1042,7 +1042,7 @@ export class Filter {
             case "mentioned":
                 return verb + "@-mentions";
             case "dm":
-            case "private":
+            case "direct":
                 return verb + "direct messages";
             case "resolved":
                 return verb + "topics marked as resolved";

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -874,7 +874,7 @@ export function process_hotkey(e, hotkey) {
             return true;
         case "compose_private_message":
             if (!compose_state.composing()) {
-                compose_actions.start("private", {trigger: "compose_hotkey"});
+                compose_actions.start("direct", {trigger: "compose_hotkey"});
             }
             return true;
         case "open_drafts":
@@ -1026,7 +1026,7 @@ export function process_hotkey(e, hotkey) {
             // `window.location = hashutil.by_conversation_and_time_url(msg)`
             // but we use `narrow.activate` to pass in the `trigger` parameter
             switch (msg.type) {
-                case "private":
+                case "direct":
                     narrow.activate(
                         [
                             {operator: "dm", operand: msg.reply_to},

--- a/web/src/message_helper.js
+++ b/web/src/message_helper.js
@@ -56,7 +56,7 @@ export function process_new_message(message) {
             message_user_ids.add_user_id(message.sender_id);
             break;
 
-        case "private":
+        case "direct":
             message.is_private = true;
             message.reply_to = util.normalize_recipients(message_store.get_pm_emails(message));
             message.display_reply_to = message_store.get_pm_full_names(message);

--- a/web/src/message_list_data.js
+++ b/web/src/message_list_data.js
@@ -235,7 +235,7 @@ export class MessageListData {
         }
 
         return messages.filter((message) => {
-            if (message.type !== "private") {
+            if (message.type !== "direct") {
                 return true;
             }
             const recipients = util.extract_pm_recipients(message.to_user_ids);

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -950,7 +950,7 @@ export function by_recipient(target_id, opts) {
     unread_ops.notify_server_message_read(message);
 
     switch (message.type) {
-        case "private":
+        case "direct":
             by("dm", message.reply_to, opts);
             break;
 
@@ -987,7 +987,7 @@ export function to_compose_target() {
         return;
     }
 
-    if (compose_state.get_message_type() === "private") {
+    if (compose_state.get_message_type() === "direct") {
         const recipient_string = compose_state.private_message_recipient();
         const emails = util.extract_pm_recipients(recipient_string);
         const invalid = emails.filter((email) => !people.is_valid_email_for_compose(email));

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -217,7 +217,7 @@ if (window.electron_bridge !== undefined) {
         const data = {
             type: message.type,
             content: reply,
-            to: message.type === "private" ? message.reply_to : message.stream,
+            to: message.type === "direct" ? message.reply_to : message.stream,
             topic: message.topic,
         };
 
@@ -277,7 +277,7 @@ export function process_notification(notification) {
         content = message.sender_full_name + content.slice(3);
     }
 
-    if (message.type === "private" || message.type === "test-notification") {
+    if (message.type === "direct" || message.type === "test-notification") {
         if (
             user_settings.pm_content_in_desktop_notifications !== undefined &&
             !user_settings.pm_content_in_desktop_notifications
@@ -320,7 +320,7 @@ export function process_notification(notification) {
         notification_object.close();
     }
 
-    if (message.type === "private") {
+    if (message.type === "direct") {
         if (message.display_recipient.length > 2) {
             // If the message has too many recipients to list them all...
             if (content.length + title.length + other_recipients.length > 230) {
@@ -439,7 +439,7 @@ export function should_send_desktop_notification(message) {
 
     // And then we need to check if the message is a PM, mention,
     // wildcard mention with wildcard_mentions_notify, or alert.
-    if (message.type === "private") {
+    if (message.type === "direct") {
         return true;
     }
 
@@ -485,7 +485,7 @@ export function should_send_audible_notification(message) {
 
     // And then we need to check if the message is a PM, mention,
     // wildcard mention with wildcard_mentions_notify, or alert.
-    if (message.type === "private" || message.type === "test-notification") {
+    if (message.type === "direct" || message.type === "test-notification") {
         return true;
     }
 

--- a/web/src/people.js
+++ b/web/src/people.js
@@ -187,7 +187,7 @@ function sort_numerically(user_ids) {
 }
 
 export function huddle_string(message) {
-    if (message.type !== "private") {
+    if (message.type !== "direct") {
         return undefined;
     }
 
@@ -467,7 +467,7 @@ export function pm_lookup_key(user_ids_string) {
 }
 
 export function all_user_ids_in_pm(message) {
-    if (message.type !== "private") {
+    if (message.type !== "direct") {
         return undefined;
     }
 
@@ -483,7 +483,7 @@ export function all_user_ids_in_pm(message) {
 }
 
 export function pm_with_user_ids(message) {
-    if (message.type !== "private") {
+    if (message.type !== "direct") {
         return undefined;
     }
 
@@ -1289,7 +1289,7 @@ export function extract_people_from_message(message) {
             ];
             break;
 
-        case "private":
+        case "direct":
             involved_people = message.display_recipient;
             break;
 
@@ -1347,7 +1347,7 @@ export function filter_for_user_settings_search(persons, query) {
 }
 
 export function maybe_incr_recipient_count(message) {
-    if (message.type !== "private") {
+    if (message.type !== "direct") {
         return;
     }
 

--- a/web/src/pm_list_dom.js
+++ b/web/src/pm_list_dom.js
@@ -44,7 +44,7 @@ export function more_private_conversations_li(more_conversations_unread_count) {
 export function pm_ul(nodes) {
     const attrs = [
         ["class", "pm-list"],
-        ["data-name", "private"],
+        ["data-name", "direct"],
     ];
     return vdom.ul({
         attrs,

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -317,7 +317,7 @@ export function initialize() {
                 instance.hide();
             });
             $popper.one("click", ".compose_mobile_private_button", (e) => {
-                compose_actions.start("private");
+                compose_actions.start("direct");
                 e.stopPropagation();
                 instance.hide();
             });

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1045,7 +1045,7 @@ export function register_click_handlers() {
     $("body").on("click", ".respond_personal_button, .compose_private_message", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const email = people.get_by_user_id(user_id).email;
-        compose_actions.start("private", {
+        compose_actions.start("direct", {
             trigger: "popover send private",
             private_message_recipient: email,
         });

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -129,14 +129,14 @@ function is_table_focused() {
 }
 
 function get_row_type(row) {
-    // Return "private" or "stream"
+    // Return "direct" or "stream"
     // We use CSS method for finding row type until topics_widget gets initialized.
     if (!topics_widget) {
         const $topic_rows = $("#recent_topics_table table tbody tr");
         const $topic_row = $topic_rows.eq(row);
         const is_private = $topic_row.attr("data-private");
         if (is_private) {
-            return "private";
+            return "direct";
         }
         return "stream";
     }
@@ -149,7 +149,7 @@ function get_row_type(row) {
 function get_max_selectable_cols(row) {
     // returns maximum number of columns in stream message or private message row.
     const type = get_row_type(row);
-    if (type === "private") {
+    if (type === "direct") {
         return MAX_SELECTABLE_PM_COLS;
     }
     return MAX_SELECTABLE_TOPIC_COLS;
@@ -170,7 +170,7 @@ function set_table_focus(row, col, using_keyboard) {
         col_focus = 1;
     }
     const type = get_row_type(row);
-    if (col === 3 && type === "private") {
+    if (col === 3 && type === "direct") {
         col = unread ? 2 : 1;
         col_focus = col;
     }
@@ -201,7 +201,7 @@ function set_table_focus(row, col, using_keyboard) {
     // get_recipient_label helper inside compose_closed_ui. Surely
     // there's a more readable way to write this code.
     let message;
-    if (type === "private") {
+    if (type === "direct") {
         message = {
             display_reply_to: $topic_row.find(".recent_topic_name a").text(),
         };
@@ -312,7 +312,7 @@ export function process_messages(messages) {
 }
 
 function message_to_conversation_unread_count(msg) {
-    if (msg.type === "private") {
+    if (msg.type === "direct") {
         return unread.num_unread_for_user_ids_string(msg.to_user_ids);
     }
     return unread.num_unread_for_topic(msg.stream_id, msg.topic);
@@ -364,7 +364,7 @@ function format_conversation(conversation_data) {
     context.conversation_key = get_key_from_message(last_msg);
     context.unread_count = message_to_conversation_unread_count(last_msg);
     context.last_msg_time = timerender.relative_time_string_from_date(time);
-    context.is_private = last_msg.type === "private";
+    context.is_private = last_msg.type === "direct";
     let all_senders;
     let senders;
     let displayed_other_senders;
@@ -409,7 +409,7 @@ function format_conversation(conversation_data) {
         // Collect extra sender fullname for tooltip
         extra_sender_ids = all_senders.slice(0, -MAX_AVATAR);
         displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);
-    } else if (type === "private") {
+    } else if (type === "direct") {
         // Private message info
         context.user_ids_string = last_msg.to_user_ids;
         context.rendered_pm_with = last_msg.display_recipient
@@ -554,11 +554,11 @@ export function filters_should_hide_topic(topic_data) {
         }
     }
 
-    if (!filters.has("include_private") && topic_data.type === "private") {
+    if (!filters.has("include_private") && topic_data.type === "direct") {
         return true;
     }
 
-    if (filters.has("include_private") && topic_data.type === "private") {
+    if (filters.has("include_private") && topic_data.type === "direct") {
         const recipients = people.split_to_ints(msg.to_user_ids);
 
         if (recipients.every((id) => muted_users.is_user_muted(id))) {
@@ -716,13 +716,13 @@ function stream_sort(a, b) {
         }
         return sort_comparator(a_msg.display_reply_to, b_msg.display_reply_to);
     }
-    // if type is not same sort between "private" and "stream"
+    // if type is not same sort between "direct" and "stream"
     return sort_comparator(a.type, b.type);
 }
 
 function topic_sort_key(conversation_data) {
     const message = message_store.get(conversation_data.last_msg_id);
-    if (message.type === "private") {
+    if (message.type === "direct") {
         return message.display_reply_to;
     }
     return message.topic;

--- a/web/src/recent_topics_util.js
+++ b/web/src/recent_topics_util.js
@@ -31,7 +31,7 @@ export function get_topic_key(stream_id, topic) {
 }
 
 export function get_key_from_message(msg) {
-    if (msg.type === "private") {
+    if (msg.type === "direct") {
         // The to_user_ids field on a private message object is a
         // string containing the user IDs involved in the message in
         // sorted order.

--- a/web/src/reload.js
+++ b/web/src/reload.js
@@ -54,7 +54,7 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
             url += "+msg_type=stream";
             url += "+stream=" + encodeURIComponent(compose_state.stream_name());
             url += "+topic=" + encodeURIComponent(compose_state.topic());
-        } else if (msg_type === "private") {
+        } else if (msg_type === "direct") {
             url += "+msg_type=private";
             url += "+recipient=" + encodeURIComponent(compose_state.private_message_recipient());
         }

--- a/web/src/reminder.js
+++ b/web/src/reminder.js
@@ -33,7 +33,7 @@ export function is_deferred_delivery(message_content) {
 }
 
 export function patch_request_for_scheduling(request, message_content, deliver_at, delivery_type) {
-    if (request.type === "private") {
+    if (request.type === "direct") {
         request.to = JSON.stringify(request.to);
     } else {
         request.to = JSON.stringify([request.to]);
@@ -166,7 +166,7 @@ export function do_set_reminder_for_message(message_id, timestamp) {
     const reminder_msg_content =
         message.raw_content + "\n\n[Link to conversation](" + link_to_msg + ")";
     let reminder_message = {
-        type: "private",
+        type: "direct",
         sender_id: page_params.user_id,
         stream: "",
     };

--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -636,7 +636,7 @@ function get_sent_by_me_suggestions(last, operators) {
 
 function get_operator_suggestions(last) {
     // Suggest "is:dm" to anyone with "is:private" in their muscle memory
-    if (last.operator === "is" && common.phrase_match(last.operand, "private")) {
+    if (last.operator === "is" && common.phrase_match(last.operand, "direct")) {
         const is_dm = format_as_suggestion([
             {operator: last.operator, operand: "dm", negated: last.negated},
         ]);

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -401,7 +401,7 @@ export function initialize() {
                     });
                 } else if (
                     _.isEqual(narrow_filter.sorted_term_types(), ["is-dm"]) &&
-                    compose_state.get_message_type() === "private"
+                    compose_state.get_message_type() === "direct"
                 ) {
                     display_current_view = $t({
                         defaultMessage: "Currently viewing all direct messages.",

--- a/web/src/transmit.js
+++ b/web/src/transmit.js
@@ -95,10 +95,10 @@ export function reply_message(opts) {
         return;
     }
 
-    if (message.type === "private") {
+    if (message.type === "direct") {
         const pm_recipient = people.pm_reply_to(message);
 
-        reply.type = "private";
+        reply.type = "direct";
         reply.to = JSON.stringify(pm_recipient.split(","));
         reply.content = content;
 

--- a/web/src/tutorial.js
+++ b/web/src/tutorial.js
@@ -13,6 +13,6 @@ function set_tutorial_status(status, callback) {
 export function initialize() {
     if (page_params.needs_tutorial) {
         set_tutorial_status("started");
-        narrow.by("is", "private", {trigger: "sidebar"});
+        narrow.by("is", "direct", {trigger: "sidebar"});
     }
 }

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -186,7 +186,7 @@ export function compare_people_for_relevance(
     // We use is_broadcast for a quick check.  It will
     // true for all/everyone/stream and undefined (falsy)
     // for actual people.
-    if (compose_state.get_message_type() !== "private") {
+    if (compose_state.get_message_type() !== "direct") {
         if (person_a.is_broadcast) {
             if (person_b.is_broadcast) {
                 return person_a.idx - person_b.idx;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -5,7 +5,7 @@ export type MatchedMessage = {
 };
 
 // TODO/typescript: Move this to message_store
-export type MessageType = "private" | "stream";
+export type MessageType = "direct" | "stream";
 
 // TODO/typescript: Move this to message_store
 export type RawMessage = {

--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -630,7 +630,7 @@ export function process_loaded_messages(messages, expect_no_new_unreads = false)
             }
 
             const user_ids_string =
-                message.type === "private" ? people.pm_reply_user_string(message) : undefined;
+                message.type === "direct" ? people.pm_reply_user_string(message) : undefined;
 
             process_unread_message({
                 id: message.id,
@@ -656,7 +656,7 @@ export function process_unread_message(message) {
     // is actually unread--we don't defend against that.
     unread_messages.add(message.id);
 
-    if (message.type === "private") {
+    if (message.type === "direct") {
         unread_pm_counter.add({
             message_id: message.id,
             user_ids_string: message.user_ids_string,

--- a/web/src/unread_ops.js
+++ b/web/src/unread_ops.js
@@ -315,7 +315,7 @@ export function process_unread_messages_event({message_ids, message_details}) {
 
         let user_ids_string;
 
-        if (message_info.type === "private") {
+        if (message_info.type === "direct") {
             user_ids_string = people.pm_lookup_key_from_user_ids(message_info.user_ids);
         }
 

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -72,16 +72,16 @@ export function extract_pm_recipients(recipients: string): string[] {
     return recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");
 }
 
-// When the type is "private", properties from PMRecipient, namely to_user_ids might be
+// When the type is "direct", properties from PMRecipient, namely to_user_ids might be
 // undefined. See https://github.com/zulip/zulip/pull/23032#discussion_r1038480596.
-type Recipient = {to_user_ids?: string; type: "private"} | (StreamTopic & {type: "stream"});
+type Recipient = {to_user_ids?: string; type: "direct"} | (StreamTopic & {type: "stream"});
 
 export const same_recipient = function util_same_recipient(a?: Recipient, b?: Recipient): boolean {
     if (a === undefined || b === undefined) {
         return false;
     }
 
-    if (a.type === "private" && b.type === "private") {
+    if (a.type === "direct" && b.type === "direct") {
         if (a.to_user_ids === undefined) {
             return false;
         }

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -176,7 +176,7 @@ test("huddle_data.process_loaded_messages", () => {
 
     const messages = [
         {
-            type: "private",
+            type: "direct",
             display_recipient: [{id: jill.user_id}, {id: norbert.user_id}],
             timestamp: timestamp1,
         },
@@ -184,16 +184,16 @@ test("huddle_data.process_loaded_messages", () => {
             type: "stream",
         },
         {
-            type: "private",
+            type: "direct",
             display_recipient: [{id: me.user_id}], // PM to myself
         },
         {
-            type: "private",
+            type: "direct",
             display_recipient: [{id: alice.user_id}, {id: fred.user_id}],
             timestamp: timestamp2,
         },
         {
-            type: "private",
+            type: "direct",
             display_recipient: [{id: fred.user_id}, {id: alice.user_id}],
             timestamp: old_timestamp,
         },
@@ -215,7 +215,7 @@ test("presence_list_full_update", ({override, mock_template}) => {
 
     $(".user-list-filter").trigger("focus");
     compose_state.private_message_recipient = () => fred.email;
-    compose_fade.set_focused_recipient("private");
+    compose_fade.set_focused_recipient("direct");
 
     const user_ids = activity.build_user_sidebar();
 

--- a/web/tests/buddy_data.test.js
+++ b/web/tests/buddy_data.test.js
@@ -255,7 +255,7 @@ test("compose fade interactions (PMs)", () => {
     // Fade fred if we are narrowed to a PM narrow that does
     // not include him.
     compose_fade_helper.set_focused_recipient({
-        type: "private",
+        type: "direct",
         to_user_ids: "9999999",
     });
     assert.equal(faded(), true);
@@ -263,7 +263,7 @@ test("compose fade interactions (PMs)", () => {
     // Now include fred in a narrow with jill, and we will
     // stop fading him.
     compose_fade_helper.set_focused_recipient({
-        type: "private",
+        type: "direct",
         to_user_ids: [fred.user_id, jill.user_id].join(","),
     });
 

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -178,7 +178,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     (function test_message_send_success_codepath() {
         stub_state = initialize_state_stub_dict();
         compose_state.topic("");
-        compose_state.set_message_type("private");
+        compose_state.set_message_type("direct");
         page_params.user_id = new_user.user_id;
         override(compose_pm_pill, "get_emails", () => "alice@example.com");
 
@@ -197,7 +197,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 
         override(transmit, "send_message", (payload, success) => {
             const single_msg = {
-                type: "private",
+                type: "direct",
                 content: "[foobar](/user_uploads/123456)",
                 sender_id: new_user.user_id,
                 queue_id: undefined,
@@ -407,7 +407,7 @@ test_ui("finish", ({override, override_rewire}) => {
         $("#compose .markdown_preview").hide();
         $("#compose-textarea").val("foobarfoobar");
         compose_ui.compose_spinner_visible = false;
-        compose_state.set_message_type("private");
+        compose_state.set_message_type("direct");
         override(compose_pm_pill, "get_emails", () => "bob@example.com");
         override(compose_pm_pill, "get_user_ids", () => []);
 
@@ -542,7 +542,7 @@ test_ui("update_fade", ({override, override_rewire}) => {
     let update_narrow_to_recipient_visibility_called = false;
 
     override(compose_fade, "set_focused_recipient", (msg_type) => {
-        assert.equal(msg_type, "private");
+        assert.equal(msg_type, "direct");
         set_focused_recipient_checked = true;
     });
 
@@ -562,7 +562,7 @@ test_ui("update_fade", ({override, override_rewire}) => {
 
     update_narrow_to_recipient_visibility_called = false;
 
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     compose_recipient.update_on_recipient_change();
     assert.ok(set_focused_recipient_checked);
     assert.ok(update_all_called);
@@ -787,7 +787,7 @@ test_ui("create_message_object", ({override, override_rewire}) => {
     assert.equal(message.topic, "lunch");
     assert.equal(message.content, "burrito");
 
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     override(compose_pm_pill, "get_emails", () => "alice@example.com,bob@example.com");
 
     message = compose.create_message_object();

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -205,14 +205,14 @@ test("start", ({override, override_rewire}) => {
         content: "hello",
     };
 
-    start("private", opts);
+    start("direct", opts);
 
     assert_hidden("#compose-stream-recipient");
     assert_visible("#compose-private-recipient");
 
     assert.equal(compose_state.private_message_recipient(), "foo@example.com");
     assert.equal($("#compose-textarea").val(), "hello");
-    assert.equal(compose_state.get_message_type(), "private");
+    assert.equal(compose_state.get_message_type(), "direct");
     assert.ok(compose_state.composing());
 
     // Triggered by new private message
@@ -220,10 +220,10 @@ test("start", ({override, override_rewire}) => {
         trigger: "new private message",
     };
 
-    start("private", opts);
+    start("direct", opts);
 
     assert.equal(compose_state.private_message_recipient(), "");
-    assert.equal(compose_state.get_message_type(), "private");
+    assert.equal(compose_state.get_message_type(), "direct");
     assert.ok(compose_state.composing());
 
     // Cancel compose.
@@ -266,7 +266,7 @@ test("respond_to_message", ({override, override_rewire}) => {
     people.add_active_user(person);
 
     let msg = {
-        type: "private",
+        type: "direct",
         sender_id: person.user_id,
     };
     override(message_lists.current, "selected_message", () => msg);
@@ -436,9 +436,9 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
 });
 
 test("get_focus_area", () => {
-    assert.equal(get_focus_area("private", {}), "#private_message_recipient");
+    assert.equal(get_focus_area("direct", {}), "#private_message_recipient");
     assert.equal(
-        get_focus_area("private", {
+        get_focus_area("direct", {
             private_message_recipient: "bob@example.com",
         }),
         "#compose-textarea",

--- a/web/tests/compose_state.test.js
+++ b/web/tests/compose_state.test.js
@@ -63,7 +63,7 @@ run_test("has_full_recipient", ({override, override_rewire}) => {
     compose_state.set_stream_name("bar");
     assert.equal(compose_state.has_full_recipient(), true);
 
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     compose_state.private_message_recipient("");
     assert.equal(compose_state.has_full_recipient(), false);
 

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -206,7 +206,7 @@ run_test("compute_placeholder_text", () => {
 
     // PM Narrows
     opts = {
-        message_type: "private",
+        message_type: "direct",
         stream: "",
         topic: "",
         private_message_recipient: "",

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -178,7 +178,7 @@ test_ui("validate", ({mock_template}) => {
     }
 
     // test validating private messages
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
 
     initialize_pm_pill();
     add_content_to_compose_box();
@@ -684,7 +684,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
 
     function test_noop_case(is_private, is_zephyr_mirror, is_broadcast) {
         new_banner_rendered = false;
-        const msg_type = is_private ? "private" : "stream";
+        const msg_type = is_private ? "direct" : "stream";
         compose_state.set_message_type(msg_type);
         page_params.realm_is_zephyr_mirror_realm = is_zephyr_mirror;
         mentioned_details.is_broadcast = is_broadcast;

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -83,7 +83,7 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
 });
 
 run_test("verify wildcard mentions typeahead for private message", () => {
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     assert.equal(ct.broadcast_mentions().length, 2);
     const mention_all = ct.broadcast_mentions()[0];
     const mention_everyone = ct.broadcast_mentions()[1];

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -87,7 +87,7 @@ const draft_1 = {
 const draft_2 = {
     private_message_recipient: "aaron@zulip.com",
     reply_to: "aaron@zulip.com",
-    type: "private",
+    type: "direct",
     content: "Test private message",
 };
 const short_msg = {
@@ -235,7 +235,7 @@ test("remove_old_drafts", () => {
     const draft_4 = {
         private_message_recipient: "aaron@zulip.com",
         reply_to: "aaron@zulip.com",
-        type: "private",
+        type: "direct",
         content: "Test private message",
         updatedAt: new Date().setDate(-30),
     };
@@ -259,7 +259,7 @@ test("update_draft", ({override, override_rewire}) => {
 
     override_rewire(compose_pm_pill, "set_from_emails", noop);
     override_rewire(user_pill, "get_user_ids", () => [aaron.user_id]);
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     compose_state.message_content("dummy content");
     compose_state.private_message_recipient(aaron.email);
 
@@ -507,7 +507,7 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     const draft_2 = {
         private_message_recipient: "aaron@zulip.com",
         reply_to: "aaron@zulip.com",
-        type: "private",
+        type: "direct",
         content: "Test private message",
         updatedAt: date(-1),
     };
@@ -521,14 +521,14 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     const draft_4 = {
         private_message_recipient: "aaron@zulip.com",
         reply_to: "iago@zulip.com",
-        type: "private",
+        type: "direct",
         content: "Test private message 2",
         updatedAt: date(-5),
     };
     const draft_5 = {
         private_message_recipient: "aaron@zulip.com",
         reply_to: "zoe@zulip.com",
-        type: "private",
+        type: "direct",
         content: "Test private message 3",
         updatedAt: date(-2),
     };
@@ -602,7 +602,7 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     };
 
     override_rewire(user_pill, "get_user_ids", () => []);
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     compose_state.private_message_recipient(null);
 
     mock_template("draft_table_body.hbs", false, (data) => {
@@ -654,7 +654,7 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     const pm_draft_1 = {
         private_message_recipient: "aaron@zulip.com",
         reply_to: "aaron@zulip.com",
-        type: "private",
+        type: "direct",
         content: "Test private message",
         updatedAt: date(-1),
     };
@@ -668,14 +668,14 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     const pm_draft_2 = {
         private_message_recipient: "aaron@zulip.com",
         reply_to: "iago@zulip.com",
-        type: "private",
+        type: "direct",
         content: "Test private message 2",
         updatedAt: date(-5),
     };
     const pm_draft_3 = {
         private_message_recipient: "aaron@zulip.com",
         reply_to: "zoe@zulip.com",
-        type: "private",
+        type: "direct",
         content: "Test private message 3",
         updatedAt: date(-2),
     };
@@ -768,7 +768,7 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
 
     override_rewire(user_pill, "get_user_ids", () => [aaron.user_id]);
     override_rewire(compose_pm_pill, "set_from_emails", noop);
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     compose_state.private_message_recipient(aaron.email);
 
     $.create("#drafts_table .draft-row", {children: []});

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -146,7 +146,7 @@ run_test("build_display_recipient", () => {
     assert.equal(display_recipient, "general");
 
     message = {
-        type: "private",
+        type: "direct",
         private_message_recipient: "cordelia@zulip.com,hamlet@zulip.com",
         sender_email: "iago@zulip.com",
         sender_full_name: "Iago",
@@ -171,7 +171,7 @@ run_test("build_display_recipient", () => {
     assert.equal(hamlet.unknown_local_echo_user, true);
 
     message = {
-        type: "private",
+        type: "direct",
         private_message_recipient: "iago@zulip.com",
         sender_email: "iago@zulip.com",
         sender_full_name: "Iago",
@@ -284,7 +284,7 @@ run_test("insert_local_message PM", ({override, override_rewire}) => {
 
     const message_request = {
         private_message_recipient: "cordelia@zulip.com,hamlet@zulip.com",
-        type: "private",
+        type: "direct",
         sender_email: "iago@zulip.com",
         sender_full_name: "Iago",
         sender_id: 123,

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -205,10 +205,10 @@ test("basics", () => {
     assert.ok(!filter.is_conversation_view());
 
     // "is:private" was renamed to "is:dm"
-    operators = [{operator: "is", operand: "private"}];
+    operators = [{operator: "is", operand: "direct"}];
     filter = new Filter(operators);
     assert.ok(filter.has_operand("is", "dm"));
-    assert.ok(!filter.has_operand("is", "private"));
+    assert.ok(!filter.has_operand("is", "direct"));
 
     operators = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(operators);
@@ -697,7 +697,7 @@ test("predicate_basics", () => {
     assert.ok(predicate({type: "stream", stream_id, topic: "bar"}));
     assert.ok(!predicate({type: "stream", stream_id, topic: "whatever"}));
     assert.ok(!predicate({type: "stream", stream_id: 9999999}));
-    assert.ok(!predicate({type: "private"}));
+    assert.ok(!predicate({type: "direct"}));
 
     // For old streams that we are no longer subscribed to, we may not have
     // a sub, but these should still match by stream name.
@@ -712,10 +712,10 @@ test("predicate_basics", () => {
     assert.ok(predicate({}));
 
     predicate = get_predicate([["topic", "Bar"]]);
-    assert.ok(!predicate({type: "private"}));
+    assert.ok(!predicate({type: "direct"}));
 
     predicate = get_predicate([["is", "dm"]]);
-    assert.ok(predicate({type: "private"}));
+    assert.ok(predicate({type: "direct"}));
     assert.ok(!predicate({type: "stream"}));
 
     predicate = get_predicate([["streams", "public"]]);
@@ -750,7 +750,7 @@ test("predicate_basics", () => {
     const unknown_stream_id = 999;
     predicate = get_predicate([["in", "home"]]);
     assert.ok(!predicate({stream_id: unknown_stream_id, stream: "unknown"}));
-    assert.ok(predicate({type: "private"}));
+    assert.ok(predicate({type: "direct"}));
 
     with_overrides(({override}) => {
         override(page_params, "narrow_stream", "kiosk");
@@ -778,19 +778,19 @@ test("predicate_basics", () => {
     predicate = get_predicate([["dm", "Joe@example.com"]]);
     assert.ok(
         predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: joe.user_id}],
         }),
     );
     assert.ok(
         !predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: steve.user_id}],
         }),
     );
     assert.ok(
         !predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: 999999}],
         }),
     );
@@ -799,7 +799,7 @@ test("predicate_basics", () => {
     predicate = get_predicate([["dm", "Joe@example.com,steve@foo.com"]]);
     assert.ok(
         predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: joe.user_id}, {id: steve.user_id}],
         }),
     );
@@ -808,7 +808,7 @@ test("predicate_basics", () => {
     predicate = get_predicate([["dm", "Joe@example.com,steve@foo.com,me@example.com"]]);
     assert.ok(
         predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: joe.user_id}, {id: steve.user_id}],
         }),
     );
@@ -816,7 +816,7 @@ test("predicate_basics", () => {
     predicate = get_predicate([["dm", "nobody@example.com"]]);
     assert.ok(
         !predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: joe.user_id}],
         }),
     );
@@ -824,7 +824,7 @@ test("predicate_basics", () => {
     predicate = get_predicate([["dm-including", "nobody@example.com"]]);
     assert.ok(
         !predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: joe.user_id}, {id: me.user_id}],
         }),
     );
@@ -832,19 +832,19 @@ test("predicate_basics", () => {
     predicate = get_predicate([["dm-including", "Joe@example.com"]]);
     assert.ok(
         predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: joe.user_id}, {id: steve.user_id}, {id: me.user_id}],
         }),
     );
     assert.ok(
         predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: joe.user_id}, {id: me.user_id}],
         }),
     );
     assert.ok(
         !predicate({
-            type: "private",
+            type: "direct",
             display_recipient: [{id: steve.user_id}, {id: me.user_id}],
         }),
     );
@@ -938,7 +938,7 @@ function test_mit_exceptions() {
     assert.ok(predicate({type: "stream", stream: "foo.d", topic: ""}));
     assert.ok(!predicate({type: "stream", stream: "wrong"}));
     assert.ok(!predicate({type: "stream", stream: "foo", topic: "whatever"}));
-    assert.ok(!predicate({type: "private"}));
+    assert.ok(!predicate({type: "direct"}));
 
     predicate = get_predicate([
         ["stream", "Foo"],
@@ -1367,7 +1367,7 @@ test("term_type", () => {
     assert_term_type(term("dm", "whomever"), "dm");
     assert_term_type(term("dm", "whomever", true), "not-dm");
     assert_term_type(term("is", "dm"), "is-dm");
-    assert_term_type(term("is", "private"), "is-private");
+    assert_term_type(term("is", "direct"), "is-private");
     assert_term_type(term("has", "link"), "has-link");
     assert_term_type(term("has", "attachment", true), "not-has-attachment");
 
@@ -1775,7 +1775,7 @@ test("error_cases", () => {
 
     const predicate = get_predicate([["dm", "Joe@example.com"]]);
     blueslip.expect("error", "Empty recipient list in message");
-    assert.ok(!predicate({type: "private", display_recipient: []}));
+    assert.ok(!predicate({type: "direct", display_recipient: []}));
 });
 
 run_test("is_spectator_compatible", () => {
@@ -1811,7 +1811,7 @@ run_test("is_spectator_compatible", () => {
     assert.ok(!Filter.is_spectator_compatible([{operator: "has"}]));
 
     // "is:private" was renamed to "is:dm"
-    assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "private"}]));
+    assert.ok(!Filter.is_spectator_compatible([{operator: "is", operand: "direct"}]));
     // "pm-with" was renamed to "dm"
     assert.ok(
         !Filter.is_spectator_compatible([{operator: "pm-with", operand: "hamlet@zulip.com"}]),

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -151,7 +151,7 @@ run_test("test_by_conversation_and_time_url", () => {
     );
 
     message = {
-        type: "private",
+        type: "direct",
         display_recipient: [
             {
                 id: hamlet.user_id,

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -701,7 +701,7 @@ exports.fixtures = {
     typing__start: {
         type: "typing",
         op: "start",
-        message_type: "private",
+        message_type: "direct",
         sender: typing_person1,
         recipients: [typing_person2],
     },
@@ -709,7 +709,7 @@ exports.fixtures = {
     typing__stop: {
         type: "typing",
         op: "stop",
-        message_type: "private",
+        message_type: "direct",
         sender: typing_person1,
         recipients: [typing_person2],
     },

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -72,7 +72,7 @@ run_test("is_content_editable", () => {
     message.submessages = ["/poll"];
     assert.equal(is_content_editable(message, 55), false);
     delete message.submessages;
-    message.type = "private";
+    message.type = "direct";
     assert.equal(is_content_editable(message, 45), false);
 
     assert.equal(is_content_editable(message, 55), true);

--- a/web/tests/message_list_data.test.js
+++ b/web/tests/message_list_data.test.js
@@ -87,15 +87,15 @@ run_test("basics", () => {
     assert_contents(mld, []);
     const msgs_sent_by_6 = [
         {id: 2, sender_id: 6, type: "stream", stream_id: 1, topic: "whatever"},
-        {id: 4, sender_id: 6, type: "private", to_user_ids: "6,9,10"},
-        {id: 6, sender_id: 6, type: "private", to_user_ids: "6, 11"},
+        {id: 4, sender_id: 6, type: "direct", to_user_ids: "6,9,10"},
+        {id: 6, sender_id: 6, type: "direct", to_user_ids: "6, 11"},
     ];
     const msgs_with_sender_ids = [
         {id: 1, sender_id: 1, type: "stream", stream_id: 1, topic: "random1"},
         {id: 3, sender_id: 4, type: "stream", stream_id: 1, topic: "random2"},
-        {id: 5, sender_id: 2, type: "private", to_user_ids: "2,10,11"},
-        {id: 8, sender_id: 11, type: "private", to_user_ids: "10"},
-        {id: 9, sender_id: 11, type: "private", to_user_ids: "9"},
+        {id: 5, sender_id: 2, type: "direct", to_user_ids: "2,10,11"},
+        {id: 8, sender_id: 11, type: "direct", to_user_ids: "10"},
+        {id: 9, sender_id: 11, type: "direct", to_user_ids: "9"},
         ...msgs_sent_by_6,
     ];
     mld.add_messages(msgs_with_sender_ids);
@@ -135,12 +135,12 @@ run_test("muting", () => {
         {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true}, // mentions override muting
 
         // 10 = muted user, 9 = non-muted user, 11 = you
-        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10}, // muted to huddle
-        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9}, // non-muted to huddle
-        {id: 6, type: "private", to_user_ids: "11", sender_id: 10}, // muted to 1:1 PM
-        {id: 7, type: "private", to_user_ids: "11", sender_id: 9}, // non-muted to 1:1 PM
-        {id: 8, type: "private", to_user_ids: "10", sender_id: 11}, // 1:1 PM to muted
-        {id: 9, type: "private", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
+        {id: 4, type: "direct", to_user_ids: "9,10,11", sender_id: 10}, // muted to huddle
+        {id: 5, type: "direct", to_user_ids: "9,10,11", sender_id: 9}, // non-muted to huddle
+        {id: 6, type: "direct", to_user_ids: "11", sender_id: 10}, // muted to 1:1 PM
+        {id: 7, type: "direct", to_user_ids: "11", sender_id: 9}, // non-muted to 1:1 PM
+        {id: 8, type: "direct", to_user_ids: "10", sender_id: 11}, // 1:1 PM to muted
+        {id: 9, type: "direct", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
     ];
 
     user_topics.update_user_topics(1, "muted", user_topics.all_visibility_policies.MUTED);
@@ -163,12 +163,12 @@ run_test("muting", () => {
         {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true}, // mentions override muting
 
         // `messages_filtered_for_topic_mutes` does not affect private messages
-        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10},
-        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9},
-        {id: 6, type: "private", to_user_ids: "11", sender_id: 10},
-        {id: 7, type: "private", to_user_ids: "11", sender_id: 9},
-        {id: 8, type: "private", to_user_ids: "10", sender_id: 11},
-        {id: 9, type: "private", to_user_ids: "9", sender_id: 11},
+        {id: 4, type: "direct", to_user_ids: "9,10,11", sender_id: 10},
+        {id: 5, type: "direct", to_user_ids: "9,10,11", sender_id: 9},
+        {id: 6, type: "direct", to_user_ids: "11", sender_id: 10},
+        {id: 7, type: "direct", to_user_ids: "11", sender_id: 9},
+        {id: 8, type: "direct", to_user_ids: "10", sender_id: 11},
+        {id: 9, type: "direct", to_user_ids: "9", sender_id: 11},
     ]);
 
     const res_user = mld.messages_filtered_for_user_mutes(msgs);
@@ -178,10 +178,10 @@ run_test("muting", () => {
         {id: 2, type: "stream", stream_id: 1, topic: "whatever"},
         {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true},
 
-        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10}, // muted to huddle
-        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9}, // non-muted to huddle
-        {id: 7, type: "private", to_user_ids: "11", sender_id: 9}, // non-muted to 1:1 PM
-        {id: 9, type: "private", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
+        {id: 4, type: "direct", to_user_ids: "9,10,11", sender_id: 10}, // muted to huddle
+        {id: 5, type: "direct", to_user_ids: "9,10,11", sender_id: 9}, // non-muted to huddle
+        {id: 7, type: "direct", to_user_ids: "11", sender_id: 9}, // non-muted to 1:1 PM
+        {id: 9, type: "direct", to_user_ids: "9", sender_id: 11}, // 1:1 PM to non-muted
     ]);
 
     // Output filtered based on both topic and user muting.
@@ -190,10 +190,10 @@ run_test("muting", () => {
     assert.deepEqual(filtered_messages, [
         {id: 2, type: "stream", stream_id: 1, topic: "whatever"},
         {id: 3, type: "stream", stream_id: 1, topic: "muted", mentioned: true},
-        {id: 4, type: "private", to_user_ids: "9,10,11", sender_id: 10},
-        {id: 5, type: "private", to_user_ids: "9,10,11", sender_id: 9},
-        {id: 7, type: "private", to_user_ids: "11", sender_id: 9},
-        {id: 9, type: "private", to_user_ids: "9", sender_id: 11},
+        {id: 4, type: "direct", to_user_ids: "9,10,11", sender_id: 10},
+        {id: 5, type: "direct", to_user_ids: "9,10,11", sender_id: 9},
+        {id: 7, type: "direct", to_user_ids: "11", sender_id: 9},
+        {id: 9, type: "direct", to_user_ids: "9", sender_id: 11},
     ]);
 
     // Also verify that, the correct set of messages is stored in `_items`

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -100,7 +100,7 @@ test("process_new_message", () => {
     let message = {
         sender_email: "me@example.com",
         sender_id: me.user_id,
-        type: "private",
+        type: "direct",
         display_recipient: convert_recipients([me, bob, cindy]),
         flags: ["has_alert_word"],
         is_me_message: false,
@@ -205,7 +205,7 @@ test("message_booleans_parity", () => {
 test("errors", ({disallow_rewire}) => {
     // Test a user that doesn't exist
     let message = {
-        type: "private",
+        type: "direct",
         display_recipient: [{id: 92714}],
     };
 
@@ -231,7 +231,7 @@ test("errors", ({disallow_rewire}) => {
 });
 
 test("reify_message_id", () => {
-    const message = {type: "private", id: 500};
+    const message = {type: "direct", id: 500};
 
     message_store.update_message_cache(message);
     assert.equal(message_store.get_cached_message(500), message);

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -741,7 +741,7 @@ run_test("narrow_to_compose_target direct messages", ({override, override_rewire
     let emails;
     override(compose_pm_pill, "get_emails", () => emails);
 
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     people.add_active_user(ray);
     people.add_active_user(alice);
     people.add_active_user(me);

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -214,7 +214,7 @@ run_test("basics", () => {
     message_lists.current.get_row = () => row;
     util.sorted_ids = () => [];
 
-    narrow.activate([{operator: "is", operand: "private"}], {
+    narrow.activate([{operator: "is", operand: "direct"}], {
         then_select_id: selected_id,
     });
 

--- a/web/tests/narrow_local.test.js
+++ b/web/tests/narrow_local.test.js
@@ -173,16 +173,16 @@ run_test("near with no unreads", () => {
 
 run_test("is private with no target", () => {
     const fixture = {
-        filter_terms: [{operator: "is", operand: "private"}],
+        filter_terms: [{operator: "is", operand: "direct"}],
         unread_info: {
             flavor: "found",
             msg_id: 550,
         },
         has_found_newest: true,
         all_messages: [
-            {id: 450, type: "private", to_user_ids: "1,2"},
-            {id: 500, type: "private", to_user_ids: "1,2"},
-            {id: 550, type: "private", to_user_ids: "1,2"},
+            {id: 450, type: "direct", to_user_ids: "1,2"},
+            {id: 500, type: "direct", to_user_ids: "1,2"},
+            {id: 550, type: "direct", to_user_ids: "1,2"},
         ],
         expected_id_info: {
             target_id: undefined,
@@ -217,7 +217,7 @@ run_test("dm with target outside of range", () => {
 
 run_test("is:private with no unreads before fetch", () => {
     const fixture = {
-        filter_terms: [{operator: "is", operand: "private"}],
+        filter_terms: [{operator: "is", operand: "direct"}],
         unread_info: {
             flavor: "not_found",
         },
@@ -236,7 +236,7 @@ run_test("is:private with no unreads before fetch", () => {
 
 run_test("is:private with target and no unreads", () => {
     const fixture = {
-        filter_terms: [{operator: "is", operand: "private"}],
+        filter_terms: [{operator: "is", operand: "direct"}],
         target_id: 450,
         unread_info: {
             flavor: "not_found",
@@ -245,9 +245,9 @@ run_test("is:private with target and no unreads", () => {
         empty: false,
         all_messages: [
             {id: 350},
-            {id: 400, type: "private", to_user_ids: "1,2"},
-            {id: 450, type: "private", to_user_ids: "1,2"},
-            {id: 500, type: "private", to_user_ids: "1,2"},
+            {id: 400, type: "direct", to_user_ids: "1,2"},
+            {id: 450, type: "direct", to_user_ids: "1,2"},
+            {id: 500, type: "direct", to_user_ids: "1,2"},
         ],
         expected_id_info: {
             target_id: 450,

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -161,7 +161,7 @@ test("excludes_muted_topics", () => {
     set_filter([["search", "whatever"]]);
     assert.ok(!narrow_state.excludes_muted_topics());
 
-    set_filter([["is", "private"]]);
+    set_filter([["is", "direct"]]);
     assert.ok(!narrow_state.excludes_muted_topics());
 
     set_filter([["is", "starred"]]);

--- a/web/tests/narrow_unread.test.js
+++ b/web/tests/narrow_unread.test.js
@@ -64,7 +64,7 @@ run_test("get_unread_ids", () => {
 
     const private_msg = {
         id: 102,
-        type: "private",
+        type: "direct",
         unread: true,
         display_recipient: [{id: alice.user_id}],
     };
@@ -159,7 +159,7 @@ run_test("get_unread_ids", () => {
     });
 
     // "is:private" was renamed to "is:dm"
-    terms = [{operator: "is", operand: "private"}];
+    terms = [{operator: "is", operand: "direct"}];
     set_filter(terms);
     unread_ids = candidate_ids();
     assert.deepEqual(unread_ids, [private_msg.id]);

--- a/web/tests/people.test.js
+++ b/web/tests/people.test.js
@@ -767,7 +767,7 @@ test_people("message_methods", () => {
     ]);
 
     let message = {
-        type: "private",
+        type: "direct",
         display_recipient: [{id: maria.user_id}, {id: me.user_id}, {id: charles.user_id}],
         sender_id: charles.user_id,
     };
@@ -777,7 +777,7 @@ test_people("message_methods", () => {
     assert.equal(people.small_avatar_url(message), "http://charles.com/foo.png?s=50");
 
     message = {
-        type: "private",
+        type: "direct",
         display_recipient: [{id: maria.user_id}, {id: me.user_id}],
         avatar_url: "legacy.png",
     };
@@ -815,7 +815,7 @@ test_people("message_methods", () => {
     );
 
     message = {
-        type: "private",
+        type: "direct",
         display_recipient: [{id: me.user_id}],
     };
     assert.equal(people.pm_with_url(message), "#narrow/dm/30-Me-Myself");
@@ -875,7 +875,7 @@ test_people("extract_people_from_message", () => {
 
     // Get line coverage
     message = {
-        type: "private",
+        type: "direct",
         display_recipient: [unknown_user],
     };
     people.extract_people_from_message(message);
@@ -888,7 +888,7 @@ test_people("maybe_incr_recipient_count", () => {
     people.add_active_user(maria);
 
     let message = {
-        type: "private",
+        type: "direct",
         display_recipient: [maria_recip],
         sent_by_me: true,
     };
@@ -899,7 +899,7 @@ test_people("maybe_incr_recipient_count", () => {
     // Test all the no-op conditions to get test
     // coverage.
     message = {
-        type: "private",
+        type: "direct",
         sent_by_me: false,
         display_recipient: [maria_recip],
     };
@@ -913,7 +913,7 @@ test_people("maybe_incr_recipient_count", () => {
     };
 
     message = {
-        type: "private",
+        type: "direct",
         sent_by_me: true,
         display_recipient: [unknown_recip],
     };
@@ -1239,7 +1239,7 @@ test_people("huddle_string", () => {
 
     function huddle(user_ids) {
         return people.huddle_string({
-            type: "private",
+            type: "direct",
             display_recipient: user_ids.map((id) => ({id})),
         });
     }

--- a/web/tests/people_errors.test.js
+++ b/web/tests/people_errors.test.js
@@ -71,7 +71,7 @@ run_test("blueslip", () => {
     people.email_list_to_user_ids_string([unknown_email]);
 
     let message = {
-        type: "private",
+        type: "direct",
         display_recipient: [],
         sender_id: me.user_id,
     };
@@ -95,7 +95,7 @@ run_test("blueslip", () => {
     people.add_active_user(maria);
 
     message = {
-        type: "private",
+        type: "direct",
         display_recipient: [{id: maria.user_id}, {id: 42}, {id: charles.user_id}],
         sender_id: charles.user_id,
     };
@@ -105,7 +105,7 @@ run_test("blueslip", () => {
 
     blueslip.expect("error", "Unknown user_id in get_by_user_id: 42");
     blueslip.expect("error", "Unknown people in message");
-    const url = people.pm_with_url({type: "private", display_recipient: [{id: 42}]});
+    const url = people.pm_with_url({type: "direct", display_recipient: [{id: 42}]});
     assert.equal(url.indexOf("unk"), url.length - 3);
 
     blueslip.expect("error", "Undefined field id");

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -310,7 +310,7 @@ private_messages[0] = {
     id: (id += 1),
     sender_id: sender1,
     to_user_ids: "2,3",
-    type: "private",
+    type: "direct",
     display_recipient: [{id: 1}, {id: 2}, {id: 3}],
     pm_with_url: test_url(),
 };
@@ -318,7 +318,7 @@ private_messages[1] = {
     id: (id += 1),
     sender_id: sender1,
     to_user_ids: "2,4",
-    type: "private",
+    type: "direct",
     display_recipient: [{id: 1}, {id: 2}, {id: 4}],
     pm_with_url: test_url(),
 };
@@ -326,7 +326,7 @@ private_messages[2] = {
     id: (id += 1),
     sender_id: sender1,
     to_user_ids: "3",
-    type: "private",
+    type: "direct",
     display_recipient: [{id: 1}, {id: 3}],
     pm_with_url: test_url(),
 };
@@ -529,14 +529,14 @@ test("test_filter_pm", ({mock_template}) => {
     rt.set_filter("include_private");
 
     expected_data_to_replace_in_list_widget = [
-        {last_msg_id: 12, participated: true, type: "private"},
+        {last_msg_id: 12, participated: true, type: "direct"},
     ];
 
     rt.process_messages([private_messages[0]]);
 
-    assert.deepEqual(rt.filters_should_hide_topic({type: "private", last_msg_id: 12}), false);
-    assert.deepEqual(rt.filters_should_hide_topic({type: "private", last_msg_id: 13}), true);
-    assert.deepEqual(rt.filters_should_hide_topic({type: "private", last_msg_id: 14}), false);
+    assert.deepEqual(rt.filters_should_hide_topic({type: "direct", last_msg_id: 12}), false);
+    assert.deepEqual(rt.filters_should_hide_topic({type: "direct", last_msg_id: 13}), true);
+    assert.deepEqual(rt.filters_should_hide_topic({type: "direct", last_msg_id: 14}), false);
 });
 
 test("test_filter_unread", ({mock_template}) => {
@@ -870,7 +870,7 @@ test("basic assertions", ({mock_template, override_rewire}) => {
 
     // Process private message
     rt_data.process_message({
-        type: "private",
+        type: "direct",
         to_user_ids: "6,7,8",
     });
     all_topics = rt_data.get();

--- a/web/tests/search_suggestion_future.test.js
+++ b/web/tests/search_suggestion_future.test.js
@@ -345,7 +345,7 @@ test("group_suggestions", () => {
 
     function message(user_ids, timestamp) {
         return {
-            type: "private",
+            type: "direct",
             display_recipient: user_ids.map((id) => ({
                 id,
             })),

--- a/web/tests/search_suggestion_now.test.js
+++ b/web/tests/search_suggestion_now.test.js
@@ -350,7 +350,7 @@ test("group_suggestions", () => {
 
     function message(user_ids, timestamp) {
         return {
-            type: "private",
+            type: "direct",
             display_recipient: user_ids.map((id) => ({
                 id,
             })),

--- a/web/tests/starred_messages.test.js
+++ b/web/tests/starred_messages.test.js
@@ -49,7 +49,7 @@ run_test("get starred ids in topic", () => {
     // when message_store.get() returns undefined
     message_store.update_message_cache({
         id: 2,
-        type: "private",
+        type: "direct",
     });
     message_store.update_message_cache({
         // Different stream

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -391,7 +391,7 @@ test("default_stream_names", () => {
 
     const private_stream = {
         stream_id: 103,
-        name: "private",
+        name: "direct",
         subscribed: true,
         invite_only: true,
     };

--- a/web/tests/transmit.test.js
+++ b/web/tests/transmit.test.js
@@ -141,7 +141,7 @@ run_test("reply_message_private", ({override}) => {
     people.add_active_user(fred);
 
     const pm_message = {
-        type: "private",
+        type: "direct",
         display_recipient: [{id: fred.user_id}],
     };
 
@@ -166,7 +166,7 @@ run_test("reply_message_private", ({override}) => {
         sender_id: 155,
         queue_id: 177,
         local_id: "199",
-        type: "private",
+        type: "direct",
         to: '["fred@example.com"]',
         content: "hello",
     });

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -525,7 +525,7 @@ test("sort_recipients dup alls", () => {
 });
 
 test("sort_recipients dup alls private", () => {
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     const all_obj = ct.broadcast_mentions()[0];
 
     // full_name starts with same character but emails are 'all'
@@ -598,7 +598,7 @@ test("sort broadcast mentions for stream message type", () => {
 });
 
 test("sort broadcast mentions for private message type", () => {
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     const results = th.sort_people_for_relevance(ct.broadcast_mentions().reverse(), "", "");
 
     assert.deepEqual(
@@ -631,7 +631,7 @@ test("test compare directly for stream message type", () => {
 });
 
 test("test compare directly for private message", () => {
-    compose_state.set_message_type("private");
+    compose_state.set_message_type("direct");
     const all_obj = ct.broadcast_mentions()[0];
 
     assert.equal(th.compare_people_for_relevance(all_obj, all_obj), 0);

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -391,7 +391,7 @@ test("private_messages", () => {
 
     const message = {
         id: 15,
-        type: "private",
+        type: "direct",
         display_recipient: [{id: anybody.user_id}, {id: me.user_id}],
         unread: true,
     };
@@ -434,7 +434,7 @@ test("private_messages", () => {
     const message = {
         id: 15,
         display_recipient: [{id: alice.user_id}],
-        type: "private",
+        type: "direct",
         unread: true,
         to_user_ids: alice.user_id.toString(),
     };
@@ -772,7 +772,7 @@ test("errors", () => {
     // Test unknown message leads to zero count
     const message = {
         id: 9,
-        type: "private",
+        type: "direct",
         display_recipient: [{id: 9999}],
     };
 

--- a/web/tests/util.test.js
+++ b/web/tests/util.test.js
@@ -63,25 +63,25 @@ run_test("same_recipient", () => {
 
     assert.ok(
         util.same_recipient(
-            {type: "private", to_user_ids: "101,102"},
-            {type: "private", to_user_ids: "101,102"},
+            {type: "direct", to_user_ids: "101,102"},
+            {type: "direct", to_user_ids: "101,102"},
         ),
     );
 
     assert.ok(
         !util.same_recipient(
-            {type: "private", to_user_ids: "101,102"},
-            {type: "private", to_user_ids: "103"},
+            {type: "direct", to_user_ids: "101,102"},
+            {type: "direct", to_user_ids: "103"},
         ),
     );
 
     assert.ok(
-        !util.same_recipient({type: "stream", stream_id: 101, topic: "Bar"}, {type: "private"}),
+        !util.same_recipient({type: "stream", stream_id: 101, topic: "Bar"}, {type: "direct"}),
     );
 
-    assert.ok(!util.same_recipient({type: "private", to_user_ids: undefined}, {type: "private"}));
+    assert.ok(!util.same_recipient({type: "direct", to_user_ids: undefined}, {type: "direct"}));
 
-    assert.ok(!util.same_recipient(undefined, {type: "private"}));
+    assert.ok(!util.same_recipient(undefined, {type: "direct"}));
 
     assert.ok(!util.same_recipient(undefined, undefined));
 });

--- a/zerver/actions/message_delete.py
+++ b/zerver/actions/message_delete.py
@@ -36,7 +36,7 @@ def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
     users_to_notify = []
     if not sample_message.is_stream_message():
         assert len(messages) == 1
-        message_type = "private"
+        message_type = "direct"
         ums = UserMessage.objects.filter(message_id__in=message_ids)
         users_to_notify = [um.user_profile_id for um in ums]
         archiving_chunk_size = retention.MESSAGE_BATCH_SIZE

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -913,7 +913,7 @@ def do_send_messages(
             UserMessageNotificationsData.from_user_id_sets(
                 user_id=user_id,
                 flags=user_flags.get(user_id, []),
-                private_message=(message_type == "private"),
+                private_message=(message_type == "direct"),
                 disable_external_notifications=send_request.disable_external_notifications,
                 online_push_user_ids=send_request.online_push_user_ids,
                 pm_mention_push_disabled_user_ids=send_request.pm_mention_push_disabled_user_ids,

--- a/zerver/actions/typing.py
+++ b/zerver/actions/typing.py
@@ -19,7 +19,7 @@ def do_send_typing_notification(
     ]
     event = dict(
         type="typing",
-        message_type="private",
+        message_type="direct",
         op=operator,
         sender=sender_dict,
         recipients=recipient_dicts,

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -56,7 +56,7 @@ class Addressee:
         stream_id: Optional[int] = None,
         topic: Optional[str] = None,
     ) -> None:
-        assert msg_type in ["stream", "private"]
+        assert msg_type in ["stream", "direct"]
         if msg_type == "stream" and topic is None:
             raise JsonableError(_("Missing topic"))
         self._msg_type = msg_type
@@ -70,7 +70,7 @@ class Addressee:
         return self._msg_type == "stream"
 
     def is_private(self) -> bool:
-        return self._msg_type == "private"
+        return self._msg_type == "direct"
 
     def user_profiles(self) -> Sequence[UserProfile]:
         assert self.is_private()
@@ -131,7 +131,7 @@ class Addressee:
                 return Addressee.for_stream_id(stream_name_or_id, topic_name)
 
             return Addressee.for_stream_name(stream_name_or_id, topic_name)
-        elif recipient_type_name == "private":
+        elif recipient_type_name == "direct":
             if not message_to:
                 raise JsonableError(_("Message must have recipients"))
 
@@ -179,7 +179,7 @@ class Addressee:
         assert len(emails) > 0
         user_profiles = get_user_profiles(emails, realm)
         return Addressee(
-            msg_type="private",
+            msg_type="direct",
             user_profiles=user_profiles,
         )
 
@@ -188,7 +188,7 @@ class Addressee:
         assert len(user_ids) > 0
         user_profiles = get_user_profiles_by_ids(user_ids, realm)
         return Addressee(
-            msg_type="private",
+            msg_type="direct",
             user_profiles=user_profiles,
         )
 
@@ -196,6 +196,6 @@ class Addressee:
     def for_user_profile(user_profile: UserProfile) -> "Addressee":
         user_profiles = [user_profile]
         return Addressee(
-            msg_type="private",
+            msg_type="direct",
             user_profiles=user_profiles,
         )

--- a/zerver/lib/bot_lib.py
+++ b/zerver/lib/bot_lib.py
@@ -95,7 +95,7 @@ class EmbeddedBotHandler:
             )
             return {"id": message_id}
 
-        assert message["type"] == "private"
+        assert message["type"] == "direct"
         # Ensure that it's a comma-separated list, even though the
         # usual 'to' field could be either a List[str] or a str.
         recipients = ",".join(message["to"]).split(",")
@@ -116,10 +116,10 @@ class EmbeddedBotHandler:
     def send_reply(
         self, message: Dict[str, Any], response: str, widget_content: Optional[str] = None
     ) -> Dict[str, Any]:
-        if message["type"] == "private":
+        if message["type"] == "direct":
             result = self.send_message(
                 dict(
-                    type="private",
+                    type="direct",
                     to=[x["email"] for x in message["display_recipient"]],
                     content=response,
                     sender_email=message["sender_email"],

--- a/zerver/lib/drafts.py
+++ b/zerver/lib/drafts.py
@@ -27,7 +27,7 @@ from zerver.models import Draft, UserProfile
 from zerver.tornado.django_api import send_event
 
 ParamT = ParamSpec("ParamT")
-VALID_DRAFT_TYPES: Set[str] = {"", "private", "stream"}
+VALID_DRAFT_TYPES: Set[str] = {"", "direct", "stream"}
 
 # A validator to verify if the structure (syntax) of a dictionary
 # meets the requirements to be a draft dictionary:
@@ -73,7 +73,7 @@ def further_validated_draft_dict(
             raise JsonableError(_("Must specify exactly 1 stream ID for stream messages"))
         stream, sub = access_stream_by_id(user_profile, to[0])
         recipient = stream.recipient
-    elif draft_dict["type"] == "private" and len(to) != 0:
+    elif draft_dict["type"] == "direct" and len(to) != 0:
         to_users = get_user_profiles_by_ids(set(to), user_profile.realm)
         try:
             recipient = recipient_for_user_profiles(to_users, False, None, user_profile)

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -218,7 +218,7 @@ delete_message_event = event_dict_type(
     required_keys=[
         # force vertical
         ("type", Equals("delete_message")),
-        ("message_type", EnumType(["private", "stream"])),
+        ("message_type", EnumType(["direct", "stream"])),
     ],
     optional_keys=[
         ("message_id", int),
@@ -245,7 +245,7 @@ def check_delete_message(
 
     if message_type == "stream":
         keys |= {"stream_id", "topic"}
-    elif message_type == "private":
+    elif message_type == "direct":
         pass
     else:
         raise AssertionError("unexpected message_type")
@@ -1388,7 +1388,7 @@ typing_person_type = DictType(
 
 equals_private_or_stream = EnumType(
     [
-        "private",
+        "direct",
         "stream",
     ]
 )
@@ -1668,7 +1668,7 @@ update_message_flags_remove_event = event_dict_type(
             StringDictType(
                 DictType(
                     required_keys=[
-                        ("type", EnumType(["private", "stream"])),
+                        ("type", EnumType(["direct", "stream"])),
                     ],
                     optional_keys=[
                         ("mentioned", bool),

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -1206,7 +1206,7 @@ def apply_event(
                 remove_message_id_from_unread_mgs(state["raw_unread_msgs"], remove_id)
 
         # The remainder of this block is about maintaining recent_private_conversations
-        if "raw_recent_private_conversations" not in state or event["message_type"] != "private":
+        if "raw_recent_private_conversations" not in state or event["message_type"] != "direct":
             return
 
         # OK, we just deleted what had been the max_message_id for

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -648,7 +648,7 @@ class MessageDict:
             display_type = "stream"
         elif recipient_type in (Recipient.HUDDLE, Recipient.PERSONAL):
             assert not isinstance(display_recipient, str)
-            display_type = "private"
+            display_type = "direct"
             if len(display_recipient) == 1:
                 # add the sender in if this isn't a message between
                 # someone and themself, preserving ordering
@@ -1274,10 +1274,10 @@ def apply_unread_message_event(
     message_id = message["id"]
     if message["type"] == "stream":
         recipient_type = "stream"
-    elif message["type"] == "private":
+    elif message["type"] == "direct":
         others = [recip for recip in message["display_recipient"] if recip["id"] != user_profile.id]
         if len(others) <= 1:
-            recipient_type = "private"
+            recipient_type = "direct"
         else:
             recipient_type = "huddle"
     else:
@@ -1300,7 +1300,7 @@ def apply_unread_message_event(
         ):
             state["unmuted_stream_msgs"].add(message_id)
 
-    elif recipient_type == "private":
+    elif recipient_type == "direct":
         if len(others) == 1:
             other_user_id = others[0]["id"]
         else:
@@ -1352,7 +1352,7 @@ def format_unread_message_details(
         # Note that user_ids excludes ourself, even for the case we send messages
         # to ourself.
         message_details = MessageDetailsDict(
-            type="private",
+            type="direct",
             user_ids=user_ids,
         )
         if message_id in raw_unread_data["mentions"]:
@@ -1380,7 +1380,7 @@ def format_unread_message_details(
         user_ids = [user_id for user_id in user_ids if user_id != my_user_id]
         user_ids.sort()
         message_details = MessageDetailsDict(
-            type="private",
+            type="direct",
             user_ids=user_ids,
         )
         if message_id in raw_unread_data["mentions"]:
@@ -1399,7 +1399,7 @@ def add_message_to_unread_msgs(
     if message_details.get("mentioned"):
         state["mentions"].add(message_id)
 
-    if message_details["type"] == "private":
+    if message_details["type"] == "direct":
         user_ids: List[int] = message_details["user_ids"]
         user_ids = [user_id for user_id in user_ids if user_id != my_user_id]
         if user_ids == []:

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -157,9 +157,9 @@ def build_narrow_filter(narrow: Collection[Sequence[str]]) -> Callable[[Mapping[
             elif operator == "sender":
                 if operand.lower() != message["sender_email"].lower():
                     return False
-            elif operator == "is" and operand in ["dm", "private"]:
+            elif operator == "is" and operand in ["dm", "direct"]:
                 # "is:private" is a legacy alias for "is:dm"
-                if message["type"] != "private":
+                if message["type"] != "direct":
                     return False
             elif operator == "is" and operand in ["starred"]:
                 if operand not in flags:
@@ -342,7 +342,7 @@ class NarrowBuilder:
         assert not self.is_web_public_query
         assert self.user_profile is not None
 
-        if operand in ["dm", "private"]:
+        if operand in ["dm", "direct"]:
             # "is:private" is a legacy alias for "is:dm"
             cond = column("flags", Integer).op("&")(UserMessage.flags.is_private.mask) != 0
             return query.where(maybe_negate(cond))

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -106,7 +106,7 @@ class SlackOutgoingWebhookService(OutgoingWebhookServiceInterface):
     def make_request(
         self, base_url: str, event: Dict[str, Any], realm: Realm
     ) -> Optional[Response]:
-        if event["message"]["type"] == "private":
+        if event["message"]["type"] == "direct":
             failure_message = "Slack outgoing webhooks don't support direct messages."
             fail_with_message(event, failure_message)
             return None
@@ -179,7 +179,7 @@ def send_response_message(
     bot_id is the user_id of the bot sending the response
 
     message_info is used to address the message and should have these fields:
-        type - "stream" or "private"
+        type - "stream" or "direct"
         display_recipient - like we have in other message events
         topic - see get_topic_from_message_info
 
@@ -209,7 +209,7 @@ def send_response_message(
 
     if recipient_type_name == "stream":
         message_to = [display_recipient]
-    elif recipient_type_name == "private":
+    elif recipient_type_name == "direct":
         message_to = [recipient["email"] for recipient in display_recipient]
     else:
         raise JsonableError(_("Invalid message type"))
@@ -283,7 +283,7 @@ def notify_bot_owner(
         )
 
     message_info = dict(
-        type="private",
+        type="direct",
         display_recipient=[dict(email=bot_owner.email)],
     )
     response_data = dict(content=notification_message)

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -799,10 +799,10 @@ def get_message_payload(
         data["stream_id"] = message.recipient.type_id
         data["topic"] = message.topic_name()
     elif message.recipient.type == Recipient.HUDDLE:
-        data["recipient_type"] = "private"
+        data["recipient_type"] = "direct"
         data["pm_users"] = huddle_users(message.recipient.id)
     else:  # Recipient.PERSONAL
-        data["recipient_type"] = "private"
+        data["recipient_type"] = "direct"
 
     return data
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1006,7 +1006,7 @@ Output:
         return check_send_message(
             from_user,
             sending_client,
-            "private",
+            "direct",
             recipient_list,
             None,
             content,
@@ -1027,7 +1027,7 @@ Output:
         return check_send_message(
             from_user,
             sending_client,
-            "private",
+            "direct",
             to_user_ids,
             None,
             content,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -230,7 +230,7 @@ def get_recipient_ids(
         recipient_type_str = "stream"
         to = [recipient.type_id]
     else:
-        recipient_type_str = "private"
+        recipient_type_str = "direct"
         if recipient.type == Recipient.PERSONAL:
             to = [recipient.type_id]
         else:
@@ -3005,10 +3005,10 @@ class Message(AbstractMessage):
     #
     # A detail worth noting:
     # * "direct" was introduced in 2023 with the goal of
-    #   deprecating the original "private" and becoming the
+    #   deprecating the original "direct" and becoming the
     #   preferred way to indicate a personal or huddle
     #   Recipient type via the API.
-    API_RECIPIENT_TYPES = ["direct", "private", "stream"]
+    API_RECIPIENT_TYPES = ["direct", "direct", "stream"]
 
     search_tsvector = SearchVectorField(null=True)
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -980,7 +980,7 @@ def send_message(client: Client) -> int:
     # Send a direct message
     user_id = 10
     request = {
-        "type": "private",
+        "type": "direct",
         "to": [user_id],
         "content": "With mirth and laughter let old wrinkles come.",
     }
@@ -1056,7 +1056,7 @@ def test_nonexistent_stream_error(client: Client) -> None:
 
 def test_private_message_invalid_recipient(client: Client) -> None:
     request = {
-        "type": "private",
+        "type": "direct",
         "to": "eeshan@zulip.com",
         "content": "With mirth and laughter let old wrinkles come.",
     }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1147,7 +1147,7 @@ paths:
                                   "streams":
                                     [
                                       {
-                                        "name": "private",
+                                        "name": "direct",
                                         "stream_id": 12,
                                         "description": "",
                                         "rendered_description": "",
@@ -1193,7 +1193,7 @@ paths:
                                   "streams":
                                     [
                                       {
-                                        "name": "private",
+                                        "name": "direct",
                                         "stream_id": 12,
                                         "description": "",
                                         "rendered_description": "",
@@ -1888,7 +1888,7 @@ paths:
                                 message_type:
                                   type: string
                                   description: |
-                                    The type of message. Either `"stream"` or `"private"`.
+                                    The type of message. Either `"stream"` or `"direct"`.
                                   enum:
                                     - private
                                     - stream
@@ -1907,7 +1907,7 @@ paths:
                               example:
                                 {
                                   "type": "delete_message",
-                                  "message_type": "private",
+                                  "message_type": "direct",
                                   "message_id": 37,
                                   "id": 0,
                                 }
@@ -2423,7 +2423,7 @@ paths:
                                 message_type:
                                   type: string
                                   description: |
-                                    Type of message being composed. Must be `"stream"` or `"private"`.
+                                    Type of message being composed. Must be `"stream"` or `"direct"`.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
                                     all typing notifications were implicitly private messages.
@@ -2447,7 +2447,7 @@ paths:
                                 recipients:
                                   type: array
                                   description: |
-                                    Only present if `message_type` is `"private"`.
+                                    Only present if `message_type` is `"direct"`.
 
                                     Array of dictionaries describing the set of users who would be
                                     recipients of the message being typed. Each dictionary contains
@@ -2489,7 +2489,7 @@ paths:
                                 {
                                   "type": "typing",
                                   "op": "start",
-                                  "message_type": "private",
+                                  "message_type": "direct",
                                   "sender":
                                     {
                                       "user_id": 10,
@@ -2541,7 +2541,7 @@ paths:
                                 message_type:
                                   type: string
                                   description: |
-                                    Type of message being composed. Must be `"stream"` or `"private"`.
+                                    Type of message being composed. Must be `"stream"` or `"direct"`.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
                                     all typing notifications were implicitly private messages.
@@ -2565,7 +2565,7 @@ paths:
                                 recipients:
                                   type: array
                                   description: |
-                                    Only present if `message_type` is `"private"`.
+                                    Only present if `message_type` is `"direct"`.
 
                                     Array of dictionaries describing the set of users who would be
                                     recipients of the message that was previously being typed. Each
@@ -2607,7 +2607,7 @@ paths:
                                 {
                                   "type": "typing",
                                   "op": "stop",
-                                  "message_type": "private",
+                                  "message_type": "direct",
                                   "sender":
                                     {
                                       "user_id": 10,
@@ -4359,7 +4359,7 @@ paths:
                                     [
                                       {
                                         "id": 17,
-                                        "type": "private",
+                                        "type": "direct",
                                         "to": [6],
                                         "topic": "",
                                         "content": "Hello there!",
@@ -4392,7 +4392,7 @@ paths:
                                   "draft":
                                     {
                                       "id": 17,
-                                      "type": "private",
+                                      "type": "direct",
                                       "to": [6, 7, 8, 9, 10],
                                       "topic": "",
                                       "content": "Hello everyone!",
@@ -4480,7 +4480,7 @@ paths:
                                   "subject": "",
                                   "topic_links": [],
                                   "timestamp": 1375978404,
-                                  "type": "private",
+                                  "type": "direct",
                                 },
                               "type": "message",
                             },
@@ -4829,7 +4829,7 @@ paths:
                             },
                             {
                               "id": 2,
-                              "type": "private",
+                              "type": "direct",
                               "to": [4],
                               "topic": "",
                               "content": "What if we made it possible to sync drafts in Zulip?",
@@ -4837,7 +4837,7 @@ paths:
                             },
                             {
                               "id": 3,
-                              "type": "private",
+                              "type": "direct",
                               "to": [4, 10],
                               "topic": "",
                               "content": "What if we made it possible to sync drafts in Zulip?",
@@ -5456,7 +5456,7 @@ paths:
                             {
                               "subject": "",
                               "sender_realm_str": "zulip",
-                              "type": "private",
+                              "type": "direct",
                               "content": "<p>Security experts agree that relational algorithms are an interesting new topic in the field of networking, and scholars concur.</p>",
                               "flags": ["read"],
                               "id": 16,
@@ -5535,9 +5535,9 @@ paths:
 
             **Changes**: In Zulip 7.0 (feature level 174), `"direct"` was added as
             the preferred way to request a direct message, deprecating the original
-            `"private"`. While `"private"` is still supported for requesting direct
+            `"direct"`. While `"direct"` is still supported for requesting direct
             messages, clients are encouraged to use to the modern convention with
-            servers that support it, because support for `"private"` will eventually
+            servers that support it, because support for `"direct"` will eventually
             be removed.
           schema:
             type: string
@@ -6568,7 +6568,7 @@ paths:
                           {
                             "subject": "",
                             "sender_realm_str": "zulip",
-                            "type": "private",
+                            "type": "direct",
                             "content": "<p>Security experts agree that relational algorithms are an interesting new topic in the field of networking, and scholars concur.</p>",
                             "flags": ["read"],
                             "id": 16,
@@ -15256,7 +15256,7 @@ paths:
             **Changes**: In Zulip 7.0 (feature level 174), `"direct"` was added
             as the preferred way to indicate a direct message is being composed,
             becoming the default value for this parameter and deprecating the
-            original `"private"`.
+            original `"direct"`.
 
             New in Zulip 4.0 (feature level 58). Previously, typing notifications
             were only for direct messages.
@@ -17285,7 +17285,7 @@ components:
           type: string
           description: |
             The type of the draft. Either unaddressed (empty string), "stream",
-            or "private" (for PMs and private group messages).
+            or "direct" (for PMs and private group messages).
           enum:
             - ""
             - stream
@@ -17337,7 +17337,7 @@ components:
           type: string
           description: |
             The type of the scheduled message. Either unaddressed (empty string), "stream",
-            or "private" (for PMs and private group messages).
+            or "direct" (for PMs and private group messages).
           enum:
             - ""
             - stream

--- a/zerver/tests/fixtures/narrow.json
+++ b/zerver/tests/fixtures/narrow.json
@@ -12,7 +12,7 @@
         "reject_events":[
             {
                 "message":{
-                    "type":"private"
+                    "type":"direct"
                 },
                 "flags":null
             },
@@ -51,7 +51,7 @@
         "reject_events":[
             {
                 "message":{
-                    "type":"private"
+                    "type":"direct"
                 },
                 "flags":null
             },
@@ -91,7 +91,7 @@
         "reject_events":[
             {
                 "message":{
-                    "type":"private"
+                    "type":"direct"
                 },
                 "flags":null
             },
@@ -150,7 +150,7 @@
         "accept_events":[
             {
                 "message":{
-                    "type":"private"
+                    "type":"direct"
                 },
                 "flags":null
             }
@@ -174,7 +174,7 @@
         "accept_events":[
             {
                 "message":{
-                    "type":"private"
+                    "type":"direct"
                 },
                 "flags":null
             }
@@ -190,7 +190,7 @@
         "narrow":[
             [
                 "is",
-                "private"
+                "direct"
             ]
         ]
     },
@@ -301,7 +301,7 @@
         "reject_events":[
             {
                 "message":{
-                    "type":"private"
+                    "type":"direct"
                 },
                 "flags":null
             },

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1119,7 +1119,7 @@ class DeactivatedRealmTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": self.example_email("othello"),
             },
@@ -1136,7 +1136,7 @@ class DeactivatedRealmTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": self.example_email("othello"),
             },
@@ -1149,7 +1149,7 @@ class DeactivatedRealmTest(ZulipTestCase):
             self.example_user("hamlet"),
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": self.example_email("othello"),
             },
@@ -1270,7 +1270,7 @@ class InactiveUserTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": self.example_email("othello"),
             },
@@ -1285,7 +1285,7 @@ class InactiveUserTest(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": self.example_email("othello"),
             },
@@ -1296,7 +1296,7 @@ class InactiveUserTest(ZulipTestCase):
             self.example_user("hamlet"),
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": self.example_email("othello"),
             },
@@ -1397,7 +1397,7 @@ class TestIncomingWebhookBot(ZulipTestCase):
         webhook_bot = self.example_user("webhook_bot")
         othello = self.example_user("othello")
         payload = dict(
-            type="private",
+            type="direct",
             content="Test message",
             to=orjson.dumps([othello.email]).decode(),
         )

--- a/zerver/tests/test_drafts.py
+++ b/zerver/tests/test_drafts.py
@@ -75,7 +75,7 @@ class DraftCreationTests(ZulipTestCase):
         zoe = self.example_user("ZOE")
         draft_dicts = [
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id],
                 "topic": "This topic should be ignored.",
                 "content": "What if we made it possible to sync drafts in Zulip?",
@@ -84,7 +84,7 @@ class DraftCreationTests(ZulipTestCase):
         ]
         expected_draft_dicts = [
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id],
                 "topic": "",  # For private messages the topic should be ignored.
                 "content": "What if we made it possible to sync drafts in Zulip?",
@@ -98,7 +98,7 @@ class DraftCreationTests(ZulipTestCase):
         othello = self.example_user("othello")
         draft_dicts = [
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id, othello.id],
                 "topic": "This topic should be ignored.",
                 "content": "What if we made it possible to sync drafts in Zulip?",
@@ -107,7 +107,7 @@ class DraftCreationTests(ZulipTestCase):
         ]
         expected_draft_dicts = [
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id, othello.id],
                 "topic": "",  # For private messages the topic should be ignored.
                 "content": "What if we made it possible to sync drafts in Zulip?",
@@ -131,14 +131,14 @@ class DraftCreationTests(ZulipTestCase):
                 "timestamp": 1595479019,
             },  # Stream message draft
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id],
                 "topic": "",
                 "content": "What if we made it possible to sync drafts in Zulip?",
                 "timestamp": 1595479020,
             },  # Private message draft
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id, othello.id],
                 "topic": "",
                 "content": "What if we made it possible to sync drafts in Zulip?",
@@ -195,7 +195,7 @@ class DraftCreationTests(ZulipTestCase):
         """When "to" is an empty list, the type should become "" as well."""
         draft_dicts = [
             {
-                "type": "private",
+                "type": "direct",
                 "to": [],
                 "topic": "sync drafts",
                 "content": "Let's add backend support for syncing drafts.",
@@ -270,7 +270,7 @@ class DraftCreationTests(ZulipTestCase):
     def test_create_personal_message_draft_for_non_existing_user(self) -> None:
         draft_dicts = [
             {
-                "type": "private",
+                "type": "direct",
                 "to": [99999999999999],  # Hopefully, this doesn't exist either.
                 "topic": "This topic should be ignored.",
                 "content": "What if we made it possible to sync drafts in Zulip?",
@@ -521,14 +521,14 @@ class DraftFetchTest(ZulipTestCase):
                 "timestamp": 15954790197,
             },
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id, othello.id],
                 "topic": "",
                 "content": "What if made it possible to sync drafts in Zulip?",
                 "timestamp": 15954790198,
             },
             {
-                "type": "private",
+                "type": "direct",
                 "to": [zoe.id],
                 "topic": "",
                 "content": "What if made it possible to sync drafts in Zulip?",
@@ -543,7 +543,7 @@ class DraftFetchTest(ZulipTestCase):
 
         zoe_draft_dicts = [
             {
-                "type": "private",
+                "type": "direct",
                 "to": [hamlet.id],
                 "topic": "",
                 "content": "Hello there!",

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1011,7 +1011,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "test_receive_missed_message_email_messages",
                 "to": orjson.dumps([othello.id]).decode(),
             },
@@ -1054,7 +1054,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "test_receive_missed_message_email_messages",
                 "to": orjson.dumps([cordelia.id, iago.id]).decode(),
             },
@@ -1339,7 +1339,7 @@ class TestEmptyGatewaySetting(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         iago = self.example_user("iago")
         payload = dict(
-            type="private",
+            type="direct",
             content="test_receive_missed_message_email_messages",
             to=orjson.dumps([cordelia.id, iago.id]).decode(),
         )
@@ -1506,7 +1506,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "test_receive_missed_message_email_messages",
                 "to": orjson.dumps([cordelia.id, iago.id]).decode(),
             },
@@ -1763,7 +1763,7 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "test_redact_email_message",
                 "to": orjson.dumps([cordelia.email, iago.email]).decode(),
             },

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -517,7 +517,7 @@ class TestMissedMessages(ZulipTestCase):
         result = self.client_post(
             "/json/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([hamlet.email]).decode(),
             },
@@ -676,7 +676,7 @@ class TestMissedMessages(ZulipTestCase):
                 "Denmark > test",
                 "Othello, the Moor of Venice",
                 "1 2 3 4 5 6 7 8 9 10 @**King Hamlet**",
-                "private",
+                "direct",
                 "group",
                 "Reply to this email directly, or view it in Zulip Dev Zulip",
             ]
@@ -718,7 +718,7 @@ class TestMissedMessages(ZulipTestCase):
                 "Denmark > test",
                 "Othello, the Moor of Venice",
                 "1 2 3 4 5 @**all**",
-                "private",
+                "direct",
                 "group",
                 "Reply to this email directly, or view it in Zulip Dev Zulip",
             ]

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -324,7 +324,7 @@ class GetEventsTest(ZulipTestCase):
         check_send_message(
             sender=user_profile,
             client=get_client("whatever"),
-            recipient_type_name="private",
+            recipient_type_name="direct",
             message_to=[recipient_email],
             topic_name=None,
             message_content="hello",
@@ -357,7 +357,7 @@ class GetEventsTest(ZulipTestCase):
         check_send_message(
             sender=user_profile,
             client=get_client("whatever"),
-            recipient_type_name="private",
+            recipient_type_name="direct",
             message_to=[recipient_email],
             topic_name=None,
             message_content="hello",

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2419,7 +2419,7 @@ class NormalActionsTest(BaseAction):
         check_delete_message(
             "events[0]",
             events[0],
-            message_type="private",
+            message_type="direct",
             num_message_ids=1,
             is_legacy=False,
         )
@@ -2439,7 +2439,7 @@ class NormalActionsTest(BaseAction):
         check_delete_message(
             "events[0]",
             events[0],
-            message_type="private",
+            message_type="direct",
             num_message_ids=1,
             is_legacy=True,
         )
@@ -3114,7 +3114,7 @@ class SubscribeActionTest(BaseAction):
         check_stream_update("events[0]", events[0])
 
         # Subscribe to a totally new invite-only stream, so it's just Hamlet on it
-        stream = self.make_stream("private", self.user_profile.realm, invite_only=True)
+        stream = self.make_stream("direct", self.user_profile.realm, invite_only=True)
         stream.message_retention_days = 10
         stream.save()
 

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -281,7 +281,7 @@ class TestStreamHelpers(ZulipTestCase):
         realm = cordelia.realm
         stream_name = "Some private stream"
 
-        # Use the invite_only flag in make_stream to make a stream "private".
+        # Use the invite_only flag in make_stream to make a stream "direct".
         stream = self.make_stream(stream_name=stream_name, invite_only=True)
         self.subscribe(cordelia, stream_name)
 

--- a/zerver/tests/test_message_dict.py
+++ b/zerver/tests/test_message_dict.py
@@ -395,7 +395,7 @@ class MessageHydrationTest(ZulipTestCase):
                 ),
             ],
         )
-        self.assertEqual(obj["type"], "private")
+        self.assertEqual(obj["type"], "direct")
 
     def test_messages_for_ids(self) -> None:
         hamlet = self.example_user("hamlet")

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -533,11 +533,11 @@ class NarrowBuilderTest(ZulipTestCase):
 
     # Test "is:private" (legacy alias for "is:dm")
     def test_add_term_using_is_operator_and_private_operand(self) -> None:
-        term = dict(operator="is", operand="private")
+        term = dict(operator="is", operand="direct")
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) != %(param_1)s")
 
     def test_add_term_using_is_operator_private_operand_and_negated(self) -> None:  # NEGATED
-        term = dict(operator="is", operand="private", negated=True)
+        term = dict(operator="is", operand="direct", negated=True)
         self._do_add_term_test(term, "WHERE (flags & %(flags_1)s) = %(param_1)s")
 
     # Test that "pm-with" (legacy alias for "dm") works.
@@ -648,7 +648,7 @@ class NarrowLibraryTest(ZulipTestCase):
         self.assertFalse(is_spectator_compatible([{"operator": "has"}]))
 
         # "is:private" is a legacy alias for "is:dm".
-        self.assertFalse(is_spectator_compatible([{"operator": "is", "operand": "private"}]))
+        self.assertFalse(is_spectator_compatible([{"operator": "is", "operand": "direct"}]))
         # "pm-with:"" is a legacy alias for "dm:"
         self.assertFalse(
             is_spectator_compatible([{"operator": "pm-with", "operand": "hamlet@zulip.com"}])
@@ -714,7 +714,7 @@ class IncludeHistoryTest(ZulipTestCase):
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
         # "is:private" is a legacy alias for "is:dm".
         narrow = [
-            dict(operator="is", operand="private"),
+            dict(operator="is", operand="direct"),
         ]
         self.assertFalse(ok_to_include_history(narrow, user_profile, False))
 
@@ -1397,7 +1397,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assert_json_success(payload)
         self.assertEqual(
             set(payload["Cache-Control"].split(", ")),
-            {"must-revalidate", "no-store", "no-cache", "max-age=0", "private"},
+            {"must-revalidate", "no-store", "no-cache", "max-age=0", "direct"},
         )
 
         result = orjson.loads(payload.content)
@@ -1610,7 +1610,7 @@ class GetOldMessagesTest(ZulipTestCase):
         # "is:private" is a legacy alias for "is:dm".
         private_message_get_params: Dict[str, Union[int, str, bool]] = {
             **get_params,
-            "narrow": orjson.dumps([dict(operator="is", operand="private")]).decode(),
+            "narrow": orjson.dumps([dict(operator="is", operand="direct")]).decode(),
         }
         result = self.client_get("/json/messages", dict(private_message_get_params))
         self.check_unauthenticated_response(result)

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1619,7 +1619,7 @@ class MarkUnreadTest(ZulipTestCase):
         self.assertEqual(
             message_details,
             {
-                str(message_id): dict(type="private", user_ids=[]),
+                str(message_id): dict(type="direct", user_ids=[]),
             },
         )
 
@@ -1638,7 +1638,7 @@ class MarkUnreadTest(ZulipTestCase):
         )
 
         # message to self
-        message_details = MessageDetailsDict(type="private", user_ids=[])
+        message_details = MessageDetailsDict(type="direct", user_ids=[])
         add_message_to_unread_msgs(user.id, raw_unread_data, message_id, message_details)
         self.assertEqual(
             raw_unread_data["pm_dict"],
@@ -2091,7 +2091,7 @@ class MarkUnreadTest(ZulipTestCase):
             self.assertEqual(
                 event["message_details"][message_id],
                 dict(
-                    type="private",
+                    type="direct",
                     user_ids=[sender.id],
                 ),
             )
@@ -2158,7 +2158,7 @@ class MarkUnreadTest(ZulipTestCase):
             self.assertEqual(
                 event["message_details"][message_id],
                 dict(
-                    type="private",
+                    type="direct",
                     user_ids=[sender.id],
                     mentioned=True,
                 ),

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -632,7 +632,7 @@ class MessagePOSTTest(ZulipTestCase):
         for both valid strings for `type` parameter.
         """
         self.login("hamlet")
-        recipient_type_name = ["direct", "private"]
+        recipient_type_name = ["direct", "direct"]
 
         for type in recipient_type_name:
             result = self.client_post(
@@ -655,7 +655,7 @@ class MessagePOSTTest(ZulipTestCase):
         for both valid strings for `type` parameter.
         """
         self.login("hamlet")
-        recipient_type_name = ["direct", "private"]
+        recipient_type_name = ["direct", "direct"]
 
         for type in recipient_type_name:
             result = self.client_post(
@@ -834,7 +834,7 @@ class MessagePOSTTest(ZulipTestCase):
 
     def test_invalid_recipient_type(self) -> None:
         """
-        Messages other than the type of "direct", "private" or "stream" are invalid.
+        Messages other than the type of "direct", "direct" or "stream" are invalid.
         """
         self.login("hamlet")
         result = self.client_post(
@@ -1417,7 +1417,7 @@ class ScheduledMessageTest(ZulipTestCase):
         othello = self.example_user("othello")
         hamlet = self.example_user("hamlet")
         result = self.do_schedule_message(
-            "private", [othello.email], content + " 3", defer_until_str
+            "direct", [othello.email], content + " 3", defer_until_str
         )
         message = self.last_scheduled_message()
         self.assert_json_success(result)
@@ -1428,14 +1428,14 @@ class ScheduledMessageTest(ZulipTestCase):
 
         # Setting a reminder in PM's to other users causes a error.
         result = self.do_schedule_message(
-            "private", [othello.email], content + " 4", defer_until_str, delivery_type="remind"
+            "direct", [othello.email], content + " 4", defer_until_str, delivery_type="remind"
         )
         self.assert_json_error(result, "Reminders can only be set for streams.")
 
         # Setting a reminder in PM's to ourself is successful.
         # Required by reminders from message actions popover caret feature.
         result = self.do_schedule_message(
-            "private", [hamlet.email], content + " 5", defer_until_str, delivery_type="remind"
+            "direct", [hamlet.email], content + " 5", defer_until_str, delivery_type="remind"
         )
         message = self.last_scheduled_message()
         self.assert_json_success(result)
@@ -1557,7 +1557,7 @@ class ScheduledMessageTest(ZulipTestCase):
 
         othello = self.example_user("othello")
         result = self.do_schedule_message(
-            "private", [othello.email], content + " 3", defer_until_str
+            "direct", [othello.email], content + " 3", defer_until_str
         )
 
         # Multiple scheduled messages
@@ -2565,7 +2565,7 @@ class TestAddressee(ZulipTestCase):
 
         result = Addressee.legacy_build(
             sender=self.example_user("hamlet"),
-            recipient_type_name="private",
+            recipient_type_name="direct",
             message_to=user_ids,
             topic_name="random_topic",
             realm=realm,

--- a/zerver/tests/test_mirror_users.py
+++ b/zerver/tests/test_mirror_users.py
@@ -19,7 +19,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
 
         recipients: List[str] = []
 
-        recipient_type_name = "private"
+        recipient_type_name = "direct"
         client = get_client("banned_mirror")
 
         with self.assertRaises(InvalidMirrorInputError):
@@ -35,7 +35,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
         user = self.mit_user("starnine")
         sender = user
 
-        recipient_type_name = "private"
+        recipient_type_name = "direct"
 
         for client_name in ["zephyr_mirror", "irc_mirror", "jabber_mirror"]:
             client = get_client(client_name)
@@ -58,7 +58,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
 
         recipients = [user.email, new_user_email]
 
-        recipient_type_name = "private"
+        recipient_type_name = "direct"
         client = get_client("zephyr_mirror")
 
         mirror_sender = create_mirrored_message_users(
@@ -109,7 +109,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
             self.nonreg_email("cordelia"),
         ]
 
-        recipient_type_name = "private"
+        recipient_type_name = "direct"
         client = get_client("irc_mirror")
 
         mirror_sender = create_mirrored_message_users(
@@ -138,7 +138,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
             self.nonreg_email("cordelia"),
         ]
 
-        recipient_type_name = "private"
+        recipient_type_name = "direct"
         client = get_client("jabber_mirror")
 
         mirror_sender = create_mirrored_message_users(

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -28,7 +28,7 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
     def test_process_success_response(self) -> None:
         event = dict(
             user_profile_id=99,
-            message=dict(type="private"),
+            message=dict(type="direct"),
         )
         service_handler = self.handler
 
@@ -180,7 +180,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
                 "sender_realm_str": "zulip",
                 "timestamp": 1529821610,
                 "sender_email": "cordelia@zulip.com",
-                "type": "private",
+                "type": "direct",
                 "sender_realm_id": 1,
                 "id": 219,
                 TOPIC_NAME: "test",

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1801,7 +1801,7 @@ class TestGetAPNsPayload(PushNotificationTest):
             "custom": {
                 "zulip": {
                     "message_ids": [message.id],
-                    "recipient_type": "private",
+                    "recipient_type": "direct",
                     "sender_email": self.sender.email,
                     "sender_id": self.sender.id,
                     "server": settings.EXTERNAL_HOST,
@@ -1836,7 +1836,7 @@ class TestGetAPNsPayload(PushNotificationTest):
             "custom": {
                 "zulip": {
                     "message_ids": [message.id],
-                    "recipient_type": "private",
+                    "recipient_type": "direct",
                     "pm_users": ",".join(
                         str(user_profile_id)
                         for user_profile_id in sorted(
@@ -2009,7 +2009,7 @@ class TestGetAPNsPayload(PushNotificationTest):
             "custom": {
                 "zulip": {
                     "message_ids": [message.id],
-                    "recipient_type": "private",
+                    "recipient_type": "direct",
                     "pm_users": ",".join(
                         str(user_profile_id)
                         for user_profile_id in sorted(
@@ -2127,7 +2127,7 @@ class TestGetGCMPayload(PushNotificationTest):
                 "sender_email": hamlet.email,
                 "sender_full_name": "King Hamlet",
                 "sender_avatar_url": absolute_avatar_url(message.sender),
-                "recipient_type": "private",
+                "recipient_type": "direct",
             },
         )
         self.assertDictEqual(

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -282,7 +282,7 @@ class ReactionMessageIDTest(ZulipTestCase):
             pm_sender,
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([pm_recipient.email]).decode(),
             },
@@ -311,7 +311,7 @@ class ReactionTest(ZulipTestCase):
             pm_sender,
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([pm_recipient.email]).decode(),
             },
@@ -345,7 +345,7 @@ class ReactionTest(ZulipTestCase):
             pm_sender,
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([pm_recipient.email]).decode(),
             },
@@ -430,7 +430,7 @@ class ReactionEventTest(ZulipTestCase):
             pm_sender,
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([pm_recipient.email]).decode(),
             },
@@ -472,7 +472,7 @@ class ReactionEventTest(ZulipTestCase):
             pm_sender,
             "/api/v1/messages",
             {
-                "type": "private",
+                "type": "direct",
                 "content": "Test message",
                 "to": orjson.dumps([pm_recipient.email]).decode(),
             },

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -1098,7 +1098,7 @@ class TestDoDeleteMessages(ZulipTestCase):
             "sender": message.sender.email,
             "sender_id": message.sender_id,
             "message_id": message.id,
-            "message_type": "private",
+            "message_type": "direct",
             "recipient_id": message.recipient_id,
         }
         move_messages_to_archive([message_id])

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -411,7 +411,7 @@ class TestServiceBotConfigHandler(ZulipTestCase):
         with self.assertRaisesRegex(
             EmbeddedBotEmptyRecipientsListError, "Message must have recipients!"
         ):
-            self.bot_handler.send_message(message={"type": "private", "to": []})
+            self.bot_handler.send_message(message={"type": "direct", "to": []})
 
 
 ParamT = ParamSpec("ParamT")
@@ -578,7 +578,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             profile_ids.remove(trigger_event["user_profile_id"])
             self.assertEqual(trigger_event["trigger"], "private_message")
             self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
-            self.assertEqual(trigger_event["message"]["type"], "private")
+            self.assertEqual(trigger_event["message"]["type"], "direct")
 
         mock_queue_json_publish.side_effect = check_values_passed
 

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -562,7 +562,7 @@ class UserDraftSettingsTests(ZulipTestCase):
                 "timestamp": 15954790199,
             },
             {
-                "type": "private",
+                "type": "direct",
                 "to": [],
                 "topic": "",
                 "content": "What if made it possible to sync drafts in Zulip?",

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4471,7 +4471,7 @@ class SubscriptionAPITest(ZulipTestCase):
         realm = get_realm("zulip")
 
         # Create a private stream with Hamlet subscribed
-        stream_name = "private"
+        stream_name = "direct"
         stream = ensure_stream(realm, stream_name, invite_only=True, acting_user=None)
 
         existing_user_profile = self.example_user("hamlet")

--- a/zerver/tests/test_typing.py
+++ b/zerver/tests/test_typing.py
@@ -133,7 +133,7 @@ class TypingValidateToArgumentsTest(ZulipTestCase):
 
 class TypingHappyPathTestPMs(ZulipTestCase):
     def test_valid_type_and_op_parameters(self) -> None:
-        recipient_type_name = ["direct", "private"]
+        recipient_type_name = ["direct", "direct"]
         operator_type = ["start", "stop"]
         sender = self.example_user("hamlet")
         recipient_user = self.example_user("othello")

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -930,7 +930,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
                 self.assertIn(content_disposition, response["Content-disposition"])
             else:
                 self.assertIn("inline;", response["Content-disposition"])
-            self.assertEqual(set(response["Cache-Control"].split(", ")), {"private", "immutable"})
+            self.assertEqual(set(response["Cache-Control"].split(", ")), {"direct", "immutable"})
 
         check_xsend_links("zulip.txt", "zulip.txt", 'filename="zulip.txt"')
         check_xsend_links(

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -971,7 +971,7 @@ def process_message_event(
 
         # If the recipient was offline and the message was a single or group PM to them
         # or they were @-notified potentially notify more immediately
-        private_message = recipient_type_name == "private"
+        private_message = recipient_type_name == "direct"
         user_notifications_data = UserMessageNotificationsData.from_user_id_sets(
             user_id=user_profile_id,
             flags=flags,

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -55,7 +55,7 @@ def create_mirrored_message_users(
 ) -> UserProfile:
     sender_email = sender.strip().lower()
     referenced_users = {sender_email}
-    if recipient_type_name == "private":
+    if recipient_type_name == "direct":
         for email in recipients:
             referenced_users.add(email.lower())
 
@@ -212,10 +212,10 @@ def send_message_backend(
 ) -> HttpResponse:
     recipient_type_name = req_type
     if recipient_type_name == "direct":
-        # For now, use "private" from Message.API_RECIPIENT_TYPES.
+        # For now, use "direct" from Message.API_RECIPIENT_TYPES.
         # TODO: Use "direct" here, as well as in events and
         # message (created, schdeduled, drafts) objects/dicts.
-        recipient_type_name = "private"
+        recipient_type_name = "direct"
 
     # If req_to is None, then we default to an
     # empty list of recipients.
@@ -266,7 +266,7 @@ def send_message_backend(
         # same-realm constraint.
         if req_sender is None:
             raise JsonableError(_("Missing sender"))
-        if recipient_type_name != "private" and not can_forge_sender:
+        if recipient_type_name != "direct" and not can_forge_sender:
             raise JsonableError(_("User not authorized for this query"))
 
         # For now, mirroring only works with recipient emails, not for

--- a/zerver/views/typing.py
+++ b/zerver/views/typing.py
@@ -31,7 +31,7 @@ def send_notification_backend(
         raise JsonableError(_("Empty 'to' list"))
 
     recipient_type_name = req_type
-    if recipient_type_name == "private":
+    if recipient_type_name == "direct":
         # TODO: Use "direct" in typing notification events.
         recipient_type_name = "direct"
 

--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -110,7 +110,7 @@ Requester Bob <requester-bob@example.com> added a {} note to \
         )
 
     def test_private_note_change(self) -> None:
-        self.note_change("private_note", "private")
+        self.note_change("private_note", "direct")
 
     def test_public_note_change(self) -> None:
         self.note_change("public_note", "public")

--- a/zerver/webhooks/gosquared/view.py
+++ b/zerver/webhooks/gosquared/view.py
@@ -48,7 +48,7 @@ def api_gosquared_webhook(
     # Live chat message event
     elif payload.get("message") is not None and payload.get("person") is not None:
         # Only support non-private messages
-        if not payload["message"]["private"].tame(check_bool):
+        if not payload["message"]["direct"].tame(check_bool):
             session_title = payload["message"]["session"]["title"].tame(check_string)
             topic = f"Live chat session - {session_title}"
             body = CHAT_MESSAGE_TEMPLATE.format(


### PR DESCRIPTION
<!-- Describe your pull request here.-->
I updated the message types as direct instead of private on every file that I think was important that it changed. I did not change the name of the functions, just the types from private to direct, even in the tests.
Fixes: <!-- Issue link, or clear description.-->
#25251 
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
