### PR TITLE
compose: Fix bug with compose banners on mobile width.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -278,10 +278,22 @@
     border-radius: 5px;
     border: 1px solid;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     font-size: 15px;
     line-height: 18px;
+
+    .main-view-banner-elements-wrapper {
+        display: flex;
+        flex-grow: 1;
+        justify-content: space-between;
+
+        @media (width < $md_min) {
+            flex-direction: column;
+            flex-grow: 0;
+            align-items: flex-start;
+        }
+    }
 
     & p {
         margin: 0; /* override bootstrap */
@@ -289,8 +301,15 @@
         padding: 8px 5px 8px 15px;
     }
 
-    .banner_content {
-        flex-grow: 1;
+    @media (width >= $md_min) {
+        .banner_content {
+            align-self: center;
+        }
+
+        .banner-contains-button ~ .main-view-banner-close-button {
+            /* 2.5px: to vertically align `.main-view-banner-close-button` with `.main-view-banner-action-button`. */
+            margin-top: 2.5px;
+        }
     }
 
     .main-view-banner-action-button,
@@ -309,6 +328,11 @@
            close button. */
         &.right_edge {
             margin-right: 10px;
+        }
+
+        @media (width < $md_min) {
+            /* 100% - 10px(margin-left of the button) */
+            width: calc(100% - 10px);
         }
     }
 

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -3,14 +3,16 @@
   {{#if user_id}}data-user-id="{{user_id}}"{{/if}}
   {{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}}
   {{#if topic_name}}data-topic-name="{{topic_name}}"{{/if}}>
-    {{#if banner_text}}
-    <p class="banner_content">{{banner_text}}</p>
-    {{else}}
-    <div class="banner_content">{{> @partial-block}}</div>
-    {{/if}}
-    {{#if button_text}}
-    <button class="main-view-banner-action-button{{#if hide_close_button}} right_edge{{/if}}" {{#if scheduling_message}}data-validation-trigger="schedule"{{/if}}>{{button_text}}</button>
-    {{/if}}
+    <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
+        {{#if banner_text}}
+        <p class="banner_content">{{banner_text}}</p>
+        {{else}}
+        <div class="banner_content">{{> @partial-block}}</div>
+        {{/if}}
+        {{#if button_text}}
+        <button class="main-view-banner-action-button{{#if hide_close_button}} right_edge{{/if}}" {{#if scheduling_message}}data-validation-trigger="schedule"{{/if}}>{{button_text}}</button>
+        {{/if}}
+    </div>
     {{#if hide_close_button}}
     {{!-- hide_close_button is null by default, and false if explicitly set as false. --}}
     {{else}}


### PR DESCRIPTION
This commit lets compose banner to use more than one line on mobile widths(<576px) by wrapping .compose_banner_action_button and .banner_content in a flex .compose_banner_content_wrapper and making it column flex on width<576px shifting action button to a new line.

The close button is positioned top right on mobile widths.

CZO discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/compose.20banners.20on.20narrow.20screens

Fixes #25847

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

- Width>576px:
![image](https://github.com/zulip/zulip/assets/64723994/a24ceeb1-6bfa-43de-b608-6c52b6024cfb)

- Width = 500px:
![image](https://github.com/zulip/zulip/assets/64723994/700d7d2b-5602-4b8b-a426-6853aaa145a7)

- Width = 350px:
![image](https://github.com/zulip/zulip/assets/64723994/f96307ff-5d8b-49ec-8ac1-978eb04348eb)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
