### PR TITLE
unread: Deduplicate the logic for adding up unread counts.

### DIFF
--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -264,7 +264,7 @@ class UnreadTopicCounter {
         const res = {};
         res.stream_unread_messages = 0;
         res.stream_count = new Map(); // hash by stream_id -> count
-        for (const [stream_id, per_stream_bucketer] of this.bucketer) {
+        for (const [stream_id] of this.bucketer) {
             // We track unread counts for streams that may be currently
             // unsubscribed.  Since users may re-subscribe, we don't
             // completely throw away the data.  But we do ignore it here,
@@ -274,29 +274,8 @@ class UnreadTopicCounter {
                 continue;
             }
 
-            let unmuted_count = 0;
-            let muted_count = 0;
-            for (const [topic, msgs] of per_stream_bucketer) {
-                const topic_count = msgs.size;
-
-                if (user_topics.is_topic_unmuted(stream_id, topic)) {
-                    unmuted_count += topic_count;
-                } else if (user_topics.is_topic_muted(stream_id, topic)) {
-                    muted_count += topic_count;
-                } else if (sub.is_muted) {
-                    muted_count += topic_count;
-                } else {
-                    unmuted_count += topic_count;
-                }
-            }
-
-            res.stream_count.set(stream_id, {
-                unmuted_count,
-                muted_count,
-                stream_is_muted: sub.is_muted,
-            });
-
-            res.stream_unread_messages += unmuted_count;
+            res.stream_count.set(stream_id, this.get_stream_count(stream_id));
+            res.stream_unread_messages += res.stream_count.get(stream_id).unmuted_count;
         }
 
         return res;


### PR DESCRIPTION
Comment: https://github.com/zulip/zulip/pull/25103#issuecomment-1520652900

Deduplicated logic for calculating unread message counts and stream counts for subscribed streams by refactoring `get_counts` to use `get_stream_count` function for calculating unread message counts for each subscribed stream.

This is a follow-up PR for #25103.
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
