### PR TITLE
search: Make search box bottom border visible again.

### DIFF
--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -65,7 +65,7 @@
     #search_query {
         width: 100%;
         font-size: 16px;
-        height: var(--header-height);
+        height: calc(var(--header-height) - 1px);
         padding: 0;
         padding-left: 5px;
         padding-right: 40px;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2946,6 +2946,10 @@ select.invite-as {
         height: var(--header-height);
     }
 
+    #searchbox_form {
+        height: calc(var(--header-height) - 1px);
+    }
+
     .spectator_narrow_login_button {
         height: var(--header-height) !important;
     }


### PR DESCRIPTION
The nav bar's bottom border was being hidden by the search bar. This makes the search bar slightly less high to fix this issue.

Soon this code will be replaced with the changes in #24345.

Reported on CZO [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/search.20box.20bottom.20border)

![Kapture 2023-05-23 at 12 43 58](https://github.com/zulip/zulip/assets/5634097/83cade02-c57e-4423-8fa4-bbad71898855)
