### PR TITLE
middleware: Detect reverse proxy misconfigurations.

### DIFF
--- a/puppet/zulip/files/nginx/uwsgi_params
+++ b/puppet/zulip/files/nginx/uwsgi_params
@@ -16,5 +16,6 @@ uwsgi_param SERVER_NAME     $server_name;
 uwsgi_param HTTP_X_REAL_IP  $remote_addr;
 uwsgi_param HTTP_X_FORWARDED_PROTO $trusted_x_forwarded_proto;
 uwsgi_param HTTP_X_FORWARDED_SSL "";
+uwsgi_param HTTP_X_PROXY_MISCONFIGURATION $x_proxy_misconfiguration;
 
 uwsgi_pass django;

--- a/puppet/zulip/files/nginx/zulip-include-common/proxy
+++ b/puppet/zulip/files/nginx/zulip-include-common/proxy
@@ -6,5 +6,6 @@ proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Proto $trusted_x_forwarded_proto;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Real-Ip $remote_addr;
+proxy_set_header X-Proxy-Misconfiguration $x_proxy_misconfiguration;
 proxy_next_upstream off;
 proxy_redirect off;

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -59,6 +59,12 @@ class zulip::app_frontend_base {
       source  => 'puppet:///modules/zulip/nginx/zulip-include-app.d/keepalive-loadbalancer.conf',
       notify  => Service['nginx'],
     }
+  } else {
+    file { ['/etc/nginx/zulip-include/app.d/accept-loadbalancer.conf',
+            '/etc/nginx/zulip-include/app.d/keepalive-loadbalancer.conf']:
+      ensure => absent,
+      notify => Service['nginx'],
+    }
   }
 
   file { '/etc/nginx/zulip-include/upstreams':

--- a/puppet/zulip/templates/nginx/trusted-proto.template.erb
+++ b/puppet/zulip/templates/nginx/trusted-proto.template.erb
@@ -3,6 +3,10 @@
 map $remote_addr $trusted_x_forwarded_proto {
     default $scheme;
 }
+map $http_x_forwarded_for $x_proxy_misconfiguration {
+    default "";
+    "~." "No proxies configured in Zulip, but proxy headers detected from proxy at $remote_addr; see https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
+}
 <% else %>
 # We do this in two steps because `geo` does not support variable
 # interpolation in the value, but does support CIDR notation,
@@ -17,5 +21,10 @@ geo $realip_remote_addr $is_x_forwarded_proto_trusted {
 map $is_x_forwarded_proto_trusted $trusted_x_forwarded_proto {
     0 $scheme;
     1 $http_x_forwarded_proto;
+}
+map "$is_x_forwarded_proto_trusted:$http_x_forwarded_proto" $x_proxy_misconfiguration {
+    "~^0:" "Incorrect reverse proxy IPs set in Zulip (try $remote_addr?); see https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
+    "~^1:$" "No X-Forwarded-Proto header sent from trusted proxy $realip_remote_addr; see example configurations in https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
+    default "";
 }
 <% end %>

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -689,3 +689,7 @@ class ZulipSCIMAuthCheckMiddleware(SCIMAuthCheckMiddleware):
             return response
 
         return None
+
+
+class ZulipNoopMiddleware(MiddlewareMixin):
+    pass

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -600,6 +600,50 @@ class SetRemoteAddrFromRealIpHeader(MiddlewareMixin):
             request.META["REMOTE_ADDR"] = real_ip
 
 
+class ProxyMisconfigurationError(JsonableError):
+    http_status_code = 500
+    data_fields = ["proxy_reason"]
+
+    def __init__(self, proxy_reason: str) -> None:
+        self.proxy_reason = proxy_reason
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("Reverse proxy misconfiguration: {proxy_reason}")
+
+
+class DetectProxyMisconfiguration(MiddlewareMixin):
+    def process_view(
+        self,
+        request: HttpRequest,
+        view_func: Callable[Concatenate[HttpRequest, ParamT], HttpResponseBase],
+        args: List[object],
+        kwargs: Dict[str, Any],
+    ) -> None:
+        proxy_state_header = request.headers.get("X-Proxy-Misconfiguration", "")
+        # Our nginx configuration sets this header if:
+        #  - there is an X-Forwarded-For set but no proxies configured in Zulip
+        #  - proxies are configured but the request did not come from them
+        #  - proxies are configured and the request came from them,
+        #    but there was no X-Forwarded-Proto header
+        #
+        # Note that the first two may be false-positives.  We only
+        # display the error if the request also came in over HTTP (and
+        # a trusted proxy didn't say they get it over HTTPS), which
+        # should be impossible because Zulip only supports external
+        # https:// URLs in production.  nginx configuration ensures
+        # that request.is_secure() is only true if our nginx is
+        # serving the request over HTTPS, or it came from a trusted
+        # proxy which reports that it is doing so.  This will result
+        # in false negatives if Zulip's nginx is serving responses
+        # over HTTPS to a proxy whose IP is not configured, or
+        # misconfigured, but we cannot distinguish this from a random
+        # client which is providing proxy headers to a correctly
+        # configured Zulip.
+        if proxy_state_header != "" and not request.is_secure():
+            raise ProxyMisconfigurationError(proxy_state_header)
+
+
 def alter_content(request: HttpRequest, content: bytes) -> bytes:
     first_paragraph_text = get_content_description(content, request)
     placeholder_open_graph_description = RequestNotes.get_notes(

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -159,7 +159,7 @@ ALLOWED_HOSTS += [EXTERNAL_HOST_WITHOUT_PORT, "." + EXTERNAL_HOST_WITHOUT_PORT]
 # ... and with the hosts in REALM_HOSTS.
 ALLOWED_HOSTS += REALM_HOSTS.values()
 
-MIDDLEWARE = (
+MIDDLEWARE = [
     "zerver.middleware.TagRequests",
     "zerver.middleware.SetRemoteAddrFromRealIpHeader",
     "zerver.middleware.RequestContext",
@@ -182,7 +182,7 @@ MIDDLEWARE = (
     "two_factor.middleware.threadlocals.ThreadLocals",  # Required by Twilio
     # Needs to be after CommonMiddleware, which sets Content-Length
     "zerver.middleware.FinalizeOpenGraphDescription",
-)
+]
 
 AUTH_USER_MODEL = "zerver.UserProfile"
 

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -176,6 +176,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "zerver.middleware.LocaleMiddleware",
     "zerver.middleware.HostDomainMiddleware",
+    "zerver.middleware.DetectProxyMisconfiguration",
     "django.middleware.csrf.CsrfViewMiddleware",
     # Make sure 2FA middlewares come after authentication middleware.
     "django_otp.middleware.OTPMiddleware",  # Required by two factor auth.

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -15,6 +15,7 @@ from .settings import (
     EXTERNAL_HOST,
     LOCAL_DATABASE_PASSWORD,
     LOGGING,
+    MIDDLEWARE,
 )
 
 FULL_STACK_ZULIP_TEST = "FULL_STACK_ZULIP_TEST" in os.environ
@@ -269,3 +270,13 @@ SCIM_CONFIG: Dict[str, SCIMConfigDict] = {
         "name_formatted_included": True,
     }
 }
+
+
+while len(MIDDLEWARE) < 19:
+    # The following middleware serves to skip having exactly 17 or 18
+    # middlewares, which can segfault Python 3.11 when running with
+    # coverage enabled; see
+    # https://github.com/python/cpython/issues/106092
+    MIDDLEWARE += [
+        "zerver.middleware.ZulipNoopMiddleware",
+    ]


### PR DESCRIPTION
Combine nginx and Django middlware to stop putting misleading warnings
about `CSRF_TRUSTED_ORIGINS` when the issue is untrusted proxies.
This attempts to, in the error logs, diagnose and suggest next steps
to fix common proxy misconfigurations.

See also #24599 and zulip/docker-zulip#403.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
