### PR TITLE
typeahead: Delete display mode slash commands.

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -387,27 +387,20 @@ function should_show_custom_query(query, items) {
     return !matched;
 }
 
-export const slash_commands = [
+export const dev_only_slash_commands = [
     {
         text: $t({defaultMessage: "/dark (Switch to the dark theme)"}),
         name: "dark",
         aliases: "night",
     },
     {
-        text: $t({defaultMessage: "/fixed-width (Toggle fixed width mode)"}),
-        name: "fixed-width",
-        aliases: "",
-    },
-    {
-        text: $t({defaultMessage: "/fluid-width (Toggle fluid width mode)"}),
-        name: "fluid-width",
-        aliases: "",
-    },
-    {
         text: $t({defaultMessage: "/light (Switch to light theme)"}),
         name: "light",
         aliases: "day",
     },
+];
+
+export const slash_commands = [
     {
         text: $t({defaultMessage: "/me is excited (Display action text)"}),
         name: "me",
@@ -425,6 +418,8 @@ export const slash_commands = [
         aliases: "",
     },
 ];
+
+export const all_slash_commands = [...dev_only_slash_commands, ...slash_commands];
 
 export function filter_and_sort_mentions(is_silent, query, opts) {
     opts = {
@@ -667,7 +662,7 @@ export function get_candidates(query) {
     }
 
     function get_slash_commands_data() {
-        const commands = slash_commands;
+        const commands = page_params.development_environment ? all_slash_commands : slash_commands;
         return commands;
     }
 

--- a/web/src/zcommand.js
+++ b/web/src/zcommand.js
@@ -5,7 +5,6 @@ import * as feedback_widget from "./feedback_widget";
 import {$t} from "./i18n";
 import * as markdown from "./markdown";
 import * as message_lists from "./message_lists";
-import * as scroll_bar from "./scroll_bar";
 
 /*
 
@@ -98,50 +97,6 @@ export function switch_to_dark_theme() {
     });
 }
 
-export function enter_fluid_mode() {
-    send({
-        command: "/fluid-width",
-        on_success(data) {
-            scroll_bar.set_layout_width();
-            feedback_widget.show({
-                populate($container) {
-                    const rendered_msg = markdown.parse_non_message(data.msg);
-                    $container.html(rendered_msg);
-                },
-                on_undo() {
-                    send({
-                        command: "/fixed-width",
-                    });
-                },
-                title_text: $t({defaultMessage: "Fluid width mode"}),
-                undo_button_text: $t({defaultMessage: "Fixed width"}),
-            });
-        },
-    });
-}
-
-export function enter_fixed_mode() {
-    send({
-        command: "/fixed-width",
-        on_success(data) {
-            scroll_bar.set_layout_width();
-            feedback_widget.show({
-                populate($container) {
-                    const rendered_msg = markdown.parse_non_message(data.msg);
-                    $container.html(rendered_msg);
-                },
-                on_undo() {
-                    send({
-                        command: "/fluid-width",
-                    });
-                },
-                title_text: $t({defaultMessage: "Fixed width mode"}),
-                undo_button_text: $t({defaultMessage: "Fluid width"}),
-            });
-        },
-    });
-}
-
 export function process(message_content) {
     const content = message_content.trim();
 
@@ -170,16 +125,6 @@ export function process(message_content) {
     const night_commands = ["/night", "/dark"];
     if (night_commands.includes(content)) {
         switch_to_dark_theme();
-        return true;
-    }
-
-    if (content === "/fluid-width") {
-        enter_fluid_mode();
-        return true;
-    }
-
-    if (content === "/fixed-width") {
-        enter_fixed_mode();
         return true;
     }
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1580,7 +1580,7 @@ test("typeahead_results", () => {
     function assert_slash_matches(input, expected) {
         const returned = compose_typeahead_results(
             "slash",
-            composebox_typeahead.slash_commands,
+            composebox_typeahead.all_slash_commands,
             input,
         );
         assert.deepEqual(returned, expected);


### PR DESCRIPTION
This commit removes `/fixed-width` and `/fluid-width` slash commands from the typeahead and also hides the slash commands `/light` and `/dark` in production.

Fixes #25374.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
