### PR TITLE
compose: Add functionality for audio call.

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -459,6 +459,9 @@ function edit_message($row, raw_content) {
     $form
         .find(".message-edit-feature-group .video_link")
         .toggle(compose.compute_show_video_chat_button());
+    $form
+        .find(".message-edit-feature-group .audio_link")
+        .toggle(compose.compute_show_audio_chat_button());
     upload.feature_check($(`#edit_form_${CSS.escape(rows.id($row))} .compose_upload_file`));
 
     const $message_edit_content = $row.find("textarea.message_edit_content");

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -228,7 +228,7 @@ export function dispatch_normal_event(event) {
                 enable_spectator_access: noop,
                 signup_notifications_stream_id: noop,
                 emails_restricted_to_domains: noop,
-                video_chat_provider: compose.update_video_chat_button_display,
+                video_chat_provider: compose.update_audio_and_video_chat_button_display,
                 giphy_rating: giphy.update_giphy_rating,
                 waiting_period_threshold: noop,
                 want_advertise_in_communities_directory: noop,

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -6,6 +6,7 @@
     <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
     <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
     <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
+    <a role="button" class="compose_control_button fa fa-phone audio_link" aria-label="{{t 'Add audio call' }}" tabindex=0 data-tippy-content="{{t 'Add audio call' }}"></a>
     <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
     <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"></a>
     <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}}" data-tippy-content="{{t 'Add GIF' }}">

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -127,7 +127,7 @@ test("videos", ({override}) => {
         handler(ev);
         // video link ids consist of 15 random digits
         const video_link_regex =
-            /\[translated: Join video call\.]\(https:\/\/meet.jit.si\/\d{15}\)/;
+            /\[translated: Join video call\.]\(https:\/\/meet.jit.si\/\d{15}#config.startWithVideoMuted=false\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
     })();

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -83,9 +83,6 @@ test("videos", ({override}) => {
         const ev = {
             preventDefault() {},
             stopPropagation() {},
-            target: {
-                to_$: () => $textarea,
-            },
         };
 
         const handler = $("body").get_on_handler("click", ".video_link");


### PR DESCRIPTION
This PR adds the feature to add an audio call (video call with video muted by default) to the compose box.  Right now, the button to add that is only shown when the video call provider is set to `Jitsi Meet`. 

Fixes: #12207

Right now the PR does not have tests but I can add them once the design is finalized.

---

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


<details>

  

<summary>Adding Audio Call to the Chat</summary>

  

[Screencast from 07-06-23 04:49:20 PM IST.webm](https://github.com/sbansal1999/zulip/assets/35286603/86d068b0-a0dd-4a58-a362-53d718756ea6)

  

</details>

  

<details>

  

<summary>Changing Video Call Provider to None</summary>

  

[Screencast from 07-06-23 05:06:07 PM IST.webm](https://github.com/sbansal1999/zulip/assets/35286603/a6ca8fa0-5d45-4eaa-bd4c-abbd5d84490e)

  

</details>

  ---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
