### PR TITLE
compose recipient: Move cursor to end of topic input after stream selection.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -231,6 +231,7 @@ EXEMPT_FILES = make_set(
         "web/src/zulip.js",
         "web/src/zulip_test.js",
         "web/tests/lib/mdiff.js",
+        "web/tests/lib/zjquery_element.js",
     ]
 )
 

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -16,6 +16,7 @@ import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
+import * as ui_util from "./ui_util";
 import * as util from "./util";
 
 export let compose_recipient_widget;
@@ -191,7 +192,7 @@ export function on_compose_select_recipient_update(new_value) {
         // Always move focus to the topic input even if it's not empty,
         // since it's likely the user will want to update the topic
         // after updating the stream.
-        $("#stream_message_recipient_topic").trigger("focus").trigger("select");
+        ui_util.place_caret_at_end($("#stream_message_recipient_topic")[0]);
         check_stream_posting_policy_for_compose_box(new_value);
     }
     update_on_recipient_change();

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -56,7 +56,6 @@ const compose_state = zrequire("compose_state");
 const compose = zrequire("compose");
 const echo = zrequire("echo");
 const people = zrequire("people");
-const stream_bar = zrequire("stream_bar");
 const stream_data = zrequire("stream_data");
 
 function reset_jquery() {
@@ -305,10 +304,9 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
 test_ui("enter_with_preview_open", ({override, override_rewire}) => {
     mock_banners();
     $("#compose-textarea").toggleClass = noop;
-    override_rewire(stream_bar, "decorate", noop);
     mock_stream_header_colorblock();
     compose_recipient.open_compose_stream_dropup = noop;
-    override_rewire(compose_recipient, "update_on_recipient_change", noop);
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
     let stream_value = "";
     compose_recipient.compose_recipient_widget = {
         value() {

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -66,7 +66,6 @@ const compose_state = zrequire("compose_state");
 const compose_actions = zrequire("compose_actions");
 const message_lists = zrequire("message_lists");
 const stream_data = zrequire("stream_data");
-const stream_bar = zrequire("stream_bar");
 const compose_recipient = zrequire("compose_recipient");
 
 let stream_value = "";
@@ -129,9 +128,8 @@ test("start", ({override, override_rewire}) => {
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "blur_compose_inputs", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
-    override_rewire(compose_recipient, "update_on_recipient_change", () => {});
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
     override_rewire(compose_recipient, "check_stream_posting_policy_for_compose_box", () => {});
-    stream_bar.decorate = () => {};
     mock_stream_header_colorblock();
 
     let compose_defaults;
@@ -294,6 +292,7 @@ test("reply_with_mention", ({override, override_rewire}) => {
     mock_banners();
     mock_stream_header_colorblock();
     compose_state.set_message_type("stream");
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
     override_private_message_recipient({override});

--- a/web/tests/compose_state.test.js
+++ b/web/tests/compose_state.test.js
@@ -12,7 +12,6 @@ const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 const compose_state = zrequire("compose_state");
 const compose_fade = zrequire("compose_fade");
 const compose_recipient = zrequire("compose_recipient");
-const stream_bar = zrequire("stream_bar");
 
 const noop = () => {};
 
@@ -43,7 +42,7 @@ run_test("has_full_recipient", ({override, override_rewire}) => {
     $(`#compose_banners .topic_resolved`).remove = noop;
     compose_fade.update_all = noop;
     $(".narrow_to_compose_recipients").toggleClass = noop;
-    override_rewire(stream_bar, "decorate", noop);
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
 
     let emails;
     override(compose_pm_pill, "set_from_emails", (value) => {

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -39,7 +39,6 @@ const typeahead_helper = zrequire("typeahead_helper");
 const muted_users = zrequire("muted_users");
 const people = zrequire("people");
 const user_groups = zrequire("user_groups");
-const stream_bar = zrequire("stream_bar");
 const stream_data = zrequire("stream_data");
 const stream_list_sort = zrequire("stream_list_sort");
 const compose = zrequire("compose");
@@ -1764,8 +1763,7 @@ test("PM recipients sorted according to stream / topic being viewed", ({override
     );
     mock_stream_header_colorblock();
     mock_banners();
-    override_rewire(stream_bar, "decorate", noop);
-    override_rewire(compose_recipient, "update_on_recipient_change", noop);
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
 
     // When viewing no stream, sorting is alphabetical
     compose_state.set_stream_name("");

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -17,7 +17,6 @@ const compose_fade = zrequire("compose_fade");
 const compose_state = zrequire("compose_state");
 const compose_recipient = zrequire("compose_recipient");
 const sub_store = zrequire("sub_store");
-const stream_bar = zrequire("stream_bar");
 const stream_data = zrequire("stream_data");
 
 let stream_value = "";
@@ -167,8 +166,8 @@ test("draft_model delete", ({override}) => {
 test("snapshot_message", ({override_rewire}) => {
     override_rewire(user_pill, "get_user_ids", () => [aaron.user_id]);
     override_rewire(compose_pm_pill, "set_from_emails", noop);
+    override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
     mock_banners();
-    override_rewire(stream_bar, "decorate", noop);
 
     stream_data.get_sub = (stream_name) => {
         assert.equal(stream_name, "stream");

--- a/web/tests/lib/compose.js
+++ b/web/tests/lib/compose.js
@@ -5,7 +5,7 @@ const $ = require("./zjquery");
 exports.mock_stream_header_colorblock = () => {
     const $stream_selection_dropdown = $("#compose_recipient_selection_dropdown");
     const $stream_header_colorblock = $(".stream_header_colorblock");
-    $(".stream_header_colorblock").css = () => {};
+    $("#compose_recipient_selection_dropdown .stream_header_colorblock").css = () => {};
     $stream_selection_dropdown.set_find_results(
         ".stream_header_colorblock",
         $stream_header_colorblock,


### PR DESCRIPTION
Fixes #25321.

![Kapture 2023-05-01 at 14 19 39](https://user-images.githubusercontent.com/5634097/235533402-877e7fcf-cc59-4846-baab-948b5198a3db.gif)
