### PR TITLE
billing: Remove unintended portico-landing classes.

### DIFF
--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -15,7 +15,7 @@
 
     {% include 'zerver/billing_nav.html' %}
 
-    <div class="portico-landing billing-upgrade-page">
+    <div class="billing-upgrade-page">
         <div class="hero small-hero"></div>
 
         <div class="page-content">

--- a/templates/corporate/event_status.html
+++ b/templates/corporate/event_status.html
@@ -15,7 +15,7 @@
 
     {% include 'zerver/billing_nav.html' %}
 
-    <div class="portico-landing billing-upgrade-page">
+    <div class="billing-upgrade-page">
         <div class="hero small-hero"></div>
 
         <div class="page-content">

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -15,7 +15,7 @@
 
     {% include 'zerver/billing_nav.html' %}
 
-    <div class="portico-landing billing-upgrade-page new-style">
+    <div class="billing-upgrade-page new-style">
         <div class="hero small-hero"></div>
 
         <div class="page-content">


### PR DESCRIPTION
These classes seem to have been copy-pasted from other portico pages when styling was first done in
122dcc9760d375816cb4664c41db7a340dd942cf. With the current styles, which are just a handful of rules not scoped to a specific page, it just makes the billing pages look broken.

Without this change, there's a weird white stripe at the top of the screen: 

![image](https://github.com/zulip/zulip/assets/2746074/de07c053-c09c-414e-9056-47362083e380)

With this change:

![image](https://github.com/zulip/zulip/assets/2746074/aeb3fa34-c788-45b0-8d18-bf45738345f8)
