### PR TITLE
message_send: Don't mark scheduled messages to self as read.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -705,6 +705,7 @@ def get_active_presence_idle_user_ids(
 
 def do_send_messages(
     send_message_requests_maybe_none: Sequence[Optional[SendMessageRequest]],
+    *,
     email_gateway: bool = False,
     mark_as_read: Sequence[int] = [],
 ) -> List[int]:

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -230,7 +230,10 @@ def send_scheduled_message(scheduled_message: ScheduledMessage) -> None:
         scheduled_message.realm,
     )
 
-    message_id = do_send_messages([send_request])[0]
+    scheduled_message_to_self = scheduled_message.recipient == scheduled_message.sender.recipient
+    message_id = do_send_messages(
+        [send_request], scheduled_message_to_self=scheduled_message_to_self
+    )[0]
     scheduled_message.delivered_message_id = message_id
     scheduled_message.delivered = True
     scheduled_message.save(update_fields=["delivered", "delivered_message_id"])


### PR DESCRIPTION
The only reasonable intent for such a scheduled message is to remind
oneself of something at that time, which requires it being unread.
    
Fixes #25523.
