### PR TITLE
ts: Convert rtl.js to TypeScript.

### DIFF
--- a/web/src/rtl.ts
+++ b/web/src/rtl.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import assert from "minimalistic-assert";
 
 // How to determine the direction of a paragraph (P1-P3): https://www.unicode.org/reports/tr9/tr9-35.html#The_Paragraph_Level
 // Embedding level: https://www.unicode.org/reports/tr9/tr9-35.html#BD2
@@ -21,7 +22,7 @@ import _ from "lodash";
  * @param {string} raw
  * @returns {number[]}
  */
-function convert_from_raw(digits, part_length, raw) {
+function convert_from_raw(digits: string, part_length: number, raw: string): number[] {
     const result = [];
     for (let i = 0; i < raw.length; ) {
         let t = 0;
@@ -86,7 +87,7 @@ const lr_ranges = [
  * @param {number} ch A character to get its bidirectional class.
  * @returns {'I' | 'PDI' | 'R' | 'L' | 'Other'}
  */
-function get_bidi_class(ch) {
+function get_bidi_class(ch: number): "I" | "PDI" | "R" | "L" | "Other" {
     if (i_chars.has(ch)) {
         return "I"; // LRI, RLI, FSI
     }
@@ -109,10 +110,10 @@ function get_bidi_class(ch) {
  * @param {string} str The string to get its direction.
  * @returns {'ltr' | 'rtl'}
  */
-export function get_direction(str) {
+export function get_direction(str: string): "ltr" | "rtl" {
     let isolations = 0;
     for (const ch of str) {
-        const bidi_class = get_bidi_class(ch.codePointAt(0));
+        const bidi_class = get_bidi_class(ch.codePointAt(0)!);
         switch (bidi_class) {
             case "I":
                 // LRI, RLI, FSI
@@ -139,9 +140,10 @@ export function get_direction(str) {
     return "ltr";
 }
 
-export function set_rtl_class_for_textarea($textarea) {
+export function set_rtl_class_for_textarea($textarea: JQuery<HTMLTextAreaElement>): void {
     // Set the rtl class if the text has an rtl direction, remove it otherwise
     let text = $textarea.val();
+    assert(typeof text === "string", "Passed HTML element must be a textarea.");
     if (text.startsWith("```quote")) {
         text = text.slice(8);
     }


### PR DESCRIPTION
This pull request converts `rtl.js` to TypeScript.

Thanks to @xoldyckk for working on this one at #24859.

- I had to adjust one or two things here, mostly related to type assertion and type definitions. 

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
