### PR TITLE
ts: Convert `deprecated_feature_notice` module to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -78,7 +78,7 @@ EXEMPT_FILES = make_set(
         "web/src/css_variables.js",
         "web/src/dark_theme.ts",
         "web/src/debug.ts",
-        "web/src/deprecated_feature_notice.js",
+        "web/src/deprecated_feature_notice.ts",
         "web/src/desktop_integration.js",
         "web/src/dialog_widget.ts",
         "web/src/drafts.js",

--- a/web/src/deprecated_feature_notice.js
+++ b/web/src/deprecated_feature_notice.js
@@ -1,3 +1,5 @@
+import z from "zod";
+
 import * as blueslip from "./blueslip";
 import * as common from "./common";
 import * as dialog_widget from "./dialog_widget";
@@ -37,9 +39,13 @@ export function maybe_show_deprecation_notice(key) {
     // Here we handle the tracking for showing deprecation notices,
     // whether or not local storage is available.
     if (localstorage.supported()) {
-        const notices_from_storage = JSON.parse(localStorage.getItem("shown_deprecation_notices"));
+        const notices_from_storage = localStorage.getItem("shown_deprecation_notices");
         if (notices_from_storage !== null) {
-            shown_deprecation_notices = notices_from_storage;
+            const parsed_notices_from_storage = z
+                .array(z.string())
+                .parse(JSON.parse(notices_from_storage));
+
+            shown_deprecation_notices = parsed_notices_from_storage;
         } else {
             shown_deprecation_notices = [];
         }

--- a/web/src/deprecated_feature_notice.ts
+++ b/web/src/deprecated_feature_notice.ts
@@ -6,7 +6,10 @@ import * as dialog_widget from "./dialog_widget";
 import {$t_html} from "./i18n";
 import {localstorage} from "./localstorage";
 
-export function get_hotkey_deprecation_notice(originalHotkey, replacementHotkey) {
+export function get_hotkey_deprecation_notice(
+    originalHotkey: string,
+    replacementHotkey: string,
+): string {
     return $t_html(
         {
             defaultMessage:
@@ -16,9 +19,9 @@ export function get_hotkey_deprecation_notice(originalHotkey, replacementHotkey)
     );
 }
 
-let shown_deprecation_notices = [];
+let shown_deprecation_notices: string[] = [];
 
-export function maybe_show_deprecation_notice(key) {
+export function maybe_show_deprecation_notice(key: string): void {
     let message;
     const isCmdOrCtrl = common.has_mac_keyboard() ? "Cmd" : "Ctrl";
     switch (key) {
@@ -56,7 +59,9 @@ export function maybe_show_deprecation_notice(key) {
             html_heading: $t_html({defaultMessage: "Deprecation notice"}),
             html_body: message,
             html_submit_button: $t_html({defaultMessage: "Got it"}),
-            on_click() {},
+            on_click() {
+                return;
+            },
             close_on_submit: true,
             focus_submit_on_open: true,
             single_footer_button: true,


### PR DESCRIPTION
This PR does two things:
1) Refactors `maybe_show_deprecation_notice` function to use zod to parse `shown_deprecation_notices` array stored in localstorage for better type safety.
2) Migrates the module to TypeScript by adding some primitive types to the functions.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
