### PR TITLE
narrow: Do not mark as read when narrowing by topic or recipient.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -925,11 +925,6 @@ export function by_topic(target_id, opts) {
         return;
     }
 
-    // We don't check msg_list.can_mark_messages_read here only because
-    // the target msg_list isn't initialized yet; in any case, the
-    // message is about to be marked read in the new view.
-    unread_ops.notify_server_message_read(original);
-
     const search_terms = [
         {operator: "stream", operand: original.stream},
         {operator: "topic", operand: original.topic},
@@ -943,11 +938,6 @@ export function by_recipient(target_id, opts) {
     opts = {then_select_id: target_id, ...opts};
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
     const message = message_store.get(target_id);
-
-    // We don't check msg_list.can_mark_messages_read here only because
-    // the target msg_list isn't initialized yet; in any case, the
-    // message is about to be marked read in the new view.
-    unread_ops.notify_server_message_read(message);
 
     switch (message.type) {
         case "private":


### PR DESCRIPTION
Previously, we've been assuming that when a user narrows to a topic or recipient, that the target message would be marked as read in resulting view. This is no longer a safe assumption because a user can have their personal display settings to never mark messages as read, even in conversation views.

Removes the call to `unread_ops.notify_server_message_read` in both `narrow.by_topic` and `narrow.by_recipient` in the web app.

If the messages normally would be marked as read in the narrow based on the user's settings, they still will be once that narrow view is loaded, see second set of screencasts below.

**Screenshots and screen captures:**

<details>
<summary>Before changes - user has marked never mark as read on scroll</summary>

[Screencast from 03-05-23 15:32:59.webm](https://user-images.githubusercontent.com/63245456/235931845-41f3bd3c-ff73-44e3-a280-2c6fe6e20a20.webm)
</details>
<details>
<summary>After changes - user has marked never mark as read on scroll</summary>

[Screencast from 03-05-23 15:32:05.webm](https://user-images.githubusercontent.com/63245456/235931897-5594da2c-4c3b-42ca-831c-d21212f3188f.webm)
</details>
<details>
<summary>Before changes - default mark as read setting</summary>

[Screencast from 03-05-23 15:41:43.webm](https://user-images.githubusercontent.com/63245456/235934500-62ffca37-04b8-4511-9d75-342758e37e4c.webm)
</details>
<details>
<summary>After changes - default mark as read setting</summary>

[Screencast from 03-05-23 15:42:51.webm](https://user-images.githubusercontent.com/63245456/235934466-17ac8a76-8ce6-4a56-a14f-3963bb1df1b1.webm)
</details>


---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
