### PR TITLE
ts: Convert `confirm_dialog` module to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -72,7 +72,7 @@ EXEMPT_FILES = make_set(
         "web/src/compose_validate.js",
         "web/src/composebox_typeahead.js",
         "web/src/condense.js",
-        "web/src/confirm_dialog.js",
+        "web/src/confirm_dialog.ts",
         "web/src/copy_and_paste.js",
         "web/src/csrf.ts",
         "web/src/css_variables.js",

--- a/web/src/confirm_dialog.ts
+++ b/web/src/confirm_dialog.ts
@@ -1,7 +1,8 @@
 import * as dialog_widget from "./dialog_widget";
+import type {DialogWidgetConfig} from "./dialog_widget";
 import {$t_html} from "./i18n";
 
-export function launch(conf) {
+export function launch(conf: DialogWidgetConfig): void {
     dialog_widget.launch({
         ...conf,
         close_on_submit: true,

--- a/web/src/dialog_widget.ts
+++ b/web/src/dialog_widget.ts
@@ -43,7 +43,7 @@ import * as ui_report from "./ui_report";
  *          to DOM, it can do so by passing a post_render hook.
  */
 
-type WidgetConfig = {
+export type DialogWidgetConfig = {
     html_heading: string;
     html_body: string;
     on_click: (e: unknown) => void;
@@ -97,7 +97,7 @@ export function close_modal(on_hidden_callback?: () => void): void {
     overlays.close_modal("dialog_widget_modal", {on_hidden: on_hidden_callback});
 }
 
-export function launch(conf: WidgetConfig): void {
+export function launch(conf: DialogWidgetConfig): void {
     // Mandatory fields:
     // * html_heading
     // * html_body


### PR DESCRIPTION
Converts `confirm_dialog` module to TypeScript. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
