### PR TITLE
    compose: Show only `all` when no input for wildcard mentions.

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -335,14 +335,18 @@ export function tokenize_compose_str(s) {
     return "";
 }
 
-export function broadcast_mentions() {
-    const wildcard_mention_array = ["all", "everyone"];
+export function broadcast_mentions(query) {
+    let wildcard_mention_array = ["all", "everyone"];
     let wildcard_string = "";
     if (compose_state.get_message_type() === "private") {
         wildcard_string = $t({defaultMessage: "Notify recipients"});
     } else {
         wildcard_string = $t({defaultMessage: "Notify stream"});
         wildcard_mention_array.push("stream");
+    }
+    if (query === "") {
+        // before there is any input, show only all #25613
+        wildcard_mention_array = ["all"];
     }
     return wildcard_mention_array.map((mention, idx) => ({
         special_item_text: `${mention} (${wildcard_string})`,
@@ -455,7 +459,7 @@ export function get_person_suggestions(query, opts) {
         persons = muted_users.filter_muted_users(persons);
 
         if (opts.want_broadcast) {
-            persons = [...persons, ...broadcast_mentions()];
+            persons = [...persons, ...broadcast_mentions(query)];
         }
 
         return persons.filter((item) => query_matches_person(query, item));

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -84,6 +84,12 @@ run_test("verify wildcard mentions typeahead for private message", () => {
 
     assert.equal(mention_all.special_item_text, "all (translated: Notify recipients)");
     assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify recipients)");
+    // before there is any input, show only all #25613
+    const mentions = ct.broadcast_mentions("");
+    assert.equal(mentions[0].email, "all");
+    assert.equal(mentions[0].full_name, "all");
+    assert.equal(mentions[0].special_item_text, "all (translated: Notify recipients)");
+    assert.equal(mentions.length, 1);
 });
 
 const emoji_stadium = {


### PR DESCRIPTION
    Showing all, everyone and stream was cluttering the composebox wildcard mention popover,
    so limiting to showing only `all` was preferred.
    Fixes #25613

<!-- Describe your pull request here.-->

Fixes: [this](https://github.com/zulip/zulip/issues/25613)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/39624400/7203b9eb-685d-4306-8c9f-329bc6ebd149)



<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
