### PR TITLE
Drop User ID Column from Tables in Settings (Issue #25483)

### DIFF
--- a/web/templates/settings/admin_user_list.hbs
+++ b/web/templates/settings/admin_user_list.hbs
@@ -14,11 +14,6 @@
         <span class="hidden-email">{{t "(hidden)"}}</span>
     </td>
     {{/if}}
-    {{#unless is_bot}}
-    <td>
-        <span class="user_id">{{user_id}}</span>
-    </td>
-    {{/unless}}
     <td>
         <span class="user_role">{{user_role_text}}</span>
     </td>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -14,7 +14,6 @@
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th {{#if allow_sorting_deactivated_users_list_by_email}}data-sort="email"{{/if}}>{{t "Email" }}</th>
-                <th class="user_id" data-sort="id">{{t "User ID" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 {{#if is_admin}}
                 <th class="actions">{{t "Actions" }}</th>

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -13,7 +13,6 @@
             <thead class="table-sticky-headers">
                 <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
-                <th class="user_id" data-sort="id">{{t "User ID" }}</th>
                 <th class="user_role" data-sort="role">{{t "Role" }}</th>
                 <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>
                 {{#if is_admin}}

--- a/web/templates/stream_settings/new_stream_user.hbs
+++ b/web/templates/stream_settings/new_stream_user.hbs
@@ -8,7 +8,6 @@
     {{else}}
         <td class="hidden-subscriber-email">{{t "(hidden)"}}</td>
     {{/if}}
-    <td>{{user_id}} </td>
     <td>
         <button {{#if disabled}} disabled="disabled"{{/if}} data-user-id="{{user_id}}" class="remove_potential_subscriber button small rounded white">{{t 'Remove' }}</button>
     </td>

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -23,7 +23,6 @@
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
-                <th data-sort="id">{{t "User ID" }}</th>
                 <th>{{t "Action" }}</th>
             </thead>
             <tbody id="create_stream_subscribers" class="subscriber_table"></tbody>

--- a/web/templates/stream_settings/stream_member_list_entry.hbs
+++ b/web/templates/stream_settings/stream_member_list_entry.hbs
@@ -8,7 +8,6 @@
     {{else}}
     <td class="hidden-subscriber-email">{{t "(hidden)"}}</td>
     {{/if}}
-    <td class="subscriber-user-id">{{user_id}}</td>
     {{#if can_remove_subscribers}}
     <td class="unsubscribe">
         <div class="subscriber_list_remove">

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -23,7 +23,6 @@
                 <thead class="table-sticky-headers">
                     <th data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                     <th data-sort="email">{{t "Email" }}</th>
-                    <th data-sort="id">{{t "User ID" }}</th>
                     {{#if can_remove_subscribers}}
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -18,7 +18,6 @@
             <thead class="table-sticky-headers">
                 <th data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="email">{{t "Email" }}</th>
-                <th data-sort="id">{{t "User ID" }}</th>
                 <th>{{t "Action" }}</th>
             </thead>
             <tbody id="create_user_group_members" class="member_table"></tbody>

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -22,7 +22,6 @@
                 <thead class="table-sticky-headers">
                     <th data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                     <th data-sort="email">{{t "Email" }}</th>
-                    <th data-sort="id">{{t "User ID" }}</th>
                     <th class="actions" {{#unless can_edit}}style="display:none"{{/unless}}>{{t "Actions" }}</th>
                 </thead>
                 <tbody class="member_table"></tbody>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Remove User ID Column from tables in the following locations in settings:
-  `Manage Streams // Subscriber Tab`
- `Manage Streams // New Stream // Subscribers`
- `Organization Settings // Users`
- `Organization Settings // Deactivated Users`

The original Issue mentions linking cards to user names where they aren't already

>  Stream settings -> Create stream > Subscribers

> As a prerequisite for this one, we should make user names in this table link to user cards as well.

But this was fixed by a separate issue, [#25725 ]([https://github.com/zulip/zulip/issues/25725](https://github.com/zulip/zulip/issues/url))



**Fixes:** [#25483 ](https://github.com/zulip/zulip/issues/25483)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<img width="1019" alt="Screenshot 2023-05-31 at 12 46 11 PM" src="https://github.com/zulip/zulip/assets/73512776/1d6cfaf3-86ae-47e0-adb6-b33de9bd609a">
<img width="603" alt="Screenshot 2023-05-31 at 12 46 39 PM" src="https://github.com/zulip/zulip/assets/73512776/ccd383a3-cc96-46b2-bbd4-ca3bd31791d7">
<img width="593" alt="Screenshot 2023-05-31 at 12 46 55 PM" src="https://github.com/zulip/zulip/assets/73512776/4ce1312d-d09f-44d8-921b-629819b56d8f">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
