### PR TITLE
emails: Add "corporate_enabled" to context for emails.

### DIFF
--- a/zerver/actions/invites.py
+++ b/zerver/actions/invites.py
@@ -59,6 +59,7 @@ def do_send_confirmation_email(
         "referrer_email": referrer.delivery_email,
         "activate_url": activation_url,
         "referrer_realm_name": referrer.realm.name,
+        "corporate_enabled": settings.CORPORATE_ENABLED,
     }
     send_email(
         "zerver/emails/invitation",

--- a/zerver/actions/realm_settings.py
+++ b/zerver/actions/realm_settings.py
@@ -481,7 +481,12 @@ def do_send_realm_reactivation_email(realm: Realm, *, acting_user: Optional[User
         event_type=RealmAuditLog.REALM_REACTIVATION_EMAIL_SENT,
         event_time=timezone_now(),
     )
-    context = {"confirmation_url": url, "realm_uri": realm.uri, "realm_name": realm.name}
+    context = {
+        "confirmation_url": url,
+        "realm_uri": realm.uri,
+        "realm_name": realm.name,
+        "corporate_enabled": settings.CORPORATE_ENABLED,
+    }
     language = realm.default_language
     send_email_to_admins(
         "zerver/emails/realm_reactivation",

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -47,6 +47,7 @@ def common_context(user: UserProfile) -> Dict[str, Any]:
         "external_url_scheme": settings.EXTERNAL_URI_SCHEME,
         "external_host": settings.EXTERNAL_HOST,
         "user_name": user.full_name,
+        "corporate_enabled": settings.CORPORATE_ENABLED,
     }
 
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -692,6 +692,7 @@ def send_confirm_registration_email(
         context={
             "create_realm": (realm is None),
             "activate_url": activation_url,
+            "corporate_enabled": settings.CORPORATE_ENABLED,
         },
         realm=realm,
         request=request,


### PR DESCRIPTION
In commit fc58c35c0, we added a check in various emails for the `settings.CORPORATE_ENABLED` value, but that context is only always included for views/templates with a request (`zulip_default_context`).

The check was added to adjust the text for the "contact us" line in various emails based on whether the organization is on Zulip Cloud or a self-hosted server.

Here we add that to `common_context`, which is often used when there is not a request (like with emails). And we manually add it to the email context in various cases when there is not a user account to call with `common_context`: new user invitations, registration emails, and realm reactivation emails.

```
$ git grep corporate_enabled templates/zerver/emails
templates/zerver/emails/confirm_registration.html:    {% if corporate_enabled %}
templates/zerver/emails/confirm_registration.txt:{% if corporate_enabled %}
templates/zerver/emails/followup_day1.html:    {% if corporate_enabled %}
templates/zerver/emails/followup_day1.txt:{% if corporate_enabled %}
templates/zerver/emails/invitation.html:    {% if corporate_enabled %}
templates/zerver/emails/invitation.txt:{% if corporate_enabled %}
templates/zerver/emails/onboarding_zulip_guide.html:    {% if corporate_enabled %}
templates/zerver/emails/onboarding_zulip_guide.txt:{% if corporate_enabled %}
templates/zerver/emails/realm_reactivation.html:    {% if corporate_enabled %}
templates/zerver/emails/realm_reactivation.txt:{% if corporate_enabled %}
```

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
