### PR TITLE
css: Darken light-theme message text.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -147,7 +147,7 @@ body {
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
-    --color-default-text: hsl(0deg 0% 15%);
+    --color-text-message-default: hsl(0deg 0% 15%);
     --color-text-message-view-header: hsl(0deg 0% 20% / 100%);
     --color-text-message-header: hsl(0deg 0% 15%);
     --color-text-dropdown-input: hsl(0deg 0% 13.33%);
@@ -186,6 +186,9 @@ body {
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);
+    /* Unlike the light theme, the dark theme renders message
+       text in the default color. */
+    --color-text-message-default: var(--color-text-default);
     --color-text-message-view-header: hsl(0deg 0% 100% / 80%);
     --color-text-message-header: hsl(0deg 0% 100% / 80%);
     --color-text-sender-name: hsl(0deg 0% 100% / 85%);
@@ -1768,6 +1771,7 @@ div.focused_table {
 }
 
 .message_content {
+    color: var(--color-text-message-default);
     line-height: 1.214;
     min-height: 17px;
     display: block;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -48,9 +48,6 @@ body {
 :root {
     color-scheme: light;
 
-    --color-default-text: hsl(0deg 0% 15%);
-    --color-date: hsl(0deg 0% 15% / 75%);
-
     /*
     This is the header, aka the navbar.
     */
@@ -127,6 +124,7 @@ body {
     --max-unexpanded-compose-height: 40vh;
 
     /* Colors used across the app */
+    --color-date: hsl(0deg 0% 15% / 75%);
     --color-background-private-message-header: hsl(46deg 35% 93%);
     --color-background-private-message-content: hsl(45deg 20% 96%);
     --color-background-stream-message-content: hsl(0deg 0% 100%);
@@ -149,6 +147,7 @@ body {
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
+    --color-default-text: hsl(0deg 0% 15%);
     --color-text-message-view-header: hsl(0deg 0% 20% / 100%);
     --color-text-message-header: hsl(0deg 0% 15%);
     --color-text-dropdown-input: hsl(0deg 0% 13.33%);


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR subtly darkens the text-message color in the light theme to the HSL equivalent of a dark gray (`#262626`). See [CZO discussion](https://chat.zulip.org/#narrow/stream/431-redesign-project/topic/light.20theme.20text.20color.20change).

(Note that that color was already stored on an unused CSS variable, `--color-default-text`, which was not only unused but clashed hard with `--color-text-default`, which _is_ in use.)

This is the first time in the Zulip codebase where one CSS custom property is set to another: the dark theme preserves its use of `--color-text-default` in this way, but can be adjusted independently of the rest of the theme in the future by setting a different color value on `--color-text-message-default`. Related reading on this technique: https://css-tricks.com/a-complete-guide-to-custom-properties/#aa-properties-as-properties

Fixes a part of #22022.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before, light mode | After, light mode |
| --- | --- |
| <img width="824" alt="light-before" src="https://github.com/zulip/zulip/assets/170719/6325b6df-3708-4639-a4e3-d263adfd4436"> | <img width="824" alt="light-after" src="https://github.com/zulip/zulip/assets/170719/4bad29a3-74fd-494e-9d64-cc6108105ba2"> |

| Before, dark mode | After, dark mode (no change) |
| --- | --- |
| <img width="824" alt="dark-before" src="https://github.com/zulip/zulip/assets/170719/3979e05c-b092-4470-bb9c-34023203e500"> | <img width="824" alt="dark-after" src="https://github.com/zulip/zulip/assets/170719/8cd0dd86-38d7-4e96-992c-33388a08fda6"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
