### PR TITLE
compose: Fix buttons in error banners is not clickable.

### DIFF
--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -51,7 +51,9 @@ export const CLASSNAMES = {
     user_not_subscribed: "user_not_subscribed",
 };
 
-export function append_compose_banner_to_banner_list(new_row: HTMLElement): void {
+export function append_compose_banner_to_banner_list(
+    new_row: HTMLElement | JQuery.htmlString,
+): void {
     scroll_util.get_content_element($("#compose_banners")).append(new_row);
 }
 
@@ -99,8 +101,7 @@ export function show_error_message(message: string, classname: string, $bad_inpu
         button_text: null,
         classname,
     });
-    const $compose_banner_area = $("#compose_banners");
-    $compose_banner_area.append(new_row);
+    append_compose_banner_to_banner_list(new_row);
 
     hide_compose_spinner();
 
@@ -118,8 +119,7 @@ export function show_stream_does_not_exist_error(stream_name: string): void {
         stream_name,
         classname: CLASSNAMES.stream_does_not_exist,
     });
-    const $compose_banner_area = $("#compose_banners");
-    $compose_banner_area.append(new_row);
+    append_compose_banner_to_banner_list(new_row);
     hide_compose_spinner();
 
     // A copy of `compose_recipient.open_compose_stream_dropup()` that


### PR DESCRIPTION
This PR addresses an issue where buttons on error containers were not clickable due to error banners being incorrectly appended to the DOM. To resolve this, I have utilized the `append_compose_banner_to_banner_list` function to properly append error banners to the appropriate DOM element. This change ensures that error banners appear in the correct container, allowing buttons to be clickable.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![2023-05-01 at 16 11 21 - Amber Quail](https://user-images.githubusercontent.com/53193850/235433338-d8b9394e-9bb8-4372-b7ff-ed271aa710b9.gif)
