### PR TITLE
refactor: Move `maybe_get_stream_name` from `stream_data` to `sub_store`.

### DIFF
--- a/web/src/compose_state.js
+++ b/web/src/compose_state.js
@@ -4,6 +4,7 @@ import * as blueslip from "./blueslip";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_recipient from "./compose_recipient";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 
 let message_type = false; // 'stream', 'private', or false-y
 let recipient_edited_manually = false;
@@ -74,7 +75,7 @@ function get_or_set(fieldname, keep_leading_whitespace, no_trim) {
 export function stream_name() {
     const stream_id = compose_recipient.selected_recipient_id;
     if (typeof stream_id === "number") {
-        return stream_data.maybe_get_stream_name(stream_id) || "";
+        return sub_store.maybe_get_stream_name(stream_id) || "";
     }
     return "";
 }
@@ -100,7 +101,7 @@ export function set_compose_recipient_id(value) {
     let recipient_id = compose_recipient.DIRECT_MESSAGE_ID;
     if (typeof value === "number") {
         // value is stream name
-        recipient_id = stream_data.maybe_get_stream_name(value) || "";
+        recipient_id = sub_store.maybe_get_stream_name(value) || "";
     }
     compose_recipient.set_selected_recipient_id(recipient_id);
 }

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -18,6 +18,7 @@ import * as people from "./people";
 import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as util from "./util";
 
 let user_acknowledged_wildcard = false;
@@ -231,7 +232,7 @@ export function warn_if_topic_resolved(topic_changed) {
 
 function show_wildcard_warnings(opts) {
     const subscriber_count = peer_data.get_subscriber_count(opts.stream_id) || 0;
-    const stream_name = stream_data.maybe_get_stream_name(opts.stream_id);
+    const stream_name = sub_store.maybe_get_stream_name(opts.stream_id);
     const is_edit_container = opts.$banner_container.closest(".edit_form_banners").length > 0;
     const classname = compose_banner.CLASSNAMES.wildcard_warning;
 

--- a/web/src/hash_util.js
+++ b/web/src/hash_util.js
@@ -3,6 +3,7 @@ import * as internal_url from "../shared/src/internal_url";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 
 export function get_hash_category(hash) {
     // given "#streams/subscribed", returns "streams"
@@ -91,12 +92,12 @@ export function decode_operand(operator, operand) {
 
 export function by_stream_url(stream_id) {
     // Wrapper for web use of internal_url.by_stream_url
-    return internal_url.by_stream_url(stream_id, stream_data.maybe_get_stream_name);
+    return internal_url.by_stream_url(stream_id, sub_store.maybe_get_stream_name);
 }
 
 export function by_stream_topic_url(stream_id, topic) {
     // Wrapper for web use of internal_url.by_stream_topic_url
-    return internal_url.by_stream_topic_url(stream_id, topic, stream_data.maybe_get_stream_name);
+    return internal_url.by_stream_topic_url(stream_id, topic, sub_store.maybe_get_stream_name);
 }
 
 // Encodes an operator list into the

--- a/web/src/message_edit_history.js
+++ b/web/src/message_edit_history.js
@@ -14,7 +14,6 @@ import * as popovers from "./popovers";
 import * as rendered_markdown from "./rendered_markdown";
 import * as rows from "./rows";
 import * as spectators from "./spectators";
-import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as ui_report from "./ui_report";
@@ -72,10 +71,10 @@ export function fetch_and_render_message_history(message) {
                     if (!sub) {
                         item.prev_stream = $t({defaultMessage: "Unknown stream"});
                     } else {
-                        item.prev_stream = stream_data.maybe_get_stream_name(msg.prev_stream);
+                        item.prev_stream = sub_store.maybe_get_stream_name(msg.prev_stream);
                     }
                     if (prev_stream_item !== null) {
-                        prev_stream_item.new_stream = stream_data.maybe_get_stream_name(
+                        prev_stream_item.new_stream = sub_store.maybe_get_stream_name(
                             msg.prev_stream,
                         );
                     }
@@ -98,10 +97,10 @@ export function fetch_and_render_message_history(message) {
                     if (!sub) {
                         item.prev_stream = $t({defaultMessage: "Unknown stream"});
                     } else {
-                        item.prev_stream = stream_data.maybe_get_stream_name(msg.prev_stream);
+                        item.prev_stream = sub_store.maybe_get_stream_name(msg.prev_stream);
                     }
                     if (prev_stream_item !== null) {
-                        prev_stream_item.new_stream = stream_data.maybe_get_stream_name(
+                        prev_stream_item.new_stream = sub_store.maybe_get_stream_name(
                             msg.prev_stream,
                         );
                     }
@@ -119,7 +118,7 @@ export function fetch_and_render_message_history(message) {
                 prev_time = time;
             }
             if (prev_stream_item !== null) {
-                prev_stream_item.new_stream = stream_data.maybe_get_stream_name(message.stream_id);
+                prev_stream_item.new_stream = sub_store.maybe_get_stream_name(message.stream_id);
             }
             $("#message-history").attr("data-message-id", message.id);
             $("#message-history").html(

--- a/web/src/rendered_markdown.js
+++ b/web/src/rendered_markdown.js
@@ -11,7 +11,7 @@ import {$t, $t_html} from "./i18n";
 import * as people from "./people";
 import * as realm_playground from "./realm_playground";
 import * as rtl from "./rtl";
-import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import {show_copied_confirmation} from "./tippyjs";
 import * as user_groups from "./user_groups";
@@ -130,10 +130,10 @@ export const update_elements = ($content) => {
         if (stream_id && !$(this).find(".highlight").length) {
             // Display the current name for stream if it is not
             // being displayed in search highlight.
-            const stream_name = stream_data.maybe_get_stream_name(stream_id);
+            const stream_name = sub_store.maybe_get_stream_name(stream_id);
             if (stream_name !== undefined) {
                 // If the stream has been deleted,
-                // stream_data.maybe_get_stream_name might return
+                // sub_store.maybe_get_stream_name might return
                 // undefined.  Otherwise, display the current stream name.
                 $(this).text("#" + stream_name);
             }
@@ -145,10 +145,10 @@ export const update_elements = ($content) => {
         if (stream_id && !$(this).find(".highlight").length) {
             // Display the current name for stream if it is not
             // being displayed in search highlight.
-            const stream_name = stream_data.maybe_get_stream_name(stream_id);
+            const stream_name = sub_store.maybe_get_stream_name(stream_id);
             if (stream_name !== undefined) {
                 // If the stream has been deleted,
-                // stream_data.maybe_get_stream_name might return
+                // sub_store.maybe_get_stream_name might return
                 // undefined.  Otherwise, display the current stream name.
                 const text = $(this).text();
                 $(this).text("#" + stream_name + text.slice(text.indexOf(" > ")));

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -14,7 +14,7 @@ import {$t} from "./i18n";
 import * as narrow from "./narrow";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
-import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 
 export const MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS = 5 * 60;
@@ -122,7 +122,7 @@ export function open_scheduled_message_in_compose(scheduled_msg, should_narrow_t
     if (scheduled_msg.type === "stream") {
         compose_args = {
             type: "stream",
-            stream: stream_data.maybe_get_stream_name(scheduled_msg.to),
+            stream: sub_store.maybe_get_stream_name(scheduled_msg.to),
             topic: scheduled_msg.topic,
             content: scheduled_msg.content,
         };

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -10,6 +10,7 @@ import * as people from "./people";
 import * as scheduled_messages from "./scheduled_messages";
 import * as stream_color from "./stream_color";
 import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 
 export const keyboard_handling_context = {
@@ -57,7 +58,7 @@ function format(scheduled_messages) {
         if (msg.type === "stream") {
             msg_render_context.is_stream = true;
             msg_render_context.stream_id = msg.to;
-            msg_render_context.stream_name = stream_data.maybe_get_stream_name(
+            msg_render_context.stream_name = sub_store.maybe_get_stream_name(
                 msg_render_context.stream_id,
             );
             const color = stream_data.get_color(msg_render_context.stream_name);

--- a/web/src/starred_messages_ui.js
+++ b/web/src/starred_messages_ui.js
@@ -4,7 +4,7 @@ import render_confirm_unstar_all_messages_in_topic from "../templates/confirm_di
 import * as confirm_dialog from "./confirm_dialog";
 import {$t_html} from "./i18n";
 import * as message_flags from "./message_flags";
-import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 
 export function confirm_unstar_all_messages() {
     const html_body = render_confirm_unstar_all_messages();
@@ -21,7 +21,7 @@ export function confirm_unstar_all_messages_in_topic(stream_id, topic) {
         message_flags.unstar_all_messages_in_topic(stream_id, topic);
     }
 
-    const stream_name = stream_data.maybe_get_stream_name(stream_id);
+    const stream_name = sub_store.maybe_get_stream_name(stream_id);
     if (stream_name === undefined) {
         return;
     }

--- a/web/src/stream_color.js
+++ b/web/src/stream_color.js
@@ -11,13 +11,14 @@ import * as row from "./rows";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_settings_ui from "./stream_settings_ui";
+import * as sub_store from "./sub_store";
 
 extend([lchPlugin, mixPlugin]);
 
 export function update_stream_recipient_color($stream_header) {
     if ($stream_header.length) {
         const stream_id = Number.parseInt($($stream_header).attr("data-stream-id"), 10);
-        const stream_name = stream_data.maybe_get_stream_name(stream_id);
+        const stream_name = sub_store.maybe_get_stream_name(stream_id);
         if (!stream_name) {
             return;
         }

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -675,19 +675,6 @@ export function get_name(stream_name) {
     return sub.name;
 }
 
-export function maybe_get_stream_name(stream_id) {
-    if (!stream_id) {
-        return undefined;
-    }
-    const stream = sub_store.get(stream_id);
-
-    if (!stream) {
-        return undefined;
-    }
-
-    return stream.name;
-}
-
 export function is_user_subscribed(stream_id, user_id) {
     const sub = sub_store.get(stream_id);
     if (sub === undefined || !can_view_subscribers(sub)) {

--- a/web/src/stream_list_sort.js
+++ b/web/src/stream_list_sort.js
@@ -21,7 +21,7 @@ let filter_out_inactives = false;
 
 export function get_streams() {
     const sorted_streams = all_streams.map((stream_id) =>
-        stream_data.maybe_get_stream_name(stream_id),
+        sub_store.maybe_get_stream_name(stream_id),
     );
     return sorted_streams;
 }

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -18,7 +18,6 @@ import * as resize from "./resize";
 import * as settings_data from "./settings_data";
 import * as stream_bar from "./stream_bar";
 import * as stream_color from "./stream_color";
-import * as stream_data from "./stream_data";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as ui_report from "./ui_report";
@@ -172,7 +171,7 @@ export function build_move_topic_to_stream_popover(
     only_topic_edit,
     message,
 ) {
-    const current_stream_name = stream_data.maybe_get_stream_name(current_stream_id);
+    const current_stream_name = sub_store.maybe_get_stream_name(current_stream_id);
     const args = {
         topic_name,
         current_stream_id,
@@ -424,7 +423,7 @@ export function register_click_handlers() {
         if (e.type === "keypress" && !keydown_util.is_enter_event(e)) {
             return;
         }
-        const stream_name = stream_data.maybe_get_stream_name(
+        const stream_name = sub_store.maybe_get_stream_name(
             Number.parseInt(stream_widget.value(), 10),
         );
 

--- a/web/src/sub_store.ts
+++ b/web/src/sub_store.ts
@@ -78,3 +78,16 @@ export function add_hydrated_sub(stream_id: number, sub: StreamSubscription): vo
     // in stream_data.js. Grep there to find callers.
     subs_by_stream_id.set(stream_id, sub);
 }
+
+export function maybe_get_stream_name(stream_id: number): string | undefined {
+    if (!stream_id) {
+        return undefined;
+    }
+    const stream = get(stream_id);
+
+    if (!stream) {
+        return undefined;
+    }
+
+    return stream.name;
+}

--- a/web/src/user_topics.js
+++ b/web/src/user_topics.js
@@ -7,7 +7,7 @@ import * as feedback_widget from "./feedback_widget";
 import {FoldDict} from "./fold_dict";
 import {$t} from "./i18n";
 import {page_params} from "./page_params";
-import * as stream_data from "./stream_data";
+import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import {get_time_from_date_muted} from "./util";
 
@@ -57,7 +57,7 @@ export function is_topic_muted(stream_id, topic) {
 export function get_user_topics_for_visibility_policy(visibility_policy) {
     const topics = [];
     for (const [stream_id, sub_dict] of all_user_topics) {
-        const stream = stream_data.maybe_get_stream_name(stream_id);
+        const stream = sub_store.maybe_get_stream_name(stream_id);
         for (const topic of sub_dict.keys()) {
             if (sub_dict.get(topic).visibility_policy === visibility_policy) {
                 const date_updated = sub_dict.get(topic).date_updated;
@@ -113,7 +113,7 @@ export function set_user_topic_visibility_policy(
             // know what you did if you triggered muting with the
             // mouse.
             if (visibility_policy === all_visibility_policies.MUTED) {
-                const stream_name = stream_data.maybe_get_stream_name(stream_id);
+                const stream_name = sub_store.maybe_get_stream_name(stream_id);
                 feedback_widget.show({
                     populate($container) {
                         const rendered_html = render_topic_muted();
@@ -141,7 +141,7 @@ export function set_user_topic(user_topic) {
     const topic = user_topic.topic_name;
     const date_updated = user_topic.last_updated;
 
-    const stream_name = stream_data.maybe_get_stream_name(stream_id);
+    const stream_name = sub_store.maybe_get_stream_name(stream_id);
 
     if (!stream_name) {
         blueslip.warn("Unknown stream ID in set_user_topic: " + stream_id);

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -145,9 +145,9 @@ test("basics", () => {
     assert.ok(!stream_data.is_muted(social.stream_id));
     assert.ok(stream_data.is_muted(denmark.stream_id));
 
-    assert.equal(stream_data.maybe_get_stream_name(), undefined);
-    assert.equal(stream_data.maybe_get_stream_name(social.stream_id), "social");
-    assert.equal(stream_data.maybe_get_stream_name(42), undefined);
+    assert.equal(sub_store.maybe_get_stream_name(), undefined);
+    assert.equal(sub_store.maybe_get_stream_name(social.stream_id), "social");
+    assert.equal(sub_store.maybe_get_stream_name(42), undefined);
 
     stream_data.set_realm_default_streams([denmark]);
     assert.ok(stream_data.is_default_stream_id(denmark.stream_id));


### PR DESCRIPTION
This PR moves `maybe_get_stream_name` function from `stream_data` to `sub_store` as it didn't have any dependency on `stream_data` and it also helps us to cut off dependency on `stream_data` for some of the modules including `user_topics`.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
