### PR TITLE
help: Define "conversation" in /help/include/recent-conversations.md.

### DIFF
--- a/help/include/recent-conversations.md
+++ b/help/include/recent-conversations.md
@@ -1,6 +1,8 @@
-Use the **Recent conversations** view to get an overview of all the ongoing
-conversations. This view is particularly useful for catching up on
-messages sent while you were away.
+In Zulip, a **conversation** is a [direct message](/help/direct-messages) thread
+(one-on-one or with a group), or a [topic in a
+stream](/help/streams-and-topics). Use the **Recent conversations** view to get
+an overview of all the ongoing conversations. This view is particularly useful
+for catching up on messages sent while you were away.
 
 {start_tabs}
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -23,7 +23,7 @@ are at your computer. You will still be able to
 
 1. Under **Advanced**, click on the **Automatically mark messages as
    read** dropdown, and select **Always**, **Never** or **Only in
-   conversation views**.
+   [conversation](/help/recent-conversations) views**.
 
 {tab|mobile}
 
@@ -33,7 +33,8 @@ are at your computer. You will still be able to
 
 1. Tap **Mark messages as read on scroll**.
 
-1. Select **Always**, **Never** or **Only in conversation views**.
+1. Select **Always**, **Never** or **Only in
+   [conversation](/help/recent-conversations) views**.
 
 {end_tabs}
 


### PR DESCRIPTION
Also link to definition from /help/marking-mesages-as-read.

If we like this approach, we can link to /help/recent-conversations from some other pages as well.

Current:
https://zulip.com/help/recent-conversations
https://zulip.com/help/finding-a-topic-to-read#from-recent-conversations
https://zulip.com/help/reading-strategies#finding-a-topic-to-read
https://zulip.com/help/getting-started-with-zulip#finding-a-topic-to-read

![Screen Shot 2023-05-30 at 12 21 32 PM](https://github.com/zulip/zulip/assets/2090066/adaac0ee-f103-438c-895f-7b628b4f7c00)

Current: https://zulip.com/help/marking-messages-as-read#configure-whether-messages-are-automatically-marked-as-read

![Screen Shot 2023-05-30 at 12 23 35 PM](https://github.com/zulip/zulip/assets/2090066/4f883cf4-abc7-4630-9ca6-3a21bee8611e)
