### PR TITLE
message_edit: Do not reuse user_profile variable in "for" loop.

### DIFF
--- a/zerver/actions/message_edit.py
+++ b/zerver/actions/message_edit.py
@@ -832,25 +832,25 @@ def do_update_message(
         user_profiles_for_visibility_policy_pair: Dict[
             Tuple[int, int], List[UserProfile]
         ] = defaultdict(list)
-        for user_profile in user_profiles_having_visibility_policy:
-            if user_profile not in target_topic_user_profile_to_visibility_policy:
+        for user_profile_with_policy in user_profiles_having_visibility_policy:
+            if user_profile_with_policy not in target_topic_user_profile_to_visibility_policy:
                 target_topic_user_profile_to_visibility_policy[
-                    user_profile
+                    user_profile_with_policy
                 ] = UserTopic.VisibilityPolicy.INHERIT
             elif user_profile not in orig_topic_user_profile_to_visibility_policy:
                 orig_topic_user_profile_to_visibility_policy[
-                    user_profile
+                    user_profile_with_policy
                 ] = UserTopic.VisibilityPolicy.INHERIT
 
             orig_topic_visibility_policy = orig_topic_user_profile_to_visibility_policy[
-                user_profile
+                user_profile_with_policy
             ]
             target_topic_visibility_policy = target_topic_user_profile_to_visibility_policy[
-                user_profile
+                user_profile_with_policy
             ]
             user_profiles_for_visibility_policy_pair[
                 (orig_topic_visibility_policy, target_topic_visibility_policy)
-            ].append(user_profile)
+            ].append(user_profile_with_policy)
 
         # If the messages are being moved to a stream the user
         # cannot access, then we treat this as the


### PR DESCRIPTION
Doing so causes the "username resolved this topic" notification to be attributed to a random user who had a visibility policy on the topic.

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
