### PR TITLE
narrow: Mark as read when narrowing `by_topic` or `by_recipient`.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -37,6 +37,7 @@ import * as resize from "./resize";
 import * as search from "./search";
 import * as search_pill from "./search_pill";
 import * as search_pill_widget from "./search_pill_widget";
+import {web_mark_read_on_scroll_policy_values} from "./settings_config";
 import * as spectators from "./spectators";
 import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
@@ -46,6 +47,7 @@ import * as typing_events from "./typing_events";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
+import {user_settings} from "./user_settings";
 import * as util from "./util";
 import * as widgetize from "./widgetize";
 
@@ -902,6 +904,17 @@ export function by_topic(target_id, opts) {
         return;
     }
 
+    if (
+        user_settings.web_mark_read_on_scroll_policy !==
+        web_mark_read_on_scroll_policy_values.never.code
+    ) {
+        // We don't check message_list.can_mark_messages_read
+        // here because the target message_list isn't initialized;
+        // but the targeted message is about to be marked read
+        // in the new view.
+        unread_ops.notify_server_message_read(original);
+    }
+
     const search_terms = [
         {operator: "stream", operand: original.stream},
         {operator: "topic", operand: original.topic},
@@ -910,11 +923,21 @@ export function by_topic(target_id, opts) {
     activate(search_terms, opts);
 }
 
-// Called for the 'narrow by stream' hotkey.
 export function by_recipient(target_id, opts) {
     opts = {then_select_id: target_id, ...opts};
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
     const message = message_store.get(target_id);
+
+    if (
+        user_settings.web_mark_read_on_scroll_policy !==
+        web_mark_read_on_scroll_policy_values.never.code
+    ) {
+        // We don't check message_list.can_mark_messages_read
+        // here because the target message_list isn't initialized;
+        // but the targeted message is about to be marked read
+        // in the new view.
+        unread_ops.notify_server_message_read(message);
+    }
 
     switch (message.type) {
         case "private":


### PR DESCRIPTION
In commit a93598c22eb2, we removed, in `narrow.by_topic` and `narrow_by_recipient`, calls to `unread_ops.notify_server_message_read` because that would have marked messages as read for users who had set their preference in the web-app to never mark messages as read.

We add those calls back now, but with a check for that user setting.

**Notes**:
- When you navigate back to the stream view via the `S` key, if there are unread messages in that stream, then you will be navigated to that first unread message. Which is likely not the message you were looking at. This is the behavior before and after these changes.
- The selected message should always be read, but there is some current inconsistent marking as read behavior that may show up when manually testing these changes (see [this CZO conversation](https://chat.zulip.org/#narrow/stream/6-frontend/topic/inconsistent.20mark.20as.20read/near/1580820)).

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
