### PR TITLE
Fix post recipient selection focus behaviour.

### DIFF
--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -163,6 +163,17 @@ function switch_message_type(message_type) {
     compose_ui.set_focus(message_type, opts);
 }
 
+function update_recipient_label(stream_name) {
+    const stream = stream_data.get_sub_by_name(stream_name);
+    if (stream === undefined) {
+        $("#compose_select_recipient_name").text($t({defaultMessage: "Select a stream"}));
+    } else {
+        $("#compose_select_recipient_name").html(
+            render_inline_decorated_stream_name({stream, show_colored_icon: true}),
+        );
+    }
+}
+
 export function update_compose_for_message_type(message_type, opts) {
     if (message_type === "stream") {
         $("#compose-direct-recipient").hide();
@@ -170,14 +181,7 @@ export function update_compose_for_message_type(message_type, opts) {
         $("#stream_toggle").addClass("active");
         $("#private_message_toggle").removeClass("active");
         $("#compose-recipient").removeClass("compose-recipient-direct-selected");
-        const stream = stream_data.get_sub_by_name(opts.stream);
-        if (stream === undefined) {
-            $("#compose_select_recipient_name").text($t({defaultMessage: "Select a stream"}));
-        } else {
-            $("#compose_select_recipient_name").html(
-                render_inline_decorated_stream_name({stream, show_colored_icon: true}),
-            );
-        }
+        update_recipient_label(opts.stream);
     } else {
         $("#compose-direct-recipient").show();
         $("#stream_message_recipient_topic").hide();

--- a/web/src/dropdown_widget.js
+++ b/web/src/dropdown_widget.js
@@ -15,6 +15,7 @@ const noop = () => {};
 export function setup(tippy_props, get_options, item_click_callback, dropdown_props = {}) {
     // Define all possible `dropdown_props` here so that they are easy to track.
     const on_show_callback = dropdown_props.on_show_callback || noop;
+    const on_hidden_callback = dropdown_props.on_hidden_callback || noop;
     const on_exit_with_escape_callback = dropdown_props.on_exit_with_escape_callback || noop;
     // Used to focus the `target` after dropdown is closed. This is important since the dropdown is
     // appended to `body` and hence `body` is focused when the dropdown is closed, which makes
@@ -163,10 +164,11 @@ export function setup(tippy_props, get_options, item_click_callback, dropdown_pr
 
             on_show_callback(instance);
         },
-        onHidden() {
+        onHidden(instance) {
             if (focus_target_on_hidden) {
                 $(tippy_props.target).trigger("focus");
             }
+            on_hidden_callback(instance);
         },
         ...tippy_props,
     });

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -60,7 +60,7 @@
                             </div>
                             <div id="compose_recipient_selection_dropdown" class="new-style" tabindex="0">
                                 <div class="stream_header_colorblock"></div>
-                                <button id="compose_select_recipient_widget" class="dropdown-widget-button" type="button">
+                                <button id="compose_select_recipient_widget" class="dropdown-widget-button" type="button" tabindex="-1">
                                     <span id="compose_select_recipient_name">
                                         {{t 'Select a stream'}}
                                     </span>


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/Focus.20after.20picking.20stream

Here the cases I checked:
* When recipient selection dropdown is open and `escape` is pressed, we select the recipient dropdown button.
* When a stream is selected, we focus at the end of topic.
* When a DM is selected, we focus on users box if it is empty else we focus on compose.