### PR TITLE
send_email: Delete ScheduledEmail objects with no recipients.

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -477,10 +477,14 @@ def deliver_scheduled_emails(email: ScheduledEmail) -> None:
     data = orjson.loads(email.data)
     user_ids = list(email.users.values_list("id", flat=True))
     if not user_ids and not email.address:
-        # This state doesn't make sense, so something must be mutating,
-        # or in the process of deleting, the object. We assume it will bring
-        # things to a correct state, and we just do nothing except logging this event.
-        logger.error("ScheduledEmail id %s has empty users and address attributes.", email.id)
+        # This state doesn't make sense, so something must have mutated the object
+        logger.warning(
+            "ScheduledEmail %s at %s had empty users and address attributes: %r",
+            email.id,
+            email.scheduled_timestamp,
+            data,
+        )
+        email.delete()
         return
 
     if user_ids:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1698,16 +1698,21 @@ class ActivateTest(ZulipTestCase):
         assert email is not None
         email.users.remove(*to_user_ids)
 
+        email_id = email.id
+        scheduled_at = email.scheduled_timestamp
         with self.assertLogs("zulip.send_email", level="INFO") as info_log:
             deliver_scheduled_emails(email)
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)
-        self.assertEqual(ScheduledEmail.objects.count(), 1)
+        self.assertEqual(ScheduledEmail.objects.count(), 0)
         self.assertEqual(
             info_log.output,
             [
-                f"ERROR:zulip.send_email:ScheduledEmail id {email.id} has empty users and address attributes."
+                f"WARNING:zulip.send_email:ScheduledEmail {email_id} at {scheduled_at} "
+                "had empty users and address attributes: "
+                "{'template_prefix': 'zerver/emails/followup_day1', 'from_name': None, "
+                "'from_address': None, 'language': None, 'context': {}}"
             ],
         )
 


### PR DESCRIPTION
9d97af6ebba9 addressed the one major source of inconsistent data which would be solved by simply re-attempting the ScheduledEmail row.  Every other instance that we have seen since then has been a corrupt or modified database in some way, which does not self-resolve.  This results in an endless stream of emails to the administrator, and no forward progress.

Drop this to a warning, and make it remove the offending row.  This ensures we make forward progress.

----

See also #26018, #24081.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
