### PR TITLE
docs: Fix data type for `submessages` field on `message` type.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -17750,10 +17750,32 @@ components:
             called "subjects" and will eventually change.
         submessages:
           type: array
-          items:
-            type: string
           description: |
             Data used for certain experimental Zulip integrations.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              msg_type:
+                type: string
+                description: |
+                  The type of the message.
+              content:
+                type: string
+                description: |
+                  The new content of the submessage.
+              message_id:
+                type: integer
+                description: |
+                  The ID of the message to which the submessage has been added.
+              sender_id:
+                type: integer
+                description: |
+                  The ID of the user who sent the message.
+              submessage_id:
+                type: integer
+                description: |
+                  The ID of the submessage.
         timestamp:
           type: integer
           description: |


### PR DESCRIPTION
Before this commit our docs mentioned `string[]` data type for `submessages` field on the `message` object. This commit changes the type to `object[]` and correctly mentions all fields of the `submessage` object.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
