### PR TITLE
Rerender send later options at specific times.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -835,6 +835,11 @@ export function initialize() {
                 overlays.open_modal("send_later_modal", {
                     autoremove: true,
                     on_show() {
+                        instance._interval = setInterval(
+                            scheduled_messages.update_send_later_options,
+                            scheduled_messages.SCHEDULING_MODAL_UPDATE_INTERVAL_IN_MILLISECONDS,
+                        );
+
                         const $send_later_modal = $("#send_later_modal");
                         $send_later_modal.on("keydown", (e) => {
                             if (e.key === "Enter") {
@@ -876,6 +881,9 @@ export function initialize() {
                                 e.stopPropagation();
                             },
                         );
+                    },
+                    on_hide() {
+                        clearInterval(instance._interval);
                     },
                 });
             });

--- a/web/templates/send_later_modal.hbs
+++ b/web/templates/send_later_modal.hbs
@@ -8,32 +8,7 @@
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>
             </header>
             <main class="modal__content">
-                <div class="send_later_options">
-                    <ul class="nav nav-list">
-                        {{#if possible_send_later_today}}
-                            {{#each possible_send_later_today}}
-                                <li>
-                                    <a id="{{@key}}" class="send_later_today" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
-                                </li>
-                            {{/each}}
-                        {{/if}}
-                        {{#each send_later_tomorrow}}
-                            <li>
-                                <a id="{{@key}}" class="send_later_tomorrow" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
-                            </li>
-                        {{/each}}
-                        {{#if possible_send_later_monday }}
-                            {{#each possible_send_later_monday}}
-                                <li>
-                                    <a id="{{@key}}" class="send_later_monday" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
-                                </li>
-                            {{/each}}
-                        {{/if}}
-                        <li>
-                            <a class="send_later_custom" tabindex="0">{{t 'Custom time'}}</a>
-                        </li>
-                    </ul>
-                </div>
+                {{> send_later_modal_options }}
             </main>
         </div>
     </div>

--- a/web/templates/send_later_modal_options.hbs
+++ b/web/templates/send_later_modal_options.hbs
@@ -1,0 +1,26 @@
+<div class="send_later_options">
+    <ul class="nav nav-list">
+        {{#if possible_send_later_today}}
+            {{#each possible_send_later_today}}
+                <li>
+                    <a id="{{@key}}" class="send_later_today" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
+                </li>
+            {{/each}}
+        {{/if}}
+        {{#each send_later_tomorrow}}
+            <li>
+                <a id="{{@key}}" class="send_later_tomorrow" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
+            </li>
+        {{/each}}
+        {{#if possible_send_later_monday }}
+            {{#each possible_send_later_monday}}
+                <li>
+                    <a id="{{@key}}" class="send_later_monday" data-send-stamp="{{this.stamp}}" tabindex="0">{{this.text}}</a>
+                </li>
+            {{/each}}
+        {{/if}}
+        <li>
+            <a class="send_later_custom" tabindex="0">{{t 'Custom time'}}</a>
+        </li>
+    </ul>
+</div>

--- a/web/tests/scheduled_messages.test.js
+++ b/web/tests/scheduled_messages.test.js
@@ -104,6 +104,13 @@ function get_expected_send_opts(day, expecteds) {
     return modal_opts;
 }
 
+function get_minutes_to_hour(minutes) {
+    const date = new Date();
+    date.setMinutes(minutes);
+    date.setSeconds(0);
+    return date;
+}
+
 run_test("scheduled_modal_opts", () => {
     // Sunday thru Saturday
     const days = [
@@ -158,4 +165,23 @@ run_test("missing_or_expired_timestamps", () => {
             now_in_seconds / 1000,
         ),
     );
+});
+
+run_test("should_update_send_later_options", () => {
+    // We should rerender if it is 5 minutes before the hour
+    for (let minute = 0; minute < 60; minute += 1) {
+        const current_time = get_minutes_to_hour(minute);
+        if (minute === 55) {
+            // Should rerender
+            assert.ok(scheduled_messages.should_update_send_later_options(current_time));
+        } else {
+            // Should not rerender
+            assert.ok(!scheduled_messages.should_update_send_later_options(current_time));
+        }
+    }
+
+    // We should rerender at midnight
+    const start_of_the_day = new Date();
+    start_of_the_day.setHours(0, 0);
+    assert.ok(scheduled_messages.should_update_send_later_options(start_of_the_day));
 });


### PR DESCRIPTION
This PR introduces two changes. 

Firstly, it extracts the send later options to a separate template, allowing for the rendering of options for the send-later modal separately. This is necessary to ensure that the user can keep the modal open and still have access to actual sending options.

Secondly, it ensures that the send later options are re-rendered at a specific time.

Fixes: #25451.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>rerender at 15:55</summary>
<br>

![15:55](https://github.com/zulip/zulip/assets/53193850/f7b6857d-b57b-4e63-b826-4de4e9591ffb)

</details>

<details>
<summary>rerender at 08:55</summary>
<br>

![8:55](https://github.com/zulip/zulip/assets/53193850/4620a94a-d38c-47f4-a89b-68515cd219ae)

</details>

<details>
<summary>rerender at midnight</summary>
<br>

![midnight](https://github.com/zulip/zulip/assets/53193850/5df267e1-bee9-4435-8188-c50ebc96a82b)

</details>