### PR TITLE
css: Move mention-pill colors under rendered markdown.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -31,41 +31,8 @@ $time_column_max_width: 150px;
         background-color: var(--color-background-direct-mention);
     }
 
-    .user-mention {
-        color: var(--color-text-other-mention);
-        background-color: var(--color-background-text-direct-mention);
-
-        &.user-mention-me {
-            color: var(--color-text-self-direct-mention);
-            font-weight: 600;
-
-            &[data-user-id="*"] {
-                color: var(--color-text-self-group-mention);
-                background-color: var(--color-background-text-group-mention);
-            }
-        }
-
-        &:hover {
-            background-color: var(--color-background-text-hover-direct-mention);
-        }
-    }
-
     &.group_mention {
         background-color: var(--color-background-group-mention);
-    }
-
-    .user-group-mention {
-        color: var(--color-text-other-mention);
-        background-color: var(--color-background-text-group-mention);
-
-        &.user-mention-me {
-            color: var(--color-text-self-group-mention);
-            font-weight: 600;
-        }
-
-        &:hover {
-            background-color: var(--color-background-text-hover-group-mention);
-        }
     }
 
     .date_row {

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -170,6 +170,39 @@
         display: inline-block;
     }
 
+    .user-mention {
+        color: var(--color-text-other-mention);
+        background-color: var(--color-background-text-direct-mention);
+
+        &.user-mention-me {
+            color: var(--color-text-self-direct-mention);
+            font-weight: 600;
+
+            &[data-user-id="*"] {
+                color: var(--color-text-self-group-mention);
+                background-color: var(--color-background-text-group-mention);
+            }
+        }
+
+        &:hover {
+            background-color: var(--color-background-text-hover-direct-mention);
+        }
+    }
+
+    .user-group-mention {
+        color: var(--color-text-other-mention);
+        background-color: var(--color-background-text-group-mention);
+
+        &.user-mention-me {
+            color: var(--color-text-self-group-mention);
+            font-weight: 600;
+        }
+
+        &:hover {
+            background-color: var(--color-background-text-hover-group-mention);
+        }
+    }
+
     .alert-word {
         background-color: hsl(18deg 100% 84%);
     }


### PR DESCRIPTION
This just ensures that the mention-pill color selectors are children of `rendered_markdown`, which class appears both in the message- preview area as well as individual message rows.

Fixes #25720.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before, light mode | After, light mode |
| --- | --- |
| <img width="858" alt="before-light-preview" src="https://github.com/zulip/zulip/assets/170719/df24a0d5-33e6-4c3e-bd3b-b24769cd3045"> | <img width="858" alt="after-light-preview" src="https://github.com/zulip/zulip/assets/170719/7418e0ff-69d4-427c-84d9-0d9e7e19dc95"> |

| Before, dark mode | After, dark mode |
| --- | --- |
| <img width="858" alt="before-dark-preview" src="https://github.com/zulip/zulip/assets/170719/d22aa805-68ec-41c4-8daf-ef8dbf79f5fb"> | <img width="858" alt="after-dark-preview" src="https://github.com/zulip/zulip/assets/170719/247efae1-eab3-4909-ac25-478e397a2dfc"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
