### PR TITLE
tippyjs: Hide recipient bar tooltips on msg_list rerender.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -185,10 +185,8 @@ export function initialize() {
         },
     });
 
-    delegate("body", {
-        target: ".tippy-narrow-tooltip",
+    message_list_tooltip(".tippy-narrow-tooltip", {
         delay: LONG_HOVER_DELAY,
-        appendTo: () => document.body,
         onCreate(instance) {
             const content = instance.props.content + $("#narrow-hotkey-tooltip-template").html();
             instance.setContent(parse_html(content));


### PR DESCRIPTION
I noticed a floating "Go to direct message ..." on chat.zulip.org, and then found out that these don't use message_list_tooltip.

I am not able to reproduce, but this change makes sense on its own.