### PR TITLE
help: Restructure /help/mute-a-topic.

### DIFF
--- a/help/include/mute-unmute-intro.md
+++ b/help/include/mute-unmute-intro.md
@@ -9,14 +9,15 @@ Muting has the following effects:
   word](/help/dm-mention-alert-notifications#alert-words) notifications), unless
   you are [mentioned](/help/mention-a-user-or-group).
 - Messages in muted topics do not appear in the [**All messages**
-  view](/help/all-messages).
+  view](/help/all-messages) or the mobile **Inbox** view.
 - Muted topics appear in the [**Recent conversations**
   view](/help/recent-conversations) only if the **Include muted** filter is
   enabled.
 - Unread messages in muted topics do not contribute to stream unread counts.
-- In the left sidebar, muted topics and streams are grayed out. They are also
-  sorted to the bottom of their stream (for topics) or stream section (for
-  streams).
+- Muted topics and streams are grayed out in the left sidebar of the desktop/web
+  app, and in the mobile app.
+- In the desktop/web app, muted topics are sorted to the bottom of their stream,
+  and muted streams are sorted to the bottom of their stream section.
 
 !!! warn ""
 

--- a/help/mute-a-topic.md
+++ b/help/mute-a-topic.md
@@ -2,7 +2,7 @@
 
 {!mute-unmute-intro.md!}
 
-## Mute a topic
+## Configure topic notifications in unmuted streams
 
 {start_tabs}
 
@@ -10,7 +10,7 @@
 
 {!topic-actions.md!}
 
-1. Select **Mute topic**.
+1. Select **Mute topic** or **Unmute topic**.
 
 !!! tip ""
 
@@ -21,13 +21,13 @@
 
 {!topic-long-press-menu.md!}
 
-1. Tap **Mute topic**.
+1. Tap **Mute topic** or **Unmute topic**.
 
 {!topic-long-press-menu-tip.md!}
 
 {end_tabs}
 
-## Unmute a topic
+## Configure topic notifications in muted streams
 
 {start_tabs}
 
@@ -35,7 +35,7 @@
 
 {!topic-actions.md!}
 
-1. Select **Unmute topic**.
+1. Select **Unmute topic** or **Mute topic**.
 
 !!! tip ""
 
@@ -44,9 +44,19 @@
 
 {tab|mobile}
 
+1. Tap the **Streams**
+   (<img src="/static/images/help/mobile-hash-icon.svg" alt="hash" class="mobile-icon"/>)
+   tab at the bottom of the app.
+
+1. Select a grayed-out (muted) stream from the streams list.
+
+1. Tap the **Topics list**
+   (<img src="/static/images/help/mobile-list-icon.svg" alt="list" class="mobile-icon"/>)
+   icon in the upper right corner of the app.
+
 {!topic-long-press-menu.md!}
 
-1. Tap **Unmute topic**.
+1. Tap **Unmute topic** or **Mute topic**.
 
 {!topic-long-press-menu-tip.md!}
 


### PR DESCRIPTION
- Create separate sections for muted vs. unmuted streams.
- Combine instructions for muting/unmuting topics.

Feedback is appreciated on the difference between mobile instructions for unmuted vs. muted streams. I kept the more detailed instructions for muted streams that were suggested in #25591, because topics in muted streams are harder to find than in unmuted streams.


Fixes https://github.com/zulip/zulip/issues/25311.

Current page: https://zulip.com/help/mute-a-topic

The intro changes also affect https://zulip.com/help/mute-a-stream.

<details>

<summary>Screenshots</summary>

![Screen Shot 2023-05-15 at 4 57 09 PM](https://github.com/zulip/zulip/assets/2090066/018a13e5-98f6-406d-8bff-2207f3d868ef)

Desktop/web:
![Screen Shot 2023-05-15 at 4 57 26 PM](https://github.com/zulip/zulip/assets/2090066/5e9c569f-90f3-4141-9014-975bece90276)

Mobile:
![Screen Shot 2023-05-15 at 5 02 23 PM](https://github.com/zulip/zulip/assets/2090066/40792c4d-63f7-46ed-b4eb-431a674b081b)


</details>
