### PR TITLE
api-changelog: Update feature level 168 entry and changes notes.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -153,10 +153,10 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 168**
 
-* [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults),
-  [`POST /register`](/api/register-queue),
-  [`PATCH /settings`](/api/update-settings): Replaced the `realm_name_in_notifications`
-  boolean field with an integer field `realm_name_in_email_notifications_policy`.
+* [`POST /register`](/api/register-queue), [`PATCH /settings`](/api/update-settings),
+  [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
+  Replaced the boolean user setting `realm_name_in_notifications`
+  with an integer `realm_name_in_email_notifications_policy`.
 
 **Feature level 167**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9708,7 +9708,8 @@ paths:
         - name: realm_name_in_email_notifications_policy
           in: query
           description: |
-            Whether to [include organization name in subject of message notification emails](/help/email-notifications#include-organization-name-in-subject-line).
+            Whether to [include organization name in subject of message notification
+            emails](/help/email-notifications#include-organization-name-in-subject-line).
 
             - 1 - Automatic
             - 2 - Always
@@ -11765,7 +11766,8 @@ paths:
                           realm_name_in_email_notifications_policy:
                             type: integer
                             description: |
-                              Whether to [include organization name in subject of message notification emails](/help/email-notifications#include-organization-name-in-subject-line).
+                              Whether to [include organization name in subject of message notification
+                              emails](/help/email-notifications#include-organization-name-in-subject-line).
 
                               - 1 - Automatic
                               - 2 - Always
@@ -12177,12 +12179,14 @@ paths:
                           See [PATCH /settings](/api/update-settings) for details on
                           the meaning of this setting.
 
-                          **Changes**: Deprecated `realm_name_in_notifications` in Zulip 5.0 (feature level 89).
-                          Replaced `realm_name_in_notifications` boolean with
-                          `realm_name_in_email_notifications_policy` in Zulip 7.0 (feature level 168);
-                          `true` corresponded to `Always`, and `false` to `Never`.
+                          **Changes**: In Zulip 7.0 (feature level 168), replaced previous
+                          `realm_name_in_notifications` global notifications setting with
+                          `realm_name_in_email_notifications_policy`.
 
-                          Clients connecting to newer servers should declare the `user_settings_object`
+                          **Deprecated** since Zulip 5.0 (feature level 89); both
+                          `realm_name_in_notifications` and the newer
+                          `realm_name_in_email_notifications_policy` are deprecated. Clients
+                          connecting to newer servers should declare the `user_settings_object`
                           client capability and access the `user_settings` object instead.
                       presence_enabled:
                         deprecated: true
@@ -13714,7 +13718,8 @@ paths:
                           realm_name_in_email_notifications_policy:
                             type: integer
                             description: |
-                              Whether to [include organization name in subject of message notification emails](/help/email-notifications#include-organization-name-in-subject-line).
+                              Whether to [include organization name in subject of message notification
+                              emails](/help/email-notifications#include-organization-name-in-subject-line).
 
                               - 1 - Automatic
                               - 2 - Always
@@ -14909,7 +14914,8 @@ paths:
         - name: realm_name_in_email_notifications_policy
           in: query
           description: |
-            Whether to [include organization name in subject of message notification emails](/help/email-notifications#include-organization-name-in-subject-line).
+            Whether to [include organization name in subject of message notification
+            emails](/help/email-notifications#include-organization-name-in-subject-line).
 
             - 1 - Automatic
             - 2 - Always


### PR DESCRIPTION
Part of 7.0 API changelog audit; see [this CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/7.2E0.20API.20changelog.20audit/near/1574948) for more context.

Updates API changelog entry and related parts of API docs for: **Feature level 168**.

**Notes**:
- Updated API changelog entry to note that this is a user setting that's being updated. Otherwise, the fact that the setting starts with `realm_` could be a little bit confusing.
- Updates the **Changes** note for the deprecated global notifications setting to be in descending order.
- Original API changelog entry from commit ae72777c77.

---

**Screenshots and screen captures:**

<details>
<summary>Updated API changelog entry for feature level 168</summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-70)
![Screenshot from 2023-05-23 19-25-33](https://github.com/zulip/zulip/assets/63245456/99065943-61e9-4559-89b7-f342b5f9f222)
</details>
<details>
<summary>Updated **Changes** note in POST /register response</summary>

[Current documentation](https://zulip.com/api/register-queue) - search for "realm_name_in_email"
![Screenshot from 2023-05-23 19-25-09](https://github.com/zulip/zulip/assets/63245456/d1350224-b67a-4d1b-add0-db168a85a420)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
