### PR TITLE
Migrate giphy popover to tippy.

### DIFF
--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -30,7 +30,12 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: ".compose_control_button",
+        // Only display Tippy content on classes accompanied by a `data-` attribute.
+        target: `
+        .compose_control_button[data-tooltip-template-id],
+        .compose_control_button[data-tippy-content],
+        .compose_control_button_container
+        `,
         // Add some additional delay when they open
         // so that regular users don't have to see
         // them unless they want to.

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -19,7 +19,6 @@ import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
 import * as dialog_widget from "./dialog_widget";
 import * as emoji_picker from "./emoji_picker";
-import * as giphy from "./giphy";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
 import * as message_lists from "./message_lists";
@@ -1085,7 +1084,6 @@ export function hide_all_except_sidebars(opts) {
         hideAll();
     }
     emoji_picker.hide_emoji_popover();
-    giphy.hide_giphy_popover();
     stream_popover.hide_stream_popover();
     hide_all_user_info_popovers();
     hide_playground_links_popover();

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -668,12 +668,6 @@ input.recipient_box {
     min-height: var(--compose-recipient-box-min-height);
 }
 
-.tippy-content .compose_control_buttons_container {
-    .compose_gif_icon {
-        bottom: 5px;
-    }
-}
-
 .compose_control_buttons_container {
     margin-right: auto;
     display: flex;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -674,10 +674,26 @@ input.recipient_box {
     gap: 4px;
     align-items: center;
 
-    .compose_gif_icon {
+    /* We use the selector in this manner to maintain specificity. */
+    .compose_control_button_container .compose_gif_icon {
         font-size: 22px;
-        height: 18px;
-        line-height: 18px;
+
+        /* Remove top and bottom padding. This is necessary
+         * because `compose_gif_icon` is no longer a flex item.  */
+        padding: 0 5px;
+    }
+
+    .compose_control_button {
+        padding: 5px;
+        opacity: 0.7;
+        color: inherit;
+        text-decoration: none;
+        font-size: 17px;
+        text-align: center;
+
+        &:hover {
+            opacity: 1;
+        }
     }
 
     .fa-eye {
@@ -748,19 +764,6 @@ input.recipient_box {
             pointer-events: none;
             background-color: hsl(0deg 0% 65%);
         }
-    }
-}
-
-a.compose_control_button {
-    padding: 5px;
-    opacity: 0.7;
-    color: inherit;
-    text-decoration: none;
-    font-size: 17px;
-    text-align: center;
-
-    &:hover {
-        opacity: 1;
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -770,14 +770,6 @@ a.compose_control_button {
     }
 }
 
-/* This is used to override the
- * properties of `a.compose_control_button`
- * without using `!important`.
- */
-a.compose_control_button.hide {
-    display: none;
-}
-
 .drag {
     display: none;
     height: 18px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -735,6 +735,14 @@ ul {
     left: -1px;
 }
 
+.giphy-popover {
+    .tippy-content {
+        /* We remove the default padding from this container
+           as it is not necessary for the Giphy popover. */
+        padding: 0;
+    }
+}
+
 #giphy_grid_in_popover {
     /* 300px of GIPHY grid + 5px is the extra gutter space
      * between gif columns. */
@@ -762,6 +770,10 @@ ul {
             flex-grow: 1;
             margin: 5px;
             border-radius: 3px;
+
+            /* By resetting to the default color from the `body`,
+             * we can ignore the colors applied from `tippy-box`. */
+            color: var(--color-text-default);
         }
 
         .clear_search_button {
@@ -787,7 +799,12 @@ ul {
     .popover-footer {
         text-align: center;
         background-color: hsl(0deg 0% 0%);
-        border-radius: 0 0 6px 6px;
+        /* The border radius corresponds to the default radius value from `tippy-box`. */
+        border-radius: 0 0 4px 4px;
+
+        /* This prevents the footer from experiencing height
+           fluctuations at the moment when the image is uploaded. */
+        min-height: 25px;
 
         & img {
             width: 120px;

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -8,7 +8,9 @@
     <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
     <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
     <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"></a>
-    <a role="button" class="compose_control_button compose_gif_icon {{#unless giphy_enabled }} hide {{/unless}} zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0 data-tippy-content="{{t 'Add GIF' }}"></a>
+    <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}}" data-tippy-content="{{t 'Add GIF' }}">
+        <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
+    </div>
     <div class="divider hide-sm">|</div>
     <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
         {{> compose_control_buttons_in_popover}}

--- a/web/templates/giphy_picker.hbs
+++ b/web/templates/giphy_picker.hbs
@@ -1,4 +1,4 @@
-<div class="popover" id="giphy_grid_in_popover">
+<div id="giphy_grid_in_popover">
     <div class="arrow"></div>
     <div class="popover-inner">
         <div class="search-box">


### PR DESCRIPTION
## Description
This pull request introduces an API for popovers that can be utilized outside of `popover_menus`. Currently, it is relatively straightforward, as we are simply exporting the `register_popover_menu` function from `popover_menus`. However, there are a few questions worth discussing:

1. In this PR, I have removed the line that was hiding the Giphy popover from the `hide_all_except_sidebars` function. This change was necessary because the popover was closing itself due to being called inside the `onShow` method of the Giphy popover. It would be beneficial to discuss the approach we take regarding hiding popovers. Perhaps we should consider having a function called `hide_all_except_instance` to be used in the `onShow` method of the tooltip. I am currently uncertain about the best way to implement this system.

2. Another topic to consider is where we should store the instances. Should we store them in a centralized location to better control and manage them? This would allow us to obtain information about which instances are open and close them as needed. Alternatively, should we place them within their respective modules (e.g., `giphy.js`)? I am unsure which approach would be more suitable. For now, I have placed them in `giphy.js`, without implementing preemptive optimizations.

The second part of this PR focuses on migrating the Giphy popover to Tippy using the API created in the first part. This process was relatively straightforward.

## Testing
**I have conducted tests on the following aspects:**
1. Verification of the appearance in both dark and light themes.
2. GIF search functionality.
3. Keyboard navigation within the popover.
4. Selection of GIFs.


## Screenshots
<details>
<summary>Dark and light themes appearance:</summary>
<br>

![light](https://github.com/zulip/zulip/assets/53193850/3ba5dc64-9c93-4263-b6da-83a7d881efeb)
![dark](https://github.com/zulip/zulip/assets/53193850/37a4f051-9609-4034-8645-17c3fcbf39d9)

</details>
