### PR TITLE
tooltips: Add `S` hotkey hint to `narrow-to` tippy tooltips.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -113,7 +113,7 @@ async function test_open_close_compose_box(page: Page): Promise<void> {
 
 async function test_narrow_to_private_messages_with_cordelia(page: Page): Promise<void> {
     const you_and_cordelia_selector =
-        '*[data-tippy-content="Narrow to your direct messages with Cordelia, Lear\'s daughter"]';
+        '*[data-tippy-content="Go to direct messages with Cordelia, Lear\'s daughter"]';
     // For some unknown reason page.click() isn't working here.
     await page.evaluate(
         (selector: string) => document.querySelector<HTMLElement>(selector)!.click(),

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -186,6 +186,16 @@ export function initialize() {
     });
 
     delegate("body", {
+        target: ".tippy-narrow-tooltip",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onCreate(instance) {
+            const content = instance.props.content + $("#narrow-hotkey-tooltip-template").html();
+            instance.setContent(parse_html(content));
+        },
+    });
+
+    delegate("body", {
         target: ".toggle-subscription-tooltip",
         delay: EXTRA_LONG_HOVER_DELAY,
         appendTo: () => document.body,

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -2,7 +2,7 @@
 <div class="message_header message_header_stream right_part" data-stream-id="{{stream_id}}">
     <div class="message-header-contents" style="background: {{recipient_bar_color}};">
         {{! stream link }}
-        <a class="message_label_clickable narrows_by_recipient stream_label tippy-zulip-delayed-tooltip"
+        <a class="message_label_clickable narrows_by_recipient stream_label tippy-narrow-tooltip"
           href="{{stream_url}}"
           data-tippy-content="{{t 'Narrow to stream "{display_recipient}"' }}">
             <span class="stream-privacy-modified-color-{{stream_id}} stream-privacy filter-icon"  style="color: {{stream_privacy_icon_color}}">
@@ -20,7 +20,7 @@
         {{! topic stuff }}
         <span class="stream_topic">
             {{! topic link }}
-            <a class="message_label_clickable narrows_by_topic tippy-zulip-delayed-tooltip"
+            <a class="message_label_clickable narrows_by_topic tippy-narrow-tooltip"
               href="{{topic_url}}"
               data-tippy-content="{{t 'Narrow to stream "{display_recipient}", topic "{topic}"' }}">
                 {{#if use_match_properties}}
@@ -80,7 +80,7 @@
 {{else}}
 <div class="message_header message_header_private_message">
     <div class="message-header-contents">
-        <a class="message_label_clickable narrows_by_recipient stream_label tippy-zulip-delayed-tooltip"
+        <a class="message_label_clickable narrows_by_recipient stream_label tippy-narrow-tooltip"
           href="{{pm_with_url}}"
           data-tippy-content="{{t 'Narrow to your direct messages with {display_reply_to}' }}">
         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -4,7 +4,7 @@
         {{! stream link }}
         <a class="message_label_clickable narrows_by_recipient stream_label tippy-narrow-tooltip"
           href="{{stream_url}}"
-          data-tippy-content="{{t 'Narrow to stream "{display_recipient}"' }}">
+          data-tippy-content="{{t 'Go to #{display_recipient}' }}">
             <span class="stream-privacy-modified-color-{{stream_id}} stream-privacy filter-icon"  style="color: {{stream_privacy_icon_color}}">
                 {{> stream_privacy}}
             </span>
@@ -22,7 +22,7 @@
             {{! topic link }}
             <a class="message_label_clickable narrows_by_topic tippy-narrow-tooltip"
               href="{{topic_url}}"
-              data-tippy-content="{{t 'Narrow to stream "{display_recipient}", topic "{topic}"' }}">
+              data-tippy-content="{{t 'Go to #{display_recipient} > {topic}' }}">
                 {{#if use_match_properties}}
                     {{{match_topic}}}
                 {{else}}
@@ -82,7 +82,7 @@
     <div class="message-header-contents">
         <a class="message_label_clickable narrows_by_recipient stream_label tippy-narrow-tooltip"
           href="{{pm_with_url}}"
-          data-tippy-content="{{t 'Narrow to your direct messages with {display_reply_to}' }}">
+          data-tippy-content="{{t 'Go to direct messages with {display_reply_to}' }}">
         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
         {{t "You and {display_reply_to}" }}
         </a>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -2,3 +2,6 @@
     {{t 'View user card' }}
     {{tooltip_hotkey_hints "U"}}
 </template>
+<template id="narrow-hotkey-tooltip-template">
+    {{tooltip_hotkey_hints "S"}}
+</template>


### PR DESCRIPTION
CZO Discussion: https://chat.zulip.org/#narrow/stream/137-feedback/topic/title.20tips.20in.20recipient.20bar

Added hotkey hint to Narrow to stream/topic/DM tooltips by creating new tippy for `tippy-narrow-tooltip` with LONG_HOVER_DELAY which appends `S` hotkey to the existing tippy content set by data-tippy-content attribute on the element.

Using this approach instead of a `<template>` with
data-tooltip-template-id avoids issues with context, where `{display_recipient}/{topic}/{display_reply_to}` inside `<template>` would always show the same stream/topic name regardless of the actual stream/topic being hovered over.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- **Before:** 

![image](https://user-images.githubusercontent.com/64723994/235521957-54e80601-2d15-4240-8a02-2793f9558e76.png)

![image](https://user-images.githubusercontent.com/64723994/235522013-d0f53d2a-43df-4c19-8fd7-ba6d57f1ece7.png)

![image](https://user-images.githubusercontent.com/64723994/235522096-73e90148-a62d-4015-8800-cffd72dfb71b.png)


- **After:**

![image](https://user-images.githubusercontent.com/64723994/235522178-e6d13435-d095-4c75-884c-613d7384ac7a.png)

![image](https://user-images.githubusercontent.com/64723994/235522203-4e3efbc0-f373-40f8-96b2-5de9de803a8c.png)


- 2-line tippy tooltip:

![image](https://user-images.githubusercontent.com/64723994/235522317-e0711c06-1d57-4462-b3ca-75bea8123944.png)

![image](https://user-images.githubusercontent.com/64723994/235522396-77bc3fe7-63da-4c09-8260-8cd717556657.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
