### PR TITLE
github: Configure templates for filing issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_discussed_on_czo.md
+++ b/.github/ISSUE_TEMPLATE/1_discussed_on_czo.md
@@ -1,0 +1,10 @@
+---
+name: Issue discussed in the Zulip development community
+about: Bug report, feature or improvement already discussed on chat.zulip.org.
+---
+
+<!-- Issue description -->
+
+<!-- Link to a message in the chat.zulip.org discussion. Message links will still work even if the topic is renamed or resolved. Link back to this issue from the chat.zulip.org thread. -->
+
+CZO thread

--- a/.github/ISSUE_TEMPLATE/2_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: A concrete bug report with steps to reproduce the behavior. (See also "Possible bug" below.)
+labels: ["bug"]
+---
+
+<!-- Describe what you were expecting to see, what you saw instead, and steps to take in order to reproduce the buggy behavior. Screenshots can be helpful. -->
+
+<!-- Check the box for the version of Zulip you are using (see https://zulip.com/help/view-zulip-version).-->
+
+**Zulip Server and web app version:**
+
+- [ ] Zulip Cloud (`*.zulipchat.com`)
+- [ ] Zulip Server 7.0+
+- [ ] Zulip Server 6.0+
+- [ ] Zulip Server 5.0 or older
+- [ ] Other or not sure

--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,0 +1,6 @@
+---
+name: Feature or improvement request
+about: A specific proposal for a new feature of improvement. (See also "Feature suggestion or feedback" below.)
+---
+
+<!-- Describe the proposal, including how it would help you or your organization. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Possible bug
+    url: https://zulip.readthedocs.io/en/latest/contributing/reporting-bugs.html
+    about: Report unexpected behavior that may be a bug.
+  - name: Feature suggestion or feedback
+    url: https://zulip.readthedocs.io/en/latest/contributing/suggesting-features.html
+    about: Start a discussion about your idea for improving Zulip.
+  - name: Issue with running or upgrading a Zulip server
+    url: https://zulip.readthedocs.io/en/latest/production/troubleshooting.html
+    about: We provide free, interactive support for the vast majority of questions about running a Zulip server.
+  - name: Other support requests and sales questions
+    url: https://zulip.com/help/contact-support
+    about: Contact us — we're happy to help!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,9 @@ needs doing:
 **Non-code contributions**: Some of the most valuable ways to contribute
 don't require touching the codebase at all. For example, you can:
 
-- Report issues, including both feature requests and [bug
+- Report issues, including both [feature
+  requests](https://zulip.readthedocs.io/en/latest/contributing/suggesting-features.html)
+  and [bug
   reports](https://zulip.readthedocs.io/en/latest/contributing/reporting-bugs.html).
 - [Give feedback](#user-feedback) if you are evaluating or using Zulip.
 - [Participate

--- a/help/support-zulip-project.md
+++ b/help/support-zulip-project.md
@@ -66,7 +66,9 @@ Collective](https://opencollective.com/zulip).
 
 ## Help improve Zulip
 
-* **Report issues**, including both feature requests and [bug
+* **Report issues**, including both [feature
+  requests](https://zulip.readthedocs.io/en/latest/contributing/suggesting-features.html)
+  and [bug
   reports](https://zulip.readthedocs.io/en/latest/contributing/reporting-bugs.html).
   Many improvements to the Zulip app start with a user's suggestion.
 


### PR DESCRIPTION
Follow-up to #25998, pushed as a separate PR so that the original one can pass CI.

This PR creates templates for filing issues. The templates are intentionally quite light-weight. Note that I'm specifically not using [forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) for creating issues, as the UI for filling out such a form does not include GitHub's helpful formatting buttons and preview mode.

 More importantly, users will be presented with the following options when creating an issue:

![Screen Shot 2023-06-12 at 3 27 48 PM](https://github.com/zulip/zulip/assets/2090066/e6486a9b-1e6e-4fe5-88ff-7928b1ed6b5f)

A major goal is to guide users towards starting a CZO conversation when that's more appropriate than filing a GitHub issue.

Note that the config makes it possible to create a blank issue, which should be handy for:
- Issues filed by maintainers
- Issues for tracking follow-ups from merged PRs
- Probably some other situations

Because the blank issue option is easy to miss, it should probably be documented somewhere, but I'm not sure where. We can perhaps start with a note on CZO.

Relevant CZO threads:
- https://chat.zulip.org/#narrow/stream/137-feedback/topic/issues.20link.20in.20description/near/1561110)
- https://chat.zulip.org/#narrow/stream/2-general/topic/bug.20report.20management/near/1589141

Please review carefully, as my testing involved copy-pasting config files around to try things out.