### PR TITLE
help_pages: Highlight headings targeted by URL fragments.

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -70,6 +70,10 @@ function scrollToHash(simplebar) {
     const scrollbar = simplebar.getScrollElement();
     if (hash !== "" && $(hash).length > 0) {
         const position = $(hash).position().top - $(scrollbar.firstChild).position().top;
+        // Preserve a reference to the scroll target, so it is not lost (and the highlight
+        // along with it) when the page is updated via fetch
+        const $scroll_target = $(hash);
+        $scroll_target.addClass("scroll-target");
         scrollbar.scrollTop = position;
     } else {
         scrollbar.scrollTop = 0;

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -248,6 +248,19 @@ html {
     background-color: hsl(0deg 0% 100%);
     width: calc(100vw - 300px);
     height: calc(100vh - 59px);
+
+    & :target {
+        /* Match to where simplebar scrolls */
+        scroll-margin-top: 20px;
+        /* Increase the highlighted space around the text... */
+        padding: 6px 8px;
+        border-radius: 7px 7px 0 0;
+        /* ...but maintain apparent top and bottom margin;
+        pull left and right into the gutter. */
+        margin: 20px -8px 10px;
+        /* Derive highlight color from sidebar, here with 30% alpha */
+        background-color: hsl(152deg 70% 50% / 25%);
+    }
 }
 
 .help-center ol,

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -249,7 +249,8 @@ html {
     width: calc(100vw - 300px);
     height: calc(100vh - 59px);
 
-    & :target {
+    & :target,
+    & .scroll-target {
         /* Match to where simplebar scrolls */
         scroll-margin-top: 20px;
         /* Increase the highlighted space around the text... */


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR aims to make the help documentation more user-friendly by highlighting links targeted by URL fragments. It also ensures that targeted headings are not obscured by the floating menu bar at the top of the help pages.

~~One caveat: While the approach here works fine when loading a new docs page whose URL includes a fragment, there appears to be something about `simplebar` that clears out the `:target` reference. If you click a heading link on a help page, for example, you might momentarily see the highlighted style appear before it disappears.~~ Highlighting is also available for on-page targets of URL fragments.

See [CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/help.20page.20highlighting).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Highlighted and properly top-aligned anchor target on "Customize organization settings":
![highlighted-anchor-target](https://github.com/zulip/zulip/assets/170719/b9e77c5e-2918-4e0a-935f-84732fc2cd23)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
