### PR TITLE
ui_redesign: Apply blue links style to message view UI.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -289,6 +289,26 @@
         padding: 8px 5px 8px 15px;
     }
 
+    & a,
+    & a:link,
+    & a:visited {
+        color: hsl(210deg 94% 42%);
+        text-decoration: underline;
+        text-decoration-color: hsl(210deg 94% 42% / 20%);
+        text-decoration-style: solid;
+        text-underline-offset: 3px;
+    }
+
+    & a:hover {
+        color: hsl(212deg 100% 50%);
+        text-decoration-color: hsl(210deg 100% 50% / 70%);
+    }
+
+    & a:active {
+        color: hsl(212deg 100% 30%);
+        text-decoration-color: hsl(210deg 100% 30%);
+    }
+
     .banner_content {
         flex-grow: 1;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1542,6 +1542,27 @@
 
         & i {
             color: hsl(0deg 0% 80%);
+
+            .rendered_markdown,
+            .compose_banner,
+            #mark_read_on_scroll_state_banner {
+                & a,
+                & a:link,
+                & a:visited {
+                    color: hsl(200deg 100% 43%);
+                    text-decoration-color: hsl(200deg 100% 43% / 30%);
+                }
+
+                & a:hover {
+                    color: hsl(200deg 100% 60%);
+                    text-decoration-color: hsl(200deg 100% 60%);
+                }
+
+                & a:active {
+                    color: hsl(200deg 100% 43%);
+                    text-decoration-color: hsl(200deg 100% 40%);
+                }
+            }
         }
 
         .selected-tab {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -551,23 +551,24 @@
         border: none;
     }
 
-    & a {
-        color: hsl(200deg 100% 40%);
-        text-decoration: none;
+    & a,
+    & a:link,
+    & a:visited {
+        color: hsl(210deg 94% 42%);
+        text-decoration: underline;
+        text-decoration-color: hsl(210deg 94% 42% / 20%);
+        text-decoration-style: solid;
+        text-underline-offset: 3px;
+    }
 
-        & code {
-            color: hsl(200deg 100% 40%);
-        }
+    & a:hover {
+        color: hsl(212deg 100% 50%);
+        text-decoration-color: hsl(210deg 100% 50% / 70%);
+    }
 
-        &:hover,
-        &:focus {
-            color: hsl(200deg 100% 25%);
-            text-decoration: underline;
-
-            & code {
-                color: hsl(200deg 100% 25%);
-            }
-        }
+    & a:active {
+        color: hsl(212deg 100% 30%);
+        text-decoration-color: hsl(210deg 100% 30%);
     }
 
     & pre {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3203,3 +3203,25 @@ select.invite-as {
         padding: 5px;
     }
 }
+
+#mark_read_on_scroll_state_banner {
+    & a,
+    & a:link,
+    & a:visited {
+        color: hsl(210deg 94% 42%);
+        text-decoration: underline;
+        text-decoration-color: hsl(210deg 94% 42% / 20%);
+        text-decoration-style: solid;
+        text-underline-offset: 3px;
+    }
+
+    & a:hover {
+        color: hsl(212deg 100% 50%);
+        text-decoration-color: hsl(210deg 100% 50% / 70%);
+    }
+
+    & a:active {
+        color: hsl(212deg 100% 30%);
+        text-decoration-color: hsl(210deg 100% 30%);
+    }
+}


### PR DESCRIPTION
With the current Zulip redesign, we would like to tune the colors of the links with a slight underline for better accessibility. These changes to the links only applies to the main message view interface.

Fixes: #24877.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
**Screenshots and screen captures:**
<details>
<summary>Light mode:</summary>

Message view:
![image](https://github.com/zulip/zulip/assets/62449508/74f5cb69-d4d8-415d-bd7d-1a694dd8b2e3)
![image](https://github.com/zulip/zulip/assets/62449508/b6daeba7-1259-401b-82ea-14bd6682a623)
![image](https://github.com/zulip/zulip/assets/62449508/52fb0208-c966-43a9-ab09-d4360de9618d)

Unread banners:
![image](https://github.com/zulip/zulip/assets/62449508/df9c3aad-f3da-4069-b1b0-2658b3fbc92b)
![image](https://github.com/zulip/zulip/assets/62449508/5cc01097-c16c-4faf-a9d4-d2dc377774bc)
![image](https://github.com/zulip/zulip/assets/62449508/64e0031b-2d2a-4a18-afd3-130a00eb8ac7)

Compose banner:
![image](https://github.com/zulip/zulip/assets/62449508/adf4a017-ddc6-4ab2-86d8-e39b10f0689f)
![image](https://github.com/zulip/zulip/assets/62449508/9ccf3abb-1cc7-4ba3-9f86-6b459c633792)
![image](https://github.com/zulip/zulip/assets/62449508/2b417276-56db-4a2b-93a4-bc8d7775d7d5)

</details>

<details>
<summary>Dark mode:</summary>

Message view:
![image](https://github.com/zulip/zulip/assets/62449508/66cd3f80-7059-4168-be6d-31ea9698ffb5)
![image](https://github.com/zulip/zulip/assets/62449508/afc8a949-3f3f-4cdf-bc13-a3f2468cfb0d)
![image](https://github.com/zulip/zulip/assets/62449508/2eb8e894-460b-4ecb-a440-10a6f4bcfaa7)

Unread banners:
![image](https://github.com/zulip/zulip/assets/62449508/57c24180-97cb-413a-b69c-a3b5f76a9e8c)
![image](https://github.com/zulip/zulip/assets/62449508/18962706-4380-404c-89c9-9bf2fc8c9aa1)
![image](https://github.com/zulip/zulip/assets/62449508/c092dcc7-ae93-4aa6-8044-9d6c9e8c236a)
Compose banners:
![image](https://github.com/zulip/zulip/assets/62449508/902d5268-d9b7-4c05-ae0a-d0d0b8949d19)
![image](https://github.com/zulip/zulip/assets/62449508/446ba9cd-6164-4c2f-b095-2bb039a33367)
![image](https://github.com/zulip/zulip/assets/62449508/f0153248-24be-4d0e-8e08-fe76be0a0ebc)


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
