### PR TITLE
drafts: Add functionality to bulk delete drafts.

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -13,7 +13,7 @@ async function wait_for_drafts_to_appear(page: Page): Promise<void> {
 }
 
 async function get_drafts_count(page: Page): Promise<number> {
-    return await page.$$eval(".draft-row", (drafts) => drafts.length);
+    return await page.$$eval("#drafts_table .overlay-message-row", (drafts) => drafts.length);
 }
 
 const drafts_button = ".top_left_drafts";
@@ -76,35 +76,35 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row .message_header_stream .stream_label",
+            "#drafts_table .overlay-message-row .message_header_stream .stream_label",
         ),
         "Denmark",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row .message_header_stream .stream_topic",
+            "#drafts_table .overlay-message-row .message_header_stream .stream_topic",
         ),
         "tests",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row:nth-last-child(2) .rendered_markdown.restore-draft",
+            "#drafts_table .overlay-message-row:nth-last-child(2) .rendered_markdown.restore-overlay-message",
         ),
         "Test direct message.",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row .message_header_private_message .stream_label",
+            "#drafts_table .overlay-message-row .message_header_private_message .stream_label",
         ),
         "You and Cordelia, Lear's daughter, King Hamlet",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row:last-child .rendered_markdown.restore-draft",
+            "#drafts_table .overlay-message-row:last-child .rendered_markdown.restore-overlay-message",
         ),
         "Test stream message.",
     );
@@ -112,7 +112,7 @@ async function test_previously_created_drafts_rendered(page: Page): Promise<void
 
 async function test_restore_message_draft_via_draft_overlay(page: Page): Promise<void> {
     console.log("Restoring stream message draft");
-    await page.click("#drafts_table .message_row:not(.private-message) .restore-draft");
+    await page.click("#drafts_table .message_row:not(.private-message) .restore-overlay-message");
     await wait_for_drafts_to_disappear(page);
     await page.waitForSelector("#stream_message_recipient_topic", {visible: true});
     await page.waitForSelector("#preview_message_area", {hidden: true});
@@ -145,21 +145,21 @@ async function test_edited_draft_message(page: Page): Promise<void> {
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row .message_header_stream .stream_label",
+            "#drafts_table .overlay-message-row .message_header_stream .stream_label",
         ),
         "Denmark",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row .message_header_stream .stream_topic",
+            "#drafts_table .overlay-message-row .message_header_stream .stream_topic",
         ),
         "tests",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row .message_row:not(.private-message) .rendered_markdown.restore-draft",
+            "#drafts_table .overlay-message-row .message_row:not(.private-message) .rendered_markdown.restore-overlay-message",
         ),
         "Updated stream message",
     );
@@ -167,7 +167,7 @@ async function test_edited_draft_message(page: Page): Promise<void> {
 
 async function test_restore_private_message_draft_via_draft_overlay(page: Page): Promise<void> {
     console.log("Restoring direct message draft.");
-    await page.click(".message_row.private-message .restore-draft");
+    await page.click(".message_row.private-message .restore-overlay-message");
     await wait_for_drafts_to_disappear(page);
     await page.waitForSelector("#compose-direct-recipient", {visible: true});
     await common.check_compose_state(page, {
@@ -189,7 +189,7 @@ async function test_delete_draft(page: Page): Promise<void> {
     await page.waitForSelector(drafts_button, {visible: true});
     await page.click(drafts_button);
     await wait_for_drafts_to_appear(page);
-    await page.click("#drafts_table .message_row.private-message .delete-draft");
+    await page.click("#drafts_table .message_row.private-message .delete-overlay-message");
     const drafts_count = await get_drafts_count(page);
     assert.strictEqual(drafts_count, 1, "Draft not deleted.");
     await page.waitForSelector("#drafts_table .message_row.private-message", {hidden: true});
@@ -223,14 +223,14 @@ async function test_save_draft_by_reloading(page: Page): Promise<void> {
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row .message_header_private_message .stream_label",
+            "#drafts_table .overlay-message-row .message_header_private_message .stream_label",
         ),
         "You and Cordelia, Lear's daughter",
     );
     assert.strictEqual(
         await common.get_text_from_selector(
             page,
-            ".draft-row:nth-last-child(2) .rendered_markdown.restore-draft",
+            "#drafts_table .overlay-message-row:nth-last-child(2) .rendered_markdown.restore-overlay-message",
         ),
         "Test direct message draft.",
     );

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -614,6 +614,7 @@ export function launch() {
             });
         }
         update_rendered_drafts(narrow_drafts.length > 0, other_drafts.length > 0);
+        update_bulk_delete_ui();
     }
 
     function setup_event_handlers() {
@@ -635,8 +636,37 @@ export function launch() {
                 const $draft_row = $(this).closest(".overlay-message-row");
 
                 remove_draft($draft_row);
+                update_bulk_delete_ui();
             },
         );
+
+        $("#drafts_table .overlay_message_controls .draft-selection-checkbox").on("click", (e) => {
+            const is_checked = is_checkbox_icon_checked($(e.target));
+            toggle_checkbox_icon_state($(e.target), !is_checked);
+            update_bulk_delete_ui();
+        });
+
+        $(".select-drafts-button").on("click", (e) => {
+            e.preventDefault();
+            const $unchecked_checkboxes = $(".draft-selection-checkbox").filter(function () {
+                return !is_checkbox_icon_checked($(this));
+            });
+            const check_boxes = $unchecked_checkboxes.length > 0;
+            $(".draft-selection-checkbox").each(function () {
+                toggle_checkbox_icon_state($(this), check_boxes);
+            });
+            update_bulk_delete_ui();
+        });
+
+        $(".delete-selected-drafts-button").on("click", () => {
+            $(".drafts-list")
+                .find(".draft-selection-checkbox.fa-check-square")
+                .closest(".overlay-message-row")
+                .each(function () {
+                    remove_draft($(this));
+                });
+            update_bulk_delete_ui();
+        });
     }
 
     const drafts = draft_model.get();
@@ -660,6 +690,35 @@ export function launch() {
     setup_event_handlers();
 }
 
+function update_bulk_delete_ui() {
+    const $unchecked_checkboxes = $(".draft-selection-checkbox").filter(function () {
+        return !is_checkbox_icon_checked($(this));
+    });
+    const $checked_checkboxes = $(".draft-selection-checkbox").filter(function () {
+        return is_checkbox_icon_checked($(this));
+    });
+    const $select_drafts_button = $(".select-drafts-button");
+    const $select_state_indicator = $(".select-drafts-button .select-state-indicator");
+    const $delete_selected_drafts_button = $(".delete-selected-drafts-button");
+
+    if ($checked_checkboxes.length > 0) {
+        $delete_selected_drafts_button.prop("disabled", false);
+        if ($unchecked_checkboxes.length === 0) {
+            toggle_checkbox_icon_state($select_state_indicator, true);
+        } else {
+            toggle_checkbox_icon_state($select_state_indicator, false);
+        }
+    } else {
+        if ($unchecked_checkboxes.length > 0) {
+            toggle_checkbox_icon_state($select_state_indicator, false);
+            $delete_selected_drafts_button.prop("disabled", true);
+        } else {
+            $select_drafts_button.hide();
+            $delete_selected_drafts_button.hide();
+        }
+    }
+}
+
 function open_overlay() {
     sync_count();
     overlays.open_overlay({
@@ -670,6 +729,19 @@ function open_overlay() {
             sync_count();
         },
     });
+}
+
+function is_checkbox_icon_checked($checkbox) {
+    return $checkbox.hasClass("fa-check-square");
+}
+
+function toggle_checkbox_icon_state($checkbox, checked) {
+    $checkbox.parent().attr("aria-checked", checked);
+    if (checked) {
+        $checkbox.removeClass("fa-square-o").addClass("fa-check-square");
+    } else {
+        $checkbox.removeClass("fa-check-square").addClass("fa-square-o");
+    }
 }
 
 export function initialize() {

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -424,12 +424,12 @@ function remove_draft($draft_row) {
 
     $draft_row.remove();
 
-    if ($("#drafts_table .draft-row").length === 0) {
+    if ($("#drafts_table .overlay-message-row").length === 0) {
         $("#drafts_table .no-drafts").show();
     }
     update_rendered_drafts(
-        $("#drafts-from-conversation .draft-row").length > 0,
-        $("#other-drafts .draft-row").length > 0,
+        $("#drafts-from-conversation .overlay-message-row").length > 0,
+        $("#other-drafts .overlay-message-row").length > 0,
     );
 }
 
@@ -548,8 +548,8 @@ const keyboard_handling_context = {
     },
     items_container_selector: "drafts-container",
     items_list_selector: "drafts-list",
-    row_item_selector: "draft-row",
-    box_item_selector: "draft-info-box",
+    row_item_selector: "overlay-message-row",
+    box_item_selector: "overlay-message-info-box",
     id_attribute_name: "data-draft-id",
 };
 
@@ -603,11 +603,11 @@ export function launch() {
         });
         const $drafts_table = $("#drafts_table");
         $drafts_table.append(rendered);
-        if ($("#drafts_table .draft-row").length > 0) {
+        if ($("#drafts_table .overlay-message-row").length > 0) {
             $("#drafts_table .no-drafts").hide();
             // Update possible dynamic elements.
             const $rendered_drafts = $drafts_table.find(
-                ".message_content.rendered_markdown.restore-draft",
+                ".message_content.rendered_markdown.restore-overlay-message",
             );
             $rendered_drafts.each(function () {
                 rendered_markdown.update_elements($(this));
@@ -617,23 +617,26 @@ export function launch() {
     }
 
     function setup_event_handlers() {
-        $(".restore-draft").on("click", function (e) {
+        $("#drafts_table .restore-overlay-message").on("click", function (e) {
             if (document.getSelection().type === "Range") {
                 return;
             }
 
             e.stopPropagation();
 
-            const $draft_row = $(this).closest(".draft-row");
+            const $draft_row = $(this).closest(".overlay-message-row");
             const $draft_id = $draft_row.data("draft-id");
             restore_draft($draft_id);
         });
 
-        $(".draft_controls .delete-draft").on("click", function () {
-            const $draft_row = $(this).closest(".draft-row");
+        $("#drafts_table .overlay_message_controls .delete-overlay-message").on(
+            "click",
+            function () {
+                const $draft_row = $(this).closest(".overlay-message-row");
 
-            remove_draft($draft_row);
-        });
+                remove_draft($draft_row);
+            },
+        );
     }
 
     const drafts = draft_model.get();
@@ -682,7 +685,7 @@ export function initialize() {
 
     set_count(Object.keys(draft_model.get()).length);
 
-    $("body").on("focus", ".draft-info-box", (e) => {
+    $("body").on("focus", "#drafts_table .overlay-message-info-box", (e) => {
         messages_overlay_ui.activate_element(e.target, keyboard_handling_context);
     });
 }

--- a/web/src/messages_overlay_ui.ts
+++ b/web/src/messages_overlay_ui.ts
@@ -89,7 +89,7 @@ function row_before_focus(context: Context): JQuery {
         $focused_row.parent().attr("id") === "other-drafts" &&
         $("#drafts-from-conversation").is(":visible")
     ) {
-        return $($("#drafts-from-conversation").children(".draft-row:visible").last());
+        return $($("#drafts-from-conversation").children(".overlay-message-row:visible").last());
     }
 
     return $prev_row;
@@ -106,7 +106,7 @@ function row_after_focus(context: Context): JQuery {
         $focused_row.parent().attr("id") === "drafts-from-conversation" &&
         $("#other-drafts").is(":visible")
     ) {
-        return $("#other-drafts").children(".draft-row:visible").first();
+        return $("#other-drafts").children(".overlay-message-row:visible").first();
     }
     return $next_row;
 }

--- a/web/src/rows.js
+++ b/web/src/rows.js
@@ -71,7 +71,7 @@ export function visible_range(start_id, end_id) {
 }
 
 export function is_draft_row($row) {
-    return $row.find(".restore-draft").length >= 1;
+    return $row.find("#drafts_table .restore-overlay-message").length >= 1;
 }
 
 export function id($message_row) {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -143,12 +143,45 @@ export function initialize() {
     // below specify the target directly, elements using those should
     // not have the tippy-zulip-tooltip class.
 
-    $("body").on("blur", ".message_control_button", (e) => {
-        // Remove tooltip when user is trying to tab through all the icons.
-        // If user tabs slowly, tooltips are displayed otherwise they are
-        // destroyed before they can be displayed.
-        e.currentTarget?._tippy?.destroy();
+    delegate("body", {
+        target: ".draft-selection-tooltip",
+        delay: LONG_HOVER_DELAY,
+        appendTo: () => document.body,
+        onShow(instance) {
+            let content = $t({defaultMessage: "Select draft"});
+            const $elem = $(instance.reference);
+            if ($($elem).parent().find(".draft-selection-checkbox").hasClass("fa-check-square")) {
+                content = $t({defaultMessage: "Deselect draft"});
+            }
+            instance.setContent(content);
+            return true;
+        },
     });
+
+    delegate("body", {
+        target: ".delete-selected-drafts-button-container",
+        appendTo: () => document.body,
+        onShow(instance) {
+            let content = $t({defaultMessage: "Delete all selected drafts"});
+            const $elem = $(instance.reference);
+            if ($($elem).find(".delete-selected-drafts-button").is(":disabled")) {
+                content = $t({defaultMessage: "No drafts selected"});
+            }
+            instance.setContent(content);
+            return true;
+        },
+    });
+
+    $("body").on(
+        "blur",
+        ".message_control_button, .delete-selected-drafts-button-container",
+        (e) => {
+            // Remove tooltip when user is trying to tab through all the icons.
+            // If user tabs slowly, tooltips are displayed otherwise they are
+            // destroyed before they can be displayed.
+            e.currentTarget?._tippy?.destroy();
+        },
+    );
 
     delegate("body", {
         target: [

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -973,7 +973,10 @@ div.overlay {
         }
 
         .overlay_message_controls {
-            display: inline-block;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
             font-size: 0.9em;
 
             [data-tippy-root] {
@@ -983,7 +986,6 @@ div.overlay {
 
             .restore-overlay-message {
                 cursor: pointer;
-                margin-right: 5px;
                 color: hsl(170deg 48% 54%);
                 opacity: 0.7;
 
@@ -994,7 +996,6 @@ div.overlay {
 
             .delete-overlay-message {
                 cursor: pointer;
-                margin-left: 5px;
                 color: hsl(357deg 52% 57%);
                 opacity: 0.7;
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -610,7 +610,7 @@
     #compose-content,
     .message_list .recipient_row,
     .message_row,
-    .draft-row .draft-info-box,
+    .overlay-message-row .overlay-message-info-box,
     .preview_message_area {
         border-color: hsl(0deg 0% 0% / 40%);
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -877,6 +877,10 @@
         }
     }
 
+    .drafts-container .header-body .delete-drafts-group > *:focus {
+        background-color: hsl(228deg 11% 17%);
+    }
+
     & thead,
     .drafts-container .drafts-header,
     .nav > li > a:focus,

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -1,87 +1,9 @@
 .drafts-container {
     .drafts-list {
-        .removed-drafts {
-            display: block;
-            text-align: center;
-            font-size: 1em;
-            color: hsl(0deg 0% 67%);
-            pointer-events: none;
-        }
-
         & h2 {
             font-size: 1.1em;
             line-height: normal;
             margin-bottom: 5px;
-        }
-    }
-}
-
-.draft-row {
-    padding: 5px 0;
-
-    > div {
-        display: inline-block;
-        vertical-align: top;
-    }
-
-    .draft-info-box {
-        width: 100%;
-        margin-bottom: 10px;
-
-        &.active {
-            outline: 2px solid hsl(215deg 47% 50%);
-            border-radius: 7px;
-        }
-
-        .message_row {
-            border-radius: 0 0 7px 7px;
-            border: 1px solid var(--color-message-list-border);
-            border-top: 0;
-        }
-
-        .messagebox {
-            cursor: auto;
-            box-shadow: none;
-            border-radius: 0 0 7px 7px;
-        }
-
-        .draft_controls {
-            display: inline-block;
-            font-size: 0.9em;
-
-            [data-tippy-root] {
-                width: max-content;
-                word-wrap: unset;
-            }
-
-            .restore-draft {
-                cursor: pointer;
-                margin-right: 5px;
-                color: hsl(170deg 48% 54%);
-                opacity: 0.7;
-
-                &:hover {
-                    opacity: 1;
-                }
-            }
-
-            .delete-draft {
-                cursor: pointer;
-                margin-left: 5px;
-                color: hsl(357deg 52% 57%);
-                opacity: 0.7;
-
-                &:hover {
-                    opacity: 1;
-                }
-            }
-        }
-
-        .message_header {
-            /* We don't need these effects applied for message list in the drafts overlay. */
-            box-shadow: none !important;
-            border: 0 !important;
-            background: transparent;
         }
     }
 }

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -6,7 +6,7 @@
         justify-content: space-between;
         gap: 5px;
 
-        .removed-drafts {
+        .removed-drafts-message {
             text-align: left;
             margin-left: 25px;
 

--- a/web/styles/drafts.css
+++ b/web/styles/drafts.css
@@ -1,9 +1,73 @@
 .drafts-container {
+    .header-body {
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+        justify-content: space-between;
+        gap: 5px;
+
+        .removed-drafts {
+            text-align: left;
+            margin-left: 25px;
+
+            @media (width < $lg_min) {
+                text-align: center;
+                margin-left: 0;
+            }
+        }
+
+        .delete-drafts-group {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+
+            .delete-selected-drafts-button {
+                &:focus {
+                    background-color: hsl(0deg 0% 93%);
+                }
+            }
+
+            .select-drafts-button {
+                display: flex;
+                align-items: center;
+                gap: 5px;
+                margin-right: 25px;
+                padding-left: 15px;
+                padding-right: 15px;
+
+                &:focus {
+                    background-color: hsl(0deg 0% 93%);
+                }
+            }
+
+            .select-state-indicator {
+                width: 15px;
+            }
+
+            @media (width < $lg_min) {
+                margin-top: 5px;
+                width: 100%;
+            }
+        }
+
+        @media (width < $lg_min) {
+            display: block;
+        }
+    }
+
     .drafts-list {
         & h2 {
             font-size: 1.1em;
             line-height: normal;
             margin-bottom: 5px;
         }
+    }
+
+    .draft-selection-checkbox {
+        margin-top: 5px;
+        /* Required to make sure that the checkbox icon stays inside
+           the grid. Any value greater than 13px (original width of
+           the checkbox icon) will work. */
+        width: 15px;
     }
 }

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -1,5 +1,5 @@
-<div class="draft-row overlay-message-row" data-draft-id="{{draft_id}}">
-    <div class="draft-info-box overlay-message-info-box" tabindex="0">
+<div class="overlay-message-row" data-draft-id="{{draft_id}}">
+    <div class="overlay-message-info-box" tabindex="0">
         {{#if is_stream}}
         <div class="message_header message_header_stream">
             <div class="message-header-contents" style="background: {{recipient_bar_color}};">
@@ -34,12 +34,12 @@
             <div class="messagebox">
                 <div class="messagebox-content">
                     <div class="message_top_line">
-                        <div class="draft_controls overlay_message_controls">
-                            <i class="fa fa-pencil fa-lg restore-draft restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-draft-tooltip-template"></i>
-                            <i class="fa fa-trash-o fa-lg delete-draft delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-draft-tooltip-template"></i>
+                        <div class="overlay_message_controls">
+                            <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-draft-tooltip-template"></i>
+                            <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-draft-tooltip-template"></i>
                         </div>
                     </div>
-                    <div class="message_content rendered_markdown restore-draft restore-overlay-message tippy-zulip-delayed-tooltip" data-tooltip-template-id="restore-draft-tooltip-template">{{rendered_markdown content}}</div>
+                    <div class="message_content rendered_markdown restore-overlay-message tippy-zulip-delayed-tooltip" data-tooltip-template-id="restore-draft-tooltip-template">{{rendered_markdown content}}</div>
                 </div>
             </div>
         </div>

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -36,7 +36,7 @@
                     <div class="message_top_line">
                         <div class="overlay_message_controls">
                             <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-draft-tooltip-template"></i>
-                            <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-draft-tooltip-template"></i>
+                            <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-delayed-tooltip" aria-hidden="true" data-tooltip-template-id="delete-draft-tooltip-template"></i>
                             <div class="draft-selection-tooltip">
                                 <i class="fa fa-square-o fa-lg draft-selection-checkbox" aria-hidden="true"></i>
                             </div>

--- a/web/templates/draft.hbs
+++ b/web/templates/draft.hbs
@@ -37,6 +37,9 @@
                         <div class="overlay_message_controls">
                             <i class="fa fa-pencil fa-lg restore-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="restore-draft-tooltip-template"></i>
                             <i class="fa fa-trash-o fa-lg delete-overlay-message tippy-zulip-tooltip" aria-hidden="true" data-tooltip-template-id="delete-draft-tooltip-template"></i>
+                            <div class="draft-selection-tooltip">
+                                <i class="fa fa-square-o fa-lg draft-selection-checkbox" aria-hidden="true"></i>
+                            </div>
                         </div>
                     </div>
                     <div class="message_content rendered_markdown restore-overlay-message tippy-zulip-delayed-tooltip" data-tooltip-template-id="restore-draft-tooltip-template">{{rendered_markdown content}}</div>

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -7,7 +7,7 @@
                     <span class="exit-sign">&times;</span>
                 </div>
                 <div class="header-body">
-                    <div class="removed-drafts">
+                    <div class="removed-drafts-message">
                         {{t "Drafts are not synced to other devices and browsers." }}
                         <br />
                         {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}

--- a/web/templates/draft_table_body.hbs
+++ b/web/templates/draft_table_body.hbs
@@ -6,10 +6,23 @@
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
-                <div class="removed-drafts">
-                    {{t "Drafts are not synced to other devices and browsers." }}
-                    <br />
-                    {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
+                <div class="header-body">
+                    <div class="removed-drafts">
+                        {{t "Drafts are not synced to other devices and browsers." }}
+                        <br />
+                        {{#tr}}Drafts older than <strong>{draft_lifetime}</strong> days are automatically removed.{{/tr}}
+                    </div>
+                    <div class="delete-drafts-group">
+                        <div class="delete-selected-drafts-button-container">
+                            <button class="button small rounded delete-selected-drafts-button" type="button" disabled>
+                                <i class="fa fa-trash-o fa-lg" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                        <button class="button small rounded select-drafts-button" role="checkbox" aria-checked="false">
+                            <span>{{t "Select all drafts" }}</span>
+                            <i class="fa fa-square-o fa-lg select-state-indicator" aria-hidden="true"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div class="drafts-list overlay-messages-list">

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -616,11 +616,11 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
-    $.create("#drafts_table .draft-row", {children: []});
+    $.create("#drafts_table .overlay-message-row", {children: []});
     drafts.launch();
 
     $.clear_all_elements();
-    $.create("#drafts_table .draft-row", {children: []});
+    $.create("#drafts_table .overlay-message-row", {children: []});
     $("#draft_overlay").css = () => {};
 
     sub_store.get = function (stream_id) {
@@ -775,6 +775,6 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     compose_state.set_message_type("private");
     compose_state.private_message_recipient(aaron.email);
 
-    $.create("#drafts_table .draft-row", {children: []});
+    $.create("#drafts_table .overlay-message-row", {children: []});
     drafts.launch();
 });

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -617,6 +617,7 @@ test("format_drafts", ({override_rewire, mock_template}) => {
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     $.create("#drafts_table .overlay-message-row", {children: []});
+    $(".draft-selection-checkbox").filter = () => [];
     drafts.launch();
 
     $.clear_all_elements();
@@ -632,6 +633,7 @@ test("format_drafts", ({override_rewire, mock_template}) => {
 
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
+    $(".draft-selection-checkbox").filter = () => [];
     drafts.launch();
 });
 
@@ -776,5 +778,6 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     compose_state.private_message_recipient(aaron.email);
 
     $.create("#drafts_table .overlay-message-row", {children: []});
+    $(".draft-selection-checkbox").filter = () => [];
     drafts.launch();
 });


### PR DESCRIPTION
This PR adds functionality to bulk delete drafts quickly.

Special thanks to @juliaBichler01 for working on this one at #19943.

Fixes #19360.

- The `Select All Drafts` checkbox doesn't align with other checkboxes if a scrollbar is present on the drafts window. That can be fixed by using a function like this:
```
function adjust_select_drafts_button() {
    const $drafts_list = $(".drafts-list");
    const scroll_bar_width = $drafts_list[0].offsetWidth - $drafts_list[0].clientWidth;
    $(".select-drafts-button").css("margin-right", 25 + scroll_bar_width + "px");
}
```
But I am unsure if that's the best way to do it.

- I am not sure if I need to add any node/puppeteer tests for this one.


<hr>

**Light Theme:**
<details>
<summary>Delete All Drafts</summary>


![Delete All Drafts](https://github.com/zulip/zulip/assets/35286603/8e2dc559-a23e-4459-9d04-165132daa1df)



</details>

<details>
<summary>Delete Some Drafts</summary>

![Delete Some Messages](https://github.com/zulip/zulip/assets/35286603/e947b719-1bd8-4b91-87fa-92b558120e66)


</details>

<details> 
<summary>Phone View</summary>

![Screenshot from 2023-06-14 02-46-12](https://github.com/zulip/zulip/assets/35286603/8f49fed9-39a3-452a-beee-94743c3824de)


</details>



**Dark Theme:**
<details>
<summary>Delete All Drafts</summary>


![Delete All Drafts - Dark](https://github.com/zulip/zulip/assets/35286603/1708ec13-b9fd-4a3e-a937-0382ad2e12ed)




</details>

<details>
<summary>Delete Some Drafts</summary>
 

![Delete Some Messages - Dark (1)](https://github.com/zulip/zulip/assets/35286603/c57a8b32-f391-452d-9635-2a18a5feb76e)

 
</details>


<hr>

- The PR originally didn't make use of flexboxes due to which various values were hard-coded which affected the responsiveness of the module, so made use of flexboxes wherever possible.
- Also, made some small changes to the spacing and margins to make the whole thing more nicer.
- Replaced the checkbox used in the `Select all drafts` button to the one which is being used in all the Drafts to select them.
- I have removed the `node-tests` because I am unsure if they are required or not.

<hr>


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
