### PR TITLE
hooks: Tell Sentry the explicit commit range.

### DIFF
--- a/puppet/zulip/files/hooks/pre-deploy.d/sentry.hook
+++ b/puppet/zulip/files/hooks/pre-deploy.d/sentry.hook
@@ -24,8 +24,9 @@ curl "https://sentry.io/api/0/organizations/$sentry_org/releases/" \
 
 merge_base="${ZULIP_NEW_MERGE_BASE_COMMIT:-}"
 if [ -n "$merge_base" ]; then
+    old_merge_base="$ZULIP_OLD_MERGE_BASE_COMMIT"
     echo "sentry: Setting commit range based on merge-base to upstream of $merge_base"
-    sentry-cli releases --org="$sentry_org" set-commits "$sentry_release" --commit="zulip/zulip@$merge_base"
+    sentry-cli releases --org="$sentry_org" set-commits "$sentry_release" --commit="zulip/zulip@$old_merge_base..$merge_base"
 fi
 
 if [ -n "$sentry_frontend_project" ]; then


### PR DESCRIPTION
This is necessary if one has different deployments (with different commit ranges) using the same projects.

See https://docs.sentry.io/product/releases/associate-commits/#using-the-cli for the API of the `sentry-cli` tool.

---

Tested with a test prod instance.  We run into this with chat.zulip.org and Zulip Cloud, where their deploy ranges step on each other unless we are explicit about the commits that each deploy contains.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
