### PR TITLE
users: Use a less generic response for unauthorized user creation.

### DIFF
--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -196,7 +196,7 @@ class TestFullStack(ZulipTestCase):
 
         # We often use assert_json_error for negative tests.
         result = self.client_post("/json/users", valid_params)
-        self.assert_json_error(result, "User not authorized for this query", 400)
+        self.assert_json_error(result, "User not authorized to create users", 400)
 
         do_change_can_create_users(iago, True)
         incomplete_params = dict(

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -878,7 +878,7 @@ class AdminCreateUserTest(ZulipTestCase):
 
         self.assertEqual(admin.can_create_users, False)
         result = self.client_post("/json/users", valid_params)
-        self.assert_json_error(result, "User not authorized for this query")
+        self.assert_json_error(result, "User not authorized to create users")
 
         do_change_can_create_users(admin, True)
         # can_create_users is insufficient without being a realm administrator:

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -683,7 +683,7 @@ def create_user_backend(
     full_name_raw: str = REQ("full_name"),
 ) -> HttpResponse:
     if not user_profile.can_create_users:
-        raise JsonableError(_("User not authorized for this query"))
+        raise JsonableError(_("User not authorized to create users"))
 
     full_name = check_full_name(full_name_raw)
     form = CreateUserForm({"full_name": full_name, "email": email})


### PR DESCRIPTION
This reduces confusion when an admin user tries to create users.

This responds to an issue mentioned on CZO with a suggested improvement [here](https://chat.zulip.org/#narrow/stream/127-integrations/topic/REST.20API.3A.20create.20user.20fails/near/1485972).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
