### PR TITLE
IRC Integration: currently not working

### DIFF
--- a/templates/zerver/integrations/irc.md
+++ b/templates/zerver/integrations/irc.md
@@ -1,3 +1,9 @@
+!!! warn ""
+
+    This IRC integration is currently not working. Please consider
+    using [matterbridge](https://github.com/42wim/matterbridge)
+    until we get it working again.
+
 Mirror an IRC channel in Zulip!
 
 ### Install the bridge software


### PR DESCRIPTION
Per message: https://chat.zulip.org/#narrow/stream/9-issues/topic/IRC.20AioReactor.2Escheduler/near/1584689  this hasn't worked in a while. See the topic for more details.

Doc change: IRC integration currently not working.	

 