### PR TITLE
server_events_dispatch: Remove body fade out on changing theme.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -716,7 +716,6 @@ export function dispatch_normal_event(event) {
                 unread_ui.update_unread_banner();
             }
             if (event.property === "color_scheme") {
-                $("body").fadeOut(300);
                 setTimeout(() => {
                     if (event.value === settings_config.color_scheme_values.night.code) {
                         dark_theme.enable();
@@ -728,7 +727,6 @@ export function dispatch_normal_event(event) {
                         dark_theme.default_preference_checker();
                         realm_logo.render();
                     }
-                    $("body").fadeIn(300);
                     message_lists.update_recipient_bar_background_color();
                 }, 300);
             }

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -874,13 +874,6 @@ run_test("user_settings", ({override}) => {
     assert_same(user_settings.dense_mode, true);
     assert_same(toggled, ["less_dense_mode", "more_dense_mode"]);
 
-    $("body").fadeOut = (secs) => {
-        assert_same(secs, 300);
-    };
-    $("body").fadeIn = (secs) => {
-        assert_same(secs, 300);
-    };
-
     override(realm_logo, "render", noop);
 
     {


### PR DESCRIPTION
This causes the app to scroll to top and causes slow paint.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/changing.20theme
