### PR TITLE
unread: Fix double counting of mentions in direct messages.

### DIFF
--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -125,7 +125,7 @@ export function redraw_title() {
 
 export function update_unread_counts(counts) {
     const new_unread_count = unread.calculate_notifiable_count(counts);
-    const new_pm_count = counts.private_message_count;
+    const new_pm_count = counts.direct_message_count;
     if (new_unread_count === unread_count && new_pm_count === pm_count) {
         return;
     }

--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -120,7 +120,7 @@ export function update_dom_with_unread_counts(counts) {
     // could matter.
     update_private_messages();
     // This is just the global unread count.
-    set_count(counts.private_message_count);
+    set_count(counts.direct_message_count);
 }
 
 export function highlight_all_private_messages_view() {

--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -772,7 +772,7 @@ export function get_counts() {
     // Return a data structure with various counts.  This function should be
     // pretty cheap, even if you don't care about all the counts, and you
     // should strive to keep it free of side effects on globals or DOM.
-    res.private_message_count = 0;
+    res.direct_message_count = 0;
     res.mentioned_message_count = unread_mentions_counter.size;
     res.direct_message_with_mention_count = direct_message_with_mention_count.size;
 
@@ -787,8 +787,8 @@ export function get_counts() {
 
     const pm_res = unread_direct_message_counter.get_counts();
     res.pm_count = pm_res.pm_dict;
-    res.private_message_count = pm_res.total_count;
-    res.right_sidebar_private_message_count = pm_res.right_sidebar_count;
+    res.direct_message_count = pm_res.total_count;
+    res.right_sidebar_direct_message_count = pm_res.right_sidebar_count;
     res.home_unread_messages += pm_res.total_count;
 
     return res;
@@ -808,7 +808,7 @@ export function calculate_notifiable_count(res) {
         // DESKTOP_ICON_COUNT_DISPLAY_NOTIFIABLE
         new_message_count =
             res.mentioned_message_count +
-            res.private_message_count -
+            res.direct_message_count -
             // Avoid double-counting direct messages containing mentions
             res.direct_message_with_mention_count;
     } else if (no_notifications) {

--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -35,6 +35,7 @@ export function clear_old_unreads_missing() {
 }
 
 export const unread_mentions_counter = new Set();
+export const direct_message_with_mention_count = new Set();
 const unread_messages = new Set();
 
 // Map with keys of the form "{stream_id}:{topic.toLowerCase()}" and
@@ -695,6 +696,7 @@ export function update_message_for_mention(message, content_edited = false) {
     // an unread mention of the user.
     if (!message.unread) {
         unread_mentions_counter.delete(message.id);
+        direct_message_with_mention_count.delete(message.id);
         remove_message_from_unread_mention_topics(message.id);
         return false;
     }
@@ -707,8 +709,12 @@ export function update_message_for_mention(message, content_edited = false) {
     if (is_unmuted_mention || message.mentioned_me_directly) {
         unread_mentions_counter.add(message.id);
         add_message_to_unread_mention_topics(message.id);
+        if (!message.stream_id) {
+            direct_message_with_mention_count.add(message.id);
+        }
     } else {
         unread_mentions_counter.delete(message.id);
+        direct_message_with_mention_count.delete(message.id);
         remove_message_from_unread_mention_topics(message.id);
     }
 
@@ -730,6 +736,7 @@ export function mark_as_read(message_id) {
     remove_message_from_unread_mention_topics(message_id);
     unread_topic_counter.delete(message_id);
     unread_mentions_counter.delete(message_id);
+    direct_message_with_mention_count.delete(message_id);
     unread_messages.delete(message_id);
 
     const message = message_store.get(message_id);
@@ -743,6 +750,7 @@ export function declare_bankruptcy() {
     unread_direct_message_counter.clear();
     unread_topic_counter.clear();
     unread_mentions_counter.clear();
+    direct_message_with_mention_count.clear();
     unread_messages.clear();
     unread_mention_topics.clear();
 }
@@ -766,6 +774,7 @@ export function get_counts() {
     // should strive to keep it free of side effects on globals or DOM.
     res.private_message_count = 0;
     res.mentioned_message_count = unread_mentions_counter.size;
+    res.direct_message_with_mention_count = direct_message_with_mention_count.size;
 
     // This sets stream_count, topic_count, and home_unread_messages
     const topic_res = unread_topic_counter.get_counts();
@@ -797,7 +806,11 @@ export function calculate_notifiable_count(res) {
         settings_config.desktop_icon_count_display_values.none.code;
     if (only_show_notifiable) {
         // DESKTOP_ICON_COUNT_DISPLAY_NOTIFIABLE
-        new_message_count = res.mentioned_message_count + res.private_message_count;
+        new_message_count =
+            res.mentioned_message_count +
+            res.private_message_count -
+            // Avoid double-counting direct messages containing mentions
+            res.direct_message_with_mention_count;
     } else if (no_notifications) {
         // DESKTOP_ICON_COUNT_DISPLAY_NONE
         new_message_count = 0;
@@ -901,9 +914,11 @@ export function initialize(params) {
     unread_direct_message_counter.set_huddles(unread_msgs.huddles);
     unread_direct_message_counter.set_pms(unread_msgs.pms);
     unread_topic_counter.set_streams(unread_msgs.streams);
-
     for (const message_id of unread_msgs.mentions) {
         unread_mentions_counter.add(message_id);
+        if (unread_direct_message_counter.get_msg_ids().includes(message_id)) {
+            direct_message_with_mention_count.add(message_id);
+        }
     }
     clear_and_populate_unread_mention_topics();
 

--- a/web/src/unread_ui.js
+++ b/web/src/unread_ui.js
@@ -94,7 +94,7 @@ export function update_unread_counts(skip_animations = false) {
     // 1:1 direct messages there.
     set_count_toggle_button(
         $("#userlist-toggle-unreadcount"),
-        res.right_sidebar_private_message_count,
+        res.right_sidebar_direct_message_count,
     );
 }
 

--- a/web/tests/pm_list.test.js
+++ b/web/tests/pm_list.test.js
@@ -23,18 +23,18 @@ run_test("update_dom_with_unread_counts", () => {
     $private_li.set_find_results(".unread_count", $total_count);
 
     counts = {
-        private_message_count: 10,
+        direct_message_count: 10,
     };
 
-    pm_list.set_count(counts.private_message_count);
+    pm_list.set_count(counts.direct_message_count);
     assert.equal($total_count.text(), "10");
     assert.ok($total_count.visible());
 
     counts = {
-        private_message_count: 0,
+        direct_message_count: 0,
     };
 
-    pm_list.set_count(counts.private_message_count);
+    pm_list.set_count(counts.direct_message_count);
     assert.equal($total_count.text(), "");
     assert.ok(!$total_count.visible());
 });

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -43,7 +43,7 @@ const social = {
 stream_data.add_sub(social);
 
 function assert_zero_counts(counts) {
-    assert.equal(counts.private_message_count, 0);
+    assert.equal(counts.direct_message_count, 0);
     assert.equal(counts.home_unread_messages, 0);
     assert.equal(counts.mentioned_message_count, 0);
     assert.equal(counts.stream_count.size, 0);
@@ -387,7 +387,7 @@ test("phantom_messages", () => {
 
 test("private_messages", () => {
     let counts = unread.get_counts();
-    assert.equal(counts.private_message_count, 0);
+    assert.equal(counts.direct_message_count, 0);
 
     const message = {
         id: 15,
@@ -399,12 +399,12 @@ test("private_messages", () => {
     unread.process_loaded_messages([message]);
 
     counts = unread.get_counts();
-    assert.equal(counts.private_message_count, 1);
+    assert.equal(counts.direct_message_count, 1);
     assert.equal(counts.pm_count.get("999"), 1);
     test_notifiable_count(counts.home_unread_messages, 1);
     unread.mark_as_read(message.id);
     counts = unread.get_counts();
-    assert.equal(counts.private_message_count, 0);
+    assert.equal(counts.direct_message_count, 0);
     assert.equal(counts.pm_count.get("999"), 0);
     test_notifiable_count(counts.home_unread_messages, 0);
 });
@@ -462,7 +462,7 @@ test("private_messages", () => {
     assert.deepEqual(unread.get_msg_ids_for_private(), []);
     assert.deepEqual(unread.get_all_msg_ids(), []);
     const counts = unread.get_counts();
-    assert.equal(counts.private_message_count, 0);
+    assert.equal(counts.direct_message_count, 0);
     test_notifiable_count(counts.home_unread_messages, 0);
 });
 
@@ -791,6 +791,6 @@ test("errors", () => {
 
     unread.mark_as_read(message.id);
     const counts = unread.get_counts();
-    assert.equal(counts.private_message_count, 0);
+    assert.equal(counts.direct_message_count, 0);
     test_notifiable_count(counts.home_unread_messages, 0);
 });

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -560,7 +560,7 @@ test("mentions", () => {
         muted_direct_mention_message.id,
         private_mention_me_message.id,
     ]);
-    test_notifiable_count(counts.home_unread_messages, 5);
+    test_notifiable_count(counts.home_unread_messages, 4);
 
     unread.mark_as_read(mention_me_message.id);
     unread.mark_as_read(mention_all_message.id);


### PR DESCRIPTION
Created a new set `mentions_in_direct_message` which stores direct messages containing mentions. In `new_message_count`, direct messages with mention were added twice, once by res.mentioned_message_count and once by res.private_message_count so subtracting the intersection of both `mentions_in_direct_message` now gives an accurate count.

<!-- Describe your pull request here.-->

Fixes: #25453<!-- Issue link, or clear description.-->

Reproducer for this Issue:
1) In personal settings> notification setting, set "Unread count badge (appears in desktop sidebar and browser tab)" to `Direct messages and mentions` like this:
![image](https://github.com/zulip/zulip/assets/64723994/8134cc9c-6071-4069-8bfc-3fc54471a794)

2) Then if you have a mention in DM it shows (2) in browser tab count even though there is only one unread message.
![image](https://github.com/zulip/zulip/assets/64723994/7c7dda90-308b-4174-8300-3022669e8cc3)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Before:
![image](https://github.com/zulip/zulip/assets/64723994/cd960e26-c8fa-4645-ae8d-977f4dd7c4bf)


- After:
![image](https://github.com/zulip/zulip/assets/64723994/eef21a23-0084-43d9-b457-978f61383951)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
