### PR TITLE
linter: Lint grid-area names for quotation marks.

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -28,6 +28,9 @@ module.exports = {
             "/^(border(-top|-right|-bottom|-left)?|outline)(-width)?$/": [
                 /\b(thin|medium|thick)\b/,
             ],
+            // no quotation marks around grid-area; use
+            // `grid-area: my_area`, not `grid-area: "my_area"`
+            "grid-area": [/".*"/],
         },
         "function-disallowed-list": [
             // We use hsl instead of rgb


### PR DESCRIPTION
This adds a CSS stylelint rule that will catch erroneous quotation marks around [named grid-areas](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area), which should be [&lt;custom-ident&gt;](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident) values, not strings. So, for example, `grid-area: "my_area"` is an error. It should be `grid-area: my_area`.

This is not just a cosmetic issue: `grid-area` will not work if areas are presented in quotation marks.

Because there will likely be more use of CSS Grid on the redesign, because the Zulip project ought to encourage the use of named areas, and because quotation marks look "natural" on `grid-area` even though they are in error, it makes sense to preserve this knowledge in the linter configuration.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
