### PR TITLE
schedule: Remove 'Schedule' state of compose box.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -188,7 +188,7 @@ export function clear_compose_box() {
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
     compose_ui.hide_compose_spinner();
-    popover_menus.reset_selected_schedule_time();
+    popover_menus.reset_selected_schedule_timestamp();
 }
 
 export function send_message_success(local_id, message_id, locally_echoed) {
@@ -792,8 +792,7 @@ function schedule_message_to_custom_date() {
     const compose_message_object = create_message_object();
 
     const deliver_at = popover_menus.get_formatted_selected_send_later_time();
-    const send_later_time = popover_menus.get_selected_send_later_time();
-    const scheduled_delivery_timestamp = Math.floor(Date.parse(send_later_time) / 1000);
+    const scheduled_delivery_timestamp = popover_menus.get_selected_send_later_timestamp();
 
     const message_type = compose_message_object.type;
     let req_type;

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -78,7 +78,6 @@ function clear_box() {
     compose_ui.autosize_textarea($("#compose-textarea"));
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
-    compose.reset_compose_scheduling_state();
 }
 
 export function autosize_message_content() {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -17,7 +17,7 @@ export const ERROR = "error";
 const MESSAGE_SENT_CLASSNAMES = {
     sent_scroll_to_view: "sent_scroll_to_view",
     narrow_to_recipient: "narrow_to_recipient",
-    scheduled_message_banner: "scheduled_message_banner",
+    message_scheduled_success_compose_banner: "message_scheduled_success_compose_banner",
 };
 // Technically, unmute_topic_notification is a message sent banner, but
 // it has distinct behavior / look - it has an associated action button,

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -535,10 +535,3 @@ export function get_compose_click_target(e) {
     }
     return e.target;
 }
-
-export function get_submit_button() {
-    if (popover_menus.is_time_selected_for_schedule()) {
-        return $("#compose-schedule-confirm-button");
-    }
-    return $("#compose-send-button");
-}

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -221,7 +221,7 @@ function handle_keydown(e) {
                     // could result in focus being moved to the "Send
                     // button" after sending the message, preventing
                     // typing a next message!
-                    compose_ui.get_submit_button().trigger("focus");
+                    $("#compose-send-button").trigger("focus");
 
                     e.preventDefault();
                     e.stopPropagation();
@@ -232,7 +232,7 @@ function handle_keydown(e) {
                     e.preventDefault();
                     if (
                         compose_validate.validate_message_length() &&
-                        !compose_ui.get_submit_button().prop("disabled")
+                        !$("#compose-send-button").prop("disabled")
                     ) {
                         compose.finish();
                     }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -859,7 +859,10 @@ export function initialize() {
         },
         onMount(instance) {
             const $popper = $(instance.popper);
-
+            $popper.one("click", ".send_later_selected_send_later_time", () => {
+                const send_at_timestamp = get_selected_send_later_timestamp();
+                do_schedule_message(send_at_timestamp);
+            });
             $popper.one("click", ".open_send_later_modal", () => {
                 if (!compose_validate.validate()) {
                     return;
@@ -877,13 +880,11 @@ export function initialize() {
                     possible_send_later_today = false;
                 }
 
-                const formatted_send_later_time = get_formatted_selected_send_later_time();
                 $("body").append(
                     render_send_later_modal({
                         possible_send_later_today,
                         send_later_tomorrow,
                         send_later_custom,
-                        formatted_send_later_time,
                     }),
                 );
                 overlays.open_modal("send_later_modal", {
@@ -911,18 +912,7 @@ export function initialize() {
                             ".send_later_today, .send_later_tomorrow",
                             (e) => {
                                 const send_at_time = set_compose_box_schedule(e.currentTarget);
-                                const not_from_flatpickr = true;
-                                do_schedule_message(send_at_time, not_from_flatpickr);
-                                e.preventDefault();
-                                e.stopPropagation();
-                            },
-                        );
-                        $send_later_modal.one(
-                            "click",
-                            ".send_later_selected_send_later_time",
-                            (e) => {
-                                const send_at_timestamp = get_selected_send_later_timestamp();
-                                do_schedule_message(send_at_timestamp);
+                                do_schedule_message(send_at_time);
                                 e.preventDefault();
                                 e.stopPropagation();
                             },

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -95,8 +95,8 @@ export function get_formatted_selected_send_later_time() {
     return timerender.get_full_datetime(new Date(selected_send_later_time), "time");
 }
 
-export function set_selected_schedule_time(scheduled_time) {
-    selected_send_later_time = scheduled_time;
+export function set_selected_schedule_time(raw_scheduled_time) {
+    selected_send_later_time = raw_scheduled_time;
 }
 
 export function reset_selected_schedule_time() {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -54,7 +54,7 @@ import {user_settings} from "./user_settings";
 import * as user_topics from "./user_topics";
 
 let message_actions_popover_keyboard_toggle = false;
-let selected_send_later_time;
+let selected_send_later_timestamp;
 
 const popover_instances = {
     compose_control_buttons: null,
@@ -81,26 +81,26 @@ export function get_topic_menu_popover() {
     return popover_instances.topics_menu;
 }
 
-export function get_selected_send_later_time() {
-    if (!selected_send_later_time) {
+export function get_selected_send_later_timestamp() {
+    if (!selected_send_later_timestamp) {
         return undefined;
     }
-    return selected_send_later_time;
+    return selected_send_later_timestamp;
 }
 
 export function get_formatted_selected_send_later_time() {
-    if (!selected_send_later_time) {
+    if (!selected_send_later_timestamp) {
         return undefined;
     }
-    return timerender.get_full_datetime(new Date(selected_send_later_time), "time");
+    return timerender.get_full_datetime(new Date(selected_send_later_timestamp * 1000), "time");
 }
 
-export function set_selected_schedule_time(raw_scheduled_time) {
-    selected_send_later_time = raw_scheduled_time;
+export function set_selected_schedule_timestamp(timestamp) {
+    selected_send_later_timestamp = timestamp;
 }
 
-export function reset_selected_schedule_time() {
-    selected_send_later_time = undefined;
+export function reset_selected_schedule_timestamp() {
+    selected_send_later_timestamp = undefined;
 }
 
 export function get_scheduled_messages_popover() {
@@ -230,18 +230,14 @@ export function toggle_message_actions_menu(message) {
     return true;
 }
 
-export function do_schedule_message(send_at_time, not_from_flatpickr = false) {
+export function do_schedule_message(send_at_time) {
     overlays.close_active_modal();
 
-    // flatpickr.show_flatpickr doesn't pass any value for not_from_flatpickr,
-    // making it false by default and we pass it as true in other cases.
-    // This is used to determine if flatpickr was used to select time for the
-    // message to be sent.
-    if (!not_from_flatpickr) {
-        send_at_time = format(new Date(send_at_time), "MMM d yyyy h:mm a");
+    if (!Number.isInteger(send_at_time)) {
+        // Convert to timestamp if this is not a timestamp.
+        send_at_time = Math.floor(Date.parse(send_at_time) / 1000);
     }
-
-    selected_send_later_time = send_at_time;
+    selected_send_later_timestamp = send_at_time;
     compose.finish(true);
 }
 
@@ -925,9 +921,8 @@ export function initialize() {
                             "click",
                             ".send_later_selected_send_later_time",
                             (e) => {
-                                const send_at_time = get_selected_send_later_time();
-                                const not_from_flatpickr = true;
-                                do_schedule_message(send_at_time, not_from_flatpickr);
+                                const send_at_timestamp = get_selected_send_later_timestamp();
+                                do_schedule_message(send_at_timestamp);
                                 e.preventDefault();
                                 e.stopPropagation();
                             },

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -89,7 +89,7 @@ export function open_scheduled_message_in_compose(scheduled_msg) {
     compose_banner.clear_message_sent_banners(false);
     compose_actions.start(compose_args.type, compose_args);
     compose_ui.autosize_textarea($("#compose-textarea"));
-    popover_menus.set_selected_schedule_time(scheduled_msg.scheduled_delivery_timestamp * 1000);
+    popover_menus.set_selected_schedule_timestamp(scheduled_msg.scheduled_delivery_timestamp);
 }
 
 export function send_request_to_schedule_message(scheduled_message_data, deliver_at) {

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -65,8 +65,7 @@ export function edit_scheduled_message(scheduled_msg_id) {
     compose.clear_compose_box();
     compose_actions.start(compose_args.type, compose_args);
     compose_ui.autosize_textarea($("#compose-textarea"));
-    $("#compose-textarea").attr("data-scheduled-message-id", scheduled_msg_id);
-    popover_menus.show_schedule_confirm_button(scheduled_msg.formatted_send_at_time, true);
+    popover_menus.set_selected_schedule_time(scheduled_msg.formatted_send_at_time);
 }
 
 export function send_request_to_schedule_message(scheduled_message_data, deliver_at) {
@@ -99,7 +98,7 @@ export function send_request_to_schedule_message(scheduled_message_data, deliver
     });
 }
 
-export function delete_scheduled_message(scheduled_msg_id) {
+export function delete_scheduled_message(scheduled_msg_id, edit_if_delete_successs) {
     channel.del({
         url: "/json/scheduled_messages/" + scheduled_msg_id,
         success() {
@@ -109,25 +108,9 @@ export function delete_scheduled_message(scheduled_msg_id) {
                     `#scheduled_messages_overlay .scheduled-message-row[data-message-id=${scheduled_msg_id}]`,
                 ).remove();
             }
-            if ($("#compose-textarea").attr("data-scheduled-message-id")) {
-                const compose_scheduled_msg_id = $("#compose-textarea").attr(
-                    "data-scheduled-message-id",
-                );
-                // If user deleted the scheduled message which is being edited in compose, we clear
-                // the scheduled message id from there which converts this editing state into a normal
-                // schedule message state. So, clicking "Schedule" will now create a new scheduled message.
-                if (compose_scheduled_msg_id === scheduled_msg_id) {
-                    $("#compose-textarea").removeAttr("data-scheduled-message-id");
-                }
+            if (edit_if_delete_successs) {
+                edit_scheduled_message(scheduled_msg_id);
             }
         },
     });
-}
-
-export function delete_scheduled_message_if_sent_directly() {
-    // Delete old scheduled message if it was sent.
-    if ($("#compose-textarea").attr("data-scheduled-message-id")) {
-        delete_scheduled_message($("#compose-textarea").attr("data-scheduled-message-id"));
-        $("#compose-textarea").removeAttr("data-scheduled-message-id");
-    }
 }

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -1,13 +1,13 @@
 import $ from "jquery";
 
+import render_success_message_scheduled_banner from "../templates/compose_banner/success_message_scheduled_banner.hbs";
+
 import * as channel from "./channel";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
 import * as compose_banner from "./compose_banner";
 import * as compose_ui from "./compose_ui";
-import {$t} from "./i18n";
 import * as narrow from "./narrow";
-import * as notifications from "./notifications";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
@@ -93,15 +93,14 @@ export function open_scheduled_message_in_compose(scheduled_msg) {
 }
 
 export function send_request_to_schedule_message(scheduled_message_data, deliver_at) {
-    const success = function () {
+    const success = function (data) {
         compose.clear_compose_box();
-        notifications.notify_above_composebox(
-            $t({defaultMessage: `Your message has been scheduled for {deliver_at}.`}, {deliver_at}),
-            "scheduled_message_banner",
-            "/#scheduled",
-            "",
-            $t({defaultMessage: "View scheduled messages"}),
-        );
+        const new_row = render_success_message_scheduled_banner({
+            scheduled_message_id: data.scheduled_message_id,
+            deliver_at,
+        });
+        compose_banner.clear_message_sent_banners();
+        compose_banner.append_compose_banner_to_banner_list(new_row);
     };
 
     const error = function (xhr) {
@@ -144,4 +143,16 @@ export function initialize() {
     } else {
         add_scheduled_messages(page_params.scheduled_messages);
     }
+
+    $("body").on("click", ".undo_scheduled_message", (e) => {
+        const scheduled_message_id = Number.parseInt(
+            $(e.target)
+                .parents(".message_scheduled_success_compose_banner")
+                .attr("data-scheduled-message-id"),
+            10,
+        );
+        edit_scheduled_message(scheduled_message_id);
+        e.preventDefault();
+        e.stopPropagation();
+    });
 }

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -1,4 +1,3 @@
-import * as date_fns from "date-fns";
 import $ from "jquery";
 
 import render_scheduled_message from "../templates/scheduled_message.hbs";
@@ -31,8 +30,7 @@ function format(scheduled_messages) {
             msg_render_context.recipients = people.get_recipients(msg.to.join(","));
         }
         const time = new Date(msg.scheduled_delivery_timestamp * 1000);
-        msg_render_context.full_date_time = timerender.get_full_datetime(time);
-        msg_render_context.formatted_send_at_time = date_fns.format(time, "MMM d yyyy h:mm a");
+        msg_render_context.formatted_send_at_time = timerender.get_full_datetime(time, "time");
         formatted_msgs.push(msg_render_context);
     }
     return formatted_msgs;

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -64,19 +64,15 @@ export function launch() {
         url: "/json/scheduled_messages",
         success(data) {
             hide_loading_indicator();
-            if (data.scheduled_messages.length === 0) {
-                $(".no-overlay-messages").show();
-            } else {
-                // Saving formatted data is helpful when user is trying to edit a scheduled message.
-                scheduled_messages.override_scheduled_messages_data(
-                    format(data.scheduled_messages),
-                );
-                const rendered_list = render_scheduled_message({
-                    scheduled_messages_data: scheduled_messages.scheduled_messages_data,
-                });
-                const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
-                $messages_list.append(rendered_list);
-            }
+            // Saving formatted data is helpful when user is trying to edit a scheduled message.
+            scheduled_messages.override_scheduled_messages_data(
+                format(data.scheduled_messages),
+            );
+            const rendered_list = render_scheduled_message({
+                scheduled_messages_data: scheduled_messages.scheduled_messages_data,
+            });
+            const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
+            $messages_list.append(rendered_list);
         },
         error(xhr) {
             hide_loading_indicator();

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -4,21 +4,13 @@ import $ from "jquery";
 import render_scheduled_message from "../templates/scheduled_message.hbs";
 import render_scheduled_messages_overlay from "../templates/scheduled_messages_overlay.hbs";
 
-import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
-import * as channel from "./channel";
-import * as loading from "./loading";
 import * as overlays from "./overlays";
 import * as people from "./people";
 import * as scheduled_messages from "./scheduled_messages";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
-
-function hide_loading_indicator() {
-    loading.destroy_indicator($("#scheduled_messages_overlay .loading-indicator"));
-    $(".scheduled-messages-loading").hide();
-}
 
 function format(scheduled_messages) {
     const formatted_msgs = [];
@@ -56,29 +48,32 @@ export function launch() {
             browser_history.exit_overlay();
         },
     });
-    loading.make_indicator($("#scheduled_messages_overlay .loading-indicator"), {
-        abs_positioned: true,
-    });
 
-    channel.get({
-        url: "/json/scheduled_messages",
-        success(data) {
-            hide_loading_indicator();
-            // Saving formatted data is helpful when user is trying to edit a scheduled message.
-            scheduled_messages.override_scheduled_messages_data(
-                format(data.scheduled_messages),
-            );
-            const rendered_list = render_scheduled_message({
-                scheduled_messages_data: scheduled_messages.scheduled_messages_data,
-            });
-            const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
-            $messages_list.append(rendered_list);
-        },
-        error(xhr) {
-            hide_loading_indicator();
-            blueslip.error(xhr);
-        },
+    const rendered_list = render_scheduled_message({
+        scheduled_messages_data: format(scheduled_messages.scheduled_messages_data),
     });
+    const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
+    $messages_list.append(rendered_list);
+}
+
+export function rerender() {
+    if (!overlays.scheduled_messages_open()) {
+        return;
+    }
+    const rendered_list = render_scheduled_message({
+        scheduled_messages_data: format(scheduled_messages.scheduled_messages_data),
+    });
+    const $messages_list = $("#scheduled_messages_overlay .overlay-messages-list");
+    $messages_list.find(".scheduled-message-row").remove();
+    $messages_list.append(rendered_list);
+}
+
+export function remove_scheduled_message_id(scheduled_msg_id) {
+    if (overlays.scheduled_messages_open()) {
+        $(
+            `#scheduled_messages_overlay .scheduled-message-row[data-message-id=${scheduled_msg_id}]`,
+        ).remove();
+    }
 }
 
 export function initialize() {
@@ -87,8 +82,8 @@ export function initialize() {
             .closest(".scheduled-message-row")
             .attr("data-message-id");
         scheduled_msg_id = Number.parseInt(scheduled_msg_id, 10);
-        scheduled_messages.delete_scheduled_message(scheduled_msg_id, true);
-
+        scheduled_messages.edit_scheduled_message(scheduled_msg_id);
+        overlays.close_overlay("scheduled");
         e.stopPropagation();
         e.preventDefault();
     });

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -91,7 +91,7 @@ export function initialize() {
             .closest(".scheduled-message-row")
             .attr("data-message-id");
         scheduled_msg_id = Number.parseInt(scheduled_msg_id, 10);
-        scheduled_messages.edit_scheduled_message(scheduled_msg_id);
+        scheduled_messages.delete_scheduled_message(scheduled_msg_id, true);
 
         e.stopPropagation();
         e.preventDefault();

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -69,7 +69,7 @@ export function rerender() {
 export function remove_scheduled_message_id(scheduled_msg_id) {
     if (overlays.scheduled_messages_open()) {
         $(
-            `#scheduled_messages_overlay .scheduled-message-row[data-message-id=${scheduled_msg_id}]`,
+            `#scheduled_messages_overlay .scheduled-message-row[data-scheduled-message-id=${scheduled_msg_id}]`,
         ).remove();
     }
 }
@@ -78,7 +78,7 @@ export function initialize() {
     $("body").on("click", ".scheduled-message-row .restore-overlay-message", (e) => {
         let scheduled_msg_id = $(e.currentTarget)
             .closest(".scheduled-message-row")
-            .attr("data-message-id");
+            .attr("data-scheduled-message-id");
         scheduled_msg_id = Number.parseInt(scheduled_msg_id, 10);
         scheduled_messages.edit_scheduled_message(scheduled_msg_id);
         overlays.close_overlay("scheduled");
@@ -89,7 +89,7 @@ export function initialize() {
     $("body").on("click", ".scheduled-message-row .delete-overlay-message", (e) => {
         const scheduled_msg_id = $(e.currentTarget)
             .closest(".scheduled-message-row")
-            .attr("data-message-id");
+            .attr("data-scheduled-message-id");
         scheduled_messages.delete_scheduled_message(scheduled_msg_id);
 
         e.stopPropagation();

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -39,6 +39,8 @@ import * as realm_logo from "./realm_logo";
 import * as realm_playground from "./realm_playground";
 import {realm_user_settings_defaults} from "./realm_user_settings_defaults";
 import * as reload from "./reload";
+import * as scheduled_messages from "./scheduled_messages";
+import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui";
 import * as scroll_bar from "./scroll_bar";
 import * as settings_account from "./settings_account";
 import * as settings_bots from "./settings_bots";
@@ -80,6 +82,29 @@ import * as user_status from "./user_status";
 export function dispatch_normal_event(event) {
     const noop = function () {};
     switch (event.type) {
+        case "scheduled_messages":
+            switch (event.op) {
+                case "add": {
+                    scheduled_messages.add_scheduled_messages(event.scheduled_messages);
+                    scheduled_messages_overlay_ui.rerender();
+                    break;
+                }
+                case "remove": {
+                    scheduled_messages.remove_scheduled_message(event.scheduled_message_id);
+                    scheduled_messages_overlay_ui.remove_scheduled_message_id(
+                        event.scheduled_message_id,
+                    );
+                    break;
+                }
+                case "update": {
+                    scheduled_messages.update_scheduled_message(event.scheduled_message);
+                    scheduled_messages_overlay_ui.rerender();
+                    break;
+                }
+                // No default
+            }
+            break;
+
         case "alert_words":
             alert_words.set_words(event.alert_words);
             alert_words_ui.rerender_alert_words_ui();

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -623,27 +623,6 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: "#compose-schedule-confirm-button",
-        onShow(instance) {
-            if (popover_menus.get_scheduled_messages_popover()) {
-                return false;
-            }
-
-            const send_at_time = popover_menus.get_formatted_selected_send_later_time();
-            instance.setContent(
-                parse_html(
-                    $t(
-                        {defaultMessage: "Schedule message for <br/> {send_at_time}"},
-                        {send_at_time},
-                    ),
-                ),
-            );
-            return true;
-        },
-        appendTo: () => document.body,
-    });
-
-    delegate("body", {
         target: "#send_later",
         delay: LONG_HOVER_DELAY,
         placement: "top",

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -74,6 +74,7 @@ import * as reload from "./reload";
 import * as rendered_markdown from "./rendered_markdown";
 import * as resize from "./resize";
 import * as rows from "./rows";
+import * as scheduled_messages from "./scheduled_messages";
 import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui";
 import * as scroll_bar from "./scroll_bar";
 import * as scroll_util from "./scroll_util";
@@ -588,6 +589,8 @@ export function initialize_everything() {
 
     i18n.initialize(i18n_params);
     tippyjs.initialize();
+    // This populates data for scheduled messages.
+    scheduled_messages.initialize();
     popovers.initialize();
     popover_menus.initialize();
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -325,6 +325,19 @@
                 color: hsl(147deg 57% 25% / 75%);
             }
         }
+
+        .compose_banner_action_button {
+            background-color: hsl(147deg 57% 25% / 10%);
+            color: inherit;
+
+            &:hover {
+                background-color: hsl(147deg 57% 25% / 12%);
+            }
+
+            &:active {
+                background-color: hsl(147deg 57% 25% / 15%);
+            }
+        }
     }
 
     /* warning and warning-style classes have the same CSS; this is since
@@ -409,6 +422,32 @@
             &:active {
                 color: hsl(204deg 49% 29% / 75%);
             }
+        }
+    }
+}
+
+.compose_banner.success.message_scheduled_success_compose_banner {
+    & a.open_scheduled_message_overlay {
+        line-height: normal;
+        display: inline-block;
+        box-sizing: border-box;
+
+        &:hover,
+        &:focus {
+            text-decoration: none;
+        }
+    }
+
+    .undo_scheduled_message {
+        color: hsl(38deg 44% 27%);
+        background-color: hsl(46.29deg 46.67% 85.29%);
+
+        &:hover {
+            background-color: hsl(47.65deg 41.46% 83.92%);
+        }
+
+        &:active {
+            background-color: hsl(47.65deg 37.78% 82.35%);
         }
     }
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -525,7 +525,6 @@ input.recipient_box {
     width: 100%;
 }
 
-#compose-schedule-confirm-button,
 #compose-send-button {
     padding: 3px 12px;
     margin-bottom: 0;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -225,6 +225,19 @@
                     color: hsl(147deg 51% 55% / 75%);
                 }
             }
+
+            .compose_banner_action_button {
+                background-color: hsl(147deg 51% 55% / 10%);
+                color: inherit;
+
+                &:hover {
+                    background-color: hsl(147deg 51% 55% / 15%);
+                }
+
+                &:active {
+                    background-color: hsl(147deg 51% 55% / 20%);
+                }
+            }
         }
 
         &.warning,
@@ -306,6 +319,21 @@
                 &:active {
                     color: hsl(205deg 58% 69% / 75%);
                 }
+            }
+        }
+    }
+
+    .compose_banner.success.message_scheduled_success_compose_banner {
+        .undo_scheduled_message {
+            color: hsl(50deg 45% 61%);
+            background-color: hsl(54deg 75% 15.69%);
+
+            &:hover {
+                background-color: hsl(52.13deg 64.21% 18.63%);
+            }
+
+            &:active {
+                background-color: hsl(51.29deg 57.41% 21.18%);
             }
         }
     }

--- a/web/styles/scheduled_messages.css
+++ b/web/styles/scheduled_messages.css
@@ -12,5 +12,9 @@
 
     .no-overlay-messages {
         display: none;
+
+        &:only-child {
+            display: block;
+        }
     }
 }

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -123,10 +123,6 @@
                                             <img class="loader" alt="" src="" />
                                             <span>{{t 'Send' }}</span>
                                         </button>
-                                        <button id="compose-schedule-confirm-button" class="button small compose-submit-button hide animated-purple-button" tabindex=0>
-                                            <img class="loader" alt="" src="" />
-                                            <span>{{t 'Schedule' }}</span>
-                                        </button>
                                         <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
                                             <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
                                         </button>

--- a/web/templates/compose_banner/success_message_scheduled_banner.hbs
+++ b/web/templates/compose_banner/success_message_scheduled_banner.hbs
@@ -1,0 +1,8 @@
+<div
+  class="compose_banner success message_scheduled_success_compose_banner"
+  data-scheduled-message-id="{{scheduled_message_id}}">
+    <p class="banner_content">{{t 'Your message has been scheduled for {deliver_at}.' }}</p>
+    <a href="#scheduled" class="compose_banner_action_button open_scheduled_message_overlay">{{t "View scheduled messages" }}</a>
+    <button class="compose_banner_action_button undo_scheduled_message" >{{t "Undo"}}</button>
+    <a role="button" class="zulip-icon zulip-icon-close compose_banner_close_button"></a>
+</div>

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -38,7 +38,7 @@
                             <div class="overlay_message_controls">
                                 <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-scheduled-message-tooltip-template"></i>
                                 <template id="restore-scheduled-message-tooltip-template">
-                                    {{t 'Edit or reschedule message' }}
+                                    {{t 'Edit and reschedule message' }}
                                 </template>
                                 <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-scheduled-message-tooltip-template"></i>
                                 <template id="delete-scheduled-message-tooltip-template">

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -1,5 +1,5 @@
 {{#each scheduled_messages_data}}
-    <div class="scheduled-message-row overlay-message-row" data-message-id="{{scheduled_message_id}}">
+    <div class="scheduled-message-row overlay-message-row" data-scheduled-message-id="{{scheduled_message_id}}">
         <div class="overlay-message-info-box" tabindex="0">
             {{#if is_stream}}
             <div class="message_header message_header_stream">

--- a/web/templates/scheduled_messages_overlay.hbs
+++ b/web/templates/scheduled_messages_overlay.hbs
@@ -8,7 +8,7 @@
                 </div>
                 <div class="removed-drafts">
                     {{#tr}}
-                        Click on the pencil (<z-pencil-icon></z-pencil-icon>) icon to reschedule a message.
+                        Click on the pencil (<z-pencil-icon></z-pencil-icon>) icon to edit and reschedule a message.
                         {{#*inline "z-pencil-icon"}}<i class="fa fa-pencil"></i>{{/inline}}
                     {{/tr}}
                 </div>

--- a/web/templates/scheduled_messages_overlay.hbs
+++ b/web/templates/scheduled_messages_overlay.hbs
@@ -13,15 +13,6 @@
                     {{/tr}}
                 </div>
             </div>
-            <div class="scheduled-messages-loading">
-                <div class="scheduled-messages-loading-logo">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 773.12 773.12">
-                        <circle cx="386.56" cy="386.56" r="386.56"></circle>
-                        <path d="M566.66 527.25c0 33.03-24.23 60.05-53.84 60.05H260.29c-29.61 0-53.84-27.02-53.84-60.05 0-20.22 9.09-38.2 22.93-49.09l134.37-120c2.5-2.14 5.74 1.31 3.94 4.19l-49.29 98.69c-1.38 2.76.41 6.16 3.25 6.16h191.18c29.61 0 53.83 27.03 53.83 60.05zm0-281.39c0 20.22-9.09 38.2-22.93 49.09l-134.37 120c-2.5 2.14-5.74-1.31-3.94-4.19l49.29-98.69c1.38-2.76-.41-6.16-3.25-6.16H260.29c-29.61 0-53.84-27.02-53.84-60.05s24.23-60.05 53.84-60.05h252.54c29.61 0 53.83 27.02 53.83 60.05z"></path>
-                    </svg>
-                </div>
-                <div class="loading-indicator"></div>
-            </div>
             <div class="overlay-messages-list">
                 <div class="no-overlay-messages">
                     {{t 'No scheduled messages.'}}

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -22,6 +22,11 @@
                                 <a id="{{@key}}" class="send_later_tomorrow" tabindex="0">{{this.text}}</a>
                             </li>
                         {{/each}}
+                        {{#if formatted_send_later_time}}
+                            <li>
+                                <a class="send_later_selected_send_later_time" tabindex="0">{{formatted_send_later_time}}</a>
+                            </li>
+                        {{/if}}
                         <li>
                             <a class="send_later_custom" tabindex="0">{{t 'Custom time'}}</a>
                         </li>

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -22,11 +22,6 @@
                                 <a id="{{@key}}" class="send_later_tomorrow" tabindex="0">{{this.text}}</a>
                             </li>
                         {{/each}}
-                        {{#if formatted_send_later_time}}
-                            <li>
-                                <a class="send_later_selected_send_later_time" tabindex="0">{{formatted_send_later_time}}</a>
-                            </li>
-                        {{/if}}
                         <li>
                             <a class="send_later_custom" tabindex="0">{{t 'Custom time'}}</a>
                         </li>

--- a/web/templates/send_later_popover.hbs
+++ b/web/templates/send_later_popover.hbs
@@ -2,11 +2,6 @@
     <li>
         <a class="open_send_later_modal" tabindex="0">{{t "Schedule message" }}</a>
     </li>
-    {{#if formatted_send_later_time }}
-    <li>
-        <a id="clear_compose_schedule_state" tabindex="0">{{t "Cancel scheduling" }}</a>
-    </li>
-    {{/if}}
     <hr />
     <li>
         <a href="#scheduled" tabindex="0">{{t "View scheduled messages" }}</a>

--- a/web/templates/send_later_popover.hbs
+++ b/web/templates/send_later_popover.hbs
@@ -2,6 +2,11 @@
     <li>
         <a class="open_send_later_modal" tabindex="0">{{t "Schedule message" }}</a>
     </li>
+    {{#if formatted_send_later_time}}
+        <li>
+            <a class="send_later_selected_send_later_time" tabindex="0">{{t 'Schedule for {formatted_send_later_time}' }}</a>
+        </li>
+    {{/if}}
     <hr />
     <li>
         <a href="#scheduled" tabindex="0">{{t "View scheduled messages" }}</a>

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -40,6 +40,8 @@ const realm_icon = mock_esm("../src/realm_icon");
 const realm_logo = mock_esm("../src/realm_logo");
 const realm_playground = mock_esm("../src/realm_playground");
 const reload = mock_esm("../src/reload");
+const scheduled_messages = mock_esm("../src/scheduled_messages");
+const scheduled_messages_overlay_ui = mock_esm("../src/scheduled_messages_overlay_ui");
 const scroll_bar = mock_esm("../src/scroll_bar");
 const settings_account = mock_esm("../src/settings_account");
 const settings_bots = mock_esm("../src/settings_bots");
@@ -368,6 +370,38 @@ run_test("reaction", ({override}) => {
         const args = stub.get_args("event");
         assert_same(args.event.emoji_name, event.emoji_name);
         assert_same(args.event.message_id, event.message_id);
+    }
+});
+
+run_test("scheduled_messages", ({override}) => {
+    override(scheduled_messages_overlay_ui, "rerender", noop);
+    override(scheduled_messages_overlay_ui, "remove_scheduled_message_id", noop);
+    let event = event_fixtures.scheduled_messages__add;
+    {
+        const stub = make_stub();
+        override(scheduled_messages, "add_scheduled_messages", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("scheduled_messages");
+        assert_same(args.scheduled_messages, event.scheduled_messages);
+    }
+    event = event_fixtures.scheduled_messages__update;
+    {
+        const stub = make_stub();
+        override(scheduled_messages, "update_scheduled_message", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("scheduled_message");
+        assert_same(args.scheduled_message, event.scheduled_message);
+    }
+    event = event_fixtures.scheduled_messages__remove;
+    {
+        const stub = make_stub();
+        override(scheduled_messages, "remove_scheduled_message", stub.f);
+        dispatch(event);
+        assert.equal(stub.num_calls, 1);
+        const args = stub.get_args("scheduled_message_id");
+        assert_same(args.scheduled_message_id, event.scheduled_message_id);
     }
 });
 

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -613,6 +613,40 @@ exports.fixtures = {
         immediate: true,
     },
 
+    scheduled_messages__add: {
+        type: "scheduled_messages",
+        op: "add",
+        scheduled_messages: [
+            {
+                scheduled_message_id: 17,
+                type: "private",
+                to: [6],
+                content: "Hello there!",
+                rendered_content: "<p>Hello there!</p>",
+                scheduled_delivery_timestamp: 1681662420,
+            },
+        ],
+    },
+
+    scheduled_messages__remove: {
+        type: "scheduled_messages",
+        op: "remove",
+        scheduled_message_id: 17,
+    },
+
+    scheduled_messages__update: {
+        type: "scheduled_messages",
+        op: "update",
+        scheduled_message: {
+            scheduled_message_id: 17,
+            type: "private",
+            to: [6],
+            content: "Hello there!",
+            rendered_content: "<p>Hello there!</p>",
+            scheduled_delivery_timestamp: 1681662420,
+        },
+    },
+
     stream__create: {
         type: "stream",
         op: "create",


### PR DESCRIPTION
Fixes #25340

This means that we now schedule the message simply after selecting time if the message is valid.

Also, editing scheduled messages will now delete the scheduled message and open compose with scheduled message.

TODO:
- [x] Note that the user can always drop an accidentally scheduled message from the scheduled messages overlay, which is linked from the confirmation banner. We may also want to add an "Undo" button to that banner.
- [x] Drop the "Scheduling this message..." compose banner.
- [x] Live update schedule message overlay based on events.