### PR TITLE
migrations: Fix performance of migration 0436.

### DIFF
--- a/zerver/migrations/0436_realmauthenticationmethods.py
+++ b/zerver/migrations/0436_realmauthenticationmethods.py
@@ -11,12 +11,13 @@ def fill_RealmAuthenticationMethod_data(
 ) -> None:
     Realm = apps.get_model("zerver", "Realm")
     RealmAuthenticationMethod = apps.get_model("zerver", "RealmAuthenticationMethod")
+    rows_to_create = []
     for realm in Realm.objects.order_by("id"):
-        rows_to_create = []
         for key, value in realm.authentication_methods.iteritems():
             if value:
                 rows_to_create.append(RealmAuthenticationMethod(name=key, realm_id=realm.id))
-        RealmAuthenticationMethod.objects.bulk_create(rows_to_create)
+
+    RealmAuthenticationMethod.objects.bulk_create(rows_to_create, batch_size=10000)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This was doing bulk_create in a loop for each realm, which is too slow on very large servers. Just do a single bulk_create with a reasonable batch_size at the end.

From my understanding this is already applied on Zulip Cloud, but might still be worth tweaking the code anyway, if only to  not leave a bad example of doing things inefficiently that someone might copy when writing a future migrations.

https://github.com/zulip/zulip/pull/25146#discussion_r1183171485