### PR TITLE
code_pills: Update the border and background colors.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -955,14 +955,23 @@
             background-color: hsl(22deg 70% 35%);
         }
 
+        & code {
+            background-color: hsl(0deg 0% 100% / 13%);
+            color: hsl(0deg 0% 100% /90%);
+        }
+
+        & pre {
+            background-color: hsl(0deg 0% 100% / 4%);
+            border-color: hsl(0deg 0% 100% / 15%);
+        }
+
         .codehilite code,
         .codehilite pre {
             color: hsl(212deg 98% 82%);
-            background-color: hsl(212deg 0% 11%);
         }
 
-        .codehilite pre {
-            border: 1px solid hsl(0deg 0% 0% / 50%);
+        .codehilite code {
+            background: none;
         }
 
         .codehilite .hll {
@@ -1347,7 +1356,6 @@
     }
 
     #feedback_container,
-    code,
     .typeahead.dropdown-menu {
         background-color: hsl(212deg 25% 15%);
         border-color: hsl(0deg 0% 0% / 50%);

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -583,8 +583,9 @@
         padding: 5px 7px 3px;
         color: hsl(0deg 0% 20%);
         display: block;
-        border: 1px solid hsl(0deg 0% 0% / 15%);
         border-radius: 4px;
+        background-color: hsl(0deg 0% 100% / 85%);
+        border: 1px solid hsl(208deg 10% 70% / 50%);
 
         &:hover .copy_codeblock,
         &:hover .code_external_link {
@@ -599,6 +600,7 @@
         overflow-x: scroll;
         color: inherit;
         border: 0;
+        background: none;
     }
 
     & code {
@@ -608,12 +610,11 @@
         font-size: 0.825em;
         unicode-bidi: embed;
         direction: ltr;
-        color: hsl(0deg 0% 0%);
         white-space: pre-wrap;
-        padding: 0 4px;
-        background-color: hsl(0deg 0% 100%);
-        border: 1px solid hsl(240deg 13% 90%);
+        color: hsl(0deg 0% 0%);
+        padding: 1px 3px;
         border-radius: 3px;
+        background-color: hsl(208deg 10% 70% / 22%);
     }
 
     /* Style copy-to-clipboard button inside code blocks */


### PR DESCRIPTION
This commit modifies the styles of the code pills and is related to our ongoing redesign project.

Fixes part of #22022.

Related CZO [discussion](https://chat.zulip.org/#narrow/stream/431-redesign-project/topic/code.20pill.20colors)

<details>
<summary>Screenshots:</summary>

| Before | After |
|--------|--------|
| ![light_before](https://github.com/zulip/zulip/assets/53193850/f985c652-70b3-4286-a9c7-d70c301fc9be) | ![light_after](https://github.com/zulip/zulip/assets/53193850/25e6b2b9-daa7-4acc-b56d-3a2f82b00c41) |
| ![dark_before](https://github.com/zulip/zulip/assets/53193850/6223dba2-d32c-4831-8be8-e0cfd8b691bf) | ![dark_after](https://github.com/zulip/zulip/assets/53193850/adbb7fef-fd6c-4f59-88f5-9c3864eb8826) | 
</details>