### PR TITLE
css: Message-row css fixes leftover from #25644.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -917,10 +917,10 @@
         text-shadow: none;
     }
 
-    /* With the unread marker as a grid item, there
-      is no lefthand border to cover in dark mode,
-      so don't apply negative margin to pull the
-      unread marker to the left. */
+    /* There is no lefthand border to cover in
+      dark mode, so don't apply negative margin
+      that would otherwise pull the unread marker
+      to the left. */
     .unread_marker {
         margin-left: 0;
     }

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -432,3 +432,21 @@ $time_column_max_width: 150px;
         cursor: default;
     }
 }
+
+.recipient_row {
+    /* See https://stackoverflow.com/questions/2717480/css-selector-for-first-element-with-class/8539107#8539107
+       for details on how this works */
+    .message_row.unread {
+        .date_unread_marker {
+            display: none;
+        }
+    }
+
+    /* Select all but the first .message_row.unread,
+       and remove the properties set from the previous rule. */
+    .message_row.unread ~ .message_row.unread {
+        .date_unread_marker {
+            display: block;
+        }
+    }
+}

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -18,6 +18,137 @@ $time_column_min_width: 50px; /* + padding */
 $time_column_max_width: 150px;
 
 .message_row {
+    display: grid;
+    /* 2x2 grid:
+      date_unread_marker date_row
+      message_unread_marker messagebox */
+    grid-template: "date_unread_marker date_row" auto "message_unread_marker messagebox" auto / 2px 1fr;
+    border-left: 1px solid var(--color-message-list-border);
+    border-right: 1px solid var(--color-message-list-border);
+    background-color: var(--color-background-stream-message-content);
+
+    &.direct_mention {
+        background-color: var(--color-background-direct-mention);
+    }
+
+    .user-mention {
+        color: var(--color-text-other-mention);
+        background-color: var(--color-background-text-direct-mention);
+
+        &.user-mention-me {
+            color: var(--color-text-self-direct-mention);
+            font-weight: 600;
+
+            &[data-user-id="*"] {
+                color: var(--color-text-self-group-mention);
+                background-color: var(--color-background-text-group-mention);
+            }
+        }
+
+        &:hover {
+            background-color: var(--color-background-text-hover-direct-mention);
+        }
+    }
+
+    &.group_mention {
+        background-color: var(--color-background-group-mention);
+    }
+
+    .user-group-mention {
+        color: var(--color-text-other-mention);
+        background-color: var(--color-background-text-group-mention);
+
+        &.user-mention-me {
+            color: var(--color-text-self-group-mention);
+            font-weight: 600;
+        }
+
+        &:hover {
+            background-color: var(--color-background-text-hover-group-mention);
+        }
+    }
+
+    .date_row {
+        grid-area: date_row;
+        background-color: var(--color-background-stream-message-content);
+        /* We only want padding for the date rows between recipient blocks */
+        padding-bottom: 0;
+
+        & span {
+            font-size: calc(12em / 14);
+            font-style: normal;
+            font-weight: 600;
+            line-height: 17px; /* identical to box height, or 131% */
+            text-align: right;
+            letter-spacing: 0.04em;
+            color: var(--color-date);
+            /* To match time in message row and date in recipient row. */
+            padding-right: 6px;
+        }
+    }
+
+    .unread_marker {
+        margin-left: var(--unread-marker-left);
+        opacity: 0;
+        transition: all 0.3s ease-out;
+
+        &.slow_fade {
+            transition: all 2s ease-out;
+        }
+
+        &.fast_fade {
+            transition: all 0.3s ease-out;
+        }
+
+        &.date_unread_marker {
+            grid-area: date_unread_marker;
+
+            .unread-marker-fill {
+                border-radius: 0 !important;
+                height: 100% !important;
+            }
+        }
+
+        &.message_unread_marker {
+            grid-area: message_unread_marker;
+        }
+    }
+
+    .unread-marker-fill {
+        border-left: 2px solid var(--color-unread-marker);
+        height: 100%;
+    }
+
+    &.unread .unread_marker {
+        transition: all 0.3s ease-out;
+        opacity: 1;
+    }
+
+    .messagebox {
+        grid-area: messagebox;
+        word-wrap: break-word;
+        cursor: pointer;
+        border: none;
+        /* The left padding value accounts for a 2px
+          unread marker, ensuring a uniform 5px of
+          padding on either side of the message box. */
+        padding: 0 5px 0 3px;
+
+        &:hover .message_controls,
+        &:focus-within .message_controls,
+        &:hover .message_failed,
+        &:focus-within .message_failed {
+            .empty-star:hover {
+                cursor: pointer;
+            }
+
+            > div {
+                opacity: 1;
+                visibility: visible;
+            }
+        }
+    }
+
     .messagebox .messagebox-content {
         /* Total 868px
         1    56px   2                                        697px                                                      3     55px     4  60px(min)  5

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3069,24 +3069,6 @@ select.invite-as {
     }
 }
 
-.recipient_row {
-    /* See https://stackoverflow.com/questions/2717480/css-selector-for-first-element-with-class/8539107#8539107
-       for details on how this works */
-    .message_row.unread {
-        .date_unread_marker {
-            display: none;
-        }
-    }
-
-    /* Select all but the first .message_row.unread,
-       and remove the properties set from the previous rule. */
-    .message_row.unread ~ .message_row.unread {
-        .date_unread_marker {
-            display: block;
-        }
-    }
-}
-
 .simplebar-content-wrapper {
     /* `simplebar-content-wrapper` has `tabindex=0` set, which makes it focusable
         but we don't want it to have an outline when focused anywhere in the app. */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1155,9 +1155,9 @@ td.pointer {
     word-wrap: break-word;
     cursor: pointer;
     border: none;
-    /* The left padding value maintains the same amount
-      of space to the left of the message box from before
-      the unread marker was a grid item. */
+    /* The left padding value accounts for a 2px
+      unread marker, ensuring a uniform 5px of
+      padding on either side of the message box. */
     padding: 0 5px 0 3px;
 
     &:hover .message_controls,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1150,31 +1150,6 @@ td.pointer {
     }
 }
 
-.messagebox {
-    grid-area: messagebox;
-    word-wrap: break-word;
-    cursor: pointer;
-    border: none;
-    /* The left padding value accounts for a 2px
-      unread marker, ensuring a uniform 5px of
-      padding on either side of the message box. */
-    padding: 0 5px 0 3px;
-
-    &:hover .message_controls,
-    &:focus-within .message_controls,
-    &:hover .message_failed,
-    &:focus-within .message_failed {
-        .empty-star:hover {
-            cursor: pointer;
-        }
-
-        > div {
-            opacity: 1;
-            visibility: visible;
-        }
-    }
-}
-
 .message_header {
     vertical-align: middle;
     text-align: left;
@@ -1584,43 +1559,6 @@ td.pointer {
     }
 }
 
-.unread_marker {
-    margin-left: var(--unread-marker-left);
-    opacity: 0;
-    transition: all 0.3s ease-out;
-
-    &.slow_fade {
-        transition: all 2s ease-out;
-    }
-
-    &.fast_fade {
-        transition: all 0.3s ease-out;
-    }
-
-    &.date_unread_marker {
-        grid-area: date_unread_marker;
-
-        .unread-marker-fill {
-            border-radius: 0 !important;
-            height: 100% !important;
-        }
-    }
-
-    &.message_unread_marker {
-        grid-area: message_unread_marker;
-    }
-}
-
-.unread-marker-fill {
-    border-left: 2px solid var(--color-unread-marker);
-    height: 100%;
-}
-
-.unread .unread_marker {
-    transition: all 0.3s ease-out;
-    opacity: 1;
-}
-
 .selected_message {
     .messagebox-content {
         /* We add an outline and shift it inside the message so that without
@@ -1728,77 +1666,6 @@ div.message_table {
     margin-left: auto;
     display: none;
     width: 100%;
-}
-
-.message_row {
-    display: grid;
-    /* 2x2 grid:
-      date_unread_marker date_row
-      message_unread_marker messagebox */
-    grid-template: "date_unread_marker date_row" auto "message_unread_marker messagebox" auto / 2px 1fr;
-    border-left: 1px solid var(--color-message-list-border);
-    border-right: 1px solid var(--color-message-list-border);
-    background-color: var(--color-background-stream-message-content);
-
-    &.direct_mention {
-        background-color: var(--color-background-direct-mention);
-    }
-
-    .user-mention {
-        color: var(--color-text-other-mention);
-        background-color: var(--color-background-text-direct-mention);
-
-        &.user-mention-me {
-            color: var(--color-text-self-direct-mention);
-            font-weight: 600;
-
-            &[data-user-id="*"] {
-                color: var(--color-text-self-group-mention);
-                background-color: var(--color-background-text-group-mention);
-            }
-        }
-
-        &:hover {
-            background-color: var(--color-background-text-hover-direct-mention);
-        }
-    }
-
-    &.group_mention {
-        background-color: var(--color-background-group-mention);
-    }
-
-    .user-group-mention {
-        color: var(--color-text-other-mention);
-        background-color: var(--color-background-text-group-mention);
-
-        &.user-mention-me {
-            color: var(--color-text-self-group-mention);
-            font-weight: 600;
-        }
-
-        &:hover {
-            background-color: var(--color-background-text-hover-group-mention);
-        }
-    }
-
-    .date_row {
-        grid-area: date_row;
-        background-color: var(--color-background-stream-message-content);
-        /* We only want padding for the date rows between recipient blocks */
-        padding-bottom: 0;
-
-        & span {
-            font-size: calc(12em / 14);
-            font-style: normal;
-            font-weight: 600;
-            line-height: 17px; /* identical to box height, or 131% */
-            text-align: right;
-            letter-spacing: 0.04em;
-            color: var(--color-date);
-            /* To match time in message row and date in recipient row. */
-            padding-right: 6px;
-        }
-    }
 }
 
 div.focused_table {


### PR DESCRIPTION
This PR addresses post-merge feedback from #25644.

1. It updates comments in the CSS to be more useful to future readers of the code, by not referencing the state of the CSS before that PR.
2. It moves CSS from #25644 and related selectors into the `message_row.css` file.

The one piece of feedback from #25644 not implemented here is Tim's [comment about animating unread markers](https://github.com/zulip/zulip/pull/25644#discussion_r1199346069). From studying the code, all of the visual and interactive aspects of the unread marker are kept with the `.unread_marker` class. The two new classes from #25644, `date_unread_marker` and `message_unread_marker`, have only information about grid positioning and a couple of conditional styles.

My thinking is that those two new classes can probably eventually be merged into one (possibly just the `.unread_marker` class itself), so it doesn't seem prudent to me to remove or rewrite logic around `.unread_marker` for now.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

<details>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
