### PR TITLE
Extract logic creating links to messages

### DIFF
--- a/web/src/hash_util.js
+++ b/web/src/hash_util.js
@@ -145,6 +145,7 @@ export function huddle_with_url(user_ids_string) {
 }
 
 export function by_conversation_and_time_url(message) {
+    // Wrapper for web use of internal_url.by_conversation_and_time_url
     const absolute_url =
         window.location.protocol +
         "//" +
@@ -152,13 +153,15 @@ export function by_conversation_and_time_url(message) {
         "/" +
         window.location.pathname.split("/")[1];
 
-    const suffix = "/near/" + internal_url.encodeHashComponent(message.id);
+    const user_ids = people.all_user_ids_in_pm(message);
 
-    if (message.type === "stream") {
-        return absolute_url + by_stream_topic_url(message.stream_id, message.topic) + suffix;
-    }
-
-    return absolute_url + people.pm_perma_link(message) + suffix;
+    return internal_url.by_conversation_and_time_url(
+        absolute_url,
+        message,
+        user_ids,
+        sub_store.maybe_get_stream_name,
+        null,
+    );
 }
 
 export function stream_edit_url(sub) {

--- a/web/src/people.js
+++ b/web/src/people.js
@@ -1,6 +1,7 @@
 import md5 from "blueimp-md5";
 import {format, utcToZonedTime} from "date-fns-tz";
 
+import * as internal_url from "../shared/src/internal_url";
 import * as typeahead from "../shared/src/typeahead";
 
 import * as blueslip from "./blueslip";
@@ -497,23 +498,8 @@ export function pm_with_user_ids(message) {
 }
 
 export function pm_perma_link(message) {
-    const user_ids = all_user_ids_in_pm(message);
-
-    if (!user_ids) {
-        return undefined;
-    }
-
-    let suffix;
-
-    if (user_ids.length >= 3) {
-        suffix = "group";
-    } else {
-        suffix = "dm";
-    }
-
-    const slug = user_ids.join(",") + "-" + suffix;
-    const url = "#narrow/dm/" + slug;
-    return url;
+    // Wrapper for web use of internal_url.pm_perma_link
+    return internal_url.pm_perma_link(all_user_ids_in_pm(message), null);
 }
 
 export function pm_with_url(message) {

--- a/web/tests/internal_url.test.js
+++ b/web/tests/internal_url.test.js
@@ -50,3 +50,90 @@ run_test("test by_stream_topic_url", () => {
     const result = internal_url.by_stream_topic_url(123, "test topic", maybe_get_stream_name);
     assert.equal(result, "#narrow/stream/123-a-test-stream/topic/test.20topic");
 });
+
+run_test("test pm_perma_link", () => {
+    let message = {
+        type: "private",
+        display_recipient: [30, 301, 302],
+    };
+    assert.equal(
+        internal_url.pm_perma_link(message.display_recipient, null),
+        "#narrow/dm/30,301,302-group",
+    );
+
+    message = {
+        type: "private",
+        display_recipient: [30, 302],
+    };
+    assert.equal(
+        internal_url.pm_perma_link(message.display_recipient, 177),
+        "#narrow/dm/30,302-dm",
+    );
+
+    message = {
+        type: "private",
+        display_recipient: [30],
+    };
+    assert.equal(
+        internal_url.pm_perma_link(message.display_recipient, 173),
+        "#narrow/pm-with/30-pm",
+    );
+});
+
+run_test("test_by_conversation_and_time_url", () => {
+    const maybe_get_stream_name = () => "a test stream";
+
+    let message = {
+        type: "stream",
+        stream_id: 99,
+        topic: "testing",
+        id: 42,
+    };
+
+    assert.equal(
+        internal_url.by_conversation_and_time_url(
+            "http://zulip.zulipdev.com/",
+            message,
+            [15],
+            maybe_get_stream_name,
+            177,
+        ),
+        "http://zulip.zulipdev.com/#narrow/stream/99-a-test-stream/topic/testing/near/42",
+    );
+
+    message = {
+        type: "private",
+        stream_id: 15,
+        topic: "testing",
+        id: 43,
+    };
+
+    assert.equal(
+        internal_url.by_conversation_and_time_url(
+            "http://zulip.zulipdev.com/",
+            message,
+            [15],
+            maybe_get_stream_name,
+            173,
+        ),
+        "http://zulip.zulipdev.com/#narrow/pm-with/15-pm/near/43",
+    );
+
+    message = {
+        type: "private",
+        stream_id: 15,
+        topic: "testing",
+        id: 43,
+    };
+
+    assert.equal(
+        internal_url.by_conversation_and_time_url(
+            "http://zulip.zulipdev.com/",
+            message,
+            [15],
+            maybe_get_stream_name,
+            177,
+        ),
+        "http://zulip.zulipdev.com/#narrow/dm/15-dm/near/43",
+    );
+});


### PR DESCRIPTION
Purpose: Share the logic in zulip web for constructing links to messages with zulip mobile.

- Functions refactored and moved to internal_url.js module:
    - by_conversation_and_time_url from hash_util.js;
    - pm_perma_link from people.js.
- Wrapper functions for web use of these two functions were created.

Therefore, we would be able to take the same approach from "Copy link to topic" and "Copy link to stream" actions when implementing "Copy link to message" action.

Fixes: https://github.com/zulip/zulip/issues/21412

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
