### PR TITLE
shared: Avoid replaceAll again

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -266,7 +266,8 @@
                             }
                         ]
                     }
-                ]
+                ],
+                "unicorn/prefer-string-replace-all": "off"
             }
         }
     ]

--- a/web/shared/src/fenced_code.ts
+++ b/web/shared/src/fenced_code.ts
@@ -68,7 +68,7 @@ export function wrap_code(code: string, lang?: string): string {
     }
     // Trim trailing \n until there's just one left
     // This mirrors how pygments handles code input
-    return header + _.escape(code.replaceAll(/^\n+|\n+$/g, "")) + "\n</code></pre></div>";
+    return header + _.escape(code.replace(/^\n+|\n+$/g, "")) + "\n</code></pre></div>";
 }
 
 function wrap_quote(text: string): string {

--- a/web/shared/src/internal_url.js
+++ b/web/shared/src/internal_url.js
@@ -9,9 +9,7 @@ const hashReplacements = new Map([
 // window.location.hash.  So we hide our URI-encoding
 // by replacing % with . (like MediaWiki).
 export function encodeHashComponent(str) {
-    return encodeURIComponent(str).replaceAll(/[%().]/g, (matched) =>
-        hashReplacements.get(matched),
-    );
+    return encodeURIComponent(str).replace(/[%().]/g, (matched) => hashReplacements.get(matched));
 }
 
 export function decodeHashComponent(str) {
@@ -20,7 +18,7 @@ export function decodeHashComponent(str) {
     // of such characters when encoding. This can also,
     // fail independent of our fault.
     // Here we let the calling code handle the exception.
-    return decodeURIComponent(str.replaceAll(".", "%"));
+    return decodeURIComponent(str.replace(/\./g, "%"));
 }
 
 export function stream_id_to_slug(stream_id, maybe_get_stream_name) {
@@ -28,7 +26,10 @@ export function stream_id_to_slug(stream_id, maybe_get_stream_name) {
 
     // The name part of the URL doesn't really matter, so we try to
     // make it pretty.
-    name = name.replaceAll(" ", "-");
+
+    // TODO: Convert this to replaceAll once mobile no longer supports
+    // browsers that don't have it.
+    name = name.replace(/ /g, "-");
 
     return stream_id + "-" + name;
 }

--- a/web/shared/src/typeahead.ts
+++ b/web/shared/src/typeahead.ts
@@ -45,7 +45,7 @@ type UnicodeEmoji = {
 };
 
 export function remove_diacritics(s: string): string {
-    return s.normalize("NFKD").replaceAll(unicode_marks, "");
+    return s.normalize("NFKD").replace(unicode_marks, "");
 }
 
 // This function attempts to match a query with a source text.
@@ -79,7 +79,7 @@ function clean_query(query: string): string {
     // contenteditable widget such as the composebox PM section, the
     // space at the end was a `no break-space (U+00A0)` instead of
     // `space (U+0020)`, which lead to no matches in those cases.
-    query = query.replaceAll("\u00A0", " ");
+    query = query.replace(/\u00A0/g, " ");
 
     return query;
 }
@@ -98,7 +98,7 @@ export const parse_unicode_emoji_code = (code: string): string =>
 
 export function get_emoji_matcher(query: string): (emoji: Emoji) => boolean {
     // replace spaces with underscores for emoji matching
-    query = query.replaceAll(" ", "_");
+    query = query.replace(/ /g, "_");
     query = clean_query_lowercase(query);
 
     return function (emoji) {
@@ -166,7 +166,7 @@ export function triage<T>(
 
 export function sort_emojis<T extends Emoji>(objs: T[], query: string): T[] {
     // replace spaces with underscores for emoji matching
-    query = query.replaceAll(" ", "_");
+    query = query.replace(/ /g, "_");
     query = query.toLowerCase();
 
     function decent_match(name: string): boolean {


### PR DESCRIPTION
The JavaScript engine used by zulip-mobile on Android is still some four years out of date, apparently.

This reverts commit a3d6c47b7d8b7ff1c51554f60f93295e3460f01b (#25734) and part of commit 54f90e41c07645e34d49967cdb2e0c2089390b9f (#25554).