### PR TITLE
user_groups: Prevent cycles when adding subgroups for a user group.

### DIFF
--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -905,6 +905,7 @@ class UserGroupAPITestCase(UserGroupTestCase):
             realm, "leadership", [desdemona, iago, hamlet], acting_user=None
         )
         support_group = check_add_user_group(realm, "support", [hamlet, othello], acting_user=None)
+        test_group = check_add_user_group(realm, "test", [hamlet], acting_user=None)
 
         self.login("cordelia")
         # Non-admin and non-moderators who are not a member of group cannot add or remove subgroups.
@@ -966,6 +967,28 @@ class UserGroupAPITestCase(UserGroupTestCase):
             ("User group {group_id} is already a subgroup of this group.").format(
                 group_id=leadership_group.id
             ),
+        )
+
+        self.login("iago")
+        params = {"add": orjson.dumps([support_group.id]).decode()}
+        result = self.client_post(f"/json/user_groups/{leadership_group.id}/subgroups", info=params)
+        self.assert_json_error(
+            result,
+            (
+                "User group {user_group_id} is already a subgroup of one of the passed subgroups."
+            ).format(user_group_id=leadership_group.id),
+        )
+
+        params = {"add": orjson.dumps([support_group.id]).decode()}
+        result = self.client_post(f"/json/user_groups/{test_group.id}/subgroups", info=params)
+
+        params = {"add": orjson.dumps([test_group.id]).decode()}
+        result = self.client_post(f"/json/user_groups/{leadership_group.id}/subgroups", info=params)
+        self.assert_json_error(
+            result,
+            (
+                "User group {user_group_id} is already a subgroup of one of the passed subgroups."
+            ).format(user_group_id=leadership_group.id),
         )
 
         lear_realm = get_realm("lear")

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -25,6 +25,7 @@ from zerver.lib.user_groups import (
     access_user_group_by_id,
     access_user_groups_as_potential_subgroups,
     get_direct_memberships_of_users,
+    get_recursive_subgroups_for_groups,
     get_subgroup_ids,
     get_user_group_direct_member_ids,
     get_user_group_member_ids,
@@ -237,6 +238,14 @@ def add_subgroups_to_group_backend(
                     group_id=group.id
                 )
             )
+
+    subgroup_ids = [group.id for group in subgroups]
+    if user_group_id in get_recursive_subgroups_for_groups(subgroup_ids):
+        raise JsonableError(
+            _(
+                "User group {user_group_id} is already a subgroup of one of the passed subgroups."
+            ).format(user_group_id=user_group_id)
+        )
 
     add_subgroups_to_user_group(user_group, subgroups, acting_user=user_profile)
     return json_success(request)


### PR DESCRIPTION
The user group depedency graph should always be a DAG. This PR adds code to make sure we keep the graph DAG while adding subgroups to a user group.

<!-- Describe your pull request here.-->
https://chat.zulip.org/#narrow/stream/3-backend/topic/UserGroup.20cycles

Fixes: <!-- Issue link, or clear description.--> #25913

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
