### PR TITLE
zerver-directory: Replace "private message" and "PM" with "direct message".

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -213,7 +213,7 @@ def process_new_human_user(
         and prereg_user.referred_by is not None
         and prereg_user.referred_by.is_active
     ):
-        # This is a cross-realm private message.
+        # This is a cross-realm direct message.
         with override_language(prereg_user.referred_by.default_language):
             internal_send_private_message(
                 get_system_bot(settings.NOTIFICATION_BOT, prereg_user.referred_by.realm_id),

--- a/zerver/actions/message_delete.py
+++ b/zerver/actions/message_delete.py
@@ -17,7 +17,7 @@ class DeleteMessagesEvent(TypedDict, total=False):
 
 def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
     # messages in delete_message event belong to the same topic
-    # or is a single private message, as any other behaviour is not possible with
+    # or is a single direct message, as any other behaviour is not possible with
     # the current callers to this method.
     messages = list(messages)
     message_ids = [message.id for message in messages]

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -475,7 +475,7 @@ def get_service_bot_events(
         # Mention triggers, for stream messages
         if is_stream and user_profile_id in mentioned_user_ids:
             trigger = "mention"
-        # PM triggers for personal and huddle messages
+        # Direct message triggers for personal and huddle messages
         elif (not is_stream) and (user_profile_id in active_user_ids):
             trigger = "private_message"
         else:
@@ -1192,8 +1192,8 @@ def send_rate_limited_pm_notification_to_bot_owner(
     sender: UserProfile, realm: Realm, content: str
 ) -> None:
     """
-    Sends a PM error notification to a bot's owner if one hasn't already
-    been sent in the last 5 minutes.
+    Sends a direct message error notification to a bot's owner if one
+    hasn't already been sent in the last 5 minutes.
     """
     if sender.realm.is_zephyr_mirror_realm or sender.realm.deactivated:
         return
@@ -1209,7 +1209,7 @@ def send_rate_limited_pm_notification_to_bot_owner(
         return
 
     # We warn the user once every 5 minutes to avoid a flood of
-    # PMs on a misconfigured integration, re-using the
+    # direct messages on a misconfigured integration, re-using the
     # UserProfile.last_reminder field, which is not used for bots.
     last_reminder = sender.last_reminder
     waitperiod = datetime.timedelta(minutes=UserProfile.BOT_OWNER_STREAM_ALERT_WAITPERIOD)
@@ -1316,8 +1316,8 @@ def check_private_message_policy(
 ) -> None:
     if realm.private_message_policy == Realm.PRIVATE_MESSAGE_POLICY_DISABLED:
         if sender.is_bot or (len(user_profiles) == 1 and user_profiles[0].is_bot):
-            # We allow PMs only between users and bots, to avoid
-            # breaking the tutorial as well as automated
+            # We allow direct messages only between users and bots,
+            # to avoid breaking the tutorial as well as automated
             # notifications from system bots to users.
             return
 

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -65,7 +65,7 @@ def do_delete_user(user_profile: UserProfile, *, acting_user: Optional[UserProfi
         user_profile.delete()
         # Recipient objects don't get deleted through CASCADE, so we need to handle
         # the user's personal recipient manually. This will also delete all Messages pointing
-        # to this recipient (all private messages sent to the user).
+        # to this recipient (all direct messages sent to the user).
         assert personal_recipient is not None
         personal_recipient.delete()
         replacement_user = create_user(

--- a/zerver/data_import/mattermost.py
+++ b/zerver/data_import/mattermost.py
@@ -546,7 +546,7 @@ def process_posts(
     post_data_list = []
     for post in post_data:
         if "team" not in post:
-            # Mattermost doesn't specify a team for private messages
+            # Mattermost doesn't specify a team for direct messages
             # in its export format.  This line of code requires that
             # we only be importing data from a single team (checked
             # elsewhere) -- we just assume it's the target team.
@@ -579,9 +579,9 @@ def process_posts(
         if "channel" in post_dict:
             message_dict["channel_name"] = post_dict["channel"]
         elif "channel_members" in post_dict:
-            # This case is for handling posts from PMs and huddles, not channels.
-            # PMs and huddles are known as direct_channels in Slack and hence
-            # the name channel_members.
+            # This case is for handling posts from direct messages and huddles,
+            # not channels. Direct messages and huddles are known as direct_channels
+            # in Slack and hence the name channel_members.
             channel_members = post_dict["channel_members"]
             if len(channel_members) > 2:
                 message_dict["huddle_name"] = generate_huddle_name(channel_members)
@@ -685,7 +685,7 @@ def write_message_data(
     else:
         post_types = ["channel_post"]
         logging.warning(
-            "Skipping importing huddles and PMs since there are multiple teams in the export"
+            "Skipping importing huddles and DMs since there are multiple teams in the export"
         )
 
     for post_type in post_types:

--- a/zerver/data_import/rocketchat.py
+++ b/zerver/data_import/rocketchat.py
@@ -675,7 +675,7 @@ def process_messages(
 
         # Add recipient_id to message_dict
         if is_pm_data:
-            # Message is in a PM or a huddle.
+            # Message is in a 1:1 or group direct message.
             rc_channel_id = message["rid"]
             if rc_channel_id in huddle_id_to_huddle_map:
                 huddle_id = huddle_id_mapper.get(rc_channel_id)
@@ -684,7 +684,7 @@ def process_messages(
                 rc_member_ids = direct_id_to_direct_map[rc_channel_id]["uids"]
 
                 if len(rc_member_ids) == 1:  # nocoverage
-                    # PMs to yourself only have one user.
+                    # direct messages to yourself only have one user.
                     rc_member_ids.append(rc_member_ids[0])
                 if rc_sender_id == rc_member_ids[0]:
                     zulip_member_id = user_id_mapper.get(rc_member_ids[1])
@@ -1220,7 +1220,7 @@ def do_convert_data(rocketchat_data_dir: str, output_dir: str) -> None:
         upload_id_to_upload_data_map=upload_id_to_upload_data_map,
         output_dir=output_dir,
     )
-    # Process private messages
+    # Process direct messages
     process_messages(
         realm_id=realm_id,
         messages=private_messages,

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -40,8 +40,8 @@ class Addressee:
     # around in a non-type-safe way before this class was introduced.
     #
     # It also avoids some nonsense where you have to think about whether
-    # topic should be None or '' for a PM, or you have to make an array
-    # of one stream.
+    # topic should be None or '' for a direct message, or you have to
+    # make an array of one stream.
     #
     # Eventually we can use this to cache Stream and UserProfile objects
     # in memory.

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -411,12 +411,13 @@ def do_send_missedmessage_events_reply_in_zulip(
     user_profile: UserProfile, missed_messages: List[Dict[str, Any]], message_count: int
 ) -> None:
     """
-    Send a reminder email to a user if she's missed some PMs by being offline.
+    Send a reminder email to a user if she's missed some direct messages
+    by being offline.
 
     The email will have its reply to address set to a limited used email
     address that will send a Zulip message to the correct recipient. This
-    allows the user to respond to missed PMs, huddles, and @-mentions directly
-    from the email.
+    allows the user to respond to missed direct messages, huddles, and
+    @-mentions directly from the email.
 
     `user_profile` is the user to send the reminder to
     `missed_messages` is a list of dictionaries to Message objects and other data
@@ -639,11 +640,11 @@ def handle_missedmessage_emails(
 
     # We bucket messages by tuples that identify similar messages.
     # For streams it's recipient_id and topic.
-    # For PMs it's recipient id and sender.
+    # For direct messages it's recipient id and sender.
     messages_by_bucket: Dict[Tuple[int, Union[int, str]], List[Message]] = defaultdict(list)
     for msg in messages:
         if msg.recipient.type == Recipient.PERSONAL:
-            # For PM's group using (recipient, sender).
+            # For direct messages group using (recipient, sender).
             messages_by_bucket[(msg.recipient_id, msg.sender_id)].append(msg)
         else:
             messages_by_bucket[(msg.recipient_id, msg.topic_name().lower())].append(msg)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -515,10 +515,12 @@ def fetch_initial_state_data(
         #
         #   [{'max_message_id': 700175, 'user_ids': [801]}]
         #
-        # for all recent private message conversations, ordered by the
-        # highest message ID in the conversation.  The user_ids list
+        # for all recent direct message conversations, ordered by the
+        # highest message ID in the conversation. The user_ids list
         # is the list of users other than the current user in the
-        # private message conversation (so it is [] for PMs to self).
+        # direct message conversation (so it is [] for direct messages
+        # to self).
+        #
         # Note that raw_recent_private_conversations is an
         # intermediate form as a dictionary keyed by recipient_id,
         # which is more efficient to update, and is rewritten to the

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1253,9 +1253,10 @@ def export_partial_message_files(
     #     equates to a recipient object we are exporting)
     #
     # TODO: In theory, you should be able to export messages in
-    # cross-realm PM threads; currently, this only exports cross-realm
-    # messages received by your realm that were sent by Zulip system
-    # bots (e.g. emailgateway, notification-bot).
+    # cross-realm direct message threads; currently, this only
+    # exports cross-realm messages received by your realm that
+    # were sent by Zulip system bots (e.g. emailgateway,
+    # notification-bot).
 
     # Here, "we" and "us" refers to the inner circle of users who
     # were specified as being allowed to be exported.  "Them"
@@ -1345,12 +1346,13 @@ def export_partial_message_files(
             message_queries.append(messages_we_received_in_protected_history_streams)
 
         # The above query is missing some messages that consenting
-        # users have access to, namely, PMs sent by one of the users
-        # in our export to another user (since the only subscriber to
-        # a Recipient object for Recipient.PERSONAL is the recipient,
-        # not the sender).  The `consented_user_ids` list has
-        # precisely those users whose Recipient.PERSONAL recipient ID
-        # was already present in recipient_ids_for_us above.
+        # users have access to, namely, direct messages sent by one
+        # of the users in our export to another user (since the only
+        # subscriber to a Recipient object for Recipient.PERSONAL is
+        # the recipient, not the sender). The `consented_user_ids`
+        # list has precisely those users whose Recipient.PERSONAL
+        # recipient ID was already present in recipient_ids_for_us
+        # above.
         ids_of_non_exported_possible_recipients = ids_of_our_possible_senders - consented_user_ids
 
         recipients_for_them = Recipient.objects.filter(

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -833,7 +833,7 @@ def has_message_access(
         return True
 
     if message.recipient.type != Recipient.STREAM:
-        # You can't access private messages you didn't receive
+        # You can't access direct messages you didn't receive
         return False
 
     if stream is None:
@@ -1160,7 +1160,7 @@ def extract_unread_data_from_um_rows(
                 topic = row[MESSAGE__TOPIC]
                 if not is_row_muted(stream_id, recipient_id, topic):
                     mentions.add(message_id)
-            else:  # nocoverage # TODO: Test wildcard mentions in PMs.
+            else:  # nocoverage # TODO: Test wildcard mentions in direct messages.
                 mentions.add(message_id)
 
     # Record whether the user had more than MAX_UNREAD_MESSAGES total
@@ -1497,9 +1497,9 @@ def get_recent_conversations_recipient_id(
 def get_recent_private_conversations(user_profile: UserProfile) -> Dict[int, Dict[str, Any]]:
     """This function uses some carefully optimized SQL queries, designed
     to use the UserMessage index on private_messages.  It is
-    significantly complicated by the fact that for 1:1 private
+    significantly complicated by the fact that for 1:1 direct
     messages, we store the message against a recipient_id of whichever
-    user was the recipient, and thus for 1:1 private messages sent
+    user was the recipient, and thus for 1:1 direct messages sent
     directly to us, we need to look up the other user from the
     sender_id on those messages.  You'll see that pattern repeated
     both here and also in zerver/lib/events.py.
@@ -1579,8 +1579,8 @@ def get_recent_private_conversations(user_profile: UserProfile) -> Dict[int, Dic
 
     # The resulting rows will be (recipient_id, max_message_id)
     # objects for all parties we've had recent (group?) private
-    # message conversations with, including PMs with yourself (those
-    # will generate an empty list of user_ids).
+    # message conversations with, including direct messages with
+    # yourself (those will generate an empty list of user_ids).
     for recipient_id, max_message_id in rows:
         recipient_map[recipient_id] = dict(
             max_message_id=max_message_id,

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -245,7 +245,7 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
 
 
 def send_welcome_bot_response(send_request: SendMessageRequest) -> None:
-    """Given the send_request object for a private message from the user
+    """Given the send_request object for a direct message from the user
     to welcome-bot, trigger the welcome-bot reply."""
     welcome_bot = get_system_bot(settings.WELCOME_BOT, send_request.message.sender.realm_id)
     human_response_lower = send_request.message.content.lower()

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -157,7 +157,7 @@ def modernize_apns_payload(data: Mapping[str, Any]) -> Mapping[str, Any]:
     if "message_ids" in data:
         # The format sent by 1.6.0, from the earliest pre-1.6.0
         # version with bouncer support up until 613d093d7 pre-1.7.0:
-        #   'alert': str,              # just sender, and text about PM/group-PM/mention
+        #   'alert': str,              # just sender, and text about direct message/mention
         #   'message_ids': List[int],  # always just one
         return {
             "alert": data["alert"],
@@ -817,7 +817,7 @@ def get_apns_alert_title(message: Message) -> str:
         return ", ".join(sorted(r["full_name"] for r in recipients))
     elif message.is_stream_message():
         return f"#{get_display_recipient(message.recipient)} > {message.topic_name()}"
-    # For personal PMs, we just show the sender name.
+    # For 1:1 direct messages, we just show the sender name.
     return message.sender.full_name
 
 
@@ -841,7 +841,8 @@ def get_apns_alert_subtitle(
         return _("{full_name} mentioned everyone:").format(full_name=message.sender.full_name)
     elif message.recipient.type == Recipient.PERSONAL:
         return ""
-    # For group PMs, or regular messages to a stream, just use a colon to indicate this is the sender.
+    # For group direct messages, or regular messages to a stream,
+    # just use a colon to indicate this is the sender.
     return message.sender.full_name + ":"
 
 

--- a/zerver/lib/recipient_users.py
+++ b/zerver/lib/recipient_users.py
@@ -28,7 +28,7 @@ def get_recipient_from_user_profiles(
         if forwarder_user_profile.id not in recipient_profiles_map:
             raise ValidationError(_("User not authorized for this query"))
 
-    # If the private message is just between the sender and
+    # If the direct message is just between the sender and
     # another person, force it to be a personal internally
     if len(recipient_profiles_map) == 2 and sender.id in recipient_profiles_map:
         del recipient_profiles_map[sender.id]

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1945,7 +1945,7 @@ You can fix this by adding "{complete_event_type}" to ALL_EVENT_TYPES for this w
         We simulate the delivery of the payload with `content_type`,
         and you can pass other headers via `extra`.
 
-        For the rare cases of webhooks actually sending private messages,
+        For the rare cases of webhooks actually sending direct messages,
         see send_and_test_private_message.
 
         When no message is expected to be sent, set `expect_noop` to True.
@@ -2014,7 +2014,7 @@ one or more new messages.
     ) -> Message:
         """
         For the rare cases that you are testing a webhook that sends
-        private messages, use this function.
+        direct messages, use this function.
 
         Most webhooks send to streams, and you will want to look at
         check_webhook.

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -130,10 +130,10 @@ def check_send_webhook_message(
             else:
                 check_send_stream_message(user_profile, client, stream, topic, body)
         except StreamDoesNotExistError:
-            # A PM will be sent to the bot_owner by check_message, notifying
-            # that the webhook bot just tried to send a message to a non-existent
-            # stream, so we don't need to re-raise it since it clutters up
-            # webhook-errors.log
+            # A direct message will be sent to the bot_owner by check_message,
+            # notifying that the webhook bot just tried to send a message to a
+            # non-existent stream, so we don't need to re-raise it since it
+            # clutters up webhook-errors.log
             pass
 
 

--- a/zerver/management/commands/delete_user.py
+++ b/zerver/management/commands/delete_user.py
@@ -21,14 +21,14 @@ This will:
 * Delete the user's account, including metadata like name, email
   address, custom profile fields, historical subscriptions, etc.
 
-* Delete any messages they've sent and any non-group private messages
+* Delete any messages they've sent and any non-group direct messages
   they've received.
 
-* Group private messages in which the user participated won't be
+* Group direct messages in which the user participated won't be
   deleted (with the exceptions of those message the deleted user
   sent). An inactive, inaccessible dummy user account named "Deleted
   User <id>" is created to replace the deleted user as a recipient in
-  group private message conversations, in order to somewhat preserve
+  group direct message conversations, in order to somewhat preserve
   their integrity.
 
 * Delete other records of the user's activity, such as emoji reactions.

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1443,11 +1443,11 @@ class Recipient(models.Model):
     which is the ID of the UserProfile/Stream/Huddle object containing
     all the metadata for the audience. There are 3 recipient types:
 
-    1. 1:1 private message: The type_id is the ID of the UserProfile
+    1. 1:1 direct message: The type_id is the ID of the UserProfile
        who will receive any message to this Recipient. The sender
        of such a message is represented separately.
     2. Stream message: The type_id is the ID of the associated Stream.
-    3. Group private message: In Zulip, group private messages are
+    3. Group direct message: In Zulip, group direct messages are
        represented by Huddle objects, which encode the set of users
        in the conversation. The type_id is the ID of the associated Huddle
        object; the set of users is usually retrieved via the Subscription
@@ -1461,11 +1461,11 @@ class Recipient(models.Model):
     type = models.PositiveSmallIntegerField(db_index=True)
     # Valid types are {personal, stream, huddle}
 
-    # The type for 1:1 private messages.
+    # The type for 1:1 direct messages.
     PERSONAL = 1
     # The type for stream messages.
     STREAM = 2
-    # The type group private messages.
+    # The type group direct messages.
     HUDDLE = 3
 
     class Meta:
@@ -1596,7 +1596,7 @@ class UserBaseSettings(models.Model):
     enable_followed_topic_audible_notifications = models.BooleanField(default=True)
     enable_followed_topic_wildcard_mentions_notify = models.BooleanField(default=True)
 
-    # PM + @-mention notifications.
+    # Direct message + @-mention notifications.
     enable_desktop_notifications = models.BooleanField(default=True)
     pm_content_in_desktop_notifications = models.BooleanField(default=True)
     enable_sounds = models.BooleanField(default=True)
@@ -3330,9 +3330,9 @@ class AbstractUserMessage(models.Model):
         # their history via e.g. starring the message.  This is
         # important accounting for the "Subscribed to stream" dividers.
         "historical",
-        # Whether the message is a private message; this flag is a
+        # Whether the message is a direct message; this flag is a
         # denormalization of message.recipient.type to support an
-        # efficient index on UserMessage for a user's private messages.
+        # efficient index on UserMessage for a user's direct messages.
         "is_private",
         # Whether we've sent a push notification to the user's mobile
         # devices for this message that has not been revoked.
@@ -3685,7 +3685,7 @@ def validate_attachment_request(
 
     messages = attachment.messages.all()
     if UserMessage.objects.filter(user_profile=user_profile, message__in=messages).exists():
-        # If it was sent in a private message or private stream
+        # If it was sent in a direct message or private stream
         # message, then anyone who received that message can access it.
         return True
 
@@ -3751,7 +3751,7 @@ class Subscription(models.Model):
     """Keeps track of which users are part of the
     audience for a given Recipient object.
 
-    For private and group private message Recipient objects, only the
+    For 1:1 and group direct message Recipient objects, only the
     user_profile and recipient fields have any meaning, defining the
     immutable set of users who are in the audience for that Recipient.
 
@@ -4038,7 +4038,7 @@ def is_cross_realm_bot_email(email: str) -> bool:
 class Huddle(models.Model):
     """
     Represents a group of individuals who may have a
-    group private message conversation together.
+    group direct message conversation together.
 
     The membership of the Huddle is stored in the Subscription table just like with
     Streams - for each user in the Huddle, there is a Subscription object
@@ -4282,7 +4282,7 @@ class MissedMessageEmailAddress(models.Model):
 
 
 class NotificationTriggers:
-    # "private_message" is for 1:1 PMs as well as huddles
+    # "private_message" is for 1:1 direct messages as well as huddles
     PRIVATE_MESSAGE = "private_message"
     MENTION = "mentioned"
     WILDCARD_MENTION = "wildcard_mentioned"

--- a/zerver/tests/test_drafts.py
+++ b/zerver/tests/test_drafts.py
@@ -82,11 +82,12 @@ class DraftCreationTests(ZulipTestCase):
                 "timestamp": 1595479019,
             }
         ]
+        # For direct messages, the topic should be ignored.
         expected_draft_dicts = [
             {
                 "type": "private",
                 "to": [zoe.id],
-                "topic": "",  # For private messages the topic should be ignored.
+                "topic": "",
                 "content": "What if we made it possible to sync drafts in Zulip?",
                 "timestamp": 1595479019,
             }
@@ -105,11 +106,12 @@ class DraftCreationTests(ZulipTestCase):
                 "timestamp": 1595479019,
             }
         ]
+        # For direct messages, the topic should be ignored.
         expected_draft_dicts = [
             {
                 "type": "private",
                 "to": [zoe.id, othello.id],
-                "topic": "",  # For private messages the topic should be ignored.
+                "topic": "",
                 "content": "What if we made it possible to sync drafts in Zulip?",
                 "timestamp": 1595479019,
             }
@@ -129,21 +131,21 @@ class DraftCreationTests(ZulipTestCase):
                 "topic": "sync drafts",
                 "content": "Let's add backend support for syncing drafts.",
                 "timestamp": 1595479019,
-            },  # Stream message draft
+            },
             {
                 "type": "private",
                 "to": [zoe.id],
                 "topic": "",
                 "content": "What if we made it possible to sync drafts in Zulip?",
                 "timestamp": 1595479020,
-            },  # Private message draft
+            },
             {
                 "type": "private",
                 "to": [zoe.id, othello.id],
                 "topic": "",
                 "content": "What if we made it possible to sync drafts in Zulip?",
                 "timestamp": 1595479021,
-            },  # Private group message draft
+            },
         ]
         self.create_and_check_drafts_for_success(draft_dicts)
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -1003,9 +1003,9 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
 class TestMissedMessageEmailMessages(ZulipTestCase):
     def test_receive_missed_personal_message_email_messages(self) -> None:
-        # build dummy messages for message notification email reply
-        # have Hamlet send Othello a PM. Othello will reply via email
-        # Hamlet will receive the message.
+        # Build dummy messages for message notification email reply.
+        # Have Hamlet send Othello a direct message. Othello will
+        # reply via email Hamlet will receive the message.
         self.login("hamlet")
         othello = self.example_user("othello")
         result = self.client_post(
@@ -1045,9 +1045,10 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         self.assertEqual(message.recipient.type, Recipient.PERSONAL)
 
     def test_receive_missed_huddle_message_email_messages(self) -> None:
-        # build dummy messages for message notification email reply
-        # have Othello send Iago and Cordelia a PM. Cordelia will reply via email
-        # Iago and Othello will receive the message.
+        # Build dummy messages for message notification email reply.
+        # Have Othello send Iago and Cordelia a group direct message.
+        # Cordelia will reply via email Iago and Othello will receive
+        # the message.
         self.login("othello")
         cordelia = self.example_user("cordelia")
         iago = self.example_user("iago")

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -1435,7 +1435,7 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_personal_message(
             cordelia,
             self.example_user("hamlet"),
-            "Let's test PM link in email notifications",
+            "Let's test a direct message link in email notifications",
         )
 
         encoded_name = "Cordelia,-Lear's-daughter"
@@ -1483,7 +1483,7 @@ class TestMissedMessages(ZulipTestCase):
         assert isinstance(mail.outbox[2], EmailMultiAlternatives)
         assert isinstance(mail.outbox[2].alternatives[0][0], str)
         self.assertEqual("> Hello\n\n--\n\nReply", mail.outbox[2].body[:18])
-        # Sender name is not appended to message for PM missed messages
+        # Sender name is not appended to message for missed direct messages
         self.assertIn(
             ">\n                    \n                        <div><p>Hello</p></div>\n",
             mail.outbox[2].alternatives[0][0],
@@ -1816,7 +1816,7 @@ class TestMissedMessages(ZulipTestCase):
                 [{"message_id": stream_mentioned_message_id, "trigger": "mentioned"}],
             )
 
-        # Private message should soft reactivate the user
+        # Direct message should soft reactivate the user
         with self.soft_deactivate_and_check_long_term_idle(hamlet, expected=False):
             # Soft reactivate the user by sending a personal message
             personal_message_id = self.send_personal_message(othello, hamlet, "Message")

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -221,8 +221,8 @@ class MissedMessageHookTest(ZulipTestCase):
                 already_notified={"email_notified": False, "push_notified": False},
             )
 
-    def test_PM(self) -> None:
-        # By default, email and push notifications should be sent for PMs
+    def test_direct_message(self) -> None:
+        # By default, email and push notifications should be sent for direct messages
         msg_id = self.send_personal_message(self.iago, self.user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(self.user_profile.id, self.client_descriptor, True)
@@ -239,7 +239,8 @@ class MissedMessageHookTest(ZulipTestCase):
             )
 
     def test_enable_offline_email_notifications_setting(self) -> None:
-        # When `enable_offline_email_notifications` is off, email notifications should not be sent for PMs
+        # When `enable_offline_email_notifications` is off, email notifications
+        # should not be sent for direct messages
         do_change_user_setting(
             self.user_profile, "enable_offline_email_notifications", False, acting_user=None
         )
@@ -400,7 +401,7 @@ class MissedMessageHookTest(ZulipTestCase):
             )
 
     def test_wildcard_mentions_notify_global_setting_is_a_wrapper(self) -> None:
-        # If email notifications for PMs and mentions themselves have been turned off,
+        # If email notifications for direct messages and mentions themselves have been turned off,
         # even turning on `wildcard_mentions_notify` should not send email notifications
         do_change_user_setting(
             self.user_profile, "enable_offline_email_notifications", False, acting_user=None
@@ -964,7 +965,7 @@ class MissedMessageHookTest(ZulipTestCase):
         self.destroy_event_queue(hambot, self.client_descriptor.event_queue.id)
         self.client_descriptor = hamlet_client_descriptor
 
-    # Internal PMs
+    # Internal direct messages
     def test_disable_external_notifications(self) -> None:
         # The disable_external_notifications parameter, used for messages sent by welcome bot,
         # should result in no email/push notifications being sent regardless of the message type.

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -469,7 +469,7 @@ class NormalActionsTest(BaseAction):
             ),
         )
 
-        # Verify private message editing - content only edit
+        # Verify direct message editing - content only edit
         pm = Message.objects.order_by("-id")[0]
         content = "new content"
         rendering_result = render_markdown(pm, content)
@@ -3338,14 +3338,14 @@ class ScheduledMessagesEventsTest(BaseAction):
         self.verify_action(action)
 
     def test_private_scheduled_message_create_event(self) -> None:
-        # Create private scheduled message
+        # Create direct scheduled message
         action = lambda: check_schedule_message(
             self.user_profile,
             get_client("website"),
             "private",
             [self.example_user("hamlet").id],
             None,
-            "Private message",
+            "Direct message",
             convert_to_UTC(dateparser("2023-04-19 18:24:56")),
             self.user_profile.realm,
         )

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -558,7 +558,7 @@ class RealmImportExportTest(ExportFile):
             [self.example_user("cordelia"), self.example_user("ZOE"), self.example_user("othello")],
         )
 
-        # Create PMs
+        # Create direct messages
         pm_a_msg_id = self.send_personal_message(
             self.example_user("AARON"), self.example_user("othello")
         )

--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -427,7 +427,7 @@ class MatterMostImporter(ZulipTestCase):
         self.assertEqual(
             user_handler.get_user(zerver_attachments[0]["owner"])["email"], "ron@zulip.com"
         )
-        # TODO: Assert this for False after fixing the file permissions in PMs
+        # TODO: Assert this for False after fixing the file permissions in direct messages
         self.assertTrue(zerver_attachments[0]["is_realm_public"])
 
         self.assert_length(uploads_list, 1)
@@ -635,8 +635,8 @@ class MatterMostImporter(ZulipTestCase):
         self.assertEqual(
             warn_log.output,
             [
-                "WARNING:root:Skipping importing huddles and PMs since there are multiple teams in the export",
-                "WARNING:root:Skipping importing huddles and PMs since there are multiple teams in the export",
+                "WARNING:root:Skipping importing huddles and DMs since there are multiple teams in the export",
+                "WARNING:root:Skipping importing huddles and DMs since there are multiple teams in the export",
             ],
         )
 
@@ -870,8 +870,8 @@ class MatterMostImporter(ZulipTestCase):
         self.assertEqual(
             warn_log.output,
             [
-                "WARNING:root:Skipping importing huddles and PMs since there are multiple teams in the export",
-                "WARNING:root:Skipping importing huddles and PMs since there are multiple teams in the export",
+                "WARNING:root:Skipping importing huddles and DMs since there are multiple teams in the export",
+                "WARNING:root:Skipping importing huddles and DMs since there are multiple teams in the export",
             ],
         )
 
@@ -897,8 +897,8 @@ class MatterMostImporter(ZulipTestCase):
         self.assertEqual(
             warn_log.output,
             [
-                "WARNING:root:Skipping importing huddles and PMs since there are multiple teams in the export",
-                "WARNING:root:Skipping importing huddles and PMs since there are multiple teams in the export",
+                "WARNING:root:Skipping importing huddles and DMs since there are multiple teams in the export",
+                "WARNING:root:Skipping importing huddles and DMs since there are multiple teams in the export",
             ],
         )
 

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -400,7 +400,7 @@ class EditMessageTest(EditMessageTestCase):
             user_profile, non_web_public_stream.name, content="non-web-public message"
         )
 
-        # Generate a private message to use in verification.
+        # Generate a direct message to use in verification.
         private_message_id = self.send_personal_message(user_profile, user_profile)
 
         invalid_message_id = private_message_id + 1000
@@ -450,7 +450,7 @@ class EditMessageTest(EditMessageTestCase):
         response_dict = self.assert_json_success(result)
         self.assertEqual(response_dict["raw_content"], "web-public message")
 
-        # Verify private messages are rejected.
+        # Verify direct messages are rejected.
         result = self.client_get("/json/messages/" + str(private_message_id))
         self.assert_json_error(
             result, "Not logged in: API authentication or user session required", 401

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -1283,7 +1283,7 @@ class MessageAccessTests(ZulipTestCase):
             ),
         ]
 
-        # Starring private messages you didn't receive fails.
+        # Starring direct messages you didn't receive fails.
         self.login("cordelia")
         result = self.change_star(message_ids)
         self.assert_json_error(result, "Invalid message(s)")

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -11,8 +11,8 @@ from zerver.lib.fix_unreads import fix, fix_unsubscribed
 from zerver.lib.message import (
     MessageDetailsDict,
     MessageDict,
+    RawUnreadDirectMessageDict,
     RawUnreadMessagesResult,
-    RawUnreadPrivateMessageDict,
     UnreadMessagesResult,
     add_message_to_unread_msgs,
     aggregate_unread_data,
@@ -1602,7 +1602,7 @@ class MarkUnreadTest(ZulipTestCase):
 
         # send message to self
         pm_dict = {
-            message_id: RawUnreadPrivateMessageDict(other_user_id=user.id),
+            message_id: RawUnreadDirectMessageDict(other_user_id=user.id),
         }
 
         raw_unread_data = RawUnreadMessagesResult(
@@ -1642,7 +1642,7 @@ class MarkUnreadTest(ZulipTestCase):
         add_message_to_unread_msgs(user.id, raw_unread_data, message_id, message_details)
         self.assertEqual(
             raw_unread_data["pm_dict"],
-            {message_id: RawUnreadPrivateMessageDict(other_user_id=user.id)},
+            {message_id: RawUnreadDirectMessageDict(other_user_id=user.id)},
         )
 
     def test_stream_messages_unread(self) -> None:

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -840,7 +840,7 @@ class MessagePOSTTest(ZulipTestCase):
 
     def test_private_message_without_recipients(self) -> None:
         """
-        Sending private message without recipients should fail
+        Sending a direct message without recipients should fail
         """
         self.login("hamlet")
         result = self.client_post(
@@ -1855,7 +1855,7 @@ class PersonalMessageSendTest(ZulipTestCase):
         self, sender: UserProfile, receiver: UserProfile, content: str = "testcontent"
     ) -> None:
         """
-        Send a private message from `sender_email` to `receiver_email` and check
+        Send a direct message from `sender_email` to `receiver_email` and check
         that only those two parties actually received the message.
         """
         sender_messages = message_stream_count(sender)
@@ -1916,7 +1916,7 @@ class PersonalMessageSendTest(ZulipTestCase):
 
     def test_non_ascii_personal(self) -> None:
         """
-        Sending a PM containing non-ASCII characters succeeds.
+        Sending a direct message containing non-ASCII characters succeeds.
         """
         self.login("hamlet")
         self.assert_personal(
@@ -2208,15 +2208,16 @@ class TestCrossRealmPMs(ZulipTestCase):
             # cross-realm email, we need to hide this for now.
             support_bot = self.create_user(support_email)
 
-        # Users can PM themselves
+        # Users can send a direct message to themselves.
         self.send_personal_message(user1, user1)
         assert_message_received(user1, user1)
 
-        # Users on the same realm can PM each other
+        # Users on the same realm can send direct messages to each other.
         self.send_personal_message(user1, user1a)
         assert_message_received(user1a, user1)
 
-        # Cross-realm bots in the zulip.com realm can PM any realm
+        # Cross-realm bots in the zulip.com realm can send a direct message
+        # in any realm.
         # (They need lower level APIs to do this.)
         internal_send_private_message(
             sender=notification_bot,
@@ -2225,7 +2226,8 @@ class TestCrossRealmPMs(ZulipTestCase):
         )
         assert_message_received(user2, notification_bot)
 
-        # All users can PM cross-realm bots in the zulip.com realm
+        # All users can send a direct message to cross-realm bots in the
+        # zulip.com realm.
         self.send_personal_message(user1, notification_bot)
         assert_message_received(notification_bot, user1)
         # Verify that internal_send_private_message can also successfully
@@ -2236,43 +2238,48 @@ class TestCrossRealmPMs(ZulipTestCase):
             content="blabla",
         )
         assert_message_received(notification_bot, user2)
-        # Users can PM cross-realm bots on non-zulip realms.
+        # Users can send a direct message to cross-realm bots on non-zulip
+        # realms.
         # (The support bot represents some theoretical bot that we may
         # create in the future that does not have zulip.com as its realm.)
         self.send_personal_message(user1, support_bot)
         assert_message_received(support_bot, user1)
 
-        # Allow sending PMs to two different cross-realm bots simultaneously.
+        # Allow sending direct messages to two different cross-realm bots
+        # simultaneously.
         # (We don't particularly need this feature, but since users can
-        # already individually send PMs to cross-realm bots, we shouldn't
-        # prevent them from sending multiple bots at once.  We may revisit
-        # this if it's a nuisance for huddles.)
+        # already individually send direct messages to cross-realm bots,
+        # we shouldn't prevent them from sending multiple bots at once.
+        # We may revisit this if it's a nuisance for huddles.)
         self.send_huddle_message(user1, [notification_bot, support_bot])
         assert_message_received(notification_bot, user1)
         assert_message_received(support_bot, user1)
 
-        # Prevent old loophole where I could send PMs to other users as long
-        # as I copied a cross-realm bot from the same realm.
+        # Prevent old loophole where I could send direct messages to other
+        # users as long as I copied a cross-realm bot from the same realm.
         with assert_invalid_user():
             self.send_huddle_message(user1, [user3, support_bot])
 
-        # Users on three different realms can't PM each other,
-        # even if one of the users is a cross-realm bot.
+        # Users on three different realms can't send direct messages to
+        # each other, even if one of the users is a cross-realm bot.
         with assert_invalid_user():
             self.send_huddle_message(user1, [user2, notification_bot])
 
         with assert_invalid_user():
             self.send_huddle_message(notification_bot, [user1, user2])
 
-        # Users on the different realms cannot PM each other
+        # Users on the different realms cannot send direct messages to
+        # each other.
         with assert_invalid_user():
             self.send_personal_message(user1, user2)
 
-        # Users on non-zulip realms can't PM "ordinary" Zulip users
+        # Users on non-zulip realms can't send direct messages to
+        # "ordinary" Zulip users.
         with assert_invalid_user():
             self.send_personal_message(user1, self.example_user("hamlet"))
 
-        # Users on three different realms cannot PM each other
+        # Users on three different realms cannot send direct messages
+        # to each other.
         with assert_invalid_user():
             self.send_huddle_message(user1, [user2, user3])
 
@@ -2477,8 +2484,8 @@ class CheckMessageTest(ZulipTestCase):
         self.assertEqual(ret.message.sender.id, sender.id)
 
     def test_bot_pm_feature(self) -> None:
-        """We send a PM to a bot's owner if their bot sends a message to
-        an unsubscribed stream"""
+        """We send a direct message to a bot's owner if their bot sends a
+        message to an unsubscribed stream"""
         parent = self.example_user("othello")
         bot = do_create_user(
             email="othello-bot@zulip.com",

--- a/zerver/tests/test_mirror_users.py
+++ b/zerver/tests/test_mirror_users.py
@@ -50,7 +50,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
         return_value=[["sipbtest:*:20922:101:Fred Sipb,,,:/mit/sipbtest:/bin/athena/tcsh"]],
     )
     def test_zephyr_mirror_new_recipient(self, ignored: object) -> None:
-        """Test mirror dummy user creation for PM recipients"""
+        """Test mirror dummy user creation for direct message recipients"""
         user = self.mit_user("starnine")
         sender = self.mit_user("sipbtest")
         new_user_email = "bob_the_new_user@mit.edu"

--- a/zerver/tests/test_muted_users.py
+++ b/zerver/tests/test_muted_users.py
@@ -232,8 +232,8 @@ class MutedUsersTests(ZulipTestCase):
         # Have Cordelia send messages to Hamlet and Othello.
         stream_message = self.send_stream_message(cordelia, "general", "Spam in stream")
         huddle_message = self.send_huddle_message(cordelia, [hamlet, othello], "Spam in huddle")
-        pm_to_hamlet = self.send_personal_message(cordelia, hamlet, "Spam in PM")
-        pm_to_othello = self.send_personal_message(cordelia, othello, "Spam in PM")
+        pm_to_hamlet = self.send_personal_message(cordelia, hamlet, "Spam in direct message")
+        pm_to_othello = self.send_personal_message(cordelia, othello, "Spam in direct message")
 
         # These should be marked as read for Hamlet, since he has muted Cordelia.
         self.assert_usermessage_read_flag(hamlet, stream_message, True)
@@ -259,8 +259,8 @@ class MutedUsersTests(ZulipTestCase):
         # Have Cordelia send messages to Hamlet and Othello.
         stream_message = self.send_stream_message(cordelia, "general", "Spam in stream")
         huddle_message = self.send_huddle_message(cordelia, [hamlet, othello], "Spam in huddle")
-        pm_to_hamlet = self.send_personal_message(cordelia, hamlet, "Spam in PM")
-        pm_to_othello = self.send_personal_message(cordelia, othello, "Spam in PM")
+        pm_to_hamlet = self.send_personal_message(cordelia, hamlet, "Spam in direct message")
+        pm_to_othello = self.send_personal_message(cordelia, othello, "Spam in direct message")
 
         # These messages are unreads for both Hamlet and Othello right now.
         self.assert_usermessage_read_flag(hamlet, stream_message, False)

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -22,7 +22,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertFalse(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
-        # Private message
+        # Direct message
         user_data = self.create_user_notifications_data_object(user_id=user_id, pm_push_notify=True)
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
@@ -162,7 +162,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertFalse(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
-        # Private message
+        # Direct message
         user_data = self.create_user_notifications_data_object(
             user_id=user_id, pm_email_notify=True
         )

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1666,7 +1666,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                 {"message_id": stream_mentioned_message_id, "trigger": "mentioned"},
             )
 
-        # Private message should soft reactivate the user
+        # Direct message should soft reactivate the user
         with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=False):
             # Soft reactivate the user by sending a personal message
             personal_message_id = self.send_personal_message(othello, self.user_profile, "Message")

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -608,7 +608,7 @@ class ReactionEventTest(ZulipTestCase):
         )
         self.assert_json_success(remove)
 
-        # Private message, event should go to both participants.
+        # Direct message, event should go to both participants.
         private_message_id = self.send_personal_message(
             iago,
             hamlet,
@@ -624,7 +624,7 @@ class ReactionEventTest(ZulipTestCase):
         event_user_ids = set(events[0]["users"])
         self.assertEqual(event_user_ids, {iago.id, hamlet.id})
 
-        # Group private message; event should go to all participants.
+        # Group direct message; event should go to all participants.
         huddle_message_id = self.send_huddle_message(
             hamlet,
             [polonius, iago],

--- a/zerver/tests/test_rocketchat_importer.py
+++ b/zerver/tests/test_rocketchat_importer.py
@@ -852,7 +852,7 @@ class RocketChatImporter(ZulipTestCase):
         self.assertEqual(
             user_handler.get_user(zerver_attachments[0]["owner"])["email"], "harrypotter@email.com"
         )
-        # TODO: Assert this for False after fixing the file permissions in PMs
+        # TODO: Assert this for False after fixing the file permissions in direct messages
         self.assertTrue(zerver_attachments[0]["is_realm_public"])
 
         self.assert_length(uploads_list, 1)
@@ -974,7 +974,7 @@ class RocketChatImporter(ZulipTestCase):
         exported_usermessage_userprofiles = self.get_set(
             messages["zerver_usermessage"], "user_profile"
         )
-        # Rocket.Cat is not subscribed to any recipient (stream/PMs) with messages.
+        # Rocket.Cat is not subscribed to any recipient (stream/direct messages) with messages.
         self.assert_length(exported_usermessage_userprofiles, 5)
         exported_usermessage_messages = self.get_set(messages["zerver_usermessage"], "message")
         self.assertEqual(exported_usermessage_messages, exported_messages_id)

--- a/zerver/tests/test_scheduled_messages.py
+++ b/zerver/tests/test_scheduled_messages.py
@@ -513,7 +513,7 @@ class ScheduledMessageTest(ZulipTestCase):
 
         # Trying to edit `topic` for direct message is ignored
         payload = {
-            "topic": "Private message topic",
+            "topic": "Direct message topic",
         }
         result = self.client_patch(f"/json/scheduled_messages/{scheduled_message_id}", payload)
         self.assert_json_success(result)

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -730,10 +730,10 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         long_term_idle_user.save()
         assert_stream_message_not_sent_to_idle_user("User no email")
 
-        # Test sending a private message to soft deactivated user creates
+        # Test sending a direct message to soft deactivated user creates
         # UserMessage row.
         soft_deactivated_user_msg_count = len(get_user_messages(long_term_idle_user))
-        message = "Test PM"
+        message = "Test direct message"
         send_personal_message(message)
         assert_um_count(long_term_idle_user, soft_deactivated_user_msg_count + 1)
         assert_last_um_content(long_term_idle_user, message)

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -180,6 +180,7 @@ class TutorialTests(ZulipTestCase):
         self.send_huddle_message(user1, [bot, user2], content)
         user1_messages = message_stream_count(user1)
         self.assertEqual(most_recent_message(user1).content, content)
-        # Welcome bot should still respond to initial PM after group PM.
+        # Welcome bot should still respond to initial direct message
+        # after group direct message.
         self.send_personal_message(user1, bot, content)
         self.assertEqual(message_stream_count(user1), user1_messages + 2)

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -554,7 +554,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         self.assertFalse(Attachment.objects.get(path_id=d1_path_id).is_realm_public)
         self.assertFalse(Attachment.objects.get(path_id=d1_path_id).is_web_public)
 
-        # Then, have the owner PM it to another user, giving that other user access.
+        # Then, have it in a direct message to another user, giving that other user access.
         body = f"Second message ...[zulip.txt](http://{host}/user_uploads/" + d1_path_id + ")"
         self.send_personal_message(self.example_user("hamlet"), self.example_user("othello"), body)
         self.assertEqual(Attachment.objects.get(path_id=d1_path_id).messages.count(), 2)

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -82,7 +82,8 @@ class WebhooksCommonTestCase(ZulipTestCase):
         with self.assertRaisesRegex(JsonableError, "Malformed JSON"):
             my_webhook_no_notify(request)
 
-        # First verify that without the setting, it doesn't send a PM to bot owner.
+        # First verify that without the setting, it doesn't send a direct
+        # message to bot owner.
         msg = self.get_last_message()
         self.assertEqual(msg.id, last_message_id)
         self.assertNotEqual(msg.content, expected_msg.strip())

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -856,7 +856,7 @@ def maybe_enqueue_notifications(
             queue_json_publish("missedmessage_mobile_notifications", notice)
             notified["push_notified"] = True
 
-    # Send missed_message emails if a private message or a
+    # Send missed_message emails if a direct message or a
     # mention.  Eventually, we'll add settings to allow email
     # notifications to match the model of push notifications
     # above.
@@ -982,8 +982,8 @@ def process_message_event(
         flags: Collection[str] = user_data.get("flags", [])
         mentioned_user_group_id: Optional[int] = user_data.get("mentioned_user_group_id")
 
-        # If the recipient was offline and the message was a single or group PM to them
-        # or they were @-notified potentially notify more immediately
+        # If the recipient was offline and the message was a (1:1 or group) direct message
+        # to them or they were @-notified potentially notify more immediately
         private_message = recipient_type_name == "private"
         user_notifications_data = UserMessageNotificationsData.from_user_id_sets(
             user_id=user_profile_id,
@@ -1270,8 +1270,9 @@ def maybe_enqueue_notifications_for_message_update(
         return
 
     if private_message:
-        # We don't do offline notifications for PMs, because
-        # we already notified the user of the original message
+        # We don't do offline notifications for direct messages,
+        # because we already notified the user of the original
+        # message.
         return
 
     if prior_mentioned:

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -113,7 +113,7 @@ def detect_narrowed_window(
 
     if "stream" in request.GET:
         try:
-            # TODO: We should support stream IDs and PMs here as well.
+            # TODO: We should support stream IDs and direct messages here as well.
             narrow_stream_name = request.GET.get("stream")
             assert narrow_stream_name is not None
             (narrow_stream, ignored_sub) = access_stream_by_name(user_profile, narrow_stream_name)

--- a/zerver/views/message_fetch.py
+++ b/zerver/views/message_fetch.py
@@ -113,7 +113,7 @@ def get_messages_backend(
         # authentication code (where we should return an auth error).
         #
         # GetOldMessagesTest.test_unauthenticated_* tests ensure
-        # that we are not leaking any secure data (private messages and
+        # that we are not leaking any secure data (direct messages and
         # non-web-public stream messages) via this path.
         if not realm.allow_web_public_streams_access():
             raise MissingAuthenticationError

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -186,7 +186,7 @@ def send_message_backend(
     if client.name in ["zephyr_mirror", "irc_mirror", "jabber_mirror", "JabberMirror"]:
         # Here's how security works for mirroring:
         #
-        # For private messages, the message must be (1) both sent and
+        # For direct messages, the message must be (1) both sent and
         # received exclusively by users in your realm, and (2)
         # received by the forwarding user.
         #

--- a/zerver/webhooks/gosquared/view.py
+++ b/zerver/webhooks/gosquared/view.py
@@ -47,7 +47,7 @@ def api_gosquared_webhook(
 
     # Live chat message event
     elif payload.get("message") is not None and payload.get("person") is not None:
-        # Only support non-private messages
+        # Only support non-direct messages
         if not payload["message"]["private"].tame(check_bool):
             session_title = payload["message"]["session"]["title"].tame(check_string)
             topic = f"Live chat session - {session_title}"

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -7,7 +7,7 @@ from zerver.models import get_realm, get_system_bot
 class HelloWorldHookTests(WebhookTestCase):
     STREAM_NAME = "test"
     URL_TEMPLATE = "/api/v1/external/helloworld?&api_key={api_key}&stream={stream}"
-    PM_URL_TEMPLATE = "/api/v1/external/helloworld?&api_key={api_key}"
+    DIRECT_MESSAGE_URL_TEMPLATE = "/api/v1/external/helloworld?&api_key={api_key}"
     WEBHOOK_DIR_NAME = "helloworld"
 
     # Note: Include a test function per each distinct message condition your integration supports
@@ -37,7 +37,7 @@ class HelloWorldHookTests(WebhookTestCase):
 
     def test_pm_to_bot_owner(self) -> None:
         # Note that this is really just a test for check_send_webhook_message
-        self.URL_TEMPLATE = self.PM_URL_TEMPLATE
+        self.URL_TEMPLATE = self.DIRECT_MESSAGE_URL_TEMPLATE
         self.url = self.build_webhook_url()
         expected_message = "Hello! I am happy to be here! :smile:\nThe Wikipedia featured article for today is **[Goodbye](https://en.wikipedia.org/wiki/Goodbye)**"
 

--- a/zerver/webhooks/teamcity/doc.md
+++ b/zerver/webhooks/teamcity/doc.md
@@ -34,7 +34,7 @@ Get Zulip notifications for your TeamCity builds!
 
 When a user runs a personal build, if Zulip can map their TeamCity
 username to a Zulip user (by comparing it with the Zulip user's email
-address or full name), that Zulip user will receive a private
-message with the result of their personal build.
+address or full name), that Zulip user will receive a direct message
+with the result of their personal build.
 
 ![](/static/images/integrations/teamcity/002.png)

--- a/zerver/webhooks/teamcity/view.py
+++ b/zerver/webhooks/teamcity/view.py
@@ -109,7 +109,7 @@ def api_teamcity_webhook(
     else:
         topic = build_name
 
-    # Check if this is a personal build, and if so try to private message the user who triggered it.
+    # Check if this is a personal build, and if so try to direct message the user who triggered it.
     if (
         get_teamcity_property_value(message["teamcityProperties"], "env.BUILD_IS_PERSONAL")
         == "true"

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -1116,7 +1116,7 @@ class DeferredWorker(QueueProcessingWorker):
             export_event.extra_data = orjson.dumps(extra_data).decode()
             export_event.save(update_fields=["extra_data"])
 
-            # Send a private message notification letting the user who
+            # Send a direct message notification letting the user who
             # triggered the export know the export finished.
             with override_language(user_profile.default_language):
                 content = _(


### PR DESCRIPTION
See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/2-general/topic/private.20messages.20.3D.3E.20direct.20messages/near/1588731).

This takes care of instances of "private message" and "PM" in the `zerver/` directory, except for:
- any uses of "PM" that refer to time, e.g. "5:30 PM"
- the API documentation (`zerver/openapi/zulip.yaml`, which is updated in #26063)
- any migrations that have those references in strings. I thought if we're going to update the migrations, that should be a separate audit pass and PR.
- `NotificationTriggers.PRIVATE_MESSAGE, "Private message"` in `zerver/models.py` is also not changed in this PR.

**Notes**:
- The majority of these changes are updates to comments / doc-strings in the various files in the `zerver/` directory.
- The commits that update the backend tests and the mattermost data import change some test names and test/log strings as well as comments.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
