### PR TITLE
css: Fix unread marker leaking through message header.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -61,6 +61,12 @@ body,
     --left-sidebar-width: 270px;
     --right-sidebar-width: 250px;
 
+    /*
+    Left position of unread marker. Only needs to be tracked if it is negative so that
+    it doesn't leak through message header.
+    */
+    --unread-marker-left: -1px;
+
     /* Colors used across the app */
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-text-private-message-header: hsl(0deg 0% 100%);
@@ -1253,6 +1259,8 @@ td.pointer {
         box-shadow: 0 -1px 0 0 var(--color-background);
 
         &.sticky_header {
+            box-shadow: var(--unread-marker-left) 0 0 0 var(--color-background);
+
             .recipient_row_date {
                 display: block;
             }
@@ -1476,7 +1484,7 @@ td.pointer {
     z-index: 2;
     bottom: 1px;
     transition: all 0.3s ease-out;
-    left: -1px;
+    left: var(--unread-marker-left);
 
     &.slow_fade {
         transition: all 2s ease-out;


### PR DESCRIPTION
before: 
<img width="408" alt="Screenshot 2023-05-12 at 2 28 10 PM" src="https://github.com/zulip/zulip/assets/25124304/9bdcfa93-e002-4094-9615-40da710bf05b">

after:
<img width="408" alt="Screenshot 2023-05-12 at 2 28 17 PM" src="https://github.com/zulip/zulip/assets/25124304/ef8319cf-940b-4199-94c0-c384af389355">

Reproducer: This can happen at a random zoom level for you, or you can decrease the `left` position of `.unread_marker` to see it.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/unread.20marker.20spilling.20out