### PR TITLE
Break some import cycles.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -417,7 +417,19 @@ export function render_and_show_preview($preview_spinner, $preview_content_box, 
     }
 }
 
+function setup_compose_actions_hooks() {
+    compose_actions.register_compose_box_clear_hook(clear_invites);
+    compose_actions.register_compose_box_clear_hook(clear_private_stream_alert);
+    compose_actions.register_compose_box_clear_hook(clear_preview_area);
+
+    compose_actions.register_compose_cancel_hook(abort_xhr);
+    compose_actions.register_compose_cancel_hook(abort_video_callbacks);
+}
+
 export function initialize() {
+    // Register hooks for compose_actions.
+    setup_compose_actions_hooks();
+
     $("#below-compose-content .video_link").toggle(compute_show_video_chat_button());
 
     $("#compose-textarea").on("keydown", (event) => {

--- a/web/src/compose_pm_pill.js
+++ b/web/src/compose_pm_pill.js
@@ -1,6 +1,5 @@
 import $ from "jquery";
 
-import * as compose_recipient from "./compose_recipient";
 import * as input_pill from "./input_pill";
 import * as people from "./people";
 import * as user_pill from "./user_pill";
@@ -25,15 +24,15 @@ export function initialize_pill() {
     return pill;
 }
 
-export function initialize() {
+export function initialize({on_pill_create_or_remove}) {
     widget = initialize_pill();
 
     widget.onPillCreate(() => {
-        compose_recipient.update_placeholder_text();
+        on_pill_create_or_remove();
     });
 
     widget.onPillRemove(() => {
-        compose_recipient.update_placeholder_text();
+        on_pill_create_or_remove();
     });
 }
 

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -4,7 +4,6 @@ import _ from "lodash";
 import * as typeahead from "../shared/src/typeahead";
 import render_topic_typeahead_hint from "../templates/topic_typeahead_hint.hbs";
 
-import * as compose from "./compose";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_state from "./compose_state";
 import * as compose_ui from "./compose_ui";
@@ -193,7 +192,7 @@ export function handle_enter($textarea, e) {
 // has reliable information about whether it was a Tab or a Shift+Tab.
 let $nextFocus = false;
 
-function handle_keydown(e) {
+function handle_keydown(e, {on_enter_send}) {
     const key = e.key;
 
     if (keydown_util.is_enter_event(e) || (key === "Tab" && !e.shiftKey)) {
@@ -234,7 +233,7 @@ function handle_keydown(e) {
                         compose_validate.validate_message_length() &&
                         !$("#compose-send-button").prop("disabled")
                     ) {
-                        compose.finish();
+                        on_enter_send();
                     }
                     return;
                 }
@@ -1077,11 +1076,11 @@ export function initialize_compose_typeahead(selector) {
     });
 }
 
-export function initialize() {
+export function initialize({on_enter_send}) {
     update_emoji_data();
 
     // These handlers are at the "form" level so that they are called after typeahead
-    $("form#send_message_form").on("keydown", handle_keydown);
+    $("form#send_message_form").on("keydown", (e) => handle_keydown(e, {on_enter_send}));
     $("form#send_message_form").on("keyup", handle_keyup);
 
     $("#stream_message_recipient_topic").typeahead({

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -700,7 +700,9 @@ export function initialize_everything() {
     server_events.initialize();
     user_status.initialize(user_status_params);
     compose_recipient.initialize();
-    compose_pm_pill.initialize();
+    compose_pm_pill.initialize({
+        on_pill_create_or_remove: compose_recipient.update_placeholder_text,
+    });
     compose_closed_ui.initialize();
     reload.initialize();
     user_groups.initialize(user_groups_params);

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -714,7 +714,10 @@ export function initialize_everything() {
     linkifiers.initialize(page_params.realm_linkifiers);
     realm_playground.initialize(page_params.realm_playgrounds, generated_pygments_data);
     compose.initialize();
-    composebox_typeahead.initialize(); // Must happen after compose.initialize()
+    // Typeahead must be initialized after compose.initialize()
+    composebox_typeahead.initialize({
+        on_enter_send: compose.finish,
+    });
     compose_textarea.initialize();
     search.initialize();
     tutorial.initialize();

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -35,7 +35,10 @@ autosize.update = () => {};
 mock_esm("autosize", {default: autosize});
 
 const channel = mock_esm("../src/channel");
-const compose_actions = mock_esm("../src/compose_actions");
+const compose_actions = mock_esm("../src/compose_actions", {
+    register_compose_cancel_hook: noop,
+    register_compose_box_clear_hook: noop,
+});
 const compose_fade = mock_esm("../src/compose_fade");
 const compose_pm_pill = mock_esm("../src/compose_pm_pill");
 const loading = mock_esm("../src/loading");

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -229,6 +229,7 @@ test("start", ({override, override_rewire, mock_template}) => {
         abort_xhr_called = true;
     });
 
+    compose_actions.register_compose_cancel_hook(compose.abort_xhr);
     $("#compose-textarea").set_height(50);
 
     assert_hidden("#compose_controls");

--- a/web/tests/compose_pm_pill.test.js
+++ b/web/tests/compose_pm_pill.test.js
@@ -153,7 +153,9 @@ run_test("pills", ({override}) => {
         callback();
     };
 
-    compose_pm_pill.initialize();
+    compose_pm_pill.initialize({
+        on_pill_create_or_remove: compose_recipient.update_placeholder_text,
+    });
     assert.ok(compose_pm_pill.widget);
 
     compose_pm_pill.set_from_typeahead(othello);

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -160,7 +160,9 @@ test_ui("validate", ({override_rewire, mock_template}) => {
         $pm_pill_container.set_find_results(".input", $("#private_message_recipient"));
         $("#private_message_recipient").before = () => {};
 
-        compose_pm_pill.initialize();
+        compose_pm_pill.initialize({
+            on_pill_create_or_remove: compose_recipient.update_placeholder_text,
+        });
 
         $("#zephyr-mirror-error").is = () => {};
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -1112,8 +1112,14 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     };
 
     user_settings.enter_sends = false;
+    let compose_finish_called = false;
+    override_rewire(compose, "finish", () => {
+        compose_finish_called = true;
+    });
 
-    ct.initialize();
+    ct.initialize({
+        on_enter_send: compose.finish,
+    });
 
     $("#private_message_recipient").val("othello@zulip.com, ");
     $("#private_message_recipient").trigger("blur");
@@ -1155,10 +1161,6 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     event.target.id = "compose-textarea";
     user_settings.enter_sends = false;
     event.metaKey = true;
-    let compose_finish_called = false;
-    override_rewire(compose, "finish", () => {
-        compose_finish_called = true;
-    });
 
     $("form#send_message_form").trigger(event);
     assert.ok(compose_finish_called);
@@ -1211,7 +1213,9 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     $("form#send_message_form").off("keyup");
     $("#private_message_recipient").off("blur");
     $("#send_later").css = noop;
-    ct.initialize();
+    ct.initialize({
+        on_enter_send: compose.finish,
+    });
 
     // Now let's make sure that all the stub functions have been called
     // during the initialization.

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -705,7 +705,9 @@ test("initialize", ({override, override_rewire, mock_template}) => {
             appended_names.push(item.display_value);
         },
     }));
-    compose_pm_pill.initialize();
+    compose_pm_pill.initialize({
+        on_pill_create_or_remove: compose_recipient.update_placeholder_text,
+    });
 
     let expected_value;
 


### PR DESCRIPTION
This breaks some import cycles and brings down the metrics `126, 69` to `118, 66` measured by the https://github.com/andersk/cycle-analysis.

- For breaking import cycles for `compose_actions` module with `compose` module I used the hooks pattern.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
