### PR TITLE
scheduled_messages: Allow Today scheduling thru :54 past the hour.

### DIFF
--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -180,7 +180,8 @@ export function get_filtered_send_opts(date) {
     const send_times = compute_send_times(date);
 
     const day = date.getDay(); // Starts with 0 for Sunday.
-    const hours = date.getHours();
+    // Construct an HHMM integer of the time for comparison below
+    const hhmm = date.getHours() * 100 + date.getMinutes(); // e.g., 1806 at 6:06pm
 
     const send_later_today = {
         today_nine_am: {
@@ -257,9 +258,12 @@ export function get_filtered_send_opts(date) {
 
     let possible_send_later_today = {};
     let possible_send_later_monday = {};
-    if (hours <= 8) {
+    // Show Today send options based on time of day
+    if (hhmm <= 854) {
+        // Allow Today at 9:00am scheduling thru 8:54am
         possible_send_later_today = send_later_today;
-    } else if (hours <= 15) {
+    } else if (hhmm <= 1554) {
+        // Allow Today at 4:00pm scheduling thru 3:54pm
         possible_send_later_today.today_four_pm = send_later_today.today_four_pm;
     } else {
         possible_send_later_today = false;


### PR DESCRIPTION
This PR allows users to schedule Today messages from the modal opts thru 8:54am (8:54) for sending at 9:00am, and thru 3:54pm (15:54) for sending at 4:00pm. (That's including up to :59 seconds, of course, on :54 after. So, XX:54:59.)

The code creates a decimal integer representation of hours and minutes (HHMM). While that can be sketchy when working with time, which is of course sexagesimal, decimal representation should suffice for basic comparison here--while also avoiding more complicated string comparisons of `"HHMM"`, which would require zero-padding on the minutes value (e.g., `date.getMinutes()` returns `7` at :07 after the hour).

Fixes first part of #25451.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
