### PR TITLE
Fix buggy message list data structures handling of stream narrows

### DIFF
--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -14,7 +14,7 @@ export function get_recipient_label(message) {
     // passed in.
 
     if (message === undefined) {
-        if (message_lists.current.empty()) {
+        if (message_lists.current.visibly_empty()) {
             // For empty narrows where there's a clear reply target,
             // i.e. stream+topic or a single PM conversation, we label
             // the button as replying to the thread.

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -890,7 +890,7 @@ export function process_hotkey(e, hotkey) {
 
     // Hotkeys below this point are for the message feed, and so
     // should only function if the message feed is visible and nonempty.
-    if (!narrow_state.is_message_feed_visible() || message_lists.current.empty()) {
+    if (!narrow_state.is_message_feed_visible() || message_lists.current.visibly_empty()) {
         return false;
     }
 

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -57,7 +57,7 @@ function process_result(data, opts) {
     if (
         opts.msg_list === message_lists.current &&
         opts.msg_list.narrowed &&
-        opts.msg_list.empty()
+        opts.msg_list.visibly_empty()
     ) {
         // Even after loading more messages, we have
         // no messages to display in this narrow.
@@ -410,7 +410,7 @@ export function initialize(home_view_loaded) {
     function load_more(data) {
         // If we haven't selected a message in the home view yet, and
         // the home view isn't empty, we select the anchor message here.
-        if (message_lists.home.selected_id() === -1 && !message_lists.home.empty()) {
+        if (message_lists.home.selected_id() === -1 && !message_lists.home.visibly_empty()) {
             // We fall back to the closest selected id, as the user
             // may have removed a stream from the home view while we
             // were loading data.

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -276,12 +276,24 @@ export function load_messages(opts, attempt = 1) {
                 // for a nonexistent stream or something.  We shouldn't
                 // retry or display a connection error.
                 //
-                // FIXME: Warn the user when this has happened?
+                // FIXME: This logic unconditionally ignores the actual JSON
+                // error in the xhr status. While we have empty narrow messages
+                // for many common errors, and those have nicer HTML formatting,
+                // we certainly don't for every possible 400 error.
                 message_scroll.hide_indicators();
-                const data = {
-                    messages: [],
-                };
-                process_result(data, opts);
+
+                if (
+                    opts.msg_list === message_lists.current &&
+                    opts.msg_list.narrowed &&
+                    opts.msg_list.visibly_empty()
+                ) {
+                    narrow_banner.show_empty_narrow_message();
+                }
+
+                // TODO: This should probably do something explicit with
+                // `FetchStatus` to mark the message list as not eligible for
+                // further fetches. Currently, that happens implicitly via
+                // failing to call finish_older_batch / finish_newer_batch
                 return;
             }
 

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -33,10 +33,6 @@ const consts = {
 function process_result(data, opts) {
     let messages = data.messages;
 
-    if (!$("#connection-error").hasClass("get-events-error")) {
-        ui_report.hide_error($("#connection-error"));
-    }
-
     messages = messages.map((message) => message_helper.process_new_message(message));
 
     // In some rare situations, we expect to discover new unread
@@ -256,9 +252,20 @@ export function load_messages(opts, attempt = 1) {
         url: "/json/messages",
         data,
         success(data) {
+            if (!$("#connection-error").hasClass("get-events-error")) {
+                ui_report.hide_error($("#connection-error"));
+            }
+
             get_messages_success(data, opts);
         },
         error(xhr) {
+            if (xhr.status === 400 && !$("#connection-error").hasClass("get-events-error")) {
+                // We successfully reached the server, so hide the
+                // connection error notice, even if the request failed
+                // for other reasons.
+                ui_report.hide_error($("#connection-error"));
+            }
+
             if (opts.msg_list.narrowed && opts.msg_list !== message_lists.current) {
                 // We unnarrowed before getting an error so don't
                 // bother trying again or doing further processing.

--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -303,7 +303,9 @@ export function load_messages_for_narrow(opts) {
 
 export function get_backfill_anchor(msg_list) {
     const oldest_msg =
-        msg_list === message_lists.home ? all_messages_data.first() : msg_list.first();
+        msg_list === message_lists.home
+            ? all_messages_data.first_including_muted()
+            : msg_list.data.first_including_muted();
 
     if (oldest_msg) {
         return oldest_msg.id;
@@ -315,7 +317,10 @@ export function get_backfill_anchor(msg_list) {
 }
 
 export function get_frontfill_anchor(msg_list) {
-    const last_msg = msg_list === message_lists.home ? all_messages_data.last() : msg_list.last();
+    const last_msg =
+        msg_list === message_lists.home
+            ? all_messages_data.last_including_muted()
+            : msg_list.data.last_including_muted();
 
     if (last_msg) {
         return last_msg.id;

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -124,8 +124,12 @@ export class MessageList {
         }
 
         if (this.narrowed && !this.empty() && this.selected_id() === -1) {
-            // And also select the newly arrived message.
-            this.select_id(this.selected_id(), {then_scroll: true, use_closest: true});
+            // The message list was previously empty, but now isn't
+            // due to adding these messages, and we need to select a
+            // message. Regardless of whether the messages are new or
+            // old, we want to select a message as though we just
+            // entered this view.
+            this.select_id(this.first_unread_message_id(), {then_scroll: true, use_closest: true});
         }
 
         return render_info;

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -116,14 +116,14 @@ export class MessageList {
             render_info = this.append_to_view(bottom_messages, opts);
         }
 
-        if (this.narrowed && !this.empty()) {
+        if (this.narrowed && !this.visibly_empty()) {
             // If adding some new messages to the message tables caused
             // our current narrow to no longer be empty, hide the empty
             // feed placeholder text.
             narrow_banner.hide_empty_narrow_message();
         }
 
-        if (this.narrowed && !this.empty() && this.selected_id() === -1) {
+        if (this.narrowed && !this.visibly_empty() && this.selected_id() === -1) {
             // The message list was previously empty, but now isn't
             // due to adding these messages, and we need to select a
             // message. Regardless of whether the messages are new or
@@ -145,6 +145,10 @@ export class MessageList {
 
     empty() {
         return this.data.empty();
+    }
+
+    visibly_empty() {
+        return this.data.visibly_empty();
     }
 
     first() {
@@ -437,7 +441,7 @@ export class MessageList {
         this.view.update_render_window(this.selected_idx(), false);
 
         if (this.narrowed) {
-            if (this.empty()) {
+            if (this.visibly_empty()) {
                 narrow_banner.show_empty_narrow_message();
             } else {
                 narrow_banner.hide_empty_narrow_message();

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -441,7 +441,14 @@ export class MessageList {
         this.view.update_render_window(this.selected_idx(), false);
 
         if (this.narrowed) {
-            if (this.visibly_empty()) {
+            if (
+                this.visibly_empty() &&
+                this.data.has_found_oldest() &&
+                this.data.has_found_newest()
+            ) {
+                // Show the empty narrow message only if we're certain
+                // that the view doesn't have messages that we're
+                // waiting for the server to send us.
                 narrow_banner.show_empty_narrow_message();
             } else {
                 narrow_banner.hide_empty_narrow_message();

--- a/web/src/message_list_data.js
+++ b/web/src/message_list_data.js
@@ -63,7 +63,14 @@ export class MessageListData {
         return this._items.length;
     }
 
+    // The message list is completely empty.
     empty() {
+        // BUG: This should be checking _all_items.
+        return this._items.length === 0;
+    }
+
+    // The message list appears empty, but might contain messages that hidden by muting.
+    visibly_empty() {
         return this._items.length === 0;
     }
 

--- a/web/src/message_list_data.js
+++ b/web/src/message_list_data.js
@@ -65,8 +65,7 @@ export class MessageListData {
 
     // The message list is completely empty.
     empty() {
-        // BUG: This should be checking _all_items.
-        return this._items.length === 0;
+        return this._all_items.length === 0;
     }
 
     // The message list appears empty, but might contain messages that hidden by muting.
@@ -78,8 +77,16 @@ export class MessageListData {
         return this._items[0];
     }
 
+    first_including_muted() {
+        return this._all_items[0];
+    }
+
     last() {
         return this._items.at(-1);
+    }
+
+    last_including_muted() {
+        return this._all_items.at(-1);
     }
 
     ids_greater_or_equal_than(my_id) {
@@ -215,11 +222,6 @@ export class MessageListData {
         return messages.filter((msg) => this.get(msg.id) === undefined && predicate(msg));
     }
 
-    filter_incoming(messages) {
-        const predicate = this._get_predicate();
-        return messages.filter((message) => predicate(message));
-    }
-
     messages_filtered_for_topic_mutes(messages) {
         if (!this.excludes_muted_topics) {
             return [...messages];
@@ -289,29 +291,22 @@ export class MessageListData {
         let bottom_messages = [];
         let interior_messages = [];
 
-        // If we're initially populating the list, save the messages in
-        // bottom_messages regardless
-        if (this.selected_id() === -1 && this.empty()) {
-            const narrow_messages = this.filter_incoming(messages);
-            bottom_messages = narrow_messages.filter((msg) => !this.get(msg.id));
-        } else {
-            // Filter out duplicates that are already in self, and all messages
-            // that fail our filter predicate
-            messages = this.valid_non_duplicated_messages(messages);
+        // Filter out duplicates that are already in self, and all messages
+        // that fail our filter predicate
+        messages = this.valid_non_duplicated_messages(messages);
 
-            for (const msg of messages) {
-                // Put messages in correct order on either side of the
-                // message list.  This code path assumes that messages
-                // is a (1) sorted, and (2) consecutive block of
-                // messages that belong in this message list; those
-                // facts should be ensured by the caller.
-                if (this.empty() || msg.id > this.last().id) {
-                    bottom_messages.push(msg);
-                } else if (msg.id < this.first().id) {
-                    top_messages.push(msg);
-                } else {
-                    interior_messages.push(msg);
-                }
+        for (const msg of messages) {
+            // Put messages in correct order on either side of the
+            // message list.  This code path assumes that messages
+            // is a (1) sorted, and (2) consecutive block of
+            // messages that belong in this message list; those
+            // facts should be ensured by the caller.
+            if (this.empty() || msg.id > this.last_including_muted().id) {
+                bottom_messages.push(msg);
+            } else if (msg.id < this.first_including_muted().id) {
+                top_messages.push(msg);
+            } else {
+                interior_messages.push(msg);
             }
         }
 

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1336,6 +1336,21 @@ export class MessageListView {
     }
 
     prepend(messages) {
+        if (this._render_win_end - this._render_win_start === 0) {
+            // If the message list previously contained no visible
+            // messages, appending and prepending are equivalent, but
+            // the prepend logic will throw an exception, so just
+            // handle this as an append request.
+            //
+            // This is somewhat hacky, but matches how we do rendering
+            // for the first messages in a new msg_list_data object.
+            this.append(messages, false);
+            return;
+        }
+
+        // If we already have some messages rendered, then prepending
+        // will effectively change the meaning of the existing
+        // numbers.
         this._render_win_start += messages.length;
         this._render_win_end += messages.length;
 

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -139,7 +139,7 @@ export function hide_top_of_narrow_notices() {
 let hide_scroll_to_bottom_timer;
 export function hide_scroll_to_bottom() {
     const $show_scroll_to_bottom_button = $("#scroll-to-bottom-button-container");
-    if (message_viewport.bottom_message_visible() || message_lists.current.empty()) {
+    if (message_viewport.bottom_message_visible() || message_lists.current.visibly_empty()) {
         // If last message is visible, just hide the
         // scroll to bottom button.
         $show_scroll_to_bottom_button.removeClass("show");

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -620,14 +620,14 @@ function min_defined(a, b) {
 
 function load_local_messages(msg_data) {
     // This little helper loads messages into our narrow message
-    // data and returns true unless it's empty.  We use this for
+    // data and returns true unless it's visibly empty.  We use this for
     // cases when our local cache (all_messages_data) has at least
     // one message the user will expect to see in the new narrow.
 
     const in_msgs = all_messages_data.all_messages();
     msg_data.add_messages(in_msgs);
 
-    return !msg_data.empty();
+    return !msg_data.visibly_empty();
 }
 
 export function maybe_add_local_messages(opts) {
@@ -761,7 +761,7 @@ export function maybe_add_local_messages(opts) {
     //
     // And similarly for `near: max_int` with has_found_newest.
     if (
-        all_messages_data.empty() ||
+        all_messages_data.visibly_empty() ||
         id_info.target_id < all_messages_data.first().id ||
         id_info.target_id > all_messages_data.last().id
     ) {
@@ -795,7 +795,7 @@ export function update_selection(opts) {
         return;
     }
 
-    if (message_lists.current.empty()) {
+    if (message_lists.current.visibly_empty()) {
         // There's nothing to select if there are no messages.
         return;
     }

--- a/web/src/navigate.js
+++ b/web/src/navigate.js
@@ -101,7 +101,7 @@ export function page_down_the_right_amount() {
 }
 
 export function page_up() {
-    if (message_viewport.at_top() && !message_lists.current.empty()) {
+    if (message_viewport.at_top() && !message_lists.current.visibly_empty()) {
         message_lists.current.select_id(message_lists.current.first().id, {then_scroll: false});
     } else {
         page_up_the_right_amount();
@@ -109,7 +109,7 @@ export function page_up() {
 }
 
 export function page_down() {
-    if (message_viewport.at_bottom() && !message_lists.current.empty()) {
+    if (message_viewport.at_bottom() && !message_lists.current.visibly_empty()) {
         message_lists.current.select_id(message_lists.current.last().id, {then_scroll: false});
         unread_ops.process_scrolled_to_bottom();
     } else {

--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -119,7 +119,7 @@ function get_events_success(events) {
         }
     }
 
-    if (message_lists.home.selected_id() === -1 && !message_lists.home.empty()) {
+    if (message_lists.home.selected_id() === -1 && !message_lists.home.visibly_empty()) {
         message_lists.home.select_id(message_lists.home.first().id, {then_scroll: false});
     }
 

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -113,7 +113,7 @@ run_test("test_custom_message_input", () => {
 });
 
 run_test("empty_narrow", () => {
-    message_lists.current.empty = () => true;
+    message_lists.current.visibly_empty = () => true;
     compose_closed_ui.update_reply_recipient_label();
     const label = $(".compose_reply_button_label").text();
     assert.equal(label, "translated: Compose message");

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -89,7 +89,7 @@ const stream_popover = mock_esm("../src/stream_popover", {
 });
 
 message_lists.current = {
-    empty() {
+    visibly_empty() {
         return false;
     },
     selected_id() {
@@ -343,7 +343,7 @@ run_test("misc", ({override}) => {
 
     // Check that they do nothing without a selected message
     with_overrides(({override}) => {
-        override(message_lists.current, "empty", () => true);
+        override(message_lists.current, "visibly_empty", () => true);
         assert_unmapped(message_view_only_keys);
     });
 
@@ -470,7 +470,7 @@ run_test("motion_keys", () => {
     }
 
     list_util.inside_list = () => false;
-    message_lists.current.empty = () => true;
+    message_lists.current.visibly_empty = () => true;
     overlays.settings_open = () => false;
     overlays.streams_open = () => false;
     overlays.lightbox_open = () => false;
@@ -488,7 +488,7 @@ run_test("motion_keys", () => {
     assert_mapping("down_arrow", list_util, "go_down");
     list_util.inside_list = () => false;
 
-    message_lists.current.empty = () => false;
+    message_lists.current.visibly_empty = () => false;
     assert_mapping("down_arrow", navigate, "down");
     assert_mapping("end", navigate, "to_end");
     assert_mapping("home", navigate, "to_home");

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -129,8 +129,8 @@ function stub_message_list() {
             return this.data.get(msg_id);
         }
 
-        empty() {
-            return this.data.empty();
+        visibly_empty() {
+            return this.data.visibly_empty();
         }
 
         select_id(msg_id) {
@@ -166,7 +166,7 @@ run_test("basics", () => {
 
     all_messages_data.all_messages_data = {
         all_messages: () => messages,
-        empty: () => false,
+        visibly_empty: () => false,
         first: () => ({id: 900}),
         last: () => ({id: 1100}),
     };

--- a/web/tests/narrow_local.test.js
+++ b/web/tests/narrow_local.test.js
@@ -43,7 +43,7 @@ function test_with(fixture) {
         fetch_status: {
             has_found_newest: () => fixture.has_found_newest,
         },
-        empty: () => fixture.empty,
+        visibly_empty: () => fixture.visibly_empty,
         all_messages() {
             assert.notEqual(fixture.all_messages, undefined);
             return fixture.all_messages;
@@ -159,7 +159,7 @@ run_test("near with no unreads", () => {
             flavor: "not_found",
         },
         has_found_newest: false,
-        empty: true,
+        visibly_empty: true,
         expected_id_info: {
             target_id: 42,
             final_select_id: 42,
@@ -222,7 +222,7 @@ run_test("is:private with no unreads before fetch", () => {
             flavor: "not_found",
         },
         has_found_newest: false,
-        empty: true,
+        visibly_empty: true,
         expected_id_info: {
             target_id: undefined,
             final_select_id: undefined,
@@ -242,7 +242,7 @@ run_test("is:private with target and no unreads", () => {
             flavor: "not_found",
         },
         has_found_newest: true,
-        empty: false,
+        visibly_empty: false,
         all_messages: [
             {id: 350},
             {id: 400, type: "private", to_user_ids: "1,2"},
@@ -401,7 +401,7 @@ run_test("stream, no unread, not in all_messages", () => {
             flavor: "not_found",
         },
         has_found_newest: true,
-        empty: false,
+        visibly_empty: false,
         all_messages: [{id: 400}, {id: 500}],
         expected_id_info: {
             target_id: 450,
@@ -424,7 +424,7 @@ run_test("search, stream, not in all_messages", () => {
             flavor: "cannot_compute",
         },
         has_found_newest: true,
-        empty: false,
+        visibly_empty: false,
         all_messages: [{id: 400}, {id: 500}],
         expected_id_info: {
             target_id: undefined,
@@ -476,7 +476,7 @@ run_test("final corner case", () => {
             flavor: "not_found",
         },
         has_found_newest: true,
-        empty: false,
+        visibly_empty: false,
         all_messages: [
             {id: 400, topic: "whatever"},
             {id: 425, topic: "whatever", starred: true},


### PR DESCRIPTION
The individual commit messages detail this, but I found a cluster of bugs all related to incorrect handling of the difference between _items and _all_items in message list data structures. I did pretty extensive manual testing, but I'll want this to have some bake time on chat.zulip.org before we release a beta containing it.

Fixes the complex muting-related issue reported in https://chat.zulip.org/#narrow/stream/101-design/topic/can't.20distinguish.20muted.20topics.20in.20muted.20streams/near/1559718, as well as several other bugs.