### PR TITLE
css: Size stream recipient box for small screens.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -540,10 +540,11 @@ input.recipient_box {
 }
 
 #stream_message_recipient_topic.recipient_box {
+    width: 100%;
     /* This width roughly corresponds to how long of a topic can appear in
        the left sidebar with a single digit unread count without being
        cut off. */
-    width: 175px;
+    max-width: 175px;
 }
 
 #private_message_recipient.recipient_box {


### PR DESCRIPTION
This allows the recipient box to take 100% of the available horizontal space, up to 175px. The effect is that the compose-box buttons are available to users at mobile scales (viewports of 400px wide or less).

See [CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/Small.20device.20compose.20icons); this also relates to #24889 and the work @shameondev has in progress (who should just remove the `max-width: 175px` declaration).

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before, 325px viewport | After, 325px viewport |
| --- | --- |
| ![small-topics-bar-before](https://github.com/zulip/zulip/assets/170719/077f4233-7b7a-44e3-a605-aa017e484fcf) | ![small-topics-bar-after](https://github.com/zulip/zulip/assets/170719/b0ec1eb4-20b3-4a4c-89f9-96b444794c40) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
