### PR TITLE
compose: Visual send button tweaks

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -528,8 +528,7 @@ input.recipient_box {
 
 #compose-schedule-confirm-button,
 #compose-send-button {
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding: 3px 12px;
     margin-bottom: 0;
     font-weight: 600;
     font-size: 0.9em;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -862,10 +862,11 @@ a.compose_control_button.hide {
     padding: 0;
     margin: 0;
 
-    .fa {
-        padding: 4.5px 4px;
+    .zulip-icon {
+        vertical-align: middle;
 
         &::before {
+            padding: 5px 9px;
             position: relative;
             top: -1px;
         }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -857,7 +857,7 @@ a.compose_control_button.hide {
     float: right;
     color: hsl(0deg 0% 100%);
     border-radius: 0 4px 4px 0;
-    border-left: 1px solid hsl(213deg 14% 12% / 15%);
+    border-left: 1px solid hsl(0deg 0% 100% / 65%);
     padding: 0;
     margin: 0;
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -139,7 +139,7 @@
                                             <span>{{t 'Schedule' }}</span>
                                         </button>
                                         <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
-                                            <i class="fa fa-chevron-up"></i>
+                                            <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
                                         </button>
                                         <template id="send-enter-tooltip-template">
                                             {{t 'Send' }}


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This pull request:
* Changes the upward chevron to a vertical ellipsis, and repads/positions for fit with 9px of horizontal padding.
* Introduces 12px of horizontal padding around the Send button for clicking comfort, thanks to a larger target area.
* Changes the border separating the Send and vertical ellipsis buttons to be very light, almost white (pure white looked a little garish).

Note that I have used the same vertical-ellipsis icon behind `.zulip-icon-ellipsis-v-solid`, which is used in the sidebars.

Finally, although I was seeing some problems with button placement in the gutter on CZO, in development there was no such issue. It would be helpful if others could verify this at a 768px-width breakpoint. (The screenshots below were taken at 768px.)

Fixes: #25303.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Original:
![original-compound-send-button](https://user-images.githubusercontent.com/170719/234953720-7f145b00-6174-4e61-bac5-544f5c22e552.png)

Revised: 
![improved-compound-send-button](https://user-images.githubusercontent.com/170719/234953777-b7008b8c-7c75-4492-a3e6-c15fb21e9b5e.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
