### PR TITLE
alert_box: Maintain alert-box position despite scrolling.

### DIFF
--- a/web/styles/alerts.css
+++ b/web/styles/alerts.css
@@ -29,7 +29,10 @@ $alert-error-red: hsl(0deg 80% 40%);
 
 /* alert box component changes */
 .alert-box {
-    position: absolute;
+    /* Ensure alert box remains in viewport,
+      regardless of scroll position in message
+      list. */
+    position: fixed;
     top: 0;
     left: 0;
     width: 900px;


### PR DESCRIPTION
This uses fixed positioning to ensure that the alert box and its contents remain in the viewport, regardless of any scrolling activity.

While I revealed additional alerts by adding `show` classes to the DOM in manual testing, I would appreciate additional pokes and verification that there are no unexpected side-effects here (there shouldn't be, as `position: fixed` and `position: absolute` behave almost identically...but there's always that possibility).

Fixes #25791.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![alert-before](https://github.com/zulip/zulip/assets/170719/4710993b-1eda-425c-b27a-c40b7b6f89a6) | ![alert-after](https://github.com/zulip/zulip/assets/170719/860506fc-510a-46fb-8d4c-b0df346494e6) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
