### PR TITLE
scheduled-messages: Remove unused `send_later_custom` template variable.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -811,10 +811,6 @@ export function initialize() {
         },
     };
 
-    const send_later_custom = {
-        text: $t({defaultMessage: "Custom"}),
-    };
-
     function set_compose_box_schedule(element) {
         const send_later_in = element.id;
         const send_later_class = element.classList[0];
@@ -886,7 +882,6 @@ export function initialize() {
                     render_send_later_modal({
                         possible_send_later_today,
                         send_later_tomorrow,
-                        send_later_custom,
                     }),
                 );
                 overlays.open_modal("send_later_modal", {


### PR DESCRIPTION
In commit e89cbf0ac1fc5c34, the only use of this template variable was removed from `send_later_popover.hbs`.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
