### PR TITLE
help:  Add "Schedule a message" help center page + minor tweaks.

### DIFF
--- a/help/custom-emoji.md
+++ b/help/custom-emoji.md
@@ -51,7 +51,7 @@ while the search box is empty (you may have to scroll down a bit to find it).
 
 {settings_tab|emoji-settings}
 
-1. Click the trash icon (<i class="fa fa-trash-o"></i>) next to the
+1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon next to the
    emoji that you would like to deactivate.
 
 {end_tabs}

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -81,6 +81,7 @@
 * [Verify a message was sent](/help/verify-your-message-was-successfully-sent)
 * [Edit or delete a message](/help/edit-or-delete-a-message)
 * [Message drafts](/help/view-and-edit-your-message-drafts)
+* [Schedule a message](/help/schedule-a-message)
 * [Message a stream by email](/help/message-a-stream-by-email)
 
 ## Reading messages

--- a/help/schedule-a-message.md
+++ b/help/schedule-a-message.md
@@ -1,0 +1,105 @@
+# Schedule a message
+
+Zulip lets you schedule a message to be sent at a later time. For example, if
+you are working outside of regular business hours for your organization, you
+can schedule a message for next morning to avoid disturbing others.
+
+## Schedule a message
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{!start-composing.md!}
+
+1. Write a message.
+
+1. Click on the **ellipsis** (<i class="zulip-icon
+   zulip-icon-ellipsis-v-solid"></i>) next to the **Send** button.
+
+1. Click **Schedule message**.
+
+1. Select one of the suggested scheduling options, or pick a custom time.
+
+{end_tabs}
+
+## Edit or reschedule a message
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click on <i class="fa fa-calendar"></i> **Scheduled messages** in the left
+   sidebar. If you do not see this link, you have no scheduled messages.
+
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the message you
+   want to edit or reschedule.
+
+1. *(optional)* Edit the message.
+
+1. Click the **ellipsis** (<i class="zulip-icon
+   zulip-icon-ellipsis-v-solid"></i>) next to the **Send** button.
+
+1. Select the previously scheduled time, or click **Schedule message** to pick a
+   new time.
+
+!!! tip ""
+
+    You can also click **Undo** in the confirmation banner shown immediately
+    after a message is scheduled.
+
+{end_tabs}
+
+## Send a scheduled message now
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click on <i class="fa fa-calendar"></i> **Scheduled messages** in the left
+   sidebar. If you do not see this link, you have no scheduled messages.
+
+1. Click the **pencil** (<i class="fa fa-pencil"></i>) icon on the message you
+   want to send now.
+
+1. *(optional)* Edit the message.
+
+1. Click **Send**.
+
+!!! tip ""
+
+    You can also click **Undo** in the confirmation banner shown immediately
+    after a message is scheduled.
+
+{end_tabs}
+
+## Delete a scheduled message
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click on <i class="fa fa-calendar"></i> **Scheduled messages** in the left
+   sidebar. If you do not see this link, you have no scheduled messages.
+
+1. Click the **trash** (<i class="fa fa-trash-o"></i>) icon on the message you
+   want to delete.
+
+{end_tabs}
+
+## View scheduled messages
+
+{start_tabs}
+
+{tab|desktop-web}
+
+1. Click on <i class="fa fa-calendar"></i> **Scheduled messages** in the left sidebar.
+   If you do not see this link, you have no scheduled messages.
+
+!!! tip ""
+
+    You can also view scheduled messages by clicking on the **ellipsis** (<i class="zulip-icon
+    zulip-icon-ellipsis-v-solid"></i>) next to the **Send** button in the compose
+    box, and selecting **View scheduled messages**.
+
+{end_tabs}

--- a/help/view-and-edit-your-message-drafts.md
+++ b/help/view-and-edit-your-message-drafts.md
@@ -14,7 +14,7 @@ so that you never lose your work. Drafts are saved for 30 days.
 
 {tab|desktop-web}
 
-Simply close the compose box. You can hit <kbd>Esc</kbd>, click
+1. Simply close the compose box. You can hit <kbd>Esc</kbd>, click
 the <i class="fa fa-remove"></i> in the top right corner of the
 compose box, or click on an empty part of the app.
 
@@ -26,7 +26,7 @@ compose box, or click on an empty part of the app.
 
 {tab|desktop-web}
 
-Click on <i class="fa fa-pencil"></i> **Drafts** in the left sidebar.
+1. Click on <i class="fa fa-pencil"></i> **Drafts** in the left sidebar.
 From there, you can delete or restore any of your drafts.
 
 {end_tabs}


### PR DESCRIPTION
Fixes #25407.

## Schedule a message page

Notes:
- I put the page right after "Message drafts" in the "Sending messages" sidebar section.

Follow-ups:
1. I didn't deal with cross-linking related pages. @drrosa would be great if you could post a follow-up PR for this.
2. Can we offer links to "Drafts" and "Scheduled messages" for logged in users? If so, that's probably a good follow-up for @drrosa as well.

<details>
<summary>
Screenshots
</summary>

![Screen Shot 2023-05-05 at 12 39 21 PM](https://user-images.githubusercontent.com/2090066/236555711-732e2c6e-6727-4e70-bbfb-8005283dd003.png)

![Screen Shot 2023-05-05 at 12 42 23 PM](https://user-images.githubusercontent.com/2090066/236555725-b4e58dd1-da56-479e-9690-0e602d69c2d0.png)

</details>

## Other
The `custom-emoji.md` change is trivial. For the drafts page, I think always numbering instruction steps (even if there's just one) looks better?

Current: https://zulip.com/help/view-and-edit-your-message-drafts

<details>
<summary>
Updated
</summary>

![Screen Shot 2023-05-05 at 12 39 00 PM](https://user-images.githubusercontent.com/2090066/236555807-6a8e72d6-6e55-479e-a300-aa1cb149b26b.png)

</details>

