### PR TITLE
settings_playground: Fix sorting issues in code playgrounds table.

### DIFF
--- a/web/src/settings_playgrounds.js
+++ b/web/src/settings_playgrounds.js
@@ -21,23 +21,6 @@ export function reset() {
     meta.loaded = false;
 }
 
-function compare_by_index(a, b, i) {
-    if (a[i] > b[i]) {
-        return 1;
-    } else if (a[i] === b[i]) {
-        return 0;
-    }
-    return -1;
-}
-
-function sort_pygments_language(a, b) {
-    return compare_by_index(a, b, 0);
-}
-
-function sort_playground_name(a, b) {
-    return compare_by_index(a, b, 1);
-}
-
 export function maybe_disable_widgets() {
     if (page_params.is_admin) {
         return;
@@ -76,11 +59,7 @@ export function populate_playgrounds(playgrounds_data) {
             },
         },
         $parent_container: $("#playground-settings").expectOne(),
-        init_sort: [sort_pygments_language],
-        sort_fields: {
-            pygments_language: sort_pygments_language,
-            playground_name: sort_playground_name,
-        },
+        init_sort: ["alphabetic", "pygments_language"],
         $simplebar_container: $("#playground-settings .progressive-table-wrapper"),
     });
 }

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -71,9 +71,9 @@
         <div class="progressive-table-wrapper" data-simplebar>
             <table class="table table-condensed table-striped wrapped-table admin_playgrounds_table">
                 <thead class="table-sticky-headers">
-                    <th class="active" data-sort="pygments_language">{{t "Language" }}</th>
-                    <th data-sort="playground_name">{{t "Name" }}</th>
-                    <th data-sort="url">{{t "URL prefix" }}</th>
+                    <th class="active" data-sort="alphabetic" data-sort-prop="pygments_language">{{t "Language" }}</th>
+                    <th data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
+                    <th data-sort="alphabetic" data-sort-prop="url_prefix">{{t "URL prefix" }}</th>
                     {{#if is_admin}}
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}


### PR DESCRIPTION
Removed the sorting functions which were sorting under the assumption that our comparison items were a list instead I used the generic sort functions functionality of our `list_widget` module.

Discussion: [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Sorting.20issue.20in.20code.20playgrounds.2E)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
| Before | After |
|--------|--------|
| ![Before](https://github.com/zulip/zulip/assets/84276404/d8f84ff8-af97-4031-a23a-fa62b06f5563) | ![Screenshot 2023-05-21 142132](https://github.com/zulip/zulip/assets/84276404/3c244476-2b3c-49a9-8094-93c82c0c99dc) | 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
