### PR TITLE
drafts: Update drafts count when opening and closing the overlay.

### DIFF
--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -658,11 +658,13 @@ export function launch() {
 }
 
 function open_overlay() {
+    sync_count();
     overlays.open_overlay({
         name: "drafts",
         $overlay: $("#draft_overlay"),
         on_close() {
             browser_history.exit_overlay();
+            sync_count();
         },
     });
 }

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -613,6 +613,9 @@ test("format_drafts", ({override_rewire, mock_template}) => {
 
     override_rewire(messages_overlay_ui, "set_initial_element", noop);
 
+    const $unread_count = $("<unread-count-stub>");
+    $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
+
     $.create("#drafts_table .draft-row", {children: []});
     drafts.launch();
 
@@ -627,7 +630,6 @@ test("format_drafts", ({override_rewire, mock_template}) => {
 
     expected[0].stream_name = "stream-rename";
 
-    const $unread_count = $("<unread-count-stub>");
     $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     drafts.launch();
@@ -764,6 +766,9 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
     });
 
     override_rewire(messages_overlay_ui, "set_initial_element", noop);
+
+    const $unread_count = $("<unread-count-stub>");
+    $(".top_left_drafts").set_find_results(".unread_count", $unread_count);
 
     override_rewire(user_pill, "get_user_ids", () => [aaron.user_id]);
     override_rewire(compose_pm_pill, "set_from_emails", noop);


### PR DESCRIPTION
Previously, if the drafts modal was open in two different tabs and if the user deletes one or more drafts in one tab then the count of drafts didn't get updated on the other tab. This can be fixed by moving the drafts from local storage to the cloud. But for now, this PR updates the count whenever the modal is opened or closed.

CZO Discussion: [Link](https://chat.zulip.org/#narrow/stream/9-issues/topic/drafts.20counter.20off)

<hr>

**Screen captures:**

**Before:** [Before_Drafts.webm](https://github.com/sbansal1999/zulip/assets/35286603/9d6bf8f8-19ea-45a1-980d-ee0fb818c149)

**After:**  [After_Drafts.webm](https://github.com/sbansal1999/zulip/assets/35286603/c68ceed4-e837-4fbb-b27d-be74fb7f77fb) 


<hr>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
