### PR TITLE
navbar: Fix regression where navbar didn't extend all the way.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -448,7 +448,7 @@ p.n-margin {
 
 #navbar-middle .column-middle-inner,
 #userlist-toggle-button,
-.header-main,
+.header,
 #message_view_header {
     background-color: var(--color-background-navbar);
     box-shadow: inset 0 -1px 0 var(--color-navbar-bottom-border);


### PR DESCRIPTION
Followup to d0c1668399fd773bef7b569069dc2146e3c79a8a

fixed:
<img width="1196" alt="image" src="https://github.com/zulip/zulip/assets/5634097/14155f32-1978-4b52-8ae2-a239a8b97212">
