### PR TITLE
left_sidebar: Do not hide muted topics in muted streams.

### DIFF
--- a/web/src/topic_list_data.js
+++ b/web/src/topic_list_data.js
@@ -43,7 +43,7 @@ function choose_topics(stream_id, topic_names, zoomed, topic_choice_state) {
                 // We unconditionally skip showing muted topics
                 // when not zoomed, even if they have unread
                 // messages.
-                if (is_topic_muted) {
+                if (is_topic_muted && !sub_store.get(stream_id).is_muted) {
                     return false;
                 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -386,6 +386,10 @@ ul.filters {
                     opacity: 1;
                 }
             }
+
+            & li.muted_topic {
+                color: hsla(0deg 0% 20% / 75%);
+            }
         }
 
         & li.muted_topic {


### PR DESCRIPTION
Added `!sub_store.get(stream_id).is_muted` in && condition with is_topic_muted in should_show_topic function to not hide muted topic in a muted stream.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->
#25363

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
