### PR TITLE
stream_settings: Disable "Add subscribers" UI if user lacks permission.

### DIFF
--- a/web/src/stream_create_subscribers.js
+++ b/web/src/stream_create_subscribers.js
@@ -7,6 +7,7 @@ import * as add_subscribers_pill from "./add_subscribers_pill";
 import * as ListWidget from "./list_widget";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as settings_data from "./settings_data";
 import * as settings_users from "./settings_users";
 import * as stream_create_subscribers_data from "./stream_create_subscribers_data";
 
@@ -73,7 +74,11 @@ export function create_handlers($container) {
 
 export function build_widgets() {
     const $add_people_container = $("#people_to_add");
-    $add_people_container.html(render_new_stream_users({}));
+    $add_people_container.html(
+        render_new_stream_users({
+            permission_to_add_user: settings_data.user_can_subscribe_other_users(),
+        }),
+    );
 
     const $simplebar_container = $add_people_container.find(".subscriber_list_container");
 

--- a/web/src/stream_settings_data.js
+++ b/web/src/stream_settings_data.js
@@ -2,6 +2,7 @@ import * as hash_util from "./hash_util";
 import {page_params} from "./page_params";
 import * as peer_data from "./peer_data";
 import * as settings_config from "./settings_config";
+import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import {user_settings} from "./user_settings";
@@ -47,7 +48,7 @@ export function add_settings_fields(sub) {
     sub.can_access_subscribers = stream_data.can_view_subscribers(sub);
     sub.can_add_subscribers = stream_data.can_subscribe_others(sub);
     sub.can_remove_subscribers = stream_data.can_unsubscribe_others(sub);
-
+    sub.permission_to_add_user = settings_data.user_can_subscribe_other_users();
     sub.preview_url = hash_util.by_stream_url(sub.stream_id);
     sub.is_old_stream = sub.stream_weekly_traffic !== null;
 }

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -256,6 +256,18 @@ h4.user_group_setting_subsection_title {
     }
 }
 
+.no_permission_to_add_user {
+    .person_picker,
+    .add_subscriber_btn_wrapper {
+        opacity: 0.4;
+        cursor: not-allowed;
+
+        & button {
+            pointer-events: none;
+        }
+    }
+}
+
 .remove-subscriber-form {
     margin: 0;
 }

--- a/web/templates/stream_settings/add_subscribers_form.hbs
+++ b/web/templates/stream_settings/add_subscribers_form.hbs
@@ -1,11 +1,11 @@
-<div class="add_subscribers_container">
-    <div class="pill-container person_picker">
-        <div class="input" contenteditable="true"
+<div class="add_subscribers_container {{#unless permission_to_add_user}}no_permission_to_add_user{{/unless}}">
+    <div class="pill-container person_picker {{#unless permission_to_add_user}}tippy-zulip-tooltip{{/unless}}" data-tippy-content="You do not have permission to add other users to streams in this organization.">
+        <div class="input" {{#if permission_to_add_user}}contenteditable{{/if}}
           data-placeholder="{{t 'Add subscribers. Use usergroup or #streamname to bulk add subscribers.' }}">
             {{~! Squash whitespace so that placeholder is displayed when empty. ~}}
         </div>
     </div>
-    <div class="add_subscriber_btn_wrapper inline-block">
+    <div class="add_subscriber_btn_wrapper inline-block {{#unless permission_to_add_user}}tippy-zulip-tooltip{{/unless}}" data-tippy-content="You do not have permission to add other users to streams in this organization.">
         <button type="submit" name="add_subscriber" class="button add-subscriber-button small rounded sea-green" tabindex="0">
             {{t 'Add' }}
         </button>


### PR DESCRIPTION
If user don't have the permission to add subscribers to stream then disable the "Add subscribers" UI in stream creation UI and stream subscribers UI.

Added CSS to `cursor:disable`, `opacity: 0.4` and tippy tooltip to person_picker, add_subscriber_btn_wrapper when user lacks permission.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#25263

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/64723994/235301106-d750588d-63c4-4cfb-bd59-5ae5250112f0.png)

![image](https://user-images.githubusercontent.com/64723994/235301120-b6ab76fd-2a9d-4f50-aa6c-e99e731fe3e5.png)

![image](https://user-images.githubusercontent.com/64723994/235301229-f1e4c14d-f126-45a1-a9c4-1a19394e267a.png)

![image](https://user-images.githubusercontent.com/64723994/235301237-2ff668c5-22a9-493f-a9a3-0d6967a93fc1.png)


https://user-images.githubusercontent.com/64723994/235301281-b19936b9-feff-4c74-ab7a-5f7525d2c112.mp4

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
