### PR TITLE
ts: Migrates `web/shared/poll_data` to typescript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -44,7 +44,7 @@ def make_set(files: List[str]) -> Set[str]:
 # We do not yet require 100% line coverage for these files:
 EXEMPT_FILES = make_set(
     [
-        "web/shared/src/poll_data.js",
+        "web/shared/src/poll_data.ts",
         "web/src/about_zulip.js",
         "web/src/add_subscribers_pill.js",
         "web/src/admin.js",

--- a/web/shared/src/poll_data.js
+++ b/web/shared/src/poll_data.js
@@ -28,6 +28,140 @@ export class PollData {
         this.comma_separated_names = comma_separated_names;
         this.report_error_function = report_error_function;
 
+        this.handle = {
+            new_option: {
+                outbound: (option) => {
+                    const event = {
+                        type: "new_option",
+                        idx: this.my_idx,
+                        option,
+                    };
+
+                    this.my_idx += 1;
+
+                    return event;
+                },
+
+                inbound: (sender_id, data) => {
+                    // All message readers may add a new option to the poll.
+                    const idx = data.idx;
+                    const option = data.option;
+                    const options = this.get_widget_data().options;
+
+                    // While the UI doesn't allow adding duplicate options
+                    // to an existing poll, the /poll command syntax to create
+                    // them does not prevent duplicates, so we suppress them here.
+                    if (this.is_option_present(options, option)) {
+                        return;
+                    }
+
+                    if (!Number.isInteger(idx) || idx < 0 || idx > MAX_IDX) {
+                        this.report_error_function("poll widget: bad type for inbound option idx");
+                        return;
+                    }
+
+                    if (typeof option !== "string") {
+                        this.report_error_function("poll widget: bad type for inbound option");
+                        return;
+                    }
+
+                    const key = sender_id + "," + idx;
+                    const votes = new Map();
+
+                    this.key_to_option.set(key, {
+                        option,
+                        user_id: sender_id,
+                        votes,
+                    });
+
+                    // I may have added a poll option from another device.
+                    if (sender_id === this.me && this.my_idx <= idx) {
+                        this.my_idx = idx + 1;
+                    }
+                },
+            },
+
+            question: {
+                outbound: (question) => {
+                    const event = {
+                        type: "question",
+                        question,
+                    };
+                    if (this.is_my_poll) {
+                        return event;
+                    }
+                    return undefined;
+                },
+
+                inbound: (sender_id, data) => {
+                    // Only the message author can edit questions.
+                    if (sender_id !== this.message_sender_id) {
+                        this.report_error_function(
+                            `user ${sender_id} is not allowed to edit the question`,
+                        );
+                        return;
+                    }
+
+                    if (typeof data.question !== "string") {
+                        this.report_error_function("poll widget: bad type for inbound question");
+                        return;
+                    }
+
+                    this.set_question(data.question);
+                },
+            },
+
+            vote: {
+                outbound: (key) => {
+                    let vote = 1;
+
+                    // toggle
+                    if (this.key_to_option.get(key).votes.get(this.me)) {
+                        vote = -1;
+                    }
+
+                    const event = {
+                        type: "vote",
+                        key,
+                        vote,
+                    };
+
+                    return event;
+                },
+
+                inbound: (sender_id, data) => {
+                    // All message readers may vote on poll options.
+                    const key = data.key;
+                    const vote = data.vote;
+
+                    if (typeof key !== "string") {
+                        this.report_error_function("poll widget: bad type for inbound vote key");
+                        return;
+                    }
+
+                    if (!Number.isInteger(vote) || !(vote === 1 || vote === -1)) {
+                        this.report_error_function("poll widget: bad value for inbound vote count");
+                        return;
+                    }
+
+                    const option = this.key_to_option.get(key);
+
+                    if (option === undefined) {
+                        this.report_error_function("unknown key for poll: " + key);
+                        return;
+                    }
+
+                    const votes = option.votes;
+
+                    if (vote === 1) {
+                        votes.set(sender_id, 1);
+                    } else {
+                        votes.delete(sender_id);
+                    }
+                },
+            },
+        };
+
         if (question) {
             this.set_question(question);
         }
@@ -84,140 +218,6 @@ export class PollData {
 
         return widget_data;
     }
-
-    handle = {
-        new_option: {
-            outbound: (option) => {
-                const event = {
-                    type: "new_option",
-                    idx: this.my_idx,
-                    option,
-                };
-
-                this.my_idx += 1;
-
-                return event;
-            },
-
-            inbound: (sender_id, data) => {
-                // All message readers may add a new option to the poll.
-                const idx = data.idx;
-                const option = data.option;
-                const options = this.get_widget_data().options;
-
-                // While the UI doesn't allow adding duplicate options
-                // to an existing poll, the /poll command syntax to create
-                // them does not prevent duplicates, so we suppress them here.
-                if (this.is_option_present(options, option)) {
-                    return;
-                }
-
-                if (!Number.isInteger(idx) || idx < 0 || idx > MAX_IDX) {
-                    this.report_error_function("poll widget: bad type for inbound option idx");
-                    return;
-                }
-
-                if (typeof option !== "string") {
-                    this.report_error_function("poll widget: bad type for inbound option");
-                    return;
-                }
-
-                const key = sender_id + "," + idx;
-                const votes = new Map();
-
-                this.key_to_option.set(key, {
-                    option,
-                    user_id: sender_id,
-                    votes,
-                });
-
-                // I may have added a poll option from another device.
-                if (sender_id === this.me && this.my_idx <= idx) {
-                    this.my_idx = idx + 1;
-                }
-            },
-        },
-
-        question: {
-            outbound: (question) => {
-                const event = {
-                    type: "question",
-                    question,
-                };
-                if (this.is_my_poll) {
-                    return event;
-                }
-                return undefined;
-            },
-
-            inbound: (sender_id, data) => {
-                // Only the message author can edit questions.
-                if (sender_id !== this.message_sender_id) {
-                    this.report_error_function(
-                        `user ${sender_id} is not allowed to edit the question`,
-                    );
-                    return;
-                }
-
-                if (typeof data.question !== "string") {
-                    this.report_error_function("poll widget: bad type for inbound question");
-                    return;
-                }
-
-                this.set_question(data.question);
-            },
-        },
-
-        vote: {
-            outbound: (key) => {
-                let vote = 1;
-
-                // toggle
-                if (this.key_to_option.get(key).votes.get(this.me)) {
-                    vote = -1;
-                }
-
-                const event = {
-                    type: "vote",
-                    key,
-                    vote,
-                };
-
-                return event;
-            },
-
-            inbound: (sender_id, data) => {
-                // All message readers may vote on poll options.
-                const key = data.key;
-                const vote = data.vote;
-
-                if (typeof key !== "string") {
-                    this.report_error_function("poll widget: bad type for inbound vote key");
-                    return;
-                }
-
-                if (!Number.isInteger(vote) || !(vote === 1 || vote === -1)) {
-                    this.report_error_function("poll widget: bad value for inbound vote count");
-                    return;
-                }
-
-                const option = this.key_to_option.get(key);
-
-                if (option === undefined) {
-                    this.report_error_function("unknown key for poll: " + key);
-                    return;
-                }
-
-                const votes = option.votes;
-
-                if (vote === 1) {
-                    votes.set(sender_id, 1);
-                } else {
-                    votes.delete(sender_id);
-                }
-            },
-        },
-    };
 
     handle_event(sender_id, data) {
         const type = data.type;

--- a/web/shared/src/poll_data.ts
+++ b/web/shared/src/poll_data.ts
@@ -1,3 +1,74 @@
+import assert from "minimalistic-assert";
+import z from "zod";
+
+export type PollDataConfig = {
+    message_sender_id: number;
+    current_user_id: number;
+    is_my_poll: boolean;
+    question: string;
+    options: string[];
+    comma_separated_names: (user_ids: number[]) => string;
+    report_error_function: (msg: string, more_info?: unknown) => void;
+};
+
+export type PollOptionData = {
+    option: string;
+    names: string;
+    count: number;
+    key: string;
+    current_user_vote: boolean;
+};
+
+type PollOption = {
+    option: string;
+    user_id: number;
+    votes: Map<number, number>;
+};
+
+export type WidgetData = {
+    options: PollOptionData[];
+    question: string;
+};
+
+export type InboundData = Record<string, unknown> & {type: string};
+
+export type PollHandle = {
+    // Add generic key property to allow string indexing on PollHandle type in `handle_event` method.
+    [key: string]: {
+        outbound: (arg: string) => InboundData | undefined;
+        inbound: (sender_id: number, data: InboundData) => void;
+    };
+    new_option: {
+        outbound: (option: string) => {type: string; idx: number; option: string};
+        inbound: (sender_id: number, data: InboundData) => void;
+    };
+    question: {
+        outbound: (question: string) => {type: string; question: string} | undefined;
+        inbound: (sender_id: number, data: InboundData) => void;
+    };
+    vote: {
+        outbound: (key: string) => {type: string; key: string; vote: number};
+        inbound: (sender_id: number, data: InboundData) => void;
+    };
+};
+
+const inbound_option_schema = z.object({
+    idx: z.number(),
+    option: z.string(),
+    type: z.literal("new_option"),
+});
+
+const inbound_question_schema = z.object({
+    question: z.string(),
+    type: z.literal("question"),
+});
+
+const inbound_vote_schema = z.object({
+    key: z.string(),
+    type: z.literal("vote"),
+    vote: z.number(),
+});
+
 // Any single user should send add a finite number of options
 // to a poll. We arbitrarily pick this value.
 const MAX_IDX = 1000;
@@ -8,8 +79,16 @@ export class PollData {
     // should be represented for rendering, plus how the
     // server sends us data.
 
-    key_to_option = new Map();
+    key_to_option = new Map<string, PollOption>();
     my_idx = 1;
+    message_sender_id: number;
+    me: number;
+    is_my_poll: boolean;
+    poll_question: string;
+    input_mode: boolean;
+    comma_separated_names: (user_ids: number[]) => string;
+    report_error_function: (error_message: string) => void;
+    handle: PollHandle;
 
     constructor({
         message_sender_id,
@@ -19,7 +98,7 @@ export class PollData {
         options,
         comma_separated_names,
         report_error_function,
-    }) {
+    }: PollDataConfig) {
         this.message_sender_id = message_sender_id;
         this.me = current_user_id;
         this.is_my_poll = is_my_poll;
@@ -27,6 +106,10 @@ export class PollData {
         this.input_mode = is_my_poll; // for now
         this.comma_separated_names = comma_separated_names;
         this.report_error_function = report_error_function;
+
+        if (question) {
+            this.set_question(question);
+        }
 
         this.handle = {
             new_option: {
@@ -43,9 +126,11 @@ export class PollData {
                 },
 
                 inbound: (sender_id, data) => {
+                    const safe_data = inbound_option_schema.parse(data);
+
                     // All message readers may add a new option to the poll.
-                    const idx = data.idx;
-                    const option = data.option;
+                    const idx = safe_data.idx;
+                    const option = safe_data.option;
                     const options = this.get_widget_data().options;
 
                     // While the UI doesn't allow adding duplicate options
@@ -55,17 +140,12 @@ export class PollData {
                         return;
                     }
 
-                    if (!Number.isInteger(idx) || idx < 0 || idx > MAX_IDX) {
-                        this.report_error_function("poll widget: bad type for inbound option idx");
+                    if (idx < 0 || idx > MAX_IDX) {
+                        this.report_error_function("poll widget: idx out of bound");
                         return;
                     }
 
-                    if (typeof option !== "string") {
-                        this.report_error_function("poll widget: bad type for inbound option");
-                        return;
-                    }
-
-                    const key = sender_id + "," + idx;
+                    const key = `${sender_id},${idx}`;
                     const votes = new Map();
 
                     this.key_to_option.set(key, {
@@ -94,6 +174,8 @@ export class PollData {
                 },
 
                 inbound: (sender_id, data) => {
+                    const safe_data = inbound_question_schema.parse(data);
+
                     // Only the message author can edit questions.
                     if (sender_id !== this.message_sender_id) {
                         this.report_error_function(
@@ -102,12 +184,7 @@ export class PollData {
                         return;
                     }
 
-                    if (typeof data.question !== "string") {
-                        this.report_error_function("poll widget: bad type for inbound question");
-                        return;
-                    }
-
-                    this.set_question(data.question);
+                    this.set_question(safe_data.question);
                 },
             },
 
@@ -116,7 +193,8 @@ export class PollData {
                     let vote = 1;
 
                     // toggle
-                    if (this.key_to_option.get(key).votes.get(this.me)) {
+                    assert(this.key_to_option.has(key), `option key not found: ${key}`);
+                    if (this.key_to_option.get(key)!.votes.get(this.me)) {
                         vote = -1;
                     }
 
@@ -130,16 +208,13 @@ export class PollData {
                 },
 
                 inbound: (sender_id, data) => {
+                    const safe_data = inbound_vote_schema.parse(data);
+
                     // All message readers may vote on poll options.
-                    const key = data.key;
-                    const vote = data.vote;
+                    const key = safe_data.key;
+                    const vote = safe_data.vote;
 
-                    if (typeof key !== "string") {
-                        this.report_error_function("poll widget: bad type for inbound vote key");
-                        return;
-                    }
-
-                    if (!Number.isInteger(vote) || !(vote === 1 || vote === -1)) {
+                    if (!(vote === 1 || vote === -1)) {
                         this.report_error_function("poll widget: bad value for inbound vote count");
                         return;
                     }
@@ -162,41 +237,38 @@ export class PollData {
             },
         };
 
-        if (question) {
-            this.set_question(question);
-        }
-
         for (const [i, option] of options.entries()) {
-            this.handle.new_option.inbound("canned", {
+            this.handle.new_option.inbound(-1, {
                 idx: i,
                 option,
+                type: "new_option",
             });
         }
     }
 
-    set_question(new_question) {
+    set_question(new_question: string): void {
         this.input_mode = false;
         this.poll_question = new_question;
     }
 
-    get_question() {
+    get_question(): string {
         return this.poll_question;
     }
 
-    set_input_mode() {
+    set_input_mode(): void {
         this.input_mode = true;
     }
 
-    clear_input_mode() {
+    clear_input_mode(): void {
         this.input_mode = false;
     }
 
-    get_input_mode() {
+    get_input_mode(): boolean {
         return this.input_mode;
     }
 
-    get_widget_data() {
-        const options = [];
+    get_widget_data(): WidgetData {
+        const options: PollOptionData[] = [];
 
         for (const [key, obj] of this.key_to_option) {
             const voters = [...obj.votes.keys()];
@@ -219,9 +291,9 @@ export class PollData {
         return widget_data;
     }
 
-    handle_event(sender_id, data) {
+    handle_event(sender_id: number, data: InboundData): void {
         const type = data.type;
-        if (this.handle[type] && this.handle[type].inbound) {
+        if (this.handle[type]) {
             this.handle[type].inbound(sender_id, data);
         } else {
             this.report_error_function(`poll widget: unknown inbound type: ${type}`);
@@ -229,7 +301,7 @@ export class PollData {
     }
 
     // function to check whether option already exists
-    is_option_present(data, latest_option) {
+    is_option_present(data: PollOptionData[], latest_option: string): boolean {
         return data.some((el) => el.option === latest_option);
     }
 }


### PR DESCRIPTION
Migrates `poll_data` to TypeScript.
- I used zod schemas for validating incoming/inbound data types.
- Refactored to declare `handle` object inside the constructor of the class.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
