### PR TITLE
left-sidebar: Provide link to scheduled messages.

### DIFF
--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -66,6 +66,16 @@
                 </template>
                 <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
+            <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
+                <a href="#scheduled">
+                    <span class="filter-icon">
+                        <i class="fa fa-calendar" aria-hidden="true"></i>
+                    </span>
+                    {{~!-- squash whitespace --~}}
+                    <span>{{t 'Scheduled messages' }}</span>
+                    <span class="unread_count"></span>
+                </a>
+            </li>
         </ul>
     </div>
 


### PR DESCRIPTION
This provides a basic link to view scheduled messages. At present, the link is always visible, and it does not yet include a scheduled-message count.

There is [a discussion about a proper icon on CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/view.20scheduled.20messages/near/1556366), but for now I have used the basic calendar icon from FontAwesome. See the screenshot below.

While I have included the translation-string syntax, I don't understand how that system works yet, so I might need guidance.

<!-- Describe your pull request here.-->

Fixes part of: #25101 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="300" alt="Screen capture showing link and calendar icon" src="https://user-images.githubusercontent.com/170719/234708106-7dd75194-7910-49c6-8791-c2f4c1d6c0da.png">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
