### PR TITLE
narrow: Mark messages as read when applying -is:dm filter.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -550,10 +550,35 @@ export class Filter {
             return true;
         }
 
+        const term_types = this.sorted_term_types();
+
         // TODO: Some users really hate it when Zulip marks messages as read
         // in interleaved views, so we will eventually have a setting
         // that early-exits before the subsequent checks.
         // (in which case, is_common_narrow would also need to be modified)
+
+        // -is:dm excludes direct messages from all messages
+        if (_.isEqual(term_types, ["not-is-dm"])) {
+            return true;
+        }
+
+        // Excluding direct messages from stream and topic does not
+        // accomplish anything, still adding code to be consistent with our design.
+
+        if (_.isEqual(term_types, ["stream", "not-is-dm"])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ["topic", "not-is-dm"])) {
+            return true;
+        }
+
+        // Excluding direct messages from stream and topic does not
+        // accomplish anything, but we are still letting user mark
+        // mark messages as read to be consistent with our design.
+        if (_.isEqual(term_types, ["stream", "topic", "not-is-dm"])) {
+            return true;
+        }
 
         return false;
     }
@@ -571,10 +596,6 @@ export class Filter {
     // https://paper.dropbox.com/doc/Navbar-behavior-table--AvnMKN4ogj3k2YF5jTbOiVv_AQ-cNOGtu7kSdtnKBizKXJge
     // common narrows show a narrow description and allow the user to
     // close search bar UI and show the narrow description UI.
-    //
-    // TODO: We likely will want to rewrite this to not piggy-back on
-    // can_mark_messages_read, since that might gain some more complex behavior
-    // with near: narrows.
     is_common_narrow() {
         // can_mark_messages_read tests the following filters:
         // stream, stream + topic,


### PR DESCRIPTION
It will mark messages as read when applying -is:dm filter alone or coupled with stream and topic filters. But it will not mark messages as read when there is also search term present.

fixes #25113.
