### PR TITLE
send_later: Wildcard mention throwing error on send later.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -239,7 +239,7 @@ function set_compose_box_schedule(element) {
     return selected_send_at_time;
 }
 
-export function open_send_later_menu(instance) {
+export function open_send_later_menu() {
     if (!compose_validate.validate(true)) {
         return;
     }
@@ -248,11 +248,12 @@ export function open_send_later_menu(instance) {
     const date = new Date();
     const filtered_send_opts = scheduled_messages.get_filtered_send_opts(date);
     $("body").append(render_send_later_modal(filtered_send_opts));
+    let interval;
 
     overlays.open_modal("send_later_modal", {
         autoremove: true,
         on_show() {
-            instance._interval = setInterval(
+            interval = setInterval(
                 scheduled_messages.update_send_later_options,
                 scheduled_messages.SCHEDULING_MODAL_UPDATE_INTERVAL_IN_MILLISECONDS,
             );
@@ -312,7 +313,7 @@ export function open_send_later_menu(instance) {
             $send_later_modal_overlay.trigger("focus");
         },
         on_hide() {
-            clearInterval(instance._interval);
+            clearInterval(interval);
         },
     });
 }
@@ -905,7 +906,7 @@ export function initialize() {
                 const send_at_timestamp = get_selected_send_later_timestamp();
                 do_schedule_message(send_at_timestamp);
             });
-            $popper.one("click", ".open_send_later_modal", () => open_send_later_menu(instance));
+            $popper.one("click", ".open_send_later_modal", open_send_later_menu);
         },
         onHidden(instance) {
             instance.destroy();


### PR DESCRIPTION
It was throwing error while schudiling a message having wildcard mention, because the function `open_send_later_menu` uses instance to track down interval, but the parametere instance was not passed from when it was called from warning banner action. This commit sets a default instance to an empty object.

<!-- Describe your pull request here.-->

Fixes: https://chat.zulip.org/#narrow/stream/9-issues

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
