### PR TITLE
help_pages: Improve anchor highlights.

### DIFF
--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -253,6 +253,16 @@ html {
     & .scroll-target {
         /* Match to where simplebar scrolls */
         scroll-margin-top: 20px;
+    }
+    /* Highlight the headings as well as the first child
+      of any targeted div, as in the API documentation. */
+    & h1.scroll-target,
+    & h2.scroll-target,
+    & h3.scroll-target,
+    & h4.scroll-target,
+    & h5.scroll-target,
+    & h6.scroll-target,
+    & div.scroll-target > :first-child {
         /* Increase the highlighted space around the text... */
         padding: 6px 8px;
         border-radius: 7px 7px 0 0;


### PR DESCRIPTION
These changes ensure that only headings targeted by URL fragments are highlighted in full. Div elements will have their immediate first child element highlighted instead (e.g., the first element of an API parameter box).

The repeated `& hN.scroll-target` selectors look repetitive, but I believe they're necessary to keep from having to repeat the actual style declaration on what would be a separate block targeted just to the immediate first-child of the div.

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/help.20page.20highlighting/near/1571689).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

[Current API docs](http://zulip.com/api/update-message#parameter-propagate_mode)
Before:
![api-docs-before](https://github.com/zulip/zulip/assets/170719/cd366509-c609-4c40-8dc0-9547d83c21eb)

After:
![api-docs-after](https://github.com/zulip/zulip/assets/170719/b4b48f41-dd30-489c-9541-eee62652e904)

[Current help docs](http://zulip.com/help/getting-your-organization-started-with-zulip#advantages-of-zulip-cloud)
Before:
![help-docs-before](https://github.com/zulip/zulip/assets/170719/c1607c06-20aa-485c-b4b8-b3829c2c3332)

After (no change):
![help-docs-after](https://github.com/zulip/zulip/assets/170719/abd4dcc9-7800-4ab7-bf69-202788704c19)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
