### PR TITLE
send_button: Suppress Send tooltip on tabbing to send.

### DIFF
--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -317,6 +317,10 @@ export function initialize() {
     delegate("body", {
         target: "#compose-send-button",
         delay: EXTRA_LONG_HOVER_DELAY,
+        // By default, tippyjs uses a trigger value of "mouseenter focus",
+        // but by specifying "mouseenter", this will prevent showing the
+        // Send tooltip when tabbing to the Send button.
+        trigger: "mouseenter",
         appendTo: () => document.body,
         onShow(instance) {
             if (user_settings.enter_sends) {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR suppresses the Tippy tooltip on the send button when the send button is focused via the Tab key. Mouse hovers will still activate it after a pause, using the already-present `EXTRA_LONG_HOVER_DELAY`.

See [brief CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/tab.2Benter.20opening.20keyboard.20tooltips)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before: Tippy tooltip on tabbing to send button
![tippy-on-tab](https://github.com/zulip/zulip/assets/170719/e1908106-6259-4573-9ce6-8e989022181c)

After: No Tippy tooltip on tabbing to send button
![no-tippy-on-tab](https://github.com/zulip/zulip/assets/170719/2891efef-145f-4002-ba8e-8a8bd5e88f37)

Before & after: Tippy tooltip on mouse hover, after a delay
![tippy-on-hover](https://github.com/zulip/zulip/assets/170719/9bfbf409-4225-45d1-8875-51ef336c1b08)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
