### PR TITLE
user_topics: Update API documentation.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -137,8 +137,14 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 170**
 
-* [`POST /user_topics`](/api/update-user-topic):
-  Added a new endpoint to update the personal preferences for a topic.
+* [`POST /user_topics`](/api/update-user-topic): Added a new endpoint to
+  update a user's personal preferences for a topic, which deprecates the
+  [`PATCH /users/me/subscriptions/muted_topics`](/api/mute-topic) endpoint.
+  The deprecated endpoint is maintained for backwards-compatibility but may be
+  removed in a future release.
+* [`POST /register`](/api/register-queue), [`GET /events`](/api/get-events):
+  Unmuted added as a visibility policy option to the objects sent in response
+  to the `user_topic` event.
 
 **Feature level 169**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2007,10 +2007,13 @@ paths:
                                     preferences for the topic, such as whether the topic
                                     is muted.
 
-                                    - 0 = None. Used in events to indicate that the user no
-                                      longer has a special visibility policy for this
-                                      topic (for example, the user just unmuted it).
+                                    - 0 = None. Used to indicate that the user no
+                                      longer has a special visibility policy for this topic.
                                     - 1 = Muted. Used to record muted topics.
+                                    - 2 = Unmuted. Used to record unmuted topics.
+
+                                    **Changes**: In Zulip 7.0 (feature level 170), added unmuted as
+                                    a visibility policy option.
                               additionalProperties: false
                               example:
                                 {
@@ -8660,14 +8663,12 @@ paths:
       summary: Topic muting
       tags: ["streams"]
       description: |
-        This endpoint mutes/unmutes a topic within a stream that the current
-        user is subscribed to. Muted topics are displayed faded in the Zulip
-        UI, and are not included in the user's unread count totals.
+        [Mute or unmute a topic](/help/mute-a-topic) within a stream that
+        the current user is subscribed to.
 
         **Changes**: Deprecated in Zulip 7.0 (feature level 170). Clients connecting
-        to the newer server should use the `/user_topics` endpoint instead.
-        It will be removed once clients have migrated to use the
-        `/user_topics` endpoint.
+        to newer servers should use the [POST /user_topics](/api/update-user-topic)
+        endpoint, as this endpoint may be removed in a future release.
 
         Before Zulip 7.0 (feature level 169), this endpoint
         returned an error if asked to mute a topic that was already muted
@@ -8740,10 +8741,9 @@ paths:
         This endpoint can be used to update the visibility policy for the single
         stream and topic pair indicated by the parameters for a user.
 
-        **Changes**: New in Zulip 7.0 (feature level 170).
-        Previously, toggling the muting state for a topic was managed by the
-        `/users/me/subscriptions/muted_topics` endpoint, which this endpoint
-        is intended to replace.
+        **Changes**: New in Zulip 7.0 (feature level 170). Previously,
+        toggling whether a topic was muted or unmuted was managed by the
+        [PATCH /users/me/subscriptions/muted_topics](/api/mute-topic) endpoint.
       parameters:
         - name: stream_id
           in: query
@@ -8768,21 +8768,12 @@ paths:
           description: |
             Controls which visibility policy to set.
 
-            - 0 - INHERIT
-            - 1 - MUTED
-            - 2 - UNMUTED
+            - 0 = None. Removes the visibility policy previously set for the topic.
+            - 1 = Muted. [Mutes the topic](/help/mute-a-topic) in a stream.
+            - 2 = Unmuted. [Unmutes the topic](/help/mute-a-topic) in a muted stream.
 
-            The visibility policy, when set to MUTED, mutes a topic;
-            when set to UNMUTED, it unmutes a topic in a muted stream;
-            and INHERIT is used to remove the visibility policy already set.
-
-            MUTED topics are displayed faded in the Zulip UI, are not included
-            in the user's unread count totals, and the user doesn't receive any
-            notifications.
-
-            An UNMUTED topic will remain visible even if the stream is muted.
-            In a stream that is not muted, a policy of UNMUTED has the same effect
-            as INHERIT.
+            In an unmuted stream, a topic visibility policy of unmuted will have the
+            same effect as the "None" visibility policy.
           schema:
             type: integer
             enum:
@@ -11825,6 +11816,10 @@ paths:
                                 the topic.
 
                                 - 1 = Muted. Used to record [muted topics](/help/mute-a-topic).
+                                - 2 = Unmuted. Used to record [unmuted topics](/help/mute-a-topic).
+
+                                **Changes**: In Zulip 7.0 (feature level 170), added unmuted as
+                                a visibility policy option.
                       has_zoom_token:
                         type: boolean
                         description: |


### PR DESCRIPTION
[CZO Discussion](https://chat.zulip.org/#narrow/stream/378-api-design/topic/muted.20topics/near/1557615)

This commit adds the missing `UNMUTED` visibility policy to the documentation for `api/get-events` and `api/register-queue`.

It replaces `INHERIT` with `NONE` for a clearer name in the `api/update-user-topic` documentation.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<hr>

**Screenshots and screen captures:**
<details>
<summary>
<b>api/get-events</b>
</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/f62434bf-b8a3-4d12-b4ef-b7cd2819b3ef"></img>
</details>

<details>
<summary>
<b>api/update-user-topic (main description)</b>
</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/6bf6021a-c9bb-4d92-98d9-101f7d4363f0"></img>
</details>

<details>
<summary>
<b>api/update-user-topic</b>
</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/6ef1fad0-e188-4a03-b345-6d905f860deb"></img>
</details>

<details>
<summary>
<b>api/mute-topic (main description)</b>
</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/d9b9e3bb-7301-462d-a2d1-72a3694405ec"></img>
</details>

<details>
<summary>
<b>api/register-queue</b>
</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/baa8ea50-2ab0-4512-bdaf-68eb28a7d8ee"></img>
</details>

<details>
<summary>
<b>api/changelog</b>
</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/f0a7b7c5-4efd-468b-b342-6fbec8e4b215"></img>
</details>

<hr>
<details>

<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
