### PR TITLE
search: Link messages in search results to near view.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -23,6 +23,7 @@ import * as message_edit from "./message_edit";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as narrow from "./narrow";
+import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
 import {page_params} from "./page_params";
 import * as pm_list from "./pm_list";
@@ -181,6 +182,21 @@ export function initialize() {
 
         if (message_edit.is_editing(id)) {
             // Clicks on a message being edited shouldn't trigger a reply.
+            return;
+        }
+
+        // Clicks on a message from search results should bring the
+        // user to the message's near view instead of opening the
+        // compose box.
+        const current_filter = narrow_state.filter();
+        if (current_filter !== undefined && !current_filter.supports_collapsing_recipients()) {
+            const message = message_store.get(id);
+
+            if (message === undefined) {
+                // This might happen for locally echoed messages, for example.
+                return;
+            }
+            window.location = hash_util.by_conversation_and_time_url(message);
             return;
         }
 

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -18,6 +18,7 @@ import * as emoji_picker from "./emoji_picker";
 import * as feedback_widget from "./feedback_widget";
 import * as gear_menu from "./gear_menu";
 import * as giphy from "./giphy";
+import * as hash_util from "./hash_util";
 import * as hashchange from "./hashchange";
 import * as hotspots from "./hotspots";
 import * as lightbox from "./lightbox";
@@ -497,9 +498,25 @@ export function process_enter_key(e) {
         return false;
     }
 
-    // If we got this far, then we're presumably in the message
-    // view, so in that case "Enter" is the hotkey to respond to a message.
-    // Note that "r" has same effect, but that is handled in process_hotkey().
+    if (!narrow_state.is_message_feed_visible()) {
+        return false;
+    }
+
+    // For search views, renarrow to the current message's
+    // conversation.
+    const current_filter = narrow_state.filter();
+    if (current_filter !== undefined && !current_filter.supports_collapsing_recipients()) {
+        const message = message_lists.current.selected_message();
+
+        if (message === undefined) {
+            // No selected message.
+            return false;
+        }
+
+        window.location = hash_util.by_conversation_and_time_url(message);
+        return true;
+    }
+
     compose_actions.respond_to_message({trigger: "hotkey enter"});
     return true;
 }


### PR DESCRIPTION
Previously clicking on a message in search results opened the compose box. This was not great, because search views show messages outside of their context, and replying to a message without the context of possible more recent messages sent to that narrow can result in a bad experience.

This commit prevents the composebox from opening on click and instead moves the user to a near view for the message.

Fixes #21217.

![Kapture 2023-06-01 at 21 44 52](https://github.com/zulip/zulip/assets/5634097/4dd240ca-ce29-42fe-b06a-f747911f1b8b)
