### PR TITLE
send_later: Move some options to a modal (continued)

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -910,9 +910,9 @@ export function initialize() {
                                 e.target.click();
                             }
                         });
-                        $send_later_modal.one("click", ".send_later_date_input", (e) => {
+                        $send_later_modal.on("click", ".send_later_custom", (e) => {
                             flatpickr.show_flatpickr(
-                                $(".send_later_date_input")[0],
+                                $(".send_later_custom")[0],
                                 update_scheduled_date_from_modal,
                                 new Date(),
                             );

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -15,6 +15,7 @@ import render_delete_topic_modal from "../templates/confirm_dialog/confirm_delet
 import render_drafts_sidebar_actions from "../templates/drafts_sidebar_action.hbs";
 import render_left_sidebar_stream_setting_popover from "../templates/left_sidebar_stream_setting_popover.hbs";
 import render_mobile_message_buttons_popover_content from "../templates/mobile_message_buttons_popover_content.hbs";
+import render_send_later_modal from "../templates/send_later_modal.hbs";
 import render_send_later_popover from "../templates/send_later_popover.hbs";
 import render_starred_messages_sidebar_actions from "../templates/starred_messages_sidebar_actions.hbs";
 import render_topic_sidebar_actions from "../templates/topic_sidebar_actions.hbs";
@@ -36,6 +37,7 @@ import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
+import * as overlays from "./overlays";
 import * as popover_menus_data from "./popover_menus_data";
 import * as popovers from "./popovers";
 import * as read_receipts from "./read_receipts";
@@ -244,6 +246,11 @@ export function show_schedule_confirm_button(send_at_time, not_from_flatpickr = 
     selected_send_later_time = send_at_time;
     $("#compose-schedule-confirm-button").show();
     $("#compose-send-button").hide();
+}
+
+function update_scheduled_date_from_modal(send_at_time, not_from_flatpickr = false) {
+    overlays.close_active_modal();
+    show_schedule_confirm_button(send_at_time, not_from_flatpickr);
 }
 
 export function initialize() {
@@ -858,27 +865,10 @@ export function initialize() {
         },
         onShow(instance) {
             popovers.hide_all_except_sidebars(instance);
-
-            // Only show send later options that are possible today.
-            const date = new Date();
-            const hours = date.getHours();
-            let possible_send_later_today = {};
-            if (hours <= 8) {
-                possible_send_later_today = send_later_today;
-            } else if (hours <= 15) {
-                possible_send_later_today.today_four_pm = send_later_today.today_four_pm;
-            } else {
-                possible_send_later_today = false;
-            }
-
             const formatted_send_later_time = get_formatted_selected_send_later_time();
-
             instance.setContent(
                 parse_html(
                     render_send_later_popover({
-                        possible_send_later_today,
-                        send_later_tomorrow,
-                        send_later_custom,
                         formatted_send_later_time,
                     }),
                 ),
@@ -888,28 +878,67 @@ export function initialize() {
         },
         onMount(instance) {
             const $popper = $(instance.popper);
-            $popper.one("click", "#send-later-custom-input", () => {
-                flatpickr.show_flatpickr(
-                    $("#send_later")[0],
-                    show_schedule_confirm_button,
-                    new Date(),
+
+            $popper.one("click", ".open_send_later_modal", () => {
+                // Only show send later options that are possible today.
+                const date = new Date();
+                const hours = date.getHours();
+                let possible_send_later_today = {};
+                if (hours <= 8) {
+                    possible_send_later_today = send_later_today;
+                } else if (hours <= 15) {
+                    possible_send_later_today.today_four_pm = send_later_today.today_four_pm;
+                } else {
+                    possible_send_later_today = false;
+                }
+
+                const formatted_send_later_time = get_selected_send_later_time();
+                $("body").append(
+                    render_send_later_modal({
+                        possible_send_later_today,
+                        send_later_tomorrow,
+                        send_later_custom,
+                        formatted_send_later_time,
+                    }),
                 );
-            });
+                overlays.open_modal("send_later_modal", {
+                    autoremove: true,
+                    on_show() {
+                        const $send_later_modal = $("#send_later_modal");
+                        $send_later_modal.on("keydown", (e) => {
+                            if (e.key === "Enter") {
+                                e.target.click();
+                            }
+                        });
+                        $send_later_modal.one("click", ".send_later_date_input", (e) => {
+                            flatpickr.show_flatpickr(
+                                $(".send_later_date_input")[0],
+                                update_scheduled_date_from_modal,
+                                new Date(),
+                            );
+                            e.preventDefault();
+                            e.stopPropagation();
+                        });
+                        $send_later_modal.one(
+                            "click",
+                            ".send_later_today, .send_later_tomorrow",
+                            (e) => {
+                                const send_at_time = set_compose_box_schedule(e.currentTarget);
+                                const not_from_flatpickr = true;
+                                update_scheduled_date_from_modal(send_at_time, not_from_flatpickr);
+                                e.preventDefault();
+                                e.stopPropagation();
+                            },
+                        );
 
-            $popper.one("click", ".send_later_today, .send_later_tomorrow", (e) => {
-                const send_at_time = set_compose_box_schedule(e.currentTarget);
-                const not_from_flatpickr = true;
-                show_schedule_confirm_button(send_at_time, not_from_flatpickr);
-
-                instance.hide();
-                e.stopPropagation();
-                e.preventDefault();
-            });
-
-            $popper.one("click", "#clear_compose_schedule_state", () => {
-                // We don't to want to reset the edit state of the scheduled message when
-                // clicks "Now", since the user can still change the date to a future date.
-                compose.reset_compose_scheduling_state(false);
+                        $send_later_modal.one("click", "#clear_compose_schedule_state", (e) => {
+                            overlays.close_active_modal();
+                            compose.reset_compose_scheduling_state(false);
+                            e.preventDefault();
+                            e.stopPropagation();
+                        });
+                    },
+                });
             });
         },
         onHidden(instance) {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -930,15 +930,15 @@ export function initialize() {
                                 e.stopPropagation();
                             },
                         );
-
-                        $send_later_modal.one("click", "#clear_compose_schedule_state", (e) => {
-                            overlays.close_active_modal();
-                            compose.reset_compose_scheduling_state(false);
-                            e.preventDefault();
-                            e.stopPropagation();
-                        });
                     },
                 });
+            });
+            $popper.one("click", "#clear_compose_schedule_state", (e) => {
+                compose.reset_compose_scheduling_state(false);
+                // Close the popper instance when clearing scheduling:
+                instance.hide();
+                e.preventDefault();
+                e.stopPropagation();
             });
         },
         onHidden(instance) {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -888,9 +888,10 @@
         color: inherit;
     }
 
-    .send_later_popover_header,
-    .selected_send_later_time {
-        color: hsl(236deg 33% 90%);
+    #send_later_modal .send_later_input_group .send_later_date_input {
+        opacity: 0.8;
+        color: hsl(0deg 0% 100%);
+        background-color: hsl(0deg 0% 0% / 20%);
     }
 
     .nav-list > li > a,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -888,12 +888,6 @@
         color: inherit;
     }
 
-    #send_later_modal .send_later_input_group .send_later_date_input {
-        opacity: 0.8;
-        color: hsl(0deg 0% 100%);
-        background-color: hsl(0deg 0% 0% / 20%);
-    }
-
     .nav-list > li > a,
     .nav-list .nav-header {
         text-shadow: none;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -861,14 +861,24 @@ ul {
     & hr {
         margin: 5px 0;
     }
+}
 
-    .send_later_popover_header {
-        text-align: center;
-        font-weight: bold;
+#send_later_modal {
+    .modal__content {
+        padding-bottom: 16px;
     }
 
-    .selected_send_later_time {
-        text-align: center;
-        margin-top: 3px;
+    .send_later_input_group {
+        display: flex;
+
+        .send_later_date_input {
+            width: 100%;
+            cursor: pointer;
+            background: hsl(0deg 0% 100%);
+
+            &:focus {
+                box-shadow: none;
+            }
+        }
     }
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -867,18 +867,4 @@ ul {
     .modal__content {
         padding-bottom: 16px;
     }
-
-    .send_later_input_group {
-        display: flex;
-
-        .send_later_date_input {
-            width: 100%;
-            cursor: pointer;
-            background: hsl(0deg 0% 100%);
-
-            &:focus {
-                box-shadow: none;
-            }
-        }
-    }
 }

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -14,11 +14,6 @@
                 </div>
                 <div class="send_later_options">
                     <ul class="nav nav-list">
-                        {{#if formatted_send_later_time }}
-                        <li>
-                            <a id="clear_compose_schedule_state" tabindex="0">{{t "Now" }}</a>
-                        </li>
-                        {{/if}}
                         {{#if possible_send_later_today}}
                             {{#each possible_send_later_today}}
                                 <li>

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -8,10 +8,6 @@
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
             <main class="modal__content">
-                <div class="send_later_input_group">
-                    <input class="send_later_date_input" type="text" placeholder="{{t 'Select Date and time' }}" readonly="readonly"
-                      {{#if formatted_send_later_time }}value="{{formatted_send_later_time}}"{{/if}} />
-                </div>
                 <div class="send_later_options">
                     <ul class="nav nav-list">
                         {{#if possible_send_later_today}}

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -26,6 +26,9 @@
                                 <a id="{{@key}}" class="send_later_tomorrow" tabindex="0">{{this.text}}</a>
                             </li>
                         {{/each}}
+                        <li>
+                            <a class="send_later_custom" tabindex="0">{{t 'Custom time'}}</a>
+                        </li>
                     </ul>
                 </div>
             </main>

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -1,0 +1,39 @@
+<div class="micromodal" id="send_later_modal" aria-hidden="true">
+    <div class="modal__overlay" tabindex="-1">
+        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="send_later_modal_label">
+            <header class="modal__header">
+                <h1 class="modal__title" id="send_later_modal_label">
+                    {{t "Schedule message" }}
+                </h1>
+                <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
+            </header>
+            <main class="modal__content">
+                <div class="send_later_input_group">
+                    <input class="send_later_date_input" type="text" placeholder="{{t 'Select Date and time' }}" readonly="readonly"
+                      {{#if formatted_send_later_time }}value="{{formatted_send_later_time}}"{{/if}} />
+                </div>
+                <div class="send_later_options">
+                    <ul class="nav nav-list">
+                        {{#if formatted_send_later_time }}
+                        <li>
+                            <a id="clear_compose_schedule_state" tabindex="0">{{t "Now" }}</a>
+                        </li>
+                        {{/if}}
+                        {{#if possible_send_later_today}}
+                            {{#each possible_send_later_today}}
+                                <li>
+                                    <a id="{{@key}}" class="send_later_today" tabindex="0">{{this.text}}</a>
+                                </li>
+                            {{/each}}
+                        {{/if}}
+                        {{#each send_later_tomorrow}}
+                            <li>
+                                <a id="{{@key}}" class="send_later_tomorrow" tabindex="0">{{this.text}}</a>
+                            </li>
+                        {{/each}}
+                    </ul>
+                </div>
+            </main>
+        </div>
+    </div>
+</div>

--- a/web/templates/send_later_popover.hbs
+++ b/web/templates/send_later_popover.hbs
@@ -1,36 +1,9 @@
 <ul id="send_later_popover" class="nav nav-list">
-    <li class="send_later_popover_header">
-        {{t "Schedule message" }}
-    </li>
-    {{#if formatted_send_later_time }}
-    <li class="selected_send_later_time">
-        {{ formatted_send_later_time }}
+    <li>
+        <a class="open_send_later_modal" tabindex="0">{{t "Schedule message" }}</a>
     </li>
     <hr />
     <li>
-        <a id="clear_compose_schedule_state">{{t "Now" }}</a>
-    </li>
-    {{/if}}
-    <hr />
-    {{#if possible_send_later_today}}
-        {{#each possible_send_later_today}}
-            <li>
-                <a id="{{@key}}" class="send_later_today">{{this.text}}</a>
-            </li>
-        {{/each}}
-        <hr />
-    {{/if}}
-    {{#each send_later_tomorrow}}
-        <li>
-            <a id="{{@key}}" class="send_later_tomorrow">{{this.text}}</a>
-        </li>
-    {{/each}}
-    <hr />
-    <li>
-        <a id="send-later-custom-input">{{send_later_custom.text}}</a>
-    </li>
-    <hr />
-    <li>
-        <a href="#scheduled">{{t "View scheduled messages" }}</a>
+        <a href="#scheduled" tabindex="0">{{t "View scheduled messages" }}</a>
     </li>
 </ul>

--- a/web/templates/send_later_popover.hbs
+++ b/web/templates/send_later_popover.hbs
@@ -2,6 +2,11 @@
     <li>
         <a class="open_send_later_modal" tabindex="0">{{t "Schedule message" }}</a>
     </li>
+    {{#if formatted_send_later_time }}
+    <li>
+        <a id="clear_compose_schedule_state" tabindex="0">{{t "Cancel scheduling" }}</a>
+    </li>
+    {{/if}}
     <hr />
     <li>
         <a href="#scheduled" tabindex="0">{{t "View scheduled messages" }}</a>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR picks up from @amanagr's #25261:

The commits I have added to Aman's work address all of [Alya's feedback](https://github.com/zulip/zulip/pull/25261#issuecomment-1522062860), I believe, minus one point (the banner indications; more on that in a moment). Specifically:

* This removes "Now" from the popover menu once a message has been scheduled
* This adds "Cancel scheduling" to the popover menu insetad
* This adds "Custom time" as the last-listed option in the scheduling modal, which now opens the time widget
* This removes the former `send_later_input_group` structures, including the read-only `<input>` element that a) triggered opening the time widget and b) displayed the selected time

There are ~~three~~ two remaining issues here:

* The minor issue is that while clicking the "Custom time" option will re-open the time widget if it closes by a click elsewhere in the modal (e.g., on the modal's header), repeated clicks on the "Custom time" element causes the time widget to redraw in place. Not a huge issue, but it looks a little jangy.
* [FIXED] The major issue is that I am unfamiliar with how Tippy and the banner system work with compose events. Alya requested ~~moving~~ _adding_ the scheduling status from the Tippy tooltip to a banner above the compose box, but I need some guidance understanding how to pull that off. (I'm spelunking around in various `compose_*.js` files, but so far without any kind of lightbulb appearing over my head.)
* Related to that major issue is a minor issue, which is that the error message when attempting to schedule a message for sending in the past is that there is an "Error sending message," when probably we need to register an "Error scheduling message" preamble instead.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
