### PR TITLE
drafts: Darken background in drafts overlay.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -638,6 +638,14 @@
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }
 
+    #draft_overlay,
+    #scheduled_messages_overlay_container {
+        .flex.overlay-content > div {
+            box-shadow: 0 0 30px hsl(213deg 31% 0%);
+            background-color: var(--color-background);
+        }
+    }
+
     .tippy-box[data-theme~="light-border"],
     .dropdown-menu ul,
     .dropdown .dropdown-menu,


### PR DESCRIPTION
<img width="657" alt="image" src="https://github.com/zulip/zulip/assets/5634097/2f7a521e-eeb6-47b0-a91c-cd56c2946945">
