### PR TITLE
django: Use stdout for console logging.

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -780,6 +780,7 @@ LOGGING: Dict[str, Any] = {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "default",
+            "stream": sys.stdout,
         },
         "file": {
             "level": "DEBUG",


### PR DESCRIPTION
Apparently, Django defaults to logging console output to stderr, not stdout, even at the INFO/DEBUG log levels. I don't think this is desirable behavior for Zulip's use case.

Note that the main thing that I'd except to go to stderr, namely management command fatal errors (`raise CommandError`), still go to stderr following this change.

Fixes #23937.

@andersk @alexmv can you review this?