### PR TITLE
help: Document quick way to check Zulip version.

### DIFF
--- a/help/view-zulip-version.md
+++ b/help/view-zulip-version.md
@@ -10,12 +10,24 @@ web app your organization is using.
 Zulip Cloud organizations are always updated to the latest version of Zulip.
 
 [upgrade-zulip]:
-    https://zulip.readthedocs.io/en/stable/production/upgrade-or-modify.html
-[changelog]: https://zulip.readthedocs.io/en/stable/overview/changelog.html
+    https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html
+[changelog]: https://zulip.readthedocs.io/en/latest/overview/changelog.html
 
 ### View Zulip server and web app version
 
 {start_tabs}
+
+{tab|v6}
+
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
+   right corner of the web or desktop app.
+
+1. View the version number or Zulip Cloud plan in the top section of the menu.
+
+1. *(optional)* Click on the version number or Zulip Cloud plan for additional
+   details.
+
+{tab|v4}
 
 {relative|gear|about-zulip}
 

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -98,6 +98,8 @@ TAB_SECTION_LABELS = {
     "via-compose-box-buttons": "Via compose box buttons",
     "stream-compose": "Compose to a stream",
     "dm-compose": "Compose a DM",
+    "v6": "Zulip Server 6.0+",
+    "v4": "Zulip Server 4.0+",
 }
 
 


### PR DESCRIPTION
Version number was added to top section of gear menu in 4df8c6610f19f08be1564d755aacb6c544eadbbc.

Version number was added to "About Zulip" in 668b5137b005c915da5f00950fdc3288f76ec0fd.

Questions:
- Is "Zulip 6.0+" fine for the tab name given the context, or should it be "Zulip Server 6.0+"?

Current page: https://zulip.com/help/view-zulip-version#view-zulip-server-and-web-app-version

Updated:

![Screen Shot 2023-05-29 at 8 07 35 AM](https://github.com/zulip/zulip/assets/2090066/36880f6b-2747-4053-92cb-777b858be3aa)

![Screen Shot 2023-05-29 at 8 07 40 AM](https://github.com/zulip/zulip/assets/2090066/b6575775-ddff-46be-96f2-4961a06202af)
