### PR TITLE
user_card: Fix user_card background for dark theme on device width < $md_min.

### DIFF
--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -606,7 +606,7 @@ ul {
         width: 100%;
         height: 100%;
 
-        background-color: hsl(0deg 0% 0% / 70%);
+        background-color: hsl(0deg 0% 0% / 70%) !important;
         border-radius: 0;
         border: none;
 


### PR DESCRIPTION
CZ) Discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/message-info-popover.20has.20opaque.20background

Previously, in the dark theme, the `background-color: #18222f` of the `.popover` class took precedence over the
`background-color: hsla(0,0%,0%,.7)` of the `.message-info-popover` and `.user-info-popover` classes. This commit fixes this issue by adding !important to the background-color property of `.message-info-popover, .user-info-popover` classes.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Before: 
![image](https://user-images.githubusercontent.com/64723994/235256212-66341f35-60c8-44d9-944a-fe7c54f601b5.png)
 
- After:
  - Message Info popover:
![image](https://user-images.githubusercontent.com/64723994/235256274-c519820a-20fa-448b-b1b9-4907eef4d3c5.png)
 
  - User Info popover:
![image](https://user-images.githubusercontent.com/64723994/235256472-d8cb7489-e50c-44bb-8045-58657dcd45d3.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
