### PR TITLE
support: Add option to delete user from /activity/support.

### DIFF
--- a/analytics/tests/test_support_views.py
+++ b/analytics/tests/test_support_views.py
@@ -249,6 +249,12 @@ class TestSupportEndpoint(ZulipTestCase):
         check_hamlet_user_query_result(result)
         check_zulip_realm_query_result(result)
 
+        # Search should be case-insensitive:
+        assert self.example_email("hamlet") != self.example_email("hamlet").upper()
+        result = get_check_query_result(self.example_email("hamlet").upper(), 1)
+        check_hamlet_user_query_result(result)
+        check_zulip_realm_query_result(result)
+
         result = get_check_query_result(lear_user.email, 1)
         check_lear_user_query_result(result)
         check_lear_realm_query_result(result)

--- a/analytics/views/support.py
+++ b/analytics/views/support.py
@@ -9,6 +9,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
+from django.db.models import Q
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -289,7 +290,10 @@ def support(
     if query:
         key_words = get_invitee_emails_set(query)
 
-        users = set(UserProfile.objects.filter(delivery_email__in=key_words))
+        case_insensitive_users_q = Q()
+        for key_word in key_words:
+            case_insensitive_users_q |= Q(delivery_email__iexact=key_word)
+        users = set(UserProfile.objects.filter(case_insensitive_users_q))
         realms = set(Realm.objects.filter(string_id__in=key_words))
 
         for key_word in key_words:

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -41,6 +41,12 @@
             <b>Date joined</b>: {{ user.date_joined|timesince }} ago<br />
             <b>Is active</b>: {{ user.is_active }}<br />
             <b>Role</b>: {{ user.get_role_name() }}<br />
+            <form method="POST" class="delete-user-form">
+                {{ csrf_input }}
+                <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+                <input type="hidden" name="delete_user_by_id" value="{{ user.id }}" />
+                <button data-email="{{ user.delivery_email }}" data-string-id="{{ realm.string_id }}" class="btn btn-danger small delete-user-button">Delete user (danger)</button>
+            </form>
             <hr />
             <div>
                 {% include "analytics/realm_details.html" %}

--- a/web/src/analytics/support.ts
+++ b/web/src/analytics/support.ts
@@ -18,6 +18,31 @@ $(() => {
         }
     });
 
+    $("body").on("click", ".delete-user-button", function (e) {
+        e.preventDefault();
+        const message =
+            "Confirm the email of the user you want to delete.\n\n WARNING! This action is irreversible!";
+        const actual_email = $(this).attr("data-email");
+        // eslint-disable-next-line no-alert
+        const confirmed_email = window.prompt(message);
+        if (confirmed_email === actual_email) {
+            const actual_string_id = $(this).attr("data-string-id");
+            // eslint-disable-next-line no-alert
+            const confirmed_string_id = window.prompt(
+                "Now provide string_id of the realm to confirm.",
+            );
+            if (confirmed_string_id === actual_string_id) {
+                this.form.submit();
+            } else {
+                // eslint-disable-next-line no-alert
+                window.alert("The string_id you entered is not correct. Aborted.");
+            }
+        } else {
+            // eslint-disable-next-line no-alert
+            window.alert("The email you entered is not correct. Aborted.");
+        }
+    });
+
     $("a.copy-button").on("click", function () {
         common.copy_data_attribute_value($(this), "copytext");
     });


### PR DESCRIPTION
Mimics the implementation of "scrub realm" for /activity/support

Uses a double prompt popup to confirm both email and realm to avoid accidental deletion of a user in a different organization than supposed to :neutral_face: 

Video:
[Screencast from 2023-05-15 23-42-05.webm](https://github.com/zulip/zulip/assets/45007152/3adb8e6f-0d49-4bf6-8937-088ec450297e)
