### PR TITLE
emails: Fix some css not being applied to emails.

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -147,8 +147,8 @@ p.digest_paragraph,
 .sponsorship_request_link:hover,
 .support_request_link:hover,
 .email-preferences a:hover,
-.missed_message.no_content a:hover {
-    color: #434388;
+.missed_message.no_content-explanation a:hover {
+    color: #434388 !important;
 }
 
 .important {

--- a/templates/zerver/emails/email_base_default.html
+++ b/templates/zerver/emails/email_base_default.html
@@ -1,10 +1,12 @@
 {% import 'zerver/emails/macros.html' as  macros %}
+{% import 'zerver/emails/email.css' as css_styles %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
         <meta name="viewport" content="width=device-width" />
         <meta charset="UTF-8" />
         <title>Zulip</title>
+        <style>{{css_styles}}</style>
     </head>
     <body>
         <table border="0" cellpadding="0" cellspacing="0" class="body layout">

--- a/templates/zerver/emails/email_base_marketing.html
+++ b/templates/zerver/emails/email_base_marketing.html
@@ -1,10 +1,12 @@
 {% import 'zerver/emails/macros.html' as  macros %}
+{% import 'zerver/emails/email.css' as css_styles %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
         <meta name="viewport" content="width=device-width" />
         <meta charset="UTF-8" />
         <title>Zulip</title>
+        <style>{{css_styles}}</style>
     </head>
     <body>
         <table border="0" cellpadding="0" cellspacing="0" class="body layout">

--- a/templates/zerver/emails/email_base_messages.html
+++ b/templates/zerver/emails/email_base_messages.html
@@ -1,8 +1,10 @@
+{% import 'zerver/emails/email.css' as css_styles %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <title>Zulip</title>
+        <style>{{css_styles}}</style>
     </head>
     {% if has_preheader %}
     <span style="display:none !important;

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -32,9 +32,6 @@ from zerver.models import EMAIL_TYPES, Realm, ScheduledEmail, UserProfile, get_u
 from zproject.email_backends import EmailLogBackEnd, get_forward_address
 
 MAX_CONNECTION_TRIES = 3
-ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
-EMAIL_TEMPLATES_PATH = os.path.join(ZULIP_PATH, "templates", "zerver", "emails")
-CSS_SOURCE_PATH = os.path.join(EMAIL_TEMPLATES_PATH, "email.css")
 
 ## Logging setup ##
 
@@ -43,9 +40,7 @@ log_to_file(logger, settings.EMAIL_LOG_PATH)
 
 
 def get_inliner_instance() -> css_inline.CSSInliner:
-    with open(CSS_SOURCE_PATH) as file:
-        content = file.read()
-    return css_inline.CSSInliner(extra_css=content)
+    return css_inline.CSSInliner()
 
 
 class FromAddress:


### PR DESCRIPTION
This commit places the email CSS into the `style` tag located in the `head` section. This resolves the issue of being unable to apply certain CSS styles that cannot be inlined, such as media queries and pseudo-classes.