### PR TITLE
ts: Migrate `scroll_util.js` to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -149,7 +149,7 @@ EXEMPT_FILES = make_set(
         "web/src/scheduled_messages.js",
         "web/src/scheduled_messages_overlay_ui.js",
         "web/src/scroll_bar.ts",
-        "web/src/scroll_util.js",
+        "web/src/scroll_util.ts",
         "web/src/search_pill_widget.js",
         "web/src/sent_messages.js",
         "web/src/sentry.ts",

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -3,6 +3,8 @@ import $ from "jquery";
 import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 import render_stream_does_not_exist_error from "../templates/compose_banner/stream_does_not_exist_error.hbs";
 
+import * as scroll_util from "./scroll_util";
+
 export let scroll_to_message_banner_message_id: number | null = null;
 export function set_scroll_to_message_banner_message_id(val: number | null): void {
     scroll_to_message_banner_message_id = val;
@@ -48,6 +50,10 @@ export const CLASSNAMES = {
     generic_compose_error: "generic_compose_error",
     user_not_subscribed: "user_not_subscribed",
 };
+
+export function append_compose_banner_to_banner_list(new_row: HTMLElement): void {
+    scroll_util.get_content_element($("#compose_banners")).append(new_row);
+}
 
 export function clear_message_sent_banners(include_unmute_banner = true): void {
     for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -15,7 +15,6 @@ import {$t} from "./i18n";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as people from "./people";
-import * as scroll_util from "./scroll_util";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
@@ -25,10 +24,6 @@ let user_acknowledged_wildcard = false;
 let wildcard_mention;
 
 export let wildcard_mention_large_stream_threshold = 15;
-
-export function append_compose_banner_to_banner_list(new_row) {
-    scroll_util.get_content_element($("#compose_banners")).append(new_row);
-}
 
 export function needs_subscribe_warning(user_id, stream_id) {
     // This returns true if all of these conditions are met:
@@ -110,7 +105,7 @@ export function warn_if_private_stream_is_linked(linked_stream) {
         classname: compose_banner.CLASSNAMES.private_stream_warning,
     });
 
-    append_compose_banner_to_banner_list(new_row);
+    compose_banner.append_compose_banner_to_banner_list(new_row);
 }
 
 export function warn_if_mentioning_unsubscribed_user(mentioned) {
@@ -166,7 +161,7 @@ export function warn_if_mentioning_unsubscribed_user(mentioned) {
             };
 
             const new_row = render_not_subscribed_warning(context);
-            append_compose_banner_to_banner_list(new_row);
+            compose_banner.append_compose_banner_to_banner_list(new_row);
         }
     }
 }
@@ -226,7 +221,7 @@ export function warn_if_topic_resolved(topic_changed) {
         };
 
         const new_row = render_compose_banner(context);
-        append_compose_banner_to_banner_list(new_row);
+        compose_banner.append_compose_banner_to_banner_list(new_row);
         compose_state.set_recipient_viewed_topic_resolved_banner(true);
     } else {
         clear_topic_resolved_warning();
@@ -249,7 +244,7 @@ function show_wildcard_warnings(stream_id) {
 
     // only show one error for any number of @all or @everyone mentions
     if ($(`#compose_banners .${CSS.escape(classname)}`).length === 0) {
-        append_compose_banner_to_banner_list(wildcard_template);
+        compose_banner.append_compose_banner_to_banner_list(wildcard_template);
     }
 
     user_acknowledged_wildcard = false;
@@ -424,7 +419,7 @@ export function validation_error(error_type, stream_name) {
                 // closing the banner would be more confusing than helpful.
                 hide_close_button: true,
             });
-            append_compose_banner_to_banner_list(new_row);
+            compose_banner.append_compose_banner_to_banner_list(new_row);
             return false;
         }
     }

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -7,7 +7,6 @@ import * as alert_words from "./alert_words";
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as compose_banner from "./compose_banner";
-import * as compose_validate from "./compose_validate";
 import * as favicon from "./favicon";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
@@ -179,7 +178,7 @@ function notify_unmute(muted_narrow, stream_id, topic_name) {
         }),
     );
     compose_banner.clear_unmute_topic_notifications();
-    compose_validate.append_compose_banner_to_banner_list($unmute_notification);
+    compose_banner.append_compose_banner_to_banner_list($unmute_notification);
 }
 
 export function notify_above_composebox(
@@ -201,7 +200,7 @@ export function notify_above_composebox(
     // We pass in include_unmute_banner as false because we don't want to
     // clear any unmute_banner associated with this same message.
     compose_banner.clear_message_sent_banners(false);
-    compose_validate.append_compose_banner_to_banner_list($notification);
+    compose_banner.append_compose_banner_to_banner_list($notification);
 }
 
 if (window.electron_bridge !== undefined) {

--- a/web/src/scroll_util.ts
+++ b/web/src/scroll_util.ts
@@ -1,7 +1,10 @@
 import $ from "jquery";
 import SimpleBar from "simplebar";
 
-export function get_content_element($element) {
+// This type is helpful for testing, where we may have a dummy object instead of an actual jquery object.
+type JQueryOrZJQuery = {__zjquery?: true} & JQuery;
+
+export function get_content_element($element: JQuery): JQuery {
     const element = $element.expectOne()[0];
     const sb = SimpleBar.instances.get(element);
     if (sb) {
@@ -10,9 +13,9 @@ export function get_content_element($element) {
     return $element;
 }
 
-export function get_scroll_element($element) {
+export function get_scroll_element($element: JQueryOrZJQuery): JQuery {
     // For testing we just return the element itself.
-    if ($element && $element.__zjquery) {
+    if ($element?.__zjquery) {
         return $element;
     }
 
@@ -23,12 +26,12 @@ export function get_scroll_element($element) {
     } else if ("simplebar" in element.dataset) {
         // The SimpleBar mutation observer hasn’t processed this element yet.
         // Create the SimpleBar early in case we need to add event listeners.
-        return $(new SimpleBar(element).getScrollElement());
+        return $(new SimpleBar(element).getScrollElement()!);
     }
     return $element;
 }
 
-export function reset_scrollbar($element) {
+export function reset_scrollbar($element: JQuery): void {
     const element = $element.expectOne()[0];
     const sb = SimpleBar.instances.get(element);
     if (sb) {
@@ -38,7 +41,11 @@ export function reset_scrollbar($element) {
     }
 }
 
-export function scroll_delta(opts) {
+export function scroll_delta(opts: {
+    elem_top: number;
+    elem_bottom: number;
+    container_height: number;
+}): number {
     const elem_top = opts.elem_top;
     const container_height = opts.container_height;
     const elem_bottom = opts.elem_bottom;
@@ -58,16 +65,19 @@ export function scroll_delta(opts) {
     return delta;
 }
 
-export function scroll_element_into_container($elem, $container, sticky_header_height = 0) {
+export function scroll_element_into_container(
+    $elem: JQuery,
+    $container: JQuery,
+    sticky_header_height = 0,
+): void {
     // This does the minimum amount of scrolling that is needed to make
     // the element visible.  It doesn't try to center the element, so
     // this will be non-intrusive to users when they already have
     // the element visible.
-
     $container = get_scroll_element($container);
     const elem_top = $elem.position().top - sticky_header_height;
-    const elem_bottom = elem_top + $elem.innerHeight();
-    const container_height = $container.height() - sticky_header_height;
+    const elem_bottom = elem_top + ($elem.innerHeight() ?? 0);
+    const container_height = ($container.height() ?? 0) - sticky_header_height;
 
     const opts = {
         elem_top,
@@ -81,5 +91,5 @@ export function scroll_element_into_container($elem, $container, sticky_header_h
         return;
     }
 
-    $container.scrollTop($container.scrollTop() + delta);
+    $container.scrollTop(($container.scrollTop() ?? 0) + delta);
 }

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -5,9 +5,9 @@ import $ from "jquery";
 import render_upload_banner from "../templates/compose_banner/upload_banner.hbs";
 
 import * as compose_actions from "./compose_actions";
+import * as compose_banner from "./compose_banner";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
-import * as compose_validate from "./compose_validate";
 import {csrf_token} from "./csrf";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
@@ -123,10 +123,10 @@ function add_upload_banner(config, banner_type, banner_text, file_id) {
         banner_text,
         file_id,
     });
-    // TODO: Extend compose_validate.append_compose_banner_to_banner_list
+    // TODO: Extend compose_banner.append_compose_banner_to_banner_list
     // to support the message edit container too.
     if (config.mode === "compose") {
-        compose_validate.append_compose_banner_to_banner_list(new_banner);
+        compose_banner.append_compose_banner_to_banner_list(new_banner);
     } else {
         get_item("banner_container", config).append(new_banner);
     }


### PR DESCRIPTION
This PR contains two commits:
1) Migrating `scroll_util` to TypeScript.
2) Moved `append_compose_banner_to_banner_list` from `compose_validate.js` to `compose_banner.ts`.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
