### PR TITLE
css: Allow `actions_hover` icon to have a focus outline.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1037,7 +1037,6 @@ td.pointer {
 
         .zulip-icon-ellipsis-v-solid {
             padding: 2px 5.33px;
-            outline: none;
         }
     }
 


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/no.20blue.20box.20on.20message.20menu

<img width="193" alt="Screenshot 2023-05-16 at 8 04 54 PM" src="https://github.com/zulip/zulip/assets/25124304/e02aa631-f66a-4d09-bf4e-bfb588380058">
