### PR TITLE
Add zulip-flutter to total-contributions script

### DIFF
--- a/tools/total-contributions
+++ b/tools/total-contributions
@@ -39,6 +39,26 @@ def find_path(repository: str) -> str:
     return str(pathlib.Path().resolve().parents[0] / repository)
 
 
+def process_repo(
+    *,
+    out_dict: Dict[str, int],
+    repo_short: str,
+    repo_full: str,
+    lower_version: str,
+    upper_version: str,
+) -> None:
+    commit_count = len(
+        subprocess.check_output(
+            ["git", "log", "--pretty=oneline", f"{lower_version}..{upper_version}"],
+            cwd=find_path(repo_short),
+            text=True,
+        ).splitlines()
+    )
+    repo_log = retrieve_log(repo_short, lower_version, upper_version)
+    print(f"{commit_count} commits from {repo_full}: {lower_version[0:12]}..{upper_version[0:12]}")
+    add_log(out_dict, repo_log)
+
+
 def find_last_commit_before_time(repository: str, branch: str, time: str) -> str:
     """Find the latest release version for the target repository as of the
     specified time.
@@ -141,18 +161,13 @@ print(
 repository_dict: Dict[str, int] = defaultdict(int)
 out_dict: Dict[str, int] = defaultdict(int)
 subprocess.check_call(["git", "fetch"], cwd=find_path("zulip"))
-commit_count = len(
-    subprocess.check_output(
-        ["git", "log", "--pretty=oneline", f"{lower_zulip_version}..{upper_zulip_version}"],
-        cwd=find_path("zulip"),
-        text=True,
-    ).splitlines()
+process_repo(
+    out_dict=out_dict,
+    repo_short="zulip",
+    repo_full="zulip/zulip",
+    lower_version=lower_zulip_version,
+    upper_version=upper_zulip_version,
 )
-repo_log = retrieve_log("zulip", lower_zulip_version, upper_zulip_version)
-print(
-    f"{commit_count} commits from zulip/zulip: {lower_zulip_version[0:12]}..{upper_zulip_version[0:12]}"
-)
-add_log(out_dict, repo_log)
 
 # TODO: We should migrate the last couple repositories to use the
 # `main` default branch name and then simplify this.
@@ -186,18 +201,13 @@ for full_repository, branch in [
     subprocess.check_call(["git", "fetch", "-a"], cwd=find_path(repository))
     lower_repo_version = find_last_commit_before_time(repository, branch, lower_time)
     upper_repo_version = find_last_commit_before_time(repository, branch, upper_time)
-    commit_count = len(
-        subprocess.check_output(
-            ["git", "log", "--pretty=oneline", f"{lower_repo_version}..{upper_repo_version}"],
-            cwd=find_path(repository),
-            text=True,
-        ).splitlines()
+    process_repo(
+        out_dict=out_dict,
+        repo_short=repository,
+        repo_full=full_repository,
+        lower_version=lower_repo_version,
+        upper_version=upper_repo_version,
     )
-    repo_log = retrieve_log(repository, lower_repo_version, upper_repo_version)
-    print(
-        f"{commit_count} commits from {full_repository}: {lower_repo_version[0:12]}..{upper_repo_version[0:12]}"
-    )
-    add_log(out_dict, repo_log)
 
 # Sorting based on number of commits
 grand_total = 0

--- a/tools/total-contributions
+++ b/tools/total-contributions
@@ -27,9 +27,9 @@ def add_log(committer_dict: Dict[str, int], input: List[str]) -> None:
         committer_dict[committer_name] += commit_count
 
 
-def retrieve_log(repo: str, lower_version: str, upper_version: str) -> List[str]:
+def retrieve_log(repo: str, revisions: str) -> List[str]:
     return subprocess.check_output(
-        ["git", "shortlog", "-s", lower_version + ".." + upper_version],
+        ["git", "shortlog", "-s", revisions],
         cwd=find_path(repo),
         text=True,
     ).splitlines()
@@ -47,15 +47,21 @@ def process_repo(
     lower_version: str,
     upper_version: str,
 ) -> None:
+    if not lower_version:
+        revisions = upper_version
+        revisions_display = f"(start)..{upper_version[0:12]}"
+    else:
+        revisions = f"{lower_version}..{upper_version}"
+        revisions_display = f"{lower_version[0:12]}..{upper_version[0:12]}"
     commit_count = len(
         subprocess.check_output(
-            ["git", "log", "--pretty=oneline", f"{lower_version}..{upper_version}"],
+            ["git", "log", "--pretty=oneline", revisions],
             cwd=find_path(repo_short),
             text=True,
         ).splitlines()
     )
-    repo_log = retrieve_log(repo_short, lower_version, upper_version)
-    print(f"{commit_count} commits from {repo_full}: {lower_version[0:12]}..{upper_version[0:12]}")
+    repo_log = retrieve_log(repo_short, revisions)
+    print(f"{commit_count} commits from {repo_full}: {revisions_display}")
     add_log(out_dict, repo_log)
 
 

--- a/tools/total-contributions
+++ b/tools/total-contributions
@@ -179,6 +179,7 @@ process_repo(
 # `main` default branch name and then simplify this.
 for full_repository, branch in [
     ("zulip/zulip-mobile", "main"),
+    ("zulip/zulip-flutter", "main"),
     ("zulip/zulip-desktop", "main"),
     ("zulip/docker-zulip", "main"),
     ("zulip/python-zulip-api", "main"),


### PR DESCRIPTION
This adds zulip/zulip-flutter to the list of repositories canvassed by the `tools/total-contributions` script.

It also fixes a bug that would cause us to leave out a repo's history when the start date is older than the oldest commit in the repo — so in particular we'd leave out a repo's history whenever what we actually wanted was the repo's *entire* history.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
