### PR TITLE
help: Document "Inbox view" mobile feature.

### DIFF
--- a/help/all-messages.md
+++ b/help/all-messages.md
@@ -12,5 +12,6 @@
 ## Related articles
 * [Reading strategies](/help/reading-strategies)
 * [Recent conversations](/help/recent-conversations)
+* [Inbox](/help/inbox)
 * [Configure default view](/help/configure-default-view)
 * [Reading topics](/help/reading-topics)

--- a/help/inbox.md
+++ b/help/inbox.md
@@ -1,0 +1,37 @@
+# Inbox
+
+The **Inbox** is the default view in the Zulip mobile app. It's a great way to
+get an overview of all the unmuted conversations where you have unread messages,
+excluding [inactive streams](/help/manage-inactive-streams).
+
+The **Inbox** view shows your unread direct message conversations, followed by
+all topics with unread messages, grouped by stream. The list of streams is
+sorted alphabetically, with [pinned streams](/help/pin-a-stream) at the top.
+
+{start_tabs}
+
+{tab|mobile}
+
+1. Tap the **Inbox**
+   (<img src="/static/images/help/mobile-inbox-icon.svg" alt="inbox" class="mobile-icon"/>)
+   tab in the bottom left corner of the app.
+
+{end_tabs}
+
+!!! tip ""
+
+    You can collapse or expand the list of topics in a stream by tapping the
+    **collapse**
+    (<img src="/static/images/help/mobile-expand-less-icon.svg" alt="inbox" class="mobile-icon"/>)
+    or **expand**
+    (<img src="/static/images/help/mobile-expand-more-icon.svg" alt="inbox" class="mobile-icon"/>)
+    icon to the left of a stream name.
+
+## Related articles
+
+* [Reading strategies](/help/reading-strategies)
+* [Recent conversations](/help/recent-conversations)
+* [All messages](/help/all-messages)
+* [Mute or unmute a stream](/help/mute-a-stream)
+* [Mute or unmute a topic](/help/mute-a-topic)
+* [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -88,6 +88,7 @@
 * [Reading strategies](/help/reading-strategies)
 * [Recent conversations](/help/recent-conversations)
 * [All messages](/help/all-messages)
+* [Inbox](/help/inbox)
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)

--- a/help/recent-conversations.md
+++ b/help/recent-conversations.md
@@ -12,4 +12,5 @@
 * [Reading topics](/help/reading-topics)
 * [Reading strategies](/help/reading-strategies)
 * [All messages](/help/all-messages)
+* [Inbox](/help/inbox)
 * [Configure default view](/help/configure-default-view)

--- a/static/images/help/mobile-expand-less-icon.svg
+++ b/static/images/help/mobile-expand-less-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/>
+</svg>

--- a/static/images/help/mobile-expand-more-icon.svg
+++ b/static/images/help/mobile-expand-more-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000000">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
+</svg>

--- a/static/images/help/mobile-inbox-icon.svg
+++ b/static/images/help/mobile-inbox-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-inbox">
+    <polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline>
+    <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"></path>
+</svg>


### PR DESCRIPTION
- Adds a new page under the "Reading messages" section documenting
the Inbox view on mobile.
- Adds Inbox, expand more, and expand less SVG mobile icons.
- Cross-links with "Recent conversations" and "All messages".

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/2d42f7ff-8ee2-4f76-ad88-7ac61357fe08)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>