### PR TITLE
migrations: Avoid crash upgrading presence schema.

### DIFF
--- a/zerver/migrations/0443_userpresence_new_table_schema.py
+++ b/zerver/migrations/0443_userpresence_new_table_schema.py
@@ -33,6 +33,11 @@ def rename_indexes_constraints(
                     suffix = "_idx" if len(infodict["columns"]) > 1 else ""
                     is_index = True
                 new_name = schema_editor._create_index_name(new_table, infodict["columns"], suffix)
+
+                if old_name == new_name:
+                    # Don't crash if these already have the right names.
+                    continue
+
                 if is_index:
                     raw_query = SQL("ALTER INDEX {old_name} RENAME TO {new_name}").format(
                         old_name=Identifier(old_name), new_name=Identifier(new_name)


### PR DESCRIPTION
This hopefully will fix this error, seen in a couple production systems today:

ERROR:  constraint "zerver_userpresence_user_profile_id_b67b4092_fk_zerver_us" for relation "zerver_userpresence" already exists

See https://chat.zulip.org/#narrow/stream/31-production-help/topic/presence.20migration.20upgrading.206.2E2.20to.207.2E0/near/1583327 for background.