### PR TITLE
scheduled-messages: Limit `to` parameter to user and stream IDs.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5189,17 +5189,13 @@ paths:
           description: |
             The scheduled message's tentative target audience.
 
-            For stream messages, integer ID of the stream. For direct messages,
-            either a list containing integer user IDs or a list containing string
-            email addresses.
+            For stream messages, the integer ID of the stream.
+            For direct messages, a list containing integer user IDs.
           content:
             application/json:
               schema:
                 oneOf:
                   - type: integer
-                  - type: array
-                    items:
-                      type: string
                   - type: array
                     items:
                       type: integer

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -5,6 +5,11 @@ from typing import TYPE_CHECKING, List, Union
 
 import orjson
 
+from zerver.actions.scheduled_messages import (
+    extract_direct_message_recipient_ids,
+    extract_stream_id,
+)
+from zerver.lib.exceptions import JsonableError
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.models import Attachment, ScheduledMessage
@@ -70,7 +75,7 @@ class ScheduledMessageTest(ZulipTestCase):
         # Scheduling a private message is successful.
         othello = self.example_user("othello")
         result = self.do_schedule_message(
-            "direct", [othello.email], content + " 3", scheduled_delivery_timestamp
+            "direct", [othello.id], content + " 3", scheduled_delivery_timestamp
         )
         scheduled_message = self.last_scheduled_message()
         self.assert_json_success(result)
@@ -163,7 +168,7 @@ class ScheduledMessageTest(ZulipTestCase):
 
         othello = self.example_user("othello")
         result = self.do_schedule_message(
-            "direct", [othello.email], content + " 3", scheduled_delivery_timestamp
+            "direct", [othello.id], content + " 3", scheduled_delivery_timestamp
         )
 
         # Multiple scheduled messages
@@ -288,3 +293,42 @@ class ScheduledMessageTest(ZulipTestCase):
             [scheduled_message.id],
         )
         self.assertEqual(scheduled_message.has_attachment, True)
+
+    def test_extract_stream_id(self) -> None:
+        # Scheduled stream message recipient = single stream ID.
+        stream_id = extract_stream_id("1")
+        self.assertEqual(stream_id, [1])
+
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+            extract_stream_id("1,2")
+
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+            extract_stream_id("[1]")
+
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for stream ID"):
+            extract_stream_id("general")
+
+    def test_extract_recipient_ids(self) -> None:
+        # Scheduled direct message recipients = user IDs.
+        user_ids = "[3,2,1]"
+        result = sorted(extract_direct_message_recipient_ids(user_ids))
+        self.assertEqual(result, [1, 2, 3])
+
+        # JSON list w/duplicates
+        user_ids = orjson.dumps([3, 3, 12]).decode()
+        result = sorted(extract_direct_message_recipient_ids(user_ids))
+        self.assertEqual(result, [3, 12])
+
+        # Invalid data
+        user_ids = "1, 12"
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
+            extract_direct_message_recipient_ids(user_ids)
+
+        user_ids = orjson.dumps(dict(recipient=12)).decode()
+        with self.assertRaisesRegex(JsonableError, "Invalid data type for recipients"):
+            extract_direct_message_recipient_ids(user_ids)
+
+        # Heterogeneous lists are not supported
+        user_ids = orjson.dumps([3, 4, "eeshan@example.com"]).decode()
+        with self.assertRaisesRegex(JsonableError, "Recipient list may only contain user IDs"):
+            extract_direct_message_recipient_ids(user_ids)

--- a/zerver/views/scheduled_messages.py
+++ b/zerver/views/scheduled_messages.py
@@ -1,13 +1,14 @@
-from typing import Optional, Sequence, Union
+from typing import Optional
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
-from zerver.actions.message_send import extract_private_recipients
 from zerver.actions.scheduled_messages import (
     check_schedule_message,
     delete_scheduled_message,
+    extract_direct_message_recipient_ids,
+    extract_stream_id,
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, RequestNotes, has_request_variables
@@ -61,10 +62,9 @@ def scheduled_messages_backend(
     assert client is not None
 
     if recipient_type_name == "stream":
-        # req_to is ID of the recipient stream.
-        message_to: Union[Sequence[str], Sequence[int]] = [int(req_to)]
+        message_to = extract_stream_id(req_to)
     else:
-        message_to = extract_private_recipients(req_to)
+        message_to = extract_direct_message_recipient_ids(req_to)
 
     scheduled_message_id = check_schedule_message(
         sender,


### PR DESCRIPTION
For scheduled stream messages, we already limited the `to` parameter to be the stream ID, but now we return a `JsonableError` in the case of a `ValueError` when the passed value is not an integer.

For scheduled direct messages, we limit the list for the `to` parameter to be user IDs. Previously, we accepted emails like we do when sending messages.

See [this CZO conversation](https://chat.zulip.org/#narrow/stream/378-api-design/topic/scheduled.20messages/near/1560744) for more context.

**Notes**:
- I added a `JsonableError` for the case where a client sends a stream name instead of the stream ID. The message string is slightly different from the one in the send message path:
  - "Invalid data type for stream ID" instead of "Invalid data type for stream".
  - If the distinction of "ID" isn't important enough to have another translated string, I can make that change.
- These new functions mirror [`extract_stream_indicator`](https://github.com/zulip/zulip/blob/3a358a9a1129d4e17c508fc362f452cfd59c6f36/zerver/actions/message_send.py#L970-L997) and [`extract_private_recipients`](https://github.com/zulip/zulip/blob/3a358a9a1129d4e17c508fc362f452cfd59c6f36/zerver/actions/message_send.py#L1000-L1025) in `zerver/actions/message_send.py`.
- Confirmed locally that these changes don't add any missing coverage to `zerver/actions/scheduled_messages.py`. The only line missing coverage after these changes is the same one as prior to these changes).
- I didn't make a API feature level change/note. We're still on **API feature level 179** which implemented the endpoint with this parameter, so I thought we could just document this as the behavior from the beginning, but it would be easy to add those if that's not what we want to do.

**Screenshot**:

<details>
<summary>Updated `to` parameter in create-or-edit-scheduled-message</summary>

![Screenshot from 2023-05-09 20-17-08](https://github.com/zulip/zulip/assets/63245456/bd36478e-e33e-4446-add2-16c79fec7858)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
