### PR TITLE
narrow: Fix "pm-with" narrow in scheduled messages.

### DIFF
--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -54,7 +54,7 @@ export function edit_scheduled_message(scheduled_msg_id) {
             {trigger: "edit scheduled message"},
         );
     } else {
-        narrow.activate([{operator: "pm-with", operand: compose_args.private_message_recipient}], {
+        narrow.activate([{operator: "dm", operand: compose_args.private_message_recipient}], {
             trigger: "edit scheduled message",
         });
     }


### PR DESCRIPTION
"pm-with" was deprecated in #25003. This addition for scheduled messages must have gotten missed in the overlap of that change.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
