### PR TITLE
bootstrap: Remove unused stylings for btn-primary and btn-success. 

### DIFF
--- a/web/third/bootstrap/css/bootstrap-btn.css
+++ b/web/third/bootstrap/css/bootstrap-btn.css
@@ -126,39 +126,10 @@ fieldset[disabled] .btn-default.active {
 }
 .btn-primary:hover,
 .btn-primary:focus,
-.btn-primary:active,
-.btn-primary.active,
-.open .dropdown-toggle.btn-primary {
+.btn-primary:active {
   color: #fff;
   background-color: #3276b1;
   border-color: #285e8e;
-}
-.btn-primary:active,
-.btn-primary.active,
-.open .dropdown-toggle.btn-primary {
-  background-image: none;
-}
-.btn-primary.disabled,
-.btn-primary[disabled],
-fieldset[disabled] .btn-primary,
-.btn-primary.disabled:hover,
-.btn-primary[disabled]:hover,
-fieldset[disabled] .btn-primary:hover,
-.btn-primary.disabled:focus,
-.btn-primary[disabled]:focus,
-fieldset[disabled] .btn-primary:focus,
-.btn-primary.disabled:active,
-.btn-primary[disabled]:active,
-fieldset[disabled] .btn-primary:active,
-.btn-primary.disabled.active,
-.btn-primary[disabled].active,
-fieldset[disabled] .btn-primary.active {
-  background-color: #428bca;
-  border-color: #357ebd;
-}
-.btn-primary .badge {
-  color: #428bca;
-  background-color: #fff;
 }
 .btn-success {
   color: #fff;

--- a/web/third/bootstrap/css/bootstrap-btn.css
+++ b/web/third/bootstrap/css/bootstrap-btn.css
@@ -131,46 +131,11 @@ fieldset[disabled] .btn-default.active {
   background-color: #3276b1;
   border-color: #285e8e;
 }
-.btn-success {
-  color: #fff;
-  background-color: #5cb85c;
-  border-color: #4cae4c;
-}
 .btn-success:hover,
-.btn-success:focus,
-.btn-success:active,
-.btn-success.active,
-.open .dropdown-toggle.btn-success {
+.btn-success:focus {
   color: #fff;
   background-color: #47a447;
   border-color: #398439;
-}
-.btn-success:active,
-.btn-success.active,
-.open .dropdown-toggle.btn-success {
-  background-image: none;
-}
-.btn-success.disabled,
-.btn-success[disabled],
-fieldset[disabled] .btn-success,
-.btn-success.disabled:hover,
-.btn-success[disabled]:hover,
-fieldset[disabled] .btn-success:hover,
-.btn-success.disabled:focus,
-.btn-success[disabled]:focus,
-fieldset[disabled] .btn-success:focus,
-.btn-success.disabled:active,
-.btn-success[disabled]:active,
-fieldset[disabled] .btn-success:active,
-.btn-success.disabled.active,
-.btn-success[disabled].active,
-fieldset[disabled] .btn-success.active {
-  background-color: #5cb85c;
-  border-color: #4cae4c;
-}
-.btn-success .badge {
-  color: #5cb85c;
-  background-color: #fff;
 }
 .btn-info {
   color: #fff;


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Currently, we are in the process of removing bootstrap out of the current
Zulip codebase. 

A quick git grep on btn-primary shows that the class is
only used in /devtools/integrations.

A quick git grep on btn-success shows that the class is
only used in `templates/corporate/billing.html`. 

In both cases, it doesn't take advantage or use most of the styling rules that
are set with some that are overwritten by other CSS rules, rendering them useless.

We should get rid of those rules as it's not being used and help simplify
the process in removing bootstrap.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<details>
<summary>Before:</summary>

![15d4aea09e16e6bfb5aeae91e0513006](https://github.com/zulip/zulip/assets/62449508/38aa63df-ddd9-4ac9-ac77-48c391253f84)

![f31cae71ea0887557562f68d0aafa0ad](https://github.com/zulip/zulip/assets/62449508/553d1b2c-0ca1-47a2-968d-c3fe6263f996)
</details>

<details>
<summary>After:</summary>

![620e97c556bb29799917870c5c3bf737](https://github.com/zulip/zulip/assets/62449508/014b5adc-bec6-4b52-8f70-a5048d444d2a)

![052828ef49bd224011349160ac0a7db5](https://github.com/zulip/zulip/assets/62449508/d111a6fa-cc01-401b-9099-3039665d705d)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
