### PR TITLE
compose: Add wildcard mentions check on client side.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -474,7 +474,8 @@ export function initialize() {
         `.${CSS.escape(compose_banner.CLASSNAMES.wildcard_warning)} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
-            compose_validate.clear_wildcard_warnings();
+            const {$banner_container} = get_input_info(event);
+            compose_validate.clear_wildcard_warnings($banner_container);
             compose_validate.set_user_acknowledged_wildcard_flag(true);
             finish();
         },

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -474,10 +474,15 @@ export function initialize() {
         `.${CSS.escape(compose_banner.CLASSNAMES.wildcard_warning)} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
-            const {$banner_container} = get_input_info(event);
+            const {$banner_container, is_edit_input} = get_input_info(event);
+            const $row = $(event.target).closest(".message_row");
             compose_validate.clear_wildcard_warnings($banner_container);
             compose_validate.set_user_acknowledged_wildcard_flag(true);
-            finish();
+            if (is_edit_input) {
+                message_edit.save_message_row_edit($row);
+            } else {
+                finish();
+            }
         },
     );
 

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -460,6 +460,15 @@ export function initialize() {
 
     upload.feature_check($("#compose .compose_upload_file"));
 
+    function get_input_info(event) {
+        const $edit_banners_container = $(event.target).closest(".edit_form_banners");
+        const is_edit_input = Boolean($edit_banners_container.length);
+        const $banner_container = $edit_banners_container.length
+            ? $edit_banners_container
+            : $("#compose_banners");
+        return {is_edit_input, $banner_container};
+    }
+
     $("body").on(
         "click",
         `.${CSS.escape(compose_banner.CLASSNAMES.wildcard_warning)} .compose_banner_action_button`,
@@ -536,9 +545,7 @@ export function initialize() {
         )} .compose_banner_action_button`,
         (event) => {
             event.preventDefault();
-            const $edit_form = $(event.target)
-                .closest(".message_edit_form")
-                .find(".edit_form_banners");
+            const {$banner_container} = get_input_info(event);
             const $invite_row = $(event.target).parents(".compose_banner");
 
             const user_id = Number.parseInt($invite_row.data("user-id"), 10);
@@ -553,7 +560,7 @@ export function initialize() {
                 compose_banner.show_error_message(
                     error_msg,
                     compose_banner.CLASSNAMES.generic_compose_error,
-                    $edit_form.length ? $edit_form : $("#compose_banners"),
+                    $banner_container,
                     $("#compose-textarea"),
                 );
                 $(event.target).prop("disabled", true);

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -65,7 +65,7 @@ function clear_box() {
 
     // TODO: Better encapsulate at-mention warnings.
     compose_validate.clear_topic_resolved_warning();
-    compose_validate.clear_wildcard_warnings();
+    compose_validate.clear_wildcard_warnings($("#compose_banners"));
     compose.clear_private_stream_alert();
     compose_validate.set_user_acknowledged_wildcard_flag(undefined);
 

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -67,7 +67,7 @@ function clear_box() {
     compose_validate.clear_topic_resolved_warning();
     compose_validate.clear_wildcard_warnings($("#compose_banners"));
     compose.clear_private_stream_alert();
-    compose_validate.set_user_acknowledged_wildcard_flag(undefined);
+    compose_validate.set_user_acknowledged_wildcard_flag(false);
 
     compose_state.set_recipient_edited_manually(false);
     compose.clear_preview_area();

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -106,7 +106,9 @@ export function show_error_message(
     $container: JQuery,
     $bad_input?: JQuery,
 ): void {
-    $(`#compose_banners .${CSS.escape(classname)}`).remove();
+    // To prevent the same banner from appearing twice,
+    // we remove the banner with a matched classname.
+    $container.find(`.${CSS.escape(classname)}`).remove();
 
     const new_row = render_compose_banner({
         banner_type: ERROR,

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -21,7 +21,6 @@ import * as stream_data from "./stream_data";
 import * as util from "./util";
 
 let user_acknowledged_wildcard = false;
-let wildcard_mention;
 
 export let wildcard_mention_large_stream_threshold = 15;
 
@@ -230,7 +229,7 @@ export function warn_if_topic_resolved(topic_changed) {
     }
 }
 
-function show_wildcard_warnings(stream_id, $banner_container) {
+function show_wildcard_warnings(stream_id, $banner_container, wildcard_mention) {
     const subscriber_count = peer_data.get_subscriber_count(stream_id) || 0;
     const stream_name = stream_data.maybe_get_stream_name(stream_id);
     const is_edit_container = $banner_container.closest(".edit_form_banners").length > 0;
@@ -357,7 +356,7 @@ export function set_wildcard_mention_large_stream_threshold(value) {
     wildcard_mention_large_stream_threshold = value;
 }
 
-export function validate_stream_message_mentions(stream_id, $banner_container) {
+export function validate_stream_message_mentions(stream_id, $banner_container, wildcard_mention) {
     const subscriber_count = peer_data.get_subscriber_count(stream_id) || 0;
 
     // If the user is attempting to do a wildcard mention in a large
@@ -376,7 +375,7 @@ export function validate_stream_message_mentions(stream_id, $banner_container) {
         }
 
         if (user_acknowledged_wildcard === undefined || user_acknowledged_wildcard === false) {
-            show_wildcard_warnings(stream_id, $banner_container);
+            show_wildcard_warnings(stream_id, $banner_container, wildcard_mention);
 
             $("#compose-send-button").prop("disabled", false);
             compose_ui.hide_compose_spinner();
@@ -488,14 +487,11 @@ function validate_stream_message() {
         return false;
     }
 
-    /* Note: This is a global and thus accessible in the functions
-       below; it's important that we update this state here before
-       proceeding with further validation. */
-    wildcard_mention = util.find_wildcard_mentions(compose_state.message_content());
+    const wildcard_mention = util.find_wildcard_mentions(compose_state.message_content());
 
     if (
         !validate_stream_message_address_info(stream_name) ||
-        !validate_stream_message_mentions(sub.stream_id, $banner_container)
+        !validate_stream_message_mentions(sub.stream_id, $banner_container, wildcard_mention)
     ) {
         return false;
     }

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -374,7 +374,7 @@ export function validate_stream_message_mentions(stream_id, $banner_container, w
             return false;
         }
 
-        if (user_acknowledged_wildcard === undefined || user_acknowledged_wildcard === false) {
+        if (!user_acknowledged_wildcard) {
             show_wildcard_warnings(stream_id, $banner_container, wildcard_mention);
 
             $("#compose-send-button").prop("disabled", false);
@@ -386,7 +386,7 @@ export function validate_stream_message_mentions(stream_id, $banner_container, w
         clear_wildcard_warnings($banner_container);
     }
     // at this point, the user has either acknowledged the warning or removed @all / @everyone
-    user_acknowledged_wildcard = undefined;
+    user_acknowledged_wildcard = false;
 
     return true;
 }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -907,14 +907,17 @@ export function save_message_row_edit($row) {
         changed = old_content !== new_content;
     }
 
-    const wildcard_mention = util.find_wildcard_mentions(new_content);
-    const is_stream_message_mentions_valid = compose_validate.validate_stream_message_mentions(
-        stream_id,
-        $banner_container,
-        wildcard_mention,
-    );
-    if (!is_stream_message_mentions_valid) {
-        return;
+    const already_has_wildcard_mention = message.wildcard_mentioned;
+    if (!already_has_wildcard_mention) {
+        const wildcard_mention = util.find_wildcard_mentions(new_content);
+        const is_stream_message_mentions_valid = compose_validate.validate_stream_message_mentions(
+            stream_id,
+            $banner_container,
+            wildcard_mention,
+        );
+        if (!is_stream_message_mentions_valid) {
+            return;
+        }
     }
 
     show_message_edit_spinner($row);

--- a/web/src/message_store.js
+++ b/web/src/message_store.js
@@ -70,6 +70,7 @@ export function set_message_booleans(message) {
     message.starred = convert_flag("starred");
     message.mentioned = convert_flag("mentioned") || convert_flag("wildcard_mentioned");
     message.mentioned_me_directly = convert_flag("mentioned");
+    message.wildcard_mentioned = convert_flag("wildcard_mentioned");
     message.collapsed = convert_flag("collapsed");
     message.alerted = convert_flag("has_alert_word");
 
@@ -89,6 +90,7 @@ export function update_booleans(message, flags) {
 
     message.mentioned = convert_flag("mentioned") || convert_flag("wildcard_mentioned");
     message.mentioned_me_directly = convert_flag("mentioned");
+    message.wildcard_mentioned = convert_flag("wildcard_mentioned");
     message.alerted = convert_flag("has_alert_word");
 }
 

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -366,7 +366,6 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
     // of execution should not be changed.
     mock_banners();
     override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
-    $("#compose_banners .wildcard_warning").length = 0;
     page_params.user_id = me.user_id;
     page_params.realm_mandatory_topics = false;
     const sub = {

--- a/web/tests/lib/compose_banner.js
+++ b/web/tests/lib/compose_banner.js
@@ -12,4 +12,23 @@ exports.mock_banners = () => {
     }
     $("#compose_banners .warning").remove = () => {};
     $("#compose_banners .error").remove = () => {};
+
+    const $stub = $.create("stub_to_remove");
+    const $cb = $("#compose_banners");
+
+    $stub.remove = () => {};
+    $stub.length = 0;
+
+    $cb.closest = () => [];
+    $cb.set_find_results(".no_post_permissions", $stub);
+    $cb.set_find_results(".message_too_long", $stub);
+    $cb.set_find_results(".wildcards_not_allowed", $stub);
+    $cb.set_find_results(".wildcard_warning", $stub);
+    $cb.set_find_results(".topic_missing", $stub);
+    $cb.set_find_results(".missing_stream", $stub);
+    $cb.set_find_results(".zephyr_not_running", $stub);
+    $cb.set_find_results(".deactivated_user", $stub);
+    $cb.set_find_results(".missing_private_message_recipient", $stub);
+    $cb.set_find_results(".subscription_error", $stub);
+    $cb.set_find_results(".generic_compose_error", $stub);
 };

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -133,6 +133,7 @@ run_test("update_messages", () => {
             is_stream: true,
             last_edit_timestamp: undefined,
             mentioned: false,
+            wildcard_mentioned: false,
             mentioned_me_directly: false,
             raw_content: "**new content**",
             reactions: [],

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -186,18 +186,21 @@ test("message_booleans_parity", () => {
     assert_bool_match(["wildcard_mentioned"], {
         mentioned: true,
         mentioned_me_directly: false,
+        wildcard_mentioned: true,
         alerted: false,
     });
 
     assert_bool_match(["mentioned"], {
         mentioned: true,
         mentioned_me_directly: true,
+        wildcard_mentioned: false,
         alerted: false,
     });
 
     assert_bool_match(["has_alert_word"], {
         mentioned: false,
         mentioned_me_directly: false,
+        wildcard_mentioned: false,
         alerted: true,
     });
 });
@@ -247,24 +250,28 @@ test("update_booleans", () => {
     // First, test fields that we do actually want to update.
     message.mentioned = false;
     message.mentioned_me_directly = false;
+    message.wildcard_mentioned = false;
     message.alerted = false;
 
     let flags = ["mentioned", "has_alert_word", "read"];
     message_store.update_booleans(message, flags);
     assert.equal(message.mentioned, true);
     assert.equal(message.mentioned_me_directly, true);
+    assert.equal(message.wildcard_mentioned, false);
     assert.equal(message.alerted, true);
 
     flags = ["wildcard_mentioned", "unread"];
     message_store.update_booleans(message, flags);
     assert.equal(message.mentioned, true);
     assert.equal(message.mentioned_me_directly, false);
+    assert.equal(message.wildcard_mentioned, true);
 
     flags = ["read"];
     message_store.update_booleans(message, flags);
     assert.equal(message.mentioned, false);
     assert.equal(message.mentioned_me_directly, false);
     assert.equal(message.alerted, false);
+    assert.equal(message.wildcard_mentioned, false);
 
     // Make sure we don't muck with unread.
     message.unread = false;


### PR DESCRIPTION
This PR is intended to implement client-side checking of wildcard mentions in message edit mode, while preserving the existing behavior from the compose box. The main changes made to accomplish the goal is:
1. Added a `$banner_container` parameter to certain functions, such as `show_wildcard_warnings` in the `compose_validate` module. This allows for their reuse in both the compose box and edit context.
2. Significantly changed the way wildcard banners are tracked. The system has become more complex, as we now need to track banners not only for the compose box but also for multiple edit inputs. The system now checks if the banner has been displayed for each input. If the banner has already been shown, we skip displaying it, return true for validation, and proceed with the API request.
3. Added message mention validation for message editing. The behavior will be similar to the validation found in the compose box when a user sends a message.

Fixes: #25411.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![2023-05-05 at 18 53 26 - Amethyst Fowl](https://user-images.githubusercontent.com/53193850/236451200-b10d0594-d761-45c8-a56d-f82dab5b70d5.gif)
