### PR TITLE
compose_box: Topic input box fixes.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -516,6 +516,7 @@ textarea.new_message_textarea,
     border: 1px solid hsl(0deg 0% 0% / 20%);
     box-shadow: none;
     transition: border 0.2s ease;
+    color: var(--color-text-default);
 
     &:focus {
         outline: 0;
@@ -830,6 +831,7 @@ a.compose_control_button.hide {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        color: var(--color-text-default);
 
         .stream-privacy-type-icon {
             font-size: 13px;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -117,11 +117,20 @@
             }
         }
 
-        .fa-angle-right {
-            font-size: 0.9em;
-            -webkit-text-stroke: 0.05em;
-            align-self: center;
-            margin: 0 5px;
+        .topic-marker-container {
+            /* Ensure the marker ( < ) stays centered vertically
+              with the dropdown, even when adjacent stacking pills
+              in, e.g., a group DM. */
+            display: flex;
+            align-items: center;
+            height: var(--compose-recipient-box-min-height);
+
+            .fa-angle-right {
+                font-size: 0.9em;
+                -webkit-text-stroke: 0.05em;
+                align-self: center;
+                margin: 0 5px;
+            }
         }
 
         & a.narrow_to_compose_recipients {
@@ -233,12 +242,14 @@
 #compose_top {
     display: flex;
     justify-content: space-between;
+    align-items: flex-start;
     padding-bottom: 5px;
 }
 
 #compose_top_right {
     display: flex;
     align-items: center;
+    height: var(--compose-recipient-box-min-height);
 
     & button {
         background: transparent;
@@ -789,6 +800,7 @@ a.compose_control_button.hide {
 #compose_recipient_selection_dropdown {
     display: flex;
     justify-content: flex-start;
+    height: var(--compose-recipient-box-min-height);
 
     .stream_header_colorblock {
         margin: 0;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -107,11 +107,6 @@
     }
 
     #compose-recipient {
-        padding: 0;
-        display: flex;
-        align-items: center;
-        flex: 1;
-
         &.compose-recipient-direct-selected {
             #compose_select_recipient_widget {
                 border-radius: 4px !important;
@@ -125,14 +120,15 @@
         .fa-angle-right {
             font-size: 0.9em;
             -webkit-text-stroke: 0.05em;
-            position: relative;
+            align-self: center;
             margin: 0 5px;
         }
 
         & a.narrow_to_compose_recipients {
             background: transparent;
             font-size: 18px;
-            padding: 1px;
+            padding: 0 1px;
+            align-self: center;
             line-height: 20px;
             opacity: 0.7;
             border: 0;
@@ -519,7 +515,8 @@ textarea.new_message_textarea,
 
 input.recipient_box {
     margin: 0;
-    height: 1.1em;
+    padding: 0 6px;
+    height: auto;
     border-radius: 3px;
 }
 
@@ -527,6 +524,10 @@ input.recipient_box {
     border-radius: 0 4px 4px 0;
     width: auto;
     outline: none;
+
+    &.dropdown-widget-button {
+        padding: 0 6px;
+    }
 }
 
 #stream_message_recipient_topic.recipient_box {
@@ -629,10 +630,20 @@ input.recipient_box {
 }
 
 #compose-recipient {
-    min-width: 0;
     display: flex;
-    align-items: center;
     width: 100%;
+    /* Use this containing flex element to
+      establish the minimum height of all its
+      children; the default `align-items: stretch`
+      (which is set on any flexbox without specifying
+      it) ensures that the child flex items will
+      always stretch to fit the height set here;
+      larger heights, such as on group-DM pills,
+      will allow this to grow as needed.
+      Child flex items like chevrons take
+      `align-self: center` to center only
+      themselves, where necessary. */
+    min-height: var(--compose-recipient-box-min-height);
 }
 
 .tippy-content .compose_control_buttons_container {
@@ -832,10 +843,6 @@ a.compose_control_button.hide {
     .text-warning {
         color: inherit;
     }
-}
-
-#stream_message_recipient_topic {
-    min-width: 0;
 }
 
 .dropdown-menu {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -75,6 +75,13 @@ body {
     */
     --unread-marker-left: -1px;
 
+    /*
+    Compose-recipient box minimum height. Used in a flexbox context to
+    allow elements like DM pills to stack without breaking out of their
+    flex item.
+    */
+    --compose-recipient-box-min-height: 30.5px;
+
     /* Colors used across the app */
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-background-private-message-content: hsl(45deg 20% 96%);

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -55,7 +55,9 @@
                             <button type="button" class="close fa fa-times" id='compose_close' data-tooltip-template-id="compose_close_tooltip_template"></button>
                         </div>
                         <div id="compose-recipient" class="order-1">
-                            <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle order-1" data-tooltip-template-id="narrow_to_compose_recipients_tooltip"></a>
+                            <div class="topic-marker-container order-1">
+                                <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle" data-tooltip-template-id="narrow_to_compose_recipients_tooltip"></a>
+                            </div>
                             <div id="compose_recipient_selection_dropdown" class="new-style" tabindex="0">
                                 <div class="stream_header_colorblock"></div>
                                 <button id="compose_select_recipient_widget" class="dropdown-widget-button" type="button">
@@ -65,7 +67,9 @@
                                     <i class="fa fa-chevron-down"></i>
                                 </button>
                             </div>
-                            <i class="fa fa-angle-right" aria-hidden="true"></i>
+                            <div class="topic-marker-container">
+                                <i class="fa fa-angle-right" aria-hidden="true"></i>
+                            </div>
                             <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
                             <div id="compose-direct-recipient" class="pill-container" data-before="{{t 'You and' }}">
                                 <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user...' }}"></div>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
While this PR fixes the height of the topic-box elements by relying heavily on flexbox's behavior to manage the height of the elements and vertical centering, where necessary, rather than positioning hacks or vertical padding. 

This PR also removes some additional styles that do not make sense (e.g., `min-width: 0`) or that do not need to be set (e.g., `width: 100%`, which is the same as the `width: auto` default on block-level elements).

Finally, this PR also addresses text-color portions of #24878, ensuring the uniform use of the default body color on the compose bar and message-compose box.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/Compose.20box.20topic.20input.20box)

Possible points of further discussion:

1. In a narrow group-DM window, the piled pills will cause the DM dropdown to match the height of the pills area. This maintains the uniform height, and is likely a corner case, but it's something to note here. The new `--compose-recipient-box-min-height` variable could be brought to bear, if expansion of the dropdown isn't desirable.
2. In light mode, the text of the message-compose box is darker than it was before. (Dark mode appears unchanged.)
3. In light and dark mode, the DM text and icon have less contrast than they did before, in light and dark mode. That seems desirable for the text, but the icon might warrant additional discussion.

<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Stream, light mode, before | Stream, light mode, after |
| --- | --- |
| <img width="450" alt="light-stream-before" src="https://github.com/zulip/zulip/assets/170719/a3734ed5-08a7-42da-833d-43be0edbdbb8"> | <img width="450" alt="light-stream-after" src="https://github.com/zulip/zulip/assets/170719/19891b63-6ef6-42f5-aeb6-0ba4fb11d3b0"> |

| Group DM, light mode, before | Group DM, light mode, after |
| --- | --- |
| <img width="450" alt="light-group-dm-before" src="https://github.com/zulip/zulip/assets/170719/cf325ec4-773a-4a7d-adf7-509cca3de78e"> | <img width="450" alt="light-group-dm-after" src="https://github.com/zulip/zulip/assets/170719/a48089cf-2fbe-4197-b6ed-afcf543b8e45"> |

| Stream, dark mode, before | Stream, dark mode, after |
| --- | --- |
| <img width="450" alt="dark-stream-before" src="https://github.com/zulip/zulip/assets/170719/e234582b-9d2c-4e54-8d59-f783b6e8744c"> | <img width="450" alt="dark-stream-after" src="https://github.com/zulip/zulip/assets/170719/f57fd97d-4589-464d-aafb-d35d7ac0c9a1"> |

| Group DM, dark mode, before | Group DM, dark mode, after |
| --- | --- |
| <img width="450" alt="dark-group-dm-before" src="https://github.com/zulip/zulip/assets/170719/1ced6dc4-cf2b-4518-80b5-e7477a8640ea"> | <img width="450" alt="dark-group-dm-after" src="https://github.com/zulip/zulip/assets/170719/e9a8f8c4-dfcc-4d2e-a9e1-f66d162a6e5b"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
