### PR TITLE
popovers: Improve "Add emoji reaction" three-dot menu option.

### DIFF
--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -94,7 +94,7 @@ export function get_actions_popover_content_context(message_id) {
 
     function is_add_reaction_icon_visible() {
         const $message_row = message_lists.current.get_row(message_id);
-        return $message_row.find(".message_controls.reaction_button").is(":visible");
+        return $message_row.find(".message_controls .reaction_button").is(":visible");
     }
 
     // Since we only display msg actions and star icons on windows smaller than

--- a/web/templates/actions_popover_content.hbs
+++ b/web/templates/actions_popover_content.hbs
@@ -45,7 +45,7 @@
     <li>
         <a class="reaction_button" data-message-id="{{message_id}}" tabindex="0">
             <i class="fa fa-smile-o" aria-hidden="true"></i>
-            {{t "Add emoji reaction" }}
+            {{t "Add emoji reaction" }} <span class="hotkey-hint">(:)</span>
         </a>
     </li>
     <hr />


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This pull request does two things:

1. Adds the `(:)` keyboard shortcut to the "Add emoji reaction" popover menu option.
2. Hides the "Add emoji reaction" menu item on the popover of other users' messages, as there is already a button to add an emoji on hover.

Fixes: #25602. <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Keyboard shortcut</summary>

![image](https://github.com/zulip/zulip/assets/30211715/1be31bd2-3265-4706-ac40-db8bf212e117)
</details>

<details>
<summary>Hide redundant "Add emoji reaction" menu item</summary>

_Own message_
![image](https://github.com/zulip/zulip/assets/30211715/1be31bd2-3265-4706-ac40-db8bf212e117)

_Another user's message_
![image](https://github.com/zulip/zulip/assets/30211715/f34bc1ce-2bea-4788-b17c-826d15906237)
</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
