### PR TITLE
settings_users: Migrate "Manage user" and "Manage bot" modal to full profile modal.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -207,7 +207,7 @@ async function test_edit_bot_form(page: Page): Promise<void> {
     );
 
     await common.fill_form(page, edit_form_selector, {full_name: "Bot one"});
-    const save_btn_selector = "#edit_bot_modal .dialog_submit_button";
+    const save_btn_selector = "#user-profile-modal .dialog_submit_button";
     await page.click(save_btn_selector);
 
     // The form gets closed on saving. So, assert it's closed by waiting for it to be hidden.
@@ -242,7 +242,7 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
     );
 
     await common.fill_form(page, edit_form_selector, {full_name: "Bot 2"});
-    const save_btn_selector = "#edit_bot_modal .dialog_submit_button";
+    const save_btn_selector = "#user-profile-modal .dialog_submit_button";
     await page.click(save_btn_selector);
 
     // The form should not get closed on saving. Errors should be visible on the form.
@@ -253,7 +253,7 @@ async function test_invalid_edit_bot_form(page: Page): Promise<void> {
         "Failed: Name is already in use!",
     );
 
-    const cancel_button_selector = "#edit_bot_modal .dialog_exit_button";
+    const cancel_button_selector = "#user-profile-modal .dialog_exit_button";
     await page.waitForFunction(
         (cancel_button_selector: string) =>
             !document.querySelector(cancel_button_selector)?.hasAttribute("disabled"),

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -34,7 +34,6 @@ import * as popover_menus from "./popover_menus";
 import * as realm_playground from "./realm_playground";
 import * as resize from "./resize";
 import * as rows from "./rows";
-import * as settings_bots from "./settings_bots";
 import * as settings_config from "./settings_config";
 import * as settings_users from "./settings_users";
 import * as stream_popover from "./stream_popover";
@@ -1045,11 +1044,7 @@ export function register_click_handlers() {
         hide_all();
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const user = people.get_by_user_id(user_id);
-        if (user.is_bot) {
-            settings_bots.show_edit_bot_info_modal(user_id, true);
-        } else {
-            user_profile.show_user_profile(user, "manage-profile-tab");
-        }
+        user_profile.show_user_profile(user, "manage-profile-tab");
     });
 
     $("body").on("click", ".user_info_popover_manage_menu_btn", (e) => {

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1048,7 +1048,7 @@ export function register_click_handlers() {
         if (user.is_bot) {
             settings_bots.show_edit_bot_info_modal(user_id, true);
         } else {
-            settings_users.show_edit_user_info_modal(user_id, true);
+            user_profile.show_user_profile(user, "manage-profile-tab");
         }
     });
 

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -338,12 +338,12 @@ export function confirm_bot_deactivation(bot_id, handle_confirm, loading_spinner
     });
 }
 
-export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
+export function show_edit_bot_info_modal(user_id, $container) {
     const bot = people.maybe_get_user_by_id(user_id);
     const owner_id = bot_data.get(user_id).owner_id;
     const owner_full_name = people.get_full_name(owner_id);
 
-    if (!bot) {
+    if (!bot || !bot_data.get(user_id)) {
         return;
     }
 
@@ -357,15 +357,15 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
         owner_full_name,
         current_bot_owner: bot.bot_owner_id,
     });
-
+    $container.append(html_body);
     let avatar_widget;
 
     const bot_type = bot.bot_type.toString();
     const service = bot_data.get_services(bot.user_id)[0];
-
-    function submit_bot_details() {
+    edit_bot_post_render();
+    $("#user-profile-modal").on("click", ".dialog_submit_button", () => {
         const role = Number.parseInt($("#bot-role-select").val().trim(), 10);
-        const $full_name = $("#dialog_widget_modal").find("input[name='full_name']");
+        const $full_name = $("#bot-edit-form").find("input[name='full_name']");
         const url = "/json/bots/" + encodeURIComponent(bot.user_id);
 
         const formData = new FormData();
@@ -395,6 +395,11 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
             formData.append("file-" + i, file);
         }
 
+        const $submit_btn = $("#user-profile-modal .dialog_submit_button");
+        const $cancel_btn = $("#user-profile-modal .dialog_exit_button");
+        settings_users.show_button_spinner($submit_btn);
+        $cancel_btn.prop("disabled", true);
+
         channel.patch({
             url,
             data: formData,
@@ -402,14 +407,23 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
             contentType: false,
             success() {
                 avatar_widget.clear();
-                dialog_widget.close_modal();
+                user_profile.hide_user_profile();
             },
             error(xhr) {
-                ui_report.error($t_html({defaultMessage: "Failed"}), xhr, $("#dialog_error"));
-                dialog_widget.hide_dialog_spinner();
+                ui_report.error(
+                    $t_html({defaultMessage: "Failed"}),
+                    xhr,
+                    $("#bot-edit-form-error"),
+                );
+                // Scrolling modal to top, to make error visible to user.
+                $("#bot-edit-form")
+                    .closest(".simplebar-content-wrapper")
+                    .animate({scrollTop: 0}, "fast");
+                settings_users.hide_button_spinner($submit_btn);
+                $cancel_btn.prop("disabled", false);
             },
         });
-    }
+    });
 
     function edit_bot_post_render() {
         $("#edit_bot_modal .dialog_submit_button").prop("disabled", true);
@@ -488,21 +502,9 @@ export function show_edit_bot_info_modal(user_id, from_user_info_popover) {
                 const url = "/json/bots/" + encodeURIComponent(bot_id);
                 dialog_widget.submit_api_request(channel.del, url);
             }
-            const open_deactivate_modal_callback = () =>
-                confirm_bot_deactivation(bot_id, handle_confirm, true);
-            dialog_widget.close_modal(open_deactivate_modal_callback);
+            confirm_bot_deactivation(bot_id, handle_confirm, true);
         });
     }
-
-    dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Manage bot"}),
-        html_body,
-        id: "edit_bot_modal",
-        on_click: submit_bot_details,
-        post_render: edit_bot_post_render,
-        loading_spinner: from_user_info_popover,
-        update_submit_disabled_state_on_change: true,
-    });
 }
 
 export function set_up() {
@@ -590,7 +592,8 @@ export function set_up() {
         e.stopPropagation();
         const $li = $(e.currentTarget).closest("li");
         const bot_id = Number.parseInt($li.find(".bot_info").attr("data-user-id"), 10);
-        show_edit_bot_info_modal(bot_id, false);
+        const bot = people.get_by_user_id(bot_id);
+        user_profile.show_user_profile(bot, "manage-profile-tab");
     });
 
     $("#active_bots_list").on("click", "a.download_bot_zuliprc", function () {

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -732,7 +732,7 @@ export function show_edit_user_info_modal(user_id, $container) {
     });
 }
 
-function handle_human_form($tbody) {
+function handle_edit_form($tbody) {
     $tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -744,24 +744,12 @@ function handle_human_form($tbody) {
     });
 }
 
-function handle_bot_form($tbody) {
-    $tbody.on("click", ".open-user-form", (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        popovers.hide_all();
-
-        const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
-        const user = people.get_by_user_id(user_id);
-        user_profile.show_user_profile(user, 3);
-    });
-}
-
 section.active.handle_events = () => {
     const $tbody = $("#admin_users_table").expectOne();
 
     handle_deactivation($tbody);
     handle_reactivation($tbody);
-    handle_human_form($tbody);
+    handle_edit_form($tbody);
 };
 
 section.deactivated.handle_events = () => {
@@ -769,7 +757,7 @@ section.deactivated.handle_events = () => {
 
     handle_deactivation($tbody);
     handle_reactivation($tbody);
-    handle_human_form($tbody);
+    handle_edit_form($tbody);
 };
 
 section.bots.handle_events = () => {
@@ -777,7 +765,7 @@ section.bots.handle_events = () => {
 
     handle_bot_deactivation($tbody);
     handle_reactivation($tbody);
-    handle_bot_form($tbody);
+    handle_edit_form($tbody);
 };
 
 export function set_up_humans() {

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -657,6 +657,7 @@ export function show_edit_user_info_modal(user_id, $container) {
         full_name: person.full_name,
         user_role_values: settings_config.user_role_values,
         disable_role_dropdown: person.is_owner && !page_params.is_owner,
+        owner_is_only_user_in_organization: people.get_active_human_count() === 1,
     });
 
     $container.append(html_body);

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -8,6 +8,7 @@ import render_admin_user_list from "../templates/settings/admin_user_list.hbs";
 
 import * as blueslip from "./blueslip";
 import * as bot_data from "./bot_data";
+import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dialog_widget from "./dialog_widget";
@@ -740,6 +741,11 @@ function handle_edit_form($tbody) {
         popovers.hide_all();
 
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
+        if (people.is_my_user_id(user_id)) {
+            browser_history.go_to_location("#settings/profile");
+            return;
+        }
+
         const user = people.get_by_user_id(user_id);
         user_profile.show_user_profile(user, "manage-profile-tab");
     });

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -751,7 +751,8 @@ function handle_bot_form($tbody) {
         popovers.hide_all();
 
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
-        settings_bots.show_edit_bot_info_modal(user_id, false);
+        const user = people.get_by_user_id(user_id);
+        user_profile.show_user_profile(user, 3);
     });
 }
 

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -24,13 +24,34 @@ import * as settings_bots from "./settings_bots";
 import * as settings_config from "./settings_config";
 import * as settings_panel_menu from "./settings_panel_menu";
 import * as timerender from "./timerender";
+import * as ui_report from "./ui_report";
 import * as user_pill from "./user_pill";
+import * as user_profile from "./user_profile";
 
 const section = {
     active: {},
     deactivated: {},
     bots: {},
 };
+
+export function show_button_spinner($button) {
+    const $spinner = $button.find(".modal__spinner");
+    const dialog_submit_button_span_width = $button.find("span").width();
+    const dialog_submit_button_span_height = $button.find("span").height();
+    $button.prop("disabled", true);
+    $button.find("span").hide();
+    loading.make_indicator($spinner, {
+        width: dialog_submit_button_span_width,
+        height: dialog_submit_button_span_height,
+    });
+}
+
+export function hide_button_spinner($button) {
+    const $spinner = $button.find(".modal__spinner");
+    $button.prop("disabled", false);
+    $button.find("span").show();
+    loading.destroy_indicator($spinner);
+}
 
 function compare_a_b(a, b) {
     if (a > b) {
@@ -623,7 +644,7 @@ function handle_reactivation($tbody) {
     });
 }
 
-export function show_edit_user_info_modal(user_id, from_user_info_popover) {
+export function show_edit_user_info_modal(user_id, $container) {
     const person = people.maybe_get_user_by_id(user_id);
 
     if (!person) {
@@ -638,43 +659,40 @@ export function show_edit_user_info_modal(user_id, from_user_info_popover) {
         disable_role_dropdown: person.is_owner && !page_params.is_owner,
     });
 
-    let fields_user_pills;
-
-    function set_role_dropdown_and_fields_user_pills() {
-        $("#user-role-select").val(person.role);
-        if (!page_params.is_owner) {
-            $("#user-role-select")
-                .find(`option[value="${CSS.escape(settings_config.user_role_values.owner.code)}"]`)
-                .hide();
-        }
-
-        const element = "#edit-user-form .custom-profile-field-form";
-        $(element).empty();
-        settings_account.append_custom_profile_fields(element, user_id);
-        settings_account.initialize_custom_date_type_fields(element);
-        fields_user_pills = settings_account.initialize_custom_user_type_fields(
-            element,
-            user_id,
-            true,
-            false,
-        );
-        settings_account.initialize_custom_pronouns_type_fields(element);
-
-        $("#edit-user-form").on("click", ".deactivate_user_button", (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            const user_id = $("#edit-user-form").data("user-id");
-            function handle_confirm() {
-                const url = "/json/users/" + encodeURIComponent(user_id);
-                dialog_widget.submit_api_request(channel.del, url);
-            }
-            const open_deactivate_modal_callback = () =>
-                confirm_deactivation(user_id, handle_confirm, true);
-            dialog_widget.close_modal(open_deactivate_modal_callback);
-        });
+    $container.append(html_body);
+    // Set role dropdown and fields user pills
+    $("#user-role-select").val(person.role);
+    if (!page_params.is_owner) {
+        $("#user-role-select")
+            .find(`option[value="${CSS.escape(settings_config.user_role_values.owner.code)}"]`)
+            .hide();
     }
 
-    function submit_user_details() {
+    const element = "#edit-user-form .custom-profile-field-form";
+    $(element).empty();
+    settings_account.append_custom_profile_fields(element, user_id);
+    settings_account.initialize_custom_date_type_fields(element);
+    settings_account.initialize_custom_pronouns_type_fields(element);
+    const fields_user_pills = settings_account.initialize_custom_user_type_fields(
+        element,
+        user_id,
+        true,
+        false,
+    );
+
+    // Handle deactivation
+    $("#edit-user-form").on("click", ".deactivate_user_button", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const user_id = $("#edit-user-form").data("user-id");
+        function handle_confirm() {
+            const url = "/json/users/" + encodeURIComponent(user_id);
+            dialog_widget.submit_api_request(channel.del, url);
+        }
+        confirm_deactivation(user_id, handle_confirm, true);
+    });
+
+    $("#edit-user-form").on("click", ".dialog_submit_button", () => {
         const role = Number.parseInt($("#user-role-select").val().trim(), 10);
         const $full_name = $("#edit-user-form").find("input[name='full_name']");
         const profile_data = get_human_profile_data(fields_user_pills);
@@ -685,23 +703,31 @@ export function show_edit_user_info_modal(user_id, from_user_info_popover) {
             role: JSON.stringify(role),
             profile_data: JSON.stringify(profile_data),
         };
-        const opts = {
-            error_continuation() {
+        const $submit_btn = $("#edit-user-form .dialog_submit_button");
+        const $cancel_btn = $("#edit-user-form .dialog_exit_button");
+        show_button_spinner($submit_btn);
+        $cancel_btn.prop("disabled", true);
+
+        channel.patch({
+            url,
+            data,
+            success() {
+                user_profile.hide_user_profile();
+            },
+            error(xhr) {
+                ui_report.error(
+                    $t_html({defaultMessage: "Failed"}),
+                    xhr,
+                    $("#edit-user-form-error"),
+                );
                 // Scrolling modal to top, to make error visible to user.
                 $("#edit-user-form")
                     .closest(".simplebar-content-wrapper")
                     .animate({scrollTop: 0}, "fast");
+                hide_button_spinner($submit_btn);
+                $cancel_btn.prop("disabled", false);
             },
-        };
-        dialog_widget.submit_api_request(channel.patch, url, data, opts);
-    }
-
-    dialog_widget.launch({
-        html_heading: $t_html({defaultMessage: "Manage user"}),
-        html_body,
-        on_click: submit_user_details,
-        post_render: set_role_dropdown_and_fields_user_pills,
-        loading_spinner: from_user_info_popover,
+        });
     });
 }
 
@@ -712,7 +738,8 @@ function handle_human_form($tbody) {
         popovers.hide_all();
 
         const user_id = Number.parseInt($(e.currentTarget).attr("data-user-id"), 10);
-        show_edit_user_info_modal(user_id, false);
+        const user = people.get_by_user_id(user_id);
+        user_profile.show_user_profile(user, "manage-profile-tab");
     });
 }
 

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -692,7 +692,7 @@ export function show_edit_user_info_modal(user_id, $container) {
         confirm_deactivation(user_id, handle_confirm, true);
     });
 
-    $("#edit-user-form").on("click", ".dialog_submit_button", () => {
+    $("#user-profile-modal").on("click", ".dialog_submit_button", () => {
         const role = Number.parseInt($("#user-role-select").val().trim(), 10);
         const $full_name = $("#edit-user-form").find("input[name='full_name']");
         const profile_data = get_human_profile_data(fields_user_pills);
@@ -703,8 +703,9 @@ export function show_edit_user_info_modal(user_id, $container) {
             role: JSON.stringify(role),
             profile_data: JSON.stringify(profile_data),
         };
-        const $submit_btn = $("#edit-user-form .dialog_submit_button");
-        const $cancel_btn = $("#edit-user-form .dialog_exit_button");
+
+        const $submit_btn = $("#user-profile-modal .dialog_submit_button");
+        const $cancel_btn = $("#user-profile-modal .dialog_exit_button");
         show_button_spinner($submit_btn);
         $cancel_btn.prop("disabled", true);
 

--- a/web/src/settings_users.js
+++ b/web/src/settings_users.js
@@ -668,13 +668,13 @@ export function show_edit_user_info_modal(user_id, $container) {
             .hide();
     }
 
-    const element = "#edit-user-form .custom-profile-field-form";
-    $(element).empty();
-    settings_account.append_custom_profile_fields(element, user_id);
-    settings_account.initialize_custom_date_type_fields(element);
-    settings_account.initialize_custom_pronouns_type_fields(element);
+    const custom_profile_field_form_selector = "#edit-user-form .custom-profile-field-form";
+    $(custom_profile_field_form_selector).empty();
+    settings_account.append_custom_profile_fields(custom_profile_field_form_selector, user_id);
+    settings_account.initialize_custom_date_type_fields(custom_profile_field_form_selector);
+    settings_account.initialize_custom_pronouns_type_fields(custom_profile_field_form_selector);
     const fields_user_pills = settings_account.initialize_custom_user_type_fields(
-        element,
+        custom_profile_field_form_selector,
         user_id,
         true,
         false,

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -303,7 +303,10 @@ export function initialize() {
     });
 
     delegate("body", {
-        target: ["#deactivate_account_container.disabled_setting_tooltip"],
+        target: [
+            "#deactivate_account_container.disabled_setting_tooltip",
+            "#edit-user-form .deactivate_user_button_tooltip",
+        ],
         content: $t({
             defaultMessage:
                 "Because you are the only organization owner, you cannot deactivate your account.",

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -529,17 +529,18 @@ export function register_click_handlers() {
 
     $("body").on(
         "click",
-        "#user-profile-modal #name #user_profile_manage_others_edit_button",
+        "#user-profile-modal #name .user_profile_manage_others_edit_button",
         (e) => {
             show_manage_user_tab("manage-profile-tab");
             e.stopPropagation();
             e.preventDefault();
         },
     );
+
     /* These click handlers are implemented as just deep links to the
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */
-    $("body").on("click", "#user-profile-modal #name #user_profile_manage_own_edit_button", () => {
+    $("body").on("click", "#user-profile-modal #name .user_profile_manage_own_edit_button", () => {
         hide_user_profile();
     });
 

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -195,7 +195,11 @@ function render_user_group_list(groups, user) {
 function render_manage_profile_content(user) {
     const $container = $("#manage-profile-tab");
     $container.empty();
-    settings_users.show_edit_user_info_modal(user.user_id, $container);
+    if (user.is_bot) {
+        settings_bots.show_edit_bot_info_modal(user.user_id, $container);
+    } else {
+        settings_users.show_edit_user_info_modal(user.user_id, $container);
+    }
     $("#user-profile-modal .modal__footer").show();
 }
 
@@ -288,9 +292,11 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         !user.is_system_bot &&
         people.is_person_active(user.user_id);
     const groups_of_user = user_groups.get_user_groups_of_user(user.user_id);
+    // We currently have the main UI for editing your own profile in
+    // settings, so can_manage_profile is artificially false for those.
     const can_manage_profile =
-        people.is_person_active(user.user_id) &&
-        page_params.is_admin &&
+        (people.can_admin_user(user) || page_params.is_admin) &&
+        !user.is_system_bot &&
         !people.is_my_user_id(user.user_id);
     const args = {
         user_id: user.user_id,
@@ -369,8 +375,11 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     };
 
     if (can_manage_profile) {
+        const manage_profile_label = user.is_bot
+            ? $t({defaultMessage: "Manage bot"})
+            : $t({defaultMessage: "Manage user"});
         const manage_profile_tab = {
-            label: $t({defaultMessage: "Manage user"}),
+            label: manage_profile_label,
             key: "manage-profile-tab",
         };
         opts.values.push(manage_profile_tab);

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -157,6 +157,7 @@ function format_user_group_list_item(group) {
 }
 
 function render_user_stream_list(streams, user) {
+    $("#user-profile-modal .modal__footer").hide();
     streams.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-stream-list");
     $container.empty();
@@ -177,6 +178,7 @@ function render_user_stream_list(streams, user) {
 }
 
 function render_user_group_list(groups, user) {
+    $("#user-profile-modal .modal__footer").hide();
     groups.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-group-list");
     $container.empty();
@@ -194,6 +196,7 @@ function render_manage_profile_content(user) {
     const $container = $("#manage-profile-tab");
     $container.empty();
     settings_users.show_edit_user_info_modal(user.user_id, $container);
+    $("#user-profile-modal .modal__footer").show();
 }
 
 export function get_custom_profile_field_data(user, field, field_types) {
@@ -346,6 +349,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
             $(`#${CSS.escape(key)}`).show();
             switch (key) {
                 case "profile-tab":
+                    $("#user-profile-modal .modal__footer").hide();
                     initialize_user_type_fields(user);
                     break;
                 case "user-profile-groups-tab":

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -193,6 +193,11 @@ function render_user_group_list(groups, user) {
 }
 
 function render_manage_profile_content(user) {
+    // Since we want the height of the profile modal to remain consistent when switching tabs,
+    // we need to restrict the height of the main body. This will ensure that the footer of
+    // the "Manage User" tab can adjust within the provided height without expanding the modal.
+    $("#user-profile-modal .modal__body").addClass("modal__body__manage_profile_height");
+    $("#user-profile-modal .manage-profile-tab-footer").addClass("modal__footer_wrapper");
     const $container = $("#manage-profile-tab");
     $container.empty();
     if (user.is_bot) {
@@ -353,6 +358,10 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         callback(_name, key) {
             $(".tabcontent").hide();
             $(`#${CSS.escape(key)}`).show();
+            $("#user-profile-modal .modal__body").removeClass("modal__body__manage_profile_height");
+            $("#user-profile-modal .manage-profile-tab-footer").removeClass(
+                "modal__footer_wrapper",
+            );
             switch (key) {
                 case "profile-tab":
                     $("#user-profile-modal .modal__footer").hide();

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -33,6 +33,7 @@ import * as util from "./util";
 
 let user_streams_list_widget;
 let user_profile_subscribe_widget;
+let toggler;
 
 function compare_by_name(a, b) {
     return util.strcmp(a.name, b.name);
@@ -265,6 +266,10 @@ export function hide_user_profile() {
     overlays.close_modal_if_open("user-profile-modal");
 }
 
+function show_manage_user_tab(target) {
+    toggler.goto(target);
+}
+
 function initialize_user_type_fields(user) {
     // Avoid duplicate pill fields, by removing existing ones.
     $("#user-profile-modal .pill").remove();
@@ -321,6 +326,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         user_type: people.get_user_type(user.user_id),
         user_is_guest: user.is_guest,
         show_user_subscribe_widget,
+        can_manage_profile,
     };
 
     if (user.is_bot) {
@@ -394,7 +400,8 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         opts.values.push(manage_profile_tab);
     }
 
-    const $elem = components.toggle(opts).get();
+    toggler = components.toggle(opts);
+    const $elem = toggler.get();
     $elem.addClass("large allow-overflow");
     $("#tab-toggle").append($elem);
     if (show_user_subscribe_widget) {
@@ -519,10 +526,20 @@ export function register_click_handlers() {
         e.stopPropagation();
         e.preventDefault();
     });
+
+    $("body").on(
+        "click",
+        "#user-profile-modal #name #user_profile_manage_others_edit_button",
+        (e) => {
+            show_manage_user_tab("manage-profile-tab");
+            e.stopPropagation();
+            e.preventDefault();
+        },
+    );
     /* These click handlers are implemented as just deep links to the
      * relevant part of the Zulip UI, so we don't want preventDefault,
      * but we do want to close the modal when you click them. */
-    $("body").on("click", "#user-profile-modal #name .user_profile_edit_button", () => {
+    $("body").on("click", "#user-profile-modal #name #user_profile_manage_own_edit_button", () => {
         hide_user_profile();
     });
 

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -158,7 +158,6 @@ function format_user_group_list_item(group) {
 }
 
 function render_user_stream_list(streams, user) {
-    $("#user-profile-modal .modal__footer").hide();
     streams.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-stream-list");
     $container.empty();
@@ -179,7 +178,6 @@ function render_user_stream_list(streams, user) {
 }
 
 function render_user_group_list(groups, user) {
-    $("#user-profile-modal .modal__footer").hide();
     groups.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-group-list");
     $container.empty();
@@ -206,7 +204,6 @@ function render_manage_profile_content(user) {
     } else {
         settings_users.show_edit_user_info_modal(user.user_id, $container);
     }
-    $("#user-profile-modal .modal__footer").show();
 }
 
 export function get_custom_profile_field_data(user, field, field_types) {
@@ -364,13 +361,13 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
         callback(_name, key) {
             $(".tabcontent").hide();
             $(`#${CSS.escape(key)}`).show();
+            $("#user-profile-modal .modal__footer").hide();
             $("#user-profile-modal .modal__body").removeClass("modal__body__manage_profile_height");
             $("#user-profile-modal .manage-profile-tab-footer").removeClass(
                 "modal__footer_wrapper",
             );
             switch (key) {
                 case "profile-tab":
-                    $("#user-profile-modal .modal__footer").hide();
                     initialize_user_type_fields(user);
                     break;
                 case "user-profile-groups-tab":
@@ -383,6 +380,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
                     render_user_stream_list(user_streams, user);
                     break;
                 case "manage-profile-tab":
+                    $("#user-profile-modal .modal__footer").show();
                     render_manage_profile_content(user);
                     break;
             }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1300,6 +1300,12 @@
         .subscription-group-list .user-group-list tr {
             border-color: hsl(0deg 0% 0% / 40%);
         }
+
+        .manage-profile-tab-footer {
+            &.modal__footer_wrapper {
+                border-top: 1px solid hsl(0deg 0% 100% / 20%);
+            }
+        }
     }
 
     /* Arrows: */

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -68,7 +68,7 @@
         text-overflow: ellipsis;
     }
 
-    #user_profile_manage_others_edit_button {
+    .user_profile_manage_others_edit_button {
         color: hsl(200deg 100% 50%);
         cursor: pointer;
 

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -60,11 +60,21 @@
     padding-right: 1rem;
     max-width: 80%;
     display: flex;
+    align-items: center;
 
     .user_profile_name {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    #user_profile_manage_others_edit_button {
+        color: hsl(200deg 100% 50%);
+        cursor: pointer;
+
+        &:hover {
+            color: hsl(200deg 79% 66%);
+        }
     }
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -471,7 +471,7 @@ ul {
     }
 
     .zulip-icon.zulip-icon-bot {
-        padding: 3px 0 0;
+        padding: unset;
     }
 
     #default-section {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -378,6 +378,17 @@ ul {
         height: 60vh;
         padding-left: 16px;
         padding-right: 16px;
+
+        /*
+            The height of the main body of the profile modal is 60vh. However,
+            the footer is only present in the manage user tab. To make sure the
+            modal doesn't expand while switching between tabs, we can reduce
+            the height of the main body to 52vh - 1px (border radius of the footer)
+            and add a footer of 8vh.
+        */
+        &.modal__body__manage_profile_height {
+            height: calc(52vh - 1px);
+        }
     }
 
     .modal__header {
@@ -624,6 +635,27 @@ ul {
             &:empty {
                 display: block;
                 padding: 5px;
+            }
+        }
+    }
+
+    .manage-profile-tab-footer {
+        height: 0;
+
+        &.modal__footer_wrapper {
+            border-top: 1px solid hsl(0deg 0% 87%);
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            height: 8vh;
+
+            /* The default padding of the footer is 20px. However, since we have set */
+            /* the height of the footer wrapper to be 8vh on different screen sizes, */
+            /* the buttons might look odd. Instead of using padding top and bottom, we */
+            /* just use the flex and properties to align them. */
+            .modal__footer {
+                padding-top: unset;
+                padding-bottom: unset;
             }
         }
     }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -467,7 +467,7 @@ ul {
     }
 
     .user_profile_name {
-        margin-right: 10px;
+        margin: 0 10px;
     }
 
     .zulip-icon.zulip-icon-bot {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -459,8 +459,8 @@ ul {
         }
     }
 
-    #user_profile_manage_own_edit_button,
-    #user_profile_manage_others_edit_button {
+    .user_profile_manage_own_edit_button,
+    .user_profile_manage_others_edit_button {
         width: 25px;
         text-align: center;
         font-size: 18px;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -459,9 +459,11 @@ ul {
         }
     }
 
-    .user_profile_edit_button {
+    #user_profile_manage_own_edit_button,
+    #user_profile_manage_others_edit_button {
         width: 25px;
         text-align: center;
+        font-size: 18px;
     }
 
     .user_profile_name {
@@ -470,10 +472,6 @@ ul {
 
     .zulip-icon.zulip-icon-bot {
         padding: 3px 0 0;
-    }
-
-    #user_profile_edit_button_icon {
-        font-size: 18px;
     }
 
     #default-section {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1549,22 +1549,35 @@ $option_title_width: 180px;
         padding-left: 2px;
         vertical-align: middle;
     }
-
-    & input,
-    input[type="url"] {
-        /* Override undesired Bootstrap default. */
-        margin-bottom: 0;
-    }
 }
 
 #edit-user-form {
     .person_picker {
         min-width: 206px;
+        margin-top: 5px;
     }
 
     & textarea {
         width: max(206px, 25vw);
         max-width: 320px;
+    }
+}
+
+#manage-profile-tab {
+    #edit-user-form,
+    #bot-edit-form {
+        .name-setting {
+            margin-bottom: 10px;
+        }
+    }
+
+    & input,
+    input[type="url"],
+    & textarea,
+    & select {
+        /* Override undesired Bootstrap default. */
+        margin-bottom: 0;
+        margin-top: 5px;
     }
 }
 

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -27,8 +27,10 @@
         <div class="custom-profile-field-form"></div>
     </form>
     <div class="input-group new-style">
-        <button class="button rounded btn-danger deactivate_user_button">
-            {{t 'Deactivate user' }}
-        </button>
+        <span {{#if owner_is_only_user_in_organization}}class="deactivate_user_button_tooltip"{{/if}}>
+            <button class="button rounded btn-danger deactivate_user_button" {{#if owner_is_only_user_in_organization}}disabled="disabled"{{/if}}>
+                {{t 'Deactivate user' }}
+            </button>
+        </span>
     </div>
 </div>

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -1,5 +1,6 @@
 <div id="edit-user-form" data-user-id="{{user_id}}">
     <form class="name-setting">
+        <div class="alert" id="edit-user-form-error"></div>
         <input type="hidden" name="is_full_name" value="true" />
         <div class="input-group name_change_container">
             <label for="edit_user_full_name">{{t "Full name" }}</label>
@@ -30,4 +31,11 @@
             {{t 'Deactivate user' }}
         </button>
     </div>
+    <footer class="modal__footer">
+        <button type="button" class="modal__btn dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
+        <button type="button" class="modal__btn dialog_submit_button">
+            <span>{{t "Save changes"}}</span>
+            <div class="modal__spinner"></div>
+        </button>
+    </footer>
 </div>

--- a/web/templates/settings/admin_human_form.hbs
+++ b/web/templates/settings/admin_human_form.hbs
@@ -31,11 +31,4 @@
             {{t 'Deactivate user' }}
         </button>
     </div>
-    <footer class="modal__footer">
-        <button type="button" class="modal__btn dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
-        <button type="button" class="modal__btn dialog_submit_button">
-            <span>{{t "Save changes"}}</span>
-            <div class="modal__spinner"></div>
-        </button>
-    </footer>
 </div>

--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -1,5 +1,6 @@
 <div id="bot-edit-form" data-user-id="{{user_id}}" data-email="{{email}}">
     <form class="new-style edit_bot_form name-setting">
+        <div class="alert" id="bot-edit-form-error"></div>
         <div class="input-group name_change_container">
             <label for="edit_bot_full_name">{{t "Name" }}</label>
             <input type="text" autocomplete="off" name="full_name" id="edit_bot_full_name" class="modal_text_input" value="{{ full_name }}" />

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -8,10 +8,10 @@
                 </div>
                 {{/unless}}
                 <h1 class="modal__title user_profile_name_heading" id="name">
-                    <span class="user_profile_name">{{full_name}}</span>
                     {{#if is_bot}}
                         <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                     {{/if}}
+                    <span class="user_profile_name">{{full_name}}</span>
                     {{#if is_me}}
                         <a href="/#settings/profile">
                             <i class="fa fa-edit" id="user_profile_manage_own_edit_button" aria-hidden="true"></i>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -14,11 +14,11 @@
                     <span class="user_profile_name">{{full_name}}</span>
                     {{#if is_me}}
                         <a href="/#settings/profile">
-                            <i class="fa fa-edit" id="user_profile_manage_own_edit_button" aria-hidden="true"></i>
+                            <i class="fa fa-edit user_profile_manage_own_edit_button" aria-hidden="true"></i>
                         </a>
                     {{/if}}
                     {{#if can_manage_profile}}
-                        <i class="fa fa-edit" id="user_profile_manage_others_edit_button" aria-hidden="true"></i>
+                        <i class="fa fa-edit user_profile_manage_others_edit_button" aria-hidden="true"></i>
                     {{/if}}
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -10,12 +10,15 @@
                 <h1 class="modal__title user_profile_name_heading" id="name">
                     <span class="user_profile_name">{{full_name}}</span>
                     {{#if is_bot}}
-                    <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-bot" aria-hidden="true"></i>
                     {{/if}}
                     {{#if is_me}}
-                    <a href="/#settings/profile" class="user_profile_edit_button">
-                        <i class="fa fa-edit" id="user_profile_edit_button_icon" aria-hidden="true"></i>
-                    </a>
+                        <a href="/#settings/profile">
+                            <i class="fa fa-edit" id="user_profile_manage_own_edit_button" aria-hidden="true"></i>
+                        </a>
+                    {{/if}}
+                    {{#if can_manage_profile}}
+                        <i class="fa fa-edit" id="user_profile_manage_others_edit_button" aria-hidden="true"></i>
                     {{/if}}
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -14,11 +14,11 @@
                     <span class="user_profile_name">{{full_name}}</span>
                     {{#if is_me}}
                         <a href="/#settings/profile">
-                            <i class="fa fa-edit user_profile_manage_own_edit_button" aria-hidden="true"></i>
+                            <i class="fa fa-edit tippy-zulip-tooltip user_profile_manage_own_edit_button" data-tippy-content="{{t 'Edit profile' }}" aria-hidden="true"></i>
                         </a>
                     {{/if}}
                     {{#if can_manage_profile}}
-                        <i class="fa fa-edit user_profile_manage_others_edit_button" aria-hidden="true"></i>
+                        <i class="fa fa-edit tippy-zulip-tooltip user_profile_manage_others_edit_button" data-tippy-content="{{t 'Manage user' }}" aria-hidden="true"></i>
                     {{/if}}
                 </h1>
                 <button class="modal__close" aria-label="{{t 'Close modal' }}" data-micromodal-close></button>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -119,6 +119,13 @@
                     <div class="tabcontent" id="manage-profile-tab"></div>
                 </div>
             </main>
+            <footer class="modal__footer">
+                <button type="button" class="modal__btn dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
+                <button type="button" class="modal__btn dialog_submit_button">
+                    <span>{{t "Save changes"}}</span>
+                    <div class="modal__spinner"></div>
+                </button>
+            </footer>
         </div>
     </div>
 </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -116,6 +116,7 @@
                             <table class="user-group-list" data-empty="{{t 'No user group subscriptions.'}}"></table>
                         </div>
                     </div>
+                    <div class="tabcontent" id="manage-profile-tab"></div>
                 </div>
             </main>
         </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -119,13 +119,15 @@
                     <div class="tabcontent" id="manage-profile-tab"></div>
                 </div>
             </main>
-            <footer class="modal__footer">
-                <button type="button" class="modal__btn dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
-                <button type="button" class="modal__btn dialog_submit_button">
-                    <span>{{t "Save changes"}}</span>
-                    <div class="modal__spinner"></div>
-                </button>
-            </footer>
+            <div class="manage-profile-tab-footer">
+                <footer class="modal__footer">
+                    <button type="button" class="modal__btn dialog_exit_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
+                    <button type="button" class="modal__btn dialog_submit_button">
+                        <span>{{t "Save changes"}}</span>
+                        <div class="modal__spinner"></div>
+                    </button>
+                </footer>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Migrate Manage user to full profile modal.
- Migrate Manage bot to full profile modal.
- Disable the deactivate user button if the owner is the only user in the organization.
- Redirect edit pencil to manage user tab.

---------------
Fixes: #21806 

Czo: [Bot icon feedback](https://chat.zulip.org/#narrow/stream/137-feedback/topic/list.20of.20streams.20for.20another.20user)

------------------
**Screenshots and screen captures:**

<details>
<summary>Manage user:</summary>
<br>

![user_profile](https://github.com/zulip/zulip/assets/66828942/a5677019-c2d9-4c9e-a9d2-f16bd0867844)


</details>

<details>
<summary>Manage bot:</summary>
<br>

<img width="547" alt="Screenshot 2023-07-20 at 9 45 51 PM" src="https://github.com/zulip/zulip/assets/66828942/e40674fd-36bb-4ecc-b750-b527563e8e41">



</details>

<details>
<summary>Disabled button:</summary>
<br>


![deactivated_button](https://github.com/zulip/zulip/assets/66828942/327a256c-0dbe-4147-a89d-0c6dd18c94a8)



</details>

<details>
<summary>System bot:</summary>
<br>


<img width="547" alt="Screenshot 2023-07-20 at 9 39 47 PM" src="https://github.com/zulip/zulip/assets/66828942/add05f56-d406-4a0c-9111-75757f79fa47">




</details>

<details>
<summary>Edit Pencil:</summary>
<br>


![edit_pencil_to_manage_user](https://github.com/zulip/zulip/assets/66828942/ee343df6-8a10-4a30-a28a-1e527a2f56d1)




</details>

-----------------


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
