### PR TITLE
api-docs: API feature level 163 revisions and related changes.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -213,6 +213,14 @@ format used by the Zulip server that they are interacting with.
 * [`GET /events`](/api/get-events): Event for updating a user's
   `delivery_email` is now sent to all users who have access to it, and
   is also sent when a user's `email_address_visibility` setting changes.
+* [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue)
+  [`GET /users`](/api/get-users), [`GET /users/{user_id}`](/api/get-user),
+  [`GET /users/{email}`](/api/get-user-by-email),
+  [`GET /users/me`](/api/get-own-user), [`GET /messages`](/api/get-messages),
+  [`GET /messages/{message_id}`](/api/get-message): Whether the `avatar_url`
+  field in message and user objects returned by these endpoints can be `null`
+  now depends on if the current user has access to the other user's real
+  email address based on the other user's `email_address_visibility` policy.
 * [`POST /register`](/api/register-queue), [`PATCH /settings`](/api/update-settings),
   [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
   Added user setting `email_address_visibility`, to replace the

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -204,21 +204,21 @@ format used by the Zulip server that they are interacting with.
 
 * [`GET /users`](/api/get-users), [`GET /users/{user_id}`](/api/get-user),
   [`GET /users/{email}`](/api/get-user-by-email),
-  [`GET /users/me`](/api/get-own-user) and [`GET /events`](/api/get-events):
-  The `delivery_email` field is always present in user objects, including the case
-  when `email_address_visibility` is set to `EMAIL_ADDRESS_VISIBILITY_EVERYONE`,
-  with the value being `None` if the requestor does not have access to the user's
-  real email. For bot users, the `delivery_email` field is always set to the real email.
-* [`GET /events`](/api/get-events): Event for updating `delivery_email`  is now sent to
-  all users who have access to it and is also sent when `email_address_visibility` setting
-  changes.
-* [`POST /register`](/api/register-queue), [`PATCH
-  /settings`](/api/update-settings), [`PATCH
-  /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults): Added
-  user setting `email_address_visibility`  which will replace the existing realm
+  [`GET /users/me`](/api/get-own-user), [`GET /events`](/api/get-events):
+  The `delivery_email` field is always present in user objects, including
+  the case when a user's `email_address_visibility` is set to everyone.
+  The value will be `null` if the requestor does not have access to the
+  user's real email. For bot users, the `delivery_email` field is always
+  set to the bot user's real email.
+* [`GET /events`](/api/get-events): Event for updating a user's
+  `delivery_email` is now sent to all users who have access to it, and
+  is also sent when a user's `email_address_visibility` setting changes.
+* [`POST /register`](/api/register-queue), [`PATCH /settings`](/api/update-settings),
+  [`PATCH /realm/user_settings_defaults`](/api/update-realm-user-settings-defaults):
+  Added user setting `email_address_visibility`, to replace the
+  realm setting `email_address_visibility`.
+* [`POST /register`](/api/register-queue), `PATCH /realm`: Removed realm
   setting `email_address_visibility`.
-* [`POST /register`](/api/register-queue), `PATCH /realm`: Removed realm-level
-  `email_address_visibility` setting.
 
 **Feature level 162**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -569,7 +569,7 @@ paths:
                                     - type: object
                                       additionalProperties: false
                                       description: |
-                                        When the Zulip display email address of a user changes,
+                                        When the Zulip API email address of a user changes,
                                         either due to the user's email address changing, or
                                         due to changes in the user's
                                         [email address visibility][help-email-visibility].
@@ -586,7 +586,7 @@ paths:
                                             The new value of `email` for the user. The client
                                             should update any data structures associated
                                             with this user to use this new value as the
-                                            user's Zulip display email address.
+                                            user's Zulip API email address.
                               additionalProperties: false
                               example:
                                 {
@@ -1049,7 +1049,7 @@ paths:
                                 email:
                                   type: string
                                   description: |
-                                    The Zulip display email of the user.
+                                    The Zulip API email of the user.
 
                                     **Deprecated**: This field will be removed in a future
                                     release as it is redundant with the `user_id`.
@@ -2457,7 +2457,7 @@ paths:
                                     email:
                                       type: string
                                       description: |
-                                        The Zulip display email address for the user.
+                                        The Zulip API email address for the user.
                                 recipients:
                                   type: array
                                   description: |
@@ -2480,7 +2480,7 @@ paths:
                                       email:
                                         type: string
                                         description: |
-                                          The Zulip display email address for the user.
+                                          The Zulip API email address for the user.
                                 stream_id:
                                   type: integer
                                   description: |
@@ -2575,7 +2575,7 @@ paths:
                                     email:
                                       type: string
                                       description: |
-                                        The Zulip display email address for the user.
+                                        The Zulip API email address for the user.
                                 recipients:
                                   type: array
                                   description: |
@@ -2598,7 +2598,7 @@ paths:
                                       email:
                                         type: string
                                         description: |
-                                          The Zulip display email address for the user.
+                                          The Zulip API email address for the user.
                                 stream_id:
                                   type: integer
                                   description: |
@@ -7539,10 +7539,10 @@ paths:
         - name: user_id_or_email
           in: path
           description: |
-            The ID or Zulip display email address of the user whose presence you want to fetch.
+            The ID or Zulip API email address of the user whose presence you want to fetch.
 
             **Changes**: New in Zulip 4.0 (feature level 43). Previous versions only supported
-            identifying the user by Zulip display email.
+            identifying the user by Zulip API email.
           schema:
             type: string
           example: iago@zulip.com
@@ -9088,7 +9088,7 @@ paths:
                           type: object
                           description: |
                             `{user_email}`: Object containing the details of a user's presence.
-                            The object's key is the user's Zulip display email.
+                            The object's key is the user's Zulip API email.
                           additionalProperties:
                             $ref: "#/components/schemas/Presence"
                     example:
@@ -9922,8 +9922,8 @@ paths:
       summary: Get a user by email
       tags: ["users"]
       description: |
-        Fetch details for a single user in the organization given a Zulip display
-        email address.
+        Fetch details for a single user in the organization given a Zulip
+        API email address.
 
         Note that this endpoint uses Zulip display emails addresses
         for organizations that have configured limited [email address
@@ -9951,7 +9951,7 @@ paths:
         - name: email
           in: path
           description: |
-            The email address of the user whose details you want to fetch.
+            The Zulip API email address of the user whose details you want to fetch.
           schema:
             type: string
           example: iago@zulip.com
@@ -10028,7 +10028,7 @@ paths:
         Fetch details for a single user in the organization.
 
         You can also fetch details on [all users in the organization](/api/get-users)
-        or [by email](/api/get-user-by-email).
+        or [by a user's Zulip API email](/api/get-user-by-email).
 
         **Changes**: New in Zulip 3.0 (feature level 1).
       x-curl-examples-parameters:
@@ -10988,7 +10988,7 @@ paths:
                           description: |
                             `{user_id}` or `{user_email}`: Object containing the details of a user's
                             presence . Depending on the value of `slim_presence`, the object's key is
-                            either the user's ID or the user's Zulip display email.
+                            either the user's ID or the user's Zulip API email.
                           additionalProperties:
                             $ref: "#/components/schemas/Presence"
                       server_timestamp:
@@ -14058,9 +14058,9 @@ paths:
                         description: |
                           Present if `realm_user` is present in `fetch_event_types`.
 
-                          The Zulip display email address for the current user. See also
+                          The Zulip API email address for the current user. See also
                           `delivery_email`; these may be the same or different depending
-                          on the organization's `email_address_visibility` policy.
+                          on the user's `email_address_visibility` policy.
                       delivery_email:
                         type: string
                         description: |
@@ -17347,7 +17347,7 @@ components:
                 email:
                   type: string
                   description: |
-                    Email of the user.
+                    Zulip API email of the user.
                 full_name:
                   type: string
                   description: |
@@ -17426,7 +17426,7 @@ components:
                   email:
                     type: string
                     description: |
-                      Email of the user.
+                      Zulip API email of the user.
                   full_name:
                     type: string
                     description: |
@@ -17572,7 +17572,7 @@ components:
         sender_email:
           type: string
           description: |
-            The Zulip display email address of the message's sender.
+            The Zulip API email address of the message's sender.
         sender_full_name:
           type: string
           description: |
@@ -18674,7 +18674,7 @@ components:
       name: principals
       in: query
       description: |
-        A list of user IDs (preferred) or Zulip display email
+        A list of user IDs (preferred) or Zulip API email
         addresses of the users to be subscribed to or unsubscribed
         from the streams specified in the `subscriptions` parameter. If
         not provided, then the requesting user/bot is subscribed.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -505,9 +505,10 @@ paths:
                                     - type: object
                                       additionalProperties: false
                                       description: |
-                                        When the value of the user's delivery email as visible to you changes,
+                                        When the value of a user's delivery email as visible to you changes,
                                         either due to the email address changing or your access to the user's
-                                        email via their `email_address_visibility` policy changing.
+                                        email changing via an update to their `email_address_visibility`
+                                        setting.
 
                                         **Changes**: Prior to Zulip 7.0 (feature level 163), this event was
                                         sent only to the affected user, and this event would only be triggered
@@ -523,13 +524,14 @@ paths:
                                           description: |
                                             The new delivery email of the user.
 
-                                            This value can be `null` if user changes the
-                                            `email_address_visibility` value such that
-                                            you cannot access user's real email.
+                                            This value can be `null` if the affected user
+                                            changed their `email_address_visibility` setting
+                                            such that you cannot access their real email.
 
-                                            **Changes**: As of Zulip 7.0 (feature level 163),
-                                            `null` is a possible value as this event is also
-                                            sent on changing `email_address_visibility` setting.
+                                            **Changes**: Before Zulip 7.0 (feature level 163),
+                                            `null` was not a possible value for this event as
+                                            it was only sent to the affected user when their
+                                            email address was changed.
                                     - type: object
                                       additionalProperties: false
                                       description: |
@@ -3803,11 +3805,15 @@ paths:
                                 event type supports multiple properties being changed in a
                                 single event.
 
-                                **Changes**: The `email_address_visibility` setting was removed in Zulip 7.0 (feature level 163).
-                                It was replaced by a [user setting](/api/update-settings) with a
-                                [realm user default](/api/update-realm-user-settings-defaults), with the encoding of different
-                                values preserved. Clients can support all versions by supporting the current API and treating
-                                every user as having the realm's email address visibility value.
+                                **Changes**: In Zulip 7.0 (feature level 163), the realm setting
+                                `email_address_visibility` was removed. It was replaced by a [user
+                                setting](/api/update-settings#parameter-email_address_visibility) with
+                                a [realm user default][user-defaults], with the encoding of different
+                                values preserved. Clients can support all versions by supporting the
+                                current API and treating every user as having the realm's
+                                `email_address_visibility` value.
+
+                                [user-defaults]: /api/update-realm-user-settings-defaults#parameter-email_address_visibility
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -7744,20 +7750,13 @@ paths:
                         example: 1
                       delivery_email:
                         type: string
-                        nullable: true
                         description: |
-                          The user's real email address. This value will be `null` if you cannot
-                          access this user's real email address. For bot users, this field is
-                          always set to the real email of the bot, because bot users always have
-                          `email_address_visibility` as `EMAIL_ADDRESS_VISIBILITY_EVERYONE`.
+                          The requesting user's real email address.
 
-                          **Changes**: Prior to Zulip 7.0 (feature level 163), this field was present
-                          only when `email_address_visibility` was restricted and you had access to
-                          the user's real email. Now, this field is always present, including the case
-                          when `email_address_visibility` is set to `EMAIL_ADDRESS_VISIBILITY_EVERYONE`,
-                          with the value being `null` if you don't have access to the user's real email.
-                          For bot users, this field is now always set to the real email irrespective of
-                          `email_address_visibility` setting.
+                          **Changes**: Prior to Zulip 7.0 (feature level 163), this field was
+                          present only when `email_address_visibility` was restricted and the
+                          requesting user had permission to access realm users' emails. As of
+                          this feature level, this field is always present.
                       profile_data:
                         $ref: "#/components/schemas/profile_data"
                     example:
@@ -9786,9 +9785,8 @@ paths:
         - name: email_address_visibility
           in: query
           description: |
-            The [policy][permission-level] this user has selected for [which other
-            users][help-email-visibility] in this organization can see the real email
-            address of this user.
+            The [policy][permission-level] for [which other users][help-email-visibility]
+            in this organization can see the user's real email address.
 
             - 1 = Everyone
             - 2 = Members only
@@ -9796,7 +9794,7 @@ paths:
             - 4 = Nobody
             - 5 = Moderators only
 
-            **Changes**: New in Zulip 7.0 (feature level 163) replacing the existing
+            **Changes**: New in Zulip 7.0 (feature level 163), replacing the
             realm-level setting.
 
             [permission-level]: /api/roles-and-permissions#permission-levels
@@ -10516,11 +10514,15 @@ paths:
         `move_messages_within_stream_limit_seconds` was introduced
         in feature level 162.
 
-        The `email_address_visibility` setting was removed in Zulip 7.0 (feature level 163).
-        It was replaced by a [user setting](/api/update-settings) with a
-        [realm user default](/api/update-realm-user-settings-defaults), with the encoding of different
-        values preserved. Clients can support all versions by supporting the current API and treating
-        every user as having the realm's email address visibility value.
+        In Zulip 7.0 (feature level 163), the realm setting
+        `email_address_visibility` was removed. It was replaced by a [user
+        setting](/api/update-settings#parameter-email_address_visibility) with
+        a [realm user default][user-defaults], with the encoding of different
+        values preserved. Clients can support all versions by supporting the
+        current API and treating every user as having the realm's
+        `email_address_visibility` value.
+
+        [user-defaults]: /api/update-realm-user-settings-defaults#parameter-email_address_visibility
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -15066,8 +15068,8 @@ paths:
           in: query
           description: |
             The [policy][permission-level] this user has selected for [which other
-            users][help-email-visibility] in this organization can see the real email
-            address of this user.
+            users][help-email-visibility] in this organization can see their real
+            email address.
 
             - 1 = Everyone
             - 2 = Members only
@@ -15075,7 +15077,7 @@ paths:
             - 4 = Nobody
             - 5 = Moderators only
 
-            **Changes**: New in Zulip 7.0 (feature level 163) replacing the existing
+            **Changes**: New in Zulip 7.0 (feature level 163), replacing the
             realm-level setting.
 
             [permission-level]: /api/roles-and-permissions#permission-levels
@@ -17261,9 +17263,8 @@ components:
     EmailAddressVisibility:
       type: integer
       description: |
-        The [policy][permission-level] this user has selected for [which other
-        users][help-email-visibility] in this organization can see the real email
-        address of this user.
+        The [policy][permission-level] for [which other users][help-email-visibility]
+        in this organization can see the user's real email address.
 
         - 1 = Everyone
         - 2 = Members only
@@ -17271,7 +17272,7 @@ components:
         - 4 = Nobody
         - 5 = Moderators only
 
-        **Changes**: New in Zulip 7.0 (feature level 163) replacing the existing
+        **Changes**: New in Zulip 7.0 (feature level 163), replacing the
         realm-level setting.
 
         [permission-level]: /api/roles-and-permissions#permission-levels
@@ -17865,15 +17866,13 @@ components:
             The user's real email address. This value will be `null` if you cannot
             access user's real email address. For bot users, this field is always
             set to the real email of the bot, because bot users always have
-            `email_address_visibility` as `EMAIL_ADDRESS_VISIBILITY_EVERYONE`.
+            `email_address_visibility` set to everyone.
 
-            **Changes**: Prior to Zulip 7.0 (feature level 163), this field was present
-            only when `email_address_visibility` was restricted and you had access to the
-            user's real email. Now, this field is always present, including the case when
-            `email_address_visibility` is set to `EMAIL_ADDRESS_VISIBILITY_EVERYONE`,
-            with the value being `null` if you don't have access the user's real email.
-            For bot users, this field is now always set to the real email irrespective of
-            `email_address_visibility` setting.
+            **Changes**: Prior to Zulip 7.0 (feature level 163), this field was
+            present only when `email_address_visibility` was restricted and you had
+            access to the user's real email. As of this feature level, this field
+            is always present, including the case when `email_address_visibility`
+            is set to everyone (and therefore not restricted).
         email:
           type: string
           description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17402,10 +17402,18 @@ components:
           type: string
           nullable: true
           description: |
-            The URL of the user's avatar. Can be `null` only if client_gravatar was passed,
-            which means that the user has not uploaded an avatar in Zulip, and the
-            client should compute the gravatar URL by hashing the
-            user's Zulip API email address itself for this user.
+            The URL of the message sender's avatar. Can be `null` only if
+            the current user has access to the sender's real email address
+            and `client_gravatar` was `true`.
+
+            If `null`, then the sender has not uploaded an avatar in Zulip,
+            and the client can compute the gravatar URL by hashing the
+            sender's email address, which corresponds in this case to their
+            real email address.
+
+            **Changes**: Before Zulip 7.0 (feature level 163), access to a
+            user's real email address was a realm-level setting. As of this
+            feature level, `email_address_visibility` is a user setting.
         client:
           type: string
           description: |
@@ -17970,11 +17978,18 @@ components:
           type: string
           nullable: true
           description: |
-            URL for the user's avatar. Will be `null` if the `client_gravatar`
-            query parameter was set to `true` and the user's avatar is hosted by
-            the Gravatar provider (i.e. the user has never uploaded an avatar).
+            URL for the user's avatar.
 
-            **Changes**: In Zulip 3.0 (feature level 18), if the client has the
+            Will be `null` if the `client_gravatar`
+            query parameter was set to `true`, the current user has access to
+            this user's real email address, and this user's avatar is hosted by
+            the Gravatar provider (i.e. this user has never uploaded an avatar).
+
+            **Changes**: Before Zulip 7.0 (feature level 163), access to a
+            user's real email address was a realm-level setting. As of this
+            feature level, `email_address_visibility` is a user setting.
+
+            In Zulip 3.0 (feature level 18), if the client has the
             `user_avatar_url_field_optional` capability, this will be missing at
             the server's sole discretion.
         avatar_version:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7638,14 +7638,14 @@ paths:
                       avatar_url:
                         type: string
                         description: |
-                          URL for the user's avatar.
+                          URL for the requesting user's avatar.
 
                           **Changes**: New in Zulip 2.1.0.
                         example: "x"
                       avatar_version:
                         type: integer
                         description: |
-                          Version for the user's avatar. Used for cache-busting requests
+                          Version for the requesting user's avatar. Used for cache-busting requests
                           for the user's avatar. Clients generally shouldn't need to use this;
                           most avatar URLs sent by Zulip will already end with `?v={avatar_version}`.
 
@@ -7654,7 +7654,7 @@ paths:
                       email:
                         type: string
                         description: |
-                          Email of the requesting user.
+                          Zulip API email of the requesting user.
                         example: "iago@zulip.com"
                       full_name:
                         type: string
@@ -7691,7 +7691,8 @@ paths:
                           - 400
                           - 600
                         description: |
-                          [Organization-level role](/api/roles-and-permissions) of the user.
+                          [Organization-level role](/api/roles-and-permissions) of
+                          the requesting user.
                           Possible values are:
 
                           - 100 = Organization owner
@@ -7716,21 +7717,22 @@ paths:
                       is_active:
                         type: boolean
                         description: |
-                          A boolean specifying whether the user account has been deactivated.
+                          A boolean specifying whether the requesting user account
+                          has been deactivated.
 
                           **Changes**: New in Zulip 3.0 (feature level 10).
                         example: true
                       timezone:
                         type: string
                         description: |
-                          The time zone of the user.
+                          The time zone of the requesting user.
 
                           **Changes**: New in Zulip 3.0 (feature level 10).
                         example: ""
                       date_joined:
                         type: string
                         description: |
-                          The time the user account was created.
+                          The time the requesting user's account was created.
 
                           **Changes**: New in Zulip 3.0 (feature level 10).
                         example: "2019-10-20T07:50:53.728864+00:00"
@@ -7738,7 +7740,8 @@ paths:
                         type: integer
                         deprecated: true
                         description: |
-                          The integer ID of the last message received by your account.
+                          The integer ID of the last message received by the requesting
+                          user's account.
 
                           **Deprecated**. We plan to remove this in favor of recommending
                           using `GET /messages` with `"anchor": "newest"`.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -10504,8 +10504,7 @@ paths:
         doing this often saves 90% of the total bandwidth and other resources
         consumed by a client using this API.
 
-        See the
-        [events system developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/events-system.html)
+        See the [events system developer documentation][events-system-docs]
         if you need deeper details about how the Zulip event queue system
         works, avoids clients needing to worry about large classes of
         potentially messy races, etc.
@@ -10526,6 +10525,7 @@ paths:
         `email_address_visibility` value.
 
         [user-defaults]: /api/update-realm-user-settings-defaults#parameter-email_address_visibility
+        [events-system-docs]: https://zulip.readthedocs.io/en/latest/subsystems/events-system.html
       x-curl-examples-parameters:
         oneOf:
           - type: include

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -446,7 +446,7 @@ paths:
                                         email:
                                           type: string
                                           description: |
-                                            The email of the user.
+                                            The Zulip API email of the user.
 
                                             **Deprecated**: This field will be removed in a future
                                             release as it is redundant with the `user_id`.
@@ -2474,7 +2474,7 @@ paths:
                                     type: object
                                     additionalProperties: false
                                     description: |
-                                      Object containing the user ID and email of a recipient.
+                                      Object containing the user ID and Zulip API email of a recipient.
                                     properties:
                                       user_id:
                                         type: integer
@@ -5833,7 +5833,7 @@ paths:
           description: |
             For stream messages, either the name or integer ID of the stream. For
             direct messages, either a list containing integer user IDs or a list
-            containing string email addresses.
+            containing string Zulip API email addresses.
 
             **Changes**: Support for using user/stream IDs was added in Zulip 2.0.0.
           content:
@@ -8552,7 +8552,7 @@ paths:
                       subscribed:
                         type: object
                         description: |
-                          A dictionary where the key is the email
+                          A dictionary where the key is the Zulip API email
                           address of the user/bot and the value is a
                           list of the names of the streams that were
                           subscribed to as a result of the query.
@@ -8566,7 +8566,7 @@ paths:
                       already_subscribed:
                         type: object
                         description: |
-                          A dictionary where the key is the email
+                          A dictionary where the key is the Zulip API email
                           address of the user/bot and the value is a
                           list of the names of the streams that the
                           user/bot is already subscribed to.
@@ -10591,7 +10591,7 @@ paths:
           in: query
           description: |
             Setting this to `true` will make presence dictionaries be keyed by
-            user_id instead of email.
+            user ID instead of Zulip API email.
 
             **Changes**: New in Zulip 3.0 (Unstable with no feature level yet).
           schema:
@@ -17405,7 +17405,7 @@ components:
             The URL of the user's avatar. Can be `null` only if client_gravatar was passed,
             which means that the user has not uploaded an avatar in Zulip, and the
             client should compute the gravatar URL by hashing the
-            user's email address itself for this user.
+            user's Zulip API email address itself for this user.
         client:
           type: string
           description: |
@@ -18266,9 +18266,9 @@ components:
             subscribed:
               type: object
               description: |
-                A dictionary where the key is the email address of the user/bot and the
-                value is a list of the names of the streams that were subscribed to as a
-                result of the query.
+                A dictionary where the key is the Zulip API email address of the user/bot
+                and the value is a list of the names of the streams that were subscribed
+                to as a result of the query.
               additionalProperties:
                 description: |
                   `{email_address}`: List of the names of the streams that were subscribed
@@ -18279,9 +18279,9 @@ components:
             already_subscribed:
               type: object
               description: |
-                A dictionary where the key is the email address of the user/bot and the
-                value is a list of the names of the streams that the user/bot is already
-                subscribed to.
+                A dictionary where the key is the Zulip API email address of the user/bot
+                and the value is a list of the names of the streams that the user/bot is
+                already subscribed to.
               additionalProperties:
                 description: |
                   `{email_address}`: List of the names of the streams that the user is

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9925,16 +9925,15 @@ paths:
         Fetch details for a single user in the organization given a Zulip
         API email address.
 
-        Note that this endpoint uses Zulip display emails addresses
-        for organizations that have configured limited [email address
-        visibility](/help/configure-email-visibility).
+        You can also fetch details on [all users in the organization](/api/get-users)
+        or [by user ID](/api/get-user).
 
-        You can also fetch details on [all users in the organization](/api/get-users) or
-        [by user ID](/api/get-user). Fetching by user ID is generally recommended
-        when possible, as users can
-        [change their email address](/help/change-your-email-address).
+        Fetching by user ID is generally recommended when possible,
+        as a user might [change their email address](/help/change-your-email-address)
+        or change their [email address visibility](/help/configure-email-visibility),
+        either of which could change the value of their Zulip API email address.
 
-        _This endpoint is new in Zulip Server 4.0 (feature level 39)._
+        **Changes**: New in Zulip Server 4.0 (feature level 39).
       x-curl-examples-parameters:
         oneOf:
           - type: include

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -966,6 +966,7 @@ paths:
                                   "person":
                                     {
                                       "email": "foo@zulip.com",
+                                      "delivery_email": null,
                                       "user_id": 38,
                                       "avatar_version": 1,
                                       "is_admin": false,
@@ -7345,6 +7346,7 @@ paths:
                             {
                               "is_active": true,
                               "email": "AARON@zulip.com",
+                              "delivery_email": null,
                               "is_admin": false,
                               "is_owner": false,
                               "is_billing_admin": false,
@@ -7397,6 +7399,7 @@ paths:
                               "avatar_url": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1",
                               "is_active": true,
                               "email": "hamlet@zulip.com",
+                              "delivery_email": null,
                             },
                             {
                               "bot_owner_id": 11,
@@ -7404,6 +7407,7 @@ paths:
                               "date_joined": "2019-10-20T12:52:17.862053+00:00",
                               "full_name": "Iago's Bot",
                               "email": "iago-bot@zulipdev.com",
+                              "delivery_email": "iago-bot@zulipdev.com",
                               "is_active": true,
                               "avatar_url": "https://secure.gravatar.com/avatar/7328586831cdbb1627649bd857b1ee8c?d=identicon&version=1",
                               "is_admin": false,
@@ -7761,6 +7765,7 @@ paths:
                         "avatar_url": "https://secure.gravatar.com/avatar/af4f06322c177ef4e1e9b2c424986b54?d=identicon&version=1",
                         "avatar_version": 1,
                         "email": "iago@zulip.com",
+                        "delivery_email": iago@zulip.com,
                         "full_name": "Iago",
                         "is_admin": true,
                         "is_owner": false,
@@ -10016,6 +10021,7 @@ paths:
                             "avatar_url": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1",
                             "is_active": true,
                             "email": "hamlet@zulip.com",
+                            "delivery_email": null,
                           },
                       }
   /users/{user_id}:
@@ -10105,6 +10111,7 @@ paths:
                             "avatar_url": "https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1",
                             "is_active": true,
                             "email": "hamlet@zulip.com",
+                            "delivery_email": null,
                           },
                       }
     patch:


### PR DESCRIPTION
Part of 7.0 API changelog audit; see [this CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/7.2E0.20API.20changelog.20audit/near/1576702) for more context.

**Notes**:
- Makes the switch from "Zulip display email" to "Zulip API email" in the API documentation; discussed [here](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/api.20send.20message.20using.20mail.20addresses/near/1572194) on CZO.
- Updates the main description of the documentation for [Get a user by email](https://zulip.com/api/get-user-by-email) for the email address visibility change from an organization-level setting to a user-level setting.
- Fixes examples that were now missing the always present `delivery_email` field, though sometimes it is `null`.
- General updates and revisions to the **feature level 163** API documentation - both the changelog entry and **Changes** notes. See screenshots below.
- Updates the response in [Get own user](https://zulip.com/api/get-own-user) to consistently use "requesting user" in the response descriptions.
- Changes a link in the main description of the `POST /register` response to be a reference link for readability and consistency in that section of the documentation.

---

**Screenshots and screen captures:**

<details>
<summary>API changelog: feature level 163</summary>

[Current documentation](https://zulip.com/api/changelog)
![Screenshot from 2023-05-25 18-44-00](https://github.com/zulip/zulip/assets/63245456/f9c8892b-f045-446e-b5eb-33fc0cdf7d0b)
</details>
<details>
<summary>Get users: response `delivery_email`</summary>

[Current documentation](https://zulip.com/api/get-users#response) *Same response description in Get user by ID and by email, so not including screenshots of those. And same in user objects returned in register response.*
![Screenshot from 2023-05-25 18-46-48](https://github.com/zulip/zulip/assets/63245456/64bb6663-cf23-410e-b836-da408aa63753)

</details>
<details>
<summary>Get user by email: main description</summary>

[Current documentation](https://zulip.com/api/get-user-by-email)
![Screenshot from 2023-05-25 18-49-20](https://github.com/zulip/zulip/assets/63245456/83e629e7-3a87-43d5-8658-d4eac415ba46)

</details>
<details>
<summary>Get own user: response</summary>

[Current documentation](https://zulip.com/api/get-own-user#response)
![Screenshot from 2023-05-25 18-50-56](https://github.com/zulip/zulip/assets/63245456/21e5c3f7-7dcf-4f5f-8e48-ff2e79108eae)
![Screenshot from 2023-05-25 18-51-08](https://github.com/zulip/zulip/assets/63245456/34935472-82d4-4d23-85b7-c418a8580e28)

</details>
<details>
<summary>User settings: email_address_visibility parameter</summary>

[Current documentation](https://zulip.com/api/update-settings#parameter-email_address_visibility)
![Screenshot from 2023-05-25 18-52-56](https://github.com/zulip/zulip/assets/63245456/d2c28cdd-a1a9-470b-a386-42b598ddb794)

</details>
<details>
<summary>Realm user settings defaults: email_address_visibility parameter</summary>

[Current documentation](https://zulip.com/api/update-realm-user-settings-defaults#parameter-email_address_visibility)
![Screenshot from 2023-05-25 18-53-54](https://github.com/zulip/zulip/assets/63245456/7b01b254-3e13-468e-99f8-1a9779d6d9c7)

</details>
<details>
<summary>Get events: realm_user op: update event for delivery_email</summary>

[Current documentation](https://zulip.com/api/get-events#realm_user-update)
![Screenshot from 2023-05-25 18-55-16](https://github.com/zulip/zulip/assets/63245456/7e785b6b-8f6d-48ee-9087-4fd61b8613b3)
</details>
<details>
<summary>Get events: realm op: update event</summary>

[Current documentation](https://zulip.com/api/get-events#realm-update_dict)
![Screenshot from 2023-05-25 18-57-28](https://github.com/zulip/zulip/assets/63245456/f7ef420d-f7ff-4651-ae56-04f8f720000a)
</details>
<details>
<summary>Register queue: main description changes note</summary>

[Current documentation](https://zulip.com/api/register-queue)
![Screenshot from 2023-05-25 19-01-24](https://github.com/zulip/zulip/assets/63245456/f76f4ca2-c66b-4f6d-adc4-b3b883a980ee)

</details>
<details>
<summary>Register queue: email_address_visibility in user settings objects</summary>

[Current documentation](https://zulip.com/api/register-queue) *Same for realm defaults*.
![Screenshot from 2023-05-25 19-01-59](https://github.com/zulip/zulip/assets/63245456/26b2feb8-a001-47ce-8835-5aaa27751f9c)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
