### PR TITLE
tests: Append to test_events.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -38,7 +38,6 @@ target_fully_covered = [
     "analytics/views/*.py",
     # zerver/ and zerver/lib/ are important core files
     "zerver/*.py",
-    "zerver/actions/*.py",
     "zerver/lib/*.py",
     "zerver/lib/*/*.py",
     "zerver/lib/*/*/*.py",
@@ -75,7 +74,6 @@ not_yet_fully_covered = [
     "analytics/views/stats.py",
     "analytics/views/support.py",
     # Major lib files should have 100% coverage
-    "zerver/actions/presence.py",
     "zerver/lib/addressee.py",
     "zerver/lib/markdown/__init__.py",
     "zerver/lib/cache.py",


### PR DESCRIPTION
Added test for updating presence on user with 'None' last-connected. Achieved 100% Coverage on zerver/actions/*.

Previous test_presence_event would only cover existing user, hamlet. The problem was that hamlet's last connection time would always be initialized by the UserPresence model as some timestamp instance by default. Thus, testing the 'do_update_user_presence' on null last_connected would almost never be covered. I had to bypass the default value of the UserPresence Model to achieve 100% coverage on the actions/presence.py. 

Under the test_presence_events function, I created a new user with last_connected None, and tested the update logic in similar manner as the existing testing logic for 'do_update_user_presence' in presence.py.

Fixes: #25498 

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
