### PR TITLE
web: Avoid slow jQuery `:input`, `:checkbox`, `:radio`, `:selected` selectors

### DIFF
--- a/web/src/billing/upgrade.js
+++ b/web/src/billing/upgrade.js
@@ -50,7 +50,7 @@ export const initialize = () => {
     });
 
     $("select[name=organization-type]").on("change", (e) => {
-        const string_value = $(e.currentTarget).find(":selected").attr("data-string-value");
+        const string_value = $(e.currentTarget.selectedOptions).attr("data-string-value");
         helpers.update_discount_details(string_value);
     });
 

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -153,7 +153,7 @@ export function launch(conf: WidgetConfig): void {
     }
 
     if (conf.update_submit_disabled_state_on_change) {
-        const $inputs = $dialog.find(".modal__content :input");
+        const $inputs = $dialog.find(".modal__content").find("input,select,textarea,button");
 
         const original_values = get_current_values($inputs);
 

--- a/web/src/invite.js
+++ b/web/src/invite.js
@@ -320,12 +320,12 @@ function open_invite_user_modal(e) {
         });
 
         $("#invite_check_all_button").on("click", () => {
-            $("#streams_to_add :checkbox").prop("checked", true);
+            $("#streams_to_add input[type=checkbox]").prop("checked", true);
             toggle_invite_submit_button();
         });
 
         $("#invite_uncheck_all_button").on("click", () => {
-            $("#streams_to_add :checkbox").prop("checked", false);
+            $("#streams_to_add input[type=checkbox]").prop("checked", false);
             $("#invite-user-modal .dialog_submit_button").prop(
                 "disabled",
                 !$("#generate_multiuse_invite_radio").is(":checked"),

--- a/web/src/portico/integrations_dev_panel.js
+++ b/web/src/portico/integrations_dev_panel.js
@@ -61,11 +61,11 @@ function set_results_notice(msg, level) {
 }
 
 function get_api_key_from_selected_bot() {
-    return $("#bot_name").children("option:selected").val();
+    return $("#bot_name").val();
 }
 
 function get_selected_integration_name() {
-    return $("#integration_name").children("option:selected").val();
+    return $("#integration_name").val();
 }
 
 function get_fixture_format(fixture_name) {
@@ -338,7 +338,7 @@ $(() => {
 
     $("#integration_name").on("change", function () {
         clear_elements(["custom_http_headers", "fixture_body", "fixture_name", "results_notice"]);
-        const integration_name = $(this).children("option:selected").val();
+        const integration_name = $(this.selectedOptions).val();
         get_fixtures(integration_name);
         update_url();
         return;
@@ -346,7 +346,7 @@ $(() => {
 
     $("#fixture_name").on("change", function () {
         clear_elements(["fixture_body", "results_notice"]);
-        const fixture_name = $(this).children("option:selected").val();
+        const fixture_name = $(this.selectedOptions).val();
         load_fixture_body(fixture_name);
         return;
     });

--- a/web/src/portico/signup.js
+++ b/web/src/portico/signup.js
@@ -198,14 +198,15 @@ $(() => {
     }
 
     function update_full_name_section() {
-        if (
-            $("#source_realm_select").length &&
-            $("#source_realm_select").find(":selected").val() !== ""
-        ) {
+        if ($("#source_realm_select").length && $("#source_realm_select").val() !== "") {
             $("#full_name_input_section").hide();
             $("#profile_info_section").show();
-            const avatar_url = $("#source_realm_select").find(":selected").attr("data-avatar");
-            const full_name = $("#source_realm_select").find(":selected").attr("data-full-name");
+            const avatar_url = $($("#source_realm_select").prop("selectedOptions")).attr(
+                "data-avatar",
+            );
+            const full_name = $($("#source_realm_select").prop("selectedOptions")).attr(
+                "data-full-name",
+            );
             $("#profile_full_name").text(full_name);
             $("#id_full_name").val(full_name);
             $("#profile_avatar").attr("src", avatar_url);

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -206,12 +206,12 @@ export function add_a_new_bot() {
     let create_avatar_widget;
 
     function create_a_new_bot() {
-        const bot_type = $("#create_bot_type :selected").val();
+        const bot_type = $("#create_bot_type").val();
         const full_name = $("#create_bot_name").val();
         const short_name = $("#create_bot_short_name").val() || $("#create_bot_short_name").text();
         const payload_url = $("#create_payload_url").val();
         const interface_type = $("#create_interface_type").val();
-        const service_name = $("#select_service_name :selected").val();
+        const service_name = $("#select_service_name").val();
         const formData = new FormData();
 
         formData.append("csrfmiddlewaretoken", csrf_token);
@@ -267,7 +267,7 @@ export function add_a_new_bot() {
         create_avatar_widget = avatar.build_bot_create_widget();
 
         $("#create_bot_type").on("change", () => {
-            const bot_type = $("#create_bot_type :selected").val();
+            const bot_type = $("#create_bot_type").val();
             // For "generic bot" or "incoming webhook" both these fields need not be displayed.
             $("#service_name_list").hide();
             $("#select_service_name").removeClass("required");
@@ -288,7 +288,7 @@ export function add_a_new_bot() {
 
         $("#select_service_name").on("change", () => {
             $("#config_inputbox").children().hide();
-            const selected_bot = $("#select_service_name :selected").val();
+            const selected_bot = $("#select_service_name").val();
             $(`[name*='${CSS.escape(selected_bot)}']`).show();
         });
     }
@@ -382,7 +382,7 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
 
         if (bot_type === OUTGOING_WEBHOOK_BOT_TYPE) {
             const service_payload_url = $("#edit_service_base_url").val();
-            const service_interface = $("#edit_service_interface :selected").val();
+            const service_interface = $("#edit_service_interface").val();
             formData.append("service_payload_url", JSON.stringify(service_payload_url));
             formData.append("service_interface", service_interface);
         } else if (bot_type === EMBEDDED_BOT_TYPE && service !== undefined) {

--- a/web/src/stream_create.js
+++ b/web/src/stream_create.js
@@ -133,7 +133,7 @@ function update_announce_stream_state() {
     const $announce_stream_checkbox = $("#announce-new-stream input");
     const $announce_stream_label = $("#announce-new-stream");
     let disable_it = false;
-    const privacy_type = $("#stream_creation_form input:radio[name=privacy]:checked").val();
+    const privacy_type = $("#stream_creation_form input[type=radio][name=privacy]:checked").val();
     const is_invite_only =
         privacy_type === "invite-only" || privacy_type === "invite-only-public-history";
     $announce_stream_label.removeClass("control-label-disabled");


### PR DESCRIPTION
[`:input`](https://api.jquery.com/input-selector/), [`:checkbox`](https://api.jquery.com/checkbox-selector/), [`:radio`](https://api.jquery.com/radio-selector/), and [`:selected`](https://api.jquery.com/selected-selector/) are jQuery-specific selector extensions that prevent jQuery from using native `querySelectorAll` and force it into the Sizzle slow path. These are easy to avoid; do so.

[`:animated`](https://api.jquery.com/animated-selector/), [`:visible`](https://api.jquery.com/visible-selector/), and [`:hidden`](https://api.jquery.com/hidden-selector/) have the same problem, but will need some more use-specific attention.

https://chat.zulip.org/#narrow/stream/6-frontend/topic/clean_user_content_links.20perf/near/1559809