### PR TITLE
help: Update suggested review sites on Support the Zulip project page.

### DIFF
--- a/help/support-zulip-project.md
+++ b/help/support-zulip-project.md
@@ -49,16 +49,11 @@ Collective](https://opencollective.com/zulip).
   [Python API](https://github.com/zulip/python-zulip-api).
 
 * **Review** Zulip on product comparison websites, such as
-  [Capterra](https://reviews.capterra.com/new/197945) and
-  [G2](https://www.g2.com/products/zulip/take_survey). Organizations rely on
+  [G2](https://www.g2.com/products/zulip/reviews/start) and [Software
+  Advice](https://reviews.softwareadvice.com/new/316022). Organizations rely on
   review sites more and more when choosing software for their team, and sharing
   your experience with Zulip (good or bad) helps them evaluate whether Zulip
   might work for their needs.
-
-!!! tip ""
-    For a limited time, you can receive a $15 gift card by leaving a Capterra
-    review using [this
-    link](https://reviews.capterra.com/new/197945/b0a11684-ef99-43d0-8cb8-1b4afac9b03b?lang=en).
 
 * **Mention** Zulip on social media, or like and retweet [Zulip's
   tweets](https://twitter.com/zulip).


### PR DESCRIPTION
I tested the new links.

Current page: https://zulip.com/help/support-zulip-project#help-others-find-zulip

Updated:
![Screen Shot 2023-05-29 at 11 53 40 AM](https://github.com/zulip/zulip/assets/2090066/d411018f-8ca8-43eb-af01-d276d5bc08cc)

