### PR TITLE
portico: Add Atolio case study

### DIFF
--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -95,6 +95,11 @@ landing_page_urls = [
         {"template_name": "corporate/case-studies/end-point-case-study.html"},
     ),
     path(
+        "case-studies/atolio/",
+        landing_view,
+        {"template_name": "corporate/case-studies/atolio-case-study.html"},
+    ),
+    path(
         "case-studies/tum/",
         landing_view,
         {"template_name": "corporate/case-studies/tum-case-study.html"},

--- a/templates/corporate/case-studies/atolio-case-study.html
+++ b/templates/corporate/case-studies/atolio-case-study.html
@@ -1,0 +1,37 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
+
+{% set PAGE_TITLE = "Case study: Atolio | Zulip" %}
+
+{% set PAGE_DESCRIPTION = "Learn how Zulip helps create an open communication
+  culture at Atolio, a distributed tech startup." %}
+
+{% block customhead %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{% endblock %}
+
+{% block portico_content %}
+
+{% include 'zerver/landing_nav.html' %}
+
+<div class="portico-landing why-page solutions-page case-study-page">
+    <div class="hero bg-education">
+        <div class="bg-dimmer"></div>
+        <div class="content">
+            <h1 class="center">Case study: Atolio</h1>
+            <p>Distributed startup</p>
+        </div>
+        <div class="hero-text">
+            Learn more about using Zulip for <a href="/for/business/">business</a>.
+        </div>
+    </div>
+    <div class="main">
+        <div class="padded-content">
+            <div class="inner-content markdown">
+                {{ render_markdown_path('corporate/case-studies/atolio-case-study.md') }}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/corporate/case-studies/atolio-case-study.md
+++ b/templates/corporate/case-studies/atolio-case-study.md
@@ -1,0 +1,118 @@
+Founded in 2019 by a seasoned team of engineering and sales leaders, Atolio is a
+small startup with big ambitions to radically improve the way people deal with
+information at work. They have deep expertise in what it takes to [empower teams
+to collaborate effectively](/why-zulip/), and have thought hard about how to
+enable effective collaboration for their own team.
+
+> “The first-class threads in Zulip are absolutely critical to how we work.  As
+> a fully distributed company, we needed a modern way to support the different
+> ways people work, while ensuring that everyone can find the current and
+> historical topics that are important to them.  So many people on Hacker News
+> talk about using Zulip - I'm so glad we joined them!”
+>
+> — David Lanstein, co-founder and CEO of [Atolio](https://www.atolio.com/)
+
+
+## Taking the opportunity to pick the best collaboration tools
+
+Atolio’s founders set out to build a fully distributed company from the get-go,
+and they knew how important it would be to choose the right set of collaboration
+tools. “We had all used Slack, Jira and Confluence before, but we didn’t want to
+default to those options,” says Atolio’s co-founder and CTO Gareth Watts. “We
+wanted to take the opportunity to pick the best tools for our future team.”
+
+As past users of Slack’s team chat, Atolio’s founders were well aware of its
+downsides. "Slack is an extremely noisy environment. It’s very difficult to keep
+up with what your colleagues are doing, and it’s hard to separate chitchat from
+what’s important,” says Atolio’s CTO Gareth Watts. “Information in Slack’s
+threads ends up being even more hidden than other messages.”
+
+Thus the search was on to find a team chat tool that would truly serve Atolio’s
+needs. “We didn’t want Slack,” Gareth says. “We wanted a tool designed for
+asynchronous distributed communication, and Zulip seemed to fit the bill.”
+
+> "Slack is an extremely noisy environment. It’s very difficult to keep up with
+> what your colleagues are doing.”
+>
+> — Gareth Watts, co-founder and CTO of [Atolio](https://www.atolio.com/)
+
+## Trying out Zulip’s open-source team chat
+
+Beyond Zulip’s [topic-based threading model](/why-zulip/), Atolio’s team felt
+confident that they could [count on Zulip in the coming years](/values/) as they
+built out their company. “We liked that Zulip is an open-source tool with a
+[huge community](/team/) around it,” Atolio’s CTO Gareth Watts explains. “We are
+using Zulip Cloud, but if we want, we can export our data and
+[self-host](/self-hosting/) our own Zulip server. So we know Zulip will always
+be there for us.”
+
+Having decided to test out Zulip, Atolio’s founders realized that they should go
+all-in on a trial period. “We decided to turn off all other chat tools and try
+Zulip for a full month,” Gareth says. This way, the team could really see how
+Zulip would fit into the company’s communication patterns and workflows after an
+initial adjustment period. “After that, we could discuss if it wasn’t working
+out,” says Gareth. “But as it turned out, we never looked back.”
+
+> “We decided to turn off all other chat tools and try Zulip for a full month…
+> We never looked back.”
+>
+> — Gareth Watts, co-founder and CTO of [Atolio](https://www.atolio.com/)
+
+## “Zulip is at the core of our business”
+
+Since February 2020, Zulip has been the primary tool for internal communication
+at Atolio. “Zulip is at the core of our business,” Atolio’s CTO Gareth Watts
+explains. The team has always been able to rely on this crucial piece of company
+infrastructure. “The Zulip Cloud hosting has been bulletproof — we haven’t had
+any down time,” says Gareth.
+
+Zulip’s organized team chat has enabled Atolio to create the open communication
+culture the founders wanted. “Zulip lets us have conversations in public, not
+behind closed doors,” Gareth explains. “In Slack, two thirds of communication is
+not in public just to avoid noise. In Zulip, you can talk about what you want —
+you just give everything its own topic.”
+
+> “In Zulip, it’s super easy to find things 24 hours later if you weren’t online
+> when a discussion happened.”
+>
+> — Gareth Watts, co-founder and CTO of [Atolio](https://www.atolio.com/)
+
+Atolio’s distributed team also uses Zulip to build personal connections. With
+each conversation getting its own space in a dedicated topic, team members can
+share pictures of their cats or GIPHY memes without disrupting serious work
+discussions. And if a topic ever goes off on a tangent, it’s easy to split it in
+two and continue from there.
+
+When new team members join the company, the onboarding process welcomes them to
+Zulip and the company’s communication culture. An internal Wiki introduces
+Zulip’s [topic-based threading](/help/streams-and-topics), [search
+tools](/help/search-for-messages), and some handy [keyboard
+shortcuts](/help/keyboard-shortcuts), with pointers to [Zulip’s help
+center](/help/) for more information. Gareth hasn’t seen much difference between
+onboarding to Zulip compared to other team chat tools: “If someone hasn’t used
+Slack before, they need onboarding too.”
+
+> “Zulip lets us have conversations in public, not behind closed doors.”
+>
+> — Gareth Watts, co-founder and CTO of [Atolio](https://www.atolio.com/)
+
+## Easy to integrate
+
+To make Zulip a central hub for updates about what’s happening, Atolio has
+integrated Zulip with its engineering tools. In a #tickets stream, a topic is
+created automatically for each ticket, so there is a dedicated space to discuss
+the issue at hand. There are topics in other Zulip streams for automated
+deployment announcements, and for bot posts when pull requests are opened or
+merged.
+
+Atolio has also [connected Zulip](https://www.atolio.com/connectors/) to their
+own unified search product. “Writing against the [Zulip APIs](/api/) has not
+been hard,” Gareth says. “And since it’s open-source, we can always [read the
+source code](https://github.com/zulip/zulip#readme) if we find the docs
+confusing.”
+
+---
+
+Check out our guide on [using Zulip for business](/for/business/). You can also
+learn how Zulip is being used at the [iDrift AS](/case-studies/idrift/) company,
+and the [End Point Dev](/case-studies/end-point/) software consultancy.

--- a/templates/corporate/case-studies/end-point-case-study.md
+++ b/templates/corporate/case-studies/end-point-case-study.md
@@ -140,5 +140,6 @@ chat apps. We love it."
 
 ---
 
-Check out our guide on [using Zulip for business](/for/business/), and learn how
-Zulip is being used at the [iDrift AS](/case-studies/idrift/) company.
+Check out our guide on [using Zulip for business](/for/business/). You can also
+learn how Zulip is being used at the [iDrift AS](/case-studies/idrift/) company,
+and the startup [Atolio](/case-studies/atolio/).

--- a/templates/corporate/case-studies/idrift-case-study.md
+++ b/templates/corporate/case-studies/idrift-case-study.md
@@ -112,6 +112,6 @@ easy to review past interactions,” Gaute Lund says.
 
 ---
 
-Check out our guide on [using Zulip for business](/for/business/), and learn how
-Zulip is being used at the [End Point Dev](/case-studies/end-point/) software
-consultancy.
+Check out our guide on [using Zulip for business](/for/business/). You can also
+learn how Zulip is being used at the [End Point Dev](/case-studies/end-point/)
+software consultancy, and the startup [Atolio](/case-studies/atolio/).

--- a/templates/corporate/for/business.html
+++ b/templates/corporate/for/business.html
@@ -21,10 +21,12 @@
         <h1 class="center">Efficient communication for your business.</h1>
         <p>Organized and inclusive threaded team chat.<br/>Free for light use!</p>
         <div class="hero-text">
-            Learn how the <a href="/case-studies/idrift/">iDrift AS company</a>
-            and the
-            <br /> <a href="/case-studies/end-point/">End Point Dev software
-            consultancy</a> are using Zulip.
+            Learn how the <a href="/case-studies/idrift/">iDrift AS</a> company,
+            <br /> the
+            <a href="/case-studies/end-point/">End Point Dev</a> software
+            consultancy,
+            <br /> and the startup <a href="/case-studies/atolio/">Atolio</a>
+            are using Zulip.
         </div>
         <div class="hero-buttons center">
             <a href="/new/" class="button">

--- a/templates/corporate/for/use-cases.md
+++ b/templates/corporate/for/use-cases.md
@@ -11,6 +11,7 @@
 
 * [iDrift AS company](/case-studies/idrift/)
 * [End Point Dev software consultancy](/case-studies/end-point/)
+* [Atolio startup](/case-studies/atolio/)
 * [Technical University of Munich](/case-studies/tum/)
 * [University of California San Diego](/case-studies/ucsd/)
 * [Lean theorem prover community](/case-studies/lean/)

--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -56,8 +56,21 @@
                     <div class="top-menu-submenu-column">
                         <span class="top-menu-submenu-section">CUSTOMER STORIES</span>
                         <ul class="top-menu-submenu-list">
-                            <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/idrift/">Efficient distributed team management at iDrift AS</a></li>
-                            <li class="top-menu-submenu-list-item"><a href="/case-studies/end-point/">Managing hundreds of projects at End Point Dev</a></li>
+                            <li class="top-menu-submenu-list-item">
+                                <a href="https://zulip.com/case-studies/idrift/">
+                                Efficient distributed team management at iDrift AS
+                                </a>
+                            </li>
+                            <li class="top-menu-submenu-list-item">
+                                <a href="/case-studies/end-point/">
+                                Managing hundreds of projects at End Point Dev
+                                </a>
+                            </li>
+                            <li class="top-menu-submenu-list-item">
+                                <a href="/case-studies/atolio/">
+                                Open distributed communication at Atolio
+                                </a>
+                            </li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/tum/">Organized chat for 1000s of students at TUM</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/ucsd/">Communication hub across 6 continents at UCSD</a></li>
                             <li class="top-menu-submenu-list-item"><a href="https://zulip.com/case-studies/lean/">Research collaboration at scale in the Lean mathematical community</a></li>

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -213,6 +213,7 @@ class DocPageTest(ZulipTestCase):
         self._test("/case-studies/lean/", "Lean theorem prover")
         self._test("/case-studies/idrift/", "Case study: iDrift AS")
         self._test("/case-studies/end-point/", "Case study: End Point")
+        self._test("/case-studies/atolio/", "Case study: Atolio")
         self._test("/case-studies/asciidoctor/", "Case study: Asciidoctor")
         # <meta name="robots" content="noindex,nofollow" /> always true on these pages
         self._test("/attribution/", "Website attributions", search_disabled=True)


### PR DESCRIPTION
Testing:
- Clicked on links
- Tested top banner area on narrow screens for /for/business and /case-studies/atolio.

Highlight for review:
- All the link names, especially in the top nav
- Subtitle and PAGE_DESCRIPTION on the new page
- Wording for links to other business case studies (bottom of case study pages). In particular, I worry a bit that it's not clear that we're linking to a case study, as opposed to the company's home page. We can increase how much of the text is in the link; not sure if that would help.

Follow-ups:
- Figure out which quote(s) to feature on other pages

<details>
<summary>
Top nav screenshot
</summary>

![Screen Shot 2023-04-26 at 1 21 12 PM](https://user-images.githubusercontent.com/2090066/234694373-c8c87ecb-bac5-4691-86fc-9c7e63ee9600.png)

</details>

<details>
<summary>
Screenshots of changes on other pages
</summary>

![Screen Shot 2023-04-26 at 1 21 01 PM](https://user-images.githubusercontent.com/2090066/234694173-34adef2a-1a4b-47be-97b7-211bd063d4c3.png)

![Screen Shot 2023-04-26 at 1 22 11 PM](https://user-images.githubusercontent.com/2090066/234694146-9cf0b8d4-7207-4749-86fc-a51616732796.png)

![Screen Shot 2023-04-26 at 1 22 02 PM](https://user-images.githubusercontent.com/2090066/234694149-6a78654b-d4fc-41c8-a80d-3f18205d743e.png)

![Screen Shot 2023-04-26 at 1 26 02 PM](https://user-images.githubusercontent.com/2090066/234694293-7a39e190-f1fe-4888-a35c-61f3a54613bc.png)


</details>