### PR TITLE
unread: Fix exception handling mentions in private messages.

### DIFF
--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -411,6 +411,10 @@ class UnreadTopicCounter {
 
         for (const message_id of unread_mentions_counter) {
             const stream_id = this.bucketer.reverse_lookup.get(message_id);
+            if (stream_id === undefined) {
+                // This is a private message containing a mention.
+                continue;
+            }
             streams_with_mentions.add(stream_id);
         }
 
@@ -423,6 +427,11 @@ class UnreadTopicCounter {
         // in an unmuted topic within a muted stream.
         for (const message_id of unread_mentions_counter) {
             const stream_id = this.bucketer.reverse_lookup.get(message_id);
+            if (stream_id === undefined) {
+                // This is a private message containing a mention.
+                continue;
+            }
+
             const stream_bucketer = this.bucketer.get_bucket(stream_id);
             const topic = stream_bucketer.reverse_lookup.get(message_id);
             if (user_topics.is_topic_unmuted(stream_id, topic)) {


### PR DESCRIPTION
Private messages with mentions are included in unread_mentions_counter, but of course don't have a stream ID, so should be skipped when calculating which streams contain unread mentions.

This code has always been wrong, it put `undefined` in the set of stream IDs with unread mentions.

What changed recently is that in 98162b7a3a01ef97aed935908e43c42ebd950bb9, we started using the `stream_id` to do an additional lookup in the unmuted version of the function, and doing that lookup with `undefined` threw an exception.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
