### PR TITLE
ui_init: Properly call reject with an error, not an xhr.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -731,8 +731,19 @@ $(async () => {
             }),
             client_gravatar: false,
         };
-        const {result, msg, ...state} = await new Promise((success, error) => {
-            channel.post({url: "/json/register", data, success, error});
+        const {result, msg, ...state} = await new Promise((resolve, reject) => {
+            channel.post({
+                url: "/json/register",
+                data,
+                resolve,
+                error(xhr) {
+                    blueslip.error("Spectator failed to register", {
+                        status: xhr.status,
+                        bodt: xhr.responseText,
+                    });
+                    reject(new Error("Spectator failed to register"));
+                },
+            });
         });
         Object.assign(page_params, state);
     }


### PR DESCRIPTION
If the spectator registration call fails, properly log the error and call `reject` with an error object, not the xhr that `channel.post` calls its error callback with.

This does nothing to address the UI question of what to do should this request fail.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
