### PR TITLE
billing-helpers: Add commas to formatted amount.

### DIFF
--- a/web/src/billing/helpers.js
+++ b/web/src/billing/helpers.js
@@ -75,8 +75,10 @@ export function format_money(cents) {
     } else {
         precision = 2;
     }
-    // TODO: Add commas for thousands, millions, etc.
-    return (cents / 100).toFixed(precision);
+    return new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: precision,
+        maximumFractionDigits: precision,
+    }).format((cents / 100).toFixed(precision));
 }
 
 export function update_charged_amount(prices, schedule) {

--- a/web/tests/billing_helpers.test.js
+++ b/web/tests/billing_helpers.test.js
@@ -188,8 +188,8 @@ run_test("format_money", () => {
     assert.equal(helpers.format_money("666.6666666666666"), "6.67");
     assert.equal(helpers.format_money("7600"), "76");
     assert.equal(helpers.format_money("8000"), "80");
-    assert.equal(helpers.format_money("123416.323"), "1234.17");
-    assert.equal(helpers.format_money("927268238"), "9272682.38");
+    assert.equal(helpers.format_money("123416.323"), "1,234.17");
+    assert.equal(helpers.format_money("927268238"), "9,272,682.38");
 });
 
 run_test("update_charged_amount", () => {
@@ -198,11 +198,13 @@ run_test("update_charged_amount", () => {
     prices.monthly = 800;
     page_params.seat_count = 35;
 
+    // 80 * 35 = 2800
     helpers.update_charged_amount(prices, "annual");
-    assert.equal($("#charged_amount").text(), (80 * 35).toString());
+    assert.equal($("#charged_amount").text(), "2,800");
 
+    // 8 * 35 = 280
     helpers.update_charged_amount(prices, "monthly");
-    assert.equal($("#charged_amount").text(), (8 * 35).toString());
+    assert.equal($("#charged_amount").text(), "280");
 });
 
 run_test("show_license_section", () => {


### PR DESCRIPTION

This uses `Intl.NumberFormat` to format the converted amount. 

It is 96.92 % supported across various browsers. Source: [caniuse.com](https://caniuse.com/?search=Intl.NumberFormat)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
