### PR TITLE
left_sidebar: Don't change active stream color on filter highlight.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -299,10 +299,23 @@ li.show-more-topics {
 
 :not(.active-sub-filter) {
     &.top_left_row:hover,
-    &.bottom_left_row:hover,
-    &#stream_filters li.highlighted_stream {
+    &.bottom_left_row:hover {
         background-color: var(--color-background-hover-narrow-filter);
         border-radius: 4px;
+    }
+}
+
+#stream_filters .narrow-filter.highlighted_stream {
+    &.active-filter > .bottom_left_row {
+        background-color: var(--color-background-hover-narrow-filter);
+    }
+
+    &.active-filter .topic-list .bottom_left_row {
+        background-color: var(--color-background-active-narrow-filter);
+    }
+
+    .bottom_left_row:not(.active-sub-filter) {
+        background-color: var(--color-background-hover-narrow-filter);
     }
 }
 


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/highlighting.20with.20stream.20filter

before:
![image](https://github.com/zulip/zulip/assets/25124304/46d6e582-5fb9-4aa4-b478-04ad3bee5898)


after:
<img width="478" alt="Screenshot 2023-05-11 at 10 49 46 AM" src="https://github.com/zulip/zulip/assets/25124304/76884396-c6b6-44bf-b105-2b6f08c2ae0b">
<img width="478" alt="Screenshot 2023-05-11 at 10 52 00 AM" src="https://github.com/zulip/zulip/assets/25124304/1005cda8-2d22-4877-9333-536e00d720ca">
