### PR TITLE
message_feed: Improve edited/moved tooltip.

### DIFF
--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -1,11 +1,13 @@
 import $ from "jquery";
 import {delegate} from "tippy.js";
 
+import render_message_edit_notice_tooltip from "../templates/message_edit_notice_tooltip.hbs";
 import render_message_inline_image_tooltip from "../templates/message_inline_image_tooltip.hbs";
 import render_narrow_tooltip from "../templates/narrow_tooltip.hbs";
 
 import {$t} from "./i18n";
 import * as message_lists from "./message_lists";
+import {page_params} from "./page_params";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
 import * as timerender from "./timerender";
@@ -230,6 +232,36 @@ export function initialize() {
 
     message_list_tooltip(".view_user_card_tooltip", {
         delay: LONG_HOVER_DELAY,
+        onHidden(instance) {
+            instance.destroy();
+        },
+    });
+
+    message_list_tooltip(".message_edit_notice", {
+        trigger: "mouseenter",
+        delay: LONG_HOVER_DELAY,
+        popperOptions: {
+            modifiers: [
+                {
+                    name: "flip",
+                    options: {
+                        fallbackPlacements: "bottom",
+                    },
+                },
+            ],
+        },
+        onShow(instance) {
+            const $elem = $(instance.reference);
+            const edited_notice_str = $elem.attr("data-tippy-content");
+            instance.setContent(
+                parse_html(
+                    render_message_edit_notice_tooltip({
+                        edited_notice_str,
+                        realm_allow_edit_history: page_params.realm_allow_edit_history,
+                    }),
+                ),
+            );
+        },
         onHidden(instance) {
             instance.destroy();
         },

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -287,10 +287,17 @@ export class MessageListView {
         if (last_edit_timestamp !== undefined) {
             const last_edit_time = new Date(last_edit_timestamp * 1000);
             const today = new Date();
+            let date = timerender.render_date(last_edit_time, today)[0].textContent;
+            // If the date is today or yesterday, we don't want to show the date as capitalized.
+            // Thus, we need to check if the date string contains a digit or not using regex,
+            // since any other date except today/yesterday will contain a digit.
+            if (date && !/\d/.test(date)) {
+                date = date.toLowerCase();
+            }
             return $t(
                 {defaultMessage: "{date} at {time}"},
                 {
-                    date: timerender.render_date(last_edit_time, today)[0].textContent,
+                    date,
                     time: timerender.stringify_time(last_edit_time),
                 },
             );

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,13 +1,13 @@
 {{#if msg/local_edit_timestamp}}
-<div class="message_edit_notice auto-select tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edited ({last_edit_timestr})' }}">
+<div class="message_edit_notice auto-select" data-tippy-content="{{t 'Last edited {last_edit_timestr}' }}">
     {{t "SAVING" }}
 </div>
 {{else if moved}}
-<div class="message_edit_notice auto-select tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Moved ({last_edit_timestr})' }}">
+<div class="message_edit_notice auto-select" data-tippy-content="{{t 'Last moved {last_edit_timestr}' }}">
     {{t "MOVED" }}
 </div>
 {{else}}
-<div class="message_edit_notice auto-select tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Edited ({last_edit_timestr})' }}">
+<div class="message_edit_notice auto-select" data-tippy-content="{{t 'Last edited {last_edit_timestr}' }}">
     {{t "EDITED" }}
 </div>
 {{/if}}

--- a/web/templates/message_edit_notice_tooltip.hbs
+++ b/web/templates/message_edit_notice_tooltip.hbs
@@ -1,0 +1,6 @@
+<div>
+    <div>{{edited_notice_str}}</div>
+    {{#if realm_allow_edit_history}}
+        <i>{{t 'Click to view edit history.' }}</i>
+    {{/if}}
+</div>


### PR DESCRIPTION
- [x] Change the text to:
- First line: Last {moved/edited} [date/time]. [note: no parens around date, don't capitalize date unless required by rules of English, i.e., "today", not "Today"]
- Second line, shown only if edit history is enabled in the organization: Click to view edit history.

---

Fixes: #23075
----------------------

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>
<br>


![Screenshot from 2023-06-04 07-59-56](https://github.com/zulip/zulip/assets/66828942/2c178eba-1851-40fe-8aa1-ee266e11e983)

<br>

![Screenshot from 2023-06-04 08-00-05](https://github.com/zulip/zulip/assets/66828942/ea0ba0f8-77a1-443e-b334-76b358b09b3d)

</details>

<details>
<summary>After:</summary>
<br>

![Screenshot from 2023-06-04 07-58-02](https://github.com/zulip/zulip/assets/66828942/fe89f587-ceb6-411b-9606-f69a21722a84)

<br>

![Screenshot from 2023-06-04 07-58-15](https://github.com/zulip/zulip/assets/66828942/ad7feb4e-4172-4dc8-afd1-2e46f1e0c932)

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x]  Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
