### PR TITLE
util: Speed up clean_user_content_links with parse5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "mini-css-extract-plugin": "^2.2.2",
     "minimalistic-assert": "^1.0.1",
     "panzoom": "^9.4.2",
+    "parse5": "^7.1.2",
     "plotly.js": "^2.0.0",
     "postcss": "^8.0.3",
     "postcss-extend-rule": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ dependencies:
   panzoom:
     specifier: ^9.4.2
     version: 9.4.3
+  parse5:
+    specifier: ^7.1.2
+    version: 7.1.2
   plotly.js:
     specifier: ^2.0.0
     version: 2.21.0
@@ -8741,7 +8744,6 @@ packages:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
       entities: 4.5.0
-    dev: true
 
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 179
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (237, 0)
+PROVISION_VERSION = (237, 1)

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -37,11 +37,13 @@
                     {{tooltip_hotkey_hints "?"}}
                 </template>
             </a>
+            {{#if realm_rendered_description}}
             <div class="only-visible-for-spectators">
                 <div class="realm-description">
                     <div class="rendered_markdown">{{rendered_markdown realm_rendered_description }}</div>
                 </div>
             </div>
+            {{/if}}
         </div>
     </div>
 </div>

--- a/web/tests/lib/index.js
+++ b/web/tests/lib/index.js
@@ -19,7 +19,6 @@ const zpage_params = require("./zpage_params");
 process.env.NODE_ENV = "test";
 
 const dom = new JSDOM("", {url: "http://zulip.zulipdev.com/"});
-global.DOMParser = dom.window.DOMParser;
 global.navigator = {
     userAgent: "node.js",
 };


### PR DESCRIPTION
This seems to make `clean_user_content_links` run about 4× faster when looping over many short inputs.

https://chat.zulip.org/#narrow/stream/6-frontend/topic/clean_user_content_links.20perf/near/1559471