### PR TITLE
message-list: Narrow to "near" view if current message list does not collapse messages.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -450,7 +450,10 @@ export function initialize() {
 
         const nearest = message_lists.current.get(msg_id);
         const selected = message_lists.current.selected_message();
-        if (util.same_recipient(nearest, selected)) {
+        if (
+            message_lists.current.view.collapse_messages &&
+            util.same_recipient(nearest, selected)
+        ) {
             return selected.id;
         }
         return nearest.id;

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -487,6 +487,17 @@ export class MessageListView {
                     current_group,
                     current_group.message_containers[0],
                 );
+                // Clicking on the message header from search-like views (where
+                // collapse_messages is false) should link to the near view for
+                // the message. Otherwise, we link more generally to the topic
+                // or direct message conversation.
+                if (this.collapse_messages) {
+                    current_group.recipient_bar_url = current_group.is_stream
+                        ? current_group.topic_url
+                        : current_group.pm_with_url;
+                } else {
+                    current_group.recipient_bar_url = current_group.message_containers[0].msg.url;
+                }
                 new_message_groups.push(current_group);
             }
         };

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -19,9 +19,9 @@
 
         {{! topic stuff }}
         <span class="stream_topic">
-            {{! topic link }}
+            {{! link to topic or near view of message }}
             <a class="message_label_clickable narrows_by_topic tippy-narrow-tooltip"
-              href="{{topic_url}}"
+              href="{{recipient_bar_url}}"
               data-tippy-content="{{t 'Go to #{display_recipient} > {topic}' }}">
                 {{#if use_match_properties}}
                     {{{match_topic}}}
@@ -93,7 +93,7 @@
 <div class="message_header message_header_private_message">
     <div class="message-header-contents">
         <a class="message_label_clickable narrows_by_recipient stream_label tippy-narrow-tooltip"
-          href="{{pm_with_url}}"
+          href="{{recipient_bar_url}}"
           data-tippy-content="{{t 'Go to direct messages with {display_reply_to}' }}">
         <span class="private_message_header_icon"><i class="zulip-icon zulip-icon-user"></i></span>
         <span class="private_message_header_name">{{t "You and {display_reply_to}" }}</span>


### PR DESCRIPTION
This is an updated version of #21417.

**Changes**:
- Added 2 prep commits:
  - The first one makes the update discussed here on CZO: [#frontend > narrow via message header click handler](https://chat.zulip.org/#narrow/stream/6-frontend/topic/narrow.20via.20message.20header.20click.20handler/near/1560779). This also fixes [this review comment](https://github.com/zulip/zulip/pull/21417#issuecomment-1083474300) on the original PR.
  - The second one is a duplicate of #25421, as I felt like this was a visible issue with the new user setting for not marking messages as read. It also is the change discussed [here](https://github.com/zulip/zulip/pull/21417#discussion_r848956470) in the original PR, but expanded to both `narrow.by_topic` and `narrow.by_recipient`.
- The main changes in the above PR only addressed stream messages, so I made the adjustments so that direct messages would also be updated to link/narrow to near views from a search-like view.
  - Expanded the test created in the original PR for a direct message case.
  - Limits the new `narrow.by_near` so that it's only is possible for `trigger="message header"` or `trigger="hotkey"`. This way other triggers from `/web/src/notifications.js` that use `narrow.by_topic` and `narrow.by_recipient` won't be altered by these updates.
  - Instead of focusing on whether the current message list view can mark messages as read, I focused checks on whether the current message view could collapse messages.

**Notes**:
- There are still no documentation updates with this. I looked around in the help center, but I don't think we explicitly say anywhere where these message headers link to. The `S` hotkey shortcut documentation might need to be updated in some way because these near views do not work for the flipping between the stream view and the topic view.
- In the screenshots, you'll note the tooltip with the keyboard shortcut shows up even if the message is not selected. This could be confusing for users in general because if they do use the keyboard shortcut instead of the mouse (for some reason), then they might be narrowed to a view they didn't intend to be. This seems orthogonal to these changes since the problem exists with or without these changes for search-like views. Noted [here in CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/title.20tips.20in.20recipient.20bar/near/1560921).

Fixes #21216.

**Screenshots and screencasts**:

<details>
<summary>Screenshots hovering over message headers after changes</summary>

![Screenshot from 2023-05-03 17-53-31](https://user-images.githubusercontent.com/63245456/235970757-bbf3fd2e-b8f0-46de-b3e0-eae9e2f9d5c9.png)
![Screenshot from 2023-05-03 17-53-36](https://user-images.githubusercontent.com/63245456/235970860-8dd4185a-49cc-47d7-8b8b-ab818ee82a79.png)
![Screenshot from 2023-05-03 17-53-42](https://user-images.githubusercontent.com/63245456/235970869-c6e5a782-7907-4955-87c0-d15c035fed92.png)
![Screenshot from 2023-05-03 17-53-47](https://user-images.githubusercontent.com/63245456/235970911-70ab6868-437d-47e7-b271-73b9e2174aa9.png)
</details>

<details>
<summary>Screencast after changes</summary>

[Screencast from 03-05-23 17:50:47.webm](https://user-images.githubusercontent.com/63245456/235970259-fe5b290f-63b8-4813-afac-25484a92b7ca.webm)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
