### PR TITLE
css: Change mention text and background colors.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -934,21 +934,6 @@
             background-color: hsl(22deg 70% 35%);
         }
 
-        .user-mention,
-        .user-group-mention {
-            background: linear-gradient(
-                to bottom,
-                hsl(0deg 0% 0% / 20%) 0%,
-                hsl(0deg 0% 0% / 10%) 100%
-            );
-            box-shadow: 0 0 0 1px hsl(0deg 0% 0% / 40%);
-        }
-
-        .user-mention-me :not(.silent) {
-            background-color: hsl(355deg 37% 31%);
-            box-shadow: 0 0 0 1px hsl(330deg 40% 20%);
-        }
-
         .codehilite code,
         .codehilite pre {
             color: hsl(212deg 98% 82%);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -162,19 +162,12 @@
 
     .user-group-mention,
     .user-mention {
+        font-size: 14px;
+        line-height: 17px;
+        padding: 0 3px;
         border-radius: 3px;
-        padding: 0 0.2em;
-        box-shadow: 0 0 0 1px hsl(0deg 0% 80%);
-        margin-right: 2px;
-        margin-left: 2px;
         white-space: nowrap;
-        background: linear-gradient(
-            to bottom,
-            hsl(0deg 0% 0% / 10%) 0%,
-            hsl(0deg 0% 0% / 0%) 100%
-        );
         display: inline-block;
-        margin-bottom: 1px;
     }
 
     .alert-word {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -83,16 +83,22 @@ body {
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
-    
+
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
     --color-text-message-view-header: hsl(0deg 0% 20% / 100%);
     --color-text-message-header: hsl(0deg 0% 15%);
     --color-text-dropdown-input: hsl(0deg 0% 13.33%);
+    --color-text-self-direct-mention: hsl(240deg 52% 45% / 100%);
+    --color-text-self-group-mention: hsl(183deg 52% 26% / 100%);
 
     /* Mention pill colors */
     --color-background-direct-mention: hsl(240deg 52% 95%);
     --color-background-group-mention: hsl(180deg 40% 94%);
+    --color-background-text-direct-mention: hsl(240deg 70% 70% / 20%);
+    --color-background-text-hover-direct-mention: hsl(240deg 70% 70% / 30%);
+    --color-background-text-group-mention: hsl(183deg 60% 45% / 18%);
+    --color-background-text-hover-group-mention: hsl(183deg 60% 45% / 30%);
 }
 
 %dark-theme {
@@ -121,10 +127,17 @@ body {
     --color-text-message-header: hsl(0deg 0% 100% / 80%);
     --color-text-sender-name: hsl(0deg 0% 100% / 85%);
     --color-text-dropdown-input: hsl(0deg 0% 95%);
+    --color-text-other-mention: hsl(0deg 0% 100% / 80%);
+    --color-text-self-direct-mention: hsl(240deg 100% 88% / 100%);
+    --color-text-self-group-mention: hsl(184deg 52% 63% / 100%);
 
     /* Mention pill colors */
     --color-background-direct-mention: hsl(240deg 13% 20%);
     --color-background-group-mention: hsl(180deg 13% 15%);
+    --color-background-text-direct-mention: hsl(240deg 52% 60% / 25%);
+    --color-background-text-hover-direct-mention: hsl(240deg 52% 60% / 45%);
+    --color-background-text-group-mention: hsl(183deg 52% 40% / 20%);
+    --color-background-text-hover-group-mention: hsl(183deg 52% 40% / 30%);
 }
 
 :root.dark-theme {
@@ -1727,12 +1740,40 @@ div.message_table {
     border-right: 1px solid var(--color-message-list-border);
     background-color: var(--color-background-stream-message-content);
 
+    &.direct_mention {
+        background-color: var(--color-background-direct-mention);
+    }
+
+    .user-mention {
+        color: var(--color-text-other-mention);
+        background-color: var(--color-background-text-direct-mention);
+
+        &.user-mention-me {
+            color: var(--color-text-self-direct-mention);
+            font-weight: 600;
+        }
+
+        &:hover {
+            background-color: var(--color-background-text-hover-direct-mention);
+        }
+    }
+
     &.group_mention {
         background-color: var(--color-background-group-mention);
     }
 
-    &.direct_mention {
-        background-color: var(--color-background-direct-mention);
+    .user-group-mention {
+        color: var(--color-text-other-mention);
+        background-color: var(--color-background-text-group-mention);
+
+        &.user-mention-me {
+            color: var(--color-text-self-group-mention);
+            font-weight: 600;
+        }
+
+        &:hover {
+            background-color: var(--color-background-text-hover-group-mention);
+        }
     }
 
     .date_row {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -76,8 +76,6 @@ body {
     --color-message-header-icon-non-interactive: hsl(0deg 0% 0% / 30%);
     --color-message-header-icon-interactive: hsl(0deg 0% 0%);
     --color-background: hsl(0deg 0% 94%);
-    --color-background-direct-mention: hsl(240deg 52% 95%);
-    --color-background-group-mention: hsl(180deg 40% 94%);
     --color-background-dropdown-input: hsl(0deg 0% 100%);
     --color-background-navbar: hsl(0deg 0% 96%);
     --color-background-active-narrow-filter: hsl(202deg 56% 91%);
@@ -85,12 +83,16 @@ body {
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
-
+    
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
     --color-text-message-view-header: hsl(0deg 0% 20% / 100%);
     --color-text-message-header: hsl(0deg 0% 15%);
     --color-text-dropdown-input: hsl(0deg 0% 13.33%);
+
+    /* Mention pill colors */
+    --color-background-direct-mention: hsl(240deg 52% 95%);
+    --color-background-group-mention: hsl(180deg 40% 94%);
 }
 
 %dark-theme {
@@ -106,8 +108,6 @@ body {
     --color-private-message-header-border-bottom: hsl(0deg 0% 0% / 37%);
     --color-message-list-border: hsl(0deg 0% 0% / 40%);
     --color-background: hsl(0deg 0% 11%);
-    --color-background-direct-mention: hsl(240deg 13% 20%);
-    --color-background-group-mention: hsl(180deg 13% 15%);
     --color-background-dropdown-input: hsl(225deg 6% 10%);
     --color-background-navbar: hsl(0deg 0% 13%);
     --color-background-active-narrow-filter: hsl(200deg 17% 18%);
@@ -121,6 +121,10 @@ body {
     --color-text-message-header: hsl(0deg 0% 100% / 80%);
     --color-text-sender-name: hsl(0deg 0% 100% / 85%);
     --color-text-dropdown-input: hsl(0deg 0% 95%);
+
+    /* Mention pill colors */
+    --color-background-direct-mention: hsl(240deg 13% 20%);
+    --color-background-group-mention: hsl(180deg 13% 15%);
 }
 
 :root.dark-theme {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1751,6 +1751,11 @@ div.message_table {
         &.user-mention-me {
             color: var(--color-text-self-direct-mention);
             font-weight: 600;
+
+            &[data-user-id="*"] {
+                color: var(--color-text-self-group-mention);
+                background-color: var(--color-background-text-group-mention);
+            }
         }
 
         &:hover {


### PR DESCRIPTION
Implements the mention pill part of #22022

before:
<img width="588" alt="image" src="https://github.com/zulip/zulip/assets/25124304/048d7965-f033-4d11-873e-471bbfcb8208">
<img width="601" alt="image" src="https://github.com/zulip/zulip/assets/25124304/debd919f-55b5-47e8-a5af-c084f517f388">


after:
<img width="602" alt="image" src="https://github.com/zulip/zulip/assets/25124304/cd453d64-704f-4fe2-91e4-4740a463ba3d">

<img width="577" alt="image" src="https://github.com/zulip/zulip/assets/25124304/3f8b7df8-c541-4762-965e-c8eae4f77fd5">
