### PR TITLE
css: Fix date row overlapping with message header.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1219,7 +1219,8 @@ td.pointer {
         position: sticky;
         padding-top: var(--header-padding-bottom);
         top: var(--header-height);
-        z-index: 3;
+        /* Needs to be higher than the z-index of date_row. */
+        z-index: 4;
         box-shadow: 0 -1px 0 0 var(--color-background);
 
         &.sticky_header {
@@ -3000,6 +3001,7 @@ select.invite-as {
     .message_row.unread {
         .date_row {
             position: relative;
+            /* Needs to be lower than the z-index of message_header. */
             z-index: 3;
         }
     }


### PR DESCRIPTION
When there was an unread message below date row, the date row overlaps with the message header.

This was a result of #23538 not adjusting the message header z-index along with the z-index of date row.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/date.20seperator.20cuts.20off.20topic.20header
before: 
<img width="764" alt="Screenshot 2023-05-01 at 9 22 07 PM" src="https://user-images.githubusercontent.com/25124304/235481914-3160d2ae-85ef-4d08-bb34-9c25c990639e.png">



after:
<img width="774" alt="Screenshot 2023-05-01 at 9 21 31 PM" src="https://user-images.githubusercontent.com/25124304/235481804-41a64652-c735-4b3c-88e8-d4eb59749761.png">


