### PR TITLE
compose_banner: Remove uploads banners when clearing compose box.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -187,6 +187,7 @@ export function clear_compose_box() {
     compose_ui.autosize_textarea($("#compose-textarea"));
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
+    compose_banner.clear_uploads();
     compose_ui.hide_compose_spinner();
     popover_menus.reset_selected_schedule_timestamp();
 }

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -78,6 +78,7 @@ function clear_box() {
     compose_ui.autosize_textarea($("#compose-textarea"));
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
+    compose_banner.clear_uploads();
 }
 
 export function autosize_message_content() {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -106,6 +106,10 @@ export function clear_warnings(): void {
     $(`#compose_banners .${CSS.escape(WARNING)}`).remove();
 }
 
+export function clear_uploads(): void {
+    $("#compose_banners .upload_banner").remove();
+}
+
 export function clear_unmute_topic_notifications(): void {
     $(`#compose_banners .${CLASSNAMES.unmute_topic_notification.replaceAll(" ", ".")}`).remove();
 }

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -199,6 +199,7 @@ export function update_compose_for_message_type(message_type, opts) {
     }
     compose_banner.clear_errors();
     compose_banner.clear_warnings();
+    compose_banner.clear_uploads();
 }
 
 export function on_compose_select_recipient_update() {

--- a/web/tests/lib/compose_banner.js
+++ b/web/tests/lib/compose_banner.js
@@ -12,6 +12,7 @@ exports.mock_banners = () => {
     }
     $("#compose_banners .warning").remove = () => {};
     $("#compose_banners .error").remove = () => {};
+    $("#compose_banners .upload_banner").remove = () => {};
 
     const $stub = $.create("stub_to_remove");
     const $cb = $("#compose_banners");


### PR DESCRIPTION
The reason for these changes is that we had a bug where upload banners were not cleared after closing the compose box. This change will make the code simpler and help us clear all the banners with less effort.

Related CZO discussion: [#issues > Incomplete Upload banner remains on closing compose](https://chat.zulip.org/#narrow/stream/9-issues/topic/Incomplete.20Upload.20banner.20remains.20on.20closing.20compose)