### PR TITLE
user groups: Fix race conditions in user group membership changes

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Run backend tests
         run: |
           source tools/ci/activate-venv
-          ./tools/test-backend --coverage --xml-report --no-html-report --include-webhooks --no-cov-cleanup --ban-console-output
+          ./tools/test-backend --coverage --xml-report --no-html-report --include-webhooks --include-transaction-tests --no-cov-cleanup --ban-console-output
 
       - name: Run mypy
         run: |

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -224,7 +224,7 @@ python_rules = RuleList(
     rules=[
         {
             "pattern": "subject|SUBJECT",
-            "exclude_pattern": "subject to the|email|outbox|account deactivation",
+            "exclude_pattern": "subject to the|email|outbox|account deactivation|is subject to",
             "description": "avoid subject as a var",
             "good_lines": ["topic_name"],
             "bad_lines": ['subject="foo"', " MAX_SUBJECT_LEN"],

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -405,7 +405,7 @@ def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: 
 def check_delete_user_group(
     user_group_id: int, user_profile: UserProfile, *, acting_user: Optional[UserProfile]
 ) -> None:
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     user_group.delete()
     do_send_delete_user_group_event(user_profile.realm, user_group_id, user_profile.realm.id)
 

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.user_groups import (
-    access_user_group_by_id,
     get_role_based_system_groups_dict,
     set_defaults_for_group_settings,
 )
@@ -402,8 +401,8 @@ def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: 
     send_event(realm, event, active_user_ids(realm_id))
 
 
-def check_delete_user_group(user_group_id: int, *, acting_user: UserProfile) -> None:
-    user_group = access_user_group_by_id(user_group_id, acting_user, for_read=False)
+def check_delete_user_group(user_group: UserGroup, *, acting_user: UserProfile) -> None:
+    user_group_id = user_group.id
     user_group.delete()
     do_send_delete_user_group_event(acting_user.realm, user_group_id, acting_user.realm.id)
 

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -402,12 +402,10 @@ def do_send_delete_user_group_event(realm: Realm, user_group_id: int, realm_id: 
     send_event(realm, event, active_user_ids(realm_id))
 
 
-def check_delete_user_group(
-    user_group_id: int, user_profile: UserProfile, *, acting_user: Optional[UserProfile]
-) -> None:
-    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
+def check_delete_user_group(user_group_id: int, *, acting_user: UserProfile) -> None:
+    user_group = access_user_group_by_id(user_group_id, acting_user, for_read=False)
     user_group.delete()
-    do_send_delete_user_group_event(user_profile.realm, user_group_id, user_profile.realm.id)
+    do_send_delete_user_group_event(acting_user.realm, user_group_id, acting_user.realm.id)
 
 
 @transaction.atomic(savepoint=False)

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1911,9 +1911,7 @@ class ZulipTestCase(ZulipTestCaseMixin, TestCase):
         self.assert_length(lst, expected_num_events)
 
 
-def get_row_ids_in_all_tables() -> (
-    Iterator[Tuple[str, Set[int]]]
-):  # nocoverage # Will be tested with the UserGroup transaction test case
+def get_row_ids_in_all_tables() -> Iterator[Tuple[str, Set[int]]]:
     all_models = apps.get_models(include_auto_created=True)
     ignored_tables = {"django_session"}
 
@@ -1947,13 +1945,11 @@ class ZulipTransactionTestCase(ZulipTestCaseMixin, TransactionTestCase):
     ZulipTransactionTestCase tests if they leak state.
     """
 
-    def setUp(self) -> None:  # nocoverage # Will be tested with the UserGroup transaction test case
+    def setUp(self) -> None:
         super().setUp()
         self.models_ids_set = dict(get_row_ids_in_all_tables())
 
-    def tearDown(
-        self,
-    ) -> None:  # nocoverage # Will be tested with the UserGroup transaction test case
+    def tearDown(self) -> None:
         """Verifies that the test did not adjust the set of rows in the test
         database. This is a sanity check to help ensure that tests
         using this class do not have unintended side effects on the
@@ -1972,7 +1968,6 @@ class ZulipTransactionTestCase(ZulipTestCaseMixin, TransactionTestCase):
         TransactionTestCase, so that the test database does not get
         flushed/deleted after each test using this class.
         """
-        # nocoverage # Will be tested with the UserGroup transaction test case
 
 
 class WebhookTestCase(ZulipTestCase):

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -517,6 +517,8 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             "static/(?P<path>.+)",
             "flush_caches",
             "external_content/(?P<digest>[^/]+)/(?P<received_url>[^/]+)",
+            # Such endpoints are only used in certain test cases that can be skipped
+            "testing/(?P<path>.+)",
             # These are SCIM2 urls overridden from django-scim2 to return Not Implemented.
             # We actually test them, but it's not being detected as a tested pattern,
             # possibly due to the use of re_path. TODO: Investigate and get them

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -29,7 +29,7 @@ class UserGroupDict(TypedDict):
 
 
 def access_user_group_by_id(
-    user_group_id: int, user_profile: UserProfile, *, for_read: bool = False
+    user_group_id: int, user_profile: UserProfile, *, for_read: bool
 ) -> UserGroup:
     try:
         user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -253,14 +253,14 @@ def get_subgroup_ids(user_group: UserGroup, *, direct_subgroup_only: bool = Fals
     return list(subgroup_ids)
 
 
-def get_recursive_subgroups_for_groups(user_group_ids: List[int]) -> List[int]:
+def get_recursive_subgroups_for_groups(user_group_ids: List[int]) -> QuerySet[UserGroup]:
     cte = With.recursive(
         lambda cte: UserGroup.objects.filter(id__in=user_group_ids)
         .values(group_id=F("id"))
         .union(cte.join(UserGroup, direct_supergroups=cte.col.group_id).values(group_id=F("id")))
     )
     recursive_subgroups = cte.join(UserGroup, id=cte.col.group_id).with_cte(cte)
-    return list(recursive_subgroups.values_list("id", flat=True))
+    return recursive_subgroups
 
 
 def get_role_based_system_groups_dict(realm: Realm) -> Dict[str, UserGroup]:

--- a/zerver/lib/user_groups.py
+++ b/zerver/lib/user_groups.py
@@ -33,24 +33,24 @@ def access_user_group_by_id(
 ) -> UserGroup:
     try:
         user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
-        if for_read and not user_profile.is_guest:
-            # Everyone is allowed to read a user group and check who
-            # are its members. Guests should be unable to reach this
-            # code path, since they can't access user groups API
-            # endpoints, but we check for guests here for defense in
-            # depth.
-            return user_group
-        if user_group.is_system_group:
-            raise JsonableError(_("Insufficient permission"))
-        group_member_ids = get_user_group_direct_member_ids(user_group)
-        if (
-            not user_profile.is_realm_admin
-            and not user_profile.is_moderator
-            and user_profile.id not in group_member_ids
-        ):
-            raise JsonableError(_("Insufficient permission"))
     except UserGroup.DoesNotExist:
         raise JsonableError(_("Invalid user group"))
+    if for_read and not user_profile.is_guest:
+        # Everyone is allowed to read a user group and check who
+        # are its members. Guests should be unable to reach this
+        # code path, since they can't access user groups API
+        # endpoints, but we check for guests here for defense in
+        # depth.
+        return user_group
+    if user_group.is_system_group:
+        raise JsonableError(_("Insufficient permission"))
+    group_member_ids = get_user_group_direct_member_ids(user_group)
+    if (
+        not user_profile.is_realm_admin
+        and not user_profile.is_moderator
+        and user_profile.id not in group_member_ids
+    ):
+        raise JsonableError(_("Insufficient permission"))
     return user_group
 
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1463,9 +1463,7 @@ class NormalActionsTest(BaseAction):
         check_user_group_remove_subgroups("events[0]", events[0])
 
         # Test remove event
-        events = self.verify_action(
-            lambda: check_delete_user_group(backend.id, acting_user=othello)
-        )
+        events = self.verify_action(lambda: check_delete_user_group(backend, acting_user=othello))
         check_user_group_remove("events[0]", events[0])
 
     def test_default_stream_groups_events(self) -> None:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1464,7 +1464,7 @@ class NormalActionsTest(BaseAction):
 
         # Test remove event
         events = self.verify_action(
-            lambda: check_delete_user_group(backend.id, othello, acting_user=None)
+            lambda: check_delete_user_group(backend.id, acting_user=othello)
         )
         check_user_group_remove("events[0]", events[0])
 

--- a/zerver/transaction_tests/test_user_groups.py
+++ b/zerver/transaction_tests/test_user_groups.py
@@ -1,0 +1,158 @@
+import threading
+from typing import TYPE_CHECKING, List, Optional
+
+import orjson
+from django.db import connections, transaction
+
+from zerver.actions.user_groups import add_subgroups_to_user_group, check_add_user_group
+from zerver.lib.test_classes import ZulipTransactionTestCase
+from zerver.models import Realm, UserGroup, get_realm
+from zerver.views.development import user_groups as user_group_view
+
+if TYPE_CHECKING:
+    from django.test.client import _MonkeyPatchedWSGIResponse as TestHttpResponse
+
+
+class UserGroupRaceConditionTestCase(ZulipTransactionTestCase):
+    created_user_groups: List[UserGroup] = []
+    counter = 0
+    CHAIN_LENGTH = 3
+
+    def tearDown(self) -> None:
+        # Clean up the user groups created to minimize leakage
+        with transaction.atomic():
+            for group in self.created_user_groups:
+                group.delete()
+            transaction.on_commit(lambda: self.created_user_groups.clear())
+
+        super().tearDown()
+
+    def create_user_group_chain(self, realm: Realm) -> List[UserGroup]:
+        """Build a user groups forming a chain through group-group memberships
+        returning a list where each group is the supergroup of its subsequent group.
+        """
+        groups = [
+            check_add_user_group(realm, f"chain #{self.counter + i}", [], acting_user=None)
+            for i in range(self.CHAIN_LENGTH)
+        ]
+        self.counter += self.CHAIN_LENGTH
+        self.created_user_groups.extend(groups)
+        prev_group = groups[0]
+        for group in groups[1:]:
+            add_subgroups_to_user_group(prev_group, [group], acting_user=None)
+            prev_group = group
+        return groups
+
+    def test_lock_subgroups_with_respect_to_supergroup(self) -> None:
+        realm = get_realm("zulip")
+        self.login("iago")
+        test_case = self
+
+        class RacingThread(threading.Thread):
+            def __init__(
+                self,
+                subgroup_ids: List[int],
+                supergroup_id: int,
+            ) -> None:
+                threading.Thread.__init__(self)
+                self.response: Optional["TestHttpResponse"] = None
+                self.subgroup_ids = subgroup_ids
+                self.supergroup_id = supergroup_id
+
+            def run(self) -> None:
+                try:
+                    self.response = test_case.client_post(
+                        url=f"/testing/user_groups/{self.supergroup_id}/subgroups",
+                        info={"add": orjson.dumps(self.subgroup_ids).decode()},
+                    )
+                finally:
+                    # Close all thread-local database connections
+                    connections.close_all()
+
+        def assert_thread_success_count(
+            t1: RacingThread,
+            t2: RacingThread,
+            *,
+            success_count: int,
+            error_messsage: str = "",
+        ) -> None:
+            help_msg = """We access the test endpoint that wraps around the
+real subgroup update endpoint by synchronizing them after the acquisition of the
+first lock in the critical region. Though unlikely, this test might fail as we
+have no control over the scheduler when the barrier timeouts.
+""".strip()
+            barrier = threading.Barrier(parties=2, timeout=3)
+
+            user_group_view.set_sync_after_recursive_query(barrier)
+            t1.start()
+            t2.start()
+
+            succeeded = 0
+            for t in [t1, t2]:
+                t.join()
+                response = t.response
+                if response is not None and response.status_code == 200:
+                    succeeded += 1
+                    continue
+
+                assert response is not None
+                self.assert_json_error(response, error_messsage)
+            # Race condition resolution should only allow one thread to succeed
+            self.assertEqual(
+                succeeded,
+                success_count,
+                f"Exactly {success_count} thread(s) should succeed.\n{help_msg}",
+            )
+
+        foo_chain = self.create_user_group_chain(realm)
+        bar_chain = self.create_user_group_chain(realm)
+        # These two threads are conflicting because a cycle would be formed if
+        # both of them succeed. There is a deadlock in such circular dependency.
+        assert_thread_success_count(
+            RacingThread(
+                subgroup_ids=[foo_chain[0].id],
+                supergroup_id=bar_chain[-1].id,
+            ),
+            RacingThread(
+                subgroup_ids=[bar_chain[-1].id],
+                supergroup_id=foo_chain[0].id,
+            ),
+            success_count=1,
+            error_messsage="Deadlock detected",
+        )
+
+        foo_chain = self.create_user_group_chain(realm)
+        bar_chain = self.create_user_group_chain(realm)
+        # These two requests would succeed if they didn't race with each other.
+        # However, both threads will attempt to grab a lock on overlapping rows
+        # when they first do the recursive query for subgroups. In this case, we
+        # expect that one of the threads fails due to nowait=True for the
+        # .select_for_update() call.
+        assert_thread_success_count(
+            RacingThread(
+                subgroup_ids=[foo_chain[0].id],
+                supergroup_id=bar_chain[-1].id,
+            ),
+            RacingThread(
+                subgroup_ids=[foo_chain[1].id],
+                supergroup_id=bar_chain[-1].id,
+            ),
+            success_count=1,
+            error_messsage="Busy lock detected",
+        )
+
+        foo_chain = self.create_user_group_chain(realm)
+        bar_chain = self.create_user_group_chain(realm)
+        baz_chain = self.create_user_group_chain(realm)
+        # Adding non-conflicting subgroups should succeed.
+        assert_thread_success_count(
+            RacingThread(
+                subgroup_ids=[foo_chain[1].id, foo_chain[2].id, baz_chain[2].id],
+                supergroup_id=baz_chain[0].id,
+            ),
+            RacingThread(
+                subgroup_ids=[bar_chain[1].id, bar_chain[2].id],
+                supergroup_id=baz_chain[0].id,
+            ),
+            success_count=2,
+        )

--- a/zerver/views/development/user_groups.py
+++ b/zerver/views/development/user_groups.py
@@ -1,0 +1,65 @@
+import threading
+from typing import Any, Optional
+from unittest import mock
+
+from django.db import OperationalError, transaction
+from django.http import HttpRequest, HttpResponse
+
+from zerver.lib.exceptions import JsonableError
+from zerver.lib.request import REQ, has_request_variables
+from zerver.lib.response import json_success
+from zerver.lib.user_groups import access_user_group_by_id
+from zerver.lib.validator import check_int
+from zerver.models import UserGroup, UserProfile
+from zerver.views.user_groups import update_subgroups_of_user_group
+
+BARRIER: Optional[threading.Barrier] = None
+
+
+def set_sync_after_recursive_query(barrier: Optional[threading.Barrier]) -> None:
+    global BARRIER
+    BARRIER = barrier
+
+
+@has_request_variables
+def dev_update_subgroups(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    user_group_id: int = REQ(json_validator=check_int, path_only=True),
+) -> HttpResponse:
+    # The test is expected to set up the barrier before accessing this endpoint.
+    assert BARRIER is not None
+    try:
+        with transaction.atomic(), mock.patch(
+            "zerver.lib.user_groups.access_user_group_by_id"
+        ) as m:
+
+            def wait_after_recursive_query(*args: Any, **kwargs: Any) -> UserGroup:
+                # When updating the subgroups, we access the supergroup group
+                # only after finishing the recursive query.
+                BARRIER.wait()
+                return access_user_group_by_id(*args, **kwargs)
+
+            m.side_effect = wait_after_recursive_query
+
+            update_subgroups_of_user_group(request, user_profile, user_group_id=user_group_id)
+    except OperationalError as err:
+        msg = str(err)
+        if "deadlock detected" in msg:
+            raise JsonableError("Deadlock detected")
+        else:
+            assert "could not obtain lock" in msg
+            # This error is possible when nowait is set the True, which only
+            # applies to the recursive query on the subgroups. Because the
+            # recursive query fails, this thread must have not waited on the
+            # barrier yet.
+            BARRIER.wait()
+            raise JsonableError("Busy lock detected")
+    except (
+        threading.BrokenBarrierError
+    ):  # nocoverage # This is only possible when timeout happens or there is a programming error
+        raise JsonableError(
+            "Broken barrier. The tester should make sure that the exact number of parties have waited on the barrier set by the previous immediate set_sync_after_first_lock call"
+        )
+
+    return json_success(request)

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -304,7 +304,9 @@ def add_subgroups_to_group_backend(
             )
 
     subgroup_ids = [group.id for group in subgroups]
-    if user_group_id in get_recursive_subgroups_for_groups(subgroup_ids):
+    if user_group_id in get_recursive_subgroups_for_groups(subgroup_ids).values_list(
+        "id", flat=True
+    ):
         raise JsonableError(
             _(
                 "User group {user_group_id} is already a subgroup of one of the passed subgroups."

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -110,7 +110,7 @@ def edit_user_group(
     if name is None and description is None and can_mention_group_id is None:
         raise JsonableError(_("No new data supplied"))
 
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
 
     if name is not None and name != user_group.name:
         name = check_user_group_name(name)
@@ -237,7 +237,7 @@ def add_members_to_group_backend(
     if not members:
         return json_success(request)
 
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     member_users = user_ids_to_users(members, user_profile.realm)
     existing_member_ids = set(get_direct_memberships_of_users(user_group, member_users))
 
@@ -267,7 +267,7 @@ def remove_members_from_group_backend(
         return json_success(request)
 
     user_profiles = user_ids_to_users(members, user_profile.realm)
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     group_member_ids = get_user_group_direct_member_ids(user_group)
     for member in members:
         if member not in group_member_ids:
@@ -293,7 +293,7 @@ def add_subgroups_to_group_backend(
         return json_success(request)
 
     subgroups = access_user_groups_as_potential_subgroups(subgroup_ids, user_profile)
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     existing_direct_subgroup_ids = user_group.direct_subgroups.all().values_list("id", flat=True)
     for group in subgroups:
         if group.id in existing_direct_subgroup_ids:
@@ -322,7 +322,7 @@ def remove_subgroups_from_group_backend(
         return json_success(request)
 
     subgroups = access_user_groups_as_potential_subgroups(subgroup_ids, user_profile)
-    user_group = access_user_group_by_id(user_group_id, user_profile)
+    user_group = access_user_group_by_id(user_group_id, user_profile, for_read=False)
     existing_direct_subgroup_ids = user_group.direct_subgroups.all().values_list("id", flat=True)
     for group in subgroups:
         if group.id not in existing_direct_subgroup_ids:

--- a/zerver/views/user_groups.py
+++ b/zerver/views/user_groups.py
@@ -153,7 +153,7 @@ def delete_user_group(
     user_profile: UserProfile,
     user_group_id: int = REQ(json_validator=check_int, path_only=True),
 ) -> HttpResponse:
-    check_delete_user_group(user_group_id, user_profile, acting_user=user_profile)
+    check_delete_user_group(user_group_id, acting_user=user_profile)
     return json_success(request)
 
 

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -10,6 +10,7 @@ from django.urls import path
 from django.views.generic import TemplateView
 from django.views.static import serve
 
+from zerver.lib.rest import rest_path
 from zerver.views.auth import config_error, login_page
 from zerver.views.development.cache import remove_caches
 from zerver.views.development.camo import handle_camo_url
@@ -31,6 +32,7 @@ from zerver.views.development.registration import (
     register_development_realm,
     register_development_user,
 )
+from zerver.views.development.user_groups import dev_update_subgroups
 
 # These URLs are available only in the development environment
 
@@ -97,6 +99,14 @@ urls = [
     # Redirect camo URLs for development
     path("external_content/<digest>/<received_url>", handle_camo_url),
 ]
+
+testing_urls = [
+    rest_path(
+        "testing/user_groups/<int:user_group_id>/subgroups",
+        POST=(dev_update_subgroups, {"intentionally_undocumented"}),
+    ),
+]
+urls += testing_urls
 
 v1_api_mobile_patterns = [
     # This is for the signing in through the devAuthBackEnd on mobile apps.


### PR DESCRIPTION
**Background**

User groups are expected to comply with the DAG constraint for the
many-to-many inter-group membership. The check for this constraint has
to be performed recursively so that we can find all direct and indirect
subgroups of the user group to be added.

This kind of check is vulnerable to phantom reads which is possible at
the default read committed isolation level because we cannot guarantee
that the check is still valid when we are adding the subgroups to the
user group.

**Solution**

To avoid having another transaction concurrently update one of the
to-be-subgroup after the recursive check is done, and before the subgroup
is added, we use SELECT FOR UPDATE to lock the user group rows.

The lock needs to be acquired before a group membership change is about
to occur before any check has been conducted.

Suppose that we are adding/removing subgroup B to/from supergroup A, the locking protocol is specified as follows:

1. Acquire a lock for A.
2. Acquire a lock for B and all its direct and indirect subgroups.

For the removal of user groups, we acquire a lock for the user group to
be removed with all its direct and indirect subgroups.

**Error handling**

We currently rely on Postgres' deadlock detection to abort transactions
and show an error for the users. In the future, we might need some
recovery mechanism or at least better error handling.

**Notes**

An important note is that we need to reuse the recursive CTE query that
finds the direct and indirect subgroups when applying the lock on the
rows. And the lock needs to be acquired the same way for the addition and
removal of direct subgroups.

User membership (as opposed to user group membership) is not affected
by this change. Read-only queries aren't either. The locks only protect
critical regions where the user group dependency graph might violate
the DAG constraint, where users are not participating.

<!-- Describe your pull request here.-->

[Discussion](https://chat.zulip.org/#narrow/stream/3-backend/topic/UserGroup.20race.20conditions)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
