### PR TITLE
django_api: Extract send_event_on_commit helper

### DIFF
--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -13,7 +13,7 @@ from zerver.models import (
     active_non_guest_user_ids,
     get_default_stream_groups,
 )
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def check_default_stream_group_name(group_name: str) -> None:
@@ -52,7 +52,7 @@ def notify_default_streams(realm: Realm) -> None:
         type="default_streams",
         default_streams=streams_to_dicts_sorted(get_default_streams_for_realm(realm.id)),
     )
-    transaction.on_commit(lambda: send_event(realm, event, active_non_guest_user_ids(realm.id)))
+    send_event_on_commit(realm, event, active_non_guest_user_ids(realm.id))
 
 
 def notify_default_stream_groups(realm: Realm) -> None:
@@ -62,7 +62,7 @@ def notify_default_stream_groups(realm: Realm) -> None:
             get_default_stream_groups(realm)
         ),
     )
-    transaction.on_commit(lambda: send_event(realm, event, active_non_guest_user_ids(realm.id)))
+    send_event_on_commit(realm, event, active_non_guest_user_ids(realm.id))
 
 
 def do_add_default_stream(stream: Stream) -> None:

--- a/zerver/actions/reactions.py
+++ b/zerver/actions/reactions.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional
 
-from django.db import transaction
 from django.utils.translation import gettext as _
 
 from zerver.actions.create_user import create_historical_user_messages
@@ -9,7 +8,7 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message, update_to_dict_cache
 from zerver.lib.stream_subscription import subscriber_ids_with_stream_history_access
 from zerver.models import Message, Reaction, Recipient, Stream, UserMessage, UserProfile
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_reaction_update(
@@ -60,7 +59,7 @@ def notify_reaction_update(
         stream = Stream.objects.get(id=stream_id)
         user_ids |= subscriber_ids_with_stream_history_access(stream)
 
-    transaction.on_commit(lambda: send_event(user_profile.realm, event, list(user_ids)))
+    send_event_on_commit(user_profile.realm, event, list(user_ids))
 
 
 def do_add_reaction(

--- a/zerver/actions/realm_emoji.py
+++ b/zerver/actions/realm_emoji.py
@@ -12,12 +12,12 @@ from zerver.lib.exceptions import JsonableError
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.upload import upload_emoji_image
 from zerver.models import EmojiInfo, Realm, RealmAuditLog, RealmEmoji, UserProfile, active_user_ids
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_realm_emoji(realm: Realm, realm_emoji: Dict[str, EmojiInfo]) -> None:
     event = dict(type="realm_emoji", op="update", realm_emoji=realm_emoji)
-    transaction.on_commit(lambda: send_event(realm, event, active_user_ids(realm.id)))
+    send_event_on_commit(realm, event, active_user_ids(realm.id))
 
 
 def check_add_realm_emoji(

--- a/zerver/actions/realm_export.py
+++ b/zerver/actions/realm_export.py
@@ -1,17 +1,16 @@
 import orjson
-from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
 from zerver.lib.export import get_realm_exports_serialized
 from zerver.lib.upload import delete_export_tarball
 from zerver.models import RealmAuditLog, UserProfile
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_realm_export(user_profile: UserProfile) -> None:
     # In the future, we may want to send this event to all realm admins.
     event = dict(type="realm_export", exports=get_realm_exports_serialized(user_profile))
-    transaction.on_commit(lambda: send_event(user_profile.realm, event, [user_profile.id]))
+    send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
 def do_delete_realm_export(user_profile: UserProfile, export: RealmAuditLog) -> None:

--- a/zerver/actions/realm_icon.py
+++ b/zerver/actions/realm_icon.py
@@ -5,7 +5,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.models import Realm, RealmAuditLog, UserProfile, active_user_ids
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 @transaction.atomic(durable=True)
@@ -31,10 +31,8 @@ def do_change_icon_source(
         property="icon",
         data=dict(icon_source=realm.icon_source, icon_url=realm_icon_url(realm)),
     )
-    transaction.on_commit(
-        lambda: send_event(
-            realm,
-            event,
-            active_user_ids(realm.id),
-        )
+    send_event_on_commit(
+        realm,
+        event,
+        active_user_ids(realm.id),
     )

--- a/zerver/actions/realm_linkifiers.py
+++ b/zerver/actions/realm_linkifiers.py
@@ -13,12 +13,12 @@ from zerver.models import (
     active_user_ids,
     linkifiers_for_realm,
 )
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_linkifiers(realm: Realm, realm_linkifiers: List[LinkifierDict]) -> None:
     event: Dict[str, object] = dict(type="realm_linkifiers", realm_linkifiers=realm_linkifiers)
-    transaction.on_commit(lambda: send_event(realm, event, active_user_ids(realm.id)))
+    send_event_on_commit(realm, event, active_user_ids(realm.id))
 
 
 # NOTE: Regexes must be simple enough that they can be easily translated to JavaScript

--- a/zerver/actions/realm_logo.py
+++ b/zerver/actions/realm_logo.py
@@ -5,7 +5,7 @@ from django.utils.timezone import now as timezone_now
 
 from zerver.lib.realm_logo import get_realm_logo_data
 from zerver.models import Realm, RealmAuditLog, UserProfile, active_user_ids
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 @transaction.atomic(durable=True)
@@ -35,4 +35,4 @@ def do_change_logo_source(
         property="night_logo" if night else "logo",
         data=get_realm_logo_data(realm, night),
     )
-    transaction.on_commit(lambda: send_event(realm, event, active_user_ids(realm.id)))
+    send_event_on_commit(realm, event, active_user_ids(realm.id))

--- a/zerver/actions/realm_playgrounds.py
+++ b/zerver/actions/realm_playgrounds.py
@@ -13,12 +13,12 @@ from zerver.models import (
     active_user_ids,
     get_realm_playgrounds,
 )
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def notify_realm_playgrounds(realm: Realm, realm_playgrounds: List[RealmPlaygroundDict]) -> None:
     event = dict(type="realm_playgrounds", realm_playgrounds=realm_playgrounds)
-    transaction.on_commit(lambda: send_event(realm, event, active_user_ids(realm.id)))
+    send_event_on_commit(realm, event, active_user_ids(realm.id))
 
 
 @transaction.atomic(durable=True)

--- a/zerver/actions/submessage.py
+++ b/zerver/actions/submessage.py
@@ -1,9 +1,8 @@
-from django.db import transaction
 from django.utils.translation import gettext as _
 
 from zerver.lib.exceptions import JsonableError
 from zerver.models import Realm, SubMessage, UserMessage
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event_on_commit
 
 
 def verify_submessage_sender(
@@ -60,4 +59,4 @@ def do_add_submessage(
     ums = UserMessage.objects.filter(message_id=message_id)
     target_user_ids = [um.user_profile_id for um in ums]
 
-    transaction.on_commit(lambda: send_event(realm, event, target_user_ids))
+    send_event_on_commit(realm, event, target_user_ids)

--- a/zerver/actions/user_groups.py
+++ b/zerver/actions/user_groups.py
@@ -16,7 +16,7 @@ from zerver.models import (
     UserProfile,
     active_user_ids,
 )
-from zerver.tornado.django_api import send_event
+from zerver.tornado.django_api import send_event, send_event_on_commit
 
 
 class MemberGroupUserDict(TypedDict):
@@ -181,9 +181,7 @@ def do_send_user_group_members_update_event(
     event_name: str, user_group: UserGroup, user_ids: List[int]
 ) -> None:
     event = dict(type="user_group", op=event_name, group_id=user_group.id, user_ids=user_ids)
-    transaction.on_commit(
-        lambda: send_event(user_group.realm, event, active_user_ids(user_group.realm_id))
-    )
+    send_event_on_commit(user_group.realm, event, active_user_ids(user_group.realm_id))
 
 
 @transaction.atomic(savepoint=False)
@@ -216,9 +214,7 @@ def do_send_subgroups_update_event(
     event = dict(
         type="user_group", op=event_name, group_id=user_group.id, direct_subgroup_ids=subgroup_ids
     )
-    transaction.on_commit(
-        lambda: send_event(user_group.realm, event, active_user_ids(user_group.realm_id))
-    )
+    send_event_on_commit(user_group.realm, event, active_user_ids(user_group.realm_id))
 
 
 @transaction.atomic

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -4476,7 +4476,7 @@ class DeleteMessageTest(ZulipTestCase):
         message = self.get_last_message()
 
         with self.capture_send_event_calls(expected_num_events=1):
-            with mock.patch("zerver.actions.message_edit.send_event") as m:
+            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits."
                 )

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -1060,7 +1060,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
             "reaction_type": "unicode_emoji",
         }
         with self.capture_send_event_calls(expected_num_events=1) as events:
-            with mock.patch("zerver.actions.reactions.send_event") as m:
+            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits!"
                 )
@@ -1143,7 +1143,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
         )
 
         with self.capture_send_event_calls(expected_num_events=1):
-            with mock.patch("zerver.actions.reactions.send_event") as m:
+            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits."
                 )

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -195,7 +195,7 @@ class TestBasics(ZulipTestCase):
         message_id = self.send_stream_message(hamlet, "Denmark")
 
         with self.capture_send_event_calls(expected_num_events=1):
-            with mock.patch("zerver.actions.submessage.send_event") as m:
+            with mock.patch("zerver.tornado.django_api.queue_json_publish") as m:
                 m.side_effect = AssertionError(
                     "Events should be sent only after the transaction commits."
                 )

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import orjson
 import requests
 from django.conf import settings
+from django.db import transaction
 from requests.adapters import ConnectionError, HTTPAdapter
 from requests.models import PreparedRequest, Response
 from urllib3.util import Retry
@@ -186,3 +187,9 @@ def send_event(
             dict(event=event, users=port_users),
             lambda *args, **kwargs: send_notification_http(port, *args, **kwargs),
         )
+
+
+def send_event_on_commit(
+    realm: Realm, event: Mapping[str, Any], users: Union[Iterable[int], Iterable[Mapping[str, Any]]]
+) -> None:
+    transaction.on_commit(lambda: send_event(realm, event, users))


### PR DESCRIPTION
django-stubs 4.2.1 gives `transaction.on_commit` a more accurate type annotation, but this exposed that mypy can’t handle the `lambda` default parameters that we use to recapture loop variables such as

```python
for stream_id in public_stream_ids:
    peer_user_ids = …
    event = …

    transaction.on_commit(
        lambda event=event, peer_user_ids=peer_user_ids: send_event(
            realm, event, peer_user_ids
        )
    )
```

https://github.com/python/mypy/issues/15459

A workaround that mypy accepts is

```python
    transaction.on_commit(
        (
            lambda event, peer_user_ids: lambda: send_event(
                realm, event, peer_user_ids
            )
        )(event, peer_user_ids)
    )
```

But that’s kind of ugly and potentially error-prone, so let’s make a helper function for this very common pattern.

```python
     send_event_on_commit(realm, event, peer_user_ids)
```
