### PR TITLE
overlays: Stop document from occupying the extra scrollbar width.

### DIFF
--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -50,11 +50,17 @@ function call_hooks(func_list: Hook[]): void {
 }
 
 export function disable_scrolling(): void {
-    $("html").css({"overflow-y": "hidden"});
+    // Why disable scrolling?
+    // Since fixed / absolute positined elements don't capture the scroll event unless
+    // they overflow their defined container. Since fixed / absolute elements are not treated
+    // as part of the document flow, we cannot capture `scroll` events on them and prevent propagation
+    // as event bubbling doesn't work naturally.
+    const scrollbar_width = window.innerWidth - document.documentElement.clientWidth;
+    $("html").css({"overflow-y": "hidden", "--disabled-scrollbar-width": `${scrollbar_width}px`});
 }
 
 function enable_scrolling(): void {
-    $("html").css({"overflow-y": "scroll"});
+    $("html").css({"overflow-y": "scroll", "--disabled-scrollbar-width": "0px"});
 }
 
 export function is_active(): boolean {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -227,7 +227,6 @@
     bottom: 0;
     left: 0;
     z-index: 4;
-    width: 100%;
 }
 
 #compose-container {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2,11 +2,11 @@ html {
     overflow-y: scroll;
     overflow-x: hidden;
     overscroll-behavior-y: none;
+    width: calc(100% - var(--disabled-scrollbar-width));
 }
 
 body,
 html {
-    width: 100%;
     height: 100%;
     touch-action: manipulation;
 }
@@ -21,6 +21,7 @@ html {
 }
 
 body {
+    width: 100%;
     font-size: 14px;
     line-height: calc(20 / 14);
     font-family: "Source Sans 3", sans-serif;
@@ -81,6 +82,13 @@ body {
     flex item.
     */
     --compose-recipient-box-min-height: 30.5px;
+
+    /*
+    Width to be reserved for document scrollbar when scrolling is disabled.
+    Using `scrollbar-gutter` would be more appropriate but doesn't has wide
+    support and doesn't work for `fixed` elements.
+    */
+    --disabled-scrollbar-width: 0px;
 
     /* Colors used across the app */
     --color-background-private-message-header: hsl(46deg 35% 93%);
@@ -381,7 +389,13 @@ p.n-margin {
     position: fixed;
     top: 0;
     z-index: 102;
-    width: 100%;
+}
+
+/* Adjust width of any fixed / absolute positioned elements that might be visible in
+   the background when a overlay / modal is open. */
+#navbar-fixed-container,
+#compose {
+    width: calc(100% - var(--disabled-scrollbar-width));
 }
 
 .header {


### PR DESCRIPTION
When overlay / modal is displayed, scrollbar is hidden due to the disabled scrolling on `html`. Reduce width of fixed elements that will be visible in background and `html` so that they don't occupy that extra space.

Also, I was over-thinking how we can get the scrollbar width. The moment we allowed scrolling on `html`, it was easy to get the scrollbar width.

before:
<img width="332" alt="image" src="https://github.com/zulip/zulip/assets/25124304/8e0047a0-d1fa-491d-815e-18ab6dfffc40">


after:
<img width="343" alt="image" src="https://github.com/zulip/zulip/assets/25124304/417b1e2a-ec50-43eb-b270-f329c90e1b11">

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/opening.20a.20modal.20.2F.20overlay.20causes.20scrollbar.20to.20hide

Tested:

Safari, chrome and firefox on mac and  windows + scrollbar always visible / hidden + narrow width / wide width

