### PR TITLE
tooltips: Remove keyboard shortcuts from "View Scheduled Messages" modal.

### DIFF
--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -39,12 +39,10 @@
                                 <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-scheduled-message-tooltip-template"></i>
                                 <template id="restore-scheduled-message-tooltip-template">
                                     {{t 'Edit or reschedule message' }}
-                                    {{tooltip_hotkey_hints "Enter"}}
                                 </template>
                                 <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-scheduled-message-tooltip-template"></i>
                                 <template id="delete-scheduled-message-tooltip-template">
                                     {{t 'Delete scheduled message' }}
-                                    {{tooltip_hotkey_hints "Backspace"}}
                                 </template>
                             </div>
                         </div>


### PR DESCRIPTION
This PR removes the keyboard shortcut from tooltips that can be seen when hovering over the two buttons in
`View Scheduled Messages` modal.

This is a temporary change as the keyboard shortcut will be added to the tooltips when the shortcuts are actually working.

<hr>

**Screenshots and screen captures:**

| Before| After |
|--------|--------|
|![image](https://user-images.githubusercontent.com/35286603/235308471-0d6703d3-49b9-45f9-ac3c-8fbb69b46f35.png)|![image](https://user-images.githubusercontent.com/35286603/235308434-92c8cff0-21ab-4cee-b754-80af11038147.png)|

| Before| After |
|--------|--------|
|![image](https://user-images.githubusercontent.com/35286603/235308476-dab8c5ba-0b27-4054-99ea-98e119986e49.png)| ![image](https://user-images.githubusercontent.com/35286603/235308452-76f9f18b-2e27-47bb-bed4-5f440375312a.png)|

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<hr>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
