### PR TITLE
popover: Allow message actions menu to support larger max-width.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -523,9 +523,9 @@ export function initialize() {
     });
 
     tippy_no_propagation(".actions_hover .zulip-icon-ellipsis-v-solid", {
-        // The is our minimum supported width for mobile. We shouldn't
-        // make the popover wider than this.
-        maxWidth: "320px",
+        // 320px is our minimum supported width for mobile. We will allow the value to flex
+        // to a max of 350px but we shouldn't make the popover wider than this.
+        maxWidth: "min(max(320px, 100vw), 350px)",
         placement: "bottom",
         popperOptions: {
             modifiers: [


### PR DESCRIPTION
Previously, the option texts were split into 2 lines due to the lack of space in the message menu. We want to fix this by increasing the max-width of the menu so it can support the entire text in 1 line while also providing additional space for longer text.

Since, 320px is the maximum supported supported width for mobile, we will allow the max-width value to flex from 320px to 350px depending on the window_width

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
![image](https://user-images.githubusercontent.com/62449508/236888242-855acf04-0fbc-4f3b-bc36-645c88fe48d2.png)

After:
![image](https://user-images.githubusercontent.com/62449508/236888299-038eba0d-2ae8-44e2-b78b-5f137205597e.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
