### PR TITLE
tippy: Remove the focus trigger from the compose-control-buttons.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -219,6 +219,13 @@ export function initialize() {
         // so that regular users don't have to see
         // them unless they want to.
         delay: LONG_HOVER_DELAY,
+        // By default, tippyjs uses a trigger value of "mouseenter focus",
+        // which means the tooltips can appear either when the element is
+        // hovered over or when it receives focus (e.g. by being clicked).
+        // However, we only want the tooltips to appear on hover, not on click.
+        // Therefore, we need to remove the "focus" trigger from the buttons,
+        // so that the tooltips don't appear when the buttons are clicked.
+        trigger: "mouseenter",
         // This ensures that the upload files tooltip
         // doesn't hide behind the left sidebar.
         appendTo: () => document.body,


### PR DESCRIPTION
By default, tippyjs uses a trigger value of 'mouseenter focus', which means that the tooltips can appear either when the element is hovered over or when it receives focus (e.g., by being clicked). Because of this, if you click on the button to open the popover, the tooltip also appears. To prevent this behavior, we need to remove the 'focus' trigger from the buttons so that the tooltips don't appear when the buttons are clicked.

-------------------------------------------------

Fixes: #25277
CZO: [Thread](https://chat.zulip.org/#narrow/stream/6-frontend/topic/tooltip.20opens.20on.20click)

-----------------------------------

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>
<br>

![before_emoji](https://user-images.githubusercontent.com/66828942/235011960-b48f2783-eef1-4ada-a1b7-845989516319.gif)

</details>


<details>
<summary>After:</summary>
<br>

![after_emoji](https://user-images.githubusercontent.com/66828942/235012043-20f87c81-2a6f-4d09-89f5-fa521a64bca9.gif)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
