### PR TITLE
message_row: Use equal top/bottom padding in message content.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -242,12 +242,19 @@ $time_column_max_width: 150px;
         .message_content {
             grid-row-start: 1;
             grid-column-start: 2;
-            padding: 4px 0 1px;
+            /*
+            Space between two single line messages in a paragraph is 10px.
+            There is 3px margin above and below a message. So, having a 2px
+            padding above and below the message will make the space between
+            all single paragraphs the same.
+            */
+            padding: 2px 0;
         }
 
         .message_reactions {
             grid-row-start: 4;
             grid-column-start: 2;
+            margin-top: -1px;
         }
 
         .message_edit {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1243,7 +1243,7 @@ td.pointer {
 
             .messagebox {
                 border-radius: 0 0 7px 7px;
-                padding-bottom: 5px;
+                padding-bottom: 4px;
             }
         }
 


### PR DESCRIPTION
We had the `3px 0 1px` padding before migration to use grid, then I switched it to use `4px 0 1px` since we were planning to use blue box border which seemed to have helped that case.

Since we switched to using outline for blue box, it makes sense to just use equal padding.


discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/Centering.20in.20message.20row

before:
<img width="826" alt="Screenshot 2023-05-23 at 8 16 40 AM" src="https://github.com/zulip/zulip/assets/25124304/cea617b6-ed04-4037-887b-2d660b1ec2a5">


after:
<img width="826" alt="Screenshot 2023-05-23 at 8 13 14 AM" src="https://github.com/zulip/zulip/assets/25124304/58624841-97fb-43a6-8c05-146fd15bb760">

