### PR TITLE
scheduled_messages: Show Monday option on Fridays and Saturdays.

### DIFF
--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -22,6 +22,13 @@
                                 <a id="{{@key}}" class="send_later_tomorrow" tabindex="0">{{this.text}}</a>
                             </li>
                         {{/each}}
+                        {{#if possible_send_later_monday }}
+                            {{#each possible_send_later_monday}}
+                                <li>
+                                    <a id="{{@key}}" class="send_later_monday" tabindex="0">{{this.text}}</a>
+                                </li>
+                            {{/each}}
+                        {{/if}}
                         <li>
                             <a class="send_later_custom" tabindex="0">{{t 'Custom time'}}</a>
                         </li>

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -1,0 +1,114 @@
+"use strict";
+
+const {strict: assert} = require("assert");
+
+const {zrequire} = require("./lib/namespace");
+const {run_test} = require("./lib/test");
+
+const scheduled_messages = zrequire("scheduled_messages");
+
+function get_expected_send_opts(expecteds) {
+    const modal_opts = {
+        send_later_tomorrow: {
+            tomorrow_nine_am: {
+                text: "translated: Tomorrow at 9:00 AM",
+                time: "9:00 am",
+            },
+            tomorrow_four_pm: {
+                text: "translated: Tomorrow at 4:00 PM",
+                time: "4:00 pm",
+            },
+        },
+        send_later_custom: {
+            text: "translated: Custom",
+        },
+        possible_send_later_today: false,
+        possible_send_later_monday: false,
+    };
+    const optional_modal_opts = {
+        send_later_today: {
+            today_nine_am: {
+                text: "translated: Today at 9:00 AM",
+                time: "9:00 am",
+            },
+            today_four_pm: {
+                text: "translated: Today at 4:00 PM",
+                time: "4:00 pm",
+            },
+        },
+        send_later_monday: {
+            monday_nine_am: {
+                text: "translated: Monday at 9:00 AM",
+                time: "9:00 am",
+            },
+        },
+    };
+
+    // 'today_nine_am'
+    // 'today_four_pm'
+    // 'monday_nine_am'
+    for (const expect of expecteds) {
+        const day = expect.split("_")[0]; // "today", "monday"
+        if (!modal_opts[`possible_send_later_${day}`]) {
+            modal_opts[`possible_send_later_${day}`] = {};
+        }
+        modal_opts[`possible_send_later_${day}`][expect] =
+            optional_modal_opts[`send_later_${day}`][expect];
+    }
+
+    return modal_opts;
+}
+
+run_test("scheduled_modal_opts", () => {
+    // Sunday thru Saturday
+    const days = [
+        "2023-04-30",
+        "2023-05-01",
+        "2023-05-02",
+        "2023-05-03",
+        "2023-05-04",
+        "2023-05-05",
+        "2023-05-06",
+    ];
+    // Extra options change based on the hour of day
+    const options_by_hour = [
+        {hour: "T06:00:00", extras: ["today_nine_am", "today_four_pm"]},
+        {hour: "T11:00:00", extras: ["today_four_pm"]},
+        {hour: "T17:00:00", extras: []},
+    ];
+
+    // Now we can test those hourly options on each day of the week
+    for (const day of days) {
+        for (const opts of options_by_hour) {
+            const date = new Date(day + opts.hour);
+            // On Fridays (5) and Saturdays (6), add the Monday option
+            if (date.getDay() > 4) {
+                opts.extras.push("monday_nine_am");
+            }
+            const modal_opts = scheduled_messages.get_filtered_send_opts(date);
+            const expected_opts = get_expected_send_opts(opts.extras);
+            assert.deepEqual(modal_opts, expected_opts);
+        }
+    }
+});
+
+run_test("scheduled_selected_times", () => {
+    // When scheduling a message on a Monday at 6:00am
+    // that will be sent tomorrow at 4pm
+    let date = new Date("2023-05-01T06:00:00");
+    let send_at_time = scheduled_messages.get_send_at_time_from_opts(
+        "tomorrow_four_pm",
+        "send_later_tomorrow",
+        date,
+    );
+    assert.equal(send_at_time, "May 2 2023 4:00 pm");
+    // When scheduling a message on a Friday at 5:00pm
+    // that will be sent Monday at 9am
+    date = new Date("2023-05-05T17:00:00");
+    send_at_time = scheduled_messages.get_send_at_time_from_opts(
+        "monday_nine_am",
+        "send_later_monday",
+        date,
+    );
+    assert.equal(send_at_time, "May 8 2023 9:00 am");
+});


### PR DESCRIPTION
On Fridays and Saturdays, users will be presented with the option to schedule a message to send on Monday at 9:00 am.

The logic I've written uses the `getDay()` method on JavaScript Date instances. I believe that that method returns `0` for Sunday, for example, regardless of a user's locale settings. But I wanted to raise a possible internationalization issue here.

Fixes: #25402.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

Result, on Fridays and Saturdays:

<img width="570" alt="schedule-monday-message" src="https://user-images.githubusercontent.com/170719/236006277-d7542188-4a66-423b-a0f8-541bdfc12d37.png">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
