### PR TITLE
scroll_bar: Fix overlapping right sidebar and browser scrollbars.

### DIFF
--- a/web/src/scroll_bar.ts
+++ b/web/src/scroll_bar.ts
@@ -10,6 +10,27 @@ export function set_layout_width(): void {
     }
 }
 
+export function handle_overlay_scrollbars(): void {
+    // If right sidebar scrollbar overlaps with browser scrollbar, move the right
+    // sidebar scrollbar to the left. Done on fluid screen width and when scrollbars overlap.
+    const scrollbar_width = window.innerWidth - document.documentElement.clientWidth;
+    if (scrollbar_width === 0) {
+        const max_app_width = 1400;
+        const max_scrollbar_width = 20;
+        const are_scrollbars_overlapping = window.innerWidth < max_app_width + max_scrollbar_width;
+        if (user_settings.fluid_layout_width || are_scrollbars_overlapping) {
+            $("body").addClass("has-overlay-scrollbar");
+            return;
+        }
+    }
+
+    $("body").removeClass("has-overlay-scrollbar");
+}
+
 export function initialize(): void {
     set_layout_width();
+    handle_overlay_scrollbars();
+    const middle_column = $(".app .column-middle").expectOne()[0];
+    const resize_observer = new ResizeObserver(handle_overlay_scrollbars);
+    resize_observer.observe(middle_column);
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -105,6 +105,15 @@ body {
     */
     --disabled-scrollbar-width: 0px;
 
+    /*
+    Right offset of simplebar scrollbar for `.column-right` when browser has
+    overlay scrollbars which don't occupy any space. Currently only
+    known to present on Mac (all browsers) and Firefox (all OS?). This seems
+    more than enough to differentiate right sidebar scrollbar and browser
+    scrollbar even if the browser scrollbar is wider.
+    */
+    --browser-overlay-scrollbar-width: 10px;
+
     /* Colors used across the app */
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-background-private-message-content: hsl(45deg 20% 96%);
@@ -551,6 +560,14 @@ p.n-margin {
     margin: 0 auto;
     padding: 0;
     position: relative;
+}
+
+body.has-overlay-scrollbar {
+    /* Move simplebar scrollbar to the left so that
+       browser scrollbar doesn't overlap with it. */
+    .column-right .simplebar-track.simplebar-vertical {
+        right: var(--browser-overlay-scrollbar-width);
+    }
 }
 
 .column-right {
@@ -2852,6 +2869,10 @@ select.invite-as {
             float: none;
             right: 15px;
             top: 0;
+
+            .simplebar-track.simplebar-vertical {
+                right: 0;
+            }
 
             .right-sidebar {
                 box-shadow: 0 -2px 3px 0 hsl(0deg 0% 0% / 10%);


### PR DESCRIPTION

Fixes  #25779

We move the simplebar scroll on the right sidebar to a little left when there is an overlay scrollbar present so that user can drag either of them.

before: 
<img width="229" alt="image" src="https://github.com/zulip/zulip/assets/25124304/eb246d25-efbe-44ab-8470-cec9fdc3b5e6">


after:

<img width="258" alt="image" src="https://github.com/zulip/zulip/assets/25124304/d6f95169-6c10-4682-b93f-86daafcc95c9">


Tested:

Fluid layout and window width above or below 1420px. Mac browsers and firefox on windows. 

I haven't tested anything on linux.