### PR TITLE
message_view_header: Fix bad rendering of stream links in description.

### DIFF
--- a/web/e2e-tests/navigation.test.ts
+++ b/web/e2e-tests/navigation.test.ts
@@ -107,7 +107,7 @@ async function navigation_tests(page: Page): Promise<void> {
     // Verify that we're narrowed to the target stream
     await page.waitForSelector(
         `xpath///*[@id="message_view_header"]//*[${common.has_class_x(
-            "stream",
+            "message-header-stream-settings-button",
         )} and normalize-space()="Verona"]`,
     );
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1908,7 +1908,7 @@ div.focused_table {
     }
 
     .sub_count,
-    .stream,
+    .message-header-stream-settings-button,
     & > span {
         white-space: nowrap;
         list-style-type: none;
@@ -1945,7 +1945,7 @@ div.focused_table {
         }
     }
 
-    .stream {
+    .message-header-stream-settings-button {
         text-overflow: clip;
         color: inherit;
         text-decoration: none;

--- a/web/templates/message_view_header.hbs
+++ b/web/templates/message_view_header.hbs
@@ -1,5 +1,5 @@
 {{#if stream_settings_link}}
-<a class="stream" href="{{stream_settings_link}}">
+<a class="message-header-stream-settings-button" href="{{stream_settings_link}}">
     {{> navbar_icon_and_title }}
 </a>
 <div class="divider only-visible-for-spectators">|</div>


### PR DESCRIPTION
This bad rendering was the result of unwanted css applied in the stream description. In message view header, the stream link (title) we have defined has css defined but the markdown rendered stream link in stream description had the same class resulting in unwanted css applied to it.

Fixes: #25961.
