### PR TITLE
css: Present message_row as CSS Grid.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -920,8 +920,12 @@
         text-shadow: none;
     }
 
+    /* With the unread marker as a grid item, there
+      is no lefthand border to cover in dark mode,
+      so don't apply negative margin to pull the
+      unread marker to the left. */
     .unread_marker {
-        left: 0;
+        margin-left: 0;
     }
 
     .selected_message .messagebox-content {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1562,7 +1562,6 @@ td.pointer {
 }
 
 .unread_marker {
-    grid-column: 1 / 2;
     margin-left: var(--unread-marker-left);
     opacity: 0;
     transition: all 0.3s ease-out;
@@ -1576,8 +1575,7 @@ td.pointer {
     }
 
     &.date_unread_marker {
-        grid-area: "date_unread_marker";
-        grid-row: 1 / 2;
+        grid-area: date_unread_marker;
 
         .unread-marker-fill {
             border-radius: 0 !important;
@@ -1586,8 +1584,7 @@ td.pointer {
     }
 
     &.message_unread_marker {
-        grid-area: "message_unread_marker";
-        grid-row: 2 / 3;
+        grid-area: message_unread_marker;
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1562,7 +1562,7 @@ td.pointer {
 }
 
 .unread_marker {
-    grid-area: unread_marker;
+    grid-column: 1 / 2;
     margin-left: var(--unread-marker-left);
     opacity: 0;
     transition: all 0.3s ease-out;
@@ -1573,6 +1573,21 @@ td.pointer {
 
     &.fast_fade {
         transition: all 0.3s ease-out;
+    }
+
+    &.date_unread_marker {
+        grid-area: "date_unread_marker";
+        grid-row: 1 / 2;
+
+        .unread-marker-fill {
+            border-radius: 0 !important;
+            height: 100% !important;
+        }
+    }
+
+    &.message_unread_marker {
+        grid-area: "message_unread_marker";
+        grid-row: 2 / 3;
     }
 }
 
@@ -1697,10 +1712,10 @@ div.message_table {
 
 .message_row {
     display: grid;
-    /* 2x1 grid:
-      unread_marker date_row
-      unread_marker messagebox */
-    grid-template: "unread_marker date_row" auto "unread_marker messagebox" auto / 2px 1fr;
+    /* 2x2 grid:
+      date_unread_marker date_row
+      message_unread_marker messagebox */
+    grid-template: "date_unread_marker date_row" auto "message_unread_marker messagebox" auto / 2px 1fr;
     border-left: 1px solid var(--color-message-list-border);
     border-right: 1px solid var(--color-message-list-border);
     background-color: var(--color-background-stream-message-content);
@@ -3138,22 +3153,16 @@ select.invite-as {
     /* See https://stackoverflow.com/questions/2717480/css-selector-for-first-element-with-class/8539107#8539107
        for details on how this works */
     .message_row.unread {
-        .date_row {
-            position: relative;
-            border-left: 1px solid var(--color-message-list-border);
-            left: -1px;
-            /* Needs to be lower than the z-index of message_header. */
-            z-index: 3;
+        .date_unread_marker {
+            display: none;
         }
     }
 
     /* Select all but the first .message_row.unread,
        and remove the properties set from the previous rule. */
     .message_row.unread ~ .message_row.unread {
-        .date_row {
-            position: unset;
-            border-left: none;
-            z-index: 0;
+        .date_unread_marker {
+            display: block;
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1131,12 +1131,14 @@ td.pointer {
 }
 
 .messagebox {
-    position: relative;
+    grid-area: messagebox;
     word-wrap: break-word;
     cursor: pointer;
-    vertical-align: top;
     border: none;
-    padding: 0 5px;
+    /* The left padding value maintains the same amount
+      of space to the left of the message box from before
+      the unread marker was a grid item. */
+    padding: 0 5px 0 3px;
 
     &:hover .message_controls,
     &:focus-within .message_controls,
@@ -1559,20 +1561,11 @@ td.pointer {
     }
 }
 
-.recipient_row .message_row:first-child .unread_marker {
-    top: 0;
-}
-
 .unread_marker {
-    display: block;
-    position: absolute;
-    height: 100%;
-    top: 0;
+    grid-area: unread_marker;
+    margin-left: var(--unread-marker-left);
     opacity: 0;
-    z-index: 2;
-    bottom: 1px;
     transition: all 0.3s ease-out;
-    left: var(--unread-marker-left);
 
     &.slow_fade {
         transition: all 2s ease-out;
@@ -1703,7 +1696,11 @@ div.message_table {
 }
 
 .message_row {
-    position: relative;
+    display: grid;
+    /* 2x1 grid:
+      unread_marker date_row
+      unread_marker messagebox */
+    grid-template: "unread_marker date_row" auto "unread_marker messagebox" auto / 2px 1fr;
     border-left: 1px solid var(--color-message-list-border);
     border-right: 1px solid var(--color-message-list-border);
     background-color: var(--color-background-stream-message-content);
@@ -1717,6 +1714,7 @@ div.message_table {
     }
 
     .date_row {
+        grid-area: date_row;
         background-color: var(--color-background-stream-message-content);
         /* We only want padding for the date rows between recipient blocks */
         padding-bottom: 0;
@@ -3154,6 +3152,7 @@ select.invite-as {
     .message_row.unread ~ .message_row.unread {
         .date_row {
             position: unset;
+            border-left: none;
             z-index: 0;
         }
     }

--- a/web/templates/single_message.hbs
+++ b/web/templates/single_message.hbs
@@ -1,10 +1,13 @@
 <div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}"
   class="message_row{{#unless msg/is_stream}} private-message{{/unless}}{{#include_sender}} include-sender{{/include_sender}}{{#if mention_classname}} {{mention_classname}}{{/if}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}locally-echoed{{/if}} selectable_row"
   role="listitem">
-    <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     {{#if want_date_divider}}
-    <div class="date_row no-select">{{{date_divider_html}}}</div>
+    <div class="unread_marker date_unread_marker"><div class="unread-marker-fill"></div></div>
+    <div class="date_row no-select">
+        {{{date_divider_html}}}
+    </div>
     {{/if}}
+    <div class="unread_marker message_unread_marker"><div class="unread-marker-fill"></div></div>
     <div class="messagebox">
         <div class="messagebox-content">
             {{> message_body}}


### PR DESCRIPTION
This change enables the unread marker to participate as a grid item, rather than the product of various absolute/relative positioning hacks. The intention is to therefore prevent the blue active-message box from disappearing on browsers that have zoomed out (~80% zoom).

With grid in place, this also makes for a more robust presentation of each message row, and named grid areas should make it possible to modify and extend the grid into the future.

Finally, this change removes styles that are no longer necessary in the context of CSS Grid.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/blue.20box.20cut.20off).

Because this PR has potentially significant impact to the Zulip interface, particularly message rows, it needs a lot of eyeballs to make sure it breaks nothing.

Additionally, it is unclear whether this will solve the motivating issue of the active-message box outline disappearing as users zoom out on their browsers. So that behavior should be checked for, too.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

The screenshots here are meant to be identical, before and after. However, eagle-eyed reviewers will note that the unread marker more precisely follows the curvature of the rounded border introduced on the recipient row.

Light mode, before:
![before-light](https://github.com/zulip/zulip/assets/170719/d6772ece-3104-4ff9-b86e-d650efa6a7cd)

Light mode, after:
![after-light](https://github.com/zulip/zulip/assets/170719/08849343-f43e-4655-ac6c-6d8001273b2f)

Dark mode, before:
![before-dark](https://github.com/zulip/zulip/assets/170719/6e19bab0-636e-47d5-a94e-8fb91e580e45)

Dark mode, after:
![after-dark](https://github.com/zulip/zulip/assets/170719/f51d0c53-f1fc-4295-b0cb-bbaecf5e5291)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
