### PR TITLE
backend: Add failed scheduled message notification and update API dict for `failed` boolean.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,17 +20,27 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 181**
+
+* [`GET /scheduled_messages`](/api/get-scheduled-messages), [`GET
+  /events`](/api/get-events), [`POST /register`](/api/register-queue):
+  Added `failed` boolean field to scheduled message objects to
+  indicate if the server tried to send the scheduled message and was
+  unsuccessful. Clients that support unscheduling and editing
+  scheduled messages should use this field to indicate to the user
+  when a scheduled message failed to send at the appointed time.
+
 **Feature level 180**
 
 * `POST /invites`: Added support for invitations specifying the empty
   list as the user's initial stream subscriptions. Previously, this
   returned an error.
 
-**Feature level 179**:
+**Feature level 179**
 
 * [`POST /scheduled_messages`](/api/create-or-update-scheduled-message):
   Added new endpoint to create and edit scheduled messages.
-* [`GET /events`](/api/get-events)
+* [`GET /events`](/api/get-events):
   Added `scheduled_messages` events sent to clients when a user creates,
   edits or deletes scheduled messages.
 * [`POST /register`](/api/register-queue):

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 180
+API_FEATURE_LEVEL = 181
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -161,6 +161,13 @@ def edit_scheduled_message(
             scheduled_message_object, rendering_result
         )
 
+        # If the user is editing a scheduled message that the server tried
+        # and failed to send, we need to update the `failed` boolean field
+        # as well as the associated `failure_message` field.
+        if scheduled_message_object.failed:
+            scheduled_message_object.failed = False
+            scheduled_message_object.failure_message = None
+
         scheduled_message_object.save()
 
     event = {

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4303,6 +4303,7 @@ class APIScheduledStreamMessageDict(TypedDict):
     rendered_content: str
     topic: str
     scheduled_delivery_timestamp: int
+    failed: bool
 
 
 class APIScheduledDirectMessageDict(TypedDict):
@@ -4312,6 +4313,7 @@ class APIScheduledDirectMessageDict(TypedDict):
     content: str
     rendered_content: str
     scheduled_delivery_timestamp: int
+    failed: bool
 
 
 class ScheduledMessage(models.Model):
@@ -4399,6 +4401,7 @@ class ScheduledMessage(models.Model):
                 content=self.content,
                 rendered_content=self.rendered_content,
                 scheduled_delivery_timestamp=datetime_to_timestamp(self.scheduled_timestamp),
+                failed=self.failed,
             )
 
         # The recipient for stream messages should always just be the unique stream ID.
@@ -4412,6 +4415,7 @@ class ScheduledMessage(models.Model):
             rendered_content=self.rendered_content,
             topic=self.topic_name(),
             scheduled_delivery_timestamp=datetime_to_timestamp(self.scheduled_timestamp),
+            failed=self.failed,
         )
 
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4469,6 +4469,7 @@ paths:
                                         "content": "Hello there!",
                                         "rendered_content": "<p>Hello there!</p>",
                                         "scheduled_delivery_timestamp": 1681662420,
+                                        "failed": false,
                                       },
                                     ],
                                 }
@@ -4505,6 +4506,7 @@ paths:
                                       "content": "Hello there!",
                                       "rendered_content": "<p>Hello there!</p>",
                                       "scheduled_delivery_timestamp": 1681662420,
+                                      "failed": false,
                                     },
                                 }
                             - type: object
@@ -5146,6 +5148,7 @@ paths:
                               "rendered_content": "<p>Hi</p>",
                               "topic": "Introduction",
                               "scheduled_delivery_timestamp": 1681662420,
+                              "failed": false,
                             },
                           ],
                       }
@@ -17648,6 +17651,19 @@ components:
             The UNIX timestamp for when the message will be sent
             by the server, in UTC seconds.
           example: 1595479019
+        failed:
+          type: boolean
+          description: |
+            Whether the server has tried to send the scheduled message
+            and it failed to successfully send.
+
+            Clients that support unscheduling and editing scheduled messages
+            should display scheduled messages with `failed = true` with an
+            indicator that the server failed to send the message at the
+            scheduled time, so that the user is aware of the failure and can
+            get the content of the scheduled message.
+
+            **Changes**: New in Zulip 7.0 (feature level 181).
       additionalProperties: false
       required:
         - scheduled_message_id
@@ -17656,6 +17672,7 @@ components:
         - content
         - rendered_content
         - scheduled_delivery_timestamp
+        - failed
     User:
       allOf:
         - $ref: "#/components/schemas/UserBase"


### PR DESCRIPTION
Adds sending a message from Notification Bot to the user who scheduled the message if/when there is an error sending the message. The only errors that do not send these notification messages are when the realm or user sending the message has been deactivated.

Also, updates the API scheduled message dicts to have a `failed` field that will be `True` in the case that the server tried to send the scheduled message but there was an error. The same commit fixes two colons in the feature level 179 API changelog entry as well.

This is part of work on #25501. After these changes, the remaining task in that issue is to update the scheduled messages overlay and UI for the new icon.

---

**Screenshots and screen captures:**

<details>
<summary>Example of Notification Bot message</summary>

#### The yellow highlight is from my search filter as I had some other test messages, but wanted the bot avatar in the screenshot

![Screenshot from 2023-05-11 20-59-21](https://github.com/zulip/zulip/assets/63245456/db988709-2180-4e48-a11f-408ea489df52)
</details>
<details>
<summary>API changelog entry</summary>

![Screenshot from 2023-05-11 19-22-41](https://github.com/zulip/zulip/assets/63245456/0227e676-5917-47cc-b1f2-e0d63c78f7a1)
</details>
<details>
<summary>Example of `failed` field documentation</summary>

#### This description is part of a shared Schema in the OpenAPI documentation, so it will be the same in all other places it appears in the API documentation.

![Screenshot from 2023-05-11 19-22-05](https://github.com/zulip/zulip/assets/63245456/38305e21-f5cf-43e5-a4e0-ae0545db2783)
</details>



---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
