### PR TITLE
compose: Update textbox placeholder text when selecting a recipient.

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -170,10 +170,6 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
                 opts.has_status = has_status;
             }
 
-            if (store.onPillCreate !== undefined) {
-                store.onPillCreate();
-            }
-
             const pill_html = render_input_pill(opts);
             const payload: InputPill<T> = {
                 item,
@@ -182,6 +178,10 @@ export function create<T>(opts: InputPillCreateOptions<T>): InputPillContainer<T
 
             store.pills.push(payload);
             store.$input.before(payload.$element);
+
+            if (store.onPillCreate !== undefined) {
+                store.onPillCreate();
+            }
         },
 
         // this appends a pill to the end of the container but before the


### PR DESCRIPTION
This fixes a bug reported here:
https://chat.zulip.org/#narrow/stream/9-issues/topic/compose.20box.20placeholder/near/1591988

before:

![2023-06-13-at-11 47 33-Ivory-Elephant](https://github.com/zulip/zulip/assets/5634097/69d72d35-3889-4eef-9dc9-cff79d4759ae)

after:

![Kapture 2023-06-14 at 18 32 11](https://github.com/zulip/zulip/assets/5634097/ad843036-5791-42e6-9ad0-965666995b57)
