### PR TITLE
left_sidebar: Improve display of @-mentions and unread counters for muted topics in unmuted stream.

### DIFF
--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -37,6 +37,7 @@ export function update_count_in_dom(
     stream_counts,
     stream_has_any_unread_mention_messages,
     stream_has_any_unmuted_unread_mention,
+    stream_has_only_muted_unread_mention,
 ) {
     // The subscription_block properly excludes the topic list,
     // and it also has sensitive margins related to whether the
@@ -50,8 +51,14 @@ export function update_count_in_dom(
 
     if (stream_has_any_unmuted_unread_mention) {
         $subscription_block.addClass("has-unmuted-mentions");
+        $subscription_block.removeClass("has-only-muted-mentions");
     } else {
         $subscription_block.removeClass("has-unmuted-mentions");
+        if (!stream_counts.stream_is_muted && stream_has_only_muted_unread_mention) {
+            $subscription_block.addClass("has-only-muted-mentions");
+        } else {
+            $subscription_block.removeClass("has-only-muted-mentions");
+        }
     }
 
     // Here we set the count and compute the values of two classes:
@@ -64,16 +71,32 @@ export function update_count_in_dom(
         ui_util.update_unread_count_in_dom($subscription_block, stream_counts.unmuted_count);
         $subscription_block.addClass("stream-with-count");
         $subscription_block.removeClass("has-unmuted-unreads");
+        $subscription_block.removeClass("has-only-muted-unreads");
     } else if (stream_counts.unmuted_count > 0 && stream_counts.stream_is_muted) {
         // Muted stream, has unmuted unreads.
         ui_util.update_unread_count_in_dom($subscription_block, stream_counts.unmuted_count);
         $subscription_block.addClass("stream-with-count");
         $subscription_block.addClass("has-unmuted-unreads");
+        $subscription_block.removeClass("has-only-muted-unreads");
     } else if (stream_counts.muted_count > 0 && stream_counts.stream_is_muted) {
         // Muted stream, only muted unreads.
         ui_util.update_unread_count_in_dom($subscription_block, stream_counts.muted_count);
         $subscription_block.addClass("stream-with-count");
         $subscription_block.removeClass("has-unmuted-unreads");
+        $subscription_block.removeClass("has-only-muted-unreads");
+    } else if (
+        stream_counts.muted_count > 0 &&
+        !stream_counts.stream_is_muted &&
+        stream_has_only_muted_unread_mention
+    ) {
+        // Normal stream, only muted unreads, including a mention:
+        // Display the mention, faded, and a faded unread count too,
+        // so that we don't weirdly show the mention indication
+        // without an unread count.
+        ui_util.update_unread_count_in_dom($subscription_block, stream_counts.muted_count);
+        $subscription_block.removeClass("has-unmuted-unreads");
+        $subscription_block.addClass("stream-with-count");
+        $subscription_block.addClass("has-only-muted-unreads");
     } else if (stream_counts.muted_count > 0 && !stream_counts.stream_is_muted) {
         // Normal stream, only muted unreads: display nothing. The
         // current thinking is displaying those counts with muted
@@ -85,6 +108,7 @@ export function update_count_in_dom(
         // No unreads: display nothing.
         ui_util.update_unread_count_in_dom($subscription_block, 0);
         $subscription_block.removeClass("has-unmuted-unreads");
+        $subscription_block.removeClass("has-only-muted-unreads");
         $subscription_block.removeClass("stream-with-count");
     }
 }
@@ -396,11 +420,16 @@ class StreamSidebarRow {
         const stream_has_any_unmuted_unread_mention = unread.stream_has_any_unmuted_mentions(
             this.sub.stream_id,
         );
+        const stream_has_only_muted_unread_mentions =
+            !this.sub.is_muted &&
+            stream_has_any_unread_mention_messages &&
+            !stream_has_any_unmuted_unread_mention;
         update_count_in_dom(
             this.$list_item,
             count,
             stream_has_any_unread_mention_messages,
             stream_has_any_unmuted_unread_mention,
+            stream_has_only_muted_unread_mentions,
         );
     }
 }
@@ -443,6 +472,7 @@ function set_stream_unread_count(
     count,
     stream_has_any_unread_mention_messages,
     stream_has_any_unmuted_unread_mention,
+    stream_has_only_muted_unread_mentions,
 ) {
     const $stream_li = get_stream_li(stream_id);
     if (!$stream_li) {
@@ -456,6 +486,7 @@ function set_stream_unread_count(
         count,
         stream_has_any_unread_mention_messages,
         stream_has_any_unmuted_unread_mention,
+        stream_has_only_muted_unread_mentions,
     );
 }
 
@@ -492,11 +523,16 @@ export function update_dom_with_unread_counts(counts) {
             counts.streams_with_mentions.includes(stream_id);
         const stream_has_any_unmuted_unread_mention =
             counts.streams_with_unmuted_mentions.includes(stream_id);
+        const stream_has_only_muted_unread_mentions =
+            !sub_store.get(stream_id).is_muted &&
+            stream_has_any_unread_mention_messages &&
+            !stream_has_any_unmuted_unread_mention;
         set_stream_unread_count(
             stream_id,
             count,
             stream_has_any_unread_mention_messages,
             stream_has_any_unmuted_unread_mention,
+            stream_has_only_muted_unread_mentions,
         );
     }
 }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -353,6 +353,16 @@ ul.filters {
         margin-bottom: 10px;
     }
 
+    .has-only-muted-unreads {
+        .unread_count {
+            opacity: 0.5;
+        }
+    }
+
+    .has-only-muted-mentions .unread_mention_info {
+        opacity: 0.5;
+    }
+
     /* This is a noop in the current design, because unread counts for
        muted streams have the same opacity, but the logic is here to
        be explicit and because the design may change in the future. */
@@ -763,6 +773,10 @@ li.topic-list-item {
 
 .zero_count {
     visibility: hidden;
+}
+
+.zero-topic-unreads.show-more-topics .topic-box {
+    margin-right: 30px;
 }
 
 .searching-for-more-topics img {

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -15,7 +15,6 @@ page_params.realm_users = [];
 // We use this with override.
 let num_unread_for_stream;
 let stream_has_any_unread_mentions;
-let stream_has_any_unmuted_mentions;
 const noop = () => {};
 
 mock_esm("../src/narrow_state", {
@@ -36,7 +35,7 @@ mock_esm("../src/unread", {
         muted_count: 0,
     }),
     stream_has_any_unread_mentions: () => stream_has_any_unread_mentions,
-    stream_has_any_unmuted_mentions: () => stream_has_any_unmuted_mentions,
+    stream_has_any_unmuted_mentions: () => noop,
 });
 
 const {Filter} = zrequire("../src/filter");


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- [x] If all unread @ mentions being indicated are in muted topics, show the @ as faded, similarly to unread counts. This applies to the @ on streams, topics, and "more topics". 

The above point also fixes the below point as it will automatically align @ mention, as no @ align will be possible without an unread counter after executing above:
- [x] Always align the @ the same way, regardless of whether there are any unmuted unreads.


Fixes: #25382 <!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Unmuted stream having an unmuted mention in a muted topic:
![image](https://user-images.githubusercontent.com/64723994/236057874-0df1bbee-2993-439f-9ab8-4b206df1d0fb.png)

- Unmuted stream having an unmuted mention in a muted topic also having an unread message in a normal topic:
![image](https://user-images.githubusercontent.com/64723994/236054571-ffd0b261-84c8-4bc6-9666-e1f8762bd0f9.png)

- Unmuted stream having unmuted mentions in a muted and normal topic both:
![image](https://user-images.githubusercontent.com/64723994/236054426-8a55e387-a366-4992-92cd-ae347ad9f3e3.png)

![image](https://user-images.githubusercontent.com/64723994/236054439-1857f9cf-9654-458e-9afe-9b6cd5de5682.png)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
