### PR TITLE
tests: Add coverage for error when editing a sent scheduled message.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -78,7 +78,6 @@ not_yet_fully_covered = [
     "zerver/actions/create_realm.py",
     "zerver/actions/message_edit.py",
     "zerver/actions/presence.py",
-    "zerver/actions/scheduled_messages.py",
     "zerver/lib/addressee.py",
     "zerver/lib/markdown/__init__.py",
     "zerver/lib/cache.py",

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -190,6 +190,19 @@ class ScheduledMessageTest(ZulipTestCase):
                 )
                 self.assertEqual(delivered_message.date_sent, more_than_scheduled_delivery_datetime)
 
+        # Check error is sent if an edit happens after the scheduled
+        # message is successfully sent.
+        new_delivery_datetime = timezone_now() + datetime.timedelta(minutes=7)
+        new_delivery_timestamp = int(new_delivery_datetime.timestamp())
+        updated_response = self.do_schedule_message(
+            "direct",
+            [othello.id],
+            "New content!",
+            new_delivery_timestamp,
+            scheduled_message_id=str(scheduled_message.id),
+        )
+        self.assert_json_error(updated_response, "Scheduled message was already sent")
+
     def verify_deliver_scheduled_message_failure(
         self, scheduled_message: ScheduledMessage, logger: mock.Mock, expected_failure_message: str
     ) -> None:


### PR DESCRIPTION
Adds test coverage for the error sent for editing a scheduled message that was successfully sent.

`zerver/actions/scheduled_messages.py` now has 100% test coverage again. Part of fixing #25498.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
