### PR TITLE
topic_list: Show muted unread counts in muted streams.

### DIFF
--- a/web/src/topic_list.js
+++ b/web/src/topic_list.js
@@ -81,11 +81,16 @@ export function keyed_topic_li(conversation) {
     };
 }
 
-export function more_li(more_topics_unreads, more_topics_have_unread_mention_messages) {
+export function more_li(
+    more_topics_unreads,
+    more_topics_have_unread_mention_messages,
+    more_topics_unread_count_muted,
+) {
     const render = () =>
         render_more_topics({
             more_topics_unreads,
             more_topics_have_unread_mention_messages,
+            more_topics_unread_count_muted,
         });
 
     const eq = (other) => other.more_items && more_topics_unreads === other.more_topics_unreads;
@@ -147,7 +152,13 @@ export class TopicListWidget {
         if (spinner) {
             nodes.push(spinner_li());
         } else if (!is_showing_all_possible_topics) {
-            nodes.push(more_li(more_topics_unreads, more_topics_have_unread_mention_messages));
+            nodes.push(
+                more_li(
+                    more_topics_unreads,
+                    more_topics_have_unread_mention_messages,
+                    list_info.more_topics_unread_count_muted,
+                ),
+            );
         }
 
         const dom = vdom.ul({

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -342,6 +342,13 @@ ul.filters {
         margin-bottom: 10px;
     }
 
+    /* This is a noop in the current design, because unread counts for
+       muted streams have the same opacity, but the logic is here to
+       be explicit and because the design may change in the future. */
+    .more_topic_unreads_muted_only .unread_count {
+        opacity: 0.5;
+    }
+
     & li.muted_topic,
     li.out_of_home_view {
         color: hsl(0deg 0% 20% / 50%);

--- a/web/templates/more_topics.hbs
+++ b/web/templates/more_topics.hbs
@@ -1,4 +1,6 @@
-<li class="topic-list-item show-more-topics bottom_left_row {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}">
+<li class="topic-list-item show-more-topics bottom_left_row
+  {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}
+  {{#if more_topics_unread_count_muted}}more_topic_unreads_muted_only{{/if}}">
     <span class='topic-box'>
         <a class="topic-name" tabindex="0">{{t "more topics" }}</a>
         {{#if more_topics_have_unread_mention_messages}}

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -61,6 +61,7 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         items: [],
         more_topics_have_unread_mention_messages: false,
         more_topics_unreads: 0,
+        more_topics_unread_count_muted: false,
         num_possible_topics: 0,
     });
 
@@ -269,6 +270,7 @@ test("get_list_info unreads", ({override}) => {
     assert.equal(list_info.more_topics_unreads, 3);
     assert.equal(list_info.more_topics_have_unread_mention_messages, true);
     assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.more_topics_unread_count_muted, false);
 
     assert.deepEqual(
         list_info.items.map((li) => li.topic_name),
@@ -285,6 +287,89 @@ test("get_list_info unreads", ({override}) => {
             "topic 10",
             "topic 11",
             "topic 12",
+        ],
+    );
+
+    // Now test with topics 4/8/9, all the ones with unreads, being muted.
+    override(user_topics, "is_topic_muted", (stream_id, topic_name) => {
+        assert.equal(stream_id, general.stream_id);
+        return ["topic 4", "topic 8", "topic 9"].includes(topic_name);
+    });
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.more_topics_unreads, 3);
+    // Topic 14 now makes it above the "more topics" fold.
+    assert.equal(list_info.more_topics_have_unread_mention_messages, false);
+    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.more_topics_unread_count_muted, true);
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 5",
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 6",
+            "topic 7",
+            "topic 10",
+            "topic 11",
+            "topic 12",
+            "topic 13",
+            "topic 14",
+        ],
+    );
+
+    add_unreads_with_mention("topic 8", 1);
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.more_topics_unreads, 4);
+    // Topic 8's new mention gets counted here.
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.more_topics_unread_count_muted, true);
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 5",
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 6",
+            "topic 7",
+            "topic 10",
+            "topic 11",
+            "topic 12",
+            "topic 13",
+            "topic 14",
+        ],
+    );
+
+    // Adding an additional older unmuted topic with unreads should
+    // result in just the unmuted unreads being counted.
+    add_unreads("topic 15", 15);
+    list_info = get_list_info();
+    assert.equal(list_info.items.length, 12);
+    assert.equal(list_info.more_topics_unreads, 15);
+    assert.equal(list_info.more_topics_have_unread_mention_messages, true);
+    assert.equal(list_info.num_possible_topics, 16);
+    assert.equal(list_info.more_topics_unread_count_muted, false);
+    assert.deepEqual(
+        list_info.items.map((li) => li.topic_name),
+        [
+            "topic 5",
+            "topic 0",
+            "topic 1",
+            "topic 2",
+            "topic 3",
+            "topic 6",
+            "topic 7",
+            "topic 10",
+            "topic 11",
+            "topic 12",
+            "topic 13",
+            "topic 14",
         ],
     );
 });


### PR DESCRIPTION
When all the unread messages in a muted stream are in specifically muted topics, this ensures that the total unread count for the stream that the user sees before clicking "more topics" will match the total unreads number for the stream itself.

This behavior is limited to muted streams, since in a normal / not muted stream, we don't display a "muted topics only" faded unread count by the stream's summary line to avoid distracting the user with it, we match that behavior for the "more topics" line.

We also now display the `@` , again to ensure the stream's summary line never displays an `@` without some topic row having one.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
