### PR TITLE
compose: Check posting policy for direct messages.

### DIFF
--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -246,9 +246,7 @@ export function start(msg_type, opts) {
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);
 
-    if (msg_type === "stream") {
-        compose_recipient.check_stream_posting_policy_for_compose_box(opts.stream);
-    }
+    compose_recipient.check_posting_policy_for_compose_box();
 
     // Reset the `max-height` property of `compose-textarea` so that the
     // compose-box do not cover the last messages of the current stream

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -641,6 +641,7 @@ export function initialize() {
 
     delegate("body", {
         target: [".disabled-compose-send-button-container"],
+        maxWidth: 350,
         content: () => compose_recipient.get_posting_policy_error_message(),
         appendTo: () => document.body,
         onHidden(instance) {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -6,6 +6,7 @@ import render_message_inline_image_tooltip from "../templates/message_inline_ima
 import render_narrow_to_compose_recipients_tooltip from "../templates/narrow_to_compose_recipients_tooltip.hbs";
 import render_tooltip_templates from "../templates/tooltip_templates.hbs";
 
+import * as compose_recipient from "./compose_recipient";
 import * as compose_state from "./compose_state";
 import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
@@ -640,9 +641,7 @@ export function initialize() {
 
     delegate("body", {
         target: [".disabled-compose-send-button-container"],
-        content: $t({
-            defaultMessage: "You do not have permission to post in this stream.",
-        }),
+        content: () => compose_recipient.get_posting_policy_error_message(),
         appendTo: () => document.body,
         onHidden(instance) {
             instance.destroy();

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -121,7 +121,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "blur_compose_inputs", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
     override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
-    override_rewire(compose_recipient, "check_stream_posting_policy_for_compose_box", () => {});
+    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", () => {});
     mock_template("inline_decorated_stream_name.hbs", false, () => {});
     mock_stream_header_colorblock();
 
@@ -245,7 +245,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
-    override_rewire(compose_recipient, "check_stream_posting_policy_for_compose_box", noop);
+    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     override_private_message_recipient({override});
     mock_template("inline_decorated_stream_name.hbs", false, () => {});
     mock_stream_header_colorblock();
@@ -299,7 +299,7 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_actions, "complete_starting_tasks", () => {});
     override_rewire(compose_actions, "clear_textarea", () => {});
     override_private_message_recipient({override});
-    override_rewire(compose_recipient, "check_stream_posting_policy_for_compose_box", noop);
+    override_rewire(compose_recipient, "check_posting_policy_for_compose_box", noop);
     mock_template("inline_decorated_stream_name.hbs", false, () => {});
 
     const denmark = {

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -164,6 +164,11 @@ test("basics", () => {
 
     assert.equal(stream_data.slug_to_name("99-whatever"), "99-whatever");
     assert.equal(stream_data.slug_to_name("99whatever"), "99whatever");
+
+    // sub_store
+    assert.equal(sub_store.get(-3), undefined);
+    assert.equal(sub_store.get(undefined), undefined);
+    assert.equal(sub_store.get(1), denmark);
 });
 
 test("get_subscribed_streams_for_user", () => {


### PR DESCRIPTION
Prior this commit, changing the message type from a stream (where posting was not allowed) to a direct message using the compose box dropdown, did not changed the state of the submit button from disabled to enabled even though direct messages were allowed in the organization. Now, it checks if direct messages are allowed or not, and depending on that, it updates the send button's state, tooltip and displays a relevant banner.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<img width="1093" alt="Screenshot 2023-05-16 at 5 58 23 AM" src="https://github.com/zulip/zulip/assets/71015892/271c3275-e890-4abc-9d39-7181a6197be3">
<img width="1093" alt="Screenshot 2023-05-16 at 5 58 07 AM" src="https://github.com/zulip/zulip/assets/71015892/a5786051-e8b6-4cd6-bda6-fbc1a0b38aa1">

<img width="1081" alt="Screenshot 2023-05-13 at 3 06 03 AM" src="https://github.com/zulip/zulip/assets/71015892/81b51614-ee0c-4949-b090-387da0661da8">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
