### PR TITLE
user_setting: Update wording for "Mark messages as read on scroll"

### DIFF
--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -21,7 +21,9 @@ are at your computer. You will still be able to
 
 {settings_tab|display-settings}
 
-1. Under **Advanced**, select **Always**, **Never** or **Only in conversation views**.
+1. Under **Advanced**, click on the **Automatically mark messages as
+   read** dropdown, and select **Always**, **Never** or **Only in
+   conversation views**.
 
 {tab|mobile}
 

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -190,7 +190,7 @@ export class MessageList {
              properties of the message_list_data object.
            * The user recently marked messages in the view as unread, and
              we don't want to lose that state.
-           * The user has "Mark messages as read on scroll" option
+           * The user has "Automatically mark messages as read" option
              turned on in their user settings.
         */
         const filter = this.data.filter;
@@ -214,7 +214,7 @@ export class MessageList {
         /*
             Similar to can_mark_messages_read() above, this is a helper
             function to check if messages can be automatically read without
-            the "Do not mark messages as read on scroll" setting.
+            the "Automatically mark messages as read" setting.
         */
         return this.data.can_mark_messages_read() && !this.reading_prevented;
     }

--- a/web/templates/settings/display_settings.hbs
+++ b/web/templates/settings/display_settings.hbs
@@ -81,7 +81,7 @@
         </div>
 
         <div class="input-group">
-            <label for="web_mark_read_on_scroll_policy" class="dropdown-title">{{t "Mark messages as read on scroll" }}
+            <label for="web_mark_read_on_scroll_policy" class="dropdown-title">{{t "Automatically mark messages as read" }}
                 {{> ../help_link_widget link="/help/marking-messages-as-read" }}
             </label>
             <select name="web_mark_read_on_scroll_policy" class="setting_web_mark_read_on_scroll_policy prop-element settings_select bootstrap-focus-style" id="{{prefix}}web_mark_read_on_scroll_policy"  data-setting-widget-type="number">


### PR DESCRIPTION

Previously, the user setting "Mark messages as read on scroll" sounded quite awkward and possibly confusing at times. We should update the text to something more clear and concise. This change will change "Mark messages as read on scroll" to "Automatically mark messages as read".

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://user-images.githubusercontent.com/62449508/236910124-cd6a93ab-5b2e-4229-897a-274441e38d56.png)
![image](https://user-images.githubusercontent.com/62449508/236911547-26ae6181-0d8f-463d-9b99-2bdc63f5d0c8.png)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
