### PR TITLE
Set `direct_messages` link to all direct messages

### DIFF
--- a/web/src/hash_util.js
+++ b/web/src/hash_util.js
@@ -144,6 +144,10 @@ export function huddle_with_url(user_ids_string) {
     return "#narrow/dm/" + user_ids_string + "-group";
 }
 
+export function all_pm_url() {
+    return "#narrow/is/dm";
+}
+
 export function by_conversation_and_time_url(message) {
     const absolute_url =
         window.location.protocol +

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -412,6 +412,7 @@ function format_conversation(conversation_data) {
         displayed_other_senders = extra_sender_ids.slice(-MAX_EXTRA_SENDERS);
     } else if (type === "private") {
         // Private message info
+        context.all_pm_url = hash_util.all_pm_url();
         context.user_ids_string = last_msg.to_user_ids;
         context.rendered_pm_with = last_msg.display_recipient
             .filter(

--- a/web/templates/recent_topic_row.hbs
+++ b/web/templates/recent_topic_row.hbs
@@ -4,7 +4,7 @@
             <div class="left_part recent_topics_focusable">
                 {{#if is_private}}
                 <span class="fa fa-envelope"></span>
-                <a href="{{pm_url}}">Direct messages</a>
+                <a href="{{all_pm_url}}">Direct messages</a>
                 {{else}}
                 <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
                     {{> stream_privacy }}
@@ -22,7 +22,7 @@
                     <span class="zulip-icon zulip-icon-bot" aria-hidden="true"></span>
                     {{else}}
                     <span class="{{user_circle_class}} user_circle"></span>
-                    {{/if}}
+                {{/if}}
                 </span>
             </div>
             {{/if}}


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip/issues/25647

This PR changes the `Direct Messages` link in the **Recent Conversations** left-sidebar tab to link to the `Direct Messages` left-sidebar tab. The original issue describes that the keyboard navigation doesn't work for the "All Direct Messages" tab but to my knowledge, there is no keyboard to highlight that tab (there is only the `Shift + P` keyboard shortcut that goes directly to the All Direct Messages tab.

I believe that the issue is referencing the issue in this PR, which is the `Direct Messages` link in the `Recent Conversations` tab links to the original Direct Message, instead of having having a link that references the All Direct Messages tab and one Direct Messages tab. As seen in the screenshot below:
![Screen Shot 2023-06-10 at 8 48 17 PM](https://github.com/zulip/zulip/assets/57203431/c26a524e-51d0-4601-88b6-aabb38b11d49)

Happy to make further adjustments if the issue isn't resolved.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ X] Explains differences from previous plans (e.g., issue description).
- [ X] Highlights technical choices and bugs encountered.
- [ X] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ X] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ X] Visual appearance of the changes.
- [ X] Responsiveness and internationalization.
- [ X] Strings and tooltips.
- [ X] End-to-end functionality of buttons, interactions and flows.
- [ X] Corner cases, error conditions, and easily imagined bugs.
</details>
