### PR TITLE
message feed: removed copy code button outline

### DIFF
--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -593,6 +593,11 @@
         position: absolute;
         right: 2px;
         margin-top: -4px;
+
+        /* Remove the outline when clicking on the copy-to-clipboard button */
+        &:focus {
+            outline: none;
+        }
     }
 
     .code_external_link {


### PR DESCRIPTION
Added styling to change the UI for the copy-to-clipboard button to remove the rectangular outline that appears on click.


Fixes: issue #25533 

**Screenshots and screen captures:**
![issue #25533 fix](https://github.com/zulip/zulip/assets/71205057/a68a4826-41c9-421d-a140-9e4e94c720b5)


<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
