### PR TITLE
actions_popover: Hide "Add emoji reaction" in action menu in spectator mode.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -101,7 +101,7 @@ export function get_actions_popover_content_context(message_id) {
     // `media_breakpoints.sm_min`, we need to include the reaction button in the
     // popover if it is not displayed.
     const should_display_add_reaction_option =
-        !message.is_me_message && !is_add_reaction_icon_visible();
+        !message.is_me_message && !is_add_reaction_icon_visible() && not_spectator;
 
     return {
         message_id: message.id,


### PR DESCRIPTION
This PR hides the "Add emoji reaction" from the message action menu while a user is not logged in, that is when the user is in public access mode.

Fixes: #25331

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Screenshot 2023-04-29 080552](https://user-images.githubusercontent.com/84276404/235279777-11f72baa-2cf1-4cac-96f6-ec0d251aec49.png) | ![Screenshot 2023-04-29 080504](https://user-images.githubusercontent.com/84276404/235279784-1331d1ef-3bdc-4a8e-9bf3-13dc98b54c35.png) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
