### PR TITLE
node_tests: Extend unread.test.js to catch private message mentions bug.

### DIFF
--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -24,7 +24,14 @@ const me = {
     user_id: 30,
     full_name: "Me Myself",
 };
+
+const anybody = {
+    email: "anybody@example.com",
+    user_id: 999,
+    full_name: "Any Body",
+};
 people.add_active_user(me);
+people.add_active_user(anybody);
 people.initialize_current_user(me.user_id);
 
 const social = {
@@ -382,13 +389,6 @@ test("private_messages", () => {
     let counts = unread.get_counts();
     assert.equal(counts.private_message_count, 0);
 
-    const anybody = {
-        email: "anybody@example.com",
-        user_id: 999,
-        full_name: "Any Body",
-    };
-    people.add_active_user(anybody);
-
     const message = {
         id: 15,
         type: "private",
@@ -527,32 +527,45 @@ test("mentions", () => {
         unread: true,
     };
 
+    const private_mention_me_message = {
+        id: 19,
+        type: "private",
+        display_recipient: [{id: anybody.user_id}],
+        mentioned: true,
+        mentioned_me_directly: true,
+        unread: true,
+    };
+
     unread.process_loaded_messages([
         already_read_message,
         mention_me_message,
         mention_all_message,
         muted_mention_all_message,
         muted_direct_mention_message,
+        private_mention_me_message,
     ]);
 
     counts = unread.get_counts();
-    assert.equal(counts.mentioned_message_count, 3);
+    assert.equal(counts.mentioned_message_count, 4);
     assert.deepEqual(unread.get_msg_ids_for_mentions(), [
         mention_me_message.id,
         mention_all_message.id,
         muted_direct_mention_message.id,
+        private_mention_me_message.id,
     ]);
     assert.deepEqual(unread.get_all_msg_ids(), [
         mention_me_message.id,
         mention_all_message.id,
         muted_mention_all_message.id,
         muted_direct_mention_message.id,
+        private_mention_me_message.id,
     ]);
-    test_notifiable_count(counts.home_unread_messages, 3);
+    test_notifiable_count(counts.home_unread_messages, 5);
 
     unread.mark_as_read(mention_me_message.id);
     unread.mark_as_read(mention_all_message.id);
     unread.mark_as_read(muted_direct_mention_message.id);
+    unread.mark_as_read(private_mention_me_message.id);
     counts = unread.get_counts();
     assert.equal(counts.mentioned_message_count, 0);
     test_notifiable_count(counts.home_unread_messages, 0);


### PR DESCRIPTION
This is a follow-up to #25428.
Comment: https://github.com/zulip/zulip/pull/25428#issuecomment-1533644005

In the "mentions" test, an additional unread message with the type "private" and directly mentioning me has been added. This test case checks for the scenario when the stream_id is null during the reverse_lookup, which would have caused the test to fail before the bug fix was implemented which now passes after the fix is applied.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
