### PR TITLE
scheduled_messages: Don't offer to reschedule in the past.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -89,7 +89,13 @@ export function get_selected_send_later_timestamp() {
 }
 
 export function get_formatted_selected_send_later_time() {
-    if (!selected_send_later_timestamp) {
+    const current_time = Date.now() / 1000; // seconds, like selected_send_later_timestamp
+    if (
+        scheduled_messages.is_send_later_timestamp_missing_or_expired(
+            selected_send_later_timestamp,
+            current_time,
+        )
+    ) {
         return undefined;
     }
     return timerender.get_full_datetime(new Date(selected_send_later_timestamp * 1000), "time");

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -278,7 +278,7 @@ export function get_filtered_send_opts(date) {
     if (minutes_into_day < 9 * 60 - MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS / 60) {
         // Allow Today at 9:00am only up to minimum scheduled message delay
         possible_send_later_today = send_later_today;
-    } else if (minutes_into_day < (12 + 2) * 60 - MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS / 60) {
+    } else if (minutes_into_day < (12 + 4) * 60 - MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS / 60) {
         // Allow Today at 4:00pm only up to minimum scheduled message delay
         possible_send_later_today.today_four_pm = send_later_today.today_four_pm;
     } else {

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -196,7 +196,6 @@ export function get_filtered_send_opts(date) {
     const send_times = compute_send_times(date);
 
     const day = date.getDay(); // Starts with 0 for Sunday.
-    const hours = date.getHours();
 
     const send_later_today = {
         today_nine_am: {
@@ -273,9 +272,14 @@ export function get_filtered_send_opts(date) {
 
     let possible_send_later_today = {};
     let possible_send_later_monday = {};
-    if (hours <= 8) {
+
+    const minutes_into_day = date.getHours() * 60 + date.getMinutes();
+    // Show Today send options based on time of day
+    if (minutes_into_day < 9 * 60 - MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS / 60) {
+        // Allow Today at 9:00am only up to minimum scheduled message delay
         possible_send_later_today = send_later_today;
-    } else if (hours <= 15) {
+    } else if (minutes_into_day < (12 + 2) * 60 - MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS / 60) {
+        // Allow Today at 4:00pm only up to minimum scheduled message delay
         possible_send_later_today.today_four_pm = send_later_today.today_four_pm;
     } else {
         possible_send_later_today = false;

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -15,6 +15,7 @@ import * as popover_menus from "./popover_menus";
 import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 
+export const MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS = 5 * 60;
 export let scheduled_messages_data = [];
 
 function compute_send_times(now = new Date()) {
@@ -39,6 +40,21 @@ function compute_send_times(now = new Date()) {
     // next Monday at 9am
     send_times.monday_nine_am = monday.setHours(9, 0, 0, 0);
     return send_times;
+}
+
+export function is_send_later_timestamp_missing_or_expired(
+    timestamp_in_seconds,
+    current_time_in_seconds,
+) {
+    if (!timestamp_in_seconds) {
+        return true;
+    }
+    // Determine if the selected timestamp is less than the minimum
+    // scheduled message delay
+    if (timestamp_in_seconds - current_time_in_seconds < MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS) {
+        return true;
+    }
+    return false;
 }
 
 function sort_scheduled_messages_data() {

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -121,8 +121,8 @@ run_test("scheduled_modal_opts", () => {
         {hour: "T08:54:00", extras: ["today_nine_am", "today_four_pm"]},
         {hour: "T08:57:00", extras: ["today_four_pm"]},
         {hour: "T11:00:00", extras: ["today_four_pm"]},
-        {hour: "T13:54:00", extras: ["today_four_pm"]},
-        {hour: "T13:57:00", extras: []},
+        {hour: "T15:54:00", extras: ["today_four_pm"]},
+        {hour: "T15:57:00", extras: []},
         {hour: "T17:00:00", extras: []},
     ];
 

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -7,51 +7,52 @@ const {run_test} = require("./lib/test");
 
 const scheduled_messages = zrequire("scheduled_messages");
 
+const per_day_stamps = {
+    "2023-04-30": {
+        today_nine_am: 1682845200000,
+        today_four_pm: 1682870400000,
+        tomorrow_nine_am: 1682931600000,
+        tomorrow_four_pm: 1682956800000,
+    },
+    "2023-05-01": {
+        today_nine_am: 1682931600000,
+        today_four_pm: 1682956800000,
+        tomorrow_nine_am: 1683018000000,
+        tomorrow_four_pm: 1683043200000,
+    },
+    "2023-05-02": {
+        today_nine_am: 1683018000000,
+        today_four_pm: 1683043200000,
+        tomorrow_nine_am: 1683104400000,
+        tomorrow_four_pm: 1683129600000,
+    },
+    "2023-05-03": {
+        today_nine_am: 1683104400000,
+        today_four_pm: 1683129600000,
+        tomorrow_nine_am: 1683190800000,
+        tomorrow_four_pm: 1683216000000,
+    },
+    "2023-05-04": {
+        today_nine_am: 1683190800000,
+        today_four_pm: 1683216000000,
+        tomorrow_nine_am: 1683277200000,
+        tomorrow_four_pm: 1683302400000,
+    },
+    "2023-05-05": {
+        today_nine_am: 1683277200000,
+        today_four_pm: 1683302400000,
+        tomorrow_nine_am: 1683363600000,
+        tomorrow_four_pm: 1683388800000,
+    },
+    "2023-05-06": {
+        today_nine_am: 1683363600000,
+        today_four_pm: 1683388800000,
+        tomorrow_nine_am: 1683450000000,
+        tomorrow_four_pm: 1683475200000,
+    },
+};
+
 function get_expected_send_opts(day, expecteds) {
-    const per_day_stamps = {
-        "2023-04-30": {
-            today_nine_am: 1682845200000,
-            today_four_pm: 1682870400000,
-            tomorrow_nine_am: 1682931600000,
-            tomorrow_four_pm: 1682956800000,
-        },
-        "2023-05-01": {
-            today_nine_am: 1682931600000,
-            today_four_pm: 1682956800000,
-            tomorrow_nine_am: 1683018000000,
-            tomorrow_four_pm: 1683043200000,
-        },
-        "2023-05-02": {
-            today_nine_am: 1683018000000,
-            today_four_pm: 1683043200000,
-            tomorrow_nine_am: 1683104400000,
-            tomorrow_four_pm: 1683129600000,
-        },
-        "2023-05-03": {
-            today_nine_am: 1683104400000,
-            today_four_pm: 1683129600000,
-            tomorrow_nine_am: 1683190800000,
-            tomorrow_four_pm: 1683216000000,
-        },
-        "2023-05-04": {
-            today_nine_am: 1683190800000,
-            today_four_pm: 1683216000000,
-            tomorrow_nine_am: 1683277200000,
-            tomorrow_four_pm: 1683302400000,
-        },
-        "2023-05-05": {
-            today_nine_am: 1683277200000,
-            today_four_pm: 1683302400000,
-            tomorrow_nine_am: 1683363600000,
-            tomorrow_four_pm: 1683388800000,
-        },
-        "2023-05-06": {
-            today_nine_am: 1683363600000,
-            today_four_pm: 1683388800000,
-            tomorrow_nine_am: 1683450000000,
-            tomorrow_four_pm: 1683475200000,
-        },
-    };
     const modal_opts = {
         send_later_tomorrow: {
             tomorrow_nine_am: {
@@ -117,7 +118,11 @@ run_test("scheduled_modal_opts", () => {
     // Extra options change based on the hour of day
     const options_by_hour = [
         {hour: "T06:00:00", extras: ["today_nine_am", "today_four_pm"]},
+        {hour: "T08:54:00", extras: ["today_nine_am", "today_four_pm"]},
+        {hour: "T08:57:00", extras: ["today_four_pm"]},
         {hour: "T11:00:00", extras: ["today_four_pm"]},
+        {hour: "T13:54:00", extras: ["today_four_pm"]},
+        {hour: "T13:57:00", extras: []},
         {hour: "T17:00:00", extras: []},
     ];
 
@@ -134,4 +139,23 @@ run_test("scheduled_modal_opts", () => {
             assert.deepEqual(modal_opts, expected_opts);
         }
     }
+});
+
+run_test("missing_or_expired_timestamps", () => {
+    let now_in_seconds = new Date("2023-05-03T08:54:00").getTime();
+    // The today at 9am option is not expired as of 8:54am (false)
+    assert.ok(
+        !scheduled_messages.is_send_later_timestamp_missing_or_expired(
+            per_day_stamps["2023-05-03"].today_nine_am / 1000,
+            now_in_seconds / 1000,
+        ),
+    );
+    // The today at 9am option is expired as of 8:57am (true)
+    now_in_seconds = new Date("2023-05-03T08:57:00").getTime();
+    assert.ok(
+        scheduled_messages.is_send_later_timestamp_missing_or_expired(
+            per_day_stamps["2023-05-03"].today_nine_am / 1000,
+            now_in_seconds / 1000,
+        ),
+    );
 });


### PR DESCRIPTION
This introduces a function that checks for both the existence and the expiration of the `selected_send_later_timestamp`.

The logic it supports prevents users from scheduling a message to send in the past, at least the level of the UI: the popover on the \vdots component of the Send button.

**One question:** Would it make sense to look for a difference of 30 seconds or a minute to decide whether the scheduled time has expired? Currently the function checks only for a non-negative (greater than 0) difference between the timestamps for the scheduled send time and now.

I could imagine a potential corner-case where a user schedules a message just seconds before the send time is in the past, especially given browser or network latency, etc., or just having a user interrupted while opening the popover menu and choosing the previously set scheduled send time.

Fixes #25439.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
