### PR TITLE
muting: Replace JQuery fadeIn/fadeOut with native CSS transitions.

### DIFF
--- a/web/src/feedback_widget.ts
+++ b/web/src/feedback_widget.ts
@@ -64,7 +64,7 @@ const animate = {
         }
 
         if (meta.$container) {
-            meta.$container.fadeOut(500).removeClass("show");
+            meta.$container.removeClass("show");
             meta.opened = false;
             meta.alert_hover_state = false;
         }
@@ -75,7 +75,7 @@ const animate = {
         }
 
         if (meta.$container) {
-            meta.$container.fadeIn(500).addClass("show");
+            meta.$container.addClass("show");
             meta.opened = true;
             setTimeout(() => animate.maybe_close(), 100);
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -259,7 +259,7 @@ p.n-margin {
 }
 
 #feedback_container {
-    display: none;
+    opacity: 0;
     position: absolute;
     width: 400px;
     top: 0;
@@ -275,11 +275,15 @@ p.n-margin {
     animation-iteration-count: infinite;
     animation-duration: 2s;
 
-    transition-property: top, bottom;
+    transition-property: top, opacity, visibility;
     transition-duration: 0.5s;
 
+    visibility: hidden;
+
     &.show {
+        opacity: 1;
         top: 50px;
+        visibility: visible;
     }
 
     & h3 {


### PR DESCRIPTION
This commit resolves the issue of animation smoothness by replacing the fadeIn/fadeOut methods of jQuery with native CSS transitions. CSS transitions are generally faster and more efficient since they are built into the browser and do not require external libraries like jQuery.

Fixes: #25376.

<details>
<summary>Screen capture:</summary>
<br>

![2023-05-16 at 21 02 58 - Gold Dolphin](https://github.com/zulip/zulip/assets/53193850/79fcc4ea-2731-4459-a902-a1b316340998)

</details>