### PR TITLE
drafts: Fix message header overlapping outline.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -938,8 +938,6 @@ div.overlay {
 
         &.active {
             outline: 2px solid hsl(215deg 47% 50%);
-            /* this offset ensures no gap between the blue box and the draft in active state */
-            outline-offset: -1px;
             border-radius: 7px;
         }
 


### PR DESCRIPTION
Fixed it for both drafts and scheduled messages.

Discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/blue.20box.20in.20drafts/near/1573618

before:
![image](https://github.com/zulip/zulip/assets/25124304/0aad9411-a5f1-4163-b0ed-a6be03c6c7e4)

after:
<img width="839" alt="image" src="https://github.com/zulip/zulip/assets/25124304/bf089816-6788-459e-9b19-58fc24f4440f">
