### PR TITLE
#25230: Fix banner display issue in message edit form.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -465,7 +465,7 @@ export function initialize() {
 
     upload.feature_check($("#compose .compose_upload_file"));
 
-    $("#compose_banners").on(
+    $("body").on(
         "click",
         `.${CSS.escape(compose_banner.CLASSNAMES.wildcard_warning)} .compose_banner_action_button`,
         (event) => {
@@ -479,7 +479,7 @@ export function initialize() {
     const user_not_subscribed_selector = `.${CSS.escape(
         compose_banner.CLASSNAMES.user_not_subscribed,
     )}`;
-    $("#compose_banners").on(
+    $("body").on(
         "click",
         `${user_not_subscribed_selector} .compose_banner_action_button`,
         (event) => {
@@ -495,7 +495,7 @@ export function initialize() {
         },
     );
 
-    $("#compose_banners").on(
+    $("body").on(
         "click",
         `.${CSS.escape(compose_banner.CLASSNAMES.topic_resolved)} .compose_banner_action_button`,
         (event) => {
@@ -512,7 +512,7 @@ export function initialize() {
         },
     );
 
-    $("#compose_banners").on(
+    $("body").on(
         "click",
         `.${CSS.escape(
             compose_banner.CLASSNAMES.unmute_topic_notification,
@@ -534,7 +534,7 @@ export function initialize() {
         },
     );
 
-    $("#compose_banners").on(
+    $("body").on(
         "click",
         `.${CSS.escape(
             compose_banner.CLASSNAMES.recipient_not_subscribed,
@@ -574,14 +574,10 @@ export function initialize() {
 
     for (const classname of Object.values(compose_banner.CLASSNAMES)) {
         const classname_selector = `.${CSS.escape(classname)}`;
-        $("#compose_banners").on(
-            "click",
-            `${classname_selector} .compose_banner_close_button`,
-            (event) => {
-                event.preventDefault();
-                $(event.target).parents(classname_selector).remove();
-            },
-        );
+        $("body").on("click", `${classname_selector} .compose_banner_close_button`, (event) => {
+            event.preventDefault();
+            $(event.target).parents(classname_selector).remove();
+        });
     }
 
     // Click event binding for "Attach files" button

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -249,6 +249,7 @@ export function send_message(request = create_message_object()) {
             compose_banner.show_error_message(
                 response,
                 compose_banner.CLASSNAMES.generic_compose_error,
+                $("#compose_banners"),
                 $("#compose-textarea"),
             );
             // For messages that were not locally echoed, we're
@@ -541,7 +542,9 @@ export function initialize() {
         )} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
-
+            const $edit_form = $(event.target)
+                .closest(".message_edit_form")
+                .find(".edit_form_banners");
             const $invite_row = $(event.target).parents(".compose_banner");
 
             const user_id = Number.parseInt($invite_row.data("user-id"), 10);
@@ -556,6 +559,7 @@ export function initialize() {
                 compose_banner.show_error_message(
                     error_msg,
                     compose_banner.CLASSNAMES.generic_compose_error,
+                    $edit_form.length ? $edit_form : $("#compose_banners"),
                     $("#compose-textarea"),
                 );
                 $(event.target).prop("disabled", true);

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -100,7 +100,12 @@ export function clear_all(): void {
     $(`#compose_banners`).empty();
 }
 
-export function show_error_message(message: string, classname: string, $bad_input?: JQuery): void {
+export function show_error_message(
+    message: string,
+    classname: string,
+    $container: JQuery,
+    $bad_input?: JQuery,
+): void {
     $(`#compose_banners .${CSS.escape(classname)}`).remove();
 
     const new_row = render_compose_banner({
@@ -111,7 +116,7 @@ export function show_error_message(message: string, classname: string, $bad_inpu
         button_text: null,
         classname,
     });
-    append_compose_banner_to_banner_list(new_row);
+    append_compose_banner_to_banner_list(new_row, $container);
 
     hide_compose_spinner();
 
@@ -129,7 +134,7 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
         stream_name,
         classname: CLASSNAMES.stream_does_not_exist,
     });
-    append_compose_banner_to_banner_list(new_row);
+    append_compose_banner_to_banner_list(new_row, $("#compose_banners"));
     hide_compose_spinner();
 
     // A copy of `compose_recipient.open_compose_stream_dropup()` that

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -51,10 +51,14 @@ export const CLASSNAMES = {
     user_not_subscribed: "user_not_subscribed",
 };
 
+// This function provides a convenient way to add new elements
+// to a banner container. The function accepts a container element
+// as a parameter, to which a banner should be appended.
 export function append_compose_banner_to_banner_list(
-    new_row: HTMLElement | JQuery.htmlString,
+    banner: HTMLElement | JQuery.htmlString,
+    $list_container: JQuery,
 ): void {
-    scroll_util.get_content_element($("#compose_banners")).append(new_row);
+    scroll_util.get_content_element($list_container).append(banner);
 }
 
 export function clear_message_sent_banners(include_unmute_banner = true): void {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -51,6 +51,12 @@ export const CLASSNAMES = {
     user_not_subscribed: "user_not_subscribed",
 };
 
+export function get_compose_banner_container($textarea: JQuery): JQuery {
+    return $textarea.attr("id") === "compose-textarea"
+        ? $("#compose_banners")
+        : $textarea.closest(".message_edit_form").find(".edit_form_banners");
+}
+
 // This function provides a convenient way to add new elements
 // to a banner container. The function accepts a container element
 // as a parameter, to which a banner should be appended.

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -121,6 +121,7 @@ export function check_stream_posting_policy_for_compose_box(stream_name) {
                 defaultMessage: "You do not have permission to post in this stream.",
             }),
             compose_banner.CLASSNAMES.no_post_permissions,
+            $("#compose_banners"),
         );
     } else {
         $(".compose_right_float_container").removeClass("disabled-compose-send-button-container");

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -821,7 +821,7 @@ export function content_typeahead_selected(item, event) {
                 );
                 beginning += mention_text + " ";
                 if (!is_silent) {
-                    compose_validate.warn_if_mentioning_unsubscribed_user(item);
+                    compose_validate.warn_if_mentioning_unsubscribed_user(item, $textbox);
                 }
             }
             break;
@@ -848,7 +848,7 @@ export function content_typeahead_selected(item, event) {
             } else {
                 beginning += "** ";
             }
-            compose_validate.warn_if_private_stream_is_linked(item);
+            compose_validate.warn_if_private_stream_is_linked(item, $textbox);
             break;
         case "syntax": {
             // Isolate the end index of the triple backticks/tildes, including

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -178,7 +178,10 @@ function notify_unmute(muted_narrow, stream_id, topic_name) {
         }),
     );
     compose_banner.clear_unmute_topic_notifications();
-    compose_banner.append_compose_banner_to_banner_list($unmute_notification);
+    compose_banner.append_compose_banner_to_banner_list(
+        $unmute_notification,
+        $("#compose_banners"),
+    );
 }
 
 export function notify_above_composebox(
@@ -200,7 +203,7 @@ export function notify_above_composebox(
     // We pass in include_unmute_banner as false because we don't want to
     // clear any unmute_banner associated with this same message.
     compose_banner.clear_message_sent_banners(false);
-    compose_banner.append_compose_banner_to_banner_list($notification);
+    compose_banner.append_compose_banner_to_banner_list($notification, $("#compose_banners"));
 }
 
 if (window.electron_bridge !== undefined) {

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -93,6 +93,7 @@ export function open_scheduled_message_in_compose(scheduled_msg) {
 }
 
 export function send_request_to_schedule_message(scheduled_message_data, deliver_at) {
+    const $banner_container = $("#compose_banners");
     const success = function (data) {
         drafts.draft_model.deleteDraft($("#compose-textarea").data("draft-id"));
         compose.clear_compose_box();
@@ -101,7 +102,7 @@ export function send_request_to_schedule_message(scheduled_message_data, deliver
             deliver_at,
         });
         compose_banner.clear_message_sent_banners();
-        compose_banner.append_compose_banner_to_banner_list(new_row);
+        compose_banner.append_compose_banner_to_banner_list(new_row, $banner_container);
     };
 
     const error = function (xhr) {
@@ -110,6 +111,7 @@ export function send_request_to_schedule_message(scheduled_message_data, deliver
         compose_banner.show_error_message(
             response,
             compose_banner.CLASSNAMES.generic_compose_error,
+            $banner_container,
             $("#compose-textarea"),
         );
     };

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -123,13 +123,10 @@ function add_upload_banner(config, banner_type, banner_text, file_id) {
         banner_text,
         file_id,
     });
-    // TODO: Extend compose_banner.append_compose_banner_to_banner_list
-    // to support the message edit container too.
-    if (config.mode === "compose") {
-        compose_banner.append_compose_banner_to_banner_list(new_banner);
-    } else {
-        get_item("banner_container", config).append(new_banner);
-    }
+    compose_banner.append_compose_banner_to_banner_list(
+        new_banner,
+        get_item("banner_container", config),
+    );
 }
 
 export function show_error_message(

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -270,18 +270,8 @@ export function setup_upload(config) {
         event.target.value = "";
     });
 
-    // These are close-click handlers for error banners that aren't associated
-    // with a particular file.
-    $("#compose_banners").on(
-        "click",
-        ".upload_banner.file_generic_error .compose_banner_close_button",
-        (event) => {
-            event.preventDefault();
-            $(event.target).parents(".upload_banner").remove();
-        },
-    );
-
-    $("#edit_form_banners").on(
+    const $banner_container = get_item("banner_container", config);
+    $banner_container.on(
         "click",
         ".upload_banner.file_generic_error .compose_banner_close_button",
         (event) => {

--- a/web/src/zcommand.js
+++ b/web/src/zcommand.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 import * as channel from "./channel";
 import * as compose_banner from "./compose_banner";
 import * as dark_theme from "./dark_theme";
@@ -48,7 +50,11 @@ export function send(opts) {
 export function tell_user(msg) {
     // This is a bit hacky, but we don't have a super easy API now
     // for just telling users stuff.
-    compose_banner.show_error_message(msg, compose_banner.CLASSNAMES.generic_compose_error);
+    compose_banner.show_error_message(
+        msg,
+        compose_banner.CLASSNAMES.generic_compose_error,
+        $("#compose_banners"),
+    );
 }
 
 export function switch_to_light_theme() {

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -613,6 +613,7 @@ test_ui("needs_subscribe_warning", () => {
 });
 
 test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
+    const $textarea = $("<textarea>").attr("id", "compose-textarea");
     const test_sub = {
         name: compose_state.stream_name(),
         stream_id: 99,
@@ -641,7 +642,7 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
         banner_rendered = false;
         compose_state.set_message_type("stream");
         denmark.invite_only = invite_only;
-        compose_validate.warn_if_private_stream_is_linked(denmark);
+        compose_validate.warn_if_private_stream_is_linked(denmark, $textarea);
         assert.ok(!banner_rendered);
     }
 
@@ -660,11 +661,12 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     };
     stream_data.add_sub(denmark);
     banner_rendered = false;
-    compose_validate.warn_if_private_stream_is_linked(denmark);
+    compose_validate.warn_if_private_stream_is_linked(denmark, $textarea);
     assert.ok(banner_rendered);
 });
 
 test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
+    const $textarea = $("<textarea>").attr("id", "compose-textarea");
     stream_value = "";
     override(settings_data, "user_can_subscribe_other_users", () => true);
 
@@ -687,7 +689,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
         compose_state.set_message_type(msg_type);
         page_params.realm_is_zephyr_mirror_realm = is_zephyr_mirror;
         mentioned_details.is_broadcast = is_broadcast;
-        compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details);
+        compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
         assert.ok(!new_banner_rendered);
     }
 
@@ -702,7 +704,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     // Test with empty stream name in compose box. It should return noop.
     new_banner_rendered = false;
     assert.equal(compose_state.stream_name(), "");
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details);
+    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(!new_banner_rendered);
 
     compose_state.set_stream_name("random");
@@ -713,7 +715,7 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
 
     // Test with invalid stream in compose box. It should return noop.
     new_banner_rendered = false;
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details);
+    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(!new_banner_rendered);
 
     // Test mentioning a user that should gets a warning.
@@ -726,8 +728,10 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
 
     stream_data.add_sub(sub);
     new_banner_rendered = false;
-    $("#compose_banners .recipient_not_subscribed").length = 0;
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details);
+    const $banner_container = $("#compose_banners");
+    $banner_container.set_find_results(".recipient_not_subscribed", []);
+
+    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(new_banner_rendered);
 
     // Simulate that the row was added to the DOM.
@@ -743,7 +747,8 @@ test_ui("warn_if_mentioning_unsubscribed_user", ({override, mock_template}) => {
     // Now try to mention the same person again. The template should
     // not render.
     new_banner_rendered = false;
-    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details);
+    $banner_container.set_find_results(".recipient_not_subscribed", $warning_row);
+    compose_validate.warn_if_mentioning_unsubscribed_user(mentioned_details, $textarea);
     assert.ok(!new_banner_rendered);
 });
 


### PR DESCRIPTION
This PR addresses an issue where banners intended for the edit form were appearing in the compose box. The fix involves updating the banner listeners element from `#compose_banners` to `body`. This change was necessary because the `#edit_form_banners` container did not exist during initialization, preventing listeners from being applied to it. Additionally, the `append_compose_banner_to_banner_list` function was refactored to accept the banner list container as a parameter, allowing for more flexibility in adding banners. 

Overall, this PR ensures that banners are properly displayed in the intended form and should improve user experience.

Fixes: #25230.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![2023-04-28 at 15 52 32 - Teal Squid](https://user-images.githubusercontent.com/53193850/235102762-95da8023-1131-4f44-84dd-cd4d90bbf787.gif)
