### PR TITLE
bot_icon: Adjust bot-icon color for light and dark modes.

### DIFF
--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -94,7 +94,7 @@ a.no-underline:hover {
 }
 
 i.zulip-icon.zulip-icon-bot {
-    color: hsl(180deg 5% 74%);
+    color: var(--color-icon-bot);
     vertical-align: top;
     padding: 0 2px;
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -154,6 +154,9 @@ body {
     --color-text-self-direct-mention: hsl(240deg 52% 45% / 100%);
     --color-text-self-group-mention: hsl(183deg 52% 26% / 100%);
 
+    /* Icon colors */
+    --color-icon-bot: hsl(180deg 8% 65% / 100%);
+
     /* Mention pill colors */
     --color-background-direct-mention: hsl(240deg 52% 95%);
     --color-background-group-mention: hsl(180deg 40% 94%);
@@ -196,6 +199,9 @@ body {
     --color-text-other-mention: hsl(0deg 0% 100% / 80%);
     --color-text-self-direct-mention: hsl(240deg 100% 88% / 100%);
     --color-text-self-group-mention: hsl(184deg 52% 63% / 100%);
+
+    /* Icon colors */
+    --color-icon-bot: hsl(180deg 5% 50% / 100%);
 
     /* Mention pill colors */
     --color-background-direct-mention: hsl(240deg 13% 20%);


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR darkens both the light- and dark-mode bot icons for better, more consistent contrast with the bot username text. (The dark-mode adjustment is subtler than the one for light mode.)

[CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/bot.20icon)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before, light mode | After, light mode |
| --- | --- |
| <img width="674" alt="bot-icon-light-before" src="https://github.com/zulip/zulip/assets/170719/3806baf4-353e-4088-9483-4fb8b835a9eb"> | <img width="674" alt="bot-icon-light-after" src="https://github.com/zulip/zulip/assets/170719/858289fc-598b-427a-acf9-ea2646837304"> |

| Before, dark mode | After, dark mode |
| --- | --- |
| <img width="674" alt="bot-icon-dark-before" src="https://github.com/zulip/zulip/assets/170719/502462d8-6f06-4df1-9c73-73bb50b0d83c"> | <img width="674" alt="bot-icon-dark-after" src="https://github.com/zulip/zulip/assets/170719/ff0030fa-dde8-47d4-9ef1-8dfe8b585301"> |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>