### PR TITLE
test-events: Test do_delete_message with no messages specified.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -76,7 +76,6 @@ not_yet_fully_covered = [
     "analytics/views/support.py",
     # Major lib files should have 100% coverage
     "zerver/actions/create_realm.py",
-    "zerver/actions/message_delete.py",
     "zerver/actions/message_edit.py",
     "zerver/actions/presence.py",
     "zerver/actions/scheduled_messages.py",

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2512,6 +2512,14 @@ class NormalActionsTest(BaseAction):
         result = fetch_initial_state_data(user_profile)
         self.assertEqual(result["max_message_id"], -1)
 
+    def test_do_delete_message_with_no_messages(self) -> None:
+        events = self.verify_action(
+            lambda: do_delete_messages(self.user_profile.realm, []),
+            num_events=0,
+            state_change_expected=False,
+        )
+        self.assertEqual(events, [])
+
     def test_add_attachment(self) -> None:
         self.login("hamlet")
         fp = StringIO("zulip!")


### PR DESCRIPTION
Backend test coverage for `zerver/actions/message_delete.py`.

Both callers of this function (`views/streams.delete_in_topic` and `views/message_edit.delete_message_backend`) would already return if there were no Messages specified to delete, which is why existing tests did not cover this.

See [this CZO conversation](https://chat.zulip.org/#narrow/stream/3-backend/topic/actions.20files.20test.20coverage/near/1564632) for more context.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
