### PR TITLE
api-changelog: Revise feature level 160 entry.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -232,11 +232,10 @@ format used by the Zulip server that they are interacting with.
 
 **Feature level 160**
 
-* `POST /api/v1/jwt/fetch_api_key`: New API endpoint to fetch API
+* `POST /api/v1/jwt/fetch_api_key`: Added new endpoint to fetch API
   keys using JSON Web Token (JWT) authentication.
-* `accounts/login/jwt/`: Adjusted format of requests to this
-  previously undocumented, optional endpoint for
-  JWT authentication log in support.
+* `accounts/login/jwt/`: Adjusted format of requests to undocumented,
+  optional endpoint for JWT authentication log in support.
 
 **Feature level 159**
 


### PR DESCRIPTION
Part of 7.0 API changelog audit; see [this CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/7.2E0.20API.20changelog.20audit/near/1575920) for more context.

Original API feature level entry from commit ff895905586.

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-70) - *search for Feature level 160*
![Screenshot from 2023-05-25 13-04-01](https://github.com/zulip/zulip/assets/63245456/e40b597b-89a6-420c-9ac9-53c79083e731)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
