### PR TITLE
api-docs: Update mute and unmute user endpoint documentation.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8964,8 +8964,9 @@ paths:
       summary: Mute a user
       tags: ["users"]
       description: |
-        This endpoint [mutes a user](/help/mute-a-user). Messages sent by users
-        you've muted will be automatically marked as read and hidden.
+        [Mute a user](/help/mute-a-user) from the perspective of the requesting
+        user. Messages sent by muted users will be automatically marked as read
+        and hidden for the user who muted them.
 
         Muted users should be implemented by clients as follows:
 
@@ -8973,10 +8974,11 @@ paths:
           user as read. This will automatically clear any existing mobile
           push notifications related to the muted user.
         - The server will mark any new messages sent by the muted user as read
-          for your account, which prevents all email and mobile push notifications.
+          for the requesting user's account, which prevents all email and mobile
+          push notifications.
         - Clients should exclude muted users from presence lists or other UI
-          for viewing or composing 1:1 direct messages. 1:1 direct messages sent by
-          muted users should be hidden everywhere in the Zulip UI.
+          for viewing or composing one-on-one direct messages. One-on-one direct
+          messages sent by muted users should be hidden everywhere in the Zulip UI.
         - Stream messages and group direct messages sent by the muted
           user should avoid displaying the content and name/avatar,
           but should display that N messages by a muted user were
@@ -9024,7 +9026,8 @@ paths:
       summary: Unmute a user
       tags: ["users"]
       description: |
-        This endpoint unmutes a user.
+        [Unmute a user](/help/mute-a-user#see-your-list-of-muted-users)
+        from the perspective of the requesting user.
 
         **Changes**: New in Zulip 4.0 (feature level 48).
       parameters:
@@ -18939,9 +18942,10 @@ components:
       name: muted_user_id
       in: path
       description: |
-        The ID of the user to mute/un-mute.
+        The ID of the user to mute/unmute.
 
-        **Changes**: Before Zulip 8.0 (feature level 188), it was an error to specify a bot user.
+        **Changes**: Before Zulip 8.0 (feature level 188), bot users could not
+        be muted/unmuted, and specifying a bot user's ID returned an error response.
       schema:
         type: integer
       example: 10


### PR DESCRIPTION
Updates the main descriptions for the [mute a user](https://zulip.com/api/mute-user) and [unmute a user](https://zulip.com/api/unmute-user) endpoint documentation. Also, revises the `muted_user_id` parameter description and **Changes** note for feature level 188.

The feature level 188 changes were made in #26005.

**Screenshots and screen captures:**

<details>
<summary>Mute a user - main description</summary>

[Current documentation](https://zulip.com/api/mute-user)
![Screenshot from 2023-06-14 13-31-52](https://github.com/zulip/zulip/assets/63245456/2aec7e98-5ac4-4482-8a78-ec84c379f806)
</details>
<details>
<summary>Unmute a user - main description</summary>

[Current documentation](https://zulip.com/api/unmute-user)
![Screenshot from 2023-06-14 13-32-20](https://github.com/zulip/zulip/assets/63245456/fe13fdb7-1045-4de8-a535-7e0403ebf501)
</details>
<details>
<summary>muted_user_id parameter</summary>

[Current documentation](https://zulip.com/api/mute-user#parameter-muted_user_id)
![Screenshot from 2023-06-14 13-32-35](https://github.com/zulip/zulip/assets/63245456/5956ce0f-1a40-4366-8ee2-aaec93f53a46)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
