### PR TITLE
emails: Fix body tag styles being applied in messages template.

### DIFF
--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -12,7 +12,7 @@ img.bottom-illustration {
     vertical-align: bottom;
 }
 
-body {
+body.default-email-font-settings {
     font-family: sans-serif;
     font-size: 14px;
     line-height: 1.4;

--- a/templates/zerver/emails/email_base_default.html
+++ b/templates/zerver/emails/email_base_default.html
@@ -8,7 +8,7 @@
         <title>Zulip</title>
         <style>{{css_styles}}</style>
     </head>
-    <body>
+    <body class="default-email-font-settings">
         <table border="0" cellpadding="0" cellspacing="0" class="body layout">
             <tr>
                 <td>&nbsp;</td>

--- a/templates/zerver/emails/email_base_marketing.html
+++ b/templates/zerver/emails/email_base_marketing.html
@@ -8,7 +8,7 @@
         <title>Zulip</title>
         <style>{{css_styles}}</style>
     </head>
-    <body>
+    <body class="default-email-font-settings">
         <table border="0" cellpadding="0" cellspacing="0" class="body layout">
             <tr>
                 <td>&nbsp;</td>


### PR DESCRIPTION
During the Premailer migration, font sizes increased in emails based on the `email_base_messages` template. This PR narrows the CSS selector to apply styles only to the `body` tag with the `default-email-font-settings` class, rather than the entire `body` tag. This ensures that the styles are only applied to the intended emails.