### PR TITLE
Recent topics bug fix

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -451,12 +451,10 @@ export function initialize() {
 
     resize.watch_manual_resize("#compose-textarea");
 
-    // Update position of scroll to bottom button based on
-    // height of the compose box.
-    const update_scroll_to_bottom_position = new ResizeObserver(() => {
-        $("#scroll-to-bottom-button-container").css("bottom", $("#compose").outerHeight());
-    });
-    update_scroll_to_bottom_position.observe(document.querySelector("#compose"));
+    // Updates compose max-height and scroll to bottom button position when
+    // there is a change in compose height like when a compose banner is displayed.
+    const update_compose_max_height = new ResizeObserver(resize.reset_compose_message_max_height);
+    update_compose_max_height.observe(document.querySelector("#compose"));
 
     upload.feature_check($("#compose .compose_upload_file"));
 

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -35,6 +35,7 @@ import {
     is_visible,
     set_visible,
 } from "./recent_topics_util";
+import * as resize from "./resize";
 import * as scroll_util from "./scroll_util";
 import * as search from "./search";
 import * as stream_data from "./stream_data";
@@ -901,8 +902,8 @@ export function show() {
     narrow.handle_middle_pane_transition();
     pm_list.handle_narrow_deactivated();
     search.clear_search_form();
-
     complete_rerender();
+    resize.update_recent_topics_filters_height();
 }
 
 function filter_buttons() {

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -12,12 +12,14 @@ import * as navigate from "./navigate";
 import * as popovers from "./popovers";
 import * as util from "./util";
 
+function get_bottom_whitespace_height() {
+    return message_viewport.height() * 0.4;
+}
+
 function get_new_heights() {
     const res = {};
     const viewport_height = message_viewport.height();
     const right_sidebar_shortcuts_height = $(".right-sidebar-shortcuts").safeOuterHeight(true) || 0;
-
-    res.bottom_whitespace_height = viewport_height * 0.4;
 
     res.stream_filters_max_height =
         viewport_height -
@@ -90,8 +92,7 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
 
     // Compute bottom_whitespace_height if not provided by caller.
     if (bottom_whitespace_height === undefined) {
-        const h = get_new_heights();
-        bottom_whitespace_height = h.bottom_whitespace_height;
+        bottom_whitespace_height = get_bottom_whitespace_height();
     }
 
     const compose_height = $("#compose").get(0).getBoundingClientRect().height;
@@ -116,9 +117,9 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
     );
 }
 
-export function resize_bottom_whitespace(h) {
-    $("#bottom_whitespace").height(h.bottom_whitespace_height);
-
+export function resize_bottom_whitespace() {
+    const bottom_whitespace_height = get_bottom_whitespace_height();
+    $("#bottom_whitespace").height(bottom_whitespace_height);
     // The height of the compose box is tied to that of
     // bottom_whitespace, so update it if necessary.
     //
@@ -126,13 +127,13 @@ export function resize_bottom_whitespace(h) {
     // height correctly while compose is hidden. This is OK, because
     // we also resize compose every time it is opened.
     if (compose_state.composing()) {
-        reset_compose_message_max_height(h.bottom_whitespace_height);
+        reset_compose_message_max_height(bottom_whitespace_height);
     }
 }
 
 export function resize_stream_filters_container() {
     const h = get_new_heights();
-    resize_bottom_whitespace(h);
+    resize_bottom_whitespace();
     $("#left_sidebar_scroll_container").css("max-height", h.stream_filters_max_height);
 }
 

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -143,6 +143,11 @@ export function resize_sidebars() {
     return h;
 }
 
+export function update_recent_topics_filters_height() {
+    const recent_topics_filters_height = $("#recent_topics_filter_buttons").safeOuterHeight(true);
+    $("html").css("--recent-topics-filters-height", `${recent_topics_filters_height}px`);
+}
+
 export function resize_page_components() {
     navbar_alerts.resize_app();
     const h = resize_sidebars();
@@ -168,6 +173,7 @@ export function handler() {
     }
     resize_page_components();
     compose_ui.autosize_textarea($("#compose-textarea"));
+    update_recent_topics_filters_height();
 
     // Re-compute and display/remove [More] links to messages
     condense.condense_and_collapse($(".message_table .message_row"));

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -91,7 +91,7 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
     // the last message of the current stream.
 
     // Compute bottom_whitespace_height if not provided by caller.
-    if (bottom_whitespace_height === undefined) {
+    if (typeof bottom_whitespace_height !== "number") {
         bottom_whitespace_height = get_bottom_whitespace_height();
     }
 
@@ -115,6 +115,7 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
         // subtract 10 for the selected message border.
         bottom_whitespace_height - compose_non_textarea_height - 10,
     );
+    $("#scroll-to-bottom-button-container").css("bottom", compose_height);
 }
 
 export function resize_bottom_whitespace() {

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -120,7 +120,7 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
 
 export function resize_bottom_whitespace() {
     const bottom_whitespace_height = get_bottom_whitespace_height();
-    $("#bottom_whitespace").height(bottom_whitespace_height);
+    $("html").css("--max-unexpanded-compose-height", `${bottom_whitespace_height}px`);
     // The height of the compose box is tied to that of
     // bottom_whitespace, so update it if necessary.
     //

--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -8,7 +8,6 @@
 
     #recent_topics_table {
         max-width: 100%;
-        padding-top: 12px;
         overflow: hidden !important;
         display: flex;
         flex-direction: column;
@@ -87,6 +86,7 @@
         }
 
         #recent_topics_filter_buttons {
+            padding-top: 12px;
             margin: 0 10px;
             display: flex;
             /* Search box has no height without this in safari. */

--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -21,7 +21,7 @@
          * window. This makes the border span
          * fully to bottom in that case.
          */
-        min-height: 100vw;
+        min-height: 100vh;
 
         & td {
             vertical-align: middle;

--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -91,7 +91,7 @@
             expensive repaint. The downside of not doing so is that the scrollbar is not visible to user when
             user is at the bottom of scroll container when the compose box is open.
             */
-            margin-bottom: 40vh;
+            margin-bottom: var(--max-unexpanded-compose-height);
         }
 
         #recent_topics_filter_buttons {

--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -73,16 +73,25 @@
 
         .table_fix_head {
             padding: 0 !important;
-            /* 100px = space occupied by `recent_topics_filter_buttons`( ~49px)
-                     + give user some extra space at the bottom so that last
-                       topic row is clearly visible. */
-            max-height: calc(100vh - 100px);
+            max-height: calc(
+                100vh - var(--recent-topics-filters-height) -
+                    var(--navbar-fixed-height)
+            );
         }
 
         .table_fix_head table {
             /* To keep border properties to the thead th. */
             border-collapse: separate;
-            margin-bottom: 100px;
+            /*
+            Add margin bottom equal to `#bottom-whitespace`. This helps us keep
+            #compose visible at its max-height without overlapping with any visible
+            topics.
+
+            Alternative is to adjust the max-height of `table_fix_head` based on compose height which is an
+            expensive repaint. The downside of not doing so is that the scrollbar is not visible to user when
+            user is at the bottom of scroll container when the compose box is open.
+            */
+            margin-bottom: 40vh;
         }
 
         #recent_topics_filter_buttons {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -114,6 +114,10 @@ body {
     */
     --browser-overlay-scrollbar-width: 10px;
 
+    /* This is a rough estimate for height occupied by recent topics filters.
+       We expect `resize.js` to update this once UI is initialized. */
+    --recent-topics-filters-height: 50px;
+
     /* Colors used across the app */
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-background-private-message-content: hsl(45deg 20% 96%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -118,6 +118,14 @@ body {
        We expect `resize.js` to update this once UI is initialized. */
     --recent-topics-filters-height: 50px;
 
+    /*
+    Maximum height of the compose box when it is not in expanded state. This
+    is equal to the height of `#bottom_whitespace`. We expect resize.js to
+    replace it with its pixel calculation since even if `vh` has great support,
+    it can change depending on browser / OS on mobile devices.
+    */
+    --max-unexpanded-compose-height: 40vh;
+
     /* Colors used across the app */
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-background-private-message-content: hsl(45deg 20% 96%);
@@ -2346,7 +2354,7 @@ nav {
 
 #bottom_whitespace {
     display: block;
-    height: 300px;
+    height: var(--max-unexpanded-compose-height);
 }
 
 .operator_value {

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -170,6 +170,9 @@ mock_esm("../src/unread", {
     },
     topic_has_any_unread_mentions: () => false,
 });
+mock_esm("../src/resize", {
+    update_recent_topics_filters_height: noop,
+});
 
 const {all_messages_data} = zrequire("all_messages_data");
 const people = zrequire("people");


### PR DESCRIPTION
<!-- Describe your pull request here.-->
CZO discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/can't.20see.20all.20recent.20topics.20with.20open.20compose.20box

- Fixed Height of `#recent_topics_filter_buttons`: The height of the #recent_topics_filter_buttons div is now fixed at `87.2px`. This ensures consistent display across different device widths.

- Consistent Display of `#recent_topics_filter_buttons`: Previously, the #recent_topics_filter_buttons div displayed as 2 lines for device width < 1040px and 1/2 line for greater device width. Additionally, it displayed more than 2 lines for device width < 560px when filters spread to multiple lines. The behavior is now consistent, always displaying in 2 lines.
 
- Horizontal Simplebar for `#recent_filters_group`: To handle scenarios where all filters cannot fit within the available width, the `#recent_filters_group` now has a horizontal simplebar. This ensures that all filters remain accessible to users.
 
- Dynamic Height of the recent_conversations Table: The recent_conversations table now dynamically adjusts its height based on the available space. This calculation takes into account the state of the compose box (open/close), providing an optimal display experience.

Fixes: #25751

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
The simplebar on `#recent_filters_group`:
![image](https://github.com/zulip/zulip/assets/64723994/809ac012-b55b-4681-bbfe-b8568ae1cbc6)

with closed compose box:
![image](https://github.com/zulip/zulip/assets/64723994/63060c6f-3491-4e37-aa5b-647288311af2)

with open compose box:
![image](https://github.com/zulip/zulip/assets/64723994/a1893356-f5d0-4af8-8df9-8ba63fec1c91)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
