### PR TITLE
popovers: Prevent the popover from closing on scroll.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3065,6 +3065,9 @@ select.invite-as {
     /* `simplebar-content-wrapper` has `tabindex=0` set, which makes it focusable
         but we don't want it to have an outline when focused anywhere in the app. */
     outline: none;
+
+    /* This prevents the popover from closing once the top/bottom is reached */
+    overscroll-behavior: contain;
 }
 
 .dropdown-list-container {


### PR DESCRIPTION
This changes prevent popover closure when scrolling of popover reaches the top or bottom.

 Fixes: #25967 .

Related CZO discussion: [#issues > Incorrect scrollbar behavior in groups popover #25967](https://chat.zulip.org/#narrow/stream/9-issues/topic/Incorrect.20scrollbar.20behavior.20in.20groups.20popover.20.2325967)