### PR TITLE
unread_marker: Style as subtle linear gradient.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -82,8 +82,13 @@ $time_column_max_width: 150px;
     }
 
     .unread-marker-fill {
-        border-left: 2px solid var(--color-unread-marker);
         height: 100%;
+        width: 2px;
+        background: linear-gradient(
+            90deg,
+            var(--color-unread-marker) 30%,
+            hsl(217deg 64% 59% / 0%)
+        );
     }
 
     &.unread .unread_marker {


### PR DESCRIPTION
This PR introduces a 2px linear gradient background to present the unread marker.

See [the CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/UI.20redesign.3A.20unread.20style/near/1575708).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before, light mode | After, light mode |
| --- | --- |
| <img width="578" alt="before-marker-light" src="https://github.com/zulip/zulip/assets/170719/7b01bf68-8d6f-4c06-b5a0-eba38fef3cca"> | <img width="578" alt="after-marker-light" src="https://github.com/zulip/zulip/assets/170719/422c8b20-a451-43f9-8210-f5a8684d5108"> |


| Before, dark mode | After, dark mode |
| --- | --- |
| <img width="578" alt="before-marker-dark" src="https://github.com/zulip/zulip/assets/170719/334cb542-81b7-4a71-8d94-205e81d3baa4"> | <img width="578" alt="after-marker-dark" src="https://github.com/zulip/zulip/assets/170719/555a4959-132c-4d3a-8f61-175199606d78"> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
