### PR TITLE
css: Fix loading spinner position for messages loading indicator.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -223,6 +223,9 @@ p.n-margin {
        we need to position it below the padding. */
     padding-top: var(--header-padding-bottom);
     margin-bottom: 0;
+    /* To fit the logo inside the spinner. */
+    position: relative;
+    top: -2px;
 }
 
 #feedback_container {


### PR DESCRIPTION
before:

<img width="285" alt="Screenshot 2023-04-29 at 3 46 58 PM" src="https://user-images.githubusercontent.com/25124304/235297644-ff0213fe-281b-4fbd-bbc4-47521a3e6793.png">

after:

<img width="285" alt="Screenshot 2023-04-29 at 3 46 44 PM" src="https://user-images.githubusercontent.com/25124304/235297650-9c77692f-325b-4b5b-afb7-3f9e10cd47a0.png">
