### PR TITLE
compose_validate: Use correct stream_id value for different context.

### DIFF
--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -66,6 +66,15 @@ function test_ui(label, f) {
     });
 }
 
+function stub_message_row($textarea) {
+    const $stub = $.create("message_row_stub");
+    $textarea.closest = (selector) => {
+        assert.equal(selector, ".message_row");
+        $stub.length = 0;
+        return $stub;
+    };
+}
+
 test_ui("validate_stream_message_address_info", ({mock_template}) => {
     mock_banners();
     const sub = {
@@ -622,6 +631,7 @@ test_ui("needs_subscribe_warning", () => {
 
 test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
     const $textarea = $("<textarea>").attr("id", "compose-textarea");
+    stub_message_row($textarea);
     const test_sub = {
         name: compose_state.stream_name(),
         stream_id: 99,
@@ -676,6 +686,7 @@ test_ui("warn_if_private_stream_is_linked", ({mock_template}) => {
 test_ui("warn_if_mentioning_unsubscribed_user", ({override, override_rewire, mock_template}) => {
     override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
     const $textarea = $("<textarea>").attr("id", "compose-textarea");
+    stub_message_row($textarea);
     compose_state.set_stream_name("");
     override(settings_data, "user_can_subscribe_other_users", () => true);
 


### PR DESCRIPTION
This PR addresses the issue of relying on `compose_state` for retrieving the `stream_id` to display warning banners. Previously, when the compose box was closed, the warnings were not shown in the message edit box. Now, we utilize the `get_stream_id_for_textarea` function to obtain the correct `stream_id` value and resolve this problem.

Fixes: #25410.

**Screenshots and screen captures:**

<details>
<summary>Warning with compose box closed</summary>

| Before | After |
|--------|--------|
| ![before](https://github.com/zulip/zulip/assets/53193850/5e0f5f17-03df-44ca-974c-95f6cbdbbd45) | ![after](https://github.com/zulip/zulip/assets/53193850/bae67cba-071a-43f8-a37c-2d2778e96508) | 
</details>

<details>
<summary>Private stream mention with compose box closed</summary>

| Before | After |
|--------|--------|
| ![before](https://github.com/zulip/zulip/assets/53193850/fa4d4092-e4bb-4e0d-8d82-8bb352ec820d) | ![after](https://github.com/zulip/zulip/assets/53193850/240ce7e1-c143-4fa6-bed7-d41fa700aad9) | 
</details>

<details>
<summary>Different context</summary>

| Before | After |
|--------|--------|
| ![before](https://github.com/zulip/zulip/assets/53193850/0820e27d-0966-4f08-9a2c-9d4d84f6782a) | ![after](https://github.com/zulip/zulip/assets/53193850/4e1b9110-1ce5-413a-87e9-f7436b130748) | 
</details>
