### PR TITLE
models: Update the references for API dicts for scheduled messages.

### DIFF
--- a/zerver/lib/scheduled_messages.py
+++ b/zerver/lib/scheduled_messages.py
@@ -4,9 +4,9 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import ResourceNotFoundError
 from zerver.models import (
-    DirectScheduledMessageAPI,
+    APIScheduledDirectMessageDict,
+    APIScheduledStreamMessageDict,
     ScheduledMessage,
-    StreamScheduledMessageAPI,
     UserProfile,
 )
 
@@ -22,11 +22,11 @@ def access_scheduled_message(
 
 def get_undelivered_scheduled_messages(
     user_profile: UserProfile,
-) -> List[Union[DirectScheduledMessageAPI, StreamScheduledMessageAPI]]:
+) -> List[Union[APIScheduledDirectMessageDict, APIScheduledStreamMessageDict]]:
     scheduled_messages = ScheduledMessage.objects.filter(
         sender=user_profile, delivered=False, delivery_type=ScheduledMessage.SEND_LATER
     ).order_by("scheduled_timestamp")
-    scheduled_message_dicts: List[Union[DirectScheduledMessageAPI, StreamScheduledMessageAPI]] = [
-        scheduled_message.to_dict() for scheduled_message in scheduled_messages
-    ]
+    scheduled_message_dicts: List[
+        Union[APIScheduledDirectMessageDict, APIScheduledStreamMessageDict]
+    ] = [scheduled_message.to_dict() for scheduled_message in scheduled_messages]
     return scheduled_message_dicts

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4295,7 +4295,7 @@ class ScheduledMessageNotificationEmail(models.Model):
     scheduled_timestamp = models.DateTimeField(db_index=True)
 
 
-class StreamScheduledMessageAPI(TypedDict):
+class APIScheduledStreamMessageDict(TypedDict):
     scheduled_message_id: int
     to: int
     type: str
@@ -4305,7 +4305,7 @@ class StreamScheduledMessageAPI(TypedDict):
     scheduled_delivery_timestamp: int
 
 
-class DirectScheduledMessageAPI(TypedDict):
+class APIScheduledDirectMessageDict(TypedDict):
     scheduled_message_id: int
     to: List[int]
     type: str
@@ -4353,14 +4353,14 @@ class ScheduledMessage(models.Model):
     def is_stream_message(self) -> bool:
         return self.recipient.type == Recipient.STREAM
 
-    def to_dict(self) -> Union[StreamScheduledMessageAPI, DirectScheduledMessageAPI]:
+    def to_dict(self) -> Union[APIScheduledStreamMessageDict, APIScheduledDirectMessageDict]:
         recipient, recipient_type_str = get_recipient_ids(self.recipient, self.sender.id)
 
         if recipient_type_str == "private":
             # The topic for direct messages should always be an empty string.
             assert self.topic_name() == ""
 
-            return DirectScheduledMessageAPI(
+            return APIScheduledDirectMessageDict(
                 scheduled_message_id=self.id,
                 to=recipient,
                 type=recipient_type_str,
@@ -4372,7 +4372,7 @@ class ScheduledMessage(models.Model):
         # The recipient for stream messages should always just be the unique stream ID.
         assert len(recipient) == 1
 
-        return StreamScheduledMessageAPI(
+        return APIScheduledStreamMessageDict(
             scheduled_message_id=self.id,
             to=recipient[0],
             type=recipient_type_str,


### PR DESCRIPTION
Updates:
- `DirectScheduledMessageAPI` -> `APIScheduledDirectMessageDict`
- `StreamScheduledMessageAPI` -> `APIScheduledStreamMessageDict`

See [this CZO conversation](https://chat.zulip.org/#narrow/stream/3-backend/topic/scheduled.20message.20API.20dicts/near/1560746) and [this PR comment](https://github.com/zulip/zulip/pull/25318#discussion_r1180705325) for more context.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
