### PR TITLE
compose: Fix opening compose box when viewing invalid stream.

### DIFF
--- a/web/src/narrow_state.js
+++ b/web/src/narrow_state.js
@@ -88,7 +88,13 @@ export function set_compose_defaults() {
     // if they are uniquely specified in the narrow view.
 
     if (single.has("stream")) {
-        opts.stream = stream_data.get_name(single.get("stream"));
+        // The raw stream name from collect_single may be an arbitrary
+        // unvalidated string from the URL fragment and thus not be valid.
+        // So we look up the resolved stream and return that if appropriate.
+        const sub = stream_sub();
+        if (sub !== undefined) {
+            opts.stream = sub.name;
+        }
     }
 
     if (single.has("topic")) {

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -174,7 +174,14 @@ test("set_compose_defaults", () => {
         ["topic", "Bar"],
     ]);
 
-    const stream_and_topic = narrow_state.set_compose_defaults();
+    // First try with a stream that doesn't exist.
+    let stream_and_topic = narrow_state.set_compose_defaults();
+    assert.equal(stream_and_topic.stream, undefined);
+    assert.equal(stream_and_topic.topic, "Bar");
+
+    const test_stream = {name: "Foo", stream_id: 72};
+    stream_data.add_sub(test_stream);
+    stream_and_topic = narrow_state.set_compose_defaults();
     assert.equal(stream_and_topic.stream, "Foo");
     assert.equal(stream_and_topic.topic, "Bar");
 


### PR DESCRIPTION
This likely needs further refactoring to switch to using stream IDs rather than names in this code path, but this change fixes an exception that would be throw when opening the compose box while viewing a narrow to an invalid stream name/ID.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
