### PR TITLE
message-scroll: Mark read for events without previous message ID.

### DIFF
--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -164,21 +164,23 @@ export function initialize() {
                 // Mark new selected message as read
                 messages = [event.msg_list.get(event.id)];
             }
-            if (event.msg_list.can_mark_messages_read()) {
-                unread_ops.notify_server_messages_read(messages, {from: "pointer"});
-            } else if (
-                unread.get_unread_messages(messages).length !== 0 &&
-                // The below checks might seem redundant, but it's
-                // possible this logic, which runs after a delay, lost
-                // a race with switching to another view, like Recent
-                // Topics, and we don't want to display this banner
-                // in such a view.
-                //
-                // This can likely be fixed more cleanly with another approach.
-                narrow_state.filter() !== undefined &&
-                message_lists.current === event.msg_list
-            ) {
-                unread_ui.notify_messages_remain_unread();
+            if (unread_ops.is_window_focused()) {
+                if (event.msg_list.can_mark_messages_read()) {
+                    unread_ops.notify_server_messages_read(messages, {from: "pointer"});
+                } else if (
+                    unread.get_unread_messages(messages).length !== 0 &&
+                    // The below checks might seem redundant, but it's
+                    // possible this logic, which runs after a delay, lost
+                    // a race with switching to another view, like recent
+                    // conversations, and we don't want to display this banner
+                    // in such a view.
+                    //
+                    // This can likely be fixed more cleanly with another approach.
+                    narrow_state.filter() !== undefined &&
+                    message_lists.current === event.msg_list
+                ) {
+                    unread_ui.notify_messages_remain_unread();
+                }
             }
         }
     });

--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -151,13 +151,18 @@ export function initialize() {
             return;
         }
 
-        if (event.mark_read && event.previously_selected_id !== -1) {
-            // Mark messages between old pointer and new pointer as read
+        if (event.mark_read) {
             let messages;
-            if (event.id < event.previously_selected_id) {
-                messages = event.msg_list.message_range(event.id, event.previously_selected_id);
+            if (event.previously_selected_id !== -1) {
+                // Mark messages between previous and new selected message as read
+                if (event.id < event.previously_selected_id) {
+                    messages = event.msg_list.message_range(event.id, event.previously_selected_id);
+                } else {
+                    messages = event.msg_list.message_range(event.previously_selected_id, event.id);
+                }
             } else {
-                messages = event.msg_list.message_range(event.previously_selected_id, event.id);
+                // Mark new selected message as read
+                messages = [event.msg_list.get(event.id)];
             }
             if (event.msg_list.can_mark_messages_read()) {
                 unread_ops.notify_server_messages_read(messages, {from: "pointer"});

--- a/web/src/unread_ops.ts
+++ b/web/src/unread_ops.ts
@@ -609,6 +609,22 @@ export function process_visible(): void {
     }
 }
 
+function process_selected_message(): void {
+    if (
+        viewport_is_visible_and_focused() &&
+        message_lists.current !== undefined &&
+        message_lists.current.selected_id() !== -1
+    ) {
+        const selected_message = message_lists.current.selected_message();
+        if (
+            unread.message_unread(selected_message) &&
+            message_lists.current.can_mark_messages_read()
+        ) {
+            message_lists.current.select_id(selected_message.id);
+        }
+    }
+}
+
 export function mark_stream_as_read(stream_id: number): void {
     const stream_name = stream_data.get_stream_name_from_id(stream_id);
     bulk_update_read_flags_for_narrow(
@@ -675,6 +691,11 @@ export function initialize(): void {
             // Update many places on the DOM to reflect unread
             // counts.
             process_visible();
+
+            // Check selected message after process_visible
+            // in case the bottom of the message feed isn't
+            // visible.
+            process_selected_message();
         })
         .on("blur", () => {
             window_focused = false;


### PR DESCRIPTION
Previously, the event handler for marking selected messages as read was only triggered if there was a previously selected message ID. This meant that user navigation (either via hotkeys or mouse clicks) would not necessarily mark the initially selected first unread message in the view, even if the view/user settings allowed for the message to be marked read.

Occasionally, a document on scroll event would be called that would create a race where the message would get marked as read in cases where message fetch requests were received more slowly. This made the overall mark as read experience inconsistent.

We update the event handler to allow for marking the selected message as read when there was no previously selected message in the message list.

There is an initial loading of messages to the home message list where we set `mark_read: false` since we can't safely assume on a page load/reload that the home view is the user's current or default view. Once the home view message list is loaded, we add a check for the current view and mark the selected message as read if the home view is indeed the current view.

Fixes #26021.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/6-frontend/topic/inconsistent.20mark.20as.20read/near/1580820).

**Notes**:
- There's an issue with these changes in the case that a user has a unfocused browser tab open on a stream/topic view that's empty (aka there are no messages). While they are working elsewhere in the browser, someone else sends a new message to that same stream/topic. As this is the first message in the view and there is no previous selected message ID, the new message will be marked as read even though the browser tab is not focused. And, if the user doesn't go back to the tab before ending their browser session, then they may not notice the message was received and marked as read.
- Something noted in manual testing of these changes is that for users with All messages as their default view, if they logout from another view with unread messages, then the unread count will flicker down before the page loads to the log-in page. This is not due to these changes and is discussed [here on CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/logout.20hashchange/near/1591366).

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
