### PR TITLE
onboarding: Specialize Welcome Bot message for education organizations.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -252,9 +252,9 @@ def process_new_human_user(
 
     # We have an import loop here; it's intentional, because we want
     # to keep all the onboarding code in zerver/lib/onboarding.py.
-    from zerver.lib.onboarding import send_initial_pms
+    from zerver.lib.onboarding import send_initial_direct_message
 
-    send_initial_pms(user_profile)
+    send_initial_direct_message(user_profile)
 
 
 def notify_created_user(user_profile: UserProfile) -> None:

--- a/zerver/management/commands/send_welcome_bot_message.py
+++ b/zerver/management/commands/send_welcome_bot_message.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 from typing import Any
 
 from zerver.lib.management import ZulipBaseCommand
-from zerver.lib.onboarding import send_initial_pms
+from zerver.lib.onboarding import send_initial_direct_message
 
 
 class Command(ZulipBaseCommand):
@@ -18,4 +18,4 @@ class Command(ZulipBaseCommand):
 
     def handle(self, *args: Any, **options: str) -> None:
         for user_profile in self.get_users(options, self.get_realm(options), is_bot=False):
-            send_initial_pms(user_profile)
+            send_initial_direct_message(user_profile)


### PR DESCRIPTION
Because education organizations and users have slightly specialized use cases, we update the Welcome Bot message content sent to new users and new organization admins for these types of organizations to link to help center articles/guides geared toward these users and organizations.

Also, updates the demo organization warning to only go to the new demo organization owner because the 30 day deletion text is only definitely accurate when the organization is created. If we want that warning sent to all users for demo organizations, then we should update the message to either not have the number of days until deletion or accurately format the string for the number of days left (like we do the warning banner at the top of the web app).

Fixes #21694.

---

**Screenshots and screen captures:**

<details>
<summary>Business org - admin</summary>

![Screenshot from 2023-05-01 17-59-06](https://user-images.githubusercontent.com/63245456/235486348-3fef351a-8230-4a28-a24f-5d6405331449.png)
</details>
<details>
<summary>Business org - normal user</summary>

![Screenshot from 2023-05-01 17-59-22](https://user-images.githubusercontent.com/63245456/235485720-539afefe-0e34-41ec-a775-ad0f0080033b.png)
</details>
<details>
<summary>Education org - admin</summary>

![Screenshot from 2023-05-01 18-00-47](https://user-images.githubusercontent.com/63245456/235485758-687a7f30-046f-4fae-b5f7-ecc81507d1af.png)
</details>
<details>
<summary>Education org - normal user</summary>

![Screenshot from 2023-05-01 18-01-20](https://user-images.githubusercontent.com/63245456/235485954-9f090685-9964-4622-be82-21c0019d6f6a.png)
</details>
<details>
<summary>Business demo org - admin</summary>

![Screenshot from 2023-05-01 17-59-41](https://user-images.githubusercontent.com/63245456/235486057-1e39e2d1-80b9-46e3-a969-7faf414e1e4d.png)
</details>
<details>
<summary>Business demo org - normal user</summary>

![Screenshot from 2023-05-01 17-59-54](https://user-images.githubusercontent.com/63245456/235486217-cb30a801-6ee5-4d19-9d25-e55fe068802c.png)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
