### PR TITLE
provision: Disable compilemessages searching for locale directories

### DIFF
--- a/tools/i18n/sync-translations
+++ b/tools/i18n/sync-translations
@@ -14,5 +14,5 @@ find ./locale \
     -regex '^\./locale/.*/\(mobile\|translations\).json$' \
     -exec ./tools/i18n/unescape-contents {} \;
 
-./manage.py compilemessages
+./manage.py compilemessages --ignore='*'
 ./tools/i18n/process-mobile-i18n

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -286,7 +286,7 @@ def main(options: argparse.Namespace) -> int:
             print("No need to regenerate the test DB.")
 
         if options.is_force or need_to_run_compilemessages():
-            run(["./manage.py", "compilemessages"])
+            run(["./manage.py", "compilemessages", "--ignore=*"])
             write_new_digest(
                 "last_compilemessages_hash",
                 compilemessages_paths(),

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -49,7 +49,7 @@ run(["./tools/webpack", "--quiet"])
 run(["./manage.py", "collectstatic", "-v0", "--noinput"])
 
 # Compile translation strings to generate `.mo` files.
-run(["./manage.py", "compilemessages", "-v0"])
+run(["./manage.py", "compilemessages", "-v0", "--ignore=*"])
 
 # Needed if PRODUCTION
 os.makedirs("prod-static", exist_ok=True)


### PR DESCRIPTION
We explicitly configure `LOCALE_PATHS`, so we can safely disable [this search](https://github.com/django/django/blob/4.1/django/core/management/commands/compilemessages.py#L92-L100
) of the entire tree for other `locale` directories.