### PR TITLE
docs: Minor fixes around review-process doc.

### DIFF
--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -1,8 +1,8 @@
 # Reviewing Zulip code
 
 Code review is a key part of how Zulip does development. It's an essential
-aspect of our process to build a high-quality product with a maintainable code
-base. See the [pull request review process](../contributing/review-process.md)
+aspect of our process to build a high-quality product with a maintainable
+codebase. See the [pull request review process](../contributing/review-process.md)
 guide for a detailed overview of Zulip's PR review process.
 
 ## Principles of code review

--- a/docs/contributing/commit-discipline.md
+++ b/docs/contributing/commit-discipline.md
@@ -94,7 +94,7 @@ Commit messages have two parts:
 
 In Zulip, commit summaries have a two-part structure:
 
-1. A one or two word description of the part of the code base changed
+1. A one or two word description of the part of the codebase changed
    by the commit.
 2. A short sentence summarizing your changes.
 
@@ -148,7 +148,7 @@ scan commit messages to find what they need.
 Additional tips:
 
 - Use lowercase (e.g., "settings", not "Settings").
-- If it's hard to find a 1-2 word description of the part of the code base
+- If it's hard to find a 1-2 word description of the part of the codebase
   affected by your commit, consider again whether you have structured your
   commits well.
 - Never use a generic term like "bug", "fix", or "refactor".
@@ -167,7 +167,7 @@ a few rules to keep in mind:
   update tests/docs," would be better written as just, "Change X," since (as
   discussed above) _every_ commit is expected to update tests and documentation
   as needed.
-- Make it readable to someone who is familiar with Zulip's code base, but hasn't
+- Make it readable to someone who is familiar with Zulip's codebase, but hasn't
   been involved with the effort you're working on.
 - Use no more than 72 characters for the entire commit summary (parts 1 and 2).
 

--- a/docs/contributing/review-process.md
+++ b/docs/contributing/review-process.md
@@ -2,7 +2,7 @@
 
 Pull requests submitted to Zulip go through a rigorous review process, which is
 designed to ensure that we are building a high-quality product with a
-maintainable code base. This page describes the stages of review your pull
+maintainable codebase. This page describes the stages of review your pull
 request may go through, and offers guidance on how you can help keep your pull
 request moving along.
 

--- a/docs/contributing/review-process.md
+++ b/docs/contributing/review-process.md
@@ -77,9 +77,9 @@ review:
 In the Zulip server/web app repository
 ([`zulip/zulip`](https://github.com/zulip/zulip/)), we use GitHub labels to help
 everyone understand where a pull request is in the review process. These labels
-are noted below. Each label is removed by the reviewer for that stage when they
-have no more feedback on the PR and consider it ready for the next stage of
-review.
+are noted below, alongside their corresponding pull-request stage. Each label is
+removed by the reviewer for that stage when they have no more feedback on the PR
+and consider it ready for the next stage of review.
 
 Sometimes, a label may also be removed because significant changes by
 the contributor are required before the PR ready to be reviewed again. In that


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This clarifies for readers where PR labels are described in the document.

It also includes a commit that addresses a small nit, correcting the documentation's handful of instances of "code base" with the closed form "codebase," which is far and away the preferred form in the docs:

```
# on `main`
$ cd docs
$ git grep "code base" | wc
       4      59     447
$ git grep "codebase" | wc
      95     955    8532
```

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

[Original documention](https://zulip.readthedocs.io/en/latest/contributing/review-process.html#labels-for-managing-the-stages-of-pull-request-review):
<img width="930" alt="labels-before" src="https://github.com/zulip/zulip/assets/170719/8b19b15b-06d1-4a75-9ef6-b4c98965a127">

Revised form:
<img width="930" alt="labels-after" src="https://github.com/zulip/zulip/assets/170719/6edc6c1d-e298-4c4f-a073-f1cf53b14dbb">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
