### PR TITLE
resize: Use autosize on window resize.

### DIFF
--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 
 import * as blueslip from "./blueslip";
 import * as compose_state from "./compose_state";
+import * as compose_ui from "./compose_ui";
 import * as condense from "./condense";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
@@ -166,6 +167,7 @@ export function handler() {
         condense.clear_message_content_height_cache();
     }
     resize_page_components();
+    compose_ui.autosize_textarea($("#compose-textarea"));
 
     // Re-compute and display/remove [More] links to messages
     condense.condense_and_collapse($(".message_table .message_row"));


### PR DESCRIPTION
This fixes a bug where reducing the height of the window, reduces the size of textarea and doesn't instroduce scrollbars, making the textarea not scrollable.

before:
![before](https://github.com/zulip/zulip/assets/25124304/9e5720d4-7c37-4965-9bee-d7190f882462)


after:

![after](https://github.com/zulip/zulip/assets/25124304/6b4dadeb-6dba-458a-883c-622e0be60b14)
