### PR TITLE
tooltips: Convert recipient row and edit notice tooltips to tippy. 

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -113,7 +113,7 @@ async function test_open_close_compose_box(page: Page): Promise<void> {
 
 async function test_narrow_to_private_messages_with_cordelia(page: Page): Promise<void> {
     const you_and_cordelia_selector =
-        '*[title="Narrow to your direct messages with Cordelia, Lear\'s daughter"]';
+        '*[data-tippy-content="Narrow to your direct messages with Cordelia, Lear\'s daughter"]';
     // For some unknown reason page.click() isn't working here.
     await page.evaluate(
         (selector: string) => document.querySelector<HTMLElement>(selector)!.click(),

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,13 +1,13 @@
 {{#if msg/local_edit_timestamp}}
-<div class="message_edit_notice auto-select" title="{{t 'Edited ({last_edit_timestr})' }}">
+<div class="message_edit_notice auto-select tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edited ({last_edit_timestr})' }}">
     {{t "SAVING" }}
 </div>
 {{else if moved}}
-<div class="message_edit_notice auto-select" title="{{t 'Moved ({last_edit_timestr})' }}">
+<div class="message_edit_notice auto-select tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Moved ({last_edit_timestr})' }}">
     {{t "MOVED" }}
 </div>
 {{else}}
-<div class="message_edit_notice auto-select" title="{{t 'Edited ({last_edit_timestr})' }}">
+<div class="message_edit_notice auto-select tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edited ({last_edit_timestr})' }}">
     {{t "EDITED" }}
 </div>
 {{/if}}

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -2,9 +2,9 @@
 <div class="message_header message_header_stream right_part" data-stream-id="{{stream_id}}">
     <div class="message-header-contents" style="background: {{recipient_bar_color}};">
         {{! stream link }}
-        <a class="message_label_clickable narrows_by_recipient stream_label"
+        <a class="message_label_clickable narrows_by_recipient stream_label tippy-zulip-delayed-tooltip"
           href="{{stream_url}}"
-          title="{{t 'Narrow to stream "{display_recipient}"' }}">
+          data-tippy-content="{{t 'Narrow to stream "{display_recipient}"' }}">
             <span class="stream-privacy-modified-color-{{stream_id}} stream-privacy filter-icon"  style="color: {{stream_privacy_icon_color}}">
                 {{> stream_privacy}}
             </span>
@@ -20,9 +20,9 @@
         {{! topic stuff }}
         <span class="stream_topic">
             {{! topic link }}
-            <a class="message_label_clickable narrows_by_topic"
+            <a class="message_label_clickable narrows_by_topic tippy-zulip-delayed-tooltip"
               href="{{topic_url}}"
-              title="{{t 'Narrow to stream "{display_recipient}", topic "{topic}"' }}">
+              data-tippy-content="{{t 'Narrow to stream "{display_recipient}", topic "{topic}"' }}">
                 {{#if use_match_properties}}
                     {{{match_topic}}}
                 {{else}}
@@ -80,9 +80,9 @@
 {{else}}
 <div class="message_header message_header_private_message">
     <div class="message-header-contents">
-        <a class="message_label_clickable narrows_by_recipient stream_label"
+        <a class="message_label_clickable narrows_by_recipient stream_label tippy-zulip-delayed-tooltip"
           href="{{pm_with_url}}"
-          title="{{t 'Narrow to your direct messages with {display_reply_to}' }}">
+          data-tippy-content="{{t 'Narrow to your direct messages with {display_reply_to}' }}">
         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
         {{t "You and {display_reply_to}" }}
         </a>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Comment: https://github.com/zulip/zulip/pull/25047#issuecomment-1526814834

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Recipient row:

![image](https://user-images.githubusercontent.com/64723994/235146139-358cbadd-224c-4eb5-973e-c06d188bb8a2.png)

![image](https://user-images.githubusercontent.com/64723994/235146175-44b1b8f6-4e63-4b16-8eaa-273e6f4915e5.png)

![image](https://user-images.githubusercontent.com/64723994/235146310-4e09f23c-a403-44ac-a3ef-1a8f09d37ebc.png)

Edit Notice:

![image](https://user-images.githubusercontent.com/64723994/235146495-e04d259d-c1b4-4e2c-978e-f46f2868ec9c.png)

![image](https://user-images.githubusercontent.com/64723994/235146537-e4a771ab-cb76-45a6-a571-25945ecb56b9.png)
 
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
