### PR TITLE
hashchange: Hide popovers on change in hash.

### DIFF
--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -14,6 +14,7 @@ import * as narrow from "./narrow";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import * as popovers from "./popovers";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as scheduled_messages_overlay_ui from "./scheduled_messages_overlay_ui";
@@ -411,6 +412,7 @@ function hashchanged(from_reload, e) {
 
     // We are changing to a "main screen" view.
     overlays.close_for_hash_change();
+    popovers.hide_all();
     browser_history.state.changing_hash = true;
     const ret = do_hashchange_normal(from_reload);
     browser_history.state.changing_hash = false;

--- a/web/tests/hashchange.test.js
+++ b/web/tests/hashchange.test.js
@@ -23,6 +23,7 @@ const info_overlay = mock_esm("../src/info_overlay");
 const message_viewport = mock_esm("../src/message_viewport");
 const narrow = mock_esm("../src/narrow");
 const overlays = mock_esm("../src/overlays");
+const popovers = mock_esm("../src/popovers");
 const recent_topics_ui = mock_esm("../src/recent_topics_ui");
 const settings = mock_esm("../src/settings");
 const stream_settings_ui = mock_esm("../src/stream_settings_ui");
@@ -179,21 +180,28 @@ run_test("hash_interactions", ({override}) => {
     override(recent_topics_ui, "show", () => {
         recent_topics_ui_shown = true;
     });
+    let hide_all_called = false;
+    override(popovers, "hide_all", () => {
+        hide_all_called = true;
+    });
     window.location.hash = "#unknown_hash";
 
     browser_history.clear_for_testing();
     hashchange.initialize();
     // If it's an unknown hash it should show the default view.
     assert.equal(recent_topics_ui_shown, true);
+    assert.equal(hide_all_called, true);
     helper.assert_events([
         [overlays, "close_for_hash_change"],
         [message_viewport, "stop_auto_scrolling"],
     ]);
 
     window.location.hash = "#all_messages";
+    hide_all_called = false;
 
     helper.clear_events();
     $window_stub.trigger("hashchange");
+    assert.equal(hide_all_called, true);
     helper.assert_events([
         [overlays, "close_for_hash_change"],
         [message_viewport, "stop_auto_scrolling"],


### PR DESCRIPTION
Fixes #24641

When the user clicks on a link which has `stopPropagation` and doesn't trigger `scroll`, then we don't hide any existing popovers if the element being clicked doesn't hide popovers explicitly.

To fix this, we hide all popovers on change in hash, which makes sense on its own given how we use hashes.


Bug reproducer:

1. Open a topic with few messages (1-3).
2. Copy URL
3. Open a different topic with few messages (1-3).
4. Click anywhere to open a user profile popover.
5. Go to the copied URL.
