### PR TITLE
left_sidebar: Make a collapsible "Views" section.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -108,6 +108,7 @@ EXEMPT_FILES = make_set(
         "web/src/info_overlay.js",
         "web/src/integration_url_modal.js",
         "web/src/invite.ts",
+        "web/src/left_sidebar_navigation_area.js",
         "web/src/left_sidebar_navigation_area_popovers.js",
         "web/src/lightbox.js",
         "web/src/list_util.ts",

--- a/web/e2e-tests/stars.test.ts
+++ b/web/e2e-tests/stars.test.ts
@@ -28,7 +28,7 @@ async function toggle_test_star_message(page: Page): Promise<void> {
 }
 
 async function test_narrow_to_starred_messages(page: Page): Promise<void> {
-    await page.click('#global_filters a[href^="#narrow/is/starred"]');
+    await page.click('#left-sidebar-navigation-list a[href^="#narrow/is/starred"]');
     await common.check_messages_sent(page, "zfilt", [["Verona > stars", [message]]]);
 
     // Go back to all messages narrow.

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -626,7 +626,9 @@ export function initialize() {
     // MISC
 
     {
-        const sel = ["#stream_filters", "#global_filters", "#user_presences"].join(", ");
+        const sel = ["#stream_filters", "#left-sidebar-navigation-list", "#user_presences"].join(
+            ", ",
+        );
 
         $(sel).on("click", "a", function () {
             this.blur();
@@ -796,7 +798,7 @@ export function initialize() {
     // End Webathena code
 
     // disable the draggability for left-sidebar components
-    $("#stream_filters, #global_filters").on("dragstart", (e) => {
+    $("#stream_filters, #left-sidebar-navigation-list").on("dragstart", (e) => {
         e.target.blur();
         return false;
     });

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -19,6 +19,7 @@ import * as dark_theme from "./dark_theme";
 import * as emoji_picker from "./emoji_picker";
 import * as hash_util from "./hash_util";
 import * as hashchange from "./hashchange";
+import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area";
 import * as message_edit from "./message_edit";
 import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
@@ -712,6 +713,12 @@ export function initialize() {
     $(".streams_filter_icon").on("click", (e) => {
         e.stopPropagation();
         stream_list.toggle_filter_displayed(e);
+    });
+
+    $("body").on("click", "#left-sidebar-navigation-area #views-label-container", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        left_sidebar_navigation_area.toggle_top_left_navigation_area();
     });
 
     $("body").on(

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -775,9 +775,11 @@ function schedule_message_to_custom_date() {
     const success = function (data) {
         drafts.draft_model.deleteDraft($("#compose-textarea").data("draft-id"));
         clear_compose_box();
+        const scheduled_messages_count = scheduled_messages.get_count() + 1;
         const new_row = render_success_message_scheduled_banner({
             scheduled_message_id: data.scheduled_message_id,
             deliver_at,
+            scheduled_messages_count,
         });
         compose_banner.clear_message_sent_banners();
         compose_banner.append_compose_banner_to_banner_list(new_row, $banner_container);

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -31,6 +31,7 @@ import * as util from "./util";
 function set_count(count) {
     const $drafts_li = $(".top_left_drafts");
     ui_util.update_unread_count_in_dom($drafts_li, count);
+    $(".compose_draft_button .drafts-count").text(get_count_for_compose_box());
 }
 
 export const draft_model = (function () {
@@ -128,6 +129,21 @@ export function fix_drafts_with_undefined_topics() {
         }
     }
     fixed_buggy_drafts = true;
+}
+
+export function get_count() {
+    return Object.keys(draft_model.get()).length;
+}
+
+export function get_count_for_compose_box() {
+    const count = Object.keys(draft_model.get()).length;
+
+    if (count === 0) {
+        return "";
+    } else if (count >= 100) {
+        return "99+";
+    }
+    return count;
 }
 
 export function sync_count() {

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -44,7 +44,7 @@ let edit_message_id = null;
 let current_message_id = null;
 
 const EMOJI_CATEGORIES = [
-    {name: "Popular", icon: "fa-star-o"},
+    {name: "Popular", zulip_icon: "zulip-icon-star"},
     {name: "Smileys & Emotion", icon: "fa-smile-o"},
     {name: "People & Body", icon: "fa-thumbs-o-up"},
     {name: "Animals & Nature", icon: "fa-leaf"},
@@ -156,7 +156,7 @@ export function rebuild_catalog() {
     const categories = EMOJI_CATEGORIES.filter((category) => catalog.has(category.name));
     complete_emoji_catalog = categories.map((category) => ({
         name: category.name,
-        icon: category.icon,
+        [category.icon ? "icon" : "zulip_icon"]: category.icon || category.zulip_icon,
         emojis: catalog.get(category.name),
     }));
 }

--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -669,7 +669,7 @@ export class Filter {
                 context.icon = "envelope";
                 break;
             case "is-starred":
-                context.icon = "star";
+                context.zulip_icon = "star-filled";
                 break;
             case "is-mentioned":
                 context.icon = "at";

--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -1,10 +1,12 @@
 import $ from "jquery";
 
+import * as pm_list from "./pm_list";
 import * as resize from "./resize";
 import * as scheduled_messages from "./scheduled_messages";
 import * as ui_util from "./ui_util";
 
 let last_mention_count = 0;
+let left_sidebar_navigation_area_expanded = true;
 
 export function update_starred_count(count) {
     const $starred_li = $(".top_left_starred_messages");
@@ -50,6 +52,31 @@ export function deselect_top_left_corner_items() {
     remove($(".top_left_mentions"));
     remove($(".top_left_recent_view"));
     remove($(".top_left_inbox"));
+}
+
+function expand() {
+    $("#toggle-top-left-navigation-area-icon").addClass("fa-caret-down");
+    $("#toggle-top-left-navigation-area-icon").removeClass("fa-caret-right");
+
+    $(".left-sidebar-navigation-area").removeClass("collapsed");
+}
+
+function close() {
+    $("#toggle-top-left-navigation-area-icon").removeClass("fa-caret-down");
+    $("#toggle-top-left-navigation-area-icon").addClass("fa-caret-right");
+
+    $(".left-sidebar-navigation-area").addClass("collapsed");
+}
+
+export function toggle_top_left_navigation_area() {
+    if (left_sidebar_navigation_area_expanded) {
+        close();
+        left_sidebar_navigation_area_expanded = false;
+    } else {
+        expand();
+        left_sidebar_navigation_area_expanded = true;
+    }
+    pm_list.update_private_messages();
 }
 
 export function handle_narrow_activated(filter) {

--- a/web/src/left_sidebar_navigation_area.js
+++ b/web/src/left_sidebar_navigation_area.js
@@ -206,6 +206,12 @@ function do_new_messages_animation($li) {
 
 export function initialize() {
     update_scheduled_messages_row();
+
+    $("body").on(
+        "keydown",
+        "#left-sidebar-navigation-area #views-label-container",
+        ui_util.convert_enter_to_click,
+    );
 }
 
 export function highlight_inbox_view() {

--- a/web/src/left_sidebar_navigation_area_popovers.js
+++ b/web/src/left_sidebar_navigation_area_popovers.js
@@ -2,15 +2,18 @@ import $ from "jquery";
 
 import render_all_messages_sidebar_actions from "../templates/all_messages_sidebar_actions.hbs";
 import render_drafts_sidebar_actions from "../templates/drafts_sidebar_action.hbs";
+import render_left_sidebar_extra_views_menu from "../templates/left_sidebar_extra_views_menu.hbs";
 import render_starred_messages_sidebar_actions from "../templates/starred_messages_sidebar_actions.hbs";
 
 import * as channel from "./channel";
 import * as drafts from "./drafts";
 import * as popover_menus from "./popover_menus";
 import * as popovers from "./popovers";
+import * as scheduled_messages from "./scheduled_messages";
 import * as starred_messages from "./starred_messages";
 import * as starred_messages_ui from "./starred_messages_ui";
 import {parse_html} from "./ui_util";
+import * as ui_util from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
 
@@ -101,6 +104,25 @@ export function initialize() {
         onHidden(instance) {
             instance.destroy();
             popover_menus.popover_instances.all_messages = undefined;
+        },
+    });
+
+    popover_menus.register_popover_menu(".left-sidebar-navigation-menu-icon", {
+        ...popover_menus.left_sidebar_tippy_options,
+        onShow(instance) {
+            popovers.hide_all();
+            instance.setContent(parse_html(render_left_sidebar_extra_views_menu()));
+        },
+        onMount() {
+            ui_util.update_unread_count_in_dom($(".extra-views-menu-drafts"), drafts.get_count());
+            ui_util.update_unread_count_in_dom(
+                $(".extra-views-menu-scheduled-messages"),
+                scheduled_messages.get_count(),
+            );
+        },
+        onHidden(instance) {
+            instance.destroy();
+            popover_menus.popover_instances.top_left_sidebar = undefined;
         },
     });
 }

--- a/web/src/list_util.ts
+++ b/web/src/list_util.ts
@@ -2,7 +2,7 @@ import $ from "jquery";
 
 const list_selectors = [
     "#stream_filters",
-    "#global_filters",
+    "#left-sidebar-navigation-list",
     "#user_presences",
     "#send_later_options",
 ];

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -25,6 +25,7 @@ export const popover_instances = {
     starred_messages: null,
     drafts: null,
     all_messages: null,
+    top_left_sidebar: null,
     message_actions: null,
     stream_settings: null,
     compose_mobile_button: null,

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -26,9 +26,9 @@ function get_new_heights() {
     res.stream_filters_max_height =
         viewport_height -
         Number.parseInt($("#left-sidebar").css("paddingTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginBottom"), 10) -
-        ($("#global_filters").outerHeight(true) ?? 0) -
+        Number.parseInt($("#left-sidebar-navigation-area").css("marginTop"), 10) -
+        Number.parseInt($("#left-sidebar-navigation-area").css("marginBottom"), 10) -
+        ($("#left-sidebar-navigation-list").outerHeight(true) ?? 0) -
         ($("#private_messages_sticky_header").outerHeight(true) ?? 0);
 
     // Don't let us crush the stream sidebar completely out of view

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -623,7 +623,7 @@ div.overlay {
     font-size: 12px;
     font-weight: normal;
     border-radius: 4px;
-    background-color: hsl(105deg 2% 50%);
+    background-color: var(--color-background-unread-counter);
     color: hsl(0deg 0% 100%);
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -796,6 +796,15 @@ input.recipient_box {
         padding: 0 5px;
         position: relative;
         top: 0.7px;
+
+        .drafts-count {
+            margin-left: 3px;
+
+            /* Don't show count on smaller widths due to space restrictions. */
+            @media (width < calc( $lg_min)) {
+                display: none;
+            }
+        }
     }
 
     .compose_help_button {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -511,13 +511,6 @@
         color: hsl(236deg 33% 90%);
     }
 
-    .unread_count,
-    /* The actions_popover unread_count object has its own variable CSS,
-       and thus needs to be repeated here with all three classes for precedence) */
-    .actions_popover .mark_as_unread .unread_count {
-        background-color: hsl(105deg 2% 50% / 50%);
-    }
-
     .pill-container {
         border-style: solid;
         border-width: 1px;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -779,7 +779,7 @@
 
     #topics_header {
         .show-all-streams {
-            color: hsl(236deg 33% 90%);
+            color: hsl(0deg 0% 100% / 75%);
             opacity: 0.75;
         }
     }

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -197,6 +197,17 @@ li.show-more-topics {
     }
 }
 
+#views-label-container {
+    cursor: pointer;
+    /* Padding of #private_messages_section_header. */
+    padding: 0 10px 1px 6px;
+    /* The margin-left of .private_messages_container. */
+    margin-left: 6px;
+    /* Space between #views-label-container and .left-sidebar-navigation-list in collapsed state. */
+    margin-right: 10px;
+    margin-top: 3px;
+}
+
 .left-sidebar-navigation-area {
     & li.top_left_row {
         position: relative;
@@ -221,21 +232,6 @@ li.show-more-topics {
     margin-right: 16px;
     margin-left: 6px;
     z-index: 1;
-
-    #toggle_private_messages_section_icon {
-        opacity: 0.7;
-        margin-left: -15px;
-        min-width: 12px;
-
-        &.fa-caret-right {
-            position: relative;
-            left: 3px;
-        }
-
-        &:hover {
-            opacity: 1;
-        }
-    }
 
     #private_messages_section_header {
         cursor: pointer;
@@ -305,6 +301,22 @@ li.show-more-topics {
                 margin-top: 2px;
             }
         }
+    }
+}
+
+#toggle_private_messages_section_icon,
+#toggle-top-left-navigation-area-icon {
+    opacity: 0.7;
+    margin-left: -15px;
+    min-width: 12px;
+
+    &.fa-caret-right {
+        position: relative;
+        left: 3px;
+    }
+
+    &:hover {
+        opacity: 1;
     }
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -303,6 +303,20 @@ li.show-more-topics {
     }
 }
 
+.active-view-row-container {
+    display: none;
+
+    &.collapsed {
+        display: block;
+
+        .top_left_row,
+        .top_left_row:hover {
+            border-radius: 4px;
+            background-color: var(--color-background-active-view-row);
+        }
+    }
+}
+
 .extra-views-menu .unread_count {
     /* margin-top of `.top_left_row .unread_count`. */
     margin-top: 2px;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -54,14 +54,8 @@ $before_unread_count_padding: 3px;
     cursor: pointer;
 }
 
-#global_filters .filter-icon i {
-    padding-right: 3px;
-    color: var(--color-global-filter-icon);
-}
-
-#stream_filters,
-#global_filters {
-    margin-right: 12px;
+.left-sidebar-navigation-list .filter-icon i {
+    color: var(--color-left-sidebar-navigation-icon);
 }
 
 li.show-more-topics {
@@ -203,11 +197,12 @@ li.show-more-topics {
     }
 }
 
-.narrows_panel {
-    & li a {
-        margin-top: 1px;
+.left-sidebar-navigation-area {
+    & li.top_left_row {
+        position: relative;
+        padding: 2px 10px 1px $far_left_gutter_size;
 
-        &:hover {
+        & a:hover {
             text-decoration: none;
         }
     }
@@ -485,17 +480,19 @@ li.active-sub-filter {
     }
 }
 
-#global_filters {
+.left-sidebar-navigation-list {
     margin-bottom: $sections_vertical_gutter;
+    margin-right: 12px;
 
-    .global-filter-container {
+    .left-sidebar-navigation-label-container {
         display: flex;
         padding-right: 20px;
 
-        .global-filter-name {
+        .left-sidebar-navigation-label {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+            padding-left: 3px;
 
             flex-grow: 1;
         }
@@ -527,27 +524,6 @@ li.active-sub-filter {
         top: 2px;
         position: relative;
     }
-}
-
-li.top_left_all_messages,
-li.top_left_mentions,
-li.top_left_starred_messages,
-li.top_left_drafts,
-li.top_left_inbox,
-li.top_left_recent_view,
-li.top_left_scheduled_messages {
-    position: relative;
-    padding-top: 1px;
-    padding-bottom: 1px;
-
-    & a {
-        display: block;
-    }
-}
-
-.top_left_row {
-    padding-left: $far_left_gutter_size;
-    padding-right: 10px;
 }
 
 .conversation-partners {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -206,6 +206,7 @@ li.show-more-topics {
     /* Space between #views-label-container and .left-sidebar-navigation-list in collapsed state. */
     margin-right: 10px;
     margin-top: 3px;
+    outline: none;
 }
 
 .left-sidebar-navigation-area {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -219,6 +219,76 @@ li.show-more-topics {
     }
 }
 
+#left-sidebar-navigation-area.collapsed {
+    display: flex;
+    align-items: center;
+    /* 2px space between views and direct messages sections when views section is collapsed. */
+    margin-bottom: 2px;
+
+    .hide-view-in-collapsed-state {
+        display: none;
+    }
+
+    & .left-sidebar-navigation-list {
+        width: 100%;
+        display: flex;
+        /* 25px margin-right of .subscription_block + 12px margin-right of #stream_filters. */
+        margin-right: 37px;
+        margin-bottom: 0;
+
+        & .top_left_row {
+            padding: 0;
+            flex-grow: 1;
+
+            .left-sidebar-navigation-label-container {
+                padding-right: 0;
+                justify-content: center;
+
+                .filter-icon {
+                    padding-top: 4px;
+
+                    & .fa {
+                        font-size: 16px;
+                    }
+
+                    & .zulip-icon-star-filled {
+                        top: 1px;
+                    }
+                }
+
+                .left-sidebar-navigation-label {
+                    display: none;
+                }
+            }
+
+            .sidebar-menu-icon {
+                display: none;
+            }
+
+            /* Don't show counts that are not unread counts in collapsed state. */
+            &.top_left_starred_messages {
+                .unread_count {
+                    display: none;
+                }
+            }
+        }
+    }
+
+    /* CSS to align unread counters in the top right corner. */
+    .unread_count {
+        position: absolute;
+        z-index: 3;
+
+        /* The 'left' and 'bottom' values set to 100% position the unread counter just outside the top right corner of the parent container (.top_left_row li). */
+        left: 100%;
+        bottom: 100%;
+
+        /* The 'transform' property with 'translate' adjustments brings half of the unread counter back in from the right and top,
+           positioning the center point of the unread counter precisely on the top-right corner of .top_left_row li. */
+        transform: translate(-50%, 50%);
+    }
+}
+
 #left_sidebar_scroll_container {
     outline: none;
     overflow-x: hidden;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -519,7 +519,8 @@ li.active-sub-filter {
         margin-top: 1px !important;
     }
 
-    .zulip-icon-inbox {
+    .zulip-icon-inbox,
+    .zulip-icon-star-filled {
         font-size: 14px;
         top: 2px;
         position: relative;
@@ -544,8 +545,7 @@ li.active-sub-filter {
     font-size: 15px;
 }
 
-.top_left_mentions i.fa-at,
-.top_left_starred_messages i.fa-star {
+.top_left_mentions i.fa-at {
     font-size: 13px;
 }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -293,6 +293,14 @@ li.show-more-topics {
            positioning the center point of the unread counter precisely on the top-right corner of .top_left_row li. */
         transform: translate(-50%, 50%);
     }
+
+    /* Show unread counters as dots when not hovered on view icon(.top_left_row). */
+    & .top_left_row:not(:hover) .unread_count {
+        width: 8px;
+        height: 8px;
+        padding: 0;
+        font-size: 0;
+    }
 }
 
 .extra-views-menu .unread_count {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -217,6 +217,12 @@ li.show-more-topics {
             text-decoration: none;
         }
     }
+
+    & .left-sidebar-navigation-menu-icon {
+        top: auto;
+        /* 12px margin-right of #stream_filters to align with other vertical 3-dots in left sidebar. */
+        margin-right: 12px;
+    }
 }
 
 #left-sidebar-navigation-area.collapsed {
@@ -287,6 +293,13 @@ li.show-more-topics {
            positioning the center point of the unread counter precisely on the top-right corner of .top_left_row li. */
         transform: translate(-50%, 50%);
     }
+}
+
+.extra-views-menu .unread_count {
+    /* margin-top of `.top_left_row .unread_count`. */
+    margin-top: 2px;
+    margin-left: 15px;
+    background-color: var(--color-background-unread-counter-popover-menu);
 }
 
 #left_sidebar_scroll_container {
@@ -759,7 +772,8 @@ li.active-sub-filter {
     positioning.  We should fix that.
 */
 .top_left_row .sidebar-menu-icon,
-.bottom_left_row .sidebar-menu-icon {
+.bottom_left_row .sidebar-menu-icon,
+.left-sidebar-navigation-menu-icon {
     position: absolute;
     display: none;
     top: 1px;
@@ -800,6 +814,14 @@ li.active-sub-filter {
     }
 }
 
+/* Don't show 3-dot menu icon in expanded state on touch devices. */
+@media (hover: none) {
+    .left-sidebar-navigation-area:not(.collapsed)
+        .left-sidebar-navigation-menu-icon {
+        display: none;
+    }
+}
+
 /*
     When you hover over list items, we hover
     the vdots in light gray.
@@ -810,7 +832,9 @@ li.active-sub-filter {
 */
 #stream_filters li:hover .stream-sidebar-menu-icon,
 .top_left_row:hover .sidebar-menu-icon,
-.bottom_left_row:hover .sidebar-menu-icon {
+.bottom_left_row:hover .sidebar-menu-icon,
+#left-sidebar-navigation-area.collapsed:hover
+    .left-sidebar-navigation-menu-icon {
     display: inline;
     cursor: pointer;
     color: var(--color-vdots-visible);

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -303,7 +303,9 @@ ul {
             font-size: 11px;
             font-weight: 600;
             margin-right: 2px;
-            background-color: hsl(200deg 100% 40%);
+            background-color: var(
+                --color-background-unread-counter-popover-menu
+            );
             /* Override random undesired bootstrap style */
             text-shadow: none;
             /* Not center aligned but looks better. */

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2079,7 +2079,8 @@ div.focused-message-list {
             }
         }
 
-        .zulip-icon-inbox {
+        .zulip-icon-inbox,
+        .zulip-icon-star-filled {
             position: relative;
             top: 2px;
         }
@@ -3320,5 +3321,13 @@ select.invite-as {
 
     .zulip-icon {
         padding: 5px;
+    }
+}
+
+#unstar_all_messages,
+.emoji-popover-tab-item {
+    .zulip-icon-star {
+        position: relative;
+        top: 2px;
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -191,6 +191,7 @@ body {
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 10%);
     --color-background-unread-counter: hsl(105deg 2% 50%);
     --color-background-unread-counter-popover-menu: hsl(200deg 100% 40%);
+    --color-background-active-view-row: hsl(0deg 0% 100%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -283,6 +284,7 @@ body {
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 35%);
     --color-background-unread-counter: hsl(105deg 2% 50% / 50%);
     --color-background-unread-counter-popover-menu: hsl(105deg 2% 50% / 50%);
+    --color-background-active-view-row: hsl(0deg 0% 15%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -212,7 +212,7 @@ body {
     --color-message-star-action: hsl(41deg 100% 47% / 100%);
     /* The gray on the filter icons is the same as
        what's set on ul.filters, but with 70% opacity. */
-    --color-global-filter-icon: hsl(0deg 0% 20% / 70%);
+    --color-left-sidebar-navigation-icon: hsl(0deg 0% 20% / 70%);
     --color-vdots-hint: hsl(0deg 0% 0% / 30%);
     --color-vdots-visible: hsl(0deg 0% 0% / 53%);
     --color-vdots-hover: hsl(0deg 0% 0%);
@@ -305,7 +305,7 @@ body {
     --color-icon-bot: hsl(180deg 5% 50% / 100%);
     --color-message-action-visible: hsl(217deg 41% 90% / 50%);
     --color-message-action-interactive: hsl(217deg 41% 90% / 100%);
-    --color-global-filter-icon: hsl(0deg 0% 100% / 56%);
+    --color-left-sidebar-navigation-icon: hsl(0deg 0% 100% / 56%);
     --color-vdots-hint: hsl(0deg 0% 100% / 30%);
     --color-vdots-visible: hsl(236deg 33% 80%);
     --color-vdots-hover: hsl(0deg 0% 100%);
@@ -3106,7 +3106,7 @@ select.invite-as {
             }
         }
 
-        .narrows_panel {
+        #left-sidebar-navigation-area {
             margin-top: 10px;
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -189,6 +189,8 @@ body {
     --color-search-shadow-wide: hsl(0deg 0% 0% / 25%);
     --color-search-shadow-tight: hsl(0deg 0% 0% / 10%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 10%);
+    --color-background-unread-counter: hsl(105deg 2% 50%);
+    --color-background-unread-counter-popover-menu: hsl(200deg 100% 40%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -279,6 +281,8 @@ body {
     --color-background-search-option-hover: hsl(0deg 0% 30%);
     --color-search-box-hover-shadow: hsl(0deg 0% 0% / 30%);
     --color-search-dropdown-top-border: hsla(0deg 0% 0% / 35%);
+    --color-background-unread-counter: hsl(105deg 2% 50% / 50%);
+    --color-background-unread-counter-popover-menu: hsl(105deg 2% 50% / 50%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/templates/active_view_row.hbs
+++ b/web/templates/active_view_row.hbs
@@ -1,0 +1,12 @@
+<li class="top_left_{{active_view_name}} top_left_row hidden-for-spectators hide-view-in-collapsed-state">
+    <a href="{{active_view_url}}" class="{{#if active_view_tooltip}}tippy-left-sidebar-tooltip{{/if}} left-sidebar-navigation-label-container" {{#if active_view_tooltip}}data-tooltip-template-id="{{active_view_tooltip}}"{{/if}}>
+        <span class="filter-icon">
+            <i class="{{active_view_icon}}" aria-hidden="true"></i>
+        </span>
+        <span class="left-sidebar-navigation-label">{{t "{active_view_label}" }}</span>
+        <span class="unread_count hide"></span>
+    </a>
+    {{#if active_view_sidebar_menu_icon}}
+        <span class="arrow sidebar-menu-icon {{active_view_sidebar_menu_icon}}"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+    {{/if}}
+</li>

--- a/web/templates/compose_banner/success_message_scheduled_banner.hbs
+++ b/web/templates/compose_banner/success_message_scheduled_banner.hbs
@@ -3,7 +3,7 @@
   data-scheduled-message-id="{{scheduled_message_id}}">
     <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
         <p class="banner_content">{{t 'Your message has been scheduled for {deliver_at}.' }}
-            <a href="#scheduled">{{t "View scheduled messages" }}</a>
+            <a href="#scheduled">{{t "View {scheduled_messages_count} scheduled messages" }}</a>
         </p>
         <button class="main-view-banner-action-button undo_scheduled_message" >{{t "Undo"}}</button>
     </div>

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -28,6 +28,7 @@
     </div>
     <a role="button" class="compose_control_button compose_draft_button hide-sm" tabindex=0 href="#drafts" data-tooltip-template-id="compose_draft_tooltip_template">
         {{t 'Drafts' }}
+        <span class="drafts-count"></span>
     </a>
     <div class="compose_control_menu_wrapper" role="button" tabindex=0>
         <a class="compose_control_button zulip-icon zulip-icon-more-vertical hide {{#if message_id}}show-lg{{else}}show-sm hide-md show-mc{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>

--- a/web/templates/emoji_popover_content.hbs
+++ b/web/templates/emoji_popover_content.hbs
@@ -5,7 +5,7 @@
     </div>
     <div class="emoji-popover-category-tabs">
         {{#each emoji_categories}}
-            <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="fa {{icon}}"></i></span>
+            <span class="emoji-popover-tab-item {{#if @first}} active {{/if}}" data-tab-name='{{name}}' title='{{name}}'><i class="{{#if icon}}fa {{icon}}{{else}}zulip-icon {{zulip_icon}}{{/if}}"></i></span>
         {{/each}}
     </div>
     <div class="emoji-popover-emoji-map" data-simplebar data-simplebar-auto-hide="false" data-message-id="{{message_id}}">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -78,6 +78,7 @@
                 </a>
             </li>
         </ul>
+        <span class="arrow sidebar-menu-icon left-sidebar-navigation-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
     </div>
 
     <div id="private_messages_sticky_header" class="private_messages_container zoom-out hidden-for-spectators">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -44,7 +44,7 @@
             <li class="top_left_starred_messages top_left_row hidden-for-spectators">
                 <a class="left-sidebar-navigation-label-container" href="#narrow/is/starred">
                     <span class="filter-icon">
-                        <i class="fa fa-star" aria-hidden="true"></i>
+                        <i class="zulip-icon zulip-icon-star-filled" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
                     <span class="left-sidebar-navigation-label">{{t 'Starred messages' }}</span>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -81,6 +81,11 @@
         <span class="arrow sidebar-menu-icon left-sidebar-navigation-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
     </div>
 
+    <div class="left-sidebar-navigation-area active-view-row-container">
+        <ul class="left-sidebar-navigation-list filters active-view-row">
+        </ul>
+    </div>
+
     <div id="private_messages_sticky_header" class="private_messages_container zoom-out hidden-for-spectators">
         <div id="private_messages_section">
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,6 +1,6 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
-        <div id="views-label-container" class="hidden-for-spectators">
+        <div id="views-label-container" class="hidden-for-spectators" tabindex="0">
             <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down" aria-hidden="true"></i>
             <h4 class="sidebar-title">{{t 'VIEWS' }}</h4>
         </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -56,7 +56,7 @@
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_drafts top_left_row hidden-for-spectators">
+            <li class="top_left_drafts top_left_row hidden-for-spectators hide-view-in-collapsed-state">
                 <a href="#drafts" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="drafts-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
@@ -67,7 +67,7 @@
                 </a>
                 <span class="arrow sidebar-menu-icon drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
+            <li class="top_left_scheduled_messages top_left_row hidden-for-spectators hide-view-in-collapsed-state">
                 <a class="left-sidebar-navigation-label-container" href="#scheduled">
                     <span class="filter-icon">
                         <i class="fa fa-calendar" aria-hidden="true"></i>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,5 +1,9 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
     <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
+        <div id="views-label-container" class="hidden-for-spectators">
+            <i id="toggle-top-left-navigation-area-icon" class="fa fa-sm fa-caret-down" aria-hidden="true"></i>
+            <h4 class="sidebar-title">{{t 'VIEWS' }}</h4>
+        </div>
         <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
             {{!-- Special-case this link so we don't actually go to page top. --}}
             <li class="top_left_all_messages top_left_row">

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -1,75 +1,75 @@
 <div class="left-sidebar" id="left-sidebar" role="navigation">
-    <div class="narrows_panel">
-        <ul id="global_filters" class="filters">
+    <div id="left-sidebar-navigation-area" class="left-sidebar-navigation-area">
+        <ul id="left-sidebar-navigation-list" class="left-sidebar-navigation-list filters">
             {{!-- Special-case this link so we don't actually go to page top. --}}
             <li class="top_left_all_messages top_left_row">
-                <a href="#all_messages" class="home-link tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="all-message-tooltip-template">
+                <a href="#all_messages" class="home-link tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="all-message-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-align-left" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'All messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_inbox top_left_row hidden-for-spectators">
-                <a href="#inbox" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="inbox-tooltip-template">
+                <a href="#inbox" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="inbox-tooltip-template">
                     <span class="filter-icon">
                         <i class="zulip-icon zulip-icon-inbox" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span>{{t 'Inbox' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Inbox' }}</span>
                 </a>
             </li>
             <li class="top_left_recent_view top_left_row">
-                <a href="#recent" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="recent-conversations-tooltip-template">
+                <a href="#recent" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="recent-conversations-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-clock-o" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Recent conversations' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Recent conversations' }}</span>
                 </a>
             </li>
             <li class="top_left_mentions top_left_row hidden-for-spectators">
-                <a class="global-filter-container" href="#narrow/is/mentioned">
+                <a class="left-sidebar-navigation-label-container" href="#narrow/is/mentioned">
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Mentions' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Mentions' }}</span>
                     <span class="unread_count"></span>
                 </a>
             </li>
             <li class="top_left_starred_messages top_left_row hidden-for-spectators">
-                <a class="global-filter-container" href="#narrow/is/starred">
+                <a class="left-sidebar-navigation-label-container" href="#narrow/is/starred">
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Starred messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_drafts top_left_row hidden-for-spectators">
-                <a href="#drafts" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="drafts-tooltip-template">
+                <a href="#drafts" class="tippy-left-sidebar-tooltip left-sidebar-navigation-label-container" data-tooltip-template-id="drafts-tooltip-template">
                     <span class="filter-icon">
                         <i class="fa fa-pencil" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Drafts' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Drafts' }}</span>
                     <span class="unread_count"></span>
                 </a>
                 <span class="arrow sidebar-menu-icon drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
-                <a class="global-filter-container" href="#scheduled">
+                <a class="left-sidebar-navigation-label-container" href="#scheduled">
                     <span class="filter-icon">
                         <i class="fa fa-calendar" aria-hidden="true"></i>
                     </span>
                     {{~!-- squash whitespace --~}}
-                    <span class="global-filter-name">{{t 'Scheduled messages' }}</span>
+                    <span class="left-sidebar-navigation-label">{{t 'Scheduled messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
             </li>

--- a/web/templates/left_sidebar_extra_views_menu.hbs
+++ b/web/templates/left_sidebar_extra_views_menu.hbs
@@ -1,0 +1,21 @@
+{{! Extra views in `VIEWS` section in collapsed state in 3-dot Menu. }}
+<ul class="nav nav-list extra-views-menu">
+    <li class="extra-views-menu-drafts">
+        <a tabindex="0" href="#drafts" class="tippy-left-sidebar-tooltip" data-tooltip-template-id="drafts-tooltip-template">
+            <span class="filter-icon">
+                <i class="fa fa-pencil" aria-hidden="true"></i>
+            </span>
+            <span>{{t 'Drafts' }}</span>
+            <span class="unread_count"></span>
+        </a>
+    </li>
+    <li class="extra-views-menu-scheduled-messages">
+        <a tabindex="0" href="#scheduled">
+            <span class="filter-icon">
+                <i class="fa fa-calendar" aria-hidden="true"></i>
+            </span>
+            <span>{{t 'Scheduled messages' }}</span>
+            <span class="unread_count"></span>
+        </a>
+    </li>
+</ul>

--- a/web/templates/send_later_popover.hbs
+++ b/web/templates/send_later_popover.hbs
@@ -9,6 +9,6 @@
     {{/if}}
     <hr />
     <li>
-        <a href="#scheduled" tabindex="0">{{t "View scheduled messages" }}</a>
+        <a href="#scheduled" tabindex="0">{{t "View {scheduled_messages_count} scheduled messages" }}</a>
     </li>
 </ul>

--- a/web/templates/starred_messages_sidebar_actions.hbs
+++ b/web/templates/starred_messages_sidebar_actions.hbs
@@ -4,7 +4,7 @@
     {{#if show_unstar_all_button}}
     <li>
         <a tabindex="0" id="unstar_all_messages">
-            <i class="fa fa-star-o" aria-hidden="true"></i>
+            <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
             {{t "Unstar all messages" }}
         </a>
     </li>

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -68,7 +68,7 @@
     {{#if has_starred_messages}}
     <li class="hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-unstar-all-in-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="fa fa-star-o" aria-hidden="true"></i>
+            <i class="zulip-icon zulip-icon-star" aria-hidden="true"></i>
             {{t "Unstar all messages in topic" }}
         </a>
     </li>

--- a/web/tests/emoji_picker.test.js
+++ b/web/tests/emoji_picker.test.js
@@ -28,7 +28,7 @@ run_test("initialize", () => {
     let total_emoji_in_categories = 0;
 
     function assert_emoji_category(ele, icon, num) {
-        assert.equal(ele.icon, icon);
+        assert.equal(ele.icon || ele.zulip_icon, icon);
         assert.equal(ele.emojis.length, num);
         function check_emojis(val) {
             for (const this_emoji of ele.emojis) {
@@ -47,7 +47,7 @@ run_test("initialize", () => {
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-car", 195);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-hashtag", 221);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-smile-o", 162);
-    assert_emoji_category(complete_emoji_catalog.pop(), "fa-star-o", popular_emoji_count);
+    assert_emoji_category(complete_emoji_catalog.pop(), "zulip-icon-star", popular_emoji_count);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-thumbs-o-up", 361);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-lightbulb-o", 257);
     assert_emoji_category(complete_emoji_catalog.pop(), "fa-cutlery", 131);

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1574,7 +1574,7 @@ test("navbar_helpers", () => {
         {
             operator: is_starred,
             is_common_narrow: true,
-            icon: "star",
+            zulip_icon: "star-filled",
             title: "translated: Starred messages",
             redirect_url_with_search: "/#narrow/is/starred",
         },

--- a/web/tests/left_sidebar_navigation_area.test.js
+++ b/web/tests/left_sidebar_navigation_area.test.js
@@ -17,8 +17,13 @@ scheduled_messages.get_count = () => 555;
 const {Filter} = zrequire("../src/filter");
 const left_sidebar_navigation_area = zrequire("left_sidebar_navigation_area");
 
-run_test("narrowing", () => {
+run_test("narrowing", ({mock_template}) => {
     let filter = new Filter([{operator: "is", operand: "mentioned"}]);
+    mock_template("active_view_row.hbs", false, () => {});
+    const $unread_count = $.create("unread-count-stub");
+    $(".top_left_mentions").set_find_results(".unread_count", $unread_count);
+    $(".top_left_all_messages").set_find_results(".unread_count", $unread_count);
+    $(".top_left_starred_messages").set_find_results(".unread_count", $unread_count);
 
     // activating narrow
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This is the first step toward the left sidebar redesign project.
This PR puts all the links in the top left area into a collapsible views section.

- [x]  Put all the links above "Direct messages" into a collapsible section labeled as "Views" (same font as "Direct messages" and "Streams"). The selected view should always be shown even when the section is collapsed (as we do for the selected DM conversation).

- [x] When the Views section is collapsed, show the links to views as icons after the "Views" label.

This PR does not redesign anything in the left sidebar all icons, colors etc. ar kept the same.


Fixes: #25902<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Expanded views section: 
![image](https://github.com/zulip/zulip/assets/64723994/85ea588b-a5e5-492c-999e-011409809e81)

- Collapsed views section:
![image](https://github.com/zulip/zulip/assets/64723994/c65b15cd-122f-444c-8179-c8a62aee7e16)

- 3-dot menu when 3 options:
![image](https://github.com/zulip/zulip/assets/64723994/b2cd495d-6acf-40c3-8ce0-a3deb2e2338e)

- 3-dot menu when 4 options:
![image](https://github.com/zulip/zulip/assets/64723994/26131675-3956-4b23-92f2-e9dc365b3341)

- unread counter on hover:
![image](https://github.com/zulip/zulip/assets/64723994/e83fc24c-cec6-46f7-8579-67422413ac60)
- tooltips:
![image](https://github.com/zulip/zulip/assets/64723994/f735d275-aa6f-415d-a3c7-727dd00e8341)

- saved as drafts tooltip:
![image](https://github.com/zulip/zulip/assets/64723994/b09171cf-7850-4b03-9257-20bb50d9dbd6)

- Dark theme:
![image](https://github.com/zulip/zulip/assets/64723994/80efba53-ddee-41ad-b4e1-daca090a1c20)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
