### PR TITLE
puppet: Add PostgreSQL 15 support.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -52,7 +52,8 @@ as well as those mentioned in the
 [install](install.md#installer-options) documentation:
 
 - `--postgresql-version`: Sets the version of PostgreSQL that will be
-  installed. We currently support PostgreSQL 12, 13, and 14.
+  installed. We currently support PostgreSQL 12, 13, 14, and 15, with 15 being
+  the default.
 
 - `--postgresql-database-name=exampledbname`: With this option, you
   can customize the default database name. If you do not set this. The

--- a/docs/production/postgresql.md
+++ b/docs/production/postgresql.md
@@ -1,13 +1,13 @@
 # PostgreSQL database details
 
 Starting with Zulip 3.0, Zulip supports a range of PostgreSQL
-versions. PostgreSQL 14 is the current default for new installations;
-PostgreSQL 12, 13, and 14 are all supported.
+versions. PostgreSQL 15 is the current default for new installations;
+PostgreSQL 12, 13, 14, and 15 are all supported.
 
 Previous versions of Zulip used whatever version of PostgreSQL was
 included with the base operating system (E.g. PostgreSQL 12 on Ubuntu
 20.04). We recommend that installations currently using older
-PostgreSQL releases [upgrade to PostgreSQL 14][upgrade-postgresql], as
+PostgreSQL releases [upgrade to PostgreSQL 15][upgrade-postgresql], as
 we may drop support for older PostgreSQL in a future release.
 
 [upgrade-postgresql]: upgrade.md#upgrading-postgresql

--- a/docs/production/upgrade.md
+++ b/docs/production/upgrade.md
@@ -618,9 +618,9 @@ instructions for other supported platforms.
 ## Upgrading PostgreSQL
 
 Starting with Zulip 3.0, we use the latest available version of
-PostgreSQL at installation time (currently version 14). Upgrades to
+PostgreSQL at installation time (currently version 15). Upgrades to
 the version of PostgreSQL are no longer linked to upgrades of the
-distribution; that is, you may opt to upgrade to PostgreSQL 14 while
+distribution; that is, you may opt to upgrade to PostgreSQL 15 while
 running Ubuntu 20.04.
 
 To upgrade the version of PostgreSQL on the Zulip server:

--- a/puppet/zulip/templates/postgresql/zulip.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/zulip.conf.template.erb
@@ -1,0 +1,63 @@
+<% if @listen_addresses != '' -%>
+# Bind to specific address
+listen_addresses = <%= @listen_addresses %>
+<% end -%>
+
+# This has an improved set of stopwords.
+default_text_search_config = 'zulip.english_us_search'
+
+# Provide more comprehensive on-disk logs
+logging_collector = on
+log_directory = '/var/log/postgresql'
+log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'
+log_rotation_age = 7d
+log_rotation_size = 100MB
+log_min_duration_statement = 500
+log_line_prefix = '%m [%c]: [%l-1] '
+log_checkpoints = on
+log_lock_waits = on
+log_temp_files = 0
+log_autovacuum_min_duration = 100
+
+# Adjust autovacuum for having many mostly-append-only tables
+autovacuum_freeze_max_age = 2000000000
+vacuum_freeze_min_age     = 1000000000
+vacuum_freeze_table_age   = 1800000000
+
+# Performance settings
+max_connections = 1000
+maintenance_work_mem = <%= scope["zulip::profile::postgresql::maintenance_work_mem"] %>MB
+effective_cache_size = <%= scope["zulip::profile::postgresql::effective_cache_size"] %>MB
+work_mem = <%= scope["zulip::profile::postgresql::work_mem"] %>MB
+shared_buffers = <%= scope["zulip::profile::postgresql::shared_buffers"] %>MB
+wal_buffers = 4MB
+checkpoint_completion_target = 0.7
+<% if @random_page_cost != '' -%>
+random_page_cost = <%= @random_page_cost %>
+<% end -%>
+<% if @effective_io_concurrency != '' -%>
+effective_io_concurrency = <%= @effective_io_concurrency %>
+<% end -%>
+
+<% if @s3_backups_bucket != '' -%>
+# Streaming backups and replication
+archive_mode = on
+archive_command = '/usr/bin/timeout 10m /usr/local/bin/env-wal-g wal-push %p'
+restore_command = '/usr/local/bin/env-wal-g wal-fetch "%f" "%p"'
+<% if @replication_primary != '' && @replication_user != '' -%>
+primary_conninfo = 'host=<%= @replication_primary %> user=<%= @replication_user -%>
+<% if @replication_password != '' %> password=<%= @replication_password %><% end -%>
+<% if @ssl_mode != '' %> sslmode=<%= @ssl_mode %><% end -%>
+'
+<% end -%>
+<% end -%>
+
+<% if @ssl_cert_file != '' -%>
+ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
+<% end -%>
+<% if @ssl_key_file != '' -%>
+ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
+<% end -%>
+<% if @ssl_ca_file != '' -%>
+ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
+<% end -%>

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -32,7 +32,7 @@ Options:
       Sets the PostgreSQL database name.
   --postgresql-database-user=zulip
       Sets the PostgreSQL database user.
-  --postgresql-version=14
+  --postgresql-version=15
       Sets the version of PostgreSQL that will be installed.
   --postgresql-missing-dictionaries
       Set postgresql.missing_dictionaries, which alters the initial database.  Use with
@@ -140,7 +140,7 @@ read -r -a ADDITIONAL_PACKAGES <<<"${ADDITIONAL_PACKAGES:-}"
 # e.g. zulip::profile::app_frontend for a Zulip frontend server.
 PUPPET_CLASSES="${PUPPET_CLASSES:-zulip::profile::standalone}"
 VIRTUALENV_NEEDED="${VIRTUALENV_NEEDED:-yes}"
-POSTGRESQL_VERSION="${POSTGRESQL_VERSION:-14}"
+POSTGRESQL_VERSION="${POSTGRESQL_VERSION:-15}"
 
 if [ -n "$SELF_SIGNED_CERT" ] && [ -n "$USE_CERTBOT" ]; then
     set +x

--- a/scripts/setup/upgrade-postgresql
+++ b/scripts/setup/upgrade-postgresql
@@ -12,7 +12,7 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 export LANGUAGE=C.UTF-8
 
-UPGRADE_TO=${1:-14}
+UPGRADE_TO=${1:-15}
 UPGRADE_FROM=$(crudini --get /etc/zulip/zulip.conf postgresql version)
 ZULIP_PATH="$(dirname "$0")/../.."
 


### PR DESCRIPTION
Instead of copying over a mostly-unchanged `postgresql.conf`, we transition to deploying a `conf.d/zulip.conf` which contains the only material changes we made to the file, which were previously appended to the end.

While shipping separate while `postgresql.conf` files for each supported version is useful if there is large variety in supported options between versions, there is not no such variation at current, and the burden of overriding the entire default configuration is that it must be keep up to date wit the package's version.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
