### PR TITLE
adding docstring to test functions

### DIFF
--- a/tools/tests/test_capitalization_checker.py
+++ b/tools/tests/test_capitalization_checker.py
@@ -7,6 +7,10 @@ from tools.lib.capitalization import check_capitalization, get_safe_text, is_cap
 
 class GetSafeTextTestCase(TestCase):
     def test_get_safe_text(self) -> None:
+        """
+        Verifies that get_safe_text() safely passes the
+        string object handed as an argument.
+        """
         string = "Zulip Zulip. Zulip some text!"
         safe_text = get_safe_text(string)
         self.assertEqual(safe_text, "Zulip zulip. Zulip some text!")
@@ -51,6 +55,10 @@ class GetSafeTextTestCase(TestCase):
 
 class IsCapitalizedTestCase(TestCase):
     def test_process_text(self) -> None:
+        """
+        Checks that is_capitalized() properly processes
+        strings passed as an argument.
+        """
         string = "Zulip zulip. Zulip some text!"
         capitalized = is_capitalized(string)
         self.assertTrue(capitalized)
@@ -102,6 +110,10 @@ class IsCapitalizedTestCase(TestCase):
 
 class CheckCapitalizationTestCase(TestCase):
     def test_check_capitalization(self) -> None:
+        """
+        Verifies that check_capitalization() properly
+        processes strings passed as an argument.
+        """
         strings = [
             "Zulip Zulip. Zulip some text!",
             "Zulip Zulip? Zulip some text!",

--- a/tools/tests/test_hash_reqs.py
+++ b/tools/tests/test_hash_reqs.py
@@ -7,6 +7,10 @@ from tools.setup.setup_venvs import DEV_REQS_FILE
 
 class TestHashCreation(unittest.TestCase):
     def test_diff_hash_for_diff_python_version(self) -> None:
+        """
+        Verifies that different python versions hash to
+        different values.
+        """
         with mock.patch("scripts.lib.hash_reqs.python_version", return_value="Python 3.6.9"):
             deps = expand_reqs(DEV_REQS_FILE)
             hash1 = hash_deps(deps)

--- a/tools/tests/test_html_branches.py
+++ b/tools/tests/test_html_branches.py
@@ -10,6 +10,9 @@ TEST_TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "t
 
 class TestHtmlBranches(unittest.TestCase):
     def test_get_tag_info(self) -> None:
+        """
+        Verifies that get_tag_info() properly returns tag information.
+        """
         html = """<p id="test" class="test1 test2">foo</p>"""
 
         start_tag, text, end_tag = tools.lib.template_parser.tokenize(html)
@@ -22,6 +25,10 @@ class TestHtmlBranches(unittest.TestCase):
         self.assertEqual(text.s, "foo")
 
     def test_build_id_dict(self) -> None:
+        """
+        Verifies that build_id_dict() properly builds a dictionary
+        given two separate arrays of keys and values, respectively.
+        """
         templates = ["test_template1.html", "test_template2.html"]
         templates = [os.path.join(TEST_TEMPLATES_DIR, fn) for fn in templates]
 
@@ -51,6 +58,9 @@ class TestHtmlBranches(unittest.TestCase):
         )
 
     def test_split_for_id_and_class(self) -> None:
+        """
+        Verifies proper split between object ID and class.
+        """
         id1 = "{{ red|blue }}"
         id2 = "search_box_{{ page }}"
 


### PR DESCRIPTION
added docstring to several tests

Fixes: i added docstring; see diff file

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
