### PR TITLE
tooltips: Shift all tooltip templates to tooltip_templates.hbs.

### DIFF
--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -9,10 +9,6 @@
                 <i class="fa fa-chevron-down"></i>
             </div>
         </div>
-        <template id="scroll-to-bottom-button-tooltip-template">
-            {{t 'Scroll to bottom' }}
-            {{tooltip_hotkey_hints "End"}}
-        </template>
     </div>
     <div id="compose_controls" class="new-style">
         <div id="compose_buttons">
@@ -21,17 +17,6 @@
                   id="left_bar_compose_reply_button_big">
                     <span class="compose_reply_button_label">{{t 'Compose message' }}</span>
                 </button>
-                <template id="compose_reply_message_button_tooltip_template">
-                    {{t 'Reply to selected message' }}
-                    {{tooltip_hotkey_hints "R"}}
-                </template>
-                <template id="compose_reply_selected_topic_button_tooltip_template">
-                    {{t 'Reply to selected conversation' }}
-                    {{tooltip_hotkey_hints "R"}}
-                </template>
-                <template id="compose_reply_button_disabled_tooltip_template">
-                    {{t 'You are not allowed to send direct messages in this organization.' }}
-                </template>
             </span>
             <span class="new_message_button mobile_button_container">
                 <button type="button" class="button small rounded compose_mobile_button"
@@ -39,10 +24,6 @@
                   data-tooltip-template-id="left_bar_compose_mobile_button_tooltip_template">
                     <span>+</span>
                 </button>
-                <template id="left_bar_compose_mobile_button_tooltip_template">
-                    {{t 'New message' }}
-                    {{tooltip_hotkey_hints "C"}}
-                </template>
             </span>
             <span class="new_message_button stream_button_container">
                 <button type="button" class="button small rounded compose_stream_button"
@@ -50,14 +31,6 @@
                   data-tooltip-template-id="new_topic_message_button_tooltip_template">
                     <span class="compose_stream_button_label">{{t 'New topic' }}</span>
                 </button>
-                <template id="new_topic_message_button_tooltip_template">
-                    {{t 'New topic' }}
-                    {{tooltip_hotkey_hints "C"}}
-                </template>
-                <template id="new_stream_message_button_tooltip_template">
-                    {{t 'New stream message' }}
-                    {{tooltip_hotkey_hints "C"}}
-                </template>
             </span>
             {{#unless embedded }}
             <span class="new_message_button private_button_container">
@@ -66,10 +39,6 @@
                   data-tooltip-template-id="new_direct_message_button_tooltip_template">
                     <span class="compose_private_button_label">{{t 'New direct message' }}</span>
                 </button>
-                <template id="new_direct_message_button_tooltip_template">
-                    {{t 'New direct message' }}
-                    {{tooltip_hotkey_hints "X"}}
-                </template>
             </span>
             {{/unless}}
         </div>
@@ -84,14 +53,6 @@
                             <button type="button" class="expand_composebox_button fa fa-chevron-up" aria-label="{{t 'Expand compose' }}" data-tippy-content="{{t 'Expand compose' }}"></button>
                             <button type="button" class="collapse_composebox_button fa fa-chevron-down" aria-label="{{t 'Collapse compose' }}" data-tippy-content="{{t 'Collapse compose' }}"></button>
                             <button type="button" class="close fa fa-times" id='compose_close' data-tooltip-template-id="compose_close_tooltip_template"></button>
-                            <template id="compose_close_tooltip_template">
-                                {{t 'Cancel compose' }}
-                                {{tooltip_hotkey_hints "Esc"}}
-                            </template>
-                            <template id="compose_close_and_save_tooltip_template">
-                                {{t 'Cancel compose and save draft' }}
-                                {{tooltip_hotkey_hints "Esc"}}
-                            </template>
                         </div>
                         <div id="compose-recipient" class="order-1">
                             <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle order-1" data-tooltip-template-id="narrow_to_compose_recipients_tooltip" tabindex="0"></a>
@@ -127,14 +88,6 @@
                                             <div class="separator-line"></div>
                                             <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
                                         </button>
-                                        <template id="send-enter-tooltip-template">
-                                            {{t 'Send' }}
-                                            {{tooltip_hotkey_hints "Enter"}}
-                                        </template>
-                                        <template id="send-ctrl-enter-tooltip-template">
-                                            {{t 'Send' }}
-                                            {{tooltip_hotkey_hints "Ctrl" "Enter"}}
-                                        </template>
                                     </div>
                                     {{> compose_control_buttons }}
                                 </div>
@@ -164,10 +117,3 @@
         </div>
     </div>
 </div>
-
-<template id="add-global-time-tooltip">
-    <div>
-        <span>{{t "Add global time" }}</span><br/>
-        <span class="tooltip-inner-content italic">{{t "Everyone sees global times in their own time zone." }}</span>
-    </div>
-</template>

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -16,10 +16,6 @@
     <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tooltip-template-id="compose_draft_tooltip_template">
         {{t 'Drafts' }}
     </a>
-    <template id="compose_draft_tooltip_template">
-        {{t 'Drafts' }}
-        {{tooltip_hotkey_hints "D"}}
-    </template>
     <div class="compose_control_menu_wrapper" role="button" tabindex=0>
         <a class="compose_control_button zulip-icon zulip-icon-ellipsis-v-solid hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
     </div>

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -36,15 +36,7 @@
                     <div class="message_top_line">
                         <div class="draft_controls overlay_message_controls">
                             <i class="fa fa-pencil fa-lg restore-draft restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-draft-tooltip-template"></i>
-                            <template id="restore-draft-tooltip-template">
-                                {{t 'Restore draft' }}
-                                {{tooltip_hotkey_hints "Enter"}}
-                            </template>
                             <i class="fa fa-trash-o fa-lg delete-draft delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-draft-tooltip-template"></i>
-                            <template id="delete-draft-tooltip-template">
-                                {{t 'Delete draft' }}
-                                {{tooltip_hotkey_hints "Backspace"}}
-                            </template>
                         </div>
                     </div>
                     <div class="message_content rendered_markdown restore-draft restore-overlay-message" title="{{t 'Restore draft' }}">{{rendered_markdown content}}</div>

--- a/web/templates/gear_menu.hbs
+++ b/web/templates/gear_menu.hbs
@@ -3,10 +3,6 @@
         <a id="settings-dropdown" tabindex="0" role="button" class="dropdown-toggle tippy-zulip-delayed-tooltip" data-target="nada" data-toggle="dropdown" data-tooltip-template-id="gear-menu-tooltip-template">
             <i class="fa fa-cog settings-dropdown-cog" aria-hidden="true"></i>
         </a>
-        <template id="gear-menu-tooltip-template">
-            {{t 'Menu' }}
-            {{tooltip_hotkey_hints "G"}}
-        </template>
         <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
             <li class="org-info org-name">{{realm_name}}</li>
             <li class="org-info org-url">{{realm_url}}</li>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -11,10 +11,6 @@
                     <span>{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <template id="all-message-tooltip-template">
-                    {{t 'All messages' }}
-                    {{tooltip_hotkey_hints "A"}}
-                </template>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_recent_topics top_left_row tippy-left-sidebar-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
@@ -25,10 +21,6 @@
                     {{~!-- squash whitespace --~}}
                     <span>{{t 'Recent conversations' }}</span>
                 </a>
-                <template id="recent-conversations-tooltip-template">
-                    {{t 'Recent conversations' }}
-                    {{tooltip_hotkey_hints "T"}}
-                </template>
             </li>
             <li class="top_left_mentions top_left_row hidden-for-spectators">
                 <a href="#narrow/is/mentioned">
@@ -60,10 +52,6 @@
                     <span>{{t 'Drafts' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <template id="drafts-tooltip-template">
-                    {{t 'Drafts' }}
-                    {{tooltip_hotkey_hints "D"}}
-                </template>
                 <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
@@ -90,10 +78,6 @@
                 <a id="show_all_private_messages" href="#narrow/is/dm" data-tooltip-template-id="show-all-pms-template">
                     <i class="fa fa-align-right" aria-label="{{t 'All direct messages' }}"></i>
                 </a>
-                <template id="show-all-pms-template">
-                    {{t 'All direct messages' }}
-                    {{tooltip_hotkey_hints "Shift" "P"}}
-                </template>
             </div>
         </div>
         <a class="zoom-out-hide" id="hide_more_private_messages">
@@ -118,10 +102,6 @@
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>
-                <template id="filter-streams-tooltip-template">
-                    {{t 'Filter streams' }}
-                    {{tooltip_hotkey_hints "Q"}}
-                </template>
             </div>
             <div id="topics_header">
                 <a class="show-all-streams" tabindex="0">{{t 'Back to streams' }}</a>

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -63,14 +63,6 @@
 <div class="message_expander message_length_controller tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-expander-tooltip-template">{{t "[More…]" }}</div>
 <div class="message_condenser message_length_controller tippy-zulip-delayed-tooltip" data-tooltip-template-id="message-condenser-tooltip-template">[{{t "Show less" }}]</div>
 
-<template id="message-expander-tooltip-template">
-    {{t 'Show more' }}
-    {{tooltip_hotkey_hints "-"}}
-</template>
-<template id="message-condenser-tooltip-template">
-    {{t 'Show less' }}
-    {{tooltip_hotkey_hints "-"}}
-</template>
 {{#unless is_hidden}}
 <div class="message_reactions">{{> message_reactions }}</div>
 {{/unless}}

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -1,38 +1,18 @@
 <div class="message_controls{{#status_message}} sender-status-controls{{/status_message}} no-select">
     {{#if msg/sent_by_me}}
     <div class="edit_content message_control_button" data-tooltip-template-id="view-source-tooltip-template"></div>
-    <template id="edit-content-tooltip-template">
-        {{t "Edit message" }}
-        {{tooltip_hotkey_hints "E"}}
-    </template>
-    <template id="move-message-tooltip-template">
-        {{t "Move message" }}
-        {{tooltip_hotkey_hints "M"}}
-    </template>
-    <template id="view-source-tooltip-template">
-        {{t "View message source" }}
-        {{tooltip_hotkey_hints "E"}}
-    </template>
     {{/if}}
 
     {{#unless msg/sent_by_me}}
     <div class="reaction_button message_control_button" data-tooltip-template-id="add-emoji-tooltip-template">
         <i class="fa fa-smile-o" aria-label="{{t 'Add emoji reaction' }} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
     </div>
-    <template id="add-emoji-tooltip-template">
-        {{t "Add emoji reaction" }}
-        {{tooltip_hotkey_hints ":"}}
-    </template>
     {{/unless}}
 
     {{#unless msg/locally_echoed}}
     <div class="actions_hover message_control_button" data-tooltip-template-id="message-actions-tooltip-template" >
         <i class="zulip-icon zulip-icon-ellipsis-v-solid" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Message actions' }}"></i>
     </div>
-    <template id="message-actions-tooltip-template">
-        {{t "Message actions" }}
-        {{tooltip_hotkey_hints "I"}}
-    </template>
     {{/unless}}
 
     <div class="message_failed {{#unless msg.failed_request}}hide{{/unless}}">
@@ -49,14 +29,6 @@
     <div class="star_container message_control_button {{#if msg/starred}}{{else}}empty-star{{/if}}" data-tooltip-template-id="{{#if msg/starred}}unstar{{else}}star{{/if}}-message-tooltip-template">
         <i role="button" tabindex="0" class="star fa {{#if msg/starred}}fa-star{{else}}fa-star-o{{/if}}"></i>
     </div>
-    <template id="star-message-tooltip-template">
-        <span class="starred-status">{{t "Star this message" }}</span>
-        {{tooltip_hotkey_hints "Ctrl" "S"}}
-    </template>
-    <template id="unstar-message-tooltip-template">
-        <span class="starred-status">{{t "Unstar this message" }}</span>
-        {{tooltip_hotkey_hints "Ctrl" "S"}}
-    </template>
     {{/unless}}
 
 </div>

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -19,7 +19,3 @@
 </span>
 {{/if}}
 <span class="search_icon search_closed"  role="button"><i class="zulip-icon zulip-icon-search tippy-zulip-delayed-tooltip" data-tooltip-template-id="search-query-tooltip-template" aria-hidden="true"></i></span>
-<template id="search-query-tooltip-template">
-    {{t 'Search' }}
-    {{tooltip_hotkey_hints "/"}}
-</template>

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -8,10 +8,6 @@
         <div class="column-middle" id="navbar-middle">
             <div class="column-middle-inner">
                 <div id="streamlist-toggle" class="tippy-zulip-delayed-tooltip {{#if embedded}}hide-streamlist-toggle-visibility{{/if}}" data-tooltip-template-id="streamlist-toggle-tooltip-template">
-                    <template id="streamlist-toggle-tooltip-template" >
-                        {{t 'View streams' }}
-                        {{tooltip_hotkey_hints "Q"}}
-                    </template>
                     <a id="streamlist-toggle-button" role="button" tabindex="0"><i class="fa fa-reorder" aria-hidden="true"></i>
                         <span id="streamlist-toggle-unreadcount">0</span>
                     </a>
@@ -69,10 +65,6 @@
                 <a id="userlist-toggle-button" role="button" tabindex="0"><i class="fa fa-group" aria-hidden="true"></i>
                     <span id="userlist-toggle-unreadcount">0</span>
                 </a>
-                <template id="userlist-tooltip-template">
-                    {{t 'User list' }}
-                    {{tooltip_hotkey_hints "W"}}
-                </template>
             </div>
             <div id="navbar-buttons" {{#if embedded}}class="hide-navbar-buttons-visibility"{{/if}}>
             </div>

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -65,14 +65,6 @@
                   {{#if topic_muted}} data-tooltip-template-id="topic-unmute-tooltip-template" aria-label="{{t 'Unmute topic' }}" {{else}} data-tooltip-template-id="topic-mute-tooltip-template" aria-label="{{t 'Mute topic' }}" {{/if}}></i>
             {{/if}}
 
-            <template id="topic-unmute-tooltip-template">
-                {{t "Unmute topic" }}
-                {{tooltip_hotkey_hints "Shift" "M"}}
-            </template>
-            <template id="topic-mute-tooltip-template">
-                {{t "Mute topic" }}
-                {{tooltip_hotkey_hints "Shift" "M"}}
-            </template>
         </span>
         <span class="recipient_row_date {{#if date_unchanged}}recipient_row_date_unchanged{{/if}}">{{{date}}}</span>
     </div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -11,10 +11,6 @@
                   data-tooltip-template-id="search-people-tooltip-template">
                 </i>
             </div>
-            <template id="search-people-tooltip-template">
-                {{t 'Search people' }}
-                {{tooltip_hotkey_hints "W"}}
-            </template>
             <div class="input-append notdisplayed" id="user_search_section">
                 <input class="user-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />
                 <button type="button" class="btn clear_search_button" id="clear_search_people_button">
@@ -32,10 +28,6 @@
             {{/if}}
             <a id="sidebar-keyboard-shortcuts" data-overlay-trigger="keyboard-shortcuts" class="hidden-for-spectators">
                 <i class="fa fa-keyboard-o fa-2x tippy-zulip-tooltip" id="keyboard-icon" data-tooltip-template-id="keyboard-icon-tooltip-template"></i>
-                <template id="keyboard-icon-tooltip-template">
-                    {{t 'Keyboard shortcuts' }}
-                    {{tooltip_hotkey_hints "?"}}
-                </template>
             </a>
             {{#if realm_rendered_description}}
             <div class="only-visible-for-spectators">

--- a/web/templates/scheduled_message.hbs
+++ b/web/templates/scheduled_message.hbs
@@ -37,13 +37,7 @@
                         <div class="message_top_line">
                             <div class="overlay_message_controls">
                                 <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-scheduled-message-tooltip-template"></i>
-                                <template id="restore-scheduled-message-tooltip-template">
-                                    {{t 'Edit and reschedule message' }}
-                                </template>
                                 <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-scheduled-message-tooltip-template"></i>
-                                <template id="delete-scheduled-message-tooltip-template">
-                                    {{t 'Delete scheduled message' }}
-                                </template>
                             </div>
                         </div>
                         <div class="message_content rendered_markdown restore-overlay-message" title="{{t 'Edit or reschedule message' }}">{{rendered_markdown rendered_content}}</div>

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -11,19 +11,11 @@
                 {{/if}}
             </button>
         </div>
-        <template id="toggle-subscription-tooltip-template">
-            {{t 'Toggle subscription' }}
-            {{tooltip_hotkey_hints "Shift" "S"}}
-        </template>
         <a href="{{preview_url}}" class="button small rounded tippy-zulip-delayed-tooltip" id="preview-stream-button" role="button" data-tooltip-template-id="view-stream-tooltip-template" data-tippy-placement="bottom" {{#unless should_display_preview_button }}style="display: none"{{/unless}}><i class="fa fa-eye"></i></a>
         {{#if is_realm_admin}}
         <button class="button small rounded btn-danger deactivate tippy-zulip-delayed-tooltip" type="button" name="delete_button" data-tippy-content="{{t 'Archive stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
         {{/if}}
     </div>
-    <template id="view-stream-tooltip-template">
-        {{t 'View stream' }}
-        {{tooltip_hotkey_hints "Shift" "V"}}
-    </template>
     {{/with}}
 </div>
 <div class="subscription_settings" data-stream-id="{{sub.stream_id}}">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -15,10 +15,6 @@
                         <button class="create_stream_button create_stream_plus_button tippy-zulip-delayed-tooltip" data-tooltip-template-id="create-new-stream-tooltip-template" data-tippy-placement="bottom">
                             <span>+</span>
                         </button>
-                        <template id="create-new-stream-tooltip-template">
-                            {{t 'Create new stream' }}
-                            {{tooltip_hotkey_hints "N"}}
-                        </template>
                         {{/if}}
                         <div class="float-clear"></div>
                     </div>

--- a/web/templates/tooltip_templates.hbs
+++ b/web/templates/tooltip_templates.hbs
@@ -5,3 +5,174 @@
 <template id="narrow-hotkey-tooltip-template">
     {{tooltip_hotkey_hints "S"}}
 </template>
+<template id="compose_draft_tooltip_template">
+    {{t 'Drafts' }}
+    {{tooltip_hotkey_hints "D"}}
+</template>
+<template id="scroll-to-bottom-button-tooltip-template">
+    {{t 'Scroll to bottom' }}
+    {{tooltip_hotkey_hints "End"}}
+</template>
+<template id="compose_reply_message_button_tooltip_template">
+    {{t 'Reply to selected message' }}
+    {{tooltip_hotkey_hints "R"}}
+</template>
+<template id="compose_reply_selected_topic_button_tooltip_template">
+    {{t 'Reply to selected conversation' }}
+    {{tooltip_hotkey_hints "R"}}
+</template>
+<template id="compose_reply_button_disabled_tooltip_template">
+    {{t 'You are not allowed to send direct messages in this organization.' }}
+</template>
+<template id="left_bar_compose_mobile_button_tooltip_template">
+    {{t 'New message' }}
+    {{tooltip_hotkey_hints "C"}}
+</template>
+<template id="new_topic_message_button_tooltip_template">
+    {{t 'New topic' }}
+    {{tooltip_hotkey_hints "C"}}
+</template>
+<template id="new_stream_message_button_tooltip_template">
+    {{t 'New stream message' }}
+    {{tooltip_hotkey_hints "C"}}
+</template>
+<template id="new_direct_message_button_tooltip_template">
+    {{t 'New direct message' }}
+    {{tooltip_hotkey_hints "X"}}
+</template>
+<template id="compose_close_tooltip_template">
+    {{t 'Cancel compose' }}
+    {{tooltip_hotkey_hints "Esc"}}
+</template>
+<template id="compose_close_and_save_tooltip_template">
+    {{t 'Cancel compose and save draft' }}
+    {{tooltip_hotkey_hints "Esc"}}
+</template>
+<template id="send-enter-tooltip-template">
+    {{t 'Send' }}
+    {{tooltip_hotkey_hints "Enter"}}
+</template>
+<template id="send-ctrl-enter-tooltip-template">
+    {{t 'Send' }}
+    {{tooltip_hotkey_hints "Ctrl" "Enter"}}
+</template>
+<template id="add-global-time-tooltip">
+    <div>
+        <span>{{t "Add global time" }}</span><br/>
+        <span class="tooltip-inner-content italic">{{t "Everyone sees global times in their own time zone." }}</span>
+    </div>
+</template>
+<template id="delete-draft-tooltip-template">
+    {{t 'Delete draft' }}
+    {{tooltip_hotkey_hints "Backspace"}}
+</template>
+<template id="restore-draft-tooltip-template">
+    {{t 'Restore draft' }}
+    {{tooltip_hotkey_hints "Enter"}}
+</template>
+<template id="gear-menu-tooltip-template">
+    {{t 'Menu' }}
+    {{tooltip_hotkey_hints "G"}}
+</template>
+<template id="all-message-tooltip-template">
+    {{t 'All messages' }}
+    {{tooltip_hotkey_hints "A"}}
+</template>
+<template id="recent-conversations-tooltip-template">
+    {{t 'Recent conversations' }}
+    {{tooltip_hotkey_hints "T"}}
+</template>
+<template id="drafts-tooltip-template">
+    {{t 'Drafts' }}
+    {{tooltip_hotkey_hints "D"}}
+</template>
+<template id="show-all-pms-template">
+    {{t 'All direct messages' }}
+    {{tooltip_hotkey_hints "Shift" "P"}}
+</template>
+<template id="filter-streams-tooltip-template">
+    {{t 'Filter streams' }}
+    {{tooltip_hotkey_hints "Q"}}
+</template>
+<template id="message-expander-tooltip-template">
+    {{t 'Show more' }}
+    {{tooltip_hotkey_hints "-"}}
+</template>
+<template id="message-condenser-tooltip-template">
+    {{t 'Show less' }}
+    {{tooltip_hotkey_hints "-"}}
+</template>
+<template id="edit-content-tooltip-template">
+    {{t "Edit message" }}
+    {{tooltip_hotkey_hints "E"}}
+</template>
+<template id="move-message-tooltip-template">
+    {{t "Move message" }}
+    {{tooltip_hotkey_hints "M"}}
+</template>
+<template id="view-source-tooltip-template">
+    {{t "View message source" }}
+    {{tooltip_hotkey_hints "E"}}
+</template>
+<template id="add-emoji-tooltip-template">
+    {{t "Add emoji reaction" }}
+    {{tooltip_hotkey_hints ":"}}
+</template>
+<template id="message-actions-tooltip-template">
+    {{t "Message actions" }}
+    {{tooltip_hotkey_hints "I"}}
+</template>
+<template id="star-message-tooltip-template">
+    <span class="starred-status">{{t "Star this message" }}</span>
+    {{tooltip_hotkey_hints "Ctrl" "S"}}
+</template>
+<template id="unstar-message-tooltip-template">
+    <span class="starred-status">{{t "Unstar this message" }}</span>
+    {{tooltip_hotkey_hints "Ctrl" "S"}}
+</template>
+<template id="search-query-tooltip-template">
+    {{t 'Search' }}
+    {{tooltip_hotkey_hints "/"}}
+</template>
+<template id="streamlist-toggle-tooltip-template" >
+    {{t 'View streams' }}
+    {{tooltip_hotkey_hints "Q"}}
+</template>
+<template id="userlist-tooltip-template">
+    {{t 'User list' }}
+    {{tooltip_hotkey_hints "W"}}
+</template>
+<template id="topic-unmute-tooltip-template">
+    {{t "Unmute topic" }}
+    {{tooltip_hotkey_hints "Shift" "M"}}
+</template>
+<template id="topic-mute-tooltip-template">
+    {{t "Mute topic" }}
+    {{tooltip_hotkey_hints "Shift" "M"}}
+</template>
+<template id="search-people-tooltip-template">
+    {{t 'Search people' }}
+    {{tooltip_hotkey_hints "W"}}
+</template>
+<template id="keyboard-icon-tooltip-template">
+    {{t 'Keyboard shortcuts' }}
+    {{tooltip_hotkey_hints "?"}}
+</template>
+<template id="restore-scheduled-message-tooltip-template">
+    {{t 'Edit and reschedule message' }}
+</template>
+<template id="delete-scheduled-message-tooltip-template">
+    {{t 'Delete scheduled message' }}
+</template>
+<template id="create-new-stream-tooltip-template">
+    {{t 'Create new stream' }}
+    {{tooltip_hotkey_hints "N"}}
+</template>
+<template id="toggle-subscription-tooltip-template">
+    {{t 'Toggle subscription' }}
+    {{tooltip_hotkey_hints "Shift" "S"}}
+</template>
+<template id="view-stream-tooltip-template">
+    {{t 'View stream' }}
+    {{tooltip_hotkey_hints "Shift" "V"}}
+</template>


### PR DESCRIPTION
Refactored all tooltip templates with static content to be in `tooltip_templates.hbs` to avoid duplicate IDs and DOM elements.

Almost all the tooltip templates have static content, shifted them all to `tooltip_templates.hbs` except the `recent_topics_participant_overflow_tooltip` template from recent_topic_row.hbs which had dynamic content.

Fixes #25324

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
