### PR TITLE
ci: Fix pnpm store path for GitHub Actions

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -184,12 +184,6 @@ jobs:
           sudo mkdir -p "${dirs[@]}"
           sudo chown -R github "${dirs[@]}"
 
-      - name: Restore pnpm store
-        uses: actions/cache@v3
-        with:
-          path: ~/.local/share/pnpm/store
-          key: v1-pnpm-store-${{ matrix.os }}-${{ hashFiles('/tmp/pnpm-lock.yaml') }}
-
       - name: Install production
         run: sudo /tmp/production-install ${{ matrix.extra-args }}
 

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Restore pnpm store
         uses: actions/cache@v3
         with:
-          path: ~/.local/share/pnpm/store
+          path: /__w/.pnpm-store
           key: v1-pnpm-store-focal-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Restore python cache
@@ -101,6 +101,12 @@ jobs:
           name: production-tarball
           path: /tmp/production-build
           retention-days: 1
+
+      - name: Verify pnpm store path
+        run: |
+          set -x
+          path="$(pnpm store path)"
+          [[ "$path" == /__w/.pnpm-store/* ]]
 
       - name: Generate failure report string
         id: failure_report_string

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Restore pnpm store
         uses: actions/cache@v3
         with:
-          path: ~/.local/share/pnpm/store
+          path: /__w/.pnpm-store
           key: v1-pnpm-store-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Restore python cache
@@ -244,6 +244,12 @@ jobs:
 
       - name: Check development database build
         run: ./tools/ci/setup-backend
+
+      - name: Verify pnpm store path
+        run: |
+          set -x
+          path="$(pnpm store path)"
+          [[ "$path" == /__w/.pnpm-store/* ]]
 
       - name: Generate failure report string
         id: failure_report_string


### PR DESCRIPTION
This would ordinarily be determined by running `pnpm store path`, but pnpm is not installed yet at that point.

https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/CI.20pnpm.20cache.20broken.3F/near/1581885