### PR TITLE
css: Move message header padding to the element with border.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1259,11 +1259,14 @@ td.pointer {
 
     .message_header {
         position: sticky;
-        padding-top: var(--header-padding-bottom);
         top: var(--header-height);
         /* Needs to be higher than the z-index of date_row. */
         z-index: 4;
         box-shadow: 0 -1px 0 0 var(--color-background);
+
+        .message-header-contents {
+            margin-top: var(--header-padding-bottom);
+        }
 
         &.sticky_header {
             box-shadow: var(--unread-marker-left) 0 0 0 var(--color-background);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -339,6 +339,9 @@ p.n-margin {
     height: var(--header-height);
     /* Since the headers are sticky, we need non-transparent background. */
     background-color: var(--color-background);
+    /* Add 1px box-shadow below header so that if there is a gap between sticky header
+       and header at some zoom level, it is covered by this */
+    box-shadow: 0 1px 0 0 var(--color-background);
 }
 
 #navbar-middle .column-middle-inner,


### PR DESCRIPTION
Apply border and top margin on the same element so that browser has no way to introduce a gap between them.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20header.20bar.20sometimes.20off.20aligned

This change should fix the bug of message header border being overlapped by its own padding-top.
![image](https://github.com/zulip/zulip/assets/25124304/28b3bc12-8999-48c4-a0e0-7f35c0d2ca91)

I couldn't reproduce the bug so no way to test it.