### PR TITLE
narrow_banner: Drop empty action line from empty `dm-including:` views.

### DIFF
--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -414,15 +414,6 @@ function pick_empty_narrow_banner() {
                     },
                     {person: person_in_dms.full_name},
                 ),
-                html: $t_html(
-                    {
-                        defaultMessage: "Why not <z-link>start the conversation</z-link>?",
-                    },
-                    {
-                        "z-link": (content_html) =>
-                            `<a href="#" class="empty_feed_compose_private">${content_html}</a>`,
-                    },
-                ),
             };
         }
     }

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -441,10 +441,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: You have no direct messages including Example Bot yet.",
-            'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
-        ),
+        empty_narrow_html("translated: You have no direct messages including Example Bot yet."),
     );
 
     // sending direct messages enabled
@@ -454,10 +451,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html(
-            "translated: You have no direct messages including Alice Smith yet.",
-            'translated HTML: Why not <a href="#" class="empty_feed_compose_private">start the conversation</a>?',
-        ),
+        empty_narrow_html("translated: You have no direct messages including Alice Smith yet."),
     );
 
     set_filter([["dm-including", me.email]]);


### PR DESCRIPTION
Previously, when a user enters a empty dm-including view, they'll notice the "Why not start the conversation" action line and click on the link. When this happens, the compose box would open but the receipent box is never populated.

Since the dm-including view is a search view, we should drop that phrase from dm-including views altogether. It also isn't super natural to have a button that starts the conversation with the user anyways.

Fixes: #25524.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/62449508/4c714ee0-eccd-4fb8-b7b4-601b2a307d90)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
