### PR TITLE
narrow: Support string and integer encoding "id" operator.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 194**
+
+* [`GET /messages`](/api/get-messages),
+  [`GET /messages/matches_narrow`](/api/check-messages-match-narrow),
+  [`POST /message/flags/narrow`](/api/update-message-flags-for-narrow),
+  [`POST /register`](/api/register-queue):
+  For [search/narrow filters](/api/construct-narrow) with the `id`
+  operator, added support for encoding the message ID operand as either
+  a string or an integer. Previously, only string encoding was supported.
+
 **Feature level 193**
 
 * [`POST /messages/{message_id}/reactions`](/api/add-reaction),

--- a/api_docs/construct-narrow.md
+++ b/api_docs/construct-narrow.md
@@ -65,11 +65,32 @@ filters did.
 
 ## Narrows that use IDs
 
+### Message IDs
+
 The `near` and `id` operators, documented in the help center, use message
 IDs for their operands.
 
 * `near:12345`: Search messages around the message with ID `12345`.
 * `id:12345`: Search for only message with ID `12345`.
+
+The message ID operand for the `id` operator may be encoded as either a
+number or a string. The message ID operand for the `near` operator must
+be encoded as a string.
+
+**Changes**: Prior to Zulip 8.0 (feature level 194), the message ID
+operand for the `id` operator needed to be encoded as a string.
+
+
+```json
+[
+    {
+        "operator": "id",
+        "operand": 12345
+    }
+]
+```
+
+### Stream and user IDs
 
 There are a few additional narrow/search options (new in Zulip 2.1)
 that use either stream IDs or user IDs that are not documented in the

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 193
+API_FEATURE_LEVEL = 194
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -751,11 +751,17 @@ def narrow_parameter(var_name: str, json: str) -> OptionalNarrowListT:
             return dict(operator=elem[0], operand=elem[1])
 
         if isinstance(elem, dict):
-            # Make sure to sync this list to frontend also when adding a new operator.
-            # that supports user IDs. Relevant code is located in web/src/message_fetch.js
-            # in handle_operators_supporting_id_based_api function where you will need to update
-            # operators_supporting_id, or operators_supporting_ids array.
-            operators_supporting_id = ["sender", "group-pm-with", "stream", "dm-including"]
+            # Make sure to sync this list to frontend also when adding a new operator that
+            # supports integer IDs. Relevant code is located in web/src/message_fetch.js
+            # in handle_operators_supporting_id_based_api function where you will need to
+            # update operators_supporting_id, or operators_supporting_ids array.
+            operators_supporting_id = [
+                "id",
+                "stream",
+                "sender",
+                "group-pm-with",
+                "dm-including",
+            ]
             operators_supporting_ids = ["pm-with", "dm"]
             operators_non_empty_operand = {"search"}
 

--- a/zerver/tests/test_message_fetch.py
+++ b/zerver/tests/test_message_fetch.py
@@ -417,8 +417,12 @@ class NarrowBuilderTest(ZulipTestCase):
             "WHERE NOT (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s OR recipient_id IN (__[POSTCOMPILE_recipient_id_3]))",
         )
 
-    def test_add_term_using_id_operator(self) -> None:
+    def test_add_term_using_id_operator_integer(self) -> None:
         term = dict(operator="id", operand=555)
+        self._do_add_term_test(term, "WHERE id = %(param_1)s")
+
+    def test_add_term_using_id_operator_string(self) -> None:
+        term = dict(operator="id", operand="555")
         self._do_add_term_test(term, "WHERE id = %(param_1)s")
 
     def test_add_term_using_id_operator_invalid(self) -> None:
@@ -3412,10 +3416,11 @@ class GetOldMessagesTest(ZulipTestCase):
     def test_invalid_narrow_operand_in_dict(self) -> None:
         self.login("hamlet")
 
-        # str or int is required for "sender", "stream", "dm-including" and "group-pm-with" operators
+        # str or int is required for "id", "sender", "stream", "dm-including" and "group-pm-with"
+        # operators
         invalid_operands = [["1"], [2], None]
         error_msg = 'elem["operand"] is not a string or integer'
-        for operand in ["sender", "group-pm-with", "stream", "dm-including"]:
+        for operand in ["id", "sender", "stream", "dm-including", "group-pm-with"]:
             self.exercise_bad_narrow_operand_using_dict_api(operand, invalid_operands, error_msg)
 
         # str or int list is required for "dm" and "pm-with" operator
@@ -3432,7 +3437,7 @@ class GetOldMessagesTest(ZulipTestCase):
         # For others only str is acceptable
         invalid_operands = [2, None, [1]]
         error_msg = 'elem["operand"] is not a string'
-        for operand in ["is", "near", "has", "id"]:
+        for operand in ["is", "near", "has"]:
             self.exercise_bad_narrow_operand_using_dict_api(operand, invalid_operands, error_msg)
 
         # Disallow empty search terms


### PR DESCRIPTION
Expands support for the message ID operands for "near" and "id" operators to be either a string or an integer. Previously, these operands were always validated as strings.

Also, checks that the value for the operand of the "near" operator is an integer and returns the same error as the "id" operator if it is not.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60id.3A123.60.20narrow.20in.20.60GET.20.2Fmessages.60/near/1591465)

**Notes**:
- The `id` parameter already was written to support both string and integer formats, so mostly just extended the tests for both cases and adjusted the documented operators that accept integer IDs.
- Expanded the `near` operator to mirror the `id` operator in the check for the error case.
- Manually tested via curl `get-message` requests in the dev environment that sending either format for the message ID (string or integer) returns the same response after these changes.

---

**Screenshots and screen captures:**

<details>
<summary>API changelog - feature level 190 entry</summary>

![Screenshot from 2023-06-14 18-19-45](https://github.com/zulip/zulip/assets/63245456/a60e83ea-e6cc-4c90-96e2-299d2afd1a57)
</details>
<details>
<summary>Construct a narrow - Narrows that use IDs section</summary>

[Current documentation](https://zulip.com/api/construct-narrow#narrows-that-use-ids)
![Screenshot from 2023-06-14 18-21-05](https://github.com/zulip/zulip/assets/63245456/8d9d9012-afda-4b47-99e7-ad0809700417)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
