### PR TITLE
message_edit: Avoid registering duplicate events

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -590,6 +590,10 @@ export function start($row, edit_box_open_callback) {
         return;
     }
 
+    if ($row.find(".message_edit_form form").length !== 0) {
+        return;
+    }
+
     if (message.raw_content) {
         start_edit_with_content($row, message.raw_content, edit_box_open_callback);
         return;


### PR DESCRIPTION
hotkey.js is the file that handles the 'e' keyboard shortcut. It maps to the 'edit_message' event and will simply call message_edit.start().

message_edit.start() doesn't check whether it's already been opened previously, so it will go through and try to register handler for the clipboard button again. When the clipboard button gets clicked, the handler will be called twice. Once with a properly target element, and once with null.

Fixing this issue by checking if message_edit.start() has already operated on the given $row.

<!-- Describe your pull request here.-->

Fixes: #25462

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>