### PR TITLE
stream_ui_updates: Only update UI if the stream is being edited.

### DIFF
--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -70,6 +70,10 @@ export function enable_or_disable_subscribers_tab(sub) {
 }
 
 export function update_settings_button_for_sub(sub) {
+    if (!hash_util.is_editing_stream(sub.stream_id)) {
+        return;
+    }
+
     // This is for the Subscribe/Unsubscribe button in the right panel.
     const $settings_button = stream_settings_ui.settings_button_for_sub(sub);
     if (sub.subscribed) {


### PR DESCRIPTION
If the stream settings is open but the stream which was subscribed/unsubscribed wasn't open (say user unsubscribed from a different tab), `$settings_button` would
be `undefined` here.

Reproducer for bug:
* Open stream settings.
* Open a new tab.
* Unsubscribed to a stream
* See error message in the previous tab.