### PR TITLE
scheduled_message: Update count in lefthand sidebar

### DIFF
--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -140,6 +140,10 @@ export function delete_scheduled_message(scheduled_msg_id, success = () => {}) {
     });
 }
 
+export function get_count() {
+    return scheduled_messages_data.length;
+}
+
 export function initialize(scheduled_messages_params) {
     scheduled_messages_data = scheduled_messages_params.scheduled_messages;
 

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -69,6 +69,7 @@ import * as stream_topic_history from "./stream_topic_history";
 import * as stream_ui_updates from "./stream_ui_updates";
 import * as sub_store from "./sub_store";
 import * as submessage from "./submessage";
+import * as top_left_corner from "./top_left_corner";
 import * as typing_events from "./typing_events";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
@@ -473,6 +474,7 @@ export function dispatch_normal_event(event) {
                 case "add": {
                     scheduled_messages.add_scheduled_messages(event.scheduled_messages);
                     scheduled_messages_overlay_ui.rerender();
+                    top_left_corner.update_scheduled_messages_row();
                     break;
                 }
                 case "remove": {
@@ -480,11 +482,13 @@ export function dispatch_normal_event(event) {
                     scheduled_messages_overlay_ui.remove_scheduled_message_id(
                         event.scheduled_message_id,
                     );
+                    top_left_corner.update_scheduled_messages_row();
                     break;
                 }
                 case "update": {
                     scheduled_messages.update_scheduled_message(event.scheduled_message);
                     scheduled_messages_overlay_ui.rerender();
+                    top_left_corner.update_scheduled_messages_row();
                     break;
                 }
                 // No default

--- a/web/src/top_left_corner.js
+++ b/web/src/top_left_corner.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import * as resize from "./resize";
+import * as scheduled_messages from "./scheduled_messages";
 import * as ui_util from "./ui_util";
 
 let last_mention_count = 0;
@@ -8,6 +9,12 @@ let last_mention_count = 0;
 export function update_starred_count(count) {
     const $starred_li = $(".top_left_starred_messages");
     ui_util.update_unread_count_in_dom($starred_li, count);
+}
+
+export function update_scheduled_messages_row() {
+    const $scheduled_li = $(".top_left_scheduled_messages");
+    const count = scheduled_messages.get_count();
+    ui_util.update_unread_count_in_dom($scheduled_li, count);
 }
 
 export function update_dom_with_unread_counts(counts) {
@@ -98,4 +105,8 @@ function do_new_messages_animation($li) {
     }
     setTimeout(mid_animation, 3000);
     setTimeout(end_animation, 6000);
+}
+
+export function initialize() {
+    update_scheduled_messages_row();
 }

--- a/web/src/top_left_corner.js
+++ b/web/src/top_left_corner.js
@@ -14,6 +14,11 @@ export function update_starred_count(count) {
 export function update_scheduled_messages_row() {
     const $scheduled_li = $(".top_left_scheduled_messages");
     const count = scheduled_messages.get_count();
+    if (count > 0) {
+        $scheduled_li.show();
+    } else {
+        $scheduled_li.hide();
+    }
     ui_util.update_unread_count_in_dom($scheduled_li, count);
 }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -100,6 +100,7 @@ import * as stream_list_sort from "./stream_list_sort";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as timerender from "./timerender";
 import * as tippyjs from "./tippyjs";
+import * as top_left_corner from "./top_left_corner";
 import * as topic_list from "./topic_list";
 import * as topic_zoom from "./topic_zoom";
 import * as tutorial from "./tutorial";
@@ -649,6 +650,7 @@ export function initialize_everything() {
     muted_users.initialize(muted_users_params);
     stream_settings_ui.initialize();
     user_group_settings_ui.initialize();
+    top_left_corner.initialize();
     stream_list.initialize();
     stream_list_sort.initialize();
     condense.initialize();

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -440,7 +440,8 @@ li.active-sub-filter {
     }
 
     .top_left_starred_messages .unread_count,
-    .top_left_drafts .unread_count {
+    .top_left_drafts .unread_count,
+    .top_left_scheduled_messages .unread_count {
         background-color: inherit;
         color: inherit;
         border: 0.5px solid hsl(105deg 2% 50%);

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -70,6 +70,7 @@ const stream_topic_history = mock_esm("../src/stream_topic_history");
 const submessage = mock_esm("../src/submessage");
 mock_esm("../src/top_left_corner", {
     update_starred_count() {},
+    update_scheduled_messages_row() {},
 });
 const typing_events = mock_esm("../src/typing_events");
 const unread_ops = mock_esm("../src/unread_ops");

--- a/web/tests/top_left_corner.test.js
+++ b/web/tests/top_left_corner.test.js
@@ -10,6 +10,10 @@ mock_esm("../src/resize", {
     resize_stream_filters_container() {},
 });
 
+const scheduled_messages = mock_esm("../src/scheduled_messages");
+
+scheduled_messages.get_count = () => 555;
+
 const {Filter} = zrequire("../src/filter");
 const top_left_corner = zrequire("top_left_corner");
 
@@ -68,18 +72,27 @@ run_test("update_count_in_dom", () => {
 
     make_elem($(".top_left_starred_messages"), "<starred-count>");
 
+    make_elem($(".top_left_scheduled_messages"), "<scheduled-count>");
+
     top_left_corner.update_dom_with_unread_counts(counts);
     top_left_corner.update_starred_count(444);
+    // Calls top_left_corner.update_scheduled_messages_row
+    top_left_corner.initialize();
 
     assert.equal($("<mentioned-count>").text(), "222");
     assert.equal($("<home-count>").text(), "333");
     assert.equal($("<starred-count>").text(), "444");
+    assert.equal($("<scheduled-count>").text(), "555");
 
     counts.mentioned_message_count = 0;
+    scheduled_messages.get_count = () => 0;
+
     top_left_corner.update_dom_with_unread_counts(counts);
     top_left_corner.update_starred_count(0);
+    top_left_corner.update_scheduled_messages_row();
 
     assert.ok(!$("<mentioned-count>").visible());
     assert.equal($("<mentioned-count>").text(), "");
     assert.equal($("<starred-count>").text(), "");
+    assert.ok(!$(".top_left_scheduled_messages").visible());
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR adds a count to the "Scheduled messages" item in the lefthand sidebar.

Additionally, it hides the "Scheduled messages" item when the scheduled-message count is zero.

Fixes: #25101 <!-- Issue link, or clear description.-->

TODO:
- [x] Add test in `web/tests/top_left_corner.test.js`

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
