### PR TITLE
message_edit: Update placement and styling of server message edit banners.

### DIFF
--- a/web/src/channel.js
+++ b/web/src/channel.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import _ from "lodash";
 
 import * as blueslip from "./blueslip";
 import {page_params} from "./page_params";
@@ -150,7 +151,12 @@ export function xhr_error_message(message, xhr) {
     if (xhr.status.toString().charAt(0) === "4") {
         // Only display the error response for 4XX, where we've crafted
         // a nice response.
-        message += ": " + JSON.parse(xhr.responseText).msg;
+        const server_response_html = _.escape(JSON.parse(xhr.responseText).msg);
+        if (message) {
+            message += ": " + server_response_html;
+        } else {
+            message = server_response_html;
+        }
     }
     return message;
 }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -12,6 +12,7 @@ import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as compose from "./compose";
 import * as compose_actions from "./compose_actions";
+import * as compose_banner from "./compose_banner";
 import * as compose_ui from "./compose_ui";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as condense from "./condense";
@@ -967,11 +968,15 @@ export function save_message_row_edit($row) {
                 }
 
                 hide_message_edit_spinner($row);
-                const message = channel.xhr_error_message(
-                    $t({defaultMessage: "Error saving edit"}),
-                    xhr,
+                const message = channel.xhr_error_message(null, xhr);
+                const $container = compose_banner.get_compose_banner_container(
+                    $row.find("textarea"),
                 );
-                $row.find(".edit_error").text(message).show();
+                compose_banner.show_error_message(
+                    message,
+                    compose_banner.CLASSNAMES.generic_compose_error,
+                    $container,
+                );
             }
         },
     });

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -43,5 +43,4 @@
             {{/if}}
         </div>
     </div>
-    <div class="alert alert-error edit_error hide"></div>
 </form>

--- a/web/tests/channel.test.js
+++ b/web/tests/channel.test.js
@@ -343,6 +343,9 @@ test("xhr_error_message", () => {
     };
     msg = "some message";
     assert.equal(channel.xhr_error_message(msg, xhr), "some message: file not found");
+
+    msg = null;
+    assert.equal(channel.xhr_error_message(msg, xhr), "file not found");
 });
 
 test("while_reloading", () => {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR aims to update the old-style custom error banners in the message edit form to the ones we are currently using. It also fixes the placement of the banners.

Fixes: #25412.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="741" alt="image" src="https://user-images.githubusercontent.com/53193850/235827549-55ccf19c-90d2-4187-8596-fea6f4531ed2.png">