### PR TITLE
puppet: Prevent unattended upgrades of erlang-base.

### DIFF
--- a/puppet/zulip_ops/files/apt/apt.conf.d/50unattended-upgrades
+++ b/puppet/zulip_ops/files/apt/apt.conf.d/50unattended-upgrades
@@ -22,6 +22,7 @@ Unattended-Upgrade::Package-Blacklist {
     "nginx-full$";
     "postgresql-\d+$";
     "rabbitmq-server$";
+    "erlang-base$";
     "redis-server$";
     "supervisor$";
 };


### PR DESCRIPTION
When upgraded, the `erlang-base` package automatically stops all services which depend on the Erlang runtime; for Zulip, this is the `rabbitmq-server` service.  This results in an unexpected outage of Zulip.

Block unattended upgrades of the `erlang-base` package.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
