### PR TITLE
scheduled-message: Update small errors and inconsitencies.

### DIFF
--- a/zerver/actions/scheduled_messages.py
+++ b/zerver/actions/scheduled_messages.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple
 
 import orjson
 from django.conf import settings
@@ -61,7 +61,7 @@ def check_schedule_message(
     sender: UserProfile,
     client: Client,
     recipient_type_name: str,
-    message_to: Union[Sequence[str], Sequence[int]],
+    message_to: List[int],
     topic_name: Optional[str],
     message_content: str,
     scheduled_message_id: Optional[int],

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5106,7 +5106,8 @@ paths:
       tags: ["scheduled_messages"]
       summary: Get scheduled messages
       description: |
-        Fetch all scheduled messages for the current user.
+        Fetch all [scheduled messages](/help/schedule-a-message) for
+        the current user.
 
         Scheduled messages are messages the user has scheduled to be
         sent in the future via the send later feature.
@@ -5303,7 +5304,8 @@ paths:
       tags: ["scheduled_messages"]
       summary: Delete a scheduled message
       description: |
-        Delete, and therefore cancel sending, a previously scheduled message.
+        Delete, and therefore cancel sending, a previously [scheduled
+        message](/help/schedule-a-message).
 
         **Changes**: New in Zulip 7.0 (feature level 173).
       parameters:

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -79,7 +79,7 @@ class ScheduledMessageTest(ZulipTestCase):
             timestamp_to_datetime(scheduled_delivery_timestamp),
         )
 
-        # Scheduling a private message is successful.
+        # Scheduling a direct message is successful.
         othello = self.example_user("othello")
         result = self.do_schedule_message(
             "direct", [othello.id], content + " 3", scheduled_delivery_timestamp
@@ -145,7 +145,7 @@ class ScheduledMessageTest(ZulipTestCase):
                 self.assertEqual(delivered_message.topic_name(), scheduled_message.topic_name())
                 self.assertEqual(delivered_message.date_sent, more_than_scheduled_delivery_datetime)
 
-    def test_successful_deliver_private_scheduled_message(self) -> None:
+    def test_successful_deliver_direct_scheduled_message(self) -> None:
         logger = mock.Mock()
         # No scheduled message
         self.assertFalse(try_deliver_one_scheduled_message(logger))
@@ -209,7 +209,7 @@ class ScheduledMessageTest(ZulipTestCase):
         )
         self.assert_json_error(updated_response, "Scheduled message was already sent")
 
-    def test_successful_deliver_private_scheduled_message_to_self(self) -> None:
+    def test_successful_deliver_direct_scheduled_message_to_self(self) -> None:
         logger = mock.Mock()
         # No scheduled message
         self.assertFalse(try_deliver_one_scheduled_message(logger))

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -79,7 +79,7 @@ class ScheduledMessageTest(ZulipTestCase):
             timestamp_to_datetime(scheduled_delivery_timestamp),
         )
 
-        # Scheduling a direct message is successful.
+        # Scheduling a direct message with user IDs is successful.
         othello = self.example_user("othello")
         result = self.do_schedule_message(
             "direct", [othello.id], content + " 3", scheduled_delivery_timestamp
@@ -92,6 +92,12 @@ class ScheduledMessageTest(ZulipTestCase):
             scheduled_message.scheduled_timestamp,
             timestamp_to_datetime(scheduled_delivery_timestamp),
         )
+
+        # Cannot schedule a direct message with user emails.
+        result = self.do_schedule_message(
+            "direct", [othello.email], content + " 4", scheduled_delivery_timestamp
+        )
+        self.assert_json_error(result, "Recipient list may only contain user IDs")
 
     def create_scheduled_message(self) -> None:
         content = "Test message"


### PR DESCRIPTION
A few commits with some small clean ups I noted while working on #25628.

- Use "direct" instead of "private" in tests and comments.
- Simplify type for `message_to` since user emails can no longer be sent for direct message recipients.
- Add explicit test for sending user emails.
- Add link to help center article on scheduled messages for `GET` and `DELETE` endpoints now that we have one to link to.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
