### PR TITLE
notifications: Fix bad rendering of math formulas.

### DIFF
--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -247,6 +247,13 @@ def build_message_list(
         relative_to_full_url(fragment, user.realm.uri)
         fix_emojis(fragment, user.emojiset)
         fix_spoilers_in_html(fragment, user.default_language)
+
+        # Following changes are done to avoid the bad rendering of latex math formulas in emails.
+        # See: #25289 for more details.
+        katex_html_elements = fragment.cssselect("span.katex-html")
+        for element in katex_html_elements:
+            element.getparent().remove(element)
+
         html = lxml.html.tostring(fragment, encoding="unicode")
         if sender:
             plain, html = prepend_sender_to_message(plain, html, sender)


### PR DESCRIPTION
This commit fixes the bad rendering of math formulas in the email notifications. For the emails having math formulas like: `$$d^* = +\infty$$` includes them three times in a row (once as unicode, once as latex, again as unicode). This was because we were displaying KaTeX HTML without the CSS.

This is fixed by showing the raw LaTeX source.

Fixes: #25289.