### PR TITLE
uploads: Delete uppy files on message edit cancel.

### DIFF
--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -67,9 +67,7 @@ export function get_item(key, config, file_id) {
             case "textarea":
                 return $(`#edit_form_${CSS.escape(config.row)} .message_edit_content`);
             case "send_button":
-                return $(`#edit_form_${CSS.escape(config.row)} .message_edit_content`)
-                    .closest(".message_edit_form")
-                    .find(".message_edit_save");
+                return $(`#edit_form_${CSS.escape(config.row)}`).find(".message_edit_save");
             case "banner_container":
                 return $(`#edit_form_${CSS.escape(config.row)} .edit_form_banners`);
             case "upload_banner_identifier":

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -69,10 +69,10 @@ test("get_item", () => {
         $(`#edit_form_${CSS.escape(1)} .message_edit_content`),
     );
 
-    $(`#edit_form_${CSS.escape(2)} .message_edit_content`).closest = () => {
-        $(".message_edit_form").set_find_results(".message_edit_save", $(".message_edit_save"));
-        return $(".message_edit_form");
-    };
+    $(`#edit_form_${CSS.escape(2)}`).set_find_results(
+        ".message_edit_save",
+        $(".message_edit_save"),
+    );
     assert.equal(upload.get_item("send_button", {mode: "edit", row: 2}), $(".message_edit_save"));
 
     assert.equal(


### PR DESCRIPTION
This change aims to resolve a bug where canceling message editing during uploading incorrectly displays that the file already exists. However, you can still safely send the file. The issue here is the erroneous error message appearing when it shouldn't.

Related CZO [discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/additional.20upload.20if.20the.20edit.20is.20cancelled).