### PR TITLE
gear_menu: Make gear menu items scrollable.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1490,6 +1490,37 @@ $option_title_width: 180px;
     }
 }
 
+.dropdown-list-widget .dropdown-list-body,
+#gear-menu .dropdown-menu {
+    /* In bootstrap v2.3.2, we strictly need
+        .dropdown-menu > li > a as the order of the elements
+        for the bootstrap style to be applied.
+        Since we use a combination of dropdown + simplebar here,
+        the structure cannot be possible since simplebar inserts
+        elements of its own, so we copy over that style
+        from bootstrap to here. */
+    & li a {
+        display: block;
+        padding: 3px 20px;
+        clear: both;
+        font-weight: normal;
+        line-height: 20px;
+        white-space: nowrap;
+
+        &:hover,
+        &:focus {
+            color: hsl(0deg 0% 100%);
+            text-decoration: none;
+            background-color: hsl(200deg 100% 38%);
+            background-image: linear-gradient(
+                to bottom,
+                hsl(200deg 100% 40%),
+                hsl(200deg 100% 35%)
+            );
+        }
+    }
+}
+
 .dropdown-list-widget {
     & button.dropdown-toggle {
         text-align: left;
@@ -1560,33 +1591,8 @@ $option_title_width: 180px;
         margin-top: 0;
         display: block;
 
-        /* In bootstrap v2.3.2, we strictly need
-        .dropdown-menu > li > a as the order of the elements
-        for the bootstrap style to be applied.
-        Since we use a combination of dropdown + simplebar here,
-        the structure cannot be possible since simplebar inserts
-        elements of its own, so we copy over that style
-        from bootstrap to here. */
         & li a {
-            display: block;
-            padding: 3px 20px;
-            clear: both;
-            font-weight: normal;
-            line-height: 20px;
             color: hsl(0deg 0% 20%);
-            white-space: nowrap;
-
-            &:hover,
-            &:focus {
-                color: hsl(0deg 0% 100%);
-                text-decoration: none;
-                background-color: hsl(200deg 100% 38%);
-                background-image: linear-gradient(
-                    to bottom,
-                    hsl(200deg 100% 40%),
-                    hsl(200deg 100% 35%)
-                );
-            }
         }
     }
 }
@@ -1738,7 +1744,7 @@ $option_title_width: 180px;
         outline: 0;
 
         box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-            0 0 8px hsl(206.5deg 80% 62% / 60%);
+        0 0 8px hsl(206.5deg 80% 62% / 60%);
     }
 
     &:disabled {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1576,7 +1576,8 @@ $option_title_width: 180px;
             color: hsl(0deg 0% 20%);
             white-space: nowrap;
 
-            &:hover {
+            &:hover,
+            &:focus {
                 color: hsl(0deg 0% 100%);
                 text-decoration: none;
                 background-color: hsl(200deg 100% 38%);
@@ -1585,10 +1586,6 @@ $option_title_width: 180px;
                     hsl(200deg 100% 40%),
                     hsl(200deg 100% 35%)
                 );
-            }
-
-            &:focus {
-                text-decoration: none;
             }
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -393,6 +393,12 @@ p.n-margin {
 }
 
 #gear-menu .dropdown-menu {
+    /*
+    If there is sufficient space, the `.dropdown-menu` will always have a height
+    based on its content. If the screen is small, it will have a height of 85vh.
+    */
+    max-height: 85vh;
+
     .org-name,
     .org-url {
         padding: 0 20px;

--- a/web/templates/gear_menu.hbs
+++ b/web/templates/gear_menu.hbs
@@ -157,7 +157,7 @@
             <li class="divider hidden-for-spectators" role="presentation"></li>
             {{#if can_invite_others_to_realm}}
             <li role="presentation">
-                <a class="invite-user-link" role="menuitem">
+                <a tabindex="0" class="invite-user-link" role="menuitem">
                     <i class="fa fa-user-plus" aria-hidden="true"></i> {{t 'Invite users' }}
                 </a>
             </li>

--- a/web/templates/gear_menu.hbs
+++ b/web/templates/gear_menu.hbs
@@ -3,7 +3,7 @@
         <a id="settings-dropdown" tabindex="0" role="button" class="dropdown-toggle tippy-zulip-delayed-tooltip" data-target="nada" data-toggle="dropdown" data-tooltip-template-id="gear-menu-tooltip-template">
             <i class="fa fa-cog settings-dropdown-cog" aria-hidden="true"></i>
         </a>
-        <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
+        <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown" data-simplebar>
             <li class="org-info org-name">{{realm_name}}</li>
             <li class="org-info org-url">{{realm_url}}</li>
             {{#if is_self_hosted }}


### PR DESCRIPTION
This pull request aims to add scroll functionality to the gear menu.

From the user perspective, it will behave as follows: if there is sufficient space, the gear menu will always have a height based on its content. If the screen is small, it will have a height of 85vh. This number is just my personal preference and open to discussion. For me, 80vh is too small, 90vh is good, but on medium-sized screens, it covers the buttons in the compose box. 85vh strikes a balance between these two values.

From a technical perspective, there are two changes:
1. Added `max-height: 85vh;` to the dropdown menu.
2. Reused the CSS code written to copy Bootstrap styles.

<details>
<summary>Screenshots:</summary>
<br>

![big height](https://github.com/zulip/zulip/assets/53193850/b89fc217-a420-4938-9986-a6f70fbaaec3)
![medium height](https://github.com/zulip/zulip/assets/53193850/e819a270-bb6e-4c0c-913f-134c3621dc09)
![small height](https://github.com/zulip/zulip/assets/53193850/2542b0fe-568d-4784-b273-9831f7804e75)

</details>

<details>
<summary>Screencapture:</summary>
<br>

![2023-05-18 at 14 20 46 - Indigo Frog.gif](https://github.com/zulip/zulip/assets/53193850/68804c0f-0a49-4063-a477-5e0467ed8283)


</details>


Fixes: #25645.