### PR TITLE
Scheduled messages banner

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -242,6 +242,8 @@
                         </div>
                         <div class="message_table" id="zfilt" role="list" aria-live="polite" aria-label="{{ _('Messages') }}">
                         </div>
+                        <div id="scheduled_message_banner">
+                        </div>
                         <div id="typing_notifications">
                         </div>
                         <div id="mark_read_on_scroll_state_banner">

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -26,6 +26,7 @@ import * as recent_topics_ui from "./recent_topics_ui";
 import * as recent_topics_util from "./recent_topics_util";
 import * as reload_state from "./reload_state";
 import * as resize from "./resize";
+import * as scheduled_messages from "./scheduled_messages";
 import * as settings_config from "./settings_config";
 import * as spectators from "./spectators";
 import * as stream_bar from "./stream_bar";
@@ -483,6 +484,7 @@ export function quote_and_reply(opts) {
 }
 
 export function on_narrow(opts) {
+    scheduled_messages.show_scheduled_message_banner();
     // We use force_close when jumping between PM narrows with the "p" key,
     // so that we don't have an open compose box that makes it difficult
     // to cycle quickly through unread messages.

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -10,8 +10,10 @@ import * as compose_banner from "./compose_banner";
 import * as compose_ui from "./compose_ui";
 import {$t} from "./i18n";
 import * as narrow from "./narrow";
+import * as narrow_state from "./narrow_state";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
+import * as scroll_util from "./scroll_util";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 
@@ -74,6 +76,7 @@ function hide_scheduled_message_success_compose_banner(scheduled_message_id) {
 export function add_scheduled_messages(scheduled_messages) {
     scheduled_messages_data.push(...scheduled_messages);
     sort_scheduled_messages_data();
+    show_scheduled_message_banner();
 }
 
 export function remove_scheduled_message(scheduled_message_id) {
@@ -83,6 +86,7 @@ export function remove_scheduled_message(scheduled_message_id) {
     if (msg_index !== undefined) {
         scheduled_messages_data.splice(msg_index, 1);
         hide_scheduled_message_success_compose_banner(scheduled_message_id);
+        show_scheduled_message_banner();
     }
 }
 
@@ -333,5 +337,25 @@ export function update_send_later_options() {
     if (should_update_send_later_options(now)) {
         const filtered_send_opts = get_filtered_send_opts(now);
         $("#send_later_options").replaceWith(render_send_later_modal_options(filtered_send_opts));
+    }
+}
+
+export function show_scheduled_message_banner() {
+    const messages = [];
+    for (const element of scheduled_messages_data) {
+        if (
+            element.to === narrow_state.stream_sub().stream_id &&
+            element.topic === narrow_state.topic()
+        ) {
+            messages.push(element);
+        }
+    }
+    const $banner_container = $("#scheduled_message_banner");
+    scroll_util.get_content_element($(`#scheduled_message_banner`)).empty();
+    if (messages.length !== 0) {
+        compose_banner.append_compose_banner_to_banner_list(
+            `You have ${messages.length} scheduled message(s) for this conversation.`,
+            $banner_container,
+        );
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2360,6 +2360,12 @@ nav {
     height: var(--max-unexpanded-compose-height);
 }
 
+#scheduled_message_banner {
+    display: inline-block;
+    text-align: center;
+    height: 24px;
+}
+
 .operator_value {
     font-family: "Source Code Pro", monospace;
     color: hsl(353deg 70% 65%);


### PR DESCRIPTION
This pull request addresses the linked issue https://github.com/zulip/zulip/issues/25584 of indicating scheduled messages in conversation view. 
To implement this, a new function called '`show_scheduled_message_banner()`' has been added, which filters through the `scheduled_messages_data` and checks both the stream id and the topic of each message. If the currently open stream and topic match the scheduled message stream and topic, the text '_You have N scheduled message(s) for this conversation._' will be displayed above the typing box.
The function is called when scheduled messages are added / deleted and so will update in real time with no need to refresh the page for this to update. 

UPDATE: Changed location of the banner to be just below the last message in the view..

Screenshot: 
![image](https://github.com/zulip/zulip/assets/118175949/77a5b940-ef65-48af-882a-9968df4b25ac)

