### PR TITLE
api-changelog: Add 2.1.0 entry for realm_default_external_accounts.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1479,6 +1479,8 @@ No changes; feature level used for Zulip 3.0 release.
 
 ## Changes in Zulip 2.1
 
+* [`POST /register`](/api/register-queue): Added
+  `realm_default_external_accounts` to endpoint response.
 * [`GET /messages`](/api/get-messages): Added support for
   [search/narrow options](/api/construct-narrow) that use stream/user
   IDs to specify a message's sender, its stream, and/or its recipient(s).

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -13220,8 +13220,10 @@ paths:
                           Present if `realm` is present in `fetch_event_types`.
 
                           Dictionary where each entry describes a default external
-                          account type that can be configured with Zulip's custom
-                          profile fields feature.
+                          account type that can be configured with Zulip's [custom
+                          profile fields feature](/help/custom-profile-fields).
+
+                          **Changes**: New in Zulip 2.1.0.
                         additionalProperties:
                           description: |
                             `{site_name}`: Dictionary containing the details of the


### PR DESCRIPTION
Adds an API changelog note to 2.1 for the addition of `realm_default_external_accounts` to the `/register-queue` response. Also adds a Changes note to the field in the endpoint's response API documentation.

The original commit that added it to that endpoint's response was commit d7ee2aced17ecf81b.

See [this CZO message/conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/audit.20for.20change.20entries.20vs.2E.20central.20changelog/near/1393419) for more context.

**Notes**:
- Because this is more of a server setting and does not have any equivalent events in the `GET /events` endpoint, I didn't use the convention we settled on in [this #api documentation conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/realm.20settings.20names/near/1396247).
- There is a [TODO comment in `events.py`](https://github.com/zulip/zulip/blob/b312a86adabf04efee4f7d3a12e6fc0150f35728/zerver/lib/events.py#L338-L340) about possibly changing the prefix to `server_` instead of `realm_`. But for the purpose of these changes, we'll want to document the historical/current name anyway.

---

**Screenshots and screen captures:**

<details>
<summary>Updated 2.1 API changelog entry</summary>

![Screenshot from 2023-05-18 17-22-01](https://github.com/zulip/zulip/assets/63245456/7ba86703-f73e-4504-a37c-551299ba8dc5)
</details>
<details>
<summary>Updated realm_default_external_accounts description in /register response</summary>

![Screenshot from 2023-05-18 17-21-17](https://github.com/zulip/zulip/assets/63245456/80ecbc2f-8d10-4b00-8541-c5c2fce0ad2f)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
