### PR TITLE
search: Allow users to search for a stream using #.

### DIFF
--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -14,6 +14,9 @@ import * as typeahead_helper from "./typeahead_helper";
 export const max_num_of_search_results = 12;
 
 function stream_matches_query(stream_name, q) {
+    if (q.startsWith("#") && stream_name.toLowerCase().startsWith(q.slice(1).toLowerCase())) {
+        return true;
+    }
     return common.phrase_match(q, stream_name);
 }
 

--- a/web/tests/search_suggestion_now.test.js
+++ b/web/tests/search_suggestion_now.test.js
@@ -817,6 +817,16 @@ test("stream_completion", ({override}) => {
     suggestions = get_suggestions("", query);
     expected = ["hel", "stream:dev+help"];
     assert.deepEqual(suggestions.strings, expected);
+
+    query = "#de";
+    suggestions = get_suggestions("", query);
+    expected = ["#de", "stream:dev+help"];
+    assert.deepEqual(suggestions.strings, expected);
+
+    query = "#hel";
+    suggestions = get_suggestions("", query);
+    expected = ["#hel"];
+    assert.deepEqual(suggestions.strings, expected);
 });
 
 test("people_suggestions", ({override}) => {


### PR DESCRIPTION
Previously searching for e.g. "#Denmark" wouldn't show the stream Denmark. Now it does.

thanks @WesleyAC for the idea / report