### PR TITLE
compose: Add "New topic" button to topic field in compose box.

### DIFF
--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -54,7 +54,7 @@ async function create_private_message_draft(page: Page): Promise<void> {
 }
 
 async function open_compose_markdown_preview(page: Page): Promise<void> {
-    const new_topic_button = "#left_bar_compose_stream_button_big";
+    const new_topic_button = "#new_topic_button";
     await page.waitForSelector(new_topic_button, {visible: true});
     await page.click(new_topic_button);
 

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -40,10 +40,7 @@ async function expect_verona_stream_test_topic(page: Page): Promise<void> {
     await common.check_messages_sent(page, "zfilt", [
         ["Verona > test", ["verona test a", "verona test b", "verona test d"]],
     ]);
-    assert.strictEqual(
-        await common.get_text_from_selector(page, "#left_bar_compose_stream_button_big"),
-        "New topic",
-    );
+    assert.strictEqual(await common.get_text_from_selector(page, "#new_topic_button"), "New topic");
 }
 
 async function expect_verona_other_topic(page: Page): Promise<void> {
@@ -274,7 +271,7 @@ async function expect_all_direct_messages(page: Page): Promise<void> {
         ["You and Cordelia, Lear's daughter", ["direct message e"]],
     ]);
     assert.strictEqual(
-        await common.get_text_from_selector(page, "#left_bar_compose_stream_button_big"),
+        await common.get_text_from_selector(page, "#new_topic_button"),
         "New stream message",
     );
     assert.strictEqual(await page.title(), "Direct messages - Zulip Dev - Zulip");

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -783,6 +783,25 @@ export function initialize() {
         compose_recipient.update_placeholder_text();
     });
 
+    $("#compose_recipient_box").on("click", "#recipient_box_new_topic_button", () => {
+        const $input = $("#stream_message_recipient_topic");
+        const $button = $("#recipient_box_new_topic_button");
+
+        $input.val("");
+        $input.trigger("focus");
+        $button.hide();
+    });
+
+    $("#compose_recipient_box").on("input", "#stream_message_recipient_topic", (e) => {
+        const $button = $("#recipient_box_new_topic_button");
+        const value = $(e.target).val();
+        if (value.length === 0) {
+            $button.hide();
+        } else {
+            $button.show();
+        }
+    });
+
     $("#stream_message_recipient_topic").on("focus", () => {
         compose_recipient.update_placeholder_text();
     });

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -792,6 +792,16 @@ export function initialize() {
         $button.hide();
     });
 
+    $("#compose_recipient_box").on("focus", "#stream_message_recipient_topic", () => {
+        const $recipient_box = $("#compose_recipient_box");
+        $recipient_box.addClass("focused");
+    });
+
+    $("#compose_recipient_box").on("blur", "#stream_message_recipient_topic", () => {
+        const $recipient_box = $("#compose_recipient_box");
+        $recipient_box.removeClass("focused");
+    });
+
     $("#compose_recipient_box").on("input", "#stream_message_recipient_topic", (e) => {
         const $button = $("#recipient_box_new_topic_button");
         const value = $(e.target).val();

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -56,7 +56,7 @@ function hide_box() {
     // This is the main hook for saving drafts when closing the compose box.
     drafts.update_draft();
     blur_compose_inputs();
-    $("#stream_message_recipient_topic").hide();
+    $("#compose_recipient_box").hide();
     $("#compose-direct-recipient").hide();
     $(".new_message_textarea").css("min-height", "");
     compose_fade.clear_compose();

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -200,13 +200,14 @@ export function start(msg_type, opts) {
     expand_compose_box();
 
     opts = fill_in_opts_from_current_narrowed_view(msg_type, opts);
+    const is_new_topic_button_triggered = opts.trigger === "new topic button";
 
     // If we are invoked by a compose hotkey (c or x) or new topic
     // button, do not assume that we know what the message's topic or
     // direct message recipient should be.
     if (
         opts.trigger === "compose_hotkey" ||
-        opts.trigger === "new topic button" ||
+        is_new_topic_button_triggered ||
         opts.trigger === "new direct message"
     ) {
         opts.topic = "";
@@ -216,7 +217,7 @@ export function start(msg_type, opts) {
     const subbed_streams = stream_data.subscribed_subs();
     if (
         subbed_streams.length === 1 &&
-        (opts.trigger === "new topic button" ||
+        (is_new_topic_button_triggered ||
             (opts.trigger === "compose_hotkey" && msg_type === "stream"))
     ) {
         opts.stream_id = subbed_streams[0].stream_id;
@@ -261,6 +262,13 @@ export function start(msg_type, opts) {
 
     // Show either stream/topic fields or "You and" field.
     show_compose_box(msg_type, opts);
+
+    const $new_topic_button = $("#recipient_box_new_topic_button");
+    if (is_new_topic_button_triggered) {
+        $new_topic_button.hide();
+    } else {
+        $new_topic_button.show();
+    }
 
     // Show a warning if topic is resolved
     compose_validate.warn_if_topic_resolved(true);

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -138,7 +138,7 @@ export function update_buttons_for_recent_view() {
 }
 
 function set_reply_button_label(label) {
-    $(".compose_reply_button_label").text(label);
+    $("#left_bar_compose_reply_button_big").text(label);
 }
 
 export function set_standard_text_for_reply_button() {

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -62,19 +62,19 @@ export function get_recipient_label(message) {
 function update_reply_button_state(disable = false) {
     $(".compose_reply_button").attr("disabled", disable);
     if (disable) {
-        $("#compose_buttons > .reply_button_container").attr(
+        $("#compose_buttons .compose_reply_button").attr(
             "data-tooltip-template-id",
             "compose_reply_button_disabled_tooltip_template",
         );
         return;
     }
     if (narrow_state.is_message_feed_visible()) {
-        $("#compose_buttons > .reply_button_container").attr(
+        $("#compose_buttons .compose_reply_button").attr(
             "data-tooltip-template-id",
             "compose_reply_message_button_tooltip_template",
         );
     } else {
-        $("#compose_buttons > .reply_button_container").attr(
+        $("#compose_buttons .compose_reply_button").attr(
             "data-tooltip-template-id",
             "compose_reply_selected_topic_button_tooltip_template",
         );
@@ -112,7 +112,7 @@ export function update_buttons_for_private() {
     // disable the [Message X] button when in a private narrow
     // if the user cannot dm the current recipient
     const disable_reply = true;
-    $("#compose_buttons > .reply_button_container").attr(
+    $("#compose_buttons .compose_reply_button").attr(
         "data-tooltip-template-id",
         "disable_reply_compose_reply_button_tooltip_template",
     );

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -82,7 +82,7 @@ function update_reply_button_state(disable = false) {
 }
 
 function update_stream_button(btn_text) {
-    $("#left_bar_compose_stream_button_big").text(btn_text);
+    $("#new_topic_button").text(btn_text);
 }
 
 function update_conversation_button(btn_text) {
@@ -102,7 +102,7 @@ export function update_buttons_for_private() {
         !narrow_state.pm_ids_string() ||
         people.user_can_direct_message(narrow_state.pm_ids_string())
     ) {
-        $("#left_bar_compose_stream_button_big").attr(
+        $("#new_topic_button").attr(
             "data-tooltip-template-id",
             "new_stream_message_button_tooltip_template",
         );
@@ -121,7 +121,7 @@ export function update_buttons_for_private() {
 
 export function update_buttons_for_stream() {
     const text_stream = $t({defaultMessage: "New topic"});
-    $("#left_bar_compose_stream_button_big").attr(
+    $("#new_topic_button").attr(
         "data-tooltip-template-id",
         "new_topic_message_button_tooltip_template",
     );
@@ -130,7 +130,7 @@ export function update_buttons_for_stream() {
 
 export function update_buttons_for_recent_view() {
     const text_stream = $t({defaultMessage: "New stream message"});
-    $("#left_bar_compose_stream_button_big").attr(
+    $("#new_topic_button").attr(
         "data-tooltip-template-id",
         "new_stream_message_button_tooltip_template",
     );
@@ -168,7 +168,7 @@ export function initialize() {
     });
 
     // Click handlers for buttons in the compose box.
-    $("body").on("click", ".compose_stream_button", () => {
+    $("body").on("click", ".compose_new_topic_button", () => {
         compose_actions.start("stream", {trigger: "new topic button"});
     });
 

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -177,14 +177,14 @@ function update_recipient_label(stream_id) {
 export function update_compose_for_message_type(message_type, opts) {
     if (message_type === "stream") {
         $("#compose-direct-recipient").hide();
-        $("#stream_message_recipient_topic").show();
+        $("#compose_recipient_box").show();
         $("#stream_toggle").addClass("active");
         $("#private_message_toggle").removeClass("active");
         $("#compose-recipient").removeClass("compose-recipient-direct-selected");
         update_recipient_label(opts.stream_id);
     } else {
         $("#compose-direct-recipient").show();
-        $("#stream_message_recipient_topic").hide();
+        $("#compose_recipient_box").hide();
         $("#stream_toggle").removeClass("active");
         $("#private_message_toggle").addClass("active");
         $("#compose-recipient").addClass("compose-recipient-direct-selected");

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -17,7 +17,7 @@ export function initialize() {
         target: [
             // Ideally this would be `#compose_buttons .button`, but the
             // reply button's actual area is its containing span.
-            "#compose_buttons > .reply_button_container",
+            "#compose_buttons .compose_reply_button",
             "#left_bar_compose_mobile_button_big",
             "#new_topic_button",
             "#left_bar_compose_private_button_big",

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -19,7 +19,7 @@ export function initialize() {
             // reply button's actual area is its containing span.
             "#compose_buttons > .reply_button_container",
             "#left_bar_compose_mobile_button_big",
-            "#left_bar_compose_stream_button_big",
+            "#new_topic_button",
             "#left_bar_compose_private_button_big",
         ],
         delay: EXTRA_LONG_HOVER_DELAY,

--- a/web/src/hotspots.js
+++ b/web/src/hotspots.js
@@ -50,7 +50,7 @@ const HOTSPOT_LOCATIONS = new Map([
     [
         "intro_compose",
         {
-            element: "#left_bar_compose_stream_button_big",
+            element: "#new_topic_button",
             offset_x: 0,
             offset_y: 0,
         },

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -22,11 +22,31 @@
     }
 
     .reply_button_container {
-        flex: 1;
-        min-width: 0;
+        display: flex;
+        flex-grow: 1;
+
+        /* Button-like styling */
+        border-radius: 4px;
+        background-color: hsl(0deg 0% 100%);
+        border: 1px solid hsl(0deg 0% 80%);
+        transition: all 0.2s ease;
+
+        &:hover,
+        &:focus {
+            /* Applying the `border-color` to make `reply_button_container` behave like a `.button`. */
+            border-color: hsl(0deg 0% 60%);
+        }
+
+        .compose_reply_button,
+        .compose_new_topic_button {
+            /* Removing the `border` inherited from the `.button` styles. */
+            border: none;
+            background: none;
+            border-radius: 3px;
+        }
 
         .compose_reply_button {
-            width: 100%;
+            flex-grow: 1;
             text-align: left;
             overflow: hidden;
             white-space: nowrap;
@@ -39,6 +59,7 @@
             /* Removing the `min-width` inherited from the `.button` styles. */
             min-width: inherit;
             margin: 1px;
+            flex-shrink: 0;
 
             transition: background-color 0.2s ease;
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -2,11 +2,10 @@
     text-align: right;
     display: flex;
     flex-direction: row;
+    column-gap: 4px;
     align-items: center;
 
     .new_message_button {
-        margin-left: 4px;
-
         .button.small {
             font-size: 1em;
             padding: 3px 10px;
@@ -25,7 +24,6 @@
     .reply_button_container {
         flex: 1;
         min-width: 0;
-        margin-left: 0;
 
         .compose_reply_button {
             width: 100%;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -82,6 +82,8 @@
 
     .stream_button_container,
     .private_button_container {
+        flex-shrink: 0;
+
         @media (width < $sm_min) {
             display: none;
         }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -25,6 +25,9 @@
         display: flex;
         flex-grow: 1;
 
+        /* Adjust flexbox default `min-width` to allow smaller container sizes. */
+        min-width: 0;
+
         /* Button-like styling */
         border-radius: 4px;
         background-color: hsl(0deg 0% 100%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -32,6 +32,22 @@
             white-space: nowrap;
             text-overflow: ellipsis;
         }
+
+        .compose_new_topic_button {
+            /* Remove the  `padding` to prevent margin from affecting parent height. */
+            padding: 0 10px;
+            /* Removing the `min-width` inherited from the `.button` styles. */
+            min-width: inherit;
+            margin: 1px;
+
+            transition: background-color 0.2s ease;
+
+            &:hover {
+                background-color: var(
+                    --color-background-hover-new-topic-button
+                );
+            }
+        }
     }
 
     .mobile_button_container {
@@ -636,7 +652,7 @@ textarea.new_message_textarea,
         margin: 1px;
 
         &:hover {
-            background-color: hsl(231deg 100% 90% / 20%);
+            background-color: var(--color-background-hover-new-topic-button);
         }
     }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -614,10 +614,6 @@ input.recipient_box {
 
 #stream_message_recipient_topic.recipient_box {
     width: 100%;
-    /* This width roughly corresponds to how long of a topic can appear in
-       the left sidebar with a single digit unread count without being
-       cut off. */
-    max-width: 175px;
 }
 
 #private_message_recipient.recipient_box {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -66,10 +66,13 @@
 
             transition: background-color 0.2s ease;
 
+            color: hsl(231deg 20% 55%);
+
             &:hover {
                 background-color: var(
                     --color-background-hover-new-topic-button
                 );
+                color: hsl(231deg 20% 40%);
             }
         }
     }
@@ -652,7 +655,6 @@ textarea.new_message_textarea,
     #recipient_box_new_topic_button {
         background: none;
         border: none;
-        color: inherit;
     }
 
     /* Styles for input in the recipient_box */
@@ -677,8 +679,11 @@ textarea.new_message_textarea,
         padding: 3px 10px;
         margin: 1px;
 
+        color: hsl(231deg 20% 55%);
+
         &:hover {
             background-color: var(--color-background-hover-new-topic-button);
+            color: hsl(231deg 20% 40%);
         }
 
         /* This is temporary until we figure out how to display

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -582,7 +582,7 @@ textarea.new_message_textarea {
 }
 
 textarea.new_message_textarea,
-.compose_table .recipient_box {
+#compose_recipient_box {
     border: 1px solid hsl(0deg 0% 0% / 20%);
     box-shadow: none;
     transition: border 0.2s ease;
@@ -595,11 +595,51 @@ textarea.new_message_textarea,
     }
 }
 
-input.recipient_box {
-    margin: 0;
-    padding: 0 6px;
-    height: auto;
+#compose_recipient_box {
+    /* Recipient box is the div container that has input and button */
     border-radius: 3px;
+    display: flex;
+    flex-grow: 1;
+    background: hsl(0deg 0% 100%);
+
+    #stream_message_recipient_topic,
+    #recipient_box_new_topic_button {
+        background: none;
+        border: none;
+        color: inherit;
+    }
+
+    /* Styles for input in the recipient_box */
+    #stream_message_recipient_topic {
+        flex-grow: 1;
+
+        /* Adjust flexbox default `min-width` to allow smaller input sizes.  */
+        min-width: 0;
+        text-overflow: ellipsis;
+
+        box-shadow: none;
+        outline: none;
+
+        padding: 4px 6px;
+    }
+
+    /* Styles for new topic button in the recipient_box */
+    #recipient_box_new_topic_button {
+        flex-shrink: 0;
+        /* The button looks better if it have smaller radius than the parent */
+        border-radius: 2px;
+        padding: 3px 10px;
+        margin: 1px;
+
+        &:hover {
+            background-color: hsl(231deg 100% 90% / 20%);
+        }
+    }
+
+    /* This will reset the bootstrap margin-bottom: 10px value for the inputs */
+    & input {
+        margin-bottom: 0;
+    }
 }
 
 #compose_select_recipient_widget {
@@ -610,10 +650,6 @@ input.recipient_box {
     &.dropdown-widget-button {
         padding: 0 6px;
     }
-}
-
-#stream_message_recipient_topic.recipient_box {
-    width: 100%;
 }
 
 #private_message_recipient.recipient_box {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -678,6 +678,13 @@ textarea.new_message_textarea,
         &:hover {
             background-color: var(--color-background-hover-new-topic-button);
         }
+
+        /* This is temporary until we figure out how to display
+         * the "New Topic" button on mobile-sized devices. */
+        @media (width < $ml_min) {
+            /* Override inline styles from JQuery after $.show() execution. */
+            display: none !important;
+        }
     }
 
     /* This will reset the bootstrap margin-bottom: 10px value for the inputs */

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -602,6 +602,12 @@ textarea.new_message_textarea,
     flex-grow: 1;
     background: hsl(0deg 0% 100%);
 
+    &.focused {
+        outline: 0;
+        border: 1px solid hsl(0deg 0% 67%);
+        box-shadow: none;
+    }
+
     #stream_message_recipient_topic,
     #recipient_box_new_topic_button {
         background: none;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -485,6 +485,15 @@
         color: inherit;
     }
 
+    #compose_recipient_box #recipient_box_new_topic_button,
+    #compose_buttons #new_topic_button {
+        color: hsl(231deg 30% 65%);
+
+        &:hover {
+            color: hsl(231deg 30% 70%);
+        }
+    }
+
     .dropdown-list-search .dropdown-list-search-input:focus {
         background-color: hsl(225deg 6% 7%);
         border: 1px solid hsl(0deg 0% 100% / 50%);

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -476,7 +476,9 @@
     .pill-container,
     .user-status-content-wrapper,
     #custom-expiration-time-input,
-    #org-join-settings .dropdown-widget-button {
+    #org-join-settings .dropdown-widget-button,
+    #searchbox #search_query,
+    #compose_recipient_box {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
         color: inherit;
@@ -590,7 +592,7 @@
     input[type="number"]:focus,
     textarea:focus,
     textarea.new_message_textarea:focus,
-    .compose_table .recipient_box:focus {
+    #compose_recipient_box:focus {
         border-color: hsl(0deg 0% 0% / 90%);
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -478,7 +478,8 @@
     #custom-expiration-time-input,
     #org-join-settings .dropdown-widget-button,
     #searchbox #search_query,
-    #compose_recipient_box {
+    #compose_recipient_box,
+    #compose_controls .reply_button_container {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
         color: inherit;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -170,6 +170,7 @@ body {
     --color-background-navbar: hsl(0deg 0% 97%);
     --color-background-active-narrow-filter: hsl(202deg 56% 91%);
     --color-background-hover-narrow-filter: hsl(120deg 12.3% 71.4% / 38%);
+    --color-background-hover-new-topic-button: hsl(231deg 100% 90% / 20%);
     --color-navbar-bottom-border: hsl(0deg 0% 80%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -264,6 +264,7 @@ body {
     --color-background-navbar: hsl(0deg 0% 13%);
     --color-background-active-narrow-filter: hsl(200deg 17% 18%);
     --color-background-hover-narrow-filter: hsl(136deg 25% 73% / 20%);
+    --color-background-hover-new-topic-button: hsl(235deg 100% 70% / 11%);
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-background-modal: hsl(212deg 28% 18%);

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -12,24 +12,23 @@
     </div>
     <div id="compose_controls" class="new-style">
         <div id="compose_buttons">
-            <span class="new_message_button reply_button_container" data-tooltip-template-id="compose_reply_message_button_tooltip_template">
-                <button type="button" class="button small rounded compose_reply_button"
-                  id="left_bar_compose_reply_button_big">
+            <div class="new_message_button reply_button_container">
+                <button type="button" class="button small compose_reply_button"
+                  id="left_bar_compose_reply_button_big"
+                  data-tooltip-template-id="compose_reply_message_button_tooltip_template">
                     {{t 'Compose message' }}
                 </button>
-            </span>
+                <button type="button" class="button compose_new_topic_button"
+                  id="new_topic_button"
+                  data-tooltip-template-id="new_topic_message_button_tooltip_template">
+                    {{t 'New topic' }}
+                </button>
+            </div>
             <span class="new_message_button mobile_button_container">
                 <button type="button" class="button small rounded compose_mobile_button"
                   id="left_bar_compose_mobile_button_big"
                   data-tooltip-template-id="left_bar_compose_mobile_button_tooltip_template">
                     +
-                </button>
-            </span>
-            <span class="new_message_button stream_button_container">
-                <button type="button" class="button small rounded compose_new_topic_button"
-                  id="new_topic_button"
-                  data-tooltip-template-id="new_topic_message_button_tooltip_template">
-                    {{t 'New topic' }}
                 </button>
             </span>
             {{#unless embedded }}

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -15,21 +15,21 @@
             <span class="new_message_button reply_button_container" data-tooltip-template-id="compose_reply_message_button_tooltip_template">
                 <button type="button" class="button small rounded compose_reply_button"
                   id="left_bar_compose_reply_button_big">
-                    <span class="compose_reply_button_label">{{t 'Compose message' }}</span>
+                    {{t 'Compose message' }}
                 </button>
             </span>
             <span class="new_message_button mobile_button_container">
                 <button type="button" class="button small rounded compose_mobile_button"
                   id="left_bar_compose_mobile_button_big"
                   data-tooltip-template-id="left_bar_compose_mobile_button_tooltip_template">
-                    <span>+</span>
+                    +
                 </button>
             </span>
             <span class="new_message_button stream_button_container">
                 <button type="button" class="button small rounded compose_stream_button"
                   id="left_bar_compose_stream_button_big"
                   data-tooltip-template-id="new_topic_message_button_tooltip_template">
-                    <span class="compose_stream_button_label">{{t 'New topic' }}</span>
+                    {{t 'New topic' }}
                 </button>
             </span>
             {{#unless embedded }}
@@ -37,7 +37,7 @@
                 <button type="button" class="button small rounded compose_private_button"
                   id="left_bar_compose_private_button_big"
                   data-tooltip-template-id="new_direct_message_button_tooltip_template">
-                    <span class="compose_private_button_label">{{t 'New direct message' }}</span>
+                    {{t 'New direct message' }}
                 </button>
             </span>
             {{/unless}}

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -26,8 +26,8 @@
                 </button>
             </span>
             <span class="new_message_button stream_button_container">
-                <button type="button" class="button small rounded compose_stream_button"
-                  id="left_bar_compose_stream_button_big"
+                <button type="button" class="button small rounded compose_new_topic_button"
+                  id="new_topic_button"
                   data-tooltip-template-id="new_topic_message_button_tooltip_template">
                     {{t 'New topic' }}
                 </button>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -63,7 +63,10 @@
                             <div class="topic-marker-container">
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                             </div>
-                            <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                            <div id="compose_recipient_box">
+                                <input type="text" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
+                                <button type="button" id="recipient_box_new_topic_button" tabindex="-1" class="button">{{t 'New topic'}}</button>
+                            </div>
                             <div id="compose-direct-recipient" class="pill-container" data-before="{{t 'You and' }}">
                                 <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user...' }}"></div>
                             </div>

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -783,20 +783,14 @@ test_ui("narrow_button_titles", ({override}) => {
     override(narrow_state, "pm_ids_string", () => "31");
     override(narrow_state, "is_message_feed_visible", () => true);
     compose_closed_ui.update_buttons_for_private();
-    assert.equal(
-        $("#left_bar_compose_stream_button_big").text(),
-        $t({defaultMessage: "New stream message"}),
-    );
+    assert.equal($("#new_topic_button").text(), $t({defaultMessage: "New stream message"}));
     assert.equal(
         $("#left_bar_compose_private_button_big").text(),
         $t({defaultMessage: "New direct message"}),
     );
 
     compose_closed_ui.update_buttons_for_stream();
-    assert.equal(
-        $("#left_bar_compose_stream_button_big").text(),
-        $t({defaultMessage: "New topic"}),
-    );
+    assert.equal($("#new_topic_button").text(), $t({defaultMessage: "New topic"}));
     assert.equal(
         $("#left_bar_compose_private_button_big").text(),
         $t({defaultMessage: "New direct message"}),

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -136,7 +136,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     let opts = {};
     start("stream", opts);
 
-    assert_visible("#stream_message_recipient_topic");
+    assert_visible("#compose_recipient_box");
     assert_hidden("#compose-direct-recipient");
 
     assert.equal(compose_state.stream_name(), "");

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -32,7 +32,7 @@ const {MessageList} = zrequire("message_list");
 
 // Helper test function
 function test_reply_label(expected_label) {
-    const label = $(".compose_reply_button_label").text();
+    const label = $("#left_bar_compose_reply_button_big").text();
     const prepend_text_length = "translated: Message ".length;
     assert.equal(
         label.slice(prepend_text_length),
@@ -134,6 +134,6 @@ run_test("test_custom_message_input", () => {
 run_test("empty_narrow", () => {
     message_lists.current.visibly_empty = () => true;
     compose_closed_ui.update_reply_recipient_label();
-    const label = $(".compose_reply_button_label").text();
+    const label = $("#left_bar_compose_reply_button_big").text();
     assert.equal(label, "translated: Compose message");
 });


### PR DESCRIPTION
This pull request introduces two changes:
1. It expands the width of the topic input to occupy the entire available space.
2. It adds a "New topic" button inside the input (visually). To achieve this, the following modifications were made:
    - Instead of a single input element, a div container was created to hold both the input and the button.
    - The tests and selectors were adjusted to correctly show and hide the new button when switching between DM and stream messages.
    - Some additional logic was implemented to handle the functionality of the "new topic" button.
    - The styles around the custom button container were modified.
    - JavaScript code was added to apply the "focused" class to the button container, ensuring that it displays the associated styles when the input inside the container receives focus.

Fixes: #24889.

[Feedback topic in CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/new.20topic.20button)
[Issues topic in CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/new.20topic.20button)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screen captures:</summary>

![2023-06-14 at 20 15 06 - Emerald Raccoon](https://github.com/zulip/zulip/assets/53193850/b12f3a78-0279-46b2-a51f-692478ca5d62)

</details>

<details>
<summary>Screenshots</summary>

| Light | Dark |
| ------ | ------- |
| No focus |
| ![image](https://github.com/zulip/zulip/assets/53193850/a448c527-da30-4c20-86f4-151fd12db67f) | ![image](https://github.com/zulip/zulip/assets/53193850/7115ba39-ae37-468e-9c56-0c011cf8f6ba) |
| Focused |
| ![image](https://github.com/zulip/zulip/assets/53193850/41924360-8bf5-4aed-8219-b7a551f91b17) | ![image](https://github.com/zulip/zulip/assets/53193850/d0de82e9-4d96-4b2f-bf35-f982b7083fd2)  |
| No focus |
| ![image](https://github.com/zulip/zulip/assets/53193850/82f1d17f-9e2b-4d0b-bba9-74c766223db6) | ![image](https://github.com/zulip/zulip/assets/53193850/6f9a6641-236e-406c-92f5-7f002b559b2e) |
| Focused |
| ![image](https://github.com/zulip/zulip/assets/53193850/9d399a3b-32e4-4ced-85a2-53753f6e7564) | ![image](https://github.com/zulip/zulip/assets/53193850/da8e5855-9820-4431-a4d3-c653e5eae259) |
 
</details>

