### PR TITLE
api-changelog: Update and clarify docs for feature level 178 entry.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -55,11 +55,14 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 178**
 
-* `POST users/me/presence`, [`POST /register`](/api/register-queue),
-  [`GET /events`](/api/get-events), `GET /realm/presence`, `GET
-  /users/<user_id_or_email>/presence`: The server no longer stores
-  which client submitted presence data, and presence responses from
-  the server will always contain the `aggregated` and `website` keys.
+* `POST users/me/presence`,
+  [`GET /users/<user_id_or_email>/presence`](/api/get-user-presence),
+  [`GET /realm/presence`](/api/get-presence),
+  [`POST /register`](/api/register-queue),
+  [`GET /events`](/api/get-events):
+  The server no longer stores which client submitted presence data,
+  and presence responses from the server will always contain the
+  `"aggregated"` and `"website"` keys.
 
 **Feature level 177**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1049,7 +1049,7 @@ paths:
                                 email:
                                   type: string
                                   description: |
-                                    The email of the user.
+                                    The Zulip display email of the user.
 
                                     **Deprecated**: This field will be removed in a future
                                     release as it is redundant with the `user_id`.
@@ -1067,19 +1067,24 @@ paths:
                                     type: object
                                     description: |
                                       `{client_name}`: Object containing the details of the user's
-                                      presence on a particular platform. The object key is the client's
-                                      platform name, for example `website` or `ZulipDesktop`.
+                                      presence.
 
                                       **Changes**: Starting with Zulip 7.0 (feature level 178), this
-                                      will always contain two keys, `website` and `aggregated`, with
-                                      identical data. The server no longer stores which client submitted
-                                      presence updates.
+                                      will always be `"website"` as the server no longer stores which
+                                      client submitted presence updates.
+
+                                      Previously, the object key was the client's platform name, for
+                                      example `website` or `ZulipDesktop`.
                                     additionalProperties: false
                                     properties:
                                       client:
                                         type: string
                                         description: |
                                           The client's platform name.
+
+                                          **Changes**: Starting with Zulip 7.0 (feature level 178), this
+                                          will always be `"website"` as the server no longer stores which
+                                          client submitted presence updates.
                                       status:
                                         type: string
                                         enum:
@@ -1098,6 +1103,10 @@ paths:
                                         description: |
                                           Whether the client is capable of showing mobile/push notifications
                                           to the user.
+
+                                          **Changes**: Starting with Zulip 7.0 (feature level 178), this
+                                          will always be `false` as the server no longer stores which
+                                          client submitted presence updates.
                               additionalProperties: false
                               example:
                                 {
@@ -1107,9 +1116,9 @@ paths:
                                   "server_timestamp": 1594825445.320078373,
                                   "presence":
                                     {
-                                      "ZulipAndroid/1.0":
+                                      "website":
                                         {
-                                          "client": "ZulipAndroid/1.0",
+                                          "client": "website",
                                           "status": "idle",
                                           "timestamp": 1594825445,
                                           "pushable": false,
@@ -7521,8 +7530,7 @@ paths:
                       presence:
                         type: object
                         description: |
-                          An object containing the presence details for every client the user has
-                          logged into.
+                          An object containing the presence details for the user.
                         additionalProperties:
                           type: object
                           additionalProperties: false
@@ -7538,31 +7546,24 @@ paths:
                                 Whether the user had recently interacted with Zulip at the time
                                 of the timestamp.
 
-                                Will be either `active` or `idle`
+                                Will be either `"active"` or `"idle"`
                           description: |
-                            `{client_name}` or `aggregated`: Object containing the details of the user's
-                            presence on a particular platform.
+                            `{client_name}` or `"aggregated"`: Object containing the details of the user's
+                            presence.
 
-                            Generally, the keys for these objects are the names of the different clients
-                            where this user is logged in, for example `website` or `ZulipDesktop`.
+                            **Changes**: Starting with Zulip 7.0 (feature level 178), this will always
+                            contain two keys, `"website"` and `"aggregated"`, with identical data. The
+                            server no longer stores which client submitted presence updates.
 
-                            There is also an `aggregated` key, which matches the contents of the object
-                            that has been updated most recently.
-
-                            For most applications, you'll just want to look at the `aggregated` key.
-
-                            **Changes**: Starting with Zulip 7.0 (feature level 178), this
-                            will always contain two keys, `website` and `aggregated`, with
-                            identical data. The server no longer stores which client submitted
-                            presence updates.
+                            Previously, the `{client_name}` keys for these objects were the names of the
+                            different clients where the user was logged in, for example `website` or
+                            `ZulipDesktop`.
                     example:
                       {
                         "presence":
                           {
                             "website":
                               {"timestamp": 1532697622, "status": "active"},
-                            "ZulipMobile":
-                              {"timestamp": 1522687421, "status": "active"},
                             "aggregated":
                               {"timestamp": 1532697622, "status": "active"},
                           },
@@ -9052,9 +9053,8 @@ paths:
                         additionalProperties:
                           type: object
                           description: |
-                            `{user_email}`: Object containing the details of a user's presence
-                            on every client the user is logged into. The object's key is the
-                            user's email.
+                            `{user_email}`: Object containing the details of a user's presence.
+                            The object's key is the user's Zulip display email.
                           additionalProperties:
                             $ref: "#/components/schemas/Presence"
                     example:
@@ -9064,16 +9064,16 @@ paths:
                           {
                             "iago@zulip.com":
                               {
-                                "ZulipPython":
+                                "website":
                                   {
-                                    "client": "ZulipPython",
+                                    "client": "website",
                                     "pushable": false,
                                     "status": "active",
                                     "timestamp": 1656958485,
                                   },
                                 "aggregated":
                                   {
-                                    "client": "ZulipPython",
+                                    "client": "website",
                                     "status": "active",
                                     "timestamp": 1656958485,
                                   },
@@ -10931,8 +10931,8 @@ paths:
                           type: object
                           description: |
                             `{user_id}` or `{user_email}`: Object containing the details of a user's
-                            presence on every client the user is logged into. Depending on the value
-                            of `slim_presence`, the object's key is either the user's ID or email.
+                            presence . Depending on the value of `slim_presence`, the object's key is
+                            either the user's ID or the user's Zulip display email.
                           additionalProperties:
                             $ref: "#/components/schemas/Presence"
                       server_timestamp:
@@ -17508,34 +17508,34 @@ components:
     Presence:
       type: object
       description: |
-        `{client_name}` or `aggregated`: Object containing the details of the user's
-        presence on a particular platform.
+        `{client_name}` or `"aggregated"`: Object containing the details of the user's
+        presence.
 
-        Generally, the keys for these objects are the names of the different clients
-        where this user is logged in, for example `website` or `ZulipDesktop`.
+        **Changes**: Starting with Zulip 7.0 (feature level 178), this will always
+        contain two keys, `"website"` and `"aggregated"`, with identical data. The
+        server no longer stores which client submitted presence updates.
 
-        There is also an `aggregated` key, which matches the contents of the object
-        that has been updated most recently (except for the `pushable` value which is
-        not present).
-
-        **Changes**: Starting with Zulip 7.0 (feature level 178), this
-        will always contain two keys, `website` and `aggregated`, with
-        identical data. The server no longer stores which client submitted
-        presence updates.
+        Previously, the `{client_name}` keys for these objects were the names of the
+        different clients where the user was logged in, for example `website` or
+        `ZulipDesktop`.
       additionalProperties: false
       properties:
         client:
           type: string
           description: |
             The client's platform name.
+
+            **Changes**: Starting with Zulip 7.0 (feature level 178), this will
+            always be `"website"` as the server no longer stores which client
+            submitted presence data.
         status:
           type: string
           enum:
             - idle
             - active
           description: |
-            The status of the user on this client. Will be either `idle`
-            or `active`.
+            The status of the user on this client. Will be either `"idle"`
+            or `"active"`.
         timestamp:
           type: integer
           description: |
@@ -17547,7 +17547,11 @@ components:
             Whether the client is capable of showing mobile/push notifications
             to the user.
 
-            Not present in objects with the `aggregated` key.
+            Not present in objects with the `"aggregated"` key.
+
+            **Changes**: Starting with Zulip 7.0 (feature level 178), always
+            `false` when present as the server no longer stores which client
+            submitted presence data.
     Draft:
       type: object
       description: |


### PR DESCRIPTION
Part of 7.0 API changelog audit; see [this CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/7.2E0.20API.20changelog.20audit/near/1571838) for more context.

Updates API changelog entry and related parts of API docs for: **Feature level 178**.

**Notes**:
- Updates the descriptions and examples for there only being two key values: "website" and "aggregated".
- Also, clarifies that email keys are the Zulip display email.
- And removes any descriptive text that says presence objects have information about the clients the user is logged into.

---

**Screenshots and screen captures:**

<details>
<summary>Updated API changelog feature level 178 entry</summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-70)
![Screenshot from 2023-05-18 19-06-23](https://github.com/zulip/zulip/assets/63245456/67ecb589-8b2e-4c7a-8be5-4cca2c9e6e23)
</details>
<details>
<summary>Register response: search for "presences" object</summary>

[Current documentation](https://zulip.com/api/register-queue)
![Screenshot from 2023-05-18 19-06-51](https://github.com/zulip/zulip/assets/63245456/3e778329-d00a-4008-abea-2643dafb755f)
</details>
<details>
<summary>Get events: Presence event</summary>

[Current documentation](https://zulip.com/api/get-events#presence)
![Screenshot from 2023-05-18 19-07-27](https://github.com/zulip/zulip/assets/63245456/0bed9149-e40c-43a3-8ea4-c4b085788e93)
![Screenshot from 2023-05-18 19-07-40](https://github.com/zulip/zulip/assets/63245456/91efff11-4a21-4162-b354-1d95733b0bdc)

</details>
<details>
<summary>Get user presence</summary>

[Current documentation](https://zulip.com/api/get-user-presence)
![Screenshot from 2023-05-18 19-07-53](https://github.com/zulip/zulip/assets/63245456/60dd7c16-85bd-4e83-a1d8-f84e228304de)
![Screenshot from 2023-05-18 19-08-04](https://github.com/zulip/zulip/assets/63245456/2f0f87e7-4360-4c2a-a75c-7fc0f9223eae)

</details>
<details>
<summary>Get presence of all users</summary>

[Current documentation](https://zulip.com/api/get-presence)
![Screenshot from 2023-05-18 19-08-17](https://github.com/zulip/zulip/assets/63245456/e43c7e20-ad95-4be1-ae6b-ea467493b852)
![Screenshot from 2023-05-18 19-08-30](https://github.com/zulip/zulip/assets/63245456/c92c337d-dc9e-4f7a-8008-be64e0c6e8c3)
![Screenshot from 2023-05-18 19-08-38](https://github.com/zulip/zulip/assets/63245456/c3ec3d68-e20c-4e29-af71-74adfdf07378)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
