### PR TITLE
billing: Fix css for popups on the billing page.

### DIFF
--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -1,3 +1,7 @@
+:root {
+    --color-background-modal: hsl(0deg 0% 98%);
+}
+
 .billing-upgrade-page {
     font-family: "Source Sans 3", sans-serif;
     background-color: hsl(0deg 0% 98%);


### PR DESCRIPTION
As of 9427fb72301c0674fdbfd75b1903e2c9d0966769, the billing page needs a proper value for --color-background-modal.

Before:
![image](https://github.com/zulip/zulip/assets/45007152/20809725-a9d7-4083-97ed-b7f2b7c7320a)

After:
![image](https://github.com/zulip/zulip/assets/45007152/6a8e4283-181c-45d3-b21f-e52bc5bdadd6)
