### PR TITLE
upload_banner: Add a cancel button.

### DIFF
--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -46,7 +46,7 @@ export function get_item(key, config, file_id) {
                         file_id,
                     )} .upload_banner_cancel_button`,
                 );
-            case "upload_banner_close_button":
+            case "upload_banner_hide_button":
                 return $(
                     `#compose_banners .upload_banner.file_${CSS.escape(
                         file_id,
@@ -94,7 +94,7 @@ export function get_item(key, config, file_id) {
                         file_id,
                     )} .upload_banner_cancel_button`,
                 );
-            case "upload_banner_close_button":
+            case "upload_banner_hide_button":
                 return $(
                     `#edit_form_${CSS.escape(config.row)} .upload_banner.file_${CSS.escape(
                         file_id,
@@ -232,7 +232,7 @@ export async function upload_files(uppy, config, files) {
             uppy.removeFile(file.id);
             hide_upload_banner(uppy, config, file.id);
         });
-        get_item("upload_banner_close_button", config, file.id).one("click", () => {
+        get_item("upload_banner_hide_button", config, file.id).one("click", () => {
             hide_upload_banner(uppy, config, file.id);
         });
     }

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -40,6 +40,12 @@ export function get_item(key, config, file_id) {
                 return `#compose_banners .upload_banner.file_${CSS.escape(file_id)}`;
             case "upload_banner":
                 return $(`#compose_banners .upload_banner.file_${CSS.escape(file_id)}`);
+            case "upload_banner_cancel_button":
+                return $(
+                    `#compose_banners .upload_banner.file_${CSS.escape(
+                        file_id,
+                    )} .upload_banner_cancel_button`,
+                );
             case "upload_banner_close_button":
                 return $(
                     `#compose_banners .upload_banner.file_${CSS.escape(
@@ -82,6 +88,12 @@ export function get_item(key, config, file_id) {
                         file_id,
                     )}`,
                 );
+            case "upload_banner_cancel_button":
+                return $(
+                    `#edit_form_${CSS.escape(config.row)} .upload_banner.file_${CSS.escape(
+                        file_id,
+                    )} .upload_banner_cancel_button`,
+                );
             case "upload_banner_close_button":
                 return $(
                     `#edit_form_${CSS.escape(config.row)} .upload_banner.file_${CSS.escape(
@@ -117,9 +129,16 @@ export function hide_upload_banner(uppy, config, file_id) {
     }
 }
 
-function add_upload_banner(config, banner_type, banner_text, file_id) {
+function add_upload_banner(
+    config,
+    banner_type,
+    banner_text,
+    file_id,
+    is_upload_process_tracker = false,
+) {
     const new_banner = render_upload_banner({
         banner_type,
+        is_upload_process_tracker,
         banner_text,
         file_id,
     });
@@ -199,8 +218,9 @@ export async function upload_files(uppy, config, files) {
             "info",
             $t({defaultMessage: "Uploading {filename}…"}, {filename: file.name}),
             file.id,
+            true,
         );
-        get_item("upload_banner_close_button", config, file.id).one("click", () => {
+        get_item("upload_banner_cancel_button", config, file.id).one("click", () => {
             compose_ui.replace_syntax(
                 get_translated_status(file),
                 "",
@@ -210,6 +230,9 @@ export async function upload_files(uppy, config, files) {
             get_item("textarea", config).trigger("focus");
 
             uppy.removeFile(file.id);
+            hide_upload_banner(uppy, config, file.id);
+        });
+        get_item("upload_banner_close_button", config, file.id).one("click", () => {
             hide_upload_banner(uppy, config, file.id);
         });
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -292,7 +292,8 @@
         flex-grow: 1;
     }
 
-    .main-view-banner-action-button {
+    .main-view-banner-action-button,
+    .upload_banner_cancel_button {
         border: none;
         border-radius: 4px;
         padding: 5px 10px;
@@ -431,7 +432,8 @@
             }
         }
 
-        .main-view-banner-action-button {
+        .main-view-banner-action-button,
+        .upload_banner_cancel_button {
             background-color: hsl(204deg 49% 29% / 10%);
             color: inherit;
 
@@ -464,8 +466,13 @@
         bottom: 0;
     }
 
+    .upload_msg {
+        flex-grow: 1;
+    }
+
     .upload_msg,
-    .main-view-banner-close-button {
+    .main-view-banner-close-button,
+    .upload_banner_cancel_button {
         z-index: 1;
         position: relative;
     }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -332,7 +332,8 @@
                 }
             }
 
-            .main-view-banner-action-button {
+            .main-view-banner-action-button,
+            .upload_banner_cancel_button {
                 background-color: hsl(205deg 58% 69% / 10%);
                 border-color: transparent;
                 color: hsl(205deg 58% 69%);

--- a/web/templates/compose_banner/upload_banner.hbs
+++ b/web/templates/compose_banner/upload_banner.hbs
@@ -1,5 +1,8 @@
 <div class="upload_banner file_{{file_id}} main-view-banner {{banner_type}}">
     <div class="moving_bar"></div>
     <p class="upload_msg">{{banner_text}}</p>
+    {{#if is_upload_process_tracker}}
+        <button class="upload_banner_cancel_button">{{t 'Cancel' }}</button>
+    {{/if}}
     <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
 </div>

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -50,6 +50,10 @@ test("get_item", () => {
         $("#compose_banners .upload_banner.file_id_1 .upload_msg"),
     );
     assert.equal(
+        upload.get_item("upload_banner_cancel_button", {mode: "compose"}, "id_2"),
+        $("#compose_banners .upload_banner.file_id_2 .upload_banner_cancel_button"),
+    );
+    assert.equal(
         upload.get_item("upload_banner_close_button", {mode: "compose"}, "id_2"),
         $("#compose_banners .upload_banner.file_id_2 .main-view-banner-close-button"),
     );
@@ -82,6 +86,15 @@ test("get_item", () => {
     assert.equal(
         upload.get_item("upload_banner", {mode: "edit", row: 75}, "id_60"),
         $(`#edit_form_${CSS.escape(75)} .upload_banner.file_id_60`),
+    );
+
+    $(`#edit_form_${CSS.escape(2)} .upload_banner`).set_find_results(
+        ".upload_banner_cancel_button",
+        $(".upload_banner_cancel_button"),
+    );
+    assert.equal(
+        upload.get_item("upload_banner_cancel_button", {mode: "edit", row: 2}, "id_34"),
+        $(`#edit_form_${CSS.escape(2)} .upload_banner.file_id_34 .upload_banner_cancel_button`),
     );
 
     $(`#edit_form_${CSS.escape(2)} .upload_banner`).set_find_results(
@@ -240,7 +253,8 @@ test("upload_files", async ({mock_template, override_rewire}) => {
 
     page_params.max_file_upload_size_mib = 25;
     let on_click_close_button_callback;
-    $("#compose_banners .upload_banner.file_id_123 .main-view-banner-close-button").one = (
+
+    $("#compose_banners .upload_banner.file_id_123 .upload_banner_cancel_button").one = (
         event,
         callback,
     ) => {

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -54,7 +54,7 @@ test("get_item", () => {
         $("#compose_banners .upload_banner.file_id_2 .upload_banner_cancel_button"),
     );
     assert.equal(
-        upload.get_item("upload_banner_close_button", {mode: "compose"}, "id_2"),
+        upload.get_item("upload_banner_hide_button", {mode: "compose"}, "id_2"),
         $("#compose_banners .upload_banner.file_id_2 .main-view-banner-close-button"),
     );
     assert.equal(
@@ -102,7 +102,7 @@ test("get_item", () => {
         $(".main-view-banner-close-button"),
     );
     assert.equal(
-        upload.get_item("upload_banner_close_button", {mode: "edit", row: 2}, "id_34"),
+        upload.get_item("upload_banner_hide_button", {mode: "edit", row: 2}, "id_34"),
         $(`#edit_form_${CSS.escape(2)} .upload_banner.file_id_34 .main-view-banner-close-button`),
     );
 


### PR DESCRIPTION
-  Add a cancel button to the upload banner, replacing the previous close icon. Now, the cancel button is used to cancel the upload process, while the close icon is used to remove the upload banner without interrupting the upload

- To maintain consistency with other banners, the cancel button's dimensions and color have been adjusted to match the style of other buttons present in different banners.

--------------------------------

Fixes: #21156
CZO: [Thread](https://chat.zulip.org/#narrow/stream/137-feedback/topic/disable.20send.20while.20uploading)

---------------------------------

**Screenshots and screen captures:**

<details>
<summary>Demo:</summary>
<br>

![demo](https://github.com/zulip/zulip/assets/66828942/a2b16174-baf8-441a-8555-9dccf7d0d9cd)


</details>

<details>
<summary>New Banner:</summary>
<br>

![Screenshot from 2023-05-31 08-08-12](https://github.com/zulip/zulip/assets/66828942/a7c5415b-9b7c-4acc-a420-7cf622210f26)

</details>

<details>
<summary>Cancel Button:</summary>
<br>

![Screenshot from 2023-05-31 08-08-18](https://github.com/zulip/zulip/assets/66828942/1c331bf5-cdbf-4274-9a03-718c893ecc4c)


</details>

<details>
<summary>View Port changes:</summary>

- Full Screen:
<br>

![Screenshot from 2023-05-31 08-22-06](https://github.com/zulip/zulip/assets/66828942/cc1b3358-0f8a-4d39-8646-999c80b29ea2)

- Small screen:
<br>

![Screenshot from 2023-05-31 08-21-38](https://github.com/zulip/zulip/assets/66828942/17af7c09-4c60-4b66-9ea5-956c46295e77)

- Demo:
<br>


![view port ](https://github.com/zulip/zulip/assets/66828942/e35c6599-6c65-4dc8-8972-951f6be05521)


</details>

----------------------------------

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
