### PR TITLE
Redesign info overlay

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -150,7 +150,7 @@
 <div class="informational-overlays overlay new-style" data-overlay="informationalOverlays" aria-hidden="true">
     <div class="overlay-content overlay-container">
         <div class="overlay-tabs">
-            <span class="exit">&times;</span>
+            <span class="exit zulip-icon zulip-icon-close"></span>
         </div>
         <div class="overlay-body">
         </div>

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -72,7 +72,8 @@ export function adjust_mac_kbd_tags(kbd_elem_class: string): void {
         let key_text = $(this).text();
 
         if (fn_shortcuts.has(key_text)) {
-            $(this).before("<kbd>Fn</kbd> + ");
+            $(this).wrap('<span class="concurrent-hotkeys">');
+            $(this).before("<kbd>Fn</kbd>");
             $(this).addClass("arrow-key");
         }
 

--- a/web/src/info_overlay.js
+++ b/web/src/info_overlay.js
@@ -298,7 +298,7 @@ export function set_up_toggler() {
         "notdisplayed",
         !user_settings.escape_navigates_to_default_view,
     );
-    common.adjust_mac_kbd_tags(".hotkeys_table .hotkey kbd");
+    common.adjust_mac_kbd_tags(".hotkeys-table kbd");
     common.adjust_mac_kbd_tags("#markdown-instructions kbd");
 }
 

--- a/web/src/info_overlay.js
+++ b/web/src/info_overlay.js
@@ -21,7 +21,10 @@ import * as util from "./util";
 export let toggler;
 
 function format_usage_html(...keys) {
-    const get_formatted_keys = () => keys.map((key) => `<kbd>${key}</kbd>`).join("+");
+    const get_formatted_keys = () =>
+        `<span class="concurrent-hotkeys">${keys
+            .map((key) => `<kbd>${key}</kbd>`)
+            .join("")}</span>`;
     return $t_html(
         {
             defaultMessage: "(or <key-html></key-html>)",

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -658,6 +658,7 @@
     .dropdown-menu.typeahead,
     #settings_page,
     .informational-overlays .overlay-content {
+        background-color: hsl(0deg 0% 14% / 100%);
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -662,6 +662,11 @@
         box-shadow: 0 0 30px hsl(212deg 32% 7%);
     }
 
+    .informational-overlays .overlay-tabs {
+        background: hsl(0deg 0% 14% / 100%);
+        box-shadow: 0 2px 8px hsl(0deg 0% 0% / 45%);
+    }
+
     #draft_overlay,
     #scheduled_messages_overlay_container {
         .flex.overlay-content > div {

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -12,20 +12,21 @@
     }
 
     .overlay-tabs {
-        padding: 10px 0;
-        border-bottom: 1px solid hsl(0deg 0% 0% / 20%);
+        display: flex;
+        align-items: center;
+        gap: 15px;
+        padding: 0 5%;
+        height: 60px;
+        box-shadow: 0 3px 12px 1px hsl(207deg 100% 11% / 8%);
 
         .tab-switcher {
-            margin-left: 15px;
+            flex-grow: 1;
         }
 
         .exit {
-            float: right;
-            font-size: 1.5rem;
-            color: hsl(0deg 0% 67%);
-            font-weight: 600;
-            margin: 0 15px;
+            color: hsl(0deg 0% 60%);
             cursor: pointer;
+            order: 1;
         }
     }
 

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -1,12 +1,11 @@
 .informational-overlays {
+    display: grid;
+    place-items: center;
+
     .overlay-content {
-        /* because zoom breaks at 525px perhaps due to rounding errors, so add a
-           trivial amount of width so it doesn't break. */
-        width: 550px;
-        margin: 0 auto;
-        position: relative;
-        top: calc((30vh - 50px) / 2);
-        border-radius: 4px;
+        width: 90%;
+        max-width: 650px;
+        border-radius: 6px;
         overflow: hidden;
 
         background-color: var(--color-background-modal);
@@ -34,90 +33,149 @@
         padding-bottom: 10px;
 
         .overlay-scroll-container {
-            height: 70vh;
-            text-align: center;
+            height: 75vh;
             outline: none;
+        }
 
-            .help-table {
-                table-layout: fixed;
-            }
+        .simplebar-content {
+            padding: 35px 30px 35px 25px !important;
+        }
 
-            & th {
-                font-weight: 400;
+        & a {
+            color: var(--color-text-link);
+
+            &:hover {
+                color: var(--color-text-link) !important;
             }
         }
-    }
 
-    & td.operator {
-        font-size: 0.9em;
-    }
-}
-
-.hotkeys_table {
-    table-layout: fixed;
-    width: 100%;
-    vertical-align: middle;
-    display: table;
-
-    & td.definition {
-        /* keeps dividing line at same width for all tables in model. */
-        width: calc(50% - 11px);
-        text-align: right;
-    }
-
-    .hotkey {
-        font-weight: normal;
-    }
-
-    .small_hotkey {
-        font-size: 0.9em !important;
-        line-height: 12px;
+        .documentation-link {
+            text-align: center;
+            margin-top: 35px;
+        }
 
         & kbd {
-            font-size: 0.9em;
+            font-family: "Source Sans 3 VF", sans-serif;
+
+            /* Contains stylistic variant of upper-case character "I" in Source Sans 3 VF. */
+            font-feature-settings: "ss01" on;
+            margin: 6px 6px 0;
+            padding: 1px 0.5em;
+            font-size: 14px;
+            font-weight: 400;
+            color: var(--color-keyboard);
+            background: none;
+            border: solid 1.5px var(--color-keyboard);
+            border-radius: 5px;
+            text-shadow: none;
+        }
+
+        .concurrent-hotkeys {
+            display: inline-flex;
+            white-space: nowrap;
+            padding: 6px 6px 0;
+            gap: 4px;
+
+            & kbd {
+                margin: 0;
+            }
         }
     }
 
-    .arrow-key {
-        font-size: 1.36em;
-        line-height: 1;
-        padding: 0 0.2em 0.2em;
-    }
+    .help-table {
+        width: 100%;
+        margin-bottom: 2rem;
+        color: var(--color-text);
+        border-collapse: collapse;
 
-    & th {
-        width: 245px;
-        text-align: center;
-        /* aligns table name with dividing line */
-    }
-
-    & td:not(.definition) {
-        text-align: left;
-        white-space: normal;
-        font-weight: bold;
-    }
-}
-
-#keyboard-shortcuts table {
-    margin-bottom: 10px !important;
-}
-
-@media only screen and (width < $md_min) {
-    .informational-overlays {
-        .overlay-content {
-            width: calc(100% - 20px);
+        .operator {
+            width: 50%;
         }
 
-        .tab-switcher {
-            display: flex;
+        & tbody {
+            & tr {
+                border-bottom: solid 1px var(--color-table-border);
 
-            &.large .ind-tab {
-                width: 100%;
+                &:first-child {
+                    border-top: solid 1px var(--color-table-border);
+                }
             }
         }
 
-        .hotkeys_table {
-            width: 100%;
-            display: table;
+        & thead {
+            background: none !important;
+        }
+
+        & th {
+            color: var(--color-title);
+            font-size: 1.3rem;
+            line-height: 125%;
+            text-align: left;
+            padding: 0 0 1rem;
+        }
+
+        & td {
+            padding: 0.75rem 1rem 0.75rem 0;
+            width: 50%;
+            color: var(--color-text);
+            text-align: left;
+            vertical-align: middle;
+
+            &[colspan] {
+                text-align: center;
+            }
+        }
+    }
+
+    .hotkeys-table {
+        & th {
+            text-align: center;
+        }
+
+        & th,
+        & td {
+            padding: 0.5rem 0;
+        }
+
+        & td {
+            &:not(.definition) {
+                /* contradict top-margin of kbd tag */
+                padding-top: calc(0.5rem - 6px);
+
+                width: 47%;
+                color: var(--color-sub-text);
+                text-align: right;
+            }
+
+            &.definition {
+                padding-left: 0.4rem;
+
+                .emoji {
+                    width: 1.35em;
+                    height: 1.35em;
+                }
+            }
+        }
+    }
+
+    @media only screen and (width < $md_min) {
+        .informational-overlays {
+            .overlay-content {
+                width: calc(100% - 20px);
+            }
+
+            .tab-switcher {
+                display: flex;
+
+                &.large .ind-tab {
+                    width: 100%;
+                }
+            }
+
+            .hotkeys-table {
+                width: 100%;
+                display: table;
+            }
         }
     }
 }

--- a/web/styles/informational_overlays.css
+++ b/web/styles/informational_overlays.css
@@ -128,6 +128,12 @@
         }
     }
 
+    #operators-instructions {
+        & .help-table tr:last-child td {
+            padding: 20px 0;
+        }
+    }
+
     .hotkeys-table {
         & th {
             text-align: center;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -300,6 +300,14 @@ body {
     --color-background-btn-inbox-focus: hsl(0deg 0% 80%);
     --color-icons-inbox: hsl(0deg 0% 0%);
     --color-background-icon-close-hover: hsl(0deg 0% 0% / 5%);
+
+    /* Information overlay colors */
+    --color-title: hsl(0deg 0% 0%);
+    --color-text: hsl(0deg 0% 20%);
+    --color-sub-text: hsl(0deg 0% 45%);
+    --color-keyboard: hsl(227deg 78% 59%);
+    --color-text-link: hsl(217deg 100% 50%);
+    --color-table-border: hsl(0deg 0% 93%);
 }
 
 %dark-theme {
@@ -432,6 +440,14 @@ body {
     --color-background-btn-inbox-focus: hsl(0deg 0% 20%);
     --color-icons-inbox: hsl(0deg 0% 100%);
     --color-background-icon-close-hover: hsl(0deg 0% 100% / 5%);
+
+    /* Information overlay colors  */
+    --color-title: hsl(0deg 0% 100%);
+    --color-text: hsl(0deg 0% 100% / 75%);
+    --color-sub-text: hsl(0deg 0% 100% / 60%);
+    --color-keyboard: hsl(225deg 100% 84%);
+    --color-text-link: hsl(217deg 100% 65% / 100%);
+    --color-table-border: hsl(0deg 0% 0% / 40%);
 }
 
 @media screen {

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -2,241 +2,243 @@
   aria-label="{{t 'Keyboard shortcuts' }}">
     <div class="overlay-scroll-container" data-simplebar data-simplebar-auto-hide="false">
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t "The basics" }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
                     <td class="definition">{{t 'Reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>C</kbd></td>
                     <td class="definition">{{t 'New stream message' }}</td>
-                    <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>X</kbd></td>
                     <td class="definition">{{t 'New direct message' }}</td>
-                    <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Esc</kbd> or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span></td>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>D</kbd></td>
                     <td class="definition">{{t 'View drafts' }}</td>
-                    <td><span class="hotkey"><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></td>
                     <td class="definition">{{t 'Next message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>End</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>G</kbd></span></td>
                     <td class="definition">{{t 'Last message' }}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>N</kbd></td>
                     <td class="definition">{{t 'Next unread topic' }}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>P</kbd></td>
                     <td class="definition">{{t 'Next unread direct message' }}</td>
-                    <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>K</kbd></span> or <span class="concurrent-hotkeys"><kbd>/</kbd></span></td>
                     <td class="definition">{{t 'Initiate a search' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>?</kbd></td>
                     <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
-                    <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span><span id="go-to-default-view-hotkey-help"> or <kbd>Esc</kbd></span></td>
                     <td class="definition">{{t 'Go to home view' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>[</kbd><span id="go-to-default-view-hotkey-help"> or <kbd>Esc</kbd></span></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Navigation' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>K</kbd></span> or <span class="concurrent-hotkeys"><kbd>/</kbd></span></td>
                     <td class="definition">{{t 'Initiate a search' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Q</kbd></td>
                     <td class="definition">{{t 'Filter streams' }}</td>
-                    <td><span class="hotkey"><kbd>Q</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>W</kbd></td>
                     <td class="definition">{{t 'Search people' }}</td>
-                    <td><span class="hotkey"><kbd>W</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></td>
                     <td class="definition">{{t 'Previous message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></td>
                     <td class="definition">{{t 'Next message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>PgUp</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>K</kbd></span></td>
                     <td class="definition">{{t 'Scroll up' }}</td>
-                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>PgDn</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>J</kbd></span> or <span class="concurrent-hotkeys"><kbd>Space</kbd></span></td>
                     <td class="definition">{{t 'Scroll down' }}</td>
-                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Shift</kbd> + <kbd>J</kbd> or <kbd>Space</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>End</kbd> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>G</kbd></span></td>
                     <td class="definition">{{t 'Last message' }}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Home</kbd></td>
                     <td class="definition">{{t 'First message' }}</td>
-                    <td><span class="hotkey"><kbd>Home</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Alt</kbd><kbd class="arrow-key">←</kbd></span></td>
                     <td class="definition">{{t 'Go back through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">←</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Alt</kbd><kbd class="arrow-key">→</kbd></span></td>
                     <td class="definition">{{t 'Go forward through viewing history' }}</td>
-                    <td><span class="hotkey"><kbd>Alt</kbd> + <kbd class="arrow-key">→</kbd></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Composing messages' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd>C</kbd></td>
                     <td class="definition">{{t 'New stream message' }}</td>
-                    <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>X</kbd></td>
                     <td class="definition">{{t 'New direct message' }}</td>
-                    <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Enter</kbd> or <kbd>R</kbd></td>
                     <td class="definition">{{t 'Reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>></kbd></td>
                     <td class="definition">{{t 'Quote and reply to message' }}</td>
-                    <td><span class="hotkey"><kbd>></kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>R</kbd></span></td>
                     <td class="definition">{{t 'Reply directly to sender' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>@</kbd></td>
                     <td class="definition">{{t 'Reply @-mentioning sender' }}</td>
-                    <td><span class="hotkey"><kbd>@</kbd></span></td>
                 </tr>
                 <tr>
+                    <td>
+                        <span class="concurrent-hotkeys">
+                            <span><kbd>Tab</kbd></span> then <kbd>Enter</kbd>
+                        </span>
+                        or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>Enter</kbd></span>
+                    </td>
                     <td class="definition">{{t 'Send message' }}</td>
-                    <td><span class="hotkey"><span class="small_hotkey"><kbd>Tab</kbd> then <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd></span></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>Enter</kbd></span></td>
                     <td class="definition">{{t 'Insert new line' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Esc</kbd> or <span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>[</kbd></span></td>
                     <td class="definition">{{t 'Cancel compose and save draft' }}</td>
-                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Narrowing' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd>S</kbd></td>
                     <td class="definition">{{t 'Narrow to topic or DM conversation' }}</td>
-                    <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>S</kbd></td>
                     <td class="definition">{{t 'Narrow to stream from topic view' }}</td>
-                    <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>P</kbd></span></td>
                     <td class="definition">{{t 'Narrow to all direct messages' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Z</kbd></td>
                     <td class="definition">{{t 'Zoom to message in conversation context' }}</td>
-                    <td><span class="hotkey"><kbd>Z</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>N</kbd></td>
                     <td class="definition">{{t 'Narrow to next unread topic' }}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>P</kbd></td>
                     <td class="definition">{{t 'Narrow to next unread direct message' }}</td>
-                    <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>A</kbd></span> or <span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>D</kbd></span></td>
                     <td class="definition">{{t 'Cycle between stream narrows' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>A</kbd></td>
                     <td class="definition">{{t 'Narrow to all unmuted messages' }}</td>
-                    <td><span class="hotkey"><kbd>A</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>.</kbd></span></td>
                     <td class="definition">{{t 'Narrow to current compose box recipient' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>.</kbd></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Message actions' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd class="arrow-key">←</kbd></td>
                     <td class="definition">{{t 'Edit your last message' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t "Show message sender's user card"   }}</td>
-                    <td><span class="hotkey"><kbd>U</kbd></span></td>
+                    <td><kbd>U</kbd></td>
+                    <td class="definition">{{t "Show message sender's user card" }}</td>
                 </tr>
                 <tr>
+                    <td><kbd>V</kbd></td>
                     <td class="definition">{{t 'Show images in thread' }}</td>
-                    <td><span class="hotkey"><kbd>V</kbd></span></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
+                    <td><kbd>E</kbd></td>
                     <td class="definition">{{t 'Edit selected message or view source' }}</td>
-                    <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
                 <tr id="move-message-hotkey-help">
+                    <td><kbd>M</kbd></td>
                     <td class="definition">{{t 'Move messages or topic' }}</td>
-                    <td><span class="hotkey"><kbd>M</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{{t 'View edit and move history' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>H</kbd></span></td>
-                </tr>
-                <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Ctrl</kbd><kbd>S</kbd></span></td>
                     <td class="definition">{{t 'Star selected message' }}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>+</kbd></td>
                     <td class="definition">
                         {{t 'React to selected message with' }}
                         <img alt=":thumbs_up:"
@@ -244,119 +246,120 @@
                           src="../../static/generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>
-                    <td><span class="hotkey"><kbd>+</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>=</kbd></td>
                     <td class="definition">{{t 'Toggle first emoji reaction on selected message' }}</td>
-                    <td><span class="hotkey"><kbd>=</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>U</kbd></span></td>
                     <td class="definition">{{t 'Mark as unread from selected message' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>U</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>-</kbd></td>
                     <td class="definition">{{t 'Collapse/show selected message' }}</td>
-                    <td><span class="hotkey"><kbd>-</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>M</kbd></span></td>
                     <td class="definition">{{t 'Toggle topic mute' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>M</kbd></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Recent conversations' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd>T</kbd></td>
                     <td class="definition">{{t 'View recent conversations' }}</td>
-                    <td><span class="hotkey"><kbd>T</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>T</kbd></td>
                     <td class="definition">{{t 'Filter topics' }}</td>
-                    <td><span class="hotkey"><kbd>T</kbd></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Drafts' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd>D</kbd></td>
                     <td class="definition">{{t 'View drafts' }}</td>
-                    <td><span class="hotkey"><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Enter</kbd></td>
                     <td class="definition">{{t 'Edit selected draft' }}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>Backspace</kbd></td>
                     <td class="definition">{{t 'Delete selected draft' }}</td>
-                    <td><span class="hotkey"><kbd>Backspace</kbd></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Menus' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd>G</kbd></td>
                     <td class="definition">{{t 'Toggle the gear menu' }}</td>
-                    <td><span class="hotkey"><kbd>G</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>I</kbd></td>
                     <td class="definition">{{t 'Open message menu' }}</td>
-                    <td><span class="hotkey"><kbd>I</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>:</kbd></td>
                     <td class="definition">{{t 'Open reactions menu' }}</td>
-                    <td><span class="hotkey"><kbd>:</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>?</kbd></td>
                     <td class="definition">{{t 'Show keyboard shortcuts' }}</td>
-                    <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>
             </table>
         </div>
         <div>
-            <table class="hotkeys_table table table-striped table-bordered">
+            <table class="hotkeys-table help-table">
                 <thead>
                     <tr>
                         <th colspan="2">{{t 'Streams settings' }}</th>
                     </tr>
                 </thead>
                 <tr>
+                    <td><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></td>
                     <td class="definition">{{t 'Scroll through streams' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></td>
                     <td class="definition">{{t 'Switch between tabs' }}</td>
-                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>V</kbd></span></td>
                     <td class="definition">{{t 'View stream messages' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><span class="concurrent-hotkeys"><kbd>Shift</kbd><kbd>S</kbd></span></td>
                     <td class="definition">{{t 'Subscribe to/unsubscribe from selected stream' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
+                    <td><kbd>N</kbd></td>
                     <td class="definition">{{t 'Create new stream' }}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
             </table>
         </div>
-        <hr />
-        <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
+
+        <div class="documentation-link">
+            <a href="/help/keyboard-shortcuts" target="_blank" rel="noopener noreferrer">{{t 'Detailed keyboard shortcuts documentation' }}</a>
+        </div>
     </div>
 </div>

--- a/web/templates/markdown_help.hbs
+++ b/web/templates/markdown_help.hbs
@@ -2,7 +2,7 @@
   aria-label="{{t 'Message formatting' }}">
     <div class="overlay-scroll-container" data-simplebar data-simplebar-auto-hide="false">
         <div id="markdown-instructions">
-            <table class="table table-striped table-rounded table-bordered help-table">
+            <table class="help-table">
                 <thead>
                     <tr>
                         <th>{{t "You type" }}</th>
@@ -24,7 +24,9 @@
                 </tbody>
             </table>
         </div>
-        <hr />
-        <a href="/help/format-your-message-using-markdown" target="_blank" rel="noopener noreferrer">{{t "Detailed message formatting documentation" }}</a>
+
+        <div class="documentation-link" >
+            <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
+        </div>
     </div>
 </div>

--- a/web/templates/search_operators.hbs
+++ b/web/templates/search_operators.hbs
@@ -1,7 +1,7 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog" aria-label="{{t 'Search filters' }}">
     <div class="overlay-scroll-container" data-simplebar data-simplebar-auto-hide="false">
         <div id="operators-instructions">
-            <table class="table table-striped table-rounded table-bordered help-table">
+            <table class="help-table">
                 <thead>
                     <tr>
                         <th>{{t "Filter" }}</th>
@@ -156,11 +156,17 @@
                             {{/tr}}
                         </td>
                     </tr>
+                    <tr>
+                        <td colspan="2">
+                            {{t "You can combine search filters as needed." }}
+                        </td>
+                    </tr>
                 </tbody>
             </table>
-            <p>{{t "You can combine search filters as needed." }}</p>
-            <hr />
-            <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
+
+            <div class="documentation-link" >
+                <a href="help/search-for-messages#search-filters" target="_blank" rel="noopener noreferrer">{{t "Detailed search filters documentation" }}</a>
+            </div>
         </div>
     </div>
 </div>

--- a/web/tests/common.test.js
+++ b/web/tests/common.test.js
@@ -106,7 +106,7 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
     ]);
 
     const fn_shortcuts = new Set(["Home", "End", "PgUp", "PgDn"]);
-    const inserted_fn_key = "<kbd>Fn</kbd> + ";
+    const inserted_fn_key = "<kbd>Fn</kbd>";
 
     override(navigator, "platform", "MacIntel");
 
@@ -122,7 +122,12 @@ run_test("adjust_mac_kbd_tags mac", ({override}) => {
             $stub.before = ($elem) => {
                 assert.equal($elem, inserted_fn_key);
             };
+
+            $stub.wrap = ($elem) => {
+                assert.equal($elem, '<span class="concurrent-hotkeys">');
+            };
         }
+
         test_item.$stub = $stub;
         test_item.mac_key = mac_key;
         test_item.adds_arrow_key = fn_shortcuts.has(old_key);


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Rebased the Work by @Taiki-Choda in #23547.

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

Before:
![image](https://github.com/zulip/zulip/assets/64723994/4cb3d93b-7d8e-45fb-ad69-2ec020a6f667)

After:
![image](https://github.com/zulip/zulip/assets/64723994/533f9598-c962-4389-bd70-240038049865)

Before:
![image](https://github.com/zulip/zulip/assets/64723994/ab9ab7c1-d2d5-4e12-ac0a-774e103ca919)

After:
![image](https://github.com/zulip/zulip/assets/64723994/7531fe0d-93f5-469e-99cb-fada8e467b2b)

Before:
![image](https://github.com/zulip/zulip/assets/64723994/2e9d7c4c-81af-46a6-b004-5e1fd6638649)

After:
![image](https://github.com/zulip/zulip/assets/64723994/ef1026b7-46a2-4726-9c78-096ee407d2a8)

Before:
![image](https://github.com/zulip/zulip/assets/64723994/db837c1f-0168-4822-8660-c7b76404a745)

After:
![image](https://github.com/zulip/zulip/assets/64723994/49c0898c-86f2-4636-adac-281d9c4783c4)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
