### PR TITLE
install: Use set -x when installing node, shellcheck, shfmt, tx

### DIFF
--- a/scripts/lib/install-node
+++ b/scripts/lib/install-node
@@ -22,6 +22,7 @@ check_version() {
 }
 
 if ! check_version 2>/dev/null; then
+    set -x
     tmpdir="$(mktemp -d)"
     trap 'rm -r "$tmpdir"' EXIT
     cd "$tmpdir"

--- a/tools/setup/install-shellcheck
+++ b/tools/setup/install-shellcheck
@@ -16,6 +16,7 @@ version: $version
 }
 
 if ! check_version 2>/dev/null; then
+    set -x
     tmpdir="$(mktemp -d)"
     trap 'rm -r "$tmpdir"' EXIT
     cd "$tmpdir"

--- a/tools/setup/install-shfmt
+++ b/tools/setup/install-shfmt
@@ -21,6 +21,7 @@ check_version() {
 }
 
 if ! check_version 2>/dev/null; then
+    set -x
     tmpdir="$(mktemp -d)"
     trap 'rm -r "$tmpdir"' EXIT
     cd "$tmpdir"

--- a/tools/setup/install-transifex-cli
+++ b/tools/setup/install-transifex-cli
@@ -28,6 +28,7 @@ check_version() {
 }
 
 if ! check_version 2>/dev/null; then
+    set -x
     tmpdir="$(mktemp -d)"
     trap 'rm -r "$tmpdir"' EXIT
     cd "$tmpdir"


### PR DESCRIPTION
This makes it clearer which step failed if there’s an error.

Output when successfully installing all four of these:

```console
$ tools/provision 
No changes to apt dependencies, so skipping apt operations.
+ sudo -H -- env http_proxy= https_proxy= no_proxy= scripts/lib/install-node
++ mktemp -d
+ tmpdir=/tmp/tmp.cMCgAPGGmc
+ trap 'rm -r "$tmpdir"' EXIT
+ cd /tmp/tmp.cMCgAPGGmc
+ curl_opts=(-fLO --retry 3)
+ '[' -n '' ']'
+ curl -fLO --retry 3 https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22.6M  100 22.6M    0     0  36.8M      0 --:--:-- --:--:-- --:--:-- 36.8M
+ sha256sum -c
node-v18.16.0-linux-x64.tar.xz: OK
+ rm -rf /srv/zulip-node
+ mkdir -p /srv/zulip-node
+ tar -xJf node-v18.16.0-linux-x64.tar.xz --no-same-owner --strip-components=1 -C /srv/zulip-node
+ ln -sf /srv/zulip-node/bin/corepack /srv/zulip-node/bin/node /srv/zulip-node/bin/npm /srv/zulip-node/bin/npx /usr/local/bin
+ COREPACK_DEFAULT_TO_LATEST=0
+ /usr/local/bin/corepack enable
+ rm -rf /srv/zulip-yarn /usr/bin/yarn /usr/local/nvm
+ check_version
++ node --version
+ out=v18.16.0
+ '[' v18.16.0 = v18.16.0 ']'
+ '[' /usr/local/bin/pnpm -ef /srv/zulip-node/lib/node_modules/corepack/dist/pnpm.js ']'
+ rm -r /tmp/tmp.cMCgAPGGmc
+ sudo -- env http_proxy= https_proxy= no_proxy= tools/setup/install-shellcheck
++ mktemp -d
+ tmpdir=/tmp/tmp.TSMXmtPgVl
+ trap 'rm -r "$tmpdir"' EXIT
+ cd /tmp/tmp.TSMXmtPgVl
+ curl -fLO --retry 3 https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2296k  100 2296k    0     0  3362k      0 --:--:-- --:--:-- --:--:-- 3362k
+ sha256sum -c
shellcheck-v0.9.0.linux.x86_64.tar.xz: OK
+ tar -xJf shellcheck-v0.9.0.linux.x86_64.tar.xz --no-same-owner --strip-components=1 -C /usr/local/bin shellcheck-v0.9.0/shellcheck
+ check_version
++ shellcheck --version
+ out='ShellCheck - shell script analysis tool
version: 0.9.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net'
+ [[ ShellCheck - shell script analysis tool
version: 0.9.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net = *\
\v\e\r\s\i\o\n\:\ \0\.\9\.\0\
* ]]
+ rm -r /tmp/tmp.TSMXmtPgVl
+ sudo -- env http_proxy= https_proxy= no_proxy= tools/setup/install-shfmt
++ mktemp -d
+ tmpdir=/tmp/tmp.eFZyyEnwky
+ trap 'rm -r "$tmpdir"' EXIT
+ cd /tmp/tmp.eFZyyEnwky
+ curl -fLO --retry 3 https://github.com/mvdan/sh/releases/download/v3.6.0/shfmt_v3.6.0_linux_amd64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2784k  100 2784k    0     0  3866k      0 --:--:-- --:--:-- --:--:--  9.8M
+ sha256sum -c
shfmt_v3.6.0_linux_amd64: OK
+ chmod +x shfmt_v3.6.0_linux_amd64
+ mv shfmt_v3.6.0_linux_amd64 /usr/local/bin/shfmt
+ check_version
++ shfmt --version
+ out=v3.6.0
+ '[' v3.6.0 = v3.6.0 ']'
+ rm -r /tmp/tmp.eFZyyEnwky
+ sudo -- env http_proxy= https_proxy= no_proxy= tools/setup/install-transifex-cli
++ mktemp -d
+ tmpdir=/tmp/tmp.2O7Nbfc5kl
+ trap 'rm -r "$tmpdir"' EXIT
+ cd /tmp/tmp.2O7Nbfc5kl
+ curl_opts=(-fLO --retry 3)
+ curl -fLO --retry 3 https://github.com/transifex/cli/releases/download/v1.6.7/tx-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4167k  100 4167k    0     0  8505k      0 --:--:-- --:--:-- --:--:-- 8505k
+ sha256sum -c
tx-linux-amd64.tar.gz: OK
+ tar -xzf tx-linux-amd64.tar.gz --no-same-owner tx
+ install -Dm755 tx /usr/local/bin/tx
+ check_version
++ tx --version
+ out='TX Client, version=1.6.7'
+ '[' 'TX Client, version=1.6.7' = 'TX Client, version=1.6.7' ']'
+ rm -r /tmp/tmp.2O7Nbfc5kl
Using cached Python venv from /srv/zulip-venv-cache/3946edee6c0282e82d1017bc8a0b91d76152a536/zulip-py3-venv
+ sudo -- ln -nsf /srv/zulip-venv-cache/3946edee6c0282e82d1017bc8a0b91d76152a536/zulip-py3-venv /srv/zulip-py3-venv
+ sudo -- cp /srv/zulip/puppet/zulip/files/postgresql/zulip_english.stop /usr/share/postgresql/12/tsearch_data/
+ scripts/setup/generate_secrets.py --development
generate_secrets: No new secrets to generate.
+ tools/setup/emoji/build_emoji
build_emoji: Using cached emojis from /srv/zulip-emoji-cache/d366bfece8df5a9a5683ca99386d943ae2b86097/emoji
No need to run `tools/setup/build_pygments_data`.
No need to run `tools/setup/build_timezone_values`.
No need to run `scripts/setup/configure-rabbitmq.
No need to regenerate the dev DB.
No need to regenerate the test DB.
No need to run `manage.py compilemessages`.
Cleaning var/ directory files...
writing to /srv/zulip/var/ae5d2dfb-04b9-4ec7-a196-c5dbfd91e8c4/provision_version


Zulip development environment setup succeeded!
```

We remain silent if they’re already installed:

```console
$ tools/provision 
No changes to apt dependencies, so skipping apt operations.
+ sudo -H -- env http_proxy= https_proxy= no_proxy= scripts/lib/install-node
+ sudo -- env http_proxy= https_proxy= no_proxy= tools/setup/install-shellcheck
+ sudo -- env http_proxy= https_proxy= no_proxy= tools/setup/install-shfmt
+ sudo -- env http_proxy= https_proxy= no_proxy= tools/setup/install-transifex-cli
Using cached Python venv from /srv/zulip-venv-cache/3946edee6c0282e82d1017bc8a0b91d76152a536/zulip-py3-venv
+ sudo -- ln -nsf /srv/zulip-venv-cache/3946edee6c0282e82d1017bc8a0b91d76152a536/zulip-py3-venv /srv/zulip-py3-venv
+ sudo -- cp /srv/zulip/puppet/zulip/files/postgresql/zulip_english.stop /usr/share/postgresql/12/tsearch_data/
+ scripts/setup/generate_secrets.py --development
generate_secrets: No new secrets to generate.
+ tools/setup/emoji/build_emoji
build_emoji: Using cached emojis from /srv/zulip-emoji-cache/d366bfece8df5a9a5683ca99386d943ae2b86097/emoji
No need to run `tools/setup/build_pygments_data`.
No need to run `tools/setup/build_timezone_values`.
No need to run `scripts/setup/configure-rabbitmq.
No need to regenerate the dev DB.
No need to regenerate the test DB.
No need to run `manage.py compilemessages`.
Cleaning var/ directory files...
writing to /srv/zulip/var/ae5d2dfb-04b9-4ec7-a196-c5dbfd91e8c4/provision_version


Zulip development environment setup succeeded!
```