### PR TITLE
help: Tweak docs on keyboard shortcuts for composing messages.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -100,20 +100,20 @@ in the Zulip app to add more to your repertoire as needed.
 
 ## Composing messages
 
-* **Reply to message**: <kbd>R</kbd> or <kbd>Enter</kbd> — Reply to the
-  selected message (outlined in blue). Same behavior as clicking on the
-  message.
-
-* **Reply to message, mentioning author**: <kbd>@</kbd>
-
-* **Reply only to author**: <kbd>Shift</kbd> + <kbd>R</kbd>
-
-* **Quote and reply to message**: <kbd>></kbd>
-
 * **New stream message**: <kbd>C</kbd> — For starting a new topic in a
   stream.
 
 * **New direct message**: <kbd>X</kbd>
+
+* **Reply to message**: <kbd>R</kbd> or <kbd>Enter</kbd> — Reply to the
+  selected message (outlined in blue). Same behavior as clicking on the
+  message.
+
+* **Quote and reply to message**: <kbd>></kbd>
+
+* **Reply directly to sender**: <kbd>Shift</kbd> + <kbd>R</kbd>
+
+* **Reply @-mentioning sender**: <kbd>@</kbd>
 
 ### In the compose box
 

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -119,18 +119,6 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="definition">{{t 'Reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Reply to author' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>R</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'Quote and reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>></kbd></span></td>
-                </tr>
-                <tr>
                     <td class="definition">{{t 'New stream message' }}</td>
                     <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
@@ -139,7 +127,19 @@
                     <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'Compose a reply @-mentioning author' }}</td>
+                    <td class="definition">{{t 'Reply to message' }}</td>
+                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Quote and reply to message' }}</td>
+                    <td><span class="hotkey"><kbd>></kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Reply directly to sender' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>R</kbd></span></td>
+                </tr>
+                <tr>
+                    <td class="definition">{{t 'Reply @-mentioning sender' }}</td>
                     <td><span class="hotkey"><kbd>@</kbd></span></td>
                 </tr>
                 <tr>


### PR DESCRIPTION
- Adjust the order in keyboard shortucts help menu and help center.
- Make minor wording improvements.

This PR removes wording and ordering differences between the two docs that don't seem helpful to me.

<details>
<summary>`?` menu before/after</summary>

| Before | After |
| --- | --- |
| ![image-before](https://github.com/zulip/zulip/assets/2090066/f4b31158-5a0d-43ab-a156-e8aff7722794) | ![image-after](https://github.com/zulip/zulip/assets/2090066/f9f17d3c-3295-42eb-af51-a0008a616522)

</details>

Current help center page: https://zulip.com/help/keyboard-shortcuts#composing-messages

<details>
<summary> Help center changes (screenshot)</summary>

![Screen Shot 2023-05-28 at 6 36 35 PM](https://github.com/zulip/zulip/assets/2090066/53687aea-d950-4f53-afbb-ed8cce4c6120)

</details>