### PR TITLE
puppet: Support IPv6 nameservers.

### DIFF
--- a/puppet/zulip/lib/puppet/functions/resolver_ip.rb
+++ b/puppet/zulip/lib/puppet/functions/resolver_ip.rb
@@ -6,6 +6,11 @@ Puppet::Functions.create_function(:resolver_ip) do
     if parsed[:nameserver].empty?
       raise 'No nameservers found in /etc/resolv.conf!  Configure one by setting application_server.nameserver in /etc/zulip/zulip.conf'
     end
-    parsed[:nameserver][0]
+    resolver = parsed[:nameserver][0]
+    if resolver.include?(':')
+      '[' + resolver + ']'
+    else
+      resolver
+    end
   end
 end

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -78,6 +78,9 @@ class zulip::app_frontend_base {
     # This may fail in the unlikely change that there is no configured
     # resolver in /etc/resolv.conf, so only call it is unset in zulip.conf
     $nginx_resolver_ip = resolver_ip()
+  } elsif (':' in $configured_nginx_resolver) and ! ('.' in $configured_nginx_resolver)  and ! ('[' in $configured_nginx_resolver) {
+    # Assume this is IPv6, which needs square brackets.
+    $nginx_resolver_ip = "[${configured_nginx_resolver}]"
   } else {
     $nginx_resolver_ip = $configured_nginx_resolver
   }


### PR DESCRIPTION
The syntax in `/etc/resolv.conf` does not include any brackets:
```
nameserver 2001:db8::a3
```

However, the format of the nginx `resolver` directive[^1] requires that IPv6 addresses be enclosed in brackets.

Adjust the `resolver_ip` puppet function to surround any IPv6 addresses extracted from `/etc/resolv.conf` with square brackets.

Fixes: #26013.

[^1]: http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
