### PR TITLE
compose: Make it possible to schedule messages with wildcard mention confirmation.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -292,7 +292,7 @@ export function enter_with_preview_open(ctrl_pressed = false) {
 // Common entrypoint for asking the server to send the message
 // currently drafted in the compose box, including for scheduled
 // messages.
-export function finish(from_do_schedule_message = false) {
+export function finish(scheduling_message = false) {
     if (compose_ui.compose_spinner_visible) {
         // Avoid sending a message twice in parallel in races where
         // the user clicks the `Send` button very quickly twice or
@@ -318,13 +318,13 @@ export function finish(from_do_schedule_message = false) {
 
     compose_ui.show_compose_spinner();
 
-    if (!compose_validate.validate()) {
+    if (!compose_validate.validate(scheduling_message)) {
         // If the message failed validation, hide compose spinner.
         compose_ui.hide_compose_spinner();
         return false;
     }
 
-    if (from_do_schedule_message) {
+    if (scheduling_message) {
         schedule_message_to_custom_date();
     } else {
         send_message();

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -480,6 +480,13 @@ export function initialize() {
             compose_validate.set_user_acknowledged_wildcard_flag(true);
             if (is_edit_input) {
                 message_edit.save_message_row_edit($row);
+            } else if (event.target.dataset.validationTrigger === "schedule") {
+                popover_menus.open_send_later_menu();
+
+                // We need to set this flag to true here because `open_send_later_menu` validates the message and sets
+                // the user acknowledged wildcard flag back to 'false' and we don't want that to happen because then it
+                // would again show the wildcard warning banner when we actually send the message from 'send-later' modal.
+                compose_validate.set_user_acknowledged_wildcard_flag(true);
             } else {
                 finish();
             }

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -67,6 +67,19 @@ export function append_compose_banner_to_banner_list(
     scroll_util.get_content_element($list_container).append(banner);
 }
 
+export function update_or_append_banner(
+    banner: HTMLElement | JQuery.htmlString,
+    banner_classname: string,
+    $list_container: JQuery,
+): void {
+    const $banner = $list_container.find(`.${CSS.escape(banner_classname)}`);
+    if ($banner.length === 0) {
+        append_compose_banner_to_banner_list(banner, $list_container);
+    } else {
+        $banner.replaceWith(banner);
+    }
+}
+
 export function clear_message_sent_banners(include_unmute_banner = true): void {
     for (const classname of Object.values(MESSAGE_SENT_CLASSNAMES)) {
         $(`#compose_banners .${CSS.escape(classname)}`).remove();

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -110,7 +110,7 @@ export function clear_unmute_topic_notifications(): void {
 }
 
 export function clear_all(): void {
-    $(`#compose_banners`).empty();
+    scroll_util.get_content_element($(`#compose_banners`)).empty();
 }
 
 export function show_error_message(

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -251,6 +251,7 @@ function show_wildcard_warnings(opts) {
         button_text,
         hide_close_button: true,
         classname,
+        scheduling_message: opts.scheduling_message,
     });
 
     // only show one error for any number of @all or @everyone mentions

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -262,7 +262,11 @@ function show_wildcard_warnings(opts) {
         );
     } else {
         // if there is already a banner, replace it with the new one
-        opts.$banner_container.find(`.${CSS.escape(classname)}`).replaceWith(wildcard_template);
+        compose_banner.update_or_append_banner(
+            wildcard_template,
+            classname,
+            opts.$banner_container,
+        );
     }
 
     user_acknowledged_wildcard = false;

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -914,11 +914,12 @@ export function save_message_row_edit($row) {
     const already_has_wildcard_mention = message.wildcard_mentioned;
     if (!already_has_wildcard_mention) {
         const wildcard_mention = util.find_wildcard_mentions(new_content);
-        const is_stream_message_mentions_valid = compose_validate.validate_stream_message_mentions(
+        const is_stream_message_mentions_valid = compose_validate.validate_stream_message_mentions({
             stream_id,
             $banner_container,
             wildcard_mention,
-        );
+        });
+
         if (!is_stream_message_mentions_valid) {
             return;
         }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -823,7 +823,7 @@ export function initialize() {
                 do_schedule_message(send_at_timestamp);
             });
             $popper.one("click", ".open_send_later_modal", () => {
-                if (!compose_validate.validate()) {
+                if (!compose_validate.validate(true)) {
                     return;
                 }
 

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -9,7 +9,7 @@
     <div class="banner_content">{{> @partial-block}}</div>
     {{/if}}
     {{#if button_text}}
-    <button class="compose_banner_action_button{{#if hide_close_button}} right_edge{{/if}}" >{{button_text}}</button>
+    <button class="compose_banner_action_button{{#if hide_close_button}} right_edge{{/if}}" {{#if scheduling_message}}data-validation-trigger="schedule"{{/if}}>{{button_text}}</button>
     {{/if}}
     {{#if hide_close_button}}
     {{!-- hide_close_button is null by default, and false if explicitly set as false. --}}

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -389,6 +389,8 @@ test_ui("validate_stream_message", ({override_rewire, mock_template}) => {
         assert.equal(data.subscriber_count, 16);
     });
 
+    compose_banner.update_or_append_banner = () => {};
+
     override_rewire(compose_validate, "wildcard_mention_allowed", () => true);
     compose_state.message_content("Hey @**all**");
     assert.ok(!compose_validate.validate());


### PR DESCRIPTION
Before it was impossible to schedule a message if it had a wildcard @-mention because we were showing a warning banner and on clicking "Yes, send" the message was sent immediately.

Fixed this by doing:
- [x] When the banner is triggered via "Schedule message", change the button text to "Yes, schedule".
- [x] Clicking "Yes, schedule" should pop up the "Schedule message" modal for getting the message scheduled.

Fixes: #25426 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<video src="https://user-images.githubusercontent.com/84276404/236234896-2c5a9a4e-f0c3-4bc4-8454-523311936d12.webm">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
