### PR TITLE
docs: Add copy code button to portico docs.

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -1,6 +1,9 @@
+import ClipboardJS from "clipboard";
 import $ from "jquery";
 import SimpleBar from "simplebar";
+import tippy from "tippy.js";
 
+import copy_to_clipboard_svg from "../../templates/copy_to_clipboard_svg.hbs";
 import * as common from "../common";
 
 import * as google_analytics from "./google-analytics";
@@ -24,6 +27,37 @@ function registerCodeSection($codeSection) {
         if (e.key === "Enter") {
             e.target.click();
         }
+    });
+}
+
+// Display the copy-to-clipboard button inside the markdown.pre element
+// within the API and Help Center docs using clipboard.js
+function add_copy_to_clipboard_element($pre) {
+    const $copy_button = $("<button>").addClass("copy-codeblock");
+    $copy_button.html(copy_to_clipboard_svg());
+
+    $($pre).append($copy_button);
+
+    const clipboard = new ClipboardJS($copy_button[0], {
+        text(copy_element) {
+            return $(copy_element).siblings("code").text();
+        },
+    });
+
+    // Show a tippy tooltip when the code is copied
+    clipboard.on("success", () => {
+        const tooltip = tippy($copy_button[0], {
+            content: "Copied!",
+            trigger: "manual",
+            placement: "top",
+        });
+
+        tooltip.show();
+
+        // Show the tooltip for 1s
+        setTimeout(() => {
+            tooltip.hide();
+        }, 1000);
     });
 }
 
@@ -54,6 +88,11 @@ function render_code_sections() {
     $(".code-section").each(function () {
         activate_correct_tab($(this));
         registerCodeSection($(this));
+    });
+
+    // Add a copy-to-clipboard button for each pre element
+    $(".markdown pre").each(function () {
+        add_copy_to_clipboard_element($(this));
     });
 
     highlight_current_article();

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -382,6 +382,10 @@
     }
 
     & pre {
+        /* Relative positioning is used to place the copy-to-clipboard button
+           in the top-right corner. */
+        position: relative;
+
         & code {
             font-size: 14px;
             white-space: pre-wrap;
@@ -389,6 +393,23 @@
             color: inherit;
             background-color: transparent;
             border: 0;
+        }
+    }
+
+    .copy-codeblock {
+        /* Invisible default button */
+        background: none;
+        border: none;
+        padding: 0;
+        position: absolute;
+        /* Position the button in the top-right corner */
+        top: 10px;
+        right: 10px;
+        line-height: 3px;
+
+        &:focus {
+            outline-offset: -1px;
+            outline-color: hsl(176deg 46% 41%);
         }
     }
 


### PR DESCRIPTION
Added a copy-to-clipboard button to the code blocks in the API and Help Center docs. Previously, copying code from the docs required manual copying, which was cumbersome.

Used the same copy-to-clipboard svg icon as the one used in web/src but manually created the button within the js function instead of using a template. Updated the `pre` CSS element to have relative positioning and gave the `copy-codeblock` element absolute positioning to ensure the button stayed in the top-right corner.

Fixes: #25726.

**Screenshots and screen captures:**
![issue-25762-record](https://github.com/zulip/zulip/assets/71205057/0159099e-cdc6-436c-bb98-bc3b6a62c7ba)




<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
