### PR TITLE
dark_theme: Fix dark recipient background in light theme for spectators.

### DIFF
--- a/web/src/dark_theme.ts
+++ b/web/src/dark_theme.ts
@@ -2,6 +2,8 @@ import $ from "jquery";
 
 import {localstorage} from "./localstorage";
 import {page_params} from "./page_params";
+import * as settings_config from "./settings_config";
+import {user_settings} from "./user_settings";
 
 export function enable(): void {
     $(":root").removeClass("color-scheme-automatic").addClass("dark-theme");
@@ -9,6 +11,7 @@ export function enable(): void {
     if (page_params.is_spectator) {
         const ls = localstorage();
         ls.set("spectator-theme-preference", "dark");
+        user_settings.color_scheme = settings_config.color_scheme_values.night.code;
     }
 }
 
@@ -18,6 +21,7 @@ export function disable(): void {
     if (page_params.is_spectator) {
         const ls = localstorage();
         ls.set("spectator-theme-preference", "light");
+        user_settings.color_scheme = settings_config.color_scheme_values.day.code;
     }
 }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -573,6 +573,9 @@ export function initialize_everything() {
     const user_settings_params = pop_fields("user_settings");
     const realm_settings_defaults_params = pop_fields("realm_user_settings_defaults");
 
+    /* To store theme data for spectators, we need to initialize
+       user_settings before setting the theme. */
+    initialize_user_settings(user_settings_params);
     if (page_params.is_spectator) {
         const ls = localstorage();
         const preferred_theme = ls.get("spectator-theme-preference");
@@ -588,7 +591,6 @@ export function initialize_everything() {
     popovers.initialize();
     popover_menus.initialize();
 
-    initialize_user_settings(user_settings_params);
     realm_user_settings_defaults.initialize(realm_settings_defaults_params);
     people.initialize(page_params.user_id, people_params);
 


### PR DESCRIPTION
Since, we didn't update `user_settings.color_scheme` for spectators and our recipient bar color calculations were based on it, this resulted in a wrong recipient bar color if the OS default color scheme of the user was different from `spectator-theme-preference` set by the user using the gear menu.

To reproduce the bug:
* Set preferred color scheme to `dark` in your OS settings / Chrome dev tools.
* Login as spectator in Incognito.
* Switch to light theme.

You will see dark background colors in recipient bars.


before:
<img width="1002" alt="Screenshot 2023-04-28 at 11 30 55 PM" src="https://user-images.githubusercontent.com/25124304/235220513-4f2c1ced-dc78-42a6-a10b-5583c4a7cb36.png">

after:
<img width="1071" alt="Screenshot 2023-04-28 at 11 30 26 PM" src="https://user-images.githubusercontent.com/25124304/235220418-f3b18992-cd83-425d-84d3-ebe33e7df538.png">
