### PR TITLE
redesign update licenses modal

### DIFF
--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -234,7 +234,6 @@
     </div>
 </div>
 
-
 <div class="micromodal" id="confirm-licenses-modal" aria-hidden="true">
     <div class="modal__overlay" tabindex="-1">
         <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
@@ -251,9 +250,7 @@
                     <b><span id="new_license_count_holder"></span></b>?
                 </p>
                 <p>
-                    You will be charged for 
-                    <span id="additional_license_count_holder"></span>
-                    additional licenses.
+                    You will be charged for <span id="additional_license_count_holder"></span> additional licenses.
                 </p>
             </main>
             <footer class="modal__footer">

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -255,7 +255,7 @@
             </main>
             <footer class="modal__footer">
                 <button class="modal__btn dialog_cancel_button" aria-label="{{ '(Close this dialog window)' }}" data-micromodal-close>{{ _('Cancel') }}</button>
-                <button class="modal__btn confirm-license-update-button">
+                <button class="modal__btn confirm-license-update-button" id="confirm-license-update-button">
                     <span>{{ _('Confirm') }}</span>
                 </button>
             </footer>

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -235,26 +235,34 @@
 </div>
 
 
-<div id="confirm-licenses-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="deactivation_self_modal_label" aria-hidden="true">
-    <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
-        <h3 id="deactivation_self_modal_label">Confirm license increase</h3>
-    </div>
-    <div class="modal-body">
-        <p>
-            Are you sure you want to increase the licenses from
-            <b><span id="current_license_count_holder"></span></b> to
-            <b><span id="new_license_count_holder"></span></b>?
-        </p>
-        <p>
-            You would be charged for the additional licenses.
-        </p>
-    </div>
-    <div class="modal-footer">
-        <button class="button" data-dismiss="modal">Cancel</button>
-        <button class="button btn-success rounded" id="confirm-license-update-button" data-dismiss="modal" aria-hidden="true">
-            <span id="confirm-license-update">Confirm</span>
-        </button>
+<div class="micromodal" id="confirm-licenses-modal" aria-hidden="true">
+    <div class="modal__overlay" tabindex="-1">
+        <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="dialog_title">
+            <header class="modal__header">
+                <h1 class="modal__title dialog_heading">
+                    Confirm license increase
+                </h1>
+                <button class="modal__close" aria-label="{{ _('Close modal') }}" data-micromodal-close></button>
+            </header>
+            <main class="modal__content">
+                <p>
+                    Are you sure you want to increase the licenses from
+                    <b><span id="current_license_count_holder"></span></b> to
+                    <b><span id="new_license_count_holder"></span></b>?
+                </p>
+                <p>
+                    You will be charged for 
+                    <span id="additional_license_count_holder"></span>
+                    additional licenses.
+                </p>
+            </main>
+            <footer class="modal__footer">
+                <button class="modal__btn dialog_cancel_button" aria-label="{{ '(Close this dialog window)' }}" data-micromodal-close>{{ _('Cancel') }}</button>
+                <button class="modal__btn dialog_submit_button">
+                    <span>{{ _('Confirm') }}</span>
+                </button>
+            </footer>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -255,7 +255,7 @@
             </main>
             <footer class="modal__footer">
                 <button class="modal__btn dialog_cancel_button" aria-label="{{ '(Close this dialog window)' }}" data-micromodal-close>{{ _('Cancel') }}</button>
-                <button class="modal__btn dialog_submit_button">
+                <button class="modal__btn confirm-license-update-button">
                     <span>{{ _('Confirm') }}</span>
                 </button>
             </footer>

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -52,7 +52,7 @@ export function initialize() {
         }
     });
 
-    $(".confirm-license-update-button").on("click", () => {
+    $("#confirm-license-update-button").on("click", () => {
         create_update_license_request();
     });
 

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -52,7 +52,6 @@ export function initialize() {
             create_update_license_request();
         }
     });
-    
 
     $(".dialog_submit_button").on("click", () => {
         create_update_license_request();

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -2,6 +2,8 @@ import $ from "jquery";
 
 import * as helpers from "./helpers";
 
+import Micromodal from "micromodal";
+
 export function create_update_license_request() {
     helpers.create_ajax_request(
         "/json/billing/plan",
@@ -40,13 +42,19 @@ export function initialize() {
         if (new_licenses > current_licenses) {
             $("#new_license_count_holder").text(new_licenses);
             $("#current_license_count_holder").text(current_licenses);
-            $("#confirm-licenses-modal").modal("show");
+            const additional_licenses = new_licenses - current_licenses;
+            $("#additional_license_count_holder").text(additional_licenses);
+            Micromodal.show("confirm-licenses-modal", {
+                disableFocus: true,
+                openClass: "modal--opening",
+            });
         } else {
             create_update_license_request();
         }
     });
+    
 
-    $("#confirm-license-update-button").on("click", () => {
+    $(".dialog_submit_button").on("click", () => {
         create_update_license_request();
     });
 

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -52,7 +52,7 @@ export function initialize() {
         }
     });
 
-    $(".dialog_submit_button").on("click", () => {
+    $(".confirm-license-update-button").on("click", () => {
         create_update_license_request();
     });
 

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -1,8 +1,8 @@
 import $ from "jquery";
 
-import * as helpers from "./helpers";
-
 import Micromodal from "micromodal";
+
+import * as helpers from "./helpers";
 
 export function create_update_license_request() {
     helpers.create_ajax_request(

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import Micromodal from "micromodal";
+
 import * as helpers from "./helpers";
 
 export function create_update_license_request() {

--- a/web/src/billing/billing.js
+++ b/web/src/billing/billing.js
@@ -1,7 +1,5 @@
 import $ from "jquery";
-
 import Micromodal from "micromodal";
-
 import * as helpers from "./helpers";
 
 export function create_update_license_request() {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: https://github.com/zulip/zulip/issues/25649

Redesigned the license update modal using the design from `/templates/zerver/change_email_address_visibility_modal.html`

- Added additional_license_count_holder

**Screenshots and screen captures:**

Before:
![image](https://github.com/zulip/zulip/assets/91382272/b88d6b6c-2044-4c32-951a-eeb628f769b1)

After:
![image](https://github.com/zulip/zulip/assets/91382272/aaa2bc08-d054-45c9-ae65-d8d485b2d361)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
