### PR TITLE
hotkey-hint: Fix text not middle aligned at different zoom levels.

### DIFF
--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -77,15 +77,12 @@
         gap: 4px;
     }
 
-    .tooltip-hotkey-hint {
-        box-sizing: inherit;
+    & span.tooltip-hotkey-hint {
         border: 1px solid hsl(225deg 100% 84%);
         border-radius: 3px;
         color: hsl(225deg 100% 84%);
-        padding: 2px 5px;
-        min-width: 20px;
+        padding: 0 5px;
         text-align: center;
-        line-height: 14px;
     }
 
     /* If the reference of the tooltip is went offscreen while scrolling,


### PR DESCRIPTION
* Remove `box-sizing` and `min-width` properties which have no effect on `inline` positioned element. Modified class selector to add `span` which reflects this while reading the CSS.

* Remove `2px` vertical padding and `line-height` which combined are fighting for space??

80% zoom:
before:
<img width="275" alt="image" src="https://github.com/zulip/zulip/assets/25124304/a02b445c-f488-4e26-bcc2-e6f551a9aa77">


after:
<img width="143" alt="image" src="https://github.com/zulip/zulip/assets/25124304/42c8b39a-bf85-4aa3-b442-315693544106">

100% Zoom
before:
<img width="183" alt="image" src="https://github.com/zulip/zulip/assets/25124304/84d0f27d-0422-43eb-9801-f1850f09b98f">


after:
<img width="232" alt="image" src="https://github.com/zulip/zulip/assets/25124304/8e9d8bba-a337-4866-88df-af09adcd5487">
