### PR TITLE
help: Rename "Starting a new private thread" to "... new direct message".

### DIFF
--- a/help/getting-started-with-zulip.md
+++ b/help/getting-started-with-zulip.md
@@ -48,9 +48,9 @@ Like your email inbox, Zulip works best if you read it topic-by-topic.
 
 {!how-to-start-a-new-topic.md!}
 
-### Starting a new private thread
+### Starting a new direct message
 
-{!starting-a-new-private-thread.md!}
+{!starting-a-new-direct-message.md!}
 
 ### Responding to an existing thread
 

--- a/help/include/send-group-dm.md
+++ b/help/include/send-group-dm.md
@@ -13,7 +13,7 @@
 
 !!! tip ""
 
-    You can switch from composing a stream message to a composing a direct
+    You can switch from composing a stream message to composing a direct
     message by selecting **Direct message** from the dropdown in the upper left
     of the compose box.
 

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -14,7 +14,7 @@
 * [Reading topics](/help/reading-topics)
 * [Reading direct messages (DMs)](/help/reading-dms)
 * [Starting a new topic](/help/starting-a-new-topic)
-* [Starting a new private thread](/help/starting-a-new-private-thread)
+* [Starting a new direct message](/help/starting-a-new-direct-message)
 * [Replying to messages](/help/replying-to-messages)
 * [Messaging tips & tricks](/help/messaging-tips)
 * [Keyboard shortcuts](/help/keyboard-shortcuts)

--- a/help/include/starting-a-new-direct-message.md
+++ b/help/include/starting-a-new-direct-message.md
@@ -2,5 +2,5 @@
 
 !!! tip ""
 
-    Rather than kicking off a group thread, consider starting the
+    Rather than kicking off a group direct message, consider starting the
     conversation in a new topic to make it easier to browse later on.

--- a/help/messaging-tips.md
+++ b/help/messaging-tips.md
@@ -6,5 +6,5 @@
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 * [Starting a new topic](/help/starting-a-new-topic)
-* [Starting a new private thread](/help/starting-a-new-private-thread)
+* [Starting a new direct message](/help/starting-a-new-direct-message)
 * [Replying to messages](/help/replying-to-messages)

--- a/help/open-the-compose-box.md
+++ b/help/open-the-compose-box.md
@@ -35,7 +35,7 @@ arrow if the box is empty.
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 * [Starting a new topic](/help/starting-a-new-topic)
-* [Starting a new private thread](/help/starting-a-new-private-thread)
+* [Starting a new direct message](/help/starting-a-new-direct-message)
 * [Replying to messages](/help/replying-to-messages)
 * [Messaging tips & tricks](/help/messaging-tips)
 * [Keyboard shortcuts](/help/keyboard-shortcuts)

--- a/help/replying-to-messages.md
+++ b/help/replying-to-messages.md
@@ -6,6 +6,6 @@
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 * [Starting a new topic](/help/starting-a-new-topic)
-* [Starting a new private thread](/help/starting-a-new-private-thread)
+* [Starting a new direct message](/help/starting-a-new-direct-message)
 * [Quote and reply](/help/quote-and-reply)
 * [Messaging tips & tricks](/help/messaging-tips)

--- a/help/starting-a-new-direct-message.md
+++ b/help/starting-a-new-direct-message.md
@@ -1,6 +1,6 @@
-# Starting a new private thread
+# Starting a new direct message
 
-{!starting-a-new-private-thread.md!}
+{!starting-a-new-direct-message.md!}
 
 ## Related articles
 

--- a/help/starting-a-new-topic.md
+++ b/help/starting-a-new-topic.md
@@ -11,6 +11,6 @@
 ## Related articles
 
 * [Getting started with Zulip](/help/getting-started-with-zulip)
-* [Starting a new private thread](/help/starting-a-new-private-thread)
+* [Starting a new direct message](/help/starting-a-new-direct-message)
 * [Replying to messages](/help/replying-to-messages)
 * [Messaging tips & tricks](/help/messaging-tips)

--- a/zerver/lib/url_redirects.py
+++ b/zerver/lib/url_redirects.py
@@ -74,6 +74,7 @@ HELP_DOCUMENTATION_REDIRECTS: List[URLRedirect] = [
     URLRedirect("/help/night-mode", "/help/dark-theme"),
     URLRedirect("/help/enable-emoticon-translations", "/help/configure-emoticon-translations"),
     URLRedirect("/help/web-public-streams", "/help/public-access-option"),
+    URLRedirect("/help/starting-a-new-private-thread", "/help/starting-a-new-direct-message"),
 ]
 
 LANDING_PAGE_REDIRECTS = [


### PR DESCRIPTION
With the private messages -> direct messages migration, we should rename the "[Starting a new private thread](https://zulip.com/help/starting-a-new-private-thread)" help center article.

- Renames article to "Starting a new direct message"
- Updates relevant section in [/help/getting-started-with-zulip](https://zulip.com/help/getting-started-with-zulip#starting-a-new-private-thread)
- Fixes typo in /help/send-group-dm
- Updates file names and adds URL redirect.

Fixes #25506.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/734c151d-cda7-4d53-abc4-e1afb050dbb8)


<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>