### PR TITLE
compose: Shorter the separator line between Send and 3-dot buttons.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -866,21 +866,22 @@ a.compose_control_button.hide {
 /* `^` icon located next to `Send` / `Scheduled` button which shows
    options to schedule the message. */
 #send_later {
+    display: flex;
+    align-items: center;
     float: right;
     color: hsl(0deg 0% 100%);
     border-radius: 0 4px 4px 0;
-    border-left: 1px solid hsl(0deg 0% 100% / 65%);
     padding: 0;
     margin: 0;
 
     .zulip-icon {
-        vertical-align: middle;
+        padding: 5px 9px;
+    }
 
-        &::before {
-            padding: 5px 9px;
-            position: relative;
-            top: -1px;
-        }
+    .separator-line {
+        background-color: hsl(0deg 0% 100% / 65%);
+        height: 70%;
+        width: 1px;
     }
 
     &:hover,

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -124,6 +124,7 @@
                                             <span>{{t 'Send' }}</span>
                                         </button>
                                         <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
+                                            <div class="separator-line"></div>
                                             <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
                                         </button>
                                         <template id="send-enter-tooltip-template">


### PR DESCRIPTION
CZO: https://chat.zulip.org/#narrow/stream/101-design/topic/send-button.20separator

Added a div inside `#send_later` button with class separator-line, height 70%, width 1px, and `background-color: hsl(0deg 0% 100% / 65%)` to make it look like a line also made #send_later a flex with `align-items: center` so that separator line is vertically centered.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- **Before:**
![image](https://user-images.githubusercontent.com/64723994/235738820-bac3e72a-8f89-4a22-b705-477ec6d54ee1.png)

![image](https://user-images.githubusercontent.com/64723994/235738872-94831f3e-c698-4026-9609-e3b6d7dcd35c.png)

- **After:**
![image](https://user-images.githubusercontent.com/64723994/235739046-56fc7ebf-c07a-48be-97b8-76d7456b7667.png)

![image](https://user-images.githubusercontent.com/64723994/235738991-ff3eb1d0-e089-4856-8646-88e06fb0d024.png)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
