### PR TITLE
scroll_bar: Implement a custom scrollbar.

### DIFF
--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -2,7 +2,9 @@
 
 const path = require("path");
 
-const {media_breakpoints} = require("./src/css_variables");
+const _ = require("lodash");
+
+const {media_breakpoints, size_constants} = require("./src/css_variables");
 
 module.exports = ({file}) => ({
     plugins: [
@@ -14,7 +16,7 @@ module.exports = ({file}) => ({
                 plugins: [require("postcss-prefixwrap")("%dark-theme")],
             }),
         require("postcss-extend-rule"),
-        require("postcss-simple-vars")({variables: media_breakpoints}),
+        require("postcss-simple-vars")({variables: _.merge(media_breakpoints, size_constants)}),
         require("postcss-preset-env")({
             features: {
                 "nesting-rules": true,

--- a/web/src/css_variables.js
+++ b/web/src/css_variables.js
@@ -14,6 +14,8 @@ const ml = 425; // Mobile large
 const mm = 375; // Mobile medium
 const ms = 320; // Mobile small
 
+const scrollbar_width = 7;
+
 module.exports = {
     media_breakpoints: {
         xs_min: xs + "px",
@@ -36,4 +38,13 @@ module.exports = {
         mm,
         ms,
     },
+
+    size_constants: {
+        scrollbar_width: scrollbar_width + "px",
+    },
+
+    size_constants_num: {
+        scrollbar_width,
+    },
+
 };

--- a/web/src/scroll_bar.ts
+++ b/web/src/scroll_bar.ts
@@ -2,37 +2,6 @@ import $ from "jquery";
 
 import {user_settings} from "./user_settings";
 
-// A few of our width properties in Zulip depend on the width of the
-// browser scrollbar that is generated at the far right side of the
-// page, which unfortunately varies depending on the browser and
-// cannot be detected directly using CSS.  As a result, we adjust a
-// number of element widths based on the value detected here.
-//
-// From https://stackoverflow.com/questions/13382516/getting-scroll-bar-width-using-javascript
-function getScrollbarWidth(): number {
-    const outer = document.createElement("div");
-    outer.style.visibility = "hidden";
-    outer.style.width = "100px";
-
-    document.body.append(outer);
-
-    const widthNoScroll = outer.offsetWidth;
-    // force scrollbars
-    outer.style.overflow = "scroll";
-
-    // add inner div
-    const inner = document.createElement("div");
-    inner.style.width = "100%";
-    outer.append(inner);
-
-    const widthWithScroll = inner.offsetWidth;
-
-    // remove divs
-    outer.remove();
-
-    return widthNoScroll - widthWithScroll;
-}
-
 export function set_layout_width(): void {
     if (user_settings.fluid_layout_width) {
         $(".header-main, .app .app-main, #compose-container").css("max-width", "inherit");
@@ -41,14 +10,6 @@ export function set_layout_width(): void {
     }
 }
 
-let sbWidth: number;
-
 export function initialize(): void {
-    // Workaround for browsers with fixed scrollbars
-    sbWidth = getScrollbarWidth();
-    if (sbWidth > 0) {
-        // Reduce width of screen-wide parent containers, whose width doesn't vary with scrollbar width, by scrollbar width.
-        $("#navbar-container .header, #compose").css("width", `calc(100% - ${sbWidth}px)`);
-    }
     set_layout_width();
 }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -217,7 +217,7 @@
     bottom: 0;
     left: 0;
     z-index: 4;
-    width: 100%;
+    width: calc(100% - $scrollbar_width);
 
     background-color: hsl(0deg 0% 100%);
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -298,7 +298,7 @@ p.n-margin {
 .header {
     position: fixed;
     z-index: 102; /* Needs to be higher than .alert-bar-container */
-    width: 100%;
+    width: calc(100% - $scrollbar_width);
     height: var(--header-height);
     /* Since the headers are sticky, we need non-transparent background. */
     background-color: hsl(0deg 0% 100%);
@@ -417,6 +417,21 @@ p.n-margin {
     overflow-y: scroll;
     z-index: 99;
     -webkit-overflow-scrolling: touch;
+
+    &::-webkit-scrollbar {
+        appearance: none;
+        width: $scrollbar_width;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        border-radius: 4px;
+        background-color: hsl(0deg 0% 75%);
+        transition: background-color 2s;
+
+        &:hover {
+            background-color: hsl(0deg 0% 30%);
+        }
+    }
 }
 
 .app-main,


### PR DESCRIPTION
TODO: Improve how the scrollbar looks.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/users.20list.20overlaps.20compose.20box

![image](https://github.com/zulip/zulip/assets/25124304/1d20d97f-80b9-4eca-83ab-9fdd4c48314f)

This fixes a very annoying problem that mac has which changes the scrollbar width based on options selected. Since we position elements in the UI based on scroll bar width (unfortunately), it misaligns various UI components.