### PR TITLE
Hide popovers on scrolling and show them at correct position.

### DIFF
--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1022,7 +1022,7 @@ export function register_click_handlers() {
     {
         let last_scroll = 0;
 
-        $(".app").on("scroll", () => {
+        $(document).on("scroll", () => {
             if (suppress_scroll_hide) {
                 suppress_scroll_hide = false;
                 return;

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -210,6 +210,7 @@ function show_user_info_popover_manage_menu(element, user) {
         placement: "bottom",
         html: true,
         trigger: "manual",
+        fixed: true,
     });
 
     $popover_elt.popover("show");
@@ -497,6 +498,7 @@ function show_user_group_info_popover(element, group, message) {
             content: render_user_group_info_popover_content(args),
             html: true,
             trigger: "manual",
+            fixed: true,
         });
         $elt.popover("show");
         $current_message_info_popover_elem = $elt;
@@ -715,6 +717,7 @@ export function toggle_playground_link_popover(element, playground_info) {
             content: render_playground_links_popover_content({playground_info}),
             html: true,
             trigger: "manual",
+            fixed: true,
         });
         $elt.popover("show");
         $current_playground_links_popover_elem = $elt;

--- a/web/tests/popovers.test.js
+++ b/web/tests/popovers.test.js
@@ -36,6 +36,10 @@ mock_esm("../src/stream_popover", {
     hide_streamlist_sidebar: noop,
 });
 
+set_global("document", {
+    to_$: () => $("document-stub"),
+});
+
 const people = zrequire("people");
 const user_status = zrequire("user_status");
 const popovers = zrequire("popovers");


### PR DESCRIPTION
discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/user.20group.20info.20popover.20not.20opening

<img width="338" alt="image" src="https://github.com/zulip/zulip/assets/25124304/d7bc9a60-7641-4009-bc3b-039e817c5570">

Open in playground when there are multiple playgrounds for the same language.
<img width="137" alt="image" src="https://github.com/zulip/zulip/assets/25124304/8b8cdd1f-80d6-4b1f-a2c2-61f4b4eb1734">

<img width="244" alt="image" src="https://github.com/zulip/zulip/assets/25124304/9081a721-af31-4b84-be13-64930dda599f">
