### PR TITLE
Additional protections and checks on PostgreSQL version

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -208,17 +208,18 @@ def shutdown_server() -> None:
 if os.path.exists("/etc/init.d/postgresql"):
     postgresql_version = get_config(config_file, "postgresql", "version")
     if not postgresql_version:
-        default_postgresql_version = {
-            ("debian", "11"): "13",
-            ("debian", "12"): "15",
-            ("ubuntu", "20.04"): "12",
-            ("ubuntu", "22.04"): "14",
-            ("centos", "7"): "11",
-        }
-        if (vendor, os_version) in default_postgresql_version:
-            postgresql_version = default_postgresql_version[(vendor, os_version)]
-        else:
-            error_desupported_os(vendor, os_version)
+        postgresql_version = subprocess.check_output(
+            # We use the _current_ deploy's manage.py, since ours has not
+            # yet had its virtualenv configured yet.
+            [
+                "../current/manage.py",
+                "shell",
+                "-c",
+                "from django.db import connection; print(int(connection.cursor().connection.server_version/10000))",
+            ],
+            preexec_fn=su_to_zulip,
+            text=True,
+        ).strip()
         subprocess.check_call(
             [
                 "crudini",

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -207,19 +207,20 @@ def shutdown_server() -> None:
 # previously; fill it in based on what the OS provides.
 if os.path.exists("/etc/init.d/postgresql"):
     postgresql_version = get_config(config_file, "postgresql", "version")
+    django_pg_version = subprocess.check_output(
+        # We use the _current_ deploy's manage.py, since ours has not
+        # yet had its virtualenv configured yet.
+        [
+            "../current/manage.py",
+            "shell",
+            "-c",
+            "from django.db import connection; print(int(connection.cursor().connection.server_version/10000))",
+        ],
+        preexec_fn=su_to_zulip,
+        text=True,
+    ).strip()
     if not postgresql_version:
-        postgresql_version = subprocess.check_output(
-            # We use the _current_ deploy's manage.py, since ours has not
-            # yet had its virtualenv configured yet.
-            [
-                "../current/manage.py",
-                "shell",
-                "-c",
-                "from django.db import connection; print(int(connection.cursor().connection.server_version/10000))",
-            ],
-            preexec_fn=su_to_zulip,
-            text=True,
-        ).strip()
+        postgresql_version = django_pg_version
         subprocess.check_call(
             [
                 "crudini",
@@ -230,6 +231,25 @@ if os.path.exists("/etc/init.d/postgresql"):
                 postgresql_version,
             ]
         )
+    elif postgresql_version != django_pg_version:
+        logging.critical(
+            "PostgreSQL version mismatch: %s (running) vs %s (configured)",
+            django_pg_version,
+            postgresql_version,
+        )
+        logging.info(
+            "/etc/zulip/zulip.conf claims that Zulip is running PostgreSQL\n"
+            "%s, but the server is connected to a PostgreSQL running\n"
+            "version %s.  Check the output from pg_lsclusters to verify\n"
+            "which clusters are running, and update /etc/zulip/zulip.conf to match.\n"
+            "\n"
+            "In general, this results from manually upgrading PostgreSQL; you\n"
+            "should follow our instructions for using our tool to do so:\n"
+            "https://zulip.readthedocs.io/en/latest/production/upgrade.html#upgrading-postgresql",
+            postgresql_version,
+            django_pg_version,
+        )
+        sys.exit(1)
 
     if int(postgresql_version) < 12:
         logging.critical("Unsupported PostgreSQL version: %s", postgresql_version)

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -230,7 +230,7 @@ if os.path.exists("/etc/init.d/postgresql"):
             ]
         )
 
-    if tuple(map(int, postgresql_version.split("."))) < (12,):
+    if int(postgresql_version) < 12:
         logging.critical("Unsupported PostgreSQL version: %s", postgresql_version)
         logging.info(
             "Please upgrade to PostgreSQL 12 or newer first.\n"

--- a/scripts/setup/upgrade-postgresql
+++ b/scripts/setup/upgrade-postgresql
@@ -26,6 +26,27 @@ if [[ "$UPGRADE_TO" -lt "$UPGRADE_FROM" ]]; then
     exit 1
 fi
 
+# Verify that the version in /etc/zulip/zulip.conf is the version that
+# Django actually stores its data in.  We can only do that if the
+# database server is on the same host as the application server.
+if [ -d /home/zulip/deployments/current ]; then
+    DATA_IS_IN=$(su zulip -c '/home/zulip/deployments/current/manage.py shell -c "from django.db import connection; print(int(connection.cursor().connection.server_version/10000))"')
+
+    if [ "$UPGRADE_FROM" != "$DATA_IS_IN" ]; then
+        cat <<EOF
+
+/etc/zulip/zulip.conf claims that Zulip is running PostgreSQL
+$UPGRADE_FROM, but the server is connected to a PostgreSQL running
+version $DATA_IS_IN.  Check the output from pg_lsclusters to verify
+which clusters are running, and update /etc/zulip/zulip.conf to match.
+
+In general, this results from manually upgrading PostgreSQL; you
+should use this tool for all PostgreSQL upgrades.
+EOF
+        exit 1
+    fi
+fi
+
 set -x
 
 "$ZULIP_PATH"/scripts/lib/setup-apt-repo

--- a/scripts/setup/upgrade-postgresql
+++ b/scripts/setup/upgrade-postgresql
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 if [ "$EUID" -ne 0 ]; then
     echo "Error: This script must be run as root" >&2

--- a/scripts/setup/upgrade-postgresql
+++ b/scripts/setup/upgrade-postgresql
@@ -21,6 +21,11 @@ if [ "$UPGRADE_TO" = "$UPGRADE_FROM" ]; then
     exit 1
 fi
 
+if [[ "$UPGRADE_TO" -lt "$UPGRADE_FROM" ]]; then
+    echo "Refusing to downgrade PostgreSQL $UPGRADE_FROM to $UPGRADE_TO!"
+    exit 1
+fi
+
 set -x
 
 "$ZULIP_PATH"/scripts/lib/setup-apt-repo


### PR DESCRIPTION
This does a little raise the question of if we need to store `postgresql.version` in `/etc/zulip/zulip.conf` if we just explode whenever it disagrees with what Django is running.

An alternate form of this would set a Puppet variable as a default for the initial install, and otherwise have Puppet (which is I think the only thing which cares?) shell out to Django to ask what version it's using.  That's probably fiddlier than this band-aid, though, and preventing data loss is a good thing to get a fix for quickly.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
