### PR TITLE
left_sidebar: Adjust size and position of DM icons.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -624,7 +624,7 @@ li.topic-list-item {
 
 .pm-box {
     margin-right: 16px;
-    align-items: center;
+    align-items: baseline; /* Sets .user_circle alignment relative to text; standard icons do not participate in flex. */
 
     .user_circle {
         min-width: 8px;
@@ -637,7 +637,8 @@ li.topic-list-item {
     }
 
     .zulip-icon.zulip-icon-bot {
-        padding: 3px 0;
+        font-size: 90%; /* Reduce the bulkiness of this icon */
+        padding: 3px 0 3px 1px; /* Shift reduced icon a pixel left to maintain horizontal centering. */
     }
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR attempts to tweak the positioning of DM-box icons and the size of the Zulip-bot icon, which may appear too low relative to the text, and in the bot icon's case, too large relative to other icons.

While the screenshots below are from MacOS, [the original CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/alignment.20of.20DM.20icons) shows a greater existing discrepancy.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before, 100% zoom (Firefox, MacOS)
![before-100-percent](https://github.com/zulip/zulip/assets/170719/f1a8f63e-ce72-41c0-b7da-76868d728ae0)

After, 100% zoom (Firefox, MacOS)
![after-100-percent](https://github.com/zulip/zulip/assets/170719/7f99e8fa-f730-4e57-942d-15144ab6d846)

Before, 110% zoom (Firefox, MacOS)
![before-110-percent](https://github.com/zulip/zulip/assets/170719/cd351b38-24f4-44b3-b8ce-e47b1c773462)

After, 110% zoom (Firefox, MacOS)
![after-110-percent](https://github.com/zulip/zulip/assets/170719/0ccbc31c-4bc5-4623-bb0d-a347bd63ed55)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
