### PR TITLE
wal-g: Write out a logfile.

### DIFF
--- a/puppet/zulip/files/cron.d/pg-backup-and-purge
+++ b/puppet/zulip/files/cron.d/pg-backup-and-purge
@@ -1,3 +1,3 @@
 PATH=/bin:/usr/bin:/usr/local/bin
 
-0 2 * * * postgres /usr/local/bin/pg_backup_and_purge
+0 2 * * * postgres /usr/local/bin/pg_backup_and_purge >/var/log/pg_backup_and_purge.log 2>&1

--- a/puppet/zulip/manifests/postgresql_backups.pp
+++ b/puppet/zulip/manifests/postgresql_backups.pp
@@ -4,6 +4,12 @@ class zulip::postgresql_backups {
   include zulip::postgresql_common
   include zulip::wal_g
 
+  file { '/var/log/pg_backup_and_purge.log':
+    ensure => file,
+    owner  => 'postgres',
+    group  => 'postgres',
+    mode   => '0644',
+  }
   file { '/usr/local/bin/pg_backup_and_purge':
     ensure  => file,
     owner   => 'root',
@@ -38,7 +44,10 @@ class zulip::postgresql_backups {
     group   => 'root',
     mode    => '0644',
     source  => 'puppet:///modules/zulip/cron.d/pg-backup-and-purge',
-    require => File['/usr/local/bin/pg_backup_and_purge'],
+    require => [
+      File['/var/log/pg_backup_and_purge.log'],
+      File['/usr/local/bin/pg_backup_and_purge'],
+    ],
   }
 
   file { "${zulip::common::nagios_plugins_dir}/zulip_postgresql_backups":


### PR DESCRIPTION
Otherwise, this output goes into `/var/spool/mail/postgres`, which is not terribly helpful.  We do not write to `/var/log/zulip` because the backup runs as the `postgres` user, and `/var/log/zulip` is owned by zulip and chmod 750.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
