### PR TITLE
internal_url: Remove obsolete TODO comment

### DIFF
--- a/web/shared/src/internal_url.js
+++ b/web/shared/src/internal_url.js
@@ -28,9 +28,6 @@ export function stream_id_to_slug(stream_id, maybe_get_stream_name) {
 
     // The name part of the URL doesn't really matter, so we try to
     // make it pretty.
-
-    // TODO: Convert this to replaceAll once mobile no longer supports
-    // browsers that don't have it.
     name = name.replaceAll(" ", "-");
 
     return stream_id + "-" + name;


### PR DESCRIPTION
zulip-mobile currently requires Android ≥ 7 and iOS ≥ 14, both of which support `replaceAll`. The code change was in commit 54f90e41c07645e34d49967cdb2e0c2089390b9f (#25554).