### PR TITLE
api-docs: Make realm_linkifiers current API clear in description.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3110,13 +3110,17 @@ paths:
                                 Processing this event is important for doing Markdown local echo
                                 correctly.
 
-                                **Changes**: As of Zulip 7.0 (feature level 176), clients will not
-                                receive this event unless the event queue is registered with the
-                                client capability `{"linkifier_url_template": true}`. This is because
-                                the change to specify linkifiers with a URL template instead of a
-                                URL format string is not backwards-compatible.
+                                Clients will not receive this event unless the event queue is
+                                registered with the client capability
+                                `{"linkifier_url_template": true}`.
                                 See [`POST /register`](/api/register-queue#parameter-client_capabilities)
                                 for how client capabilities can be specified.
+
+                                **Changes**: Before Zulip 7.0 (feature level 176), the
+                                `linkifier_url_template` client capability was not required. The
+                                requirement was added because linkifiers were updated to contain
+                                a URL template instead of a URL format string, which was not a
+                                backwards-compatible change.
 
                                 New in Zulip 4.0 (feature level 54), replacing the deprecated
                                 `realm_filters` event type.
@@ -3171,12 +3175,13 @@ paths:
                               additionalProperties: false
                               deprecated: true
                               description: |
-                                Legacy event type. Previously, sent to all users in a Zulip organization
-                                when the set of configured [linkifiers](/help/add-a-custom-linkifier)
-                                for the organization has changed.
+                                Legacy event type that is no longer sent to clients. Previously, sent
+                                to all users in a Zulip organization when the set of configured
+                                [linkifiers](/help/add-a-custom-linkifier) for the organization was
+                                changed.
 
-                                **Changes**: As of Zulip 7.0 (feature level 176), clients will no longer
-                                receive this event.
+                                **Changes**: Prior to Zulip 7.0 (feature level 176), this event type
+                                was sent to clients.
 
                                 **Deprecated** in Zulip 4.0 (feature level 54), and replaced by the
                                 `realm_linkifiers` event type, which has a clearer name and format.
@@ -3199,10 +3204,10 @@ paths:
                                   description: |
                                     An array of tuples, where each tuple described a linkifier. The first
                                     element of the tuple was a string regex pattern which represented the
-                                    pattern that to be linkified on matching, for example `"#(?P<id>[123])"`.
-                                    The second element was the URL with which the pattern matching string
-                                    should be linkified with, so with the above pattern an example URL would
-                                    be `"https://realm.com/my_realm_filter/%(id)s"`. And the third element
+                                    pattern to be linkified on matching, for example `"#(?P<id>[123])"`.
+                                    The second element was the URL format string that the pattern should be
+                                    linkified with. A URL format string for the above example would be
+                                    `"https://realm.com/my_realm_filter/%(id)s"`. And the third element
                                     was the ID of the realm filter.
                               example:
                                 {
@@ -10984,13 +10989,16 @@ paths:
                           Array of objects where each object describes a single
                           [linkifier](/help/add-a-custom-linkifier).
 
-                          **Changes**: As of Zulip 7.0 (feature level 176), clients will
-                          receive an empty array unless the event queue is registered with the
-                          client capability `{"linkifier_url_template": true}`. This is because
-                          the change to specify linkifiers with a URL template instead of a
-                          URL format string is not backwards-compatible.
+                          Clients will receive an empty array unless the event queue is
+                          registered with the client capability `{"linkifier_url_template": true}`.
                           See [`client_capabilities`](/api/register-queue#parameter-client_capabilities)
                           parameter for how this can be specified.
+
+                          **Changes**: Before Zulip 7.0 (feature level 176), the
+                          `linkifier_url_template` client capability was not required. The
+                          requirement was added because linkifiers were updated to contain
+                          a URL template instead of a URL format string, which was a not
+                          backwards-compatible change.
 
                           New in Zulip 4.0 (feature level 54). Clients can access this data for
                           servers on earlier feature levels via the legacy `realm_filters` property.
@@ -11033,10 +11041,10 @@ paths:
                           **Changes**: Prior to Zulip 7.0 (feature level 176), this was
                           an array of tuples, where each tuple described a linkifier. The first
                           element of the tuple was a string regex pattern which represented the
-                          pattern that to be linkified on matching, for example `"#(?P<id>[123])"`.
-                          The second element was the URL with which the pattern matching string
-                          should be linkified with, so with the above pattern an example URL would
-                          be `"https://realm.com/my_realm_filter/%(id)s"`. And the third element
+                          pattern to be linkified on matching, for example `"#(?P<id>[123])"`.
+                          The second element was a URL format string that the pattern should be
+                          linkified with. A URL format string for the above example would be
+                          `"https://realm.com/my_realm_filter/%(id)s"`. And the third element
                           was the ID of the realm filter.
 
                           **Deprecated** in Zulip 4.0 (feature level 54), replaced by the


### PR DESCRIPTION
Part of 7.0 API changelog audit; see [this CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/7.2E0.20API.20changelog.20audit/near/1573157) for more context.

Updates API changelog entry and related parts of API docs for: **Feature level 176**. Follow-up for review feedback on #25684 that was made after that PR was merged.

**Notes**:
- Adjusts the descriptions of `realm_linkifiers` (and deprecated `realm_filters`) events and register response fields so that the description of the current API is complete without the feature level 176 **Changes** notes.
- Fixes a few typos noted in the review feedback referenced above.

---

**Screenshots and screen captures:**

<details>
<summary>Events: realm_linkifiers</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-05-22 20-37-47](https://github.com/zulip/zulip/assets/63245456/7b6180ee-38ab-450e-bcca-18ce1639999d) | ![Screenshot from 2023-05-22 20-37-24](https://github.com/zulip/zulip/assets/63245456/dcc42071-09f0-4ee8-a74c-a8d3ec8429ff) |
</details>

<details>
<summary>Events: realm_filters</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-05-22 20-40-28](https://github.com/zulip/zulip/assets/63245456/3e95806a-2679-415d-a3ee-d22dae8c4261) | ![Screenshot from 2023-05-22 20-40-50](https://github.com/zulip/zulip/assets/63245456/b5ed4d11-89c1-4aaa-8502-33856d3252f0) |
</details>

<details>
<summary>Register response: realm_linkifiers field</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-05-22 20-44-29](https://github.com/zulip/zulip/assets/63245456/39a69bdc-8619-459f-9bf1-d6ce55608630) | ![Screenshot from 2023-05-22 20-43-25](https://github.com/zulip/zulip/assets/63245456/4c588f78-4709-4d4a-bc2e-13c59af039d5) |
</details>
<details>
<summary>Register response: realm_filters field</summary>

| Before | After |
| --- | --- |
| ![Screenshot from 2023-05-22 20-48-55](https://github.com/zulip/zulip/assets/63245456/3d2897c8-83fc-4c8c-bb35-6894a8cc3254) | ![Screenshot from 2023-05-22 20-49-19](https://github.com/zulip/zulip/assets/63245456/167f7ce8-8cf6-4021-87aa-5763cf2d7f74) |
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
