### PR TITLE
tests: Improve automated tests for submessages.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18080,7 +18080,7 @@ components:
                 type: integer
                 description: |
                   The ID of the user who sent the message.
-              submessage_id:
+              id:
                 type: integer
                 description: |
                   The ID of the submessage.

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -200,3 +200,33 @@ class TestBasics(ZulipTestCase):
                     "Events should be sent only after the transaction commits."
                 )
                 do_add_submessage(hamlet.realm, hamlet.id, message_id, "whatever", "whatever")
+
+    def test_fetch_message_containing_submessages(self) -> None:
+        cordelia = self.example_user("cordelia")
+        stream_name = "Verona"
+        message_id = self.send_stream_message(
+            sender=cordelia,
+            stream_name=stream_name,
+        )
+        self.login_user(cordelia)
+
+        payload = dict(
+            message_id=message_id,
+            msg_type="whatever",
+            content='{"name": "alice", "salary": 20}',
+        )
+        self.assert_json_success(self.client_post("/json/submessage", payload))
+
+        result = self.client_get(f"/json/messages/{message_id}")
+        response_dict = self.assert_json_success(result)
+        self.assert_length(response_dict["message"]["submessages"], 1)
+
+        submessage = response_dict["message"]["submessages"][0]
+        expected_data = dict(
+            id=submessage["id"],
+            message_id=message_id,
+            content='{"name": "alice", "salary": 20}',
+            msg_type="whatever",
+            sender_id=cordelia.id,
+        )
+        self.assertEqual(submessage, expected_data)


### PR DESCRIPTION
Added an additional test case to `test_submessages.py` for testing the message object containing `submessages` meta data.

Previous to this commit we were never validating the `submessage` schema in the `message` objects.

Fixes #25896.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
