### PR TITLE
scheduled_messages: Ensure minimum scheduled time on corner cases.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -237,6 +237,9 @@ export function toggle_message_actions_menu(message) {
 }
 
 export function do_schedule_message(send_at_time) {
+    // Ensure current_time in seconds is an integer, rounded down
+    const current_time = Math.floor(Date.now() / 1000);
+
     if (overlays.is_modal_open()) {
         overlays.close_modal("send_later_modal");
     }
@@ -245,6 +248,18 @@ export function do_schedule_message(send_at_time) {
         // Convert to timestamp if this is not a timestamp.
         send_at_time = Math.floor(Date.parse(send_at_time) / 1000);
     }
+
+    // Ensure send_at_time is always at least MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS
+    // in the future plus a 5-second buffer, to handle cases where send_at_time is very
+    // near the minimum delay
+    if (send_at_time - current_time < scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS) {
+        const buffer_in_seconds = 5;
+        send_at_time =
+            current_time +
+            scheduled_messages.MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS +
+            buffer_in_seconds;
+    }
+
     selected_send_later_timestamp = send_at_time;
     compose.finish(true);
 }

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -49,6 +49,10 @@ export function is_send_later_timestamp_missing_or_expired(
     if (!timestamp_in_seconds) {
         return true;
     }
+    // Ensure comparison of integer representations of time values,
+    // in seconds
+    timestamp_in_seconds = Math.floor(timestamp_in_seconds);
+    current_time_in_seconds = Math.floor(current_time_in_seconds);
     // Determine if the selected timestamp is less than the minimum
     // scheduled message delay
     if (timestamp_in_seconds - current_time_in_seconds < MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS) {


### PR DESCRIPTION
This patch ensures that the scheduled minimum time is at least five minutes into the future.

See [CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/expired.20timestamp.20for.20scheduled.20message) for background and motivation.

If, for example, a user chooses the absolute minimum time from the Flatpickr date picker or if the user selects a time value in the past, the `minDate` value Flatpickr returns under such conditions will necessarily be less than five minutes in the future. That creates problems in the UI, including a missing date in the successful message-scheduling banner.

To avoid that, the logic here updates any timestamp less than the minimum delay (currently 5 minutes/300 seconds (5 * 60) to be the current time plus the minimum message delay (5 minutes), plus another buffer of 5 seconds--just to be on the safe side for logic elsewhere in the codebase that compares the scheduled time against the current time.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
