### PR TITLE
typeahead: Always show exact matches first for streams and users.

### DIFF
--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -113,6 +113,7 @@ export function triage<T>(
     query: string,
     objs: T[],
     get_item: (x: T) => string,
+    sorting_comparator?: () => number,
 ): {matches: T[]; rest: T[]} {
     /*
         We split objs into four groups:
@@ -145,6 +146,17 @@ export function triage<T>(
         } else {
             noMatch.push(obj);
         }
+    }
+
+    if (sorting_comparator) {
+        const non_exact_sorted_matches = [
+            ...beginswithCaseSensitive,
+            ...beginswithCaseInsensitive,
+        ].sort(sorting_comparator);
+        return {
+            matches: [...exactMatch, ...non_exact_sorted_matches],
+            rest: noMatch.sort(sorting_comparator),
+        };
     }
     return {
         matches: [...exactMatch, ...beginswithCaseSensitive, ...beginswithCaseInsensitive],

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -220,10 +220,24 @@ const netherland_stream = {
     stream_id: 3,
     subscribed: false,
 };
+const mobile_stream = {
+    name: "Mobile",
+    description: "Mobile development",
+    stream_id: 4,
+    subscribed: false,
+};
+const mobile_team_stream = {
+    name: "Mobile team",
+    description: "Mobile development team",
+    stream_id: 5,
+    subscribed: true,
+};
 
 stream_data.add_sub(sweden_stream);
 stream_data.add_sub(denmark_stream);
 stream_data.add_sub(netherland_stream);
+stream_data.add_sub(mobile_stream);
+stream_data.add_sub(mobile_team_stream);
 
 const name_to_codepoint = {};
 for (const [key, val] of emojis_by_name.entries()) {
@@ -244,6 +258,12 @@ emoji.initialize({
 });
 emoji.active_realm_emojis = new Map();
 emoji.emojis_by_name = emojis_by_name;
+
+const ali = {
+    email: "ali@zulip.com",
+    user_id: 98,
+    full_name: "Ali",
+};
 
 const alice = {
     email: "alice@zulip.com",
@@ -346,6 +366,7 @@ function test(label, f) {
         people.init();
         user_groups.init();
 
+        people.add_active_user(ali);
         people.add_active_user(alice);
         people.add_active_user(hamlet);
         people.add_active_user(othello);
@@ -785,6 +806,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         // This should match the users added at the beginning of this test file.
         let actual_value = options.source("");
         let expected_value = [
+            ali,
             alice,
             cordelia,
             hal,
@@ -865,6 +887,11 @@ test("initialize", ({override, override_rewire, mock_template}) => {
         query = "othello";
         actual_value = sorter(query, [othello]);
         expected_value = [othello];
+        assert.deepEqual(actual_value, expected_value);
+
+        query = "Ali";
+        actual_value = sorter(query, [alice, ali]);
+        expected_value = [ali, alice];
         assert.deepEqual(actual_value, expected_value);
 
         // A literal match at the beginning of an element puts it at the top.
@@ -1511,7 +1538,7 @@ test("filter_and_sort_mentions (normal)", () => {
     const suggestions = ct.filter_and_sort_mentions(is_silent, "al");
 
     const mention_all = ct.broadcast_mentions()[0];
-    assert.deepEqual(suggestions, [mention_all, alice, hal, call_center]);
+    assert.deepEqual(suggestions, [mention_all, ali, alice, hal, call_center]);
 });
 
 test("filter_and_sort_mentions (silent)", () => {
@@ -1519,11 +1546,17 @@ test("filter_and_sort_mentions (silent)", () => {
 
     const suggestions = ct.filter_and_sort_mentions(is_silent, "al");
 
-    assert.deepEqual(suggestions, [alice, hal, call_center]);
+    assert.deepEqual(suggestions, [ali, alice, hal, call_center]);
 });
 
 test("typeahead_results", () => {
-    const stream_list = [denmark_stream, sweden_stream, netherland_stream];
+    const stream_list = [
+        denmark_stream,
+        sweden_stream,
+        netherland_stream,
+        mobile_team_stream,
+        mobile_stream,
+    ];
 
     function compose_typeahead_results(completing, items, token) {
         return ct.filter_and_sort_candidates(completing, items, token);
@@ -1645,6 +1678,8 @@ test("typeahead_results", () => {
     // Do not match stream descriptions
     assert_stream_matches("cold", []);
     assert_stream_matches("city", []);
+    // Always prioritise exact matches, irrespective of activity
+    assert_stream_matches("Mobile", [mobile_stream, mobile_team_stream]);
 });
 
 test("message people", ({override, override_rewire}) => {
@@ -1733,10 +1768,22 @@ test("PM recipients sorted according to stream / topic being viewed", ({override
     // When viewing no stream, sorting is alphabetical
     compose_state.set_stream_name("");
     results = ct.get_pm_people("li");
-    assert.deepEqual(results, [alice, cordelia]);
+    assert.deepEqual(results, [ali, alice, cordelia]);
 
-    // When viewing denmark stream, subscriber twin2 is placed higher
+    // When viewing denmark stream, subscriber cordelia is placed higher
     compose_state.set_stream_name("Denmark");
     results = ct.get_pm_people("li");
-    assert.deepEqual(results, [cordelia, alice]);
+    assert.deepEqual(results, [cordelia, ali, alice]);
+
+    // Simulating just alice being subscribed to denmark.
+    override_rewire(
+        stream_data,
+        "is_user_subscribed",
+        (stream_id, user_id) => stream_id === denmark_stream.stream_id && user_id === alice.user_id,
+    );
+
+    // When viewing denmark stream to which alice is subscribed, ali is still
+    // 1st by virtue of the name being an exact match with the query.
+    results = ct.get_pm_people("ali");
+    assert.deepEqual(results, [ali, alice]);
 });


### PR DESCRIPTION
We refactor the triage function to optionally take in a comparator function, and use this to sort the results, except any exact match, which is placed highest. Now we don't need to sort the results of triage for streams, languages and slash commands since we just pass in the comparator function. The overall effect is same as before, except that exact matches are always shown first.

For users, since those are sorted in a complex way, we just find any exact matches and place them at the top of the list post all the sorting.

Fixes: #25123.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Normal order according to activity when there's no exact match:
![image](https://user-images.githubusercontent.com/68962290/234817926-ba05eba0-ec3a-4595-a45d-c3002a07e03c.png)

In case of exact match, even an unsubscribed stream comes up 1st (user is not subscribed to #support):
![image](https://user-images.githubusercontent.com/68962290/234818046-6291225e-4b84-4132-b3f0-defab9eead44.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
