### PR TITLE
compose: Fix stream select dropdown search going offscreen.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -798,6 +798,17 @@ a.compose_control_button.hide {
     .dropup .dropdown-menu {
         bottom: 100%;
         margin-bottom: 17px;
+
+        @media (height <= 470px) {
+            /* To make the dropdown search visible, we move the dropdown
+               from above the compose to be inside it. This basically emulates
+               beviour for dropdown-menu when we have an expanded compose box.
+               470px was chosen based on manual testing. */
+            & {
+                top: 0;
+                bottom: auto;
+            }
+        }
     }
 
     #compose_select_recipient_name {


### PR DESCRIPTION
The intent of this PR to make stream selection work on smaller height rather than it being broken. Next step is to move the stream selection dropdowns to use tippy, which I am working on right now.


discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/dropdown.20on.20short.20screens

before:
<img width="1024" alt="Screenshot 2023-05-04 at 12 47 23 PM" src="https://user-images.githubusercontent.com/25124304/236136010-d94a44a6-0f9f-4fd5-a1c7-a8464e419d9d.png">


after:
<img width="1024" alt="Screenshot 2023-05-04 at 12 46 27 PM" src="https://user-images.githubusercontent.com/25124304/236135952-e04f42ea-3a69-4ccb-8c61-45c1b46cb172.png">

