### PR TITLE
topics: Rename (no topic) to "general chat".

### DIFF
--- a/help/require-topics.md
+++ b/help/require-topics.md
@@ -1,7 +1,7 @@
 # Require topics in stream messages
 
-If a user sends a message without a topic, the message's topic is displayed as
-**(no topic)**. Administrators can configure whether stream messages must have a
+If a user sends a message without a topic, the message's topic is set to
+**"general chat"**. Administrators can configure whether stream messages must have a
 specified topic.
 
 ## Require topics in stream messages

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -69,6 +69,7 @@ IGNORED_PHRASES = [
     r"keyword",
     r"streamname",
     r"user@example\.com",
+    r"general chat",
     # Fragments of larger strings
     (r"your subscriptions on your Streams page"),
     r"Add global time<br />Everyone sees global times in their own time zone\.",

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -115,7 +115,7 @@ export function abort_video_callbacks(edit_message_id = "") {
 }
 
 export function empty_topic_placeholder() {
-    return $t({defaultMessage: "(no topic)"});
+    return $t({defaultMessage: "general chat"});
 }
 
 export function create_message_object() {

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -500,7 +500,7 @@ function validate_stream_message(scheduling_message) {
         const topic = compose_state.topic();
         // TODO: We plan to migrate the empty topic to only using the
         // `""` representation for i18n reasons, but have not yet done so.
-        if (topic === "" || topic === "(no topic)") {
+        if (topic === "") {
             compose_banner.show_error_message(
                 $t({defaultMessage: "Topics are required in this organization."}),
                 compose_banner.CLASSNAMES.topic_missing,

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -275,6 +275,7 @@ test_ui("validate", ({override_rewire, mock_template}) => {
         name: "Denmark",
     };
     stream_data.add_sub(denmark);
+    stream_data.subscribe_myself(denmark);
     compose_state.set_stream_name("Denmark");
     page_params.realm_mandatory_topics = true;
     compose_state.topic("");
@@ -291,9 +292,9 @@ test_ui("validate", ({override_rewire, mock_template}) => {
     assert.ok(missing_topic_error_rendered);
 
     missing_topic_error_rendered = false;
-    compose_state.topic("(no topic)");
-    assert.ok(!compose_validate.validate());
-    assert.ok(missing_topic_error_rendered);
+    compose_state.topic("general chat");
+    assert.ok(compose_validate.validate());
+    assert.ok(!missing_topic_error_rendered);
 });
 
 test_ui("get_invalid_recipient_emails", ({override_rewire}) => {

--- a/web/tests/message_edit.test.js
+++ b/web/tests/message_edit.test.js
@@ -111,7 +111,7 @@ run_test("is_topic_editable", ({override}) => {
     page_params.is_admin = false;
     assert.equal(message_edit.is_topic_editable(message), false);
 
-    message.topic = "translated: (no topic)";
+    message.topic = "translated: general chat";
     assert.equal(message_edit.is_topic_editable(message), false);
 
     message.topic = "test topic";

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1338,9 +1338,6 @@ def check_message(
             # else can sneak past the access check.
             assert sender.bot_type == sender.OUTGOING_WEBHOOK_BOT
 
-        if realm.mandatory_topics and topic_name == "(no topic)":
-            raise JsonableError(_("Topics are required in this organization"))
-
     elif addressee.is_private():
         user_profiles = addressee.user_profiles()
         mirror_message = client.name in [

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -401,11 +401,11 @@ def is_forwarded(subject: str) -> bool:
 
 def process_stream_message(to: str, message: EmailMessage) -> None:
     subject_header = message.get("Subject", "")
-    subject = strip_from_subject(subject_header) or "(no topic)"
+    subject = strip_from_subject(subject_header) or "general chat"
 
     # We don't want to reject email messages with disallowed characters in the Subject,
     # so we just remove them to make it a valid Zulip topic name.
-    subject = "".join([char for char in subject if is_character_printable(char)]) or "(no topic)"
+    subject = "".join([char for char in subject if is_character_printable(char)]) or "general chat"
 
     stream, options = decode_stream_email_address(to)
     # Don't remove quotations if message is forwarded, unless otherwise specified:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -331,7 +331,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         self.assertEqual(message.content, "TestStreamEmailMessages body")
         self.assertEqual(get_display_recipient(message.recipient), stream.name)
-        self.assertEqual(message.topic_name(), "(no topic)")
+        self.assertEqual(message.topic_name(), "general chat")
 
     def test_receive_stream_email_messages_subject_with_nonprintable_chars(
         self,
@@ -363,7 +363,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         process_message(incoming_valid_message)
         message = most_recent_message(user_profile)
 
-        self.assertEqual(message.topic_name(), "(no topic)")
+        self.assertEqual(message.topic_name(), "general chat")
 
     def test_receive_private_stream_email_messages_success(self) -> None:
         user_profile = self.example_user("hamlet")
@@ -1614,12 +1614,12 @@ class TestStreamEmailMessagesSubjectStripping(ZulipTestCase):
         message = most_recent_message(user_profile)
         self.assertEqual("Test", message.topic_name())
 
-        # If after stripping we get an empty subject, it should get set to (no topic)
+        # If after stripping we get an empty subject, it should get set to "general chat"
         del incoming_valid_message["Subject"]
         incoming_valid_message["Subject"] = "Re: Fwd: Re: "
         process_message(incoming_valid_message)
         message = most_recent_message(user_profile)
-        self.assertEqual("(no topic)", message.topic_name())
+        self.assertEqual("general chat", message.topic_name())
 
     def test_strip_from_subject(self) -> None:
         subject_list = orjson.loads(self.fixture_data("subjects.json", type="email"))

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -1208,7 +1208,7 @@ class EditMessageTest(EditMessageTestCase):
         )
 
         # topic edit permissions apply on "no topic" messages as well
-        message.set_topic_name("(no topic)")
+        message.set_topic_name("general chat")
         message.save()
         do_edit_message_assert_error(
             id_, "G", "The time limit for editing this message's topic has passed.", "cordelia"

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2555,15 +2555,12 @@ class CheckMessageTest(ZulipTestCase):
         sender = self.example_user("iago")
         client = make_client(name="test suite")
         stream = get_stream("Denmark", realm)
-        topic_name = "(no topic)"
+        topic_name = "general chat"
         message_content = "whatever"
         addressee = Addressee.for_stream(stream, topic_name)
 
         do_set_realm_property(realm, "mandatory_topics", True, acting_user=None)
         realm.refresh_from_db()
-
-        with self.assertRaisesRegex(JsonableError, "Topics are required in this organization"):
-            check_message(sender, client, addressee, message_content, realm)
 
         do_set_realm_property(realm, "mandatory_topics", False, acting_user=None)
         realm.refresh_from_db()

--- a/zerver/webhooks/slack_incoming/tests.py
+++ b/zerver/webhooks/slack_incoming/tests.py
@@ -7,7 +7,7 @@ class SlackIncomingHookTests(WebhookTestCase):
     WEBHOOK_DIR_NAME = "slack_incoming"
 
     def test_message(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 Hello, world.
 """.strip()
@@ -38,7 +38,7 @@ Hello, world.
             self.assert_stream_message(
                 message=msg,
                 stream_name=self.STREAM_NAME,
-                topic_name="(no topic)",
+                topic_name="general chat",
                 content=output_value,
             )
 
@@ -86,7 +86,7 @@ Danny Torrence left the following *review* for your property:
         )
 
     def test_message_with_blocks(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 Danny Torrence left the following review for your property:
 
@@ -139,7 +139,7 @@ Danny Torrence left the following review for your property:
         # Paste the JSON into
         # https://api.slack.com/tools/block-kit-builder to see how it
         # is rendered in Slack
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## Hello from TaskBot
 
@@ -174,7 +174,7 @@ There are two ways to quickly create tasks:
     def test_attachment_blocks(self) -> None:
         # On https://api.slack.com/tools/block-kit-builder choose
         # "Attachment preview" and paste the JSON in.
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 This is a section block with an accessory image.
 
@@ -196,7 +196,7 @@ This is a section block with a button.
         )
 
     def test_attachment_fields(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 Build bla bla succeeded
 
@@ -216,7 +216,7 @@ Value without title
         )
 
     def test_attachment_pieces(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## Test
 
@@ -239,7 +239,7 @@ Value without title
         return self.webhook_fixture_data("slack_incoming", fixture_name, file_type=file_type)
 
     def test_attachment_pieces_title_null(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 Sample pretext.
 
@@ -259,7 +259,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_image_url_null(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -279,7 +279,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_ts_null(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -299,7 +299,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_text_null(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -319,7 +319,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_pretext_null(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -339,7 +339,7 @@ Sample footer.
         )
 
     def test_attachment_pieces_footer_null(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## [Sample title.](https://www.google.com)
 
@@ -359,7 +359,7 @@ Sample text.
         )
 
     def test_attachment_pieces_title_link_null(self) -> None:
-        expected_topic = "(no topic)"
+        expected_topic = "general chat"
         expected_message = """
 ## Sample title.
 

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -56,7 +56,7 @@ def api_slack_incoming_webhook(
         user_specified_topic = re.sub("^[@#]", "", channel)
 
     if user_specified_topic is None:
-        user_specified_topic = "(no topic)"
+        user_specified_topic = "general chat"
 
     pieces = []
     if "blocks" in payload and payload["blocks"]:


### PR DESCRIPTION
As plans to make it easier for new users to pick a topic and help with the onboarding process, we want to rename the default topic "(no topic)" to "general chat" for the messages sent without a topic.

Previously, when topics are required to send a message for an organization, (no topic) was no longer an option as a topic name. With the rename, this restriction has been removed.

Fixes: #23291.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
