### PR TITLE
api-changelog: Update feature level 175 entry and related changes notes.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -101,8 +101,9 @@ format used by the Zulip server that they are interacting with.
 
 * [`POST /register`](/api/register-queue), [`PATCH /settings`](/api/update-settings),
   [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
-  Added new user setting `web_mark_read_on_scroll_policy` . This determines whether to mark
-  messages as read or not as the client scrolls through their feed.
+  Added new user setting `web_mark_read_on_scroll_policy`. Clients may use this to
+  determine the user's preference on whether to mark messages as read or not when
+  scrolling through their message feed.
 
 **Feature level 174**:
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9392,15 +9392,16 @@ paths:
         - name: web_mark_read_on_scroll_policy
           in: query
           description: |
-            Whether or not to mark messages as read when the client scrolls through their
+            Whether or not to mark messages as read when the user scrolls through their
             feed.
 
             - 1 - Always
             - 2 - Only in conversation views
             - 3 - Never
 
-            **Changes**: New in Zulip 7.0 (feature level 175). Previously, the app behaved
-            like the "Always" setting, without any way to configure this.
+            **Changes**: New in Zulip 7.0 (feature level 175). Previously, there was no
+            way for the user to configure this behavior on the web, and the Zulip web and
+            desktop apps behaved like the "Always" setting when marking messages as read.
           schema:
             type: integer
             enum:
@@ -11504,15 +11505,16 @@ paths:
                           web_mark_read_on_scroll_policy:
                             type: integer
                             description: |
-                              Whether or not to mark messages as read when the client scrolls through their
+                              Whether or not to mark messages as read when the user scrolls through their
                               feed.
 
                               - 1 - Always
                               - 2 - Only in conversation views
                               - 3 - Never
 
-                              **Changes**: New in Zulip 7.0 (feature level 175). Previously, the app behaved
-                              like the "Always" setting, without any way to configure this.
+                              **Changes**: New in Zulip 7.0 (feature level 175). Previously, there was no
+                              way for the user to configure this behavior on the web, and the Zulip web and
+                              desktop apps behaved like the "Always" setting when marking messages as read.
                           starred_message_counts:
                             type: boolean
                             description: |
@@ -13471,15 +13473,16 @@ paths:
                           web_mark_read_on_scroll_policy:
                             type: integer
                             description: |
-                              Whether or not to mark messages as read when the client scrolls through their
+                              Whether or not to mark messages as read when the user scrolls through their
                               feed.
 
                               - 1 - Always
                               - 2 - Only in conversation views
                               - 3 - Never
 
-                              **Changes**: New in Zulip 7.0 (feature level 175). Previously, the app behaved
-                              like the "Always" setting, without any way to configure this.
+                              **Changes**: New in Zulip 7.0 (feature level 175). Previously, there was no
+                              way for the user to configure this behavior on the web, and the Zulip web and
+                              desktop apps behaved like the "Always" setting when marking messages as read.
                           starred_message_counts:
                             type: boolean
                             description: |
@@ -14428,15 +14431,16 @@ paths:
         - name: web_mark_read_on_scroll_policy
           in: query
           description: |
-            Whether or not to mark messages as read when the client scrolls through their
+            Whether or not to mark messages as read when the user scrolls through their
             feed.
 
             - 1 - Always
             - 2 - Only in conversation views
             - 3 - Never
 
-            **Changes**: New in Zulip 7.0 (feature level 175). Previously, the app behaved
-            like the "Always" setting, without any way to configure this.
+            **Changes**: New in Zulip 7.0 (feature level 175). Previously, there was no
+            way for the user to configure this behavior on the web, and the Zulip web and
+            desktop apps behaved like the "Always" setting when marking messages as read.
           schema:
             type: integer
             enum:


### PR DESCRIPTION
Part of 7.0 API changelog audit; see [this CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/7.2E0.20API.20changelog.20audit/near/1572765) for more context.

Updates API changelog entry and related parts of API docs for: **Feature level 175**.

**Notes**:
- Revises API changelog entry and related API documentation for new user setting to clarify language around "client" and "user".
- Updates the related **Changes** notes to clarify language around which Zulip apps are being referenced.

---

**Screenshots and screen captures:**

<details>
<summary>Updated API changelog 175 entry</summary>

[Current documentation](https://chat.zulip.org/api/changelog#changes-in-zulip-70)
![Screenshot from 2023-05-22 20-19-18](https://github.com/zulip/zulip/assets/63245456/1b450aad-3214-4fe7-9f66-dd9093e601a6)
</details>
<details>
<summary>Example of updated user setting in API documentation</summary>

[Current documentation](https://chat.zulip.org/api/update-settings#parameter-web_mark_read_on_scroll_policy)
![Screenshot from 2023-05-22 20-19-46](https://github.com/zulip/zulip/assets/63245456/c3da69bb-b347-4cb2-ad2c-2e28d6118aff)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
