### PR TITLE
localstorage: Skip localstorage warning for spectators.

### DIFF
--- a/web/src/localstorage.ts
+++ b/web/src/localstorage.ts
@@ -1,6 +1,7 @@
 import {z} from "zod";
 
 import * as blueslip from "./blueslip";
+import {page_params} from "./page_params";
 
 const formDataSchema = z
     .object({
@@ -241,6 +242,11 @@ localstorage.supported = function supports_localstorage(): boolean {
     try {
         return window.localStorage !== undefined && window.localStorage !== null;
     } catch {
+        if (page_params.is_spectator) {
+            // Many spectators are not even real users, and failure to preserve their state over a
+            // reload is not a major issue.
+            return false;
+        }
         if (!warned_of_localstorage) {
             blueslip.error(
                 "Client browser does not support local storage, will lose socket message on reload",


### PR DESCRIPTION
These are more likely than not not even caused by real human browsers, and even if so, are much less important to preserve the state of.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
