### PR TITLE
api-docs: Update API changelog for more history about moving messages between streams.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -568,7 +568,8 @@ No changes; feature level used for Zulip 5.0 release.
   /events`](/api/get-events): Improved the format of the
   `edit_history` object within message objects. Entries for stream
   edits now include a both a `prev_stream` and `stream` field to
-  indicate the previous and current stream IDs. Entries for topic
+  indicate the previous and current stream IDs. Prior to this feature
+  level, only the `prev_stream` field was present. Entries for topic
   edits now include both a `prev_topic` and `topic` field to indicate
   the previous and current topic, replacing the `prev_subject`
   field. These changes substantially simplify client complexity for

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1453,6 +1453,15 @@ No changes; feature level used for Zulip 3.0 release.
 
 **Feature level 1**:
 
+* [`PATCH /messages/{message_id}`](/api/update-message): Added the
+  `stream_id` parameter to support moving messages between streams.
+* [`GET /messages`](/api/get-messages), [`GET /events`](/api/get-events):
+  Added `prev_stream` as a potential property of the `edit_history` object
+  within message objects to indicate when a message was moved to another
+  stream.
+* [`GET messages/{message_id}/history`](/api/get-message-history):
+  `prev_stream` is present in `snapshot` objects within `message_history`
+  object when a message was moved to another stream.
 * [`GET /server_settings`](/api/get-server-settings): Added
   `zulip_feature_level`, which can be used by clients to detect which
   of the features described in this changelog are supported.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5997,6 +5997,8 @@ paths:
 
                                 The ID of the stream containing the message immediately
                                 prior to this edit event.
+
+                                **Changes**: New in Zulip 3.0 (feature level 1).
                             content:
                               type: string
                               description: |
@@ -7047,6 +7049,8 @@ paths:
             Note that a message's content and stream cannot be changed at the
             same time, so sending both `content` and `stream_id` parameters will
             throw an error.
+
+            **Changes**: New in Zulip 3.0 (feature level 1).
           schema:
             type: integer
           example: 43
@@ -17472,6 +17476,8 @@ components:
 
                   The stream ID of the message immediately prior to this
                   edit event.
+
+                  **Changes**: New in Zulip 3.0 (feature level 1).
               prev_topic:
                 type: string
                 description: |


### PR DESCRIPTION
See [this CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/prev_stream.20in.20message.20history/near/1575857) for more context.

**Notes**:
- Updates API changelog feature level 118 entry to clarify that the `prev_stream` field existed before these changes.
- Adds API changelog feature level 1 documentation for `stream_id` parameter for `PATCH /messages/{message_id}` and for `prev_stream` in message edit history information.

**Screenshots and screen captures:**

<details>
<summary>API changelog feature level 118</summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-50)
![Screenshot from 2023-05-26 20-12-02](https://github.com/zulip/zulip/assets/63245456/5a84932b-df53-4a01-9a87-8d245997a443)
</details>
<details>
<summary>API changelog feature level 1</summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-30)
![Screenshot from 2023-05-26 20-21-51](https://github.com/zulip/zulip/assets/63245456/4bdcc741-3b9e-424d-9e73-3681fe857ebb)
</details>

<details>
<summary>Edit a message: stream_id parameter</summary>

[Current documentation](https://zulip.com/api/update-message#parameter-stream_id)
![Screenshot from 2023-05-26 20-23-17](https://github.com/zulip/zulip/assets/63245456/04e8eeb7-4678-47b0-9295-f2110c321b74)
</details>
<details>
<summary>Get messages: response</summary>

[Current documentation](https://zulip.com/api/get-messages#response)
![Screenshot from 2023-05-26 20-24-17](https://github.com/zulip/zulip/assets/63245456/96731c08-41cf-412b-974b-f003b9ec8907)
</details>

<details>
<summary>Get message history: response</summary>

[Current documentation](https://zulip.com/api/get-message-history#response)
![Screenshot from 2023-05-26 20-25-11](https://github.com/zulip/zulip/assets/63245456/a9a8d228-49e6-420e-8eec-49dc25f26543)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
