### PR TITLE
message_edit: Fix edit hover icon sometimes missing

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -125,38 +125,45 @@ import * as user_topics from "./user_topics";
    things jumping around slightly when the email address is shown. */
 
 let $current_message_hover;
+let $current_message_hover_args;
 function message_unhover() {
     if ($current_message_hover === undefined) {
         return;
     }
     $current_message_hover.find("span.edit_content").empty();
     $current_message_hover = undefined;
+    $current_message_hover_args = undefined;
 }
 
 function message_hover($message_row) {
+    const message = message_lists.current.get(rows.id($message_row));
+    
+    // The message edit hover icon is determined by whether the message is still editable
+    const is_content_editable = message_edit.is_content_editable(message);
+    const can_move_message = message_edit.can_move_message(message);
     const id = rows.id($message_row);
-    if ($current_message_hover && rows.id($current_message_hover) === id) {
+    const args = {
+        is_content_editable: is_content_editable && !message.status_message,
+        can_move_message,
+        msg_id: id,
+    };
+    
+    if ($current_message_hover_args &&
+        $current_message_hover_args.is_content_editable === args.is_content_editable &&
+        $current_message_hover_args.can_move_message === args.can_move_message &&
+        $current_message_hover_args.msg_id === args.msg_id) {
         return;
     }
-
-    const message = message_lists.current.get(rows.id($message_row));
+    
     message_unhover();
     $current_message_hover = $message_row;
+    $current_message_hover_args = args;
 
     if (!message.sent_by_me) {
         // The actions and reactions icon hover logic is handled entirely by CSS
         return;
     }
 
-    // But the message edit hover icon is determined by whether the message is still editable
-    const is_content_editable = message_edit.is_content_editable(message);
-
-    const can_move_message = message_edit.can_move_message(message);
-    const args = {
-        is_content_editable: is_content_editable && !message.status_message,
-        can_move_message,
-        msg_id: id,
-    };
     const $edit_content = $message_row.find(".edit_content");
     $edit_content.html(render_edit_content_button(args));
 


### PR DESCRIPTION
Fixes #25312.

The old logic for checking whether message_hover() needs to render the hover buttons is not a proper check of whether something has changed.

It uses an indirect check to see if the zid of the row element has changed. In the locally echo case, this leads to a situation where the underlying editability has changed after updates from the server, but the old logic still thinks nothing has changed.

The new logic saves the args used to construct the hover buttons so that if the args changed, then message_hover() will rerender the buttons. This is a direct check of the conditions that affect what's rendered.

A broader issue not fixed with this commit is that there is a lot of logic spread around everywhere that does direct manipulation. src/ui_init.js packs a bunch of logic that really should be encapsulated to specific components. In this case, the message_hover() functionality should probably be moved over to message_list and its view, so that when message_list_view gets rerendered, the hover buttons are rerendered at that time as well.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before Fix:
- Notice that after the message is sent, hover buttons briefly flashes and has no edit button.

https://user-images.githubusercontent.com/122081200/236707906-b67e961a-65c4-4c64-b71c-967aa5748ce7.mov


After Fix:
- Notice that after the message is sent, hover buttons briefly flashes and now has the edit button.

https://user-images.githubusercontent.com/122081200/236707913-70735bfd-86a9-4812-b6b8-b94a018b260d.mov



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
