### PR TITLE
message_headers: Consistently abbreviate recipient name/topic name.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1172,6 +1172,8 @@ td.pointer {
             .message_label_clickable.narrows_by_topic {
                 position: relative;
                 top: 0.5px;
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
         }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1416,6 +1416,11 @@ td.pointer {
             width: 16px;
             height: 16px;
         }
+
+        .private_message_header_name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 }
 

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -24,7 +24,7 @@
             <div class="message-header-contents">
                 <div class="message_label_clickable stream_label">
                     <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
-                    {{t "You and {recipients}" }}
+                    <span class="private_message_header_name">{{t "You and {recipients}" }}</span>
                 </div>
                 <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
             </div>

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -84,7 +84,7 @@
           href="{{pm_with_url}}"
           data-tippy-content="{{t 'Narrow to your direct messages with {display_reply_to}' }}">
         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
-        {{t "You and {display_reply_to}" }}
+        <span class="private_message_header_name">{{t "You and {display_reply_to}" }}</span>
         </a>
         <span class="recipient_row_date {{#if date_unchanged}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
     </div>

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -25,7 +25,7 @@
                 <div class="message-header-contents">
                     <div class="message_label_clickable stream_label">
                         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
-                        {{t "You and {recipients}" }}
+                        <span class="private_message_header_name">{{t "You and {recipients}" }}</span>
                     </div>
                     <div class="recipient_row_date">{{ formatted_send_at_time }}</div>
                 </div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

- [x] Abbreviate long topic names the same way in the Drafts and Scheduled messages overlays.
- [x] Abbreviate DM recipient names the same way everywhere if needed (in message feed, Drafts, Scheduled messages).

Fixes: <!-- Issue link, or clear description.-->
#25353 
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- **Before:**

![image](https://user-images.githubusercontent.com/64723994/235724481-2041e13b-e40c-427a-ae8a-e08e3d82eb36.png)

![image](https://user-images.githubusercontent.com/64723994/235724627-d0ad22f0-7136-4e95-a8b8-b9f9108638c8.png)

- **After:**
  - Topic Name in Drafts and scheduled message overlays:
  
      ![image](https://user-images.githubusercontent.com/64723994/235724884-054a986e-28d4-41e6-ae4c-5a47287294be.png)
      
      ![image](https://user-images.githubusercontent.com/64723994/235724962-23c46575-956a-44bd-8ab8-674e98fa44bd.png)

  - DM recipient names in message headers:
 
    ![image](https://user-images.githubusercontent.com/64723994/235725166-79c78df9-d71a-4988-a70c-b2d42289ae85.png)
    
    ![image](https://user-images.githubusercontent.com/64723994/235725238-d54fda39-3ab5-48f9-8f42-8ae8c8773dc1.png)
    
    ![image](https://user-images.githubusercontent.com/64723994/235725317-0aa1402d-1422-49d1-9747-540d3a5641ff.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
