### PR TITLE
message_edit: Disable save btn after edit time limit

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -521,6 +521,7 @@ function edit_message($row, raw_content) {
         // I believe this needs to be defined outside the countdown_timer, since
         // row just refers to something like the currently selected message, and
         // can change out from under us
+        const $message_edit_save_container = $row.find(".message_edit_save_container");
         const $message_edit_save = $row.find("button.message_edit_save");
         // Do this right away, rather than waiting for the timer to do its first update,
         // since otherwise there is a noticeable lag
@@ -529,12 +530,13 @@ function edit_message($row, raw_content) {
             seconds_left -= 1;
             if (seconds_left <= 0) {
                 clearInterval(countdown_timer);
-                $message_edit_content.prop("readonly", "readonly");
                 // We don't go directly to a "TOPIC_ONLY" type state (with an active Save button),
                 // since it isn't clear what to do with the half-finished edit. It's nice to keep
                 // the half-finished edit around so that they can copy-paste it, but we don't want
                 // people to think "Save" will save the half-finished edit.
-                $message_edit_save.addClass("disabled");
+                $message_edit_save.prop("disabled", true);
+                $message_edit_save_container.addClass("tippy-zulip-tooltip");
+                $message_edit_countdown_timer.addClass("expired");
                 $message_edit_countdown_timer.text($t({defaultMessage: "Time's up!"}));
             } else {
                 $message_edit_countdown_timer.text(timer_text(seconds_left));

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1640,6 +1640,10 @@ div.focused_table {
     text-align: right;
     display: inline;
     color: hsl(0deg 0% 63%);
+
+    &.expired {
+        color: hsl(4deg 58% 33%);
+    }
 }
 
 .message_edit_tooltip {

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -23,11 +23,9 @@
                 <div class="btn-wrapper inline-block">
                     <button type="button" class="button small rounded message_edit_cancel">{{t "Cancel" }}</button>
                 </div>
-                {{#if is_editable}}
                 <div class="message-edit-feature-group">
                     {{> compose_control_buttons }}
                 </div>
-                {{/if}}
             {{else}}
                 <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
             {{/if}}

--- a/web/templates/message_edit_form.hbs
+++ b/web/templates/message_edit_form.hbs
@@ -14,7 +14,8 @@
         <div class="message_edit_spinner"></div>
         <div class="controls edit-controls">
             {{#if is_editable}}
-                <div class="btn-wrapper inline-block">
+                <div class="btn-wrapper inline-block message_edit_save_container"
+                  data-tippy-content="{{t 'You can no longer save changes to this message.' }}">
                     <button type="button" class="button small rounded sea-green message_edit_save">
                         <img class="loader" alt="" src="" />
                         <span>{{t "Save" }}</span>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

The old code was disabling the save button wrong by using `.addClass("disabled")` instead of `prop()`.

Added tooltip for the disabled save button as per issue https://github.com/zulip/zulip/issues/25413.

The textbox readonly logic was changed to no longer becoming readonly. Reason being there are edge cases involving the compose buttons such that simply marking the textbox as readonly is not sufficient.

E.g. using the compose buttons after readonly still modifies the content.

One solution might be to just hide the compose buttons visually. However, there are edge cases for that too. If preview mode was previously active, then perhaps that state needs to be reverted. If any modal is open, such as the emoji picker, then that needs to be closed. Solving these edge cases doesn't improve the user experience. Keeping the textbox editable allows an easier way for user to copy the text and don't have weird cases.

Fixes: #25413

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="941" alt="Screenshot 2023-05-07 at 12 24 02 AM" src="https://user-images.githubusercontent.com/122081200/236663822-f0ad0f2f-d42a-4d75-8d4e-e07fea0b11f6.png">

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
