### PR TITLE
settings: Close date-picker when settings modal is closed.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -34,6 +34,16 @@ async function open_settings(page: Page): Promise<void> {
     );
 }
 
+async function close_settings_and_date_picker(page: Page): Promise<void> {
+    const date_picker_selector = ".custom_user_field_value.datepicker.form-control";
+    await page.click(date_picker_selector);
+
+    await page.waitForSelector(".flatpickr-calendar", {visible: true});
+
+    await page.keyboard.press("Escape");
+    await page.waitForSelector(".flatpickr-calendar", {hidden: true});
+}
+
 async function test_change_full_name(page: Page): Promise<void> {
     await page.click("#full_name");
 
@@ -438,6 +448,8 @@ async function test_notifications_section(page: Page): Promise<void> {
 
 async function settings_tests(page: Page): Promise<void> {
     await common.log_in(page);
+    await open_settings(page);
+    await close_settings_and_date_picker(page);
     await open_settings(page);
     await test_change_full_name(page);
     await test_alert_words_section(page);

--- a/web/src/flatpickr.js
+++ b/web/src/flatpickr.js
@@ -134,3 +134,7 @@ export function show_flatpickr(element, callback, default_timestamp, options = {
 
     return instance;
 }
+
+export function close_all() {
+    $(".flatpickr-calendar").removeClass("open");
+}

--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -7,6 +7,7 @@ import render_settings_tab from "../templates/settings_tab.hbs";
 
 import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
+import * as flatpickr from "./flatpickr";
 import {$t, $t_html} from "./i18n";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
@@ -128,6 +129,7 @@ export function open_settings_overlay() {
         $overlay: $("#settings_overlay_container"),
         on_close() {
             browser_history.exit_overlay();
+            flatpickr.close_all();
         },
     });
 }


### PR DESCRIPTION
When the user has a date-picker on the screen in the settings menu and if the user closes the settings modal using the `Esc` key then the date-picker does not go away instead it is still there on the screen. 

This PR adds the code to remove the date-picker when the settings modal is closed.

Fixes part of #25097. 

CZO Discussion [Link](https://chat.zulip.org/#narrow/stream/9-issues/topic/Date.20picker.20bug)

<hr>


**Screenshots and screen captures:**


<details>

<summary>Before</summary>

[Before.webm](https://user-images.githubusercontent.com/35286603/234287344-0dbe523b-698c-4b0e-ac72-91e99edeb909.webm)

</details>

<details>

<summary>After</summary>

[After.webm](https://user-images.githubusercontent.com/35286603/234287363-083bd167-436b-4ee3-8950-3b95166418fe.webm)

</details>

<hr>

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
