### PR TITLE
ts: Convert `stream_settings_containers.js` to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -194,7 +194,7 @@ EXEMPT_FILES = make_set(
         "web/src/stream_list.js",
         "web/src/stream_muting.js",
         "web/src/stream_popover.js",
-        "web/src/stream_settings_containers.js",
+        "web/src/stream_settings_containers.ts",
         "web/src/stream_settings_ui.js",
         "web/src/stream_ui_updates.js",
         "web/src/submessage.js",

--- a/web/src/stream_settings_containers.js
+++ b/web/src/stream_settings_containers.js
@@ -1,9 +1,0 @@
-import $ from "jquery";
-
-export function get_edit_container(sub) {
-    return $(
-        `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
-            sub.stream_id,
-        )}']`,
-    );
-}

--- a/web/src/stream_settings_containers.ts
+++ b/web/src/stream_settings_containers.ts
@@ -1,0 +1,13 @@
+import $ from "jquery";
+import assert from "minimalistic-assert";
+
+import type {StreamSubscription} from "./sub_store";
+
+export function get_edit_container(sub: StreamSubscription): JQuery {
+    assert(sub !== undefined, "Stream subscription is undefined.");
+    return $(
+        `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
+            sub.stream_id.toString(),
+        )}']`,
+    );
+}


### PR DESCRIPTION
Added assertion to enforce `sub` is not `undefined` and thus type safe for the rest.
Added type annotation to function parameter and return value.
