### PR TITLE
narrow: Mark as read in `by_recipient` based on case ("dm" or "stream").

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -918,23 +918,32 @@ export function by_recipient(target_id, opts) {
     // don't use message_lists.current as it won't work for muted messages or for out-of-narrow links
     const message = message_store.get(target_id);
 
-    if (
-        user_settings.web_mark_read_on_scroll_policy !==
-        web_mark_read_on_scroll_policy_values.never.code
-    ) {
-        // We don't check message_list.can_mark_messages_read
-        // here because the target message_list isn't initialized;
-        // but the targeted message is about to be marked read
-        // in the new view.
-        unread_ops.notify_server_message_read(message);
-    }
-
     switch (message.type) {
         case "private":
+            if (
+                user_settings.web_mark_read_on_scroll_policy !==
+                web_mark_read_on_scroll_policy_values.never.code
+            ) {
+                // We don't check message_list.can_mark_messages_read
+                // here because the target message_list isn't initialized;
+                // but the targeted message is about to be marked read
+                // in the new view.
+                unread_ops.notify_server_message_read(message);
+            }
             by("dm", message.reply_to, opts);
             break;
 
         case "stream":
+            if (
+                user_settings.web_mark_read_on_scroll_policy ===
+                web_mark_read_on_scroll_policy_values.always.code
+            ) {
+                // We don't check message_list.can_mark_messages_read
+                // here because the target message_list isn't initialized;
+                // but the targeted message is about to be marked read
+                // in the new view.
+                unread_ops.notify_server_message_read(message);
+            }
             by("stream", message.stream, opts);
             break;
     }


### PR DESCRIPTION
In commit #25837, we added in a check for the user's mark as read policy in the frontend for `by_topic` and `by_recipient` narrowing. In that change, the assumption was that for both functions, it was sufficient to check only for whether the user policy was to never mark as read.

But because the `by_recipient` function may narrow to an interleaved stream view, it is possible that message will be marked as read when the user did not expect it to be when they have conversation views only as their mark as read  policy.

For example, the user marked all the messages in a topic narrow as unread and then used the `S` key shortcut to navigate back to the stream view. Currently, the message that was selected in the topic narrow would be marked as read even though the user has navigated to a stream view, which is not a conversation view.

Here we move the check for the user's mark as read policy to be in the two cases for `by_recipient` so that the mark as read behavior here matches the user's setting.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/6-frontend/topic/inconsistent.20mark.20as.20read/near/1583363).

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
