### PR TITLE
settings: Revert dark mode background color changes.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -63,7 +63,7 @@
     /* Restate this here for more selector specificity */
     .modal-bg,
     .modal__container {
-        background-color: var(--color-background);
+        background-color: hsl(212deg 28% 18%);
     }
 
     .modal__close {
@@ -209,9 +209,6 @@
     & body,
     .app-main,
     .column-middle,
-    #groups_overlay .right,
-    #subscription_overlay .right,
-    #settings_page .right,
     #streams_header,
     .private_messages_container,
     .header {
@@ -884,7 +881,7 @@
     }
 
     .table-striped tbody tr:nth-child(odd) td {
-        background-color: var(--color-background);
+        background-color: hsl(212deg 28% 18%);
     }
 
     .user-groups-container .right .display-type,


### PR DESCRIPTION
discussed on CZO [here](https://chat.zulip.org/#narrow/stream/101-design/topic/settings.20design.20.28dark.20theme.29/near/1570436)

Reverts some of the effects of #23724 

<img width="1165" alt="image" src="https://github.com/zulip/zulip/assets/5634097/a005daa5-4765-421a-9cd5-1bb4613f163b">