### PR TITLE
billing: Making /upgrade page header visible.

### DIFF
--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -11,6 +11,10 @@
         width: 100%;
     }
 
+    .page-content {
+        padding: 100px 0 30px;
+    }
+
     .small-hero {
         padding: 120px 50px 0;
     }


### PR DESCRIPTION
This was hidden following #25518

Events
<img width="1263" alt="Screenshot 2023-05-11 at 9 44 54 AM" src="https://github.com/zulip/zulip/assets/25124304/010c91b7-5643-4716-9307-94b69699ae77">

Billing and upgrade page:
<img width="1263" alt="Screenshot 2023-05-11 at 9 47 09 AM" src="https://github.com/zulip/zulip/assets/25124304/00a24b7b-8b1a-4a47-8d35-1e5f81e0a3ed">
