### PR TITLE
api-docs: Clarify what topics are returned by `/api/get-stream-topics`.

### DIFF
--- a/help/bots-and-integrations.md
+++ b/help/bots-and-integrations.md
@@ -55,6 +55,11 @@ A few more details:
 * Bots can be subscribed to streams, and their role can be modified if
   they need to have permission to do administrative actions.
 
+* [Stream permissions](/help/stream-permissions) are the same for bots
+  as for other users. Therefore, for private streams with protected
+  history, a bot can only access messages sent after it subscribed
+  to the stream.
+
 * **Generic**: A generic bot is like a normal Zulip user account that
   cannot log in via a browser.  Note that if you truly want to
   impersonate yourself (e.g. write messages that come from your Zulip

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8283,7 +8283,14 @@ paths:
       summary: Get topics in a stream
       tags: ["streams"]
       description: |
-        Get all the topics in a specific stream
+        Get all topics the user has access to in a specific stream.
+
+        Note that for private streams with [protected
+        history](/help/stream-permissions), the user will only have access to
+        topics of messages sent after they [subscribed to](/api/subscribe) the
+        stream. Similarly, a user's [bot](/help/bots-and-integrations#bot-type)
+        will only have access to messages sent after the bot was subscribed to
+        the stream, instead of when the user subscribed.
       parameters:
         - $ref: "#/components/parameters/StreamIdInPath"
       responses:


### PR DESCRIPTION
Updates the main description for the [`/api/get-stream-topics`](https://zulip.com/api/get-stream-topics) endpoint so that it is clear that the topics for private streams with protected history are limited to the topics / messages the user has access to.

And updates that documentation and the help center documentation for bot permissions / abilities, to clarify that bots have the same restriction and can only access messages / topics that are sent after the bot (not the bot's owner) subscribed to the stream.

See [relevant CZO discussion](https://chat.zulip.org/#narrow/stream/378-api-design/topic/API.20get.20topics/near/1592168).

---

**Screenshots and screen captures:**

<details>
<summary>Get topics in a stream</summary>

[Current documentation](https://zulip.com/api/get-stream-topics)
![Screenshot from 2023-06-14 16-23-41](https://github.com/zulip/zulip/assets/63245456/d19edda9-05ba-4665-aafc-078f3e4b3b86)
</details>

<details>
<summary>About bots - bot type section</summary>

[Current documentation](https://zulip.com/help/bots-and-integrations#bot-type)
![Screenshot from 2023-06-14 16-23-57](https://github.com/zulip/zulip/assets/63245456/9b0cecd6-a06f-4c90-b025-1323ca1c4d7e)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
