### PR TITLE
feedback_widget: Don't use non-optimal animation properties.

### DIFF
--- a/web/src/feedback_widget.ts
+++ b/web/src/feedback_widget.ts
@@ -64,7 +64,16 @@ const animate = {
         }
 
         if (meta.$container) {
-            meta.$container.fadeOut(500).removeClass("show");
+            meta.$container.addClass("slide-out-feedback-container");
+            // Delay setting `display: none` enough that the hide animation starts.
+            setTimeout(
+                () =>
+                    meta.$container?.removeClass([
+                        "show-feedback-container",
+                        "slide-out-feedback-container",
+                    ]),
+                50,
+            );
             meta.opened = false;
             meta.alert_hover_state = false;
         }
@@ -75,7 +84,7 @@ const animate = {
         }
 
         if (meta.$container) {
-            meta.$container.fadeIn(500).addClass("show");
+            meta.$container.addClass("show-feedback-container");
             meta.opened = true;
             setTimeout(() => animate.maybe_close(), 100);
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -284,28 +284,50 @@ p.n-margin {
     top: -2px;
 }
 
+/* See https://web.dev/animations-guide/#triggers before adding any funny animation properties here. */
+@keyframes feedback-slide-in {
+    from {
+        transform: translateY(-120%);
+        opacity: 0;
+    }
+
+    to {
+        transform: translateY(50px);
+        opacity: 1;
+    }
+}
+
+@keyframes feedback-slide-out {
+    from {
+        transform: translateY(50px);
+        opacity: 1;
+    }
+
+    to {
+        transform: translateY(-120%);
+        opacity: 0;
+    }
+}
+
 #feedback_container {
     display: none;
-    position: absolute;
+    position: fixed;
     width: 400px;
     top: 0;
     left: calc(50vw - 220px);
     padding: 15px;
-
     background-color: hsl(0deg 0% 98%);
     border-radius: 5px;
     box-shadow: 0 0 30px hsl(0deg 0% 0% / 25%);
     z-index: 110;
 
-    animation-name: pulse;
-    animation-iteration-count: infinite;
-    animation-duration: 2s;
+    &.show-feedback-container {
+        display: block;
+        animation: feedback-slide-in 0.6s forwards;
+    }
 
-    transition-property: top, bottom;
-    transition-duration: 0.5s;
-
-    &.show {
-        top: 50px;
+    &.slide-out-feedback-container {
+        animation: feedback-slide-out 0.6s;
     }
 
     & h3 {
@@ -318,20 +340,6 @@ p.n-margin {
         font-weight: 200;
         margin: 0 0 0 10px;
         cursor: pointer;
-    }
-}
-
-@keyframes pulse {
-    0% {
-        box-shadow: 0 0 30px hsl(0deg 0% 0% / 35%);
-    }
-
-    50% {
-        box-shadow: 0 0 30px hsl(0deg 0% 0% / 15%);
-    }
-
-    100% {
-        box-shadow: 0 0 30px hsl(0deg 0% 0% / 35%);
     }
 }
 


### PR DESCRIPTION
Fixes #25376

Animating `box-shadow` and `top` is slow since the browser drops frames when animating them. We can fix it by using `will-change` property, but it is just better to not animate them and instead use transform.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/topic.20muted.20notification.20issue

<img width="384" alt="Screenshot 2023-05-24 at 1 12 31 PM" src="https://github.com/zulip/zulip/assets/25124304/eddd4bb8-81f2-43a7-95e6-f43880c923ca">


before: 
![before](https://github.com/zulip/zulip/assets/25124304/d0a39667-2ff4-40a7-bc7a-9a2990325cf3)

after: 
![after](https://github.com/zulip/zulip/assets/25124304/272e0a57-e5e1-4c55-807e-31f6666f562f)
