### PR TITLE
left_sidebar: Move tooltips to the `focus` element.

### DIFF
--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -2,8 +2,8 @@
     <div class="narrows_panel">
         <ul id="global_filters" class="filters">
             {{!-- Special-case this link so we don't actually go to page top. --}}
-            <li class="top_left_all_messages top_left_row tippy-left-sidebar-tooltip" data-tooltip-template-id="all-message-tooltip-template">
-                <a href="#all_messages" class="home-link">
+            <li class="top_left_all_messages top_left_row">
+                <a href="#all_messages" class="home-link tippy-left-sidebar-tooltip" data-tooltip-template-id="all-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-align-left" aria-hidden="true"></i>
                     </span>
@@ -13,8 +13,8 @@
                 </a>
                 <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_recent_topics top_left_row tippy-left-sidebar-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
-                <a href="#recent">
+            <li class="top_left_recent_topics top_left_row">
+                <a href="#recent" class="tippy-left-sidebar-tooltip" data-tooltip-template-id="recent-conversations-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
@@ -43,8 +43,8 @@
                 </a>
                 <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_drafts top_left_row hidden-for-spectators tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">
-                <a href="#drafts">
+            <li class="top_left_drafts top_left_row hidden-for-spectators">
+                <a href="#drafts" class="tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </span>


### PR DESCRIPTION
Since tippy relies on the `blur` event of `target` to hide the toolips, it is important that the tooltip is triggered by the element that receives that focus in keyboard navigation which is `a` tag for left sidebar elements.

reproducer: [Issue replication](https://chat.zulip.org/user_uploads/2/be/z_eKJODeWzhezkLnPp5_hg5t/errors-Zulip-Dev-Zulip-Google-Chrome-2023-05-02-18-50-15.mp4)

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/more.20sticky.20tooltips
