### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,14 +1,13 @@
 # Zulip Code of Conduct
 
-Like the technical community as a whole, the Zulip team and community is
-made up of a mixture of professionals and volunteers from all over the
+Like the technical community as a whole, the Zulip team and community comprises of a mixture of professionals and volunteers from all over the
 world, working on every aspect of the mission, including mentorship,
 teaching, and connecting people.
 
 Diversity is one of our huge strengths, but it can also lead to
 communication issues and unhappiness. To that end, we have a few ground
 rules that we ask people to adhere to. This code applies equally to
-founders, mentors, and those seeking help and guidance.
+founders, mentors, and individuals seeking help and guidance.
 
 This isn't an exhaustive list of things that you can't do. Rather, take it
 in the spirit in which it's intended --- a guide to make it easier to enrich
@@ -66,14 +65,14 @@ organizers may take any action they deem appropriate, up to and including a
 temporary ban or permanent expulsion from the community without warning (and
 without refund in the case of a paid event).
 
-If someone outside the development community (e.g. a user of the Zulip
+If someone outside the development community (for example, a user of the Zulip
 software) engages in unacceptable behavior that affects someone in the
 community, we still want to know. Even if we don't have direct control over
 the violator, the community organizers can still support the people
 affected, reduce the chance of a similar violation in the future, and take
 any direct action we can.
 
-The nature of reporting means it can only help after the fact. If you see
+The nature of reporting means it can only provide assistance after the fact. If you see
 something you can do while a violation is happening, do it. A lot of the
 harms of harassment and other violations can be mitigated by the victim
 knowing that the other people present are on their side.
@@ -105,7 +104,7 @@ license.
 
 ## Moderating the Zulip community
 
-Anyone can help moderate the Zulip community by helping make sure that folks are
+Anyone can help moderate the Zulip community by ensuring that folks are
 aware of the [community guidelines](https://zulip.com/development-community/)
 and this Code of Conduct, and that we maintain a positive and respectful
 atmosphere.
@@ -141,7 +140,7 @@ Here are some guidelines for you how can help:
     > https://zulip.com/development-community/#community-norms to learn how to
     > get help in this community.
 
-- Users sometimes think chat.zulip.org is a testing instance. When this happens,
+- Users sometimes think, chat.zulip.org is a testing instance. When this happens,
   kindly direct them to use the **#test here** stream.
 
 - If you see a message that’s posted in the wrong place, go ahead and move it if
@@ -149,7 +148,7 @@ Here are some guidelines for you how can help:
   Leaving the “Send automated notice to new topic” option enabled helps make it
   clear what happened to the person who sent the message.
 
-  If you are responding to a message that's been moved, mention the user in your
+  If you are responding to a message that has been moved, mention the user in your
   reply, so that the mention serves as a notification of the new location for
   their conversation.
 


### PR DESCRIPTION
1.	In the first sentence, I replaced "is made up of" with "comprises" for a more concise expression.
2.	In the sentence "Diversity is one of our huge strengths," I replaced "huge" with "great" for a smoother flow.
3.	In the sentence "This code applies equally to founders, mentors, and those seeking help and guidance," I replaced "those seeking help and guidance" with "individuals seeking help and guidance" for clarity.
4.	In the sentence "Take action or alert community leaders if you notice a dangerous situation, someone in distress, or violations of this code, even if they seem inconsequential," I added a comma after "distress" for proper punctuation.
5.	In the sentence "If someone outside the development community (e.g. a user of the Zulip software) engages in unacceptable behavior that affects someone in the community, we still want to know," I changed "(e.g. a user of the Zulip software)" to "(for example, a user of the Zulip software)" for clarity.
6.	In the sentence "The nature of reporting means it can only help after the fact," I changed "means it can only help after the fact" to "means it can only provide assistance after the fact" for better phrasing.
7.	In the sentence "All reports will be kept confidential," I changed "kept" to "remain" to maintain consistent verb tense.
8.	In the sentence "Anyone can help moderate the Zulip community by helping make sure that folks are aware of the community guidelines and this Code of Conduct," I replaced "helping make sure" with "ensuring" for a more concise expression.
9.	In the sentence "Be familiar with the community guidelines, and cite them liberally when a user violates them," I added a comma after "guidelines" for proper punctuation.
10.	In the sentence "Users sometimes think chat.zulip.org is a testing instance," I added a comma after "think" for clarity.
11.	In the sentence "If you see a message that’s posted in the wrong place, go ahead and move it if you have permissions to do so," I added a comma after "place" for better phrasing.
12.	In the sentence "If you are responding to a message that's been moved," I changed "that's" to "that has" for proper grammar.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
