### PR TITLE
message_list_view: Only update scroll position for current msg list.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1160,9 +1160,7 @@ export class MessageListView {
 
     set_message_offset(offset) {
         const $msg = this.selected_row();
-        message_viewport.scrollTop(
-            message_viewport.scrollTop() + $msg.get_offset_to_window().top - offset,
-        );
+        message_viewport.scrollTop($msg.offset().top - offset);
     }
 
     rerender_with_target_scrolltop(selected_row, target_offset) {

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1178,7 +1178,7 @@ export class MessageListView {
         // window such that the newly selected message is at the
         // same location as it would have been before we
         // re-rendered.
-        if (target_offset !== undefined) {
+        if (target_offset !== undefined && message_lists.current === this) {
             if (this.selected_row().length === 0 && this.list.selected_id() > -1) {
                 this.list.select_id(this.list.selected_id(), {use_closest: true});
             }

--- a/web/src/message_viewport.js
+++ b/web/src/message_viewport.js
@@ -9,7 +9,7 @@ import * as popovers from "./popovers";
 import * as rows from "./rows";
 import * as util from "./util";
 
-export let $message_pane;
+export let $scroll_container;
 
 let $jwindow;
 const dimensions = {};
@@ -18,13 +18,13 @@ let in_stoppable_autoscroll = false;
 function make_dimen_wrapper(dimen_name, dimen_func) {
     dimensions[dimen_name] = new util.CachedValue({
         compute_value() {
-            return dimen_func.call($message_pane);
+            return dimen_func.call($scroll_container);
         },
     });
     return function viewport_dimension_wrapper(...args) {
         if (args.length !== 0) {
             dimensions[dimen_name].reset();
-            return dimen_func.apply($message_pane, args);
+            return dimen_func.apply($scroll_container, args);
         }
         return dimensions[dimen_name].get();
     };
@@ -75,7 +75,7 @@ export function message_viewport_info() {
 
 export function at_bottom() {
     const bottom = scrollTop() + height();
-    const full_height = $message_pane.prop("scrollHeight");
+    const full_height = $scroll_container.prop("scrollHeight");
 
     // We only know within a pixel or two if we're
     // exactly at the bottom, due to browser quirkiness,
@@ -283,12 +283,12 @@ export function visible_messages(require_fully_visible) {
 }
 
 export function scrollTop(target_scrollTop) {
-    const orig_scrollTop = $message_pane.scrollTop();
+    const orig_scrollTop = $scroll_container.scrollTop();
     if (target_scrollTop === undefined) {
         return orig_scrollTop;
     }
-    let $ret = $message_pane.scrollTop(target_scrollTop);
-    const new_scrollTop = $message_pane.scrollTop();
+    let $ret = $scroll_container.scrollTop(target_scrollTop);
+    const new_scrollTop = $scroll_container.scrollTop();
     const space_to_scroll = $("#bottom_whitespace").get_offset_to_window().top - height();
 
     // Check whether our scrollTop didn't move even though one could have scrolled down
@@ -307,10 +307,10 @@ export function scrollTop(target_scrollTop) {
             "ScrollTop did nothing when scrolling to " + target_scrollTop + ", fixing...",
         );
         // First scroll to 1 in order to clear the stuck state
-        $message_pane.scrollTop(1);
+        $scroll_container.scrollTop(1);
         // And then scroll where we intended to scroll to
-        $ret = $message_pane.scrollTop(target_scrollTop);
-        if ($message_pane.scrollTop() === 0) {
+        $ret = $scroll_container.scrollTop(target_scrollTop);
+        if ($scroll_container.scrollTop() === 0) {
             blueslip.info(
                 "ScrollTop fix did not work when scrolling to " +
                     target_scrollTop +
@@ -324,7 +324,7 @@ export function scrollTop(target_scrollTop) {
 
 export function stop_auto_scrolling() {
     if (in_stoppable_autoscroll) {
-        $message_pane.stop();
+        $scroll_container.stop();
     }
 }
 
@@ -332,7 +332,7 @@ export function system_initiated_animate_scroll(scroll_amount) {
     message_scroll.suppress_selection_update_on_next_scroll();
     const viewport_offset = scrollTop();
     in_stoppable_autoscroll = true;
-    $message_pane.animate({
+    $scroll_container.animate({
         scrollTop: viewport_offset + scroll_amount,
         always() {
             in_stoppable_autoscroll = false;
@@ -346,7 +346,7 @@ export function user_initiated_animate_scroll(scroll_amount) {
 
     const viewport_offset = scrollTop();
 
-    $message_pane.animate({
+    $scroll_container.animate({
         scrollTop: viewport_offset + scroll_amount,
     });
 }
@@ -480,7 +480,7 @@ export function keep_pointer_in_view() {
 
 export function initialize() {
     $jwindow = $(window);
-    $message_pane = $("html");
+    $scroll_container = $("html");
     // This handler must be placed before all resize handlers in our application
     $jwindow.on("resize", () => {
         dimensions.height.reset();

--- a/web/src/scroll_bar.ts
+++ b/web/src/scroll_bar.ts
@@ -4,9 +4,9 @@ import {user_settings} from "./user_settings";
 
 export function set_layout_width(): void {
     if (user_settings.fluid_layout_width) {
-        $(".header-main, .app .app-main, #compose-container").css("max-width", "inherit");
+        $("body").addClass("fluid_layout_width");
     } else {
-        $(".header-main, .app .app-main, #compose-container").css("max-width", "1400px");
+        $("body").removeClass("fluid_layout_width");
     }
 }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -263,7 +263,7 @@ export function initialize_kitchen_sink_stuff() {
         message_viewport.set_last_movement_direction(delta);
     }, 50);
 
-    message_viewport.$message_pane.on("wheel", (e) => {
+    message_viewport.$scroll_container.on("wheel", (e) => {
         const delta = e.originalEvent.deltaY;
         if (!overlays.is_overlay_or_modal_open() && narrow_state.is_message_feed_visible()) {
             // In the message view, we use a throttled mousewheel handler.

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -27,6 +27,14 @@ body {
     color: var(--color-text-default);
     background-color: var(--color-background);
     transition: background-color 200ms linear;
+
+    &.fluid_layout_width {
+        .header-main,
+        .app .app-main,
+        #compose-container {
+            max-width: 1400px;
+        }
+    }
 }
 
 :root {


### PR DESCRIPTION
Tim and Steve saw their message feed scroll to top when a new message arrived. This could be related to it.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/new.20message.20top.20of.20feed.20scrolling