### PR TITLE
ts: Convert `compose_textarea.js` to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -67,7 +67,7 @@ EXEMPT_FILES = make_set(
         "web/src/compose_fade.js",
         "web/src/compose_recipient.js",
         "web/src/compose_state.js",
-        "web/src/compose_textarea.js",
+        "web/src/compose_textarea.ts",
         "web/src/compose_ui.js",
         "web/src/compose_validate.js",
         "web/src/composebox_typeahead.js",

--- a/web/src/compose_textarea.ts
+++ b/web/src/compose_textarea.ts
@@ -4,7 +4,7 @@ import $ from "jquery";
 // shift-tab back in (see hotkey.js).
 let saved_compose_cursor = 0;
 
-function set_compose_textarea_handlers() {
+function set_compose_textarea_handlers(): void {
     $("#compose-textarea").on("blur", function () {
         saved_compose_cursor = $(this).caret();
     });
@@ -16,10 +16,10 @@ function set_compose_textarea_handlers() {
     });
 }
 
-export function restore_compose_cursor() {
+export function restore_compose_cursor(): void {
     $("#compose-textarea").trigger("focus").caret(saved_compose_cursor);
 }
 
-export function initialize() {
+export function initialize(): void {
     set_compose_textarea_handlers();
 }

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -5,10 +5,26 @@
 
 declare let zulip_test: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
+type JQueryCaretRange = {
+    start: number;
+    end: number;
+    length: number;
+    text: string;
+};
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface JQuery {
     expectOne(): JQuery;
     tab(action?: string): this; // From web/third/bootstrap
+
+    // Types for jquery-caret-plugin
+    caret(): number;
+    caret(arg: number | string): this;
+    range(): JQueryCaretRange;
+    range(start: number, end?: number): this;
+    range(text: string): this;
+    selectAll(): this;
+    deselectAll(): this;
 }
 
 declare const ZULIP_VERSION: string;


### PR DESCRIPTION
Added type definitions for `jquery-caret-plugin` third party package and converted `compose_textarea.js` to TypeScript.

I took reference types for `jquery-care-plugin` from here: https://github.com/acdvorak/jquery.caret#api

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
