### PR TITLE
scheduled-messages: Add separate endpoint for editing existing scheduled messages.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,15 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 7.0
 
+**Feature level 184**
+
+* [`PATCH /scheduled_messages/<int:scheduled_message_id>`](/api/update-scheduled-message):
+  Added new endpoint for editing an existing scheduled message.
+* [`POST /scheduled_messages`](/api/create-scheduled-message):
+  Removed optional `scheduled_message_id` parameter, which had
+  been a previous way for clients to support editing an existing
+  scheduled message.
+
 **Feature level 183**
 
 * [`POST /register`](/api/register-queue): Removed the
@@ -56,7 +65,7 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 179**
 
-* [`POST /scheduled_messages`](/api/create-or-update-scheduled-message):
+* [`POST /scheduled_messages`](/api/create-scheduled-message):
   Added new endpoint to create and edit scheduled messages.
 * [`GET /events`](/api/get-events):
   Added `scheduled_messages` events sent to clients when a user creates,

--- a/api_docs/create-scheduled-message.md
+++ b/api_docs/create-scheduled-message.md
@@ -17,35 +17,17 @@ curl -X POST {{ api_url }}/v1/scheduled_messages \
     --data-urlencode type=stream \
     --data-urlencode to=9 \
     --data-urlencode topic=Hello \
-    --data-urlencode 'content=Thank you for' \
+    --data-urlencode 'content=Nice to meet everyone!' \
     --data-urlencode scheduled_delivery_timestamp=3165826990
-
-# Update a scheduled stream message
-curl -X POST {{ api_url }}/v1/scheduled_messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
-    --data-urlencode type=stream \
-    --data-urlencode to=9 \
-    --data-urlencode 'topic=Welcome aboard' \
-    --data-urlencode 'content=Thank you for the help!' \
-    --data-urlencode scheduled_delivery_timestamp=3165856990 \
-    --data-urlencode scheduled_message_id=1
 
 # Create a scheduled direct message
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     --data-urlencode type=direct \
     --data-urlencode 'to=[9, 10]' \
-    --data-urlencode 'content=Can we meet tomorrow?' \
+    --data-urlencode 'content=Can we meet on Monday?' \
     --data-urlencode scheduled_delivery_timestamp=3165826990
 
-# Update a scheduled direct message
-curl -X POST {{ api_url }}/v1/messages \
-    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
-    --data-urlencode type=direct \
-    --data-urlencode 'to=[9, 10, 11]' \
-    --data-urlencode 'content=Can we meet tomorrow?' \
-    --data-urlencode scheduled_delivery_timestamp=3165856990 \
-    --data-urlencode scheduled_message_id=2
 ```
 
 {end_tabs}

--- a/api_docs/include/rest-endpoints.md
+++ b/api_docs/include/rest-endpoints.md
@@ -20,7 +20,8 @@
 #### Scheduled messages
 
 * [Get scheduled messages](/api/get-scheduled-messages)
-* [Create or edit a scheduled message](/api/create-or-update-scheduled-message)
+* [Create a scheduled message](/api/create-scheduled-message)
+* [Edit a scheduled message](/api/update-scheduled-message)
 * [Delete a scheduled message](/api/delete-scheduled-message)
 
 #### Drafts

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.4.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 183
+API_FEATURE_LEVEL = 184
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -17,14 +17,16 @@ from zerver.actions.message_send import (
 from zerver.actions.uploads import check_attachment_reference_change, do_claim_attachments
 from zerver.lib.addressee import Addressee
 from zerver.lib.exceptions import JsonableError, RealmDeactivatedError, UserDeactivatedError
-from zerver.lib.message import SendMessageRequest, render_markdown
+from zerver.lib.message import SendMessageRequest, render_markdown, truncate_topic
 from zerver.lib.scheduled_messages import access_scheduled_message
+from zerver.lib.string_validation import check_stream_topic
 from zerver.models import (
     Client,
     Realm,
     ScheduledMessage,
     Subscription,
     UserProfile,
+    get_recipient_ids,
     get_system_bot,
 )
 from zerver.tornado.django_api import send_event
@@ -141,8 +143,16 @@ def notify_update_scheduled_message(
 
 
 def edit_scheduled_message(
-    scheduled_message_id: int, send_request: SendMessageRequest, sender: UserProfile
-) -> int:
+    sender: UserProfile,
+    client: Client,
+    scheduled_message_id: int,
+    recipient_type_name: Optional[str],
+    message_to: Optional[str],
+    topic_name: Optional[str],
+    message_content: Optional[str],
+    deliver_at: Optional[datetime.datetime],
+    realm: Realm,
+) -> None:
     with transaction.atomic():
         scheduled_message_object = access_scheduled_message(sender, scheduled_message_id)
 
@@ -150,23 +160,93 @@ def edit_scheduled_message(
         if scheduled_message_object.delivered is True:
             raise JsonableError(_("Scheduled message was already sent"))
 
-        # Only override fields that user can change.
-        scheduled_message_object.recipient = send_request.message.recipient
-        topic_name = send_request.message.topic_name()
-        scheduled_message_object.set_topic_name(topic_name=topic_name)
-        rendering_result = render_markdown(
-            send_request.message, send_request.message.content, send_request.realm
-        )
-        scheduled_message_object.content = send_request.message.content
-        scheduled_message_object.rendered_content = rendering_result.rendered_content
-        scheduled_message_object.sending_client = send_request.message.sending_client
-        scheduled_message_object.stream = send_request.stream
-        assert send_request.deliver_at is not None
-        scheduled_message_object.scheduled_timestamp = send_request.deliver_at
+        # If the server failed to send the scheduled message, a new scheduled
+        # delivery timestamp (`deliver_at`) is required.
+        if scheduled_message_object.failed and deliver_at is None:
+            raise JsonableError(_("Scheduled delivery time must be in the future."))
 
-        scheduled_message_object.has_attachment = check_attachment_reference_change(
-            scheduled_message_object, rendering_result
+        # Get existing scheduled message's recipient IDs and recipient_type_name.
+        existing_recipient, existing_recipient_type_name = get_recipient_ids(
+            scheduled_message_object.recipient, sender.id
         )
+
+        # If any recipient information or message content has been updated,
+        # we check the message again.
+        if recipient_type_name is not None or message_to is not None or message_content is not None:
+            # Update message type if changed.
+            if recipient_type_name is not None:
+                updated_recipient_type_name = recipient_type_name
+            else:
+                updated_recipient_type_name = existing_recipient_type_name
+
+            # Update message recipient if changed.
+            if message_to is not None:
+                if updated_recipient_type_name == "stream":
+                    updated_recipient = extract_stream_id(message_to)
+                else:
+                    updated_recipient = extract_direct_message_recipient_ids(message_to)
+            else:
+                updated_recipient = existing_recipient
+
+            # Update topic name if changed.
+            if topic_name is not None:
+                updated_topic = topic_name
+            else:
+                # This will be ignored in Addressee.legacy_build if type
+                # is being changed from stream to direct.
+                updated_topic = scheduled_message_object.topic_name()
+
+            # Update message content if changed.
+            if message_content is not None:
+                updated_content = message_content
+            else:
+                updated_content = scheduled_message_object.content
+
+            # Check message again.
+            addressee = Addressee.legacy_build(
+                sender, updated_recipient_type_name, updated_recipient, updated_topic
+            )
+            send_request = check_message(
+                sender,
+                client,
+                addressee,
+                updated_content,
+                realm=realm,
+                forwarder_user_profile=sender,
+            )
+
+        if recipient_type_name is not None or message_to is not None:
+            # User has updated the scheduled message's recipient.
+            scheduled_message_object.recipient = send_request.message.recipient
+            scheduled_message_object.stream = send_request.stream
+            # Update the topic based on the new recipient information.
+            new_topic_name = send_request.message.topic_name()
+            scheduled_message_object.set_topic_name(topic_name=new_topic_name)
+        elif topic_name is not None and existing_recipient_type_name == "stream":
+            # User has updated the scheduled message's topic, but not
+            # the existing recipient information. We ignore topics sent
+            # for scheduled direct messages.
+            check_stream_topic(topic_name)
+            new_topic_name = truncate_topic(topic_name)
+            scheduled_message_object.set_topic_name(topic_name=new_topic_name)
+
+        if message_content is not None:
+            # User has updated the scheduled messages's content.
+            rendering_result = render_markdown(
+                send_request.message, send_request.message.content, send_request.realm
+            )
+            scheduled_message_object.content = send_request.message.content
+            scheduled_message_object.rendered_content = rendering_result.rendered_content
+            scheduled_message_object.has_attachment = check_attachment_reference_change(
+                scheduled_message_object, rendering_result
+            )
+
+        if deliver_at is not None:
+            # User has updated the scheduled message's send timestamp.
+            scheduled_message_object.scheduled_timestamp = deliver_at
+
+        # Update for most recent Client information.
+        scheduled_message_object.sending_client = client
 
         # If the user is editing a scheduled message that the server tried
         # and failed to send, we need to update the `failed` boolean field
@@ -178,7 +258,6 @@ def edit_scheduled_message(
         scheduled_message_object.save()
 
     notify_update_scheduled_message(sender, scheduled_message_object)
-    return scheduled_message_id
 
 
 def notify_remove_scheduled_message(user_profile: UserProfile, scheduled_message_id: int) -> None:

--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -64,7 +64,6 @@ def check_schedule_message(
     message_to: List[int],
     topic_name: Optional[str],
     message_content: str,
-    scheduled_message_id: Optional[int],
     deliver_at: datetime.datetime,
     realm: Optional[Realm] = None,
     forwarder_user_profile: Optional[UserProfile] = None,
@@ -79,9 +78,6 @@ def check_schedule_message(
         forwarder_user_profile=forwarder_user_profile,
     )
     send_request.deliver_at = deliver_at
-
-    if scheduled_message_id is not None:
-        return edit_scheduled_message(scheduled_message_id, send_request, sender)
 
     return do_schedule_messages([send_request], sender)[0]
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5162,19 +5162,18 @@ paths:
                           ],
                       }
     post:
-      operationId: create-or-update-scheduled-message
+      operationId: create-scheduled-message
       tags: ["scheduled_messages"]
-      summary: Create or edit scheduled message
+      summary: Create a scheduled message
       description: |
-        Create a new scheduled message or edit an existing scheduled message.
+        Create a new [scheduled message](/help/schedule-a-message).
 
-        The `scheduled_message_id` parameter determines whether a scheduled
-        message is created or updated. When it is omitted, a new scheduled
-        message is created. When it is specified, the existing scheduled
-        message with that unique ID is updated for the values passed to the
-        other endpoint parameters.
+        **Changes**: In Zulip 7.0 (feature level 184), moved support for
+        [editing a scheduled message](/api/update-scheduled-message) to a
+        separate API endpoint, which removed the `scheduled_message_id`
+        parameter from this endpoint.
 
-        **Changes**: New in Zulip 7.0 (feature level 179).
+        New in Zulip 7.0 (feature level 179).
       parameters:
         - name: type
           in: query
@@ -5228,16 +5227,6 @@ paths:
             type: string
           example: Castle
           allowEmptyValue: true
-        - name: scheduled_message_id
-          in: query
-          schema:
-            type: integer
-          description: |
-            The unique ID of the scheduled message to be updated.
-
-            If omitted, a new scheduled message will be created. Otherwise,
-            the existing scheduled message with this unique ID will be updated.
-          example: 1
         - name: scheduled_delivery_timestamp
           in: query
           schema:
@@ -5296,6 +5285,134 @@ paths:
                         description: |
                           A typical failed JSON response for when a direct message is scheduled
                           to be sent to a user that does not exist:
+  /scheduled_messages/{scheduled_message_id}:
+    patch:
+      operationId: update-scheduled-message
+      tags: ["scheduled_messages"]
+      summary: Edit a scheduled message
+      description: |
+        Edit an existing [scheduled message](/help/schedule-a-message).
+
+        **Changes**: New in Zulip 7.0 (feature level 184).
+      parameters:
+        - name: scheduled_message_id
+          in: path
+          schema:
+            type: integer
+          description: |
+            The ID of the scheduled message to update.
+
+            This is different from the unique ID that the message would have
+            after being sent.
+          required: true
+          example: 2
+        - name: type
+          in: query
+          description: |
+            The type of scheduled message to be sent. `"direct"` for a direct
+            message and `"stream"` for a stream message.
+
+            When updating the type of the scheduled message, the `to` parameter
+            is required. And, if updating the type of the scheduled message to
+            `"stream"`, then the `topic` parameter is also required.
+
+            In Zulip 7.0 (feature level 174), `"direct"` was added as the
+            preferred way to indicate the type of a direct message, deprecating
+            the original `"private"`. While `"private"` is supported for
+            scheduling direct messages, clients are encouraged to use to the
+            modern convention because support for `"private"` may eventually
+            be removed.
+          schema:
+            type: string
+            enum:
+              - direct
+              - stream
+              - private
+          example: stream
+        - name: to
+          in: query
+          description: |
+            The scheduled message's tentative target audience.
+
+            For stream messages, the integer ID of the stream.
+            For direct messages, a list containing integer user IDs.
+
+            Required when updating the `type` of the scheduled message.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: integer
+                  - type: array
+                    items:
+                      type: integer
+                    minLength: 1
+              example: 8
+        - name: content
+          in: query
+          description: |
+            The updated content of the scheduled message.
+
+            Clients should use the `max_message_length` returned by the
+            [`POST /register`](/api/register-queue) endpoint to determine
+            the maximum message size.
+          schema:
+            type: string
+          example: Hello
+        - name: topic
+          in: query
+          description: |
+            The updated topic of the scheduled message.
+
+            Required when updating the `type` of the scheduled message to
+            `"stream"`. Ignored when the existing or updated `type` of the
+            scheduled message is `"direct"` (or `"private"`).
+
+            Clients should use the `max_topic_length` returned by the
+            [`POST /register`](/api/register-queue) endpoint to determine
+            the maximum topic length.
+          schema:
+            type: string
+          example: Castle
+        - name: scheduled_delivery_timestamp
+          in: query
+          schema:
+            type: integer
+          description: |
+            The UNIX timestamp for when the message will be sent,
+            in UTC seconds.
+
+            Required when updating a scheduled message that the server
+            has already tried and failed to send. This state is indicated
+            with `"failed": true` in `scheduled_messages` objects; see
+            response description at
+            [`GET /scheduled_messages`](/api/get-scheduled-messages#response).
+          example: 3165826990
+      responses:
+        "200":
+          $ref: "#/components/responses/SimpleSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - allOf:
+                      - $ref: "#/components/schemas/NonExistingStreamIdError"
+                      - description: |
+                          A typical failed JSON response for when a stream message is scheduled
+                          to be sent to a stream that does not exist:
+                  - allOf:
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Invalid user ID 10",
+                            "result": "error",
+                          }
+                        description: |
+                          A typical failed JSON response for when a direct message is scheduled
+                          to be sent to a user that does not exist:
                   - allOf:
                       - $ref: "#/components/schemas/JsonError"
                       - description: |
@@ -5306,7 +5423,6 @@ paths:
                             "result": "error",
                             "msg": "Scheduled message does not exist",
                           }
-  /scheduled_messages/{scheduled_message_id}:
     delete:
       operationId: delete-scheduled-message
       tags: ["scheduled_messages"]
@@ -5324,8 +5440,8 @@ paths:
           description: |
             The ID of the scheduled message to delete.
 
-            This is different from the unique ID that a message would have
-            after it was sent.
+            This is different from the unique ID that the message would have
+            after being sent.
           required: true
           example: 1
       responses:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -80,6 +80,7 @@ from zerver.actions.realm_settings import (
 from zerver.actions.scheduled_messages import (
     check_schedule_message,
     delete_scheduled_message,
+    edit_scheduled_message,
 )
 from zerver.actions.streams import (
     bulk_add_subscriptions,
@@ -3348,11 +3349,12 @@ class ScheduledMessagesEventsTest(BaseAction):
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
-        action = lambda: check_schedule_message(
+        action = lambda: edit_scheduled_message(
             self.user_profile,
             get_client("website"),
-            "stream",
-            [self.get_stream_id("Verona")],
+            scheduled_message_id,
+            None,
+            None,
             "Edited test topic",
             "Edited stream message",
             convert_to_UTC(dateparser("2023-04-20 18:24:56")),

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3292,7 +3292,6 @@ class ScheduledMessagesEventsTest(BaseAction):
             [self.get_stream_id("Verona")],
             "Test topic",
             "Stream message",
-            None,
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
@@ -3307,7 +3306,6 @@ class ScheduledMessagesEventsTest(BaseAction):
             [self.get_stream_id("Verona")],
             "Test topic",
             "Stream message 1",
-            None,
             convert_to_UTC(dateparser("2023-04-19 17:24:56")),
             self.user_profile.realm,
         )
@@ -3320,7 +3318,6 @@ class ScheduledMessagesEventsTest(BaseAction):
             [self.get_stream_id("Verona")],
             "Test topic",
             "Stream message 2",
-            None,
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
@@ -3335,7 +3332,6 @@ class ScheduledMessagesEventsTest(BaseAction):
             [self.example_user("hamlet").id],
             None,
             "Private message",
-            None,
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
@@ -3349,7 +3345,6 @@ class ScheduledMessagesEventsTest(BaseAction):
             [self.get_stream_id("Verona")],
             "Test topic",
             "Stream message",
-            None,
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )
@@ -3360,7 +3355,6 @@ class ScheduledMessagesEventsTest(BaseAction):
             [self.get_stream_id("Verona")],
             "Edited test topic",
             "Edited stream message",
-            scheduled_message_id,
             convert_to_UTC(dateparser("2023-04-20 18:24:56")),
             self.user_profile.realm,
         )
@@ -3374,7 +3368,6 @@ class ScheduledMessagesEventsTest(BaseAction):
             [self.get_stream_id("Verona")],
             "Test topic",
             "Stream message",
-            None,
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -439,7 +439,7 @@ class HomeTest(ZulipTestCase):
         # Verify number of queries for Realm admin isn't much higher than for normal users.
         self.login("iago")
         flush_per_request_caches()
-        with self.assert_database_query_count(48):
+        with self.assert_database_query_count(50):
             with patch("zerver.lib.cache.cache_set") as cache_mock:
                 result = self._get_home_page()
                 self.check_rendered_logged_in_app(result)

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -818,7 +818,6 @@ class RealmImportExportTest(ExportFile):
             message_to=[Stream.objects.get(name="Denmark", realm=original_realm).id],
             topic_name="test-import",
             message_content="test message",
-            scheduled_message_id=None,
             deliver_at=timezone_now() + datetime.timedelta(days=365),
             realm=original_realm,
         )

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -38,7 +38,6 @@ class ScheduledMessageTest(ZulipTestCase):
         to: Union[int, List[str], List[int]],
         msg: str,
         scheduled_delivery_timestamp: int,
-        scheduled_message_id: str = "",
     ) -> "TestHttpResponse":
         self.login("hamlet")
 
@@ -53,9 +52,6 @@ class ScheduledMessageTest(ZulipTestCase):
             "topic": topic_name,
             "scheduled_delivery_timestamp": scheduled_delivery_timestamp,
         }
-
-        if scheduled_message_id:
-            payload["scheduled_message_id"] = scheduled_message_id
 
         result = self.client_post("/json/scheduled_messages", payload)
         return result

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -433,7 +433,6 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
             [self.get_stream_id("Verona")],
             "Test topic",
             body,
-            None,
             timezone_now() + datetime.timedelta(days=365),
             hamlet.realm,
         )

--- a/zerver/views/scheduled_messages.py
+++ b/zerver/views/scheduled_messages.py
@@ -43,7 +43,6 @@ def scheduled_messages_backend(
     req_to: str = REQ("to"),
     topic_name: Optional[str] = REQ_topic(),
     message_content: str = REQ("content"),
-    scheduled_message_id: Optional[int] = REQ(default=None, json_validator=check_int),
     scheduled_delivery_timestamp: int = REQ(json_validator=check_int),
 ) -> HttpResponse:
     recipient_type_name = req_type
@@ -73,7 +72,6 @@ def scheduled_messages_backend(
         message_to,
         topic_name,
         message_content,
-        scheduled_message_id,
         deliver_at,
         realm=user_profile.realm,
         forwarder_user_profile=user_profile,

--- a/zerver/views/scheduled_messages.py
+++ b/zerver/views/scheduled_messages.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext as _
 from zerver.actions.scheduled_messages import (
     check_schedule_message,
     delete_scheduled_message,
+    edit_scheduled_message,
     extract_direct_message_recipient_ids,
     extract_stream_id,
 )
@@ -16,7 +17,7 @@ from zerver.lib.response import json_success
 from zerver.lib.scheduled_messages import get_undelivered_scheduled_messages
 from zerver.lib.timestamp import timestamp_to_datetime
 from zerver.lib.topic import REQ_topic
-from zerver.lib.validator import check_int, check_string_in
+from zerver.lib.validator import check_int, check_string_in, to_non_negative_int
 from zerver.models import Message, UserProfile
 
 
@@ -36,7 +37,76 @@ def delete_scheduled_messages(
 
 
 @has_request_variables
-def scheduled_messages_backend(
+def update_scheduled_message_backend(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    scheduled_message_id: int = REQ(converter=to_non_negative_int, path_only=True),
+    req_type: Optional[str] = REQ(
+        "type", str_validator=check_string_in(Message.API_RECIPIENT_TYPES), default=None
+    ),
+    req_to: Optional[str] = REQ("to", default=None),
+    topic_name: Optional[str] = REQ_topic(),
+    message_content: Optional[str] = REQ("content", default=None),
+    scheduled_delivery_timestamp: Optional[int] = REQ(json_validator=check_int, default=None),
+) -> HttpResponse:
+    if (
+        req_type is None
+        and req_to is None
+        and topic_name is None
+        and message_content is None
+        and scheduled_delivery_timestamp is None
+    ):
+        raise JsonableError(_("Nothing to change"))
+
+    recipient_type_name = None
+    if req_type:
+        if req_to is None:
+            raise JsonableError(_("Recipient required when updating type of scheduled message."))
+        else:
+            recipient_type_name = req_type
+
+    if recipient_type_name is not None and recipient_type_name == "stream" and topic_name is None:
+        raise JsonableError(_("Topic required when updating scheduled message type to stream."))
+
+    if recipient_type_name is not None and recipient_type_name == "direct":
+        # For now, use "private" from Message.API_RECIPIENT_TYPES.
+        # TODO: Use "direct" here, as well as in events and
+        # scheduled message objects/dicts.
+        recipient_type_name = "private"
+
+    message_to = None
+    if req_to is not None:
+        # Because the recipient_type_name may not be updated/changed,
+        # we extract these updated recipient IDs in edit_scheduled_message.
+        message_to = req_to
+
+    deliver_at = None
+    if scheduled_delivery_timestamp is not None:
+        deliver_at = timestamp_to_datetime(scheduled_delivery_timestamp)
+        if deliver_at <= timezone_now():
+            raise JsonableError(_("Scheduled delivery time must be in the future."))
+
+    sender = user_profile
+    client = RequestNotes.get_notes(request).client
+    assert client is not None
+
+    edit_scheduled_message(
+        sender,
+        client,
+        scheduled_message_id,
+        recipient_type_name,
+        message_to,
+        topic_name,
+        message_content,
+        deliver_at,
+        realm=user_profile.realm,
+    )
+
+    return json_success(request)
+
+
+@has_request_variables
+def create_scheduled_message_backend(
     request: HttpRequest,
     user_profile: UserProfile,
     req_type: str = REQ("type", str_validator=check_string_in(Message.API_RECIPIENT_TYPES)),

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -784,7 +784,6 @@ class Command(BaseCommand):
                 message_to=[Stream.objects.get(name="Denmark", realm=zulip_realm).id],
                 topic_name="test-api",
                 message_content="It's time to celebrate the anniversary of provisioning this development environment :tada:!",
-                scheduled_message_id=None,
                 deliver_at=timezone_now() + timedelta(days=365),
                 realm=zulip_realm,
             )
@@ -795,7 +794,6 @@ class Command(BaseCommand):
                 message_to=[iago.id],
                 topic_name=None,
                 message_content="Note to self: It's been a while since you've provisioned this development environment.",
-                scheduled_message_id=None,
                 deliver_at=timezone_now() + timedelta(days=365),
                 realm=zulip_realm,
             )

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -788,6 +788,17 @@ class Command(BaseCommand):
                 deliver_at=timezone_now() + timedelta(days=365),
                 realm=zulip_realm,
             )
+            check_schedule_message(
+                sender=iago,
+                client=get_client("populate_db"),
+                recipient_type_name="private",
+                message_to=[iago.id],
+                topic_name=None,
+                message_content="Note to self: It's been a while since you've provisioned this development environment.",
+                scheduled_message_id=None,
+                deliver_at=timezone_now() + timedelta(days=365),
+                realm=zulip_realm,
+            )
         else:
             zulip_realm = get_realm("zulip")
             recipient_streams = [

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -134,9 +134,10 @@ from zerver.views.report import (
     report_csp_violations,
 )
 from zerver.views.scheduled_messages import (
+    create_scheduled_message_backend,
     delete_scheduled_messages,
     fetch_scheduled_messages,
-    scheduled_messages_backend,
+    update_scheduled_message_backend,
 )
 from zerver.views.sentry import sentry_tunnel
 from zerver.views.storage import get_storage, remove_storage, update_storage
@@ -324,8 +325,14 @@ v1_api_and_json_patterns = [
     rest_path("drafts", GET=fetch_drafts, POST=create_drafts),
     rest_path("drafts/<int:draft_id>", PATCH=edit_draft, DELETE=delete_draft),
     # New scheduled messages are created via send_message_backend.
-    rest_path("scheduled_messages", GET=fetch_scheduled_messages, POST=scheduled_messages_backend),
-    rest_path("scheduled_messages/<int:scheduled_message_id>", DELETE=delete_scheduled_messages),
+    rest_path(
+        "scheduled_messages", GET=fetch_scheduled_messages, POST=create_scheduled_message_backend
+    ),
+    rest_path(
+        "scheduled_messages/<int:scheduled_message_id>",
+        DELETE=delete_scheduled_messages,
+        PATCH=update_scheduled_message_backend,
+    ),
     # messages -> zerver.views.message*
     # GET returns messages, possibly filtered, POST sends a message
     rest_path(


### PR DESCRIPTION
Adds a new separate endpoint for editing scheduled messages: `PATCH /scheduled_messages/<int:scheduled_message_id>`.

Also, removes the `scheduled_message_id` parameter from `POST /scheduled_messages`, and updates that endpoint's `operationId` to be `create-scheduled-message`. Previously, it was `create-or-edit-scheduled-message`.

See [this CZO conversation](https://chat.zulip.org/#narrow/stream/378-api-design/topic/scheduled.20messages/near/1561281) for more context.

---

**Notes**:
- There is a prep commit that adds a second scheduled message to `populate_db.py` for Iago. This is because the `api-test` goes through the `operationId`s in alphabetical order, so the delete curl example happens before the update/edit curl example happens.
- The final three commits can all be squashes before merging:
  - Removes the `scheduled_message_id` parameter from the create scheduled message path.
  - Adds the view and actions for the new edit scheduled message path, with tests.
  - Adds the API documentation for the new endpoint.

**Questions**:
- I made some notes in the code as comments.
- My main question / thought is whether there's a better way to organize the validation aspects of this code path.
  - Currently, if I could do the validation before accessing the scheduled message in question, I did that in the view function. For example, checking if a `type` parameter was sent without a `to` parameter.
  - Then, in the action `edit_scheduled_message`, I checked / validated for information that potentially needed details from the existing scheduled message. For example, if the server had failed to send the scheduled message, in which case we want to require the `scheduled_message_timestamp` to be updated for a time in the future.

---

**Screenshots and screen captures:**

<details>
<summary>API changelog note: feature level 183</summary>


![Screenshot from 2023-05-17 18-39-26](https://github.com/zulip/zulip/assets/63245456/9a192611-e7f8-4715-bbe8-a1d9100df61f)
</details>
<details>
<summary>Edit a scheduled message</summary>

![Screenshot from 2023-05-17 18-48-46](https://github.com/zulip/zulip/assets/63245456/fa576d92-1594-4f20-b310-999294a2fe11)
![Screenshot from 2023-05-17 18-49-02](https://github.com/zulip/zulip/assets/63245456/95adc489-e8d0-4d8b-b8ac-377e3e42d9c9)
![Screenshot from 2023-05-17 18-49-14](https://github.com/zulip/zulip/assets/63245456/fce34e8f-16fa-4277-9ef9-b21da75ac4a4)
</details>
<details>
<summary>Create a scheduled message</summary>

![Screenshot from 2023-05-17 18-50-15](https://github.com/zulip/zulip/assets/63245456/8c4b3a3e-81da-48b9-bde2-69e9c03d7d14)
![Screenshot from 2023-05-17 18-50-28](https://github.com/zulip/zulip/assets/63245456/28fa5535-186a-497c-a81d-93ff0aac953e)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
