### PR TITLE
overlays: Add method to check if the correct modal is open.

### DIFF
--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -323,6 +323,27 @@ export function close_modal(modal_id: string, conf: Pick<ModalConfig, "on_hidden
     Micromodal.close(modal_id);
 }
 
+export function close_modal_if_open(modal_id: string): void {
+    if (modal_id === undefined) {
+        blueslip.error("Undefined id was passed into close_modal_if_open");
+        return;
+    }
+
+    if (!is_modal_open()) {
+        return;
+    }
+
+    const $micromodal = $(".micromodal.modal--open");
+    const active_modal_id = CSS.escape(`${CSS.escape($micromodal.attr("id") ?? "")}`);
+    if (active_modal_id === `${CSS.escape(modal_id)}`) {
+        Micromodal.close(`${CSS.escape($micromodal.attr("id") ?? "")}`);
+    } else {
+        blueslip.info(
+            `${active_modal_id} is the currently active modal and ${modal_id} is already closed.`,
+        );
+    }
+}
+
 export function close_active_modal(): void {
     if (!is_modal_open()) {
         blueslip.warn("close_active_modal() called without checking is_modal_open()");

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -235,9 +235,7 @@ export function toggle_message_actions_menu(message) {
 }
 
 export function do_schedule_message(send_at_time) {
-    if (overlays.is_modal_open()) {
-        overlays.close_modal("send_later_modal");
-    }
+    overlays.close_modal_if_open("send_later_modal");
 
     if (!Number.isInteger(send_at_time)) {
         // Convert to timestamp if this is not a timestamp.

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -162,7 +162,7 @@ export function get_custom_profile_field_data(user, field, field_types) {
 }
 
 export function hide_user_profile() {
-    overlays.close_modal("user-profile-modal");
+    overlays.close_modal_if_open("user-profile-modal");
 }
 
 function initialize_user_type_fields(user) {


### PR DESCRIPTION
This will be used to avoid this code syntax:
```
if (overlays.is_modal_open()) {
   overlays.close_modal("send_later_modal");
}
```

discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/overlays.2Eclose_modal_if_open