### PR TITLE
migrations: Fix bug in migration 0439.

### DIFF
--- a/zerver/migrations/0439_fix_deleteduser_email.py
+++ b/zerver/migrations/0439_fix_deleteduser_email.py
@@ -28,7 +28,7 @@ def get_fake_email_domain(apps: StateApps, realm_id: int) -> str:
     # Implement get_fake_email_domain
     try:
         validate_email(Address(username="bot", domain=host).addr_spec)
-        return realm.host
+        return host
     except ValidationError:
         pass
 


### PR DESCRIPTION
This code clearly meant to return host and returning realm.host is a mistake. realm.host is not accessible in a migration due to being a @property-decorated method. The code constructs the host var value just above this line.

