### PR TITLE
stream_settings: Add not-subscribed tab to stream settings.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -54,6 +54,8 @@ export function setup_subscriptions_tab_hash(tab_key_value) {
         browser_history.update("#streams/all");
     } else if (tab_key_value === "subscribed") {
         browser_history.update("#streams/subscribed");
+    } else if(tab_key_value === "not-subscribed") {
+        browser_history.update("#streams/notsubscribed");
     } else {
         blueslip.debug("Unknown tab_key_value: " + tab_key_value);
     }

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -50,14 +50,22 @@ export function setup_subscriptions_tab_hash(tab_key_value) {
     if ($("#subscription_overlay .right").hasClass("show")) {
         return;
     }
-    if (tab_key_value === "all-streams") {
-        browser_history.update("#streams/all");
-    } else if (tab_key_value === "subscribed") {
-        browser_history.update("#streams/subscribed");
-    } else if(tab_key_value === "not-subscribed") {
-        browser_history.update("#streams/notsubscribed");
-    } else {
-        blueslip.debug("Unknown tab_key_value: " + tab_key_value);
+    switch (tab_key_value) {
+        case "all-streams": {
+            browser_history.update("#streams/all");
+            break;
+        }
+        case "subscribed": {
+            browser_history.update("#streams/subscribed");
+            break;
+        }
+        case "not-subscribed": {
+            browser_history.update("#streams/notsubscribed");
+            break;
+        }
+        default: {
+            blueslip.debug("Unknown tab_key_value: " + tab_key_value);
+        }
     }
 }
 

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -470,18 +470,24 @@ export function update_empty_left_panel_message() {
         has_streams =
             stream_data.subscribed_subs().length ||
             $("#streams_overlay_container .stream-row:not(.notdisplayed)").length;
+    } else if (is_not_subscribed_stream_tab_active()) {
+        has_streams =
+            stream_data.unsubscribed_subs().length ||
+            $("#streams_overlay_container .stream-row:not(.notdisplayed)").length;
     } else {
         has_streams = stream_data.get_unsorted_subs().length;
     }
+
     if (has_streams) {
         $(".no-streams-to-show").hide();
         return;
     }
+    $(".no-streams-to-show").children().hide();
     if (is_subscribed_stream_tab_active()) {
-        $(".all_streams_tab_empty_text").hide();
         $(".subscribed_streams_tab_empty_text").show();
+    } else if (is_not_subscribed_stream_tab_active()) {
+        $(".not_subscribed_streams_tab_empty_text").show();
     } else {
-        $(".subscribed_streams_tab_empty_text").hide();
         $(".all_streams_tab_empty_text").show();
     }
     $(".no-streams-to-show").show();

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -577,15 +577,23 @@ export function switch_stream_tab(tab_name) {
         use `toggler.goto`.
     */
 
-    if (tab_name === "all-streams") {
-        show_subscribed = false;
-        show_not_subscribed = false;
-    } else if (tab_name === "subscribed") {
-        show_subscribed = true;
-        show_not_subscribed = false;
-    } else if (tab_name === "not-subscribed") {
-        show_subscribed = false;
-        show_not_subscribed = true;
+    switch (tab_name) {
+        case "all-streams": {
+            show_subscribed = false;
+            show_not_subscribed = false;
+            break;
+        }
+        case "subscribed": {
+            show_subscribed = true;
+            show_not_subscribed = false;
+            break;
+        }
+        case "not-subscribed": {
+            show_subscribed = false;
+            show_not_subscribed = true;
+            break;
+        }
+        // No default
     }
 
     redraw_left_panel();

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -158,12 +158,12 @@ export function toggle_pin_to_top_stream(sub) {
     stream_edit.set_stream_property(sub, "pin_to_top", !sub.pin_to_top);
 }
 
-let subscribed_only = true;
+let show_subscribed = true;
 
 export function is_subscribed_stream_tab_active() {
     // Returns true if "Subscribed" tab in stream settings is open
     // otherwise false.
-    return subscribed_only;
+    return show_subscribed;
 }
 
 export function update_stream_name(sub, new_name) {
@@ -380,7 +380,7 @@ export function update_settings_for_unsubscribed(slim_sub) {
 }
 
 function triage_stream(left_panel_params, sub) {
-    if (left_panel_params.subscribed_only && !sub.subscribed) {
+    if (left_panel_params.show_subscribed && !sub.subscribed) {
         // reject non-subscribed streams
         return "rejected";
     }
@@ -475,7 +475,7 @@ export function update_empty_left_panel_message() {
     $(".no-streams-to-show").show();
 }
 
-// LeftPanelParams { input: String, subscribed_only: Boolean, sort_order: String }
+// LeftPanelParams { input: String, show_subscribed: Boolean, sort_order: String }
 export function redraw_left_panel(left_panel_params = get_left_panel_params()) {
     // We only get left_panel_params passed in from tests.  Real
     // code calls get_left_panel_params().
@@ -540,7 +540,7 @@ export function get_left_panel_params() {
     const input = $search_box.expectOne().val().trim();
     const params = {
         input,
-        subscribed_only,
+        show_subscribed,
         sort_order,
     };
     return params;
@@ -565,9 +565,9 @@ export function switch_stream_tab(tab_name) {
     */
 
     if (tab_name === "all-streams") {
-        subscribed_only = false;
+        show_subscribed = false;
     } else if (tab_name === "subscribed") {
-        subscribed_only = true;
+        show_subscribed = true;
     }
 
     redraw_left_panel();
@@ -637,7 +637,7 @@ export function setup_page(callback) {
 
         // Reset our internal state to reflect that we're initially in
         // the "Subscribed" tab if we're reopening "Manage streams".
-        subscribed_only = true;
+        show_subscribed = true;
         toggler = components.toggle({
             child_wants_focus: true,
             values: [

--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -201,15 +201,22 @@ export function update_stream_row_in_settings_tab(sub) {
     // This is in the left panel.
     // This function display/hide stream row in stream settings tab,
     // used to display immediate effect of add/removal subscription event.
-    // If user is subscribed to stream, it will show sub row under
-    // "Subscribed" tab, otherwise if stream is not public hide
-    // stream row under tab.
-    if (stream_settings_ui.is_subscribed_stream_tab_active()) {
-        const $sub_row = stream_settings_ui.row_for_stream_id(sub.stream_id);
-        if (sub.subscribed) {
-            $sub_row.removeClass("notdisplayed");
+    // If user is subscribed or unsubscribed to stream, it will show sub or unsub
+    // row under "Subscribed" or "Not subscribed" (only if the stream is public) tab, otherwise
+    // if stream is not public hide stream row under tab.
+    if (
+        stream_settings_ui.is_subscribed_stream_tab_active() ||
+        stream_settings_ui.is_not_subscribed_stream_tab_active()
+    ) {
+        const $row = stream_settings_ui.row_for_stream_id(sub.stream_id);
+
+        if (
+            (stream_settings_ui.is_subscribed_stream_tab_active() && sub.subscribed) ||
+            (stream_settings_ui.is_not_subscribed_stream_tab_active() && !sub.subscribed)
+        ) {
+            $row.removeClass("notdisplayed");
         } else if (sub.invite_only || page_params.is_guest) {
-            $sub_row.addClass("notdisplayed");
+            $row.addClass("notdisplayed");
         }
     }
 }

--- a/web/templates/left_sidebar_stream_setting_popover.hbs
+++ b/web/templates/left_sidebar_stream_setting_popover.hbs
@@ -1,6 +1,6 @@
 <ul class="nav nav-list">
     <li>
-        <a href="#streams/all" class="navigate_and_close_popover">
+        <a href="#streams/notsubscribed" class="navigate_and_close_popover">
             {{t "Browse streams" }}
         </a>
     </li>

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -35,6 +35,12 @@
                             {{/if}}
                         </span>
                     </div>
+                    <div class="not_subscribed_streams_tab_empty_text">
+                        <span>
+                            {{t 'No streams to show.'}}
+                            <a href="#streams/all">{{t 'View all streams'}}</a>
+                        </span>
+                    </div>
                     <div class="all_streams_tab_empty_text">
                         <span>
                             {{t 'There are no streams you can view in this organization.'}}

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,5 +1,5 @@
 {{#if exactly_one_unsubscribed_stream}}
-    <a href="#streams/all">
+    <a href="#streams/notsubscribed">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
         {{~#tr}}Browse 1 more stream{{/tr~}}
     </a>

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -89,8 +89,41 @@ run_test("redraw_left_panel", ({mock_template}) => {
         color: "red",
         can_remove_subscribers_group_id: admins_group.id,
     };
+    const abcd = {
+        elem: "abcd",
+        subscribed: false,
+        name: "Abcd",
+        stream_id: 106,
+        description: "India town",
+        subscribers: [1, 2, 3],
+        stream_weekly_traffic: 0,
+        color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
+    };
+    const utopia = {
+        elem: "utopia",
+        subscribed: false,
+        name: "Utopia",
+        stream_id: 107,
+        description: "movie",
+        subscribers: [1, 2, 3, 4],
+        stream_weekly_traffic: 8,
+        color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
+    };
+    const jerry = {
+        elem: "jerry",
+        subscribed: false,
+        name: "Jerry",
+        stream_id: 108,
+        description: "cat",
+        subscribers: [1],
+        stream_weekly_traffic: 4,
+        color: "red",
+        can_remove_subscribers_group_id: admins_group.id,
+    };
 
-    const sub_row_data = [denmark, poland, pomona, cpp, zzyzx];
+    const sub_row_data = [denmark, poland, pomona, cpp, zzyzx, abcd, utopia, jerry];
 
     for (const sub of sub_row_data) {
         stream_data.create_sub_from_server_data(sub);
@@ -138,65 +171,106 @@ run_test("redraw_left_panel", ({mock_template}) => {
     }
 
     // Search with single keyword
-    test_filter({input: "Po", show_subscribed: false}, [poland, pomona]);
+    test_filter({input: "Po", show_subscribed: false, show_not_subscribed: false}, [
+        poland,
+        pomona,
+    ]);
     assert.ok(ui_called);
 
     // The denmark row is active, even though it's not displayed.
     assert.ok($denmark_row.hasClass("active"));
 
     // Search with multiple keywords
-    test_filter({input: "Denmark, Pol", show_subscribed: false}, [denmark, poland]);
-    test_filter({input: "Den, Pol", show_subscribed: false}, [denmark, poland]);
+    test_filter({input: "Denmark, Pol", show_subscribed: false, show_not_subscribed: false}, [
+        denmark,
+        poland,
+    ]);
+    test_filter({input: "Den, Pol", show_subscribed: false, show_not_subscribed: false}, [
+        denmark,
+        poland,
+    ]);
 
     // Search is case-insensitive
-    test_filter({input: "po", show_subscribed: false}, [poland, pomona]);
+    test_filter({input: "po", show_subscribed: false, show_not_subscribed: false}, [
+        poland,
+        pomona,
+    ]);
 
     // Search handles unusual characters like C++
-    test_filter({input: "c++", show_subscribed: false}, [cpp]);
+    test_filter({input: "c++", show_subscribed: false, show_not_subscribed: false}, [cpp]);
 
     // Search subscribed streams only
-    test_filter({input: "d", show_subscribed: true}, [poland]);
+    test_filter({input: "d", show_subscribed: true, show_not_subscribed: false}, [poland]);
+
+    // Search unsubscribed streams only
+    test_filter({input: "d", show_subscribed: false, show_not_subscribed: true}, [abcd, denmark]);
 
     // Search terms match stream description
-    test_filter({input: "Co", show_subscribed: false}, [denmark, pomona]);
+    test_filter({input: "Co", show_subscribed: false, show_not_subscribed: false}, [
+        denmark,
+        pomona,
+    ]);
 
     // Search names AND descriptions
-    test_filter({input: "Mon", show_subscribed: false}, [pomona, poland]);
+    test_filter({input: "Mon", show_subscribed: false, show_not_subscribed: false}, [
+        pomona,
+        poland,
+    ]);
 
     // Explicitly order streams by name
-    test_filter({input: "", show_subscribed: false, sort_order: "by-stream-name"}, [
-        cpp,
-        denmark,
-        poland,
-        pomona,
-        zzyzx,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: false,
+            sort_order: "by-stream-name",
+        },
+        [abcd, cpp, denmark, jerry, poland, pomona, utopia, zzyzx],
+    );
 
     // Order streams by subscriber count
-    test_filter({input: "", show_subscribed: false, sort_order: "by-subscriber-count"}, [
-        poland,
-        cpp,
-        zzyzx,
-        denmark,
-        pomona,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: false,
+            sort_order: "by-subscriber-count",
+        },
+        [utopia, abcd, poland, cpp, zzyzx, denmark, jerry, pomona],
+    );
 
     // Order streams by weekly traffic
-    test_filter({input: "", show_subscribed: false, sort_order: "by-weekly-traffic"}, [
-        poland,
-        cpp,
-        zzyzx,
-        pomona,
-        denmark,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: false,
+            sort_order: "by-weekly-traffic",
+        },
+        [poland, utopia, cpp, zzyzx, jerry, abcd, pomona, denmark],
+    );
 
     // Sort for subscribed only.
-    test_filter({input: "", show_subscribed: true, sort_order: "by-subscriber-count"}, [
-        poland,
-        cpp,
-        zzyzx,
-        pomona,
-    ]);
+    test_filter(
+        {
+            input: "",
+            show_subscribed: true,
+            show_not_subscribed: false,
+            sort_order: "by-subscriber-count",
+        },
+        [poland, cpp, zzyzx, pomona],
+    );
+
+    // Sort for unsubscribed only.
+    test_filter(
+        {
+            input: "",
+            show_subscribed: false,
+            show_not_subscribed: true,
+            sort_order: "by-subscriber-count",
+        },
+        [utopia, abcd, denmark, jerry],
+    );
 
     // active stream-row is not included in results
     $(".stream-row-denmark").addClass("active");

--- a/web/tests/stream_settings_ui.test.js
+++ b/web/tests/stream_settings_ui.test.js
@@ -138,33 +138,33 @@ run_test("redraw_left_panel", ({mock_template}) => {
     }
 
     // Search with single keyword
-    test_filter({input: "Po", subscribed_only: false}, [poland, pomona]);
+    test_filter({input: "Po", show_subscribed: false}, [poland, pomona]);
     assert.ok(ui_called);
 
     // The denmark row is active, even though it's not displayed.
     assert.ok($denmark_row.hasClass("active"));
 
     // Search with multiple keywords
-    test_filter({input: "Denmark, Pol", subscribed_only: false}, [denmark, poland]);
-    test_filter({input: "Den, Pol", subscribed_only: false}, [denmark, poland]);
+    test_filter({input: "Denmark, Pol", show_subscribed: false}, [denmark, poland]);
+    test_filter({input: "Den, Pol", show_subscribed: false}, [denmark, poland]);
 
     // Search is case-insensitive
-    test_filter({input: "po", subscribed_only: false}, [poland, pomona]);
+    test_filter({input: "po", show_subscribed: false}, [poland, pomona]);
 
     // Search handles unusual characters like C++
-    test_filter({input: "c++", subscribed_only: false}, [cpp]);
+    test_filter({input: "c++", show_subscribed: false}, [cpp]);
 
     // Search subscribed streams only
-    test_filter({input: "d", subscribed_only: true}, [poland]);
+    test_filter({input: "d", show_subscribed: true}, [poland]);
 
     // Search terms match stream description
-    test_filter({input: "Co", subscribed_only: false}, [denmark, pomona]);
+    test_filter({input: "Co", show_subscribed: false}, [denmark, pomona]);
 
     // Search names AND descriptions
-    test_filter({input: "Mon", subscribed_only: false}, [pomona, poland]);
+    test_filter({input: "Mon", show_subscribed: false}, [pomona, poland]);
 
     // Explicitly order streams by name
-    test_filter({input: "", subscribed_only: false, sort_order: "by-stream-name"}, [
+    test_filter({input: "", show_subscribed: false, sort_order: "by-stream-name"}, [
         cpp,
         denmark,
         poland,
@@ -173,7 +173,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
     ]);
 
     // Order streams by subscriber count
-    test_filter({input: "", subscribed_only: false, sort_order: "by-subscriber-count"}, [
+    test_filter({input: "", show_subscribed: false, sort_order: "by-subscriber-count"}, [
         poland,
         cpp,
         zzyzx,
@@ -182,7 +182,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
     ]);
 
     // Order streams by weekly traffic
-    test_filter({input: "", subscribed_only: false, sort_order: "by-weekly-traffic"}, [
+    test_filter({input: "", show_subscribed: false, sort_order: "by-weekly-traffic"}, [
         poland,
         cpp,
         zzyzx,
@@ -191,7 +191,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
     ]);
 
     // Sort for subscribed only.
-    test_filter({input: "", subscribed_only: true, sort_order: "by-subscriber-count"}, [
+    test_filter({input: "", show_subscribed: true, sort_order: "by-subscriber-count"}, [
         poland,
         cpp,
         zzyzx,
@@ -209,7 +209,7 @@ run_test("redraw_left_panel", ({mock_template}) => {
         $(".stream-row-denmark").removeClass("active");
     };
 
-    test_filter({input: "d", subscribed_only: true}, [poland]);
+    test_filter({input: "d", show_subscribed: true}, [poland]);
     assert.ok(!$(".stream-row-denmark").hasClass("active"));
     assert.ok(!$(".right .settings").visible());
     assert.ok($(".nothing-selected").visible());


### PR DESCRIPTION
- [x] Add a `Not Subscribed` tab to the stream settings that will contain all the streams the user is not subscribed to.
- [x] Display the text `No streams to show. View all streams` when no stream is available to show.
- [x] Changes the redirect links for `Browse streams` and `Browse 1 more stream` to the not-subscribed tab.
- [x] Hide the `Not subscribed` tab if the user is a guest user.

------------------

Fixes: #21869
Rebases and made some major changes to fix bugs: #21904

---------------

**Screenshots and screen captures:**

<details>
<summary>stream settings screenshots:</summary>

<br>

- When the user is not a guest.

![08117B5D-E8EB-4FC9-B1D9-0914CA3B5CE0](https://github.com/zulip/zulip/assets/66828942/981a140e-c5c4-44d9-b5d9-aabe119829df)

<br>

- When the user is a guest.

![F5D33907-2FDF-43A3-A0EB-259B77326713_4_5005_c](https://github.com/zulip/zulip/assets/66828942/6f9a25f9-c6d1-4e86-8298-4e1053b6133d)

<br>

- When no streams to show

<img width="607" alt="Screenshot 2023-06-17 at 12 39 02 PM" src="https://github.com/zulip/zulip/assets/66828942/eee0c524-316d-4ff0-839d-019d343fc597">


</details>

<details>
<summary>Demo:</summary>
<br>

![not-subscribed tab](https://github.com/zulip/zulip/assets/66828942/e83f5631-b87f-47b3-936a-aa055dae19b2)


</details>


-------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
