### PR TITLE
popovers: Improve Tippy-based stream-popover UI lifecycle.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -332,12 +332,10 @@ export function do_schedule_message(send_at_time) {
 export function initialize() {
     register_popover_menu("#streams_inline_icon", {
         onShow(instance) {
-            popover_instances.stream_settings = instance;
             const can_create_streams =
                 settings_data.user_can_create_private_streams() ||
                 settings_data.user_can_create_public_streams() ||
                 settings_data.user_can_create_web_public_streams();
-            on_show_prep(instance);
 
             if (!can_create_streams) {
                 // If the user can't create streams, we directly
@@ -347,7 +345,12 @@ export function initialize() {
                 return false;
             }
 
+            // Assuming that the instance can be shown, track and
+            // prep the instance for showing
+            popover_instances.stream_settings = instance;
             instance.setContent(parse_html(render_left_sidebar_stream_setting_popover()));
+            on_show_prep(instance);
+
             //  When showing the popover menu, we want the
             // "Add streams" and the "Filter streams" tooltip
             //  to appear below the "Add streams" icon.
@@ -361,6 +364,8 @@ export function initialize() {
             filter_streams_tooltip._tippy?.setProps({
                 placement: "bottom",
             });
+
+            // The linter complains about unbalanced returns
             return true;
         },
         onHidden(instance) {


### PR DESCRIPTION
These changes appear to correct the keyboard-navigation repro from #25907, and it makes it possible for users without the permission to create streams to exit the streams modal by
hitting Esc.

This reorganizes logic within the Tippy `onShow` method to ensure that nothing is set or called for those users without stream-creation privileges.

These changes probably require broader testing to determine whether the fix addresses only that specific reproducer, or the broader problems #25907 addresses with malfunctioning j, k, Esc, and Return keys (when Ctrl + Return to send is enabled).

Fixes a part of #25907.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before, user (Polonious) without stream-create permissions:
![polonious-before](https://github.com/zulip/zulip/assets/170719/93f37fa7-34f2-4b80-a7ba-b459e5d9d0a3)
1. Open Streams modal (no tooltip)
2. Type `jkjkjk` in Filter streams box
3. Attempt to exit modal with Esc (nothing happens, although the cursor blinks out)
4. Exit modal by clicking ×
5. Attempt to type `just kidding` in message box, and Return for newlines
6. Return to Streams modal; type `jkjkjk` again without issue

After, user (Polonious) without stream-create permissions
![polonious-after](https://github.com/zulip/zulip/assets/170719/37537714-fd2e-45c3-b2ee-4b8b537df421)
1. Open Streams modal (no tooltip)
2. Type `jkjkjk` in Filter streams box
3. Exit modal with Esc (modal closes)
5. Type `just kidding` in message box, Return for newlines

Before (and After), user (Cordelia) with stream-create permissions
![cordelia-no-change](https://github.com/zulip/zulip/assets/170719/a5363981-ad60-4ff3-947c-ca0f49f30023)
1. Open Streams modal from Create stream (with tooltip)
2. Type `jkjkjk` in Filter streams box
3. Exit modal with Esc (modal closes)
5. Type `just kidding` in message box, Return for newlines

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
