### PR TITLE
overlays: Use `close_overlay` to close overlays!

### DIFF
--- a/web/src/overlays.ts
+++ b/web/src/overlays.ts
@@ -385,9 +385,8 @@ export function close_active_modal(): void {
 }
 
 export function close_for_hash_change(): void {
-    $("div.overlay.show").removeClass("show");
-    if (active_overlay) {
-        active_overlay.close_handler();
+    if (open_overlay_name) {
+        close_overlay(open_overlay_name);
     }
 }
 


### PR DESCRIPTION
It is unusal to use a hack to close overlays when there is a method to do it.

This fixes a bug where user is unable to scroll message feed after opening an overlay and then using browser back button.

This could have easily cause other bugs too.

Bug reproducer:
Open an overlay and then press the browser back button. You will not be able to scroll messages.