### PR TITLE
help: Update "Restrict stream invitation" page.

### DIFF
--- a/help/add-or-remove-users-from-a-stream.md
+++ b/help/add-or-remove-users-from-a-stream.md
@@ -1,15 +1,16 @@
 # Add or remove users from a stream
 
-## Add users to a stream
-
 By default, anyone (other than guests) subscribed to a stream can add
 users to that stream. Additionally, anyone (other than guests) can add
 users to a public stream, whether or not they are subscribed to the
-stream.
+stream. Anyone can always [unsubscribe themselves from a stream](/help/unsubscribe-from-a-stream).
 
-Organization administrators can configure which
+Organization administrators can also unsubscribe *other* users from any stream,
+including streams the admin is not subscribed to. They can also configure which
 [roles](/help/roles-and-permissions) have access to [add other users
 to a stream][configure-invites].
+
+## Add users to a stream
 
 {start_tabs}
 
@@ -49,13 +50,6 @@ subscribe the user.
       the user to be subscribed this way.
 
 ## Remove users from a stream
-
-{!admin-only.md!}
-
-Anyone can always [unsubscribe themselves from a stream](/help/unsubscribe-from-a-stream).
-
-Organization administrators can also unsubscribe *other* users from any stream,
-including streams the admin is not subscribed to.
 
 {start_tabs}
 

--- a/help/add-or-remove-users-from-a-stream.md
+++ b/help/add-or-remove-users-from-a-stream.md
@@ -7,8 +7,11 @@ stream. Anyone can always [unsubscribe themselves from a stream](/help/unsubscri
 
 Organization administrators can also unsubscribe *other* users from any stream,
 including streams the admin is not subscribed to. They can also configure which
-[roles](/help/roles-and-permissions) have access to [add other users
-to a stream][configure-invites].
+[roles](/help/roles-and-permissions) have access to [add other users to a
+stream][add-users] or [remove other users from a stream][remove-users].
+
+[add-users]: /help/configure-who-can-invite-to-streams#configure-who-can-add-users
+[remove-users]: /help/configure-who-can-invite-to-streams#configure-who-can-remove-users
 
 ## Add users to a stream
 
@@ -65,8 +68,6 @@ subscribe the user.
 
 {end_tabs}
 
-[configure-invites]: /help/configure-who-can-invite-to-streams
-
 ### From a user's profile (alternate method)
 
 This method is useful if you need to remove one user from multiple streams.
@@ -81,29 +82,6 @@ This method is useful if you need to remove one user from multiple streams.
    to remove the user from.
 
 1. Click the **Unsubscribe** button in that row.
-
-{end_tabs}
-
-## Configure who can remove users
-
-{!admin-only.md!}
-
-Organization administrators can configure who can remove other users from a
-public stream. For private streams, administrators must be subscribed to the
-stream to configure this setting.
-
-{start_tabs}
-
-{relative|stream|all}
-
-1. Select a stream.
-
-{!select-stream-view-general.md!}
-
-1. Under **Stream permissions**, configure
-   **Who can unsubscribe others from this stream?**
-
-{!save-changes.md!}
 
 {end_tabs}
 

--- a/help/configure-who-can-invite-to-streams.md
+++ b/help/configure-who-can-invite-to-streams.md
@@ -1,18 +1,37 @@
-# Restrict stream invitation
+# Restrict stream membership management
 
 {!admin-only.md!}
 
 By default, anyone other than guests can add other users to streams. However,
 you can restrict the ability to do so to specific
-[roles](/help/roles-and-permissions).
+[roles](/help/roles-and-permissions). You can also can configure who can remove
+other users from a public stream. For private streams, administrators must be
+subscribed to the stream to configure these settings.
 
-### Manage who can add users to streams
+## Configure who can add users
 
 {start_tabs}
 
 {settings_tab|organization-permissions}
 
-2. Under **Stream permissions**, configure **Who can add users to streams**.
+1. Under **Stream permissions**, configure **Who can add users to streams**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+## Configure who can remove users
+
+{start_tabs}
+
+{relative|stream|all}
+
+1. Select a stream.
+
+{!select-stream-view-general.md!}
+
+1. Under **Stream permissions**, configure
+   **Who can unsubscribe others from this stream?**
 
 {!save-changes.md!}
 

--- a/help/create-a-stream.md
+++ b/help/create-a-stream.md
@@ -44,7 +44,7 @@ There are several parameters you can set while creating a stream. All but
 * **Who can post to the stream?**: See [Stream permissions](/help/stream-permissions).
 
 * **Who can unsubscribe others from this stream?**: See
-  [Add or remove users from a stream](/help/add-or-remove-users-from-a-stream#configure-who-can-remove-users).
+  [Restrict stream membership management](/help/configure-who-can-invite-to-streams#configure-who-can-remove-users).
 
 * **Message retention period**: See
   [Message retention policy](/help/message-retention-policy#configure-message-retention-policy-for-individual-streams).

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -186,7 +186,7 @@
 * [Public access option](/help/public-access-option)
 * [Stream posting policy](/help/stream-sending-policy)
 * [Restrict stream creation](/help/configure-who-can-create-streams)
-* [Restrict stream invitation](/help/configure-who-can-invite-to-streams)
+* [Restrict stream membership management](/help/configure-who-can-invite-to-streams)
 * [Add or remove users from a stream](/help/add-or-remove-users-from-a-stream)
 * [Set default streams for new users](/help/set-default-streams-for-new-users)
 * [Rename a stream](/help/rename-a-stream)

--- a/help/stream-permissions.md
+++ b/help/stream-permissions.md
@@ -64,7 +64,7 @@ administrator can access private stream messages:
 | View stream name      | &#10004;          | &#10004;   | &#10004;  | &#9726;
 | Join                  | &#10004;          | &#10004;   | &#10004;  |
 | Unsubscribe           | &#9726;           | &#9726;    | &#9726;   | &#9726;
-| Add others            | &#10004;          | &#10004;   | &#10004;  |
+| Add others            | &#10004;          | &#10038;   | &#10038;  |
 | Remove others         | &#10004;          | &#10038;   | &#10038;  | &#10038;
 | See subscriber list   | &#10004;          | &#10004;   | &#10004;  | &#9726;
 | See full history      | &#10004;          | &#10004;   | &#10004;  | &#9726;
@@ -80,8 +80,9 @@ administrator can access private stream messages:
 <span class="legend_symbol">&#9726;</span><span class="legend_label">If subscribed to the stream</span>
 
 <span class="legend_symbol">&#10038;</span><span class="legend_label">
-Configurable. See [Stream posting policy](/help/stream-sending-policy) and
-[Configure who can remove users](/help/add-or-remove-users-from-a-stream#configure-who-can-remove-users)
+Configurable. See [Stream posting policy](/help/stream-sending-policy),
+[Configure who can add users][add-users], and
+[Configure who can remove users][remove-users]
 for details.
 </span>
 
@@ -93,7 +94,7 @@ for details.
 | View stream name      | &#10004;          | &#9726;    | &#9726;   | &#9726;
 | Join                  |                   |            |           |
 | Unsubscribe           | &#9726;           | &#9726;    | &#9726;   | &#9726;
-| Add others            | &#9726;           | &#9726;    | &#9726;   |
+| Add others            | &#9726;           | &#10038;   | &#10038;  |
 | Remove others         | &#10004;          | &#10038;   | &#10038;  | &#10038;
 | See subscriber list   | &#10004;          | &#9726;    | &#9726;   | &#9726;
 | See full history      | &#10038;          | &#10038;   | &#10038;  | &#10038;
@@ -110,8 +111,9 @@ for details.
 
 <span class="legend_symbol">&#10038;</span><span class="legend_label">
 Configurable, but at minimum must be subscribed to the stream.
-See [Stream posting policy](/help/stream-sending-policy) and
-[Configure who can remove users](/help/add-or-remove-users-from-a-stream#configure-who-can-remove-users)
+See [Stream posting policy](/help/stream-sending-policy),
+[Configure who can add users][add-users], and
+[Configure who can remove users][remove-users]
 for details.
 </span>
 
@@ -120,3 +122,6 @@ for details.
 * [Roles and permissions](/help/roles-and-permissions)
 * [Stream sending policy](/help/stream-sending-policy)
 * [Web-public streams](/help/public-access-option)
+
+[add-users]: /help/configure-who-can-invite-to-streams#configure-who-can-add-users
+[remove-users]: /help/configure-who-can-invite-to-streams#configure-who-can-remove-users


### PR DESCRIPTION
- Renames [Restrict stream invitation](https://zulip.com/help/configure-who-can-invite-to-streams) page title.
- Renames section about "Who can add users to streams" setting.
- Adds new section "Configure who can remove users" from [help/add-or-remove-users-from-a-stream](https://zulip.com/help/add-or-remove-users-from-a-stream).
- Updates "Add others" in [help/stream-permissions](https://zulip.com/help/stream-permissions) tables.
- Consolidates all the references to permissions on https://zulip.com/help/add-or-remove-users-from-a-stream to an intro section about what's possible, with a link to the newly updated "Restrict stream membership management" page.

Fixes #25264.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/2343554/7190137e-18d8-45c1-9287-3a59329ad81d)

![image](https://github.com/zulip/zulip/assets/2343554/51b24286-e88d-487e-afb0-b46bce0da676)

![image](https://github.com/zulip/zulip/assets/2343554/7c8ebb75-fde4-4a4a-9a1c-2a32d98d03f2)

![image](https://github.com/zulip/zulip/assets/2343554/26fbc473-bf48-425c-be0a-cac5097701c4)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>