### PR TITLE
Add capability of  delete messages for bot owners

### DIFF
--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -32,6 +32,7 @@ import * as message_live_update from "./message_live_update";
 import * as message_store from "./message_store";
 import * as message_viewport from "./message_viewport";
 import {page_params} from "./page_params";
+import * as people from "./people";
 import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
@@ -153,12 +154,23 @@ export function is_content_editable(message, edit_limit_seconds_buffer = 0) {
     return false;
 }
 
+export function is_message_sent_by_my_bot(message) {
+    const user = people.get_by_user_id(message.sender_id);
+    if (user.bot_owner_id === undefined || user.bot_owner_id === null) {
+        // The message was not sent by a bot or the message was sent
+        // by a cross-realm bot which does not have an owner.
+        return false;
+    }
+
+    return people.is_my_user_id(user.bot_owner_id);
+}
+
 export function get_deletability(message) {
     if (page_params.is_admin) {
         return true;
     }
 
-    if (!message.sent_by_me) {
+    if (!message.sent_by_me && !is_message_sent_by_my_bot(message)) {
         return false;
     }
     if (message.locally_echoed) {

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -146,8 +146,8 @@ def validate_can_delete_message(user_profile: UserProfile, message: Message) -> 
     if user_profile.is_realm_admin:
         # Admin can delete any message, any time.
         return
-    if message.sender != user_profile:
-        # Users can only delete messages sent by them.
+    if message.sender != user_profile and message.sender.bot_owner_id != user_profile.id:
+        # Users can only delete messages sent by them or by their bots.
         raise JsonableError(_("You don't have permission to delete this message"))
     if not user_profile.can_delete_own_message():
         # Only user with roles as allowed by delete_own_message_policy can delete message.


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: [this](https://github.com/zulip/zulip/issues/25971)
This pr adds bot owners to delete messages of their bots' messages.

![Screenshot_20230613_142929](https://github.com/zulip/zulip/assets/39624400/5124c7be-445c-49d0-864f-5e7f251f5805)

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
