### PR TITLE
starred_messages_ui: Add initialize method for this module.

### DIFF
--- a/web/src/starred_messages_ui.js
+++ b/web/src/starred_messages_ui.js
@@ -99,3 +99,8 @@ export function confirm_unstar_all_messages_in_topic(stream_id, topic) {
         on_click,
     });
 }
+
+export function initialize() {
+    starred_messages.initialize();
+    rerender_ui();
+}

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -91,7 +91,7 @@ import * as settings_realm_user_settings_defaults from "./settings_realm_user_se
 import * as settings_sections from "./settings_sections";
 import * as settings_toggle from "./settings_toggle";
 import * as spoilers from "./spoilers";
-import * as starred_messages from "./starred_messages";
+import * as starred_messages_ui from "./starred_messages_ui";
 import * as stream_data from "./stream_data";
 import * as stream_edit from "./stream_edit";
 import * as stream_edit_subscribers from "./stream_edit_subscribers";
@@ -725,7 +725,7 @@ export function initialize_everything() {
     sent_messages.initialize();
     hotspots.initialize();
     typing.initialize();
-    starred_messages.initialize();
+    starred_messages_ui.initialize();
     user_status_ui.initialize();
     fenced_code.initialize(generated_pygments_data);
     message_edit_history.initialize();


### PR DESCRIPTION
We need to call `rerender_ui` once on the initial page load, hence we need to initialize `starred_message` module and call `rerender_ui` together.

Fixes #25935.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
