### PR TITLE
css: Remove superflous background color on date row.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -37,7 +37,6 @@ $time_column_max_width: 150px;
 
     .date_row {
         grid-area: date_row;
-        background-color: var(--color-background-stream-message-content);
         /* We only want padding for the date rows between recipient blocks */
         padding-bottom: 0;
 


### PR DESCRIPTION
This fix prevents the active-message outline from being obscured under certain conditions, such as when setting a browser to zoom out at 90% or less.

See [CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/blue.20box.20cut.20off)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

While this PR introduces no visual changes, here is a set of screenshots that mimic its effects by artificially increasing the active-message outline to 5px. Before this PR, the border gets cut off; after, it does not. Again, this is only to demonstrate the effects. Other than the edge case of zooming out, this PR should have NO effect on ordinary display of active messages.

| Before (mimicking a zoomed-out state) | After (mimicking a zoomed-out state) |
| --- | --- |
|  <img width="984" alt="faux-active-before" src="https://github.com/zulip/zulip/assets/170719/649b1bdd-d172-4bf3-b298-8cef98308fe1"> | <img width="984" alt="faux-active-after" src="https://github.com/zulip/zulip/assets/170719/7680276b-8f48-4407-8041-bc1814c66eae"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
