### PR TITLE
scheduled_messages: Respect localization and user preferences.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -790,14 +790,7 @@ export function initialize() {
     });
 
     function set_compose_box_schedule(element) {
-        const send_later_in = element.id;
-        const send_later_class = element.classList[0];
-        const date = new Date();
-        const selected_send_at_time = scheduled_messages.get_send_at_time_from_opts(
-            send_later_in,
-            send_later_class,
-            date,
-        );
+        const selected_send_at_time = element.dataset.sendStamp / 1000;
         return selected_send_at_time;
     }
 

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -13,19 +13,19 @@
                         {{#if possible_send_later_today}}
                             {{#each possible_send_later_today}}
                                 <li>
-                                    <a id="{{@key}}" class="send_later_today" tabindex="0">{{this.text}}</a>
+                                    <a id="{{@key}}" class="send_later_today" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
                                 </li>
                             {{/each}}
                         {{/if}}
                         {{#each send_later_tomorrow}}
                             <li>
-                                <a id="{{@key}}" class="send_later_tomorrow" tabindex="0">{{this.text}}</a>
+                                <a id="{{@key}}" class="send_later_tomorrow" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
                             </li>
                         {{/each}}
                         {{#if possible_send_later_monday }}
                             {{#each possible_send_later_monday}}
                                 <li>
-                                    <a id="{{@key}}" class="send_later_monday" tabindex="0">{{this.text}}</a>
+                                    <a id="{{@key}}" class="send_later_monday" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
                                 </li>
                             {{/each}}
                         {{/if}}

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -12,11 +12,11 @@ function get_expected_send_opts(expecteds) {
         send_later_tomorrow: {
             tomorrow_nine_am: {
                 text: "translated: Tomorrow at 9:00 AM",
-                time: "9:00 am",
+                stamp: 1683363600000,
             },
             tomorrow_four_pm: {
                 text: "translated: Tomorrow at 4:00 PM",
-                time: "4:00 pm",
+                stamp: 1683388800000,
             },
         },
         send_later_custom: {
@@ -29,17 +29,17 @@ function get_expected_send_opts(expecteds) {
         send_later_today: {
             today_nine_am: {
                 text: "translated: Today at 9:00 AM",
-                time: "9:00 am",
+                stamp: 1683277200000,
             },
             today_four_pm: {
                 text: "translated: Today at 4:00 PM",
-                time: "4:00 pm",
+                stamp: 1683302400000,
             },
         },
         send_later_monday: {
             monday_nine_am: {
                 text: "translated: Monday at 9:00 AM",
-                time: "9:00 am",
+                stamp: 1683536400000,
             },
         },
     };
@@ -90,25 +90,4 @@ run_test("scheduled_modal_opts", () => {
             assert.deepEqual(modal_opts, expected_opts);
         }
     }
-});
-
-run_test("scheduled_selected_times", () => {
-    // When scheduling a message on a Monday at 6:00am
-    // that will be sent tomorrow at 4pm
-    let date = new Date("2023-05-01T06:00:00");
-    let send_at_time = scheduled_messages.get_send_at_time_from_opts(
-        "tomorrow_four_pm",
-        "send_later_tomorrow",
-        date,
-    );
-    assert.equal(send_at_time, "May 2 2023 4:00 pm");
-    // When scheduling a message on a Friday at 5:00pm
-    // that will be sent Monday at 9am
-    date = new Date("2023-05-05T17:00:00");
-    send_at_time = scheduled_messages.get_send_at_time_from_opts(
-        "monday_nine_am",
-        "send_later_monday",
-        date,
-    );
-    assert.equal(send_at_time, "May 8 2023 9:00 am");
 });


### PR DESCRIPTION
This commit ensures that user-locale and 24-hour preferences are respected in the message-scheduling modal. It also simplifies the translation of text strings in the scheduling modal.

Available scheduling options and their time values, including whether the options are allowed, are now calculated every time a user opens the scheduling modal.

In order to achieve those things, additional interrelated fixes here accomplish the following:

1. Modal-scheduling opts now have data- attributes containing timestamps for the time a message will be scheduled to send.

2. With those timestamps in place, the logic for setting the scheduled send-time is simplified.

3. There are no more `send_later_xxx` global variables in the `schedule_send` module.

Fixes #25403.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

Screenshot showing proper display of 24-hour time:
<img width="558" alt="schedule-24hr-time" src="https://user-images.githubusercontent.com/170719/236543686-4de0c56c-010f-49ea-8252-6995c8351c9f.png">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
