### PR TITLE
settings: Improve organization settings for bots.

### DIFF
--- a/web/src/settings.js
+++ b/web/src/settings.js
@@ -173,6 +173,7 @@ export function initialize() {
         show_uploaded_files_section: page_params.max_file_upload_size_mib > 0,
         show_emoji_settings_lock:
             !page_params.is_admin && page_params.realm_add_emoji_by_admins_only,
+        can_create_new_bots: settings_bots.can_create_new_bots(),
     });
     $("#settings_overlay_container").append(rendered_settings_overlay);
 }

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -1,9 +1,27 @@
 <div id="admin-bot-list" class="settings-section" data-name="bot-list-admin">
-    <div class="bot-settings-tip" id="admin-bot-settings-tip">
-    </div>
+    {{#if is_admin}}
+        <div class="bot-settings-tip" id="admin-bot-settings-tip">
+        </div>
+    {{/if}}
     <div class="clear-float"></div>
     <div>
-        <button class="button rounded sea-green add-a-new-bot {{#unless can_create_new_bots}}hide{{/unless}}">{{t "Add a new bot" }}</button>
+        {{#if is_admin}}
+            {{t "You are viewing all the bots in this organization." }}
+        {{else}}
+            {{t "You are viewing all your bots in this organization." }}
+        {{/if}}
+        {{#if can_create_new_bots}}
+            {{#tr}}
+                You can <z-link-new-bot>add a new bot</z-link-new-bot> or <z-link-manage-bot>manage</z-link-manage-bot> your own bots.
+                {{#*inline "z-link-new-bot"}}<a class="add-a-new-bot">{{> @partial-block}}</a>{{/inline}}
+                {{#*inline "z-link-manage-bot"}}<a href="/#settings/your-bots">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        {{else}}
+            {{#tr}}
+                You can <z-link>manage</z-link> your own bots.
+                {{#*inline "z-link"}}<a href="/#settings/your-bots">{{> @partial-block}}</a>{{/inline}}
+            {{/tr}}
+        {{/if}}
     </div>
     <div class="settings_panel_list_header">
         <h3>{{t "Bots"}}</h3>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -58,7 +58,7 @@
                     <li tabindex="0" data-section="organization-profile">
                         <i class="icon fa fa-id-card" aria-hidden="true"></i>
                         <div class="text">{{t "Organization profile" }}</div>
-                        {{#unless is_admin}}
+                        {{#unless can_create_new_bots}}
                         <i class="locked fa fa-lock" title="{{t 'Only organization administrators can edit these settings.' }}"></i>
                         {{/unless}}
                     </li>


### PR DESCRIPTION
This commit improves the organization settings for bots. The changes made are as follows:

- Remove the lock icon when the user can add bots.
- Remove the "Add a new bot" button from the admin page when the user doesn't have permission to create new bots.
- Show the bot settings tip only for admins.

-----------------------------------------------------

Fixes: #24154

-----------------------------------------------

**Screenshots and screen captures:**

<details>
<summary>Admin:</summary>
<br>

![Screenshot from 2023-05-27 05-28-19](https://github.com/zulip/zulip/assets/99144185/a4b425bb-be4e-4455-be2c-cc9aab7324b1)

</details>

<details>
<summary>Non Admin (Can Add Bot):</summary>
<br>

![Screenshot from 2023-05-27 05-26-13](https://github.com/zulip/zulip/assets/99144185/01a6ec49-bf3d-41a9-a6a7-99c5942d171f)


</details>

<details>
<summary>Non Admin (Can't Add Bot):</summary>
<br>

![Screenshot from 2023-05-27 05-28-04](https://github.com/zulip/zulip/assets/99144185/bb806d9d-cb67-4c26-a222-c6c2928f57f8)



</details>
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
