### PR TITLE
api-docs: Update `zulip.yaml` for "direct message".

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1872,7 +1872,7 @@ paths:
                                 Sent to all users who received the message.
 
                                 **Changes**: Before Zulip 5.0 (feature level 77), events
-                                for private messages contained additional `sender_id` and
+                                for direct messages contained additional `sender_id` and
                                 `recipient_id` fields.
                               properties:
                                 id:
@@ -2446,7 +2446,7 @@ paths:
                                     Type of message being composed. Must be `"stream"` or `"private"`.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    all typing notifications were implicitly private messages.
+                                    all typing notifications were implicitly direct messages.
                                   enum:
                                     - private
                                     - stream
@@ -2495,7 +2495,7 @@ paths:
                                     The unique ID of the stream to which message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    typing notifications were only for private messages.
+                                    typing notifications were only for direct messages.
                                 topic:
                                   type: string
                                   description: |
@@ -2504,7 +2504,7 @@ paths:
                                     Topic within the stream where the message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    typing notifications were only for private messages.
+                                    typing notifications were only for direct messages.
                               example:
                                 {
                                   "type": "typing",
@@ -2564,7 +2564,7 @@ paths:
                                     Type of message being composed. Must be `"stream"` or `"private"`.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    all typing notifications were implicitly private messages.
+                                    all typing notifications were implicitly direct messages.
                                   enum:
                                     - private
                                     - stream
@@ -2613,7 +2613,7 @@ paths:
                                     The unique ID of the stream to which message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    typing notifications were only for private messages.
+                                    typing notifications were only for direct messages.
                                 topic:
                                   type: string
                                   description: |
@@ -2622,7 +2622,7 @@ paths:
                                     Topic within the stream where the message is being typed.
 
                                     **Changes**: New in Zulip 4.0 (feature level 58). Previously,
-                                    typing notifications were only for private messages.
+                                    typing notifications were only for direct messages.
                               example:
                                 {
                                   "type": "typing",
@@ -2803,7 +2803,7 @@ paths:
                                         description: |
                                           Present only if `type` is `private`.
 
-                                          The user IDs of every recipient of this private message, excluding yourself.
+                                          The user IDs of every recipient of this direct message, excluding yourself.
                                           Will be the empty list for a message you had sent to only yourself.
                                       stream_id:
                                         type: integer
@@ -7011,8 +7011,8 @@ paths:
                   - $ref: "#/components/schemas/InvalidMessageError"
                   - description: |
                       An example JSON response for when the specified message does not exist or it
-                      is not visible to the user making the query (e.g. it was a PM between other
-                      two users):
+                      is not visible to the user making the query (e.g. it was a direct message
+                      between two other users):
     patch:
       operationId: update-message
       summary: Edit a message
@@ -8972,14 +8972,14 @@ paths:
         - The server will mark any new messages sent by the muted user as read
           for your account, which prevents all email and mobile push notifications.
         - Clients should exclude muted users from presence lists or other UI
-          for viewing or composing 1:1 private messages. 1:1 private messages sent by
+          for viewing or composing 1:1 direct messages. 1:1 direct messages sent by
           muted users should be hidden everywhere in the Zulip UI.
-        - Stream messages and group private messages sent by the muted
+        - Stream messages and group direct messages sent by the muted
           user should avoid displaying the content and name/avatar,
           but should display that N messages by a muted user were
           hidden (so that it is possible to interpret the messages by
           other users who are talking with the muted user).
-        - Group private message conversations including the muted user
+        - Group direct message conversations including the muted user
           should display muted users as "Muted user", rather than
           showing their name, in lists of such conversations, along with using
           a blank grey avatar where avatars are displayed.
@@ -9736,14 +9736,14 @@ paths:
         - name: enable_desktop_notifications
           in: query
           description: |
-            Enable visual desktop notifications for private messages and @-mentions.
+            Enable visual desktop notifications for direct messages and @-mentions.
           schema:
             type: boolean
           example: true
         - name: enable_sounds
           in: query
           description: |
-            Enable audible desktop notifications for private messages and
+            Enable audible desktop notifications for direct messages and
             @-mentions.
           schema:
             type: boolean
@@ -9795,7 +9795,7 @@ paths:
         - name: enable_offline_email_notifications
           in: query
           description: |
-            Enable email notifications for private messages and @-mentions received
+            Enable email notifications for direct messages and @-mentions received
             when the user is offline.
           schema:
             type: boolean
@@ -9803,7 +9803,7 @@ paths:
         - name: enable_offline_push_notifications
           in: query
           description: |
-            Enable mobile notification for private messages and @-mentions received
+            Enable mobile notification for direct messages and @-mentions received
             when the user is offline.
           schema:
             type: boolean
@@ -9811,7 +9811,7 @@ paths:
         - name: enable_online_push_notifications
           in: query
           description: |
-            Enable mobile notification for private messages and @-mentions received
+            Enable mobile notification for direct messages and @-mentions received
             when the user is online.
           schema:
             type: boolean
@@ -9833,7 +9833,7 @@ paths:
         - name: pm_content_in_desktop_notifications
           in: query
           description: |
-            Include content of private messages in desktop notifications.
+            Include content of direct messages in desktop notifications.
           schema:
             type: boolean
           example: true
@@ -9861,7 +9861,7 @@ paths:
             Unread count badge (appears in desktop sidebar and browser tab)
 
             - 1 - All unreads
-            - 2 - Private messages and mentions
+            - 2 - Direct messages and mentions
             - 3 - None
           schema:
             type: integer
@@ -9920,7 +9920,7 @@ paths:
           in: query
           description: |
             Whether [typing notifications](/help/typing-notifications) be sent when composing
-            private messages.
+            direct messages.
 
             **Changes**: New in Zulip 5.0 (feature level 105).
           schema:
@@ -11343,20 +11343,20 @@ paths:
                         description: |
                           Present if `recent_private_conversations` is present in `fetch_event_types`.
 
-                          An array of dictionaries containing data on all private message and group private message
+                          An array of dictionaries containing data on all direct message and group direct message
                           conversations that the user has received (or sent) messages in, organized by
                           conversation. This data set is designed to support UI elements such as the
-                          "Private messages" widget in the web application showing recent private message
+                          "Direct messages" widget in the web application showing recent direct message
                           conversations that the user has participated in.
 
                           "Recent" is defined as the server's discretion; the original implementation
-                          interpreted that as "the 1000 most recent private messages the user received".
+                          interpreted that as "the 1000 most recent direct messages the user received".
                         type: array
                         items:
                           type: object
                           additionalProperties: false
                           description: |
-                            Object describing a single recent private conversation in the user's history.
+                            Object describing a single recent direct conversation in the user's history.
                           properties:
                             max_message_id:
                               type: integer
@@ -11368,8 +11368,8 @@ paths:
                               items:
                                 type: integer
                               description: |
-                                The list of users other than the current user in the private message
-                                conversation. This will be an empty list for private messages sent to
+                                The list of users other than the current user in the direct message
+                                conversation. This will be an empty list for direct messages sent to
                                 oneself.
                       subscriptions:
                         type: array
@@ -11468,18 +11468,18 @@ paths:
                           count:
                             type: integer
                             description: |
-                              The total number of unread messages to display; this includes private
-                              and group private messages, as well as all messages to unmuted topics
+                              The total number of unread messages to display; this includes one-on-one
+                              and group direct messages, as well as all messages to unmuted topics
                               on unmuted streams.
                           pms:
                             type: array
                             description: |
                               An array of dictionaries where each entry contains details
-                              of unread private messages with a specific user.
+                              of unread direct messages with a specific user.
                             items:
                               type: object
                               description: |
-                                Object containing the details of a unread private message with
+                                Object containing the details of unread direct messages with
                                 a specific user. Note that in rare situations, it is possible
                                 for a message that you sent to another user to be marked as
                                 unread and thus appear here.
@@ -11488,7 +11488,7 @@ paths:
                                 other_user_id:
                                   type: integer
                                   description: |
-                                    The user ID of the other participant in this non-group private
+                                    The user ID of the other participant in this non-group direct
                                     message conversation. Will be your own user ID for messages
                                     that you sent to only yourself.
                                 sender_id:
@@ -11505,7 +11505,8 @@ paths:
                                 message_ids:
                                   type: array
                                   description: |
-                                    The message IDs of the recent unread PM messages sent by the other user.
+                                    The message IDs of the recent unread direct messages sent
+                                    by the other user.
                                   items:
                                     type: integer
                           streams:
@@ -11542,22 +11543,21 @@ paths:
                           huddles:
                             type: array
                             description: |
-                              An array of dictionaries where each dictionary contains
-                              details of all unread group private messages of a single
-                              group.
+                              An array of dictionaries where each entry contains details
+                              of unread group direct messages with a specific group of users.
                             items:
                               type: object
                               description: |
-                                Object containing the details of a unread group PM
-                                messages of a single group.
+                                Object containing the details of unread group direct messages
+                                with a specific group of users.
                               additionalProperties: false
                               properties:
                                 user_ids_string:
                                   type: string
                                   description: |
                                     A string containing the IDs of all users in the group
-                                    private message conversation separated by commas
-                                    (,). Example: "1,2,3".
+                                    direct message conversation separated by commas; for
+                                    example: `"1,2,3"`.
                                 message_ids:
                                   type: array
                                   description: |
@@ -11880,11 +11880,11 @@ paths:
                           enable_desktop_notifications:
                             type: boolean
                             description: |
-                              Enable visual desktop notifications for private messages and @-mentions.
+                              Enable visual desktop notifications for direct messages and @-mentions.
                           enable_sounds:
                             type: boolean
                             description: |
-                              Enable audible desktop notifications for private messages and
+                              Enable audible desktop notifications for direct messages and
                               @-mentions.
                           enable_followed_topic_desktop_notifications:
                             type: boolean
@@ -11918,17 +11918,17 @@ paths:
                           enable_offline_email_notifications:
                             type: boolean
                             description: |
-                              Enable email notifications for private messages and @-mentions received
+                              Enable email notifications for direct messages and @-mentions received
                               when the user is offline.
                           enable_offline_push_notifications:
                             type: boolean
                             description: |
-                              Enable mobile notification for private messages and @-mentions received
+                              Enable mobile notification for direct messages and @-mentions received
                               when the user is offline.
                           enable_online_push_notifications:
                             type: boolean
                             description: |
-                              Enable mobile notification for private messages and @-mentions received
+                              Enable mobile notification for direct messages and @-mentions received
                               when the user is online.
                           enable_digest_emails:
                             type: boolean
@@ -11949,7 +11949,7 @@ paths:
                           pm_content_in_desktop_notifications:
                             type: boolean
                             description: |
-                              Include content of private messages in desktop notifications.
+                              Include content of direct messages in desktop notifications.
                           wildcard_mentions_notify:
                             type: boolean
                             description: |
@@ -11968,7 +11968,7 @@ paths:
                               Unread count badge (appears in desktop sidebar and browser tab)
 
                               - 1 - All unreads
-                              - 2 - Private messages and mentions
+                              - 2 - Direct messages and mentions
                               - 3 - None
                           realm_name_in_email_notifications_policy:
                             type: integer
@@ -12026,8 +12026,8 @@ paths:
                             description: |
                               Whether the user has chosen to send [typing
                               notifications](/help/typing-notifications)
-                              when composing private messages. The client should send typing
-                              notifications for private messages if and only if this setting is enabled.
+                              when composing direct messages. The client should send typing
+                              notifications for direct messages if and only if this setting is enabled.
 
                               **Changes**: New in Zulip 5.0 (feature level 105).
                           send_stream_typing_notifications:
@@ -13956,26 +13956,26 @@ paths:
                           enable_desktop_notifications:
                             type: boolean
                             description: |
-                              Enable visual desktop notifications for private messages and @-mentions.
+                              Enable visual desktop notifications for direct messages and @-mentions.
                           enable_sounds:
                             type: boolean
                             description: |
-                              Enable audible desktop notifications for private messages and
+                              Enable audible desktop notifications for direct messages and
                               @-mentions.
                           enable_offline_email_notifications:
                             type: boolean
                             description: |
-                              Enable email notifications for private messages and @-mentions received
+                              Enable email notifications for direct messages and @-mentions received
                               when the user is offline.
                           enable_offline_push_notifications:
                             type: boolean
                             description: |
-                              Enable mobile notification for private messages and @-mentions received
+                              Enable mobile notification for direct messages and @-mentions received
                               when the user is offline.
                           enable_online_push_notifications:
                             type: boolean
                             description: |
-                              Enable mobile notification for private messages and @-mentions received
+                              Enable mobile notification for direct messages and @-mentions received
                               when the user is online.
                           enable_followed_topic_desktop_notifications:
                             type: boolean
@@ -14020,7 +14020,7 @@ paths:
                           pm_content_in_desktop_notifications:
                             type: boolean
                             description: |
-                              Include content of private messages in desktop notifications.
+                              Include content of direct messages in desktop notifications.
                           wildcard_mentions_notify:
                             type: boolean
                             description: |
@@ -14039,7 +14039,7 @@ paths:
                               Unread count badge (appears in desktop sidebar and browser tab)
 
                               - 1 - All unreads
-                              - 2 - Private messages and mentions
+                              - 2 - Direct messages and mentions
                               - 3 - None
                           realm_name_in_email_notifications_policy:
                             type: integer
@@ -14115,7 +14115,7 @@ paths:
                             type: boolean
                             description: |
                               Whether [typing notifications](/help/typing-notifications) be sent when composing
-                              private messages.
+                              direct messages.
 
                               **Changes**: New in Zulip 5.0 (feature level 105).
                           send_stream_typing_notifications:
@@ -15080,7 +15080,7 @@ paths:
         - name: enable_desktop_notifications
           in: query
           description: |
-            Enable visual desktop notifications for private messages and @-mentions.
+            Enable visual desktop notifications for direct messages and @-mentions.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
             the `PATCH /settings/notifications` endpoint.
@@ -15090,7 +15090,7 @@ paths:
         - name: enable_sounds
           in: query
           description: |
-            Enable audible desktop notifications for private messages and
+            Enable audible desktop notifications for direct messages and
             @-mentions.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
@@ -15111,7 +15111,7 @@ paths:
         - name: enable_offline_email_notifications
           in: query
           description: |
-            Enable email notifications for private messages and @-mentions received
+            Enable email notifications for direct messages and @-mentions received
             when the user is offline.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
@@ -15122,7 +15122,7 @@ paths:
         - name: enable_offline_push_notifications
           in: query
           description: |
-            Enable mobile notification for private messages and @-mentions received
+            Enable mobile notification for direct messages and @-mentions received
             when the user is offline.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
@@ -15133,7 +15133,7 @@ paths:
         - name: enable_online_push_notifications
           in: query
           description: |
-            Enable mobile notification for private messages and @-mentions received
+            Enable mobile notification for direct messages and @-mentions received
             when the user is online.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
@@ -15220,7 +15220,7 @@ paths:
         - name: pm_content_in_desktop_notifications
           in: query
           description: |
-            Include content of private messages in desktop notifications.
+            Include content of direct messages in desktop notifications.
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
             the `PATCH /settings/notifications` endpoint.
@@ -15254,7 +15254,7 @@ paths:
             Unread count badge (appears in desktop sidebar and browser tab)
 
             - 1 - All unreads
-            - 2 - Private messages and mentions
+            - 2 - Direct messages and mentions
             - 3 - None
 
             **Changes**: Before Zulip 5.0 (feature level 80), this setting was managed by
@@ -15314,7 +15314,7 @@ paths:
           in: query
           description: |
             Whether [typing notifications](/help/typing-notifications) be sent when composing
-            private messages.
+            direct messages.
 
             **Changes**: New in Zulip 5.0 (feature level 105).
           schema:
@@ -17896,8 +17896,8 @@ components:
         subject:
           type: string
           description: |
-            The `topic` of the message. Currently always `""` for private messages,
-            though this could change if Zulip adds support for topics in private
+            The `topic` of the message. Currently always `""` for direct messages,
+            though this could change if Zulip adds support for topics in direct
             message conversations.
 
             The field name is a legacy holdover from when topics were
@@ -18027,7 +18027,7 @@ components:
           type: string
           description: |
             The type of the draft. Either unaddressed (empty string), "stream",
-            or "private" (for PMs and private group messages).
+            or "private" (for one-on-one and group direct messages).
           enum:
             - ""
             - stream
@@ -18037,7 +18037,7 @@ components:
           description: |
             An array of the tentative target audience IDs. For "stream"
             messages, this should contain exactly 1 ID, the ID of the
-            target stream. For private messages, this should be an array
+            target stream. For direct messages, this should be an array
             of target user IDs. For unaddressed drafts, this is ignored,
             and clients should send an empty array.
           items:
@@ -18045,7 +18045,7 @@ components:
         topic:
           type: string
           description: |
-            For stream message drafts, the tentative topic name. For private
+            For stream message drafts, the tentative topic name. For direct
             or unaddressed messages, this will be ignored and should ideally
             be the empty string. Should not contain null bytes.
         content:
@@ -18095,7 +18095,7 @@ components:
             The scheduled message's tentative target audience.
 
             For stream messages, it will be the unique ID of the target
-            stream. For private messages, it will be an array with the
+            stream. For direct messages, it will be an array with the
             target users' IDs.
         topic:
           type: string


### PR DESCRIPTION
See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/2-general/topic/private.20messages.20.3D.3E.20direct.20messages/near/1588731).

This takes care of instances of "private message" and "PM" in `zerver/openapi/zulip.yaml`.

Posting this as a separate PR because this updates the API documentation, which is user-facing, as there may be more rounds of review for content/text changes than there will be for the changes in the rest of the files in the `zerver/` directory.

**Notes**:
- These changes impact 12 API documentation pages. See diff below for detailed changes.
  - create-drafts
  - edit-draft
  - get-drafts
  - get-events
  - get-message
  - get-messages
  - get-scheduled-messages
  - mute-user
  - outgoing-webhooks
  - register-queue
  - update-realm-user-settings-defaults
  - update-settings
- Only providing screenshots of updates that are more than a 1-to-1 switch of "private" to "direct".

<details>
<summary>diff of current main to changes</summary>

```diff
diff -r -B -u current_api_html/create-drafts.html new_api_html/create-drafts.html
--- current_api_html/create-drafts.html	2023-06-19 18:50:22.083846941 +0200
+++ new_api_html/create-drafts.html	2023-06-19 19:18:40.520193147 +0200
@@ -300,18 +300,18 @@
 </li>
 <li>
 <code>type</code>: <span class=api-field-type>string</span> <span class="api-argument-required">required</span> <p>The type of the draft. Either unaddressed (empty string), "stream",
-or "private" (for PMs and private group messages).</p>
+or "private" (for one-on-one and group direct messages).</p>
 <p>Must be one of: <code>""</code>, <code>"stream"</code>, <code>"private"</code>.</p>
 </li>
 <li>
 <code>to</code>: <span class=api-field-type>(integer)[]</span> <span class="api-argument-required">required</span> <p>An array of the tentative target audience IDs. For "stream"
 messages, this should contain exactly 1 ID, the ID of the
-target stream. For private messages, this should be an array
+target stream. For direct messages, this should be an array
 of target user IDs. For unaddressed drafts, this is ignored,
 and clients should send an empty array.</p>
 </li>
 <li>
-<code>topic</code>: <span class=api-field-type>string</span> <span class="api-argument-required">required</span> <p>For stream message drafts, the tentative topic name. For private
+<code>topic</code>: <span class=api-field-type>string</span> <span class="api-argument-required">required</span> <p>For stream message drafts, the tentative topic name. For direct
 or unaddressed messages, this will be ignored and should ideally
 be the empty string. Should not contain null bytes.</p>
 </li>
diff -r -B -u current_api_html/edit-draft.html new_api_html/edit-draft.html
--- current_api_html/edit-draft.html	2023-06-19 18:50:22.171847586 +0200
+++ new_api_html/edit-draft.html	2023-06-19 19:18:40.624194353 +0200
@@ -308,18 +308,18 @@
 </li>
 <li>
 <code>type</code>: <span class=api-field-type>string</span> <span class="api-argument-required">required</span> <p>The type of the draft. Either unaddressed (empty string), "stream",
-or "private" (for PMs and private group messages).</p>
+or "private" (for one-on-one and group direct messages).</p>
 <p>Must be one of: <code>""</code>, <code>"stream"</code>, <code>"private"</code>.</p>
 </li>
 <li>
 <code>to</code>: <span class=api-field-type>(integer)[]</span> <span class="api-argument-required">required</span> <p>An array of the tentative target audience IDs. For "stream"
 messages, this should contain exactly 1 ID, the ID of the
-target stream. For private messages, this should be an array
+target stream. For direct messages, this should be an array
 of target user IDs. For unaddressed drafts, this is ignored,
 and clients should send an empty array.</p>
 </li>
 <li>
-<code>topic</code>: <span class=api-field-type>string</span> <span class="api-argument-required">required</span> <p>For stream message drafts, the tentative topic name. For private
+<code>topic</code>: <span class=api-field-type>string</span> <span class="api-argument-required">required</span> <p>For stream message drafts, the tentative topic name. For direct
 or unaddressed messages, this will be ignored and should ideally
 be the empty string. Should not contain null bytes.</p>
 </li>
diff -r -B -u current_api_html/get-drafts.html new_api_html/get-drafts.html
--- current_api_html/get-drafts.html	2023-06-19 18:50:22.003846358 +0200
+++ new_api_html/get-drafts.html	2023-06-19 19:18:40.428192080 +0200
@@ -307,19 +307,19 @@
 <li>
 <p><code>type</code>: <span class="api-field-type">string</span></p>
 <p>The type of the draft. Either unaddressed (empty string), "stream",
-or "private" (for PMs and private group messages).</p>
+or "private" (for one-on-one and group direct messages).</p>
 </li>
 <li>
 <p><code>to</code>: <span class="api-field-type">(integer)[]</span></p>
 <p>An array of the tentative target audience IDs. For "stream"
 messages, this should contain exactly 1 ID, the ID of the
-target stream. For private messages, this should be an array
+target stream. For direct messages, this should be an array
 of target user IDs. For unaddressed drafts, this is ignored,
 and clients should send an empty array.</p>
 </li>
 <li>
 <p><code>topic</code>: <span class="api-field-type">string</span></p>
-<p>For stream message drafts, the tentative topic name. For private
+<p>For stream message drafts, the tentative topic name. For direct
 or unaddressed messages, this will be ignored and should ideally
 be the empty string. Should not contain null bytes.</p>
 </li>
diff -r -B -u current_api_html/get-events.html new_api_html/get-events.html
--- current_api_html/get-events.html	2023-06-19 18:50:30.347907430 +0200
+++ new_api_html/get-events.html	2023-06-19 19:18:51.060315235 +0200
@@ -1392,8 +1392,8 @@
 </li>
 <li>
 <p><code>subject</code>: <span class="api-field-type">string</span></p>
-<p>The <code>topic</code> of the message. Currently always <code>""</code> for private messages,
-though this could change if Zulip adds support for topics in private
+<p>The <code>topic</code> of the message. Currently always <code>""</code> for direct messages,
+though this could change if Zulip adds support for topics in direct
 message conversations.</p>
 <p>The field name is a legacy holdover from when topics were
 called "subjects" and will eventually change.</p>
@@ -3237,7 +3237,7 @@
 <p>Event sent when a message has been deleted.
 Sent to all users who received the message.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 77), events
-for private messages contained additional <code>sender_id</code> and
+for direct messages contained additional <code>sender_id</code> and
 <code>recipient_id</code> fields.</p>
 <ul>
 <li>
@@ -3764,7 +3764,7 @@
 <p><code>message_type</code>: <span class="api-field-type">string</span></p>
 <p>Type of message being composed. Must be <code>"stream"</code> or <code>"private"</code>.</p>
 <p><strong>Changes</strong>: New in Zulip 4.0 (feature level 58). Previously,
-all typing notifications were implicitly private messages.</p>
+all typing notifications were implicitly direct messages.</p>
 </li>
 <li>
 <p><code>sender</code>: <span class="api-field-type">object</span></p>
@@ -3803,14 +3803,14 @@
 <p>Only present if <code>message_type</code> is <code>"stream"</code>.</p>
 <p>The unique ID of the stream to which message is being typed.</p>
 <p><strong>Changes</strong>: New in Zulip 4.0 (feature level 58). Previously,
-typing notifications were only for private messages.</p>
+typing notifications were only for direct messages.</p>
 </li>
 <li>
 <p><code>topic</code>: <span class="api-field-type">string</span></p>
 <p>Only present if <code>message_type</code> is <code>"stream"</code>.</p>
 <p>Topic within the stream where the message is being typed.</p>
 <p><strong>Changes</strong>: New in Zulip 4.0 (feature level 58). Previously,
-typing notifications were only for private messages.</p>
+typing notifications were only for direct messages.</p>
 </li>
 </ul>
 <p><strong>Example</strong></p>
@@ -3860,7 +3860,7 @@
 <p><code>message_type</code>: <span class="api-field-type">string</span></p>
 <p>Type of message being composed. Must be <code>"stream"</code> or <code>"private"</code>.</p>
 <p><strong>Changes</strong>: New in Zulip 4.0 (feature level 58). Previously,
-all typing notifications were implicitly private messages.</p>
+all typing notifications were implicitly direct messages.</p>
 </li>
 <li>
 <p><code>sender</code>: <span class="api-field-type">object</span></p>
@@ -3899,14 +3899,14 @@
 <p>Only present if <code>message_type</code> is <code>"stream"</code>.</p>
 <p>The unique ID of the stream to which message is being typed.</p>
 <p><strong>Changes</strong>: New in Zulip 4.0 (feature level 58). Previously,
-typing notifications were only for private messages.</p>
+typing notifications were only for direct messages.</p>
 </li>
 <li>
 <p><code>topic</code>: <span class="api-field-type">string</span></p>
 <p>Only present if <code>message_type</code> is <code>"stream"</code>.</p>
 <p>Topic within the stream where the message is being typed.</p>
 <p><strong>Changes</strong>: New in Zulip 4.0 (feature level 58). Previously,
-typing notifications were only for private messages.</p>
+typing notifications were only for direct messages.</p>
 </li>
 </ul>
 <p><strong>Example</strong></p>
@@ -4041,7 +4041,7 @@
 <li>
 <p><code>user_ids</code>: <span class="api-field-type">(integer)[]</span></p>
 <p>Present only if <code>type</code> is <code>private</code>.</p>
-<p>The user IDs of every recipient of this private message, excluding yourself.
+<p>The user IDs of every recipient of this direct message, excluding yourself.
 Will be the empty list for a message you had sent to only yourself.</p>
 </li>
 <li>
@@ -5738,19 +5738,19 @@
 <li>
 <p><code>type</code>: <span class="api-field-type">string</span></p>
 <p>The type of the draft. Either unaddressed (empty string), "stream",
-or "private" (for PMs and private group messages).</p>
+or "private" (for one-on-one and group direct messages).</p>
 </li>
 <li>
 <p><code>to</code>: <span class="api-field-type">(integer)[]</span></p>
 <p>An array of the tentative target audience IDs. For "stream"
 messages, this should contain exactly 1 ID, the ID of the
-target stream. For private messages, this should be an array
+target stream. For direct messages, this should be an array
 of target user IDs. For unaddressed drafts, this is ignored,
 and clients should send an empty array.</p>
 </li>
 <li>
 <p><code>topic</code>: <span class="api-field-type">string</span></p>
-<p>For stream message drafts, the tentative topic name. For private
+<p>For stream message drafts, the tentative topic name. For direct
 or unaddressed messages, this will be ignored and should ideally
 be the empty string. Should not contain null bytes.</p>
 </li>
@@ -5810,19 +5810,19 @@
 <li>
 <p><code>type</code>: <span class="api-field-type">string</span></p>
 <p>The type of the draft. Either unaddressed (empty string), "stream",
-or "private" (for PMs and private group messages).</p>
+or "private" (for one-on-one and group direct messages).</p>
 </li>
 <li>
 <p><code>to</code>: <span class="api-field-type">(integer)[]</span></p>
 <p>An array of the tentative target audience IDs. For "stream"
 messages, this should contain exactly 1 ID, the ID of the
-target stream. For private messages, this should be an array
+target stream. For direct messages, this should be an array
 of target user IDs. For unaddressed drafts, this is ignored,
 and clients should send an empty array.</p>
 </li>
 <li>
 <p><code>topic</code>: <span class="api-field-type">string</span></p>
-<p>For stream message drafts, the tentative topic name. For private
+<p>For stream message drafts, the tentative topic name. For direct
 or unaddressed messages, this will be ignored and should ideally
 be the empty string. Should not contain null bytes.</p>
 </li>
@@ -5917,7 +5917,7 @@
 <p><code>to</code>: <span class="api-field-type">integer | (integer)[]</span></p>
 <p>The scheduled message's tentative target audience.</p>
 <p>For stream messages, it will be the unique ID of the target
-stream. For private messages, it will be an array with the
+stream. For direct messages, it will be an array with the
 target users' IDs.</p>
 </li>
 <li>
@@ -6004,7 +6004,7 @@
 <p><code>to</code>: <span class="api-field-type">integer | (integer)[]</span></p>
 <p>The scheduled message's tentative target audience.</p>
 <p>For stream messages, it will be the unique ID of the target
-stream. For private messages, it will be an array with the
+stream. For direct messages, it will be an array with the
 target users' IDs.</p>
 </li>
 <li>
diff -r -B -u current_api_html/get-message.html new_api_html/get-message.html
--- current_api_html/get-message.html	2023-06-19 18:50:20.971838826 +0200
+++ new_api_html/get-message.html	2023-06-19 19:18:38.612171020 +0200
@@ -576,8 +576,8 @@
 </li>
 <li>
 <p><code>subject</code>: <span class="api-field-type">string</span></p>
-<p>The <code>topic</code> of the message. Currently always <code>""</code> for private messages,
-though this could change if Zulip adds support for topics in private
+<p>The <code>topic</code> of the message. Currently always <code>""</code> for direct messages,
+though this could change if Zulip adds support for topics in direct
 message conversations.</p>
 <p>The field name is a legacy holdover from when topics were
 called "subjects" and will eventually change.</p>
@@ -701,8 +701,8 @@
 <span class="p">}</span>
 </code></pre></div>
 <p>An example JSON response for when the specified message does not exist or it
-is not visible to the user making the query (e.g. it was a PM between other
-two users):</p>
+is not visible to the user making the query (e.g. it was a direct message
+between two other users):</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
 <span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Invalid message(s)"</span><span class="p">,</span>
diff -r -B -u current_api_html/get-messages.html new_api_html/get-messages.html
--- current_api_html/get-messages.html	2023-06-19 18:50:20.455835066 +0200
+++ new_api_html/get-messages.html	2023-06-19 19:18:37.760161137 +0200
@@ -753,8 +753,8 @@
 </li>
 <li>
 <p><code>subject</code>: <span class="api-field-type">string</span></p>
-<p>The <code>topic</code> of the message. Currently always <code>""</code> for private messages,
-though this could change if Zulip adds support for topics in private
+<p>The <code>topic</code> of the message. Currently always <code>""</code> for direct messages,
+though this could change if Zulip adds support for topics in direct
 message conversations.</p>
 <p>The field name is a legacy holdover from when topics were
 called "subjects" and will eventually change.</p>
diff -r -B -u current_api_html/get-scheduled-messages.html new_api_html/get-scheduled-messages.html
--- current_api_html/get-scheduled-messages.html	2023-06-19 18:50:21.663843876 +0200
+++ new_api_html/get-scheduled-messages.html	2023-06-19 19:18:39.972186792 +0200
@@ -313,7 +313,7 @@
 <p><code>to</code>: <span class="api-field-type">integer | (integer)[]</span></p>
 <p>The scheduled message's tentative target audience.</p>
 <p>For stream messages, it will be the unique ID of the target
-stream. For private messages, it will be an array with the
+stream. For direct messages, it will be an array with the
 target users' IDs.</p>
 </li>
 <li>
diff -r -B -u current_api_html/mute-user.html new_api_html/mute-user.html
--- current_api_html/mute-user.html	2023-06-19 18:50:26.655880356 +0200
+++ new_api_html/mute-user.html	2023-06-19 19:18:46.836266335 +0200
@@ -279,14 +279,14 @@
 <li>The server will mark any new messages sent by the muted user as read
   for your account, which prevents all email and mobile push notifications.</li>
 <li>Clients should exclude muted users from presence lists or other UI
-  for viewing or composing 1:1 private messages. 1:1 private messages sent by
+  for viewing or composing 1:1 direct messages. 1:1 direct messages sent by
   muted users should be hidden everywhere in the Zulip UI.</li>
-<li>Stream messages and group private messages sent by the muted
+<li>Stream messages and group direct messages sent by the muted
   user should avoid displaying the content and name/avatar,
   but should display that N messages by a muted user were
   hidden (so that it is possible to interpret the messages by
   other users who are talking with the muted user).</li>
-<li>Group private message conversations including the muted user
+<li>Group direct message conversations including the muted user
   should display muted users as "Muted user", rather than
   showing their name, in lists of such conversations, along with using
   a blank grey avatar where avatars are displayed.</li>
diff -r -B -u current_api_html/outgoing-webhooks.html new_api_html/outgoing-webhooks.html
--- current_api_html/outgoing-webhooks.html	2023-06-19 18:50:19.175825744 +0200
+++ new_api_html/outgoing-webhooks.html	2023-06-19 19:18:35.520135147 +0200
@@ -598,8 +598,8 @@
 </li>
 <li>
 <p><code>subject</code>: <span class="api-field-type">string</span></p>
-<p>The <code>topic</code> of the message. Currently always <code>""</code> for private messages,
-though this could change if Zulip adds support for topics in private
+<p>The <code>topic</code> of the message. Currently always <code>""</code> for direct messages,
+though this could change if Zulip adds support for topics in direct
 message conversations.</p>
 <p>The field name is a legacy holdover from when topics were
 called "subjects" and will eventually change.</p>
diff -r -B -u current_api_html/register-queue.html new_api_html/register-queue.html
--- current_api_html/register-queue.html	2023-06-19 18:50:29.423900646 +0200
+++ new_api_html/register-queue.html	2023-06-19 19:18:49.696299447 +0200
@@ -761,19 +761,19 @@
 <li>
 <p><code>type</code>: <span class="api-field-type">string</span></p>
 <p>The type of the draft. Either unaddressed (empty string), "stream",
-or "private" (for PMs and private group messages).</p>
+or "private" (for one-on-one and group direct messages).</p>
 </li>
 <li>
 <p><code>to</code>: <span class="api-field-type">(integer)[]</span></p>
 <p>An array of the tentative target audience IDs. For "stream"
 messages, this should contain exactly 1 ID, the ID of the
-target stream. For private messages, this should be an array
+target stream. For direct messages, this should be an array
 of target user IDs. For unaddressed drafts, this is ignored,
 and clients should send an empty array.</p>
 </li>
 <li>
 <p><code>topic</code>: <span class="api-field-type">string</span></p>
-<p>For stream message drafts, the tentative topic name. For private
+<p>For stream message drafts, the tentative topic name. For direct
 or unaddressed messages, this will be ignored and should ideally
 be the empty string. Should not contain null bytes.</p>
 </li>
@@ -905,7 +905,7 @@
 <p><code>to</code>: <span class="api-field-type">integer | (integer)[]</span></p>
 <p>The scheduled message's tentative target audience.</p>
 <p>For stream messages, it will be the unique ID of the target
-stream. For private messages, it will be an array with the
+stream. For direct messages, it will be an array with the
 target users' IDs.</p>
 </li>
 <li>
@@ -1298,13 +1298,13 @@
 <li>
 <p><code>recent_private_conversations</code>: <span class="api-field-type">(object)[]</span></p>
 <p>Present if <code>recent_private_conversations</code> is present in <code>fetch_event_types</code>.</p>
-<p>An array of dictionaries containing data on all private message and group private message
+<p>An array of dictionaries containing data on all direct message and group direct message
 conversations that the user has received (or sent) messages in, organized by
 conversation. This data set is designed to support UI elements such as the
-"Private messages" widget in the web application showing recent private message
+"Direct messages" widget in the web application showing recent direct message
 conversations that the user has participated in.</p>
 <p>"Recent" is defined as the server's discretion; the original implementation
-interpreted that as "the 1000 most recent private messages the user received".</p>
+interpreted that as "the 1000 most recent direct messages the user received".</p>
 <ul>
 <li>
 <p><code>max_message_id</code>: <span class="api-field-type">integer</span></p>
@@ -1313,8 +1313,8 @@
 </li>
 <li>
 <p><code>user_ids</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>The list of users other than the current user in the private message
-conversation. This will be an empty list for private messages sent to
+<p>The list of users other than the current user in the direct message
+conversation. This will be an empty list for direct messages sent to
 oneself.</p>
 </li>
 </ul>
@@ -1829,18 +1829,18 @@
 <ul>
 <li>
 <p><code>count</code>: <span class="api-field-type">integer</span></p>
-<p>The total number of unread messages to display; this includes private
-and group private messages, as well as all messages to unmuted topics
+<p>The total number of unread messages to display; this includes one-on-one
+and group direct messages, as well as all messages to unmuted topics
 on unmuted streams.</p>
 </li>
 <li>
 <p><code>pms</code>: <span class="api-field-type">(object)[]</span></p>
 <p>An array of dictionaries where each entry contains details
-of unread private messages with a specific user.</p>
+of unread direct messages with a specific user.</p>
 <ul>
 <li>
 <p><code>other_user_id</code>: <span class="api-field-type">integer</span></p>
-<p>The user ID of the other participant in this non-group private
+<p>The user ID of the other participant in this non-group direct
 message conversation. Will be your own user ID for messages
 that you sent to only yourself.</p>
 </li>
@@ -1855,7 +1855,8 @@
 </li>
 <li>
 <p><code>message_ids</code>: <span class="api-field-type">(integer)[]</span></p>
-<p>The message IDs of the recent unread PM messages sent by the other user.</p>
+<p>The message IDs of the recent unread direct messages sent
+by the other user.</p>
 </li>
 </ul>
 </li>
@@ -1884,15 +1885,14 @@
 </li>
 <li>
 <p><code>huddles</code>: <span class="api-field-type">(object)[]</span></p>
-<p>An array of dictionaries where each dictionary contains
-details of all unread group private messages of a single
-group.</p>
+<p>An array of dictionaries where each entry contains details
+of unread group direct messages with a specific group of users.</p>
 <ul>
 <li>
 <p><code>user_ids_string</code>: <span class="api-field-type">string</span></p>
 <p>A string containing the IDs of all users in the group
-private message conversation separated by commas
-(,). Example: "1,2,3".</p>
+direct message conversation separated by commas; for
+example: <code>"1,2,3"</code>.</p>
 </li>
 <li>
 <p><code>message_ids</code>: <span class="api-field-type">(integer)[]</span></p>
@@ -2483,11 +2483,11 @@
 </li>
 <li>
 <p><code>enable_desktop_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable visual desktop notifications for private messages and @-mentions.</p>
+<p>Enable visual desktop notifications for direct messages and @-mentions.</p>
 </li>
 <li>
 <p><code>enable_sounds</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable audible desktop notifications for private messages and
+<p>Enable audible desktop notifications for direct messages and
 @-mentions.</p>
 </li>
 <li>
@@ -2517,17 +2517,17 @@
 </li>
 <li>
 <p><code>enable_offline_email_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable email notifications for private messages and @-mentions received
+<p>Enable email notifications for direct messages and @-mentions received
 when the user is offline.</p>
 </li>
 <li>
 <p><code>enable_offline_push_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable mobile notification for private messages and @-mentions received
+<p>Enable mobile notification for direct messages and @-mentions received
 when the user is offline.</p>
 </li>
 <li>
 <p><code>enable_online_push_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable mobile notification for private messages and @-mentions received
+<p>Enable mobile notification for direct messages and @-mentions received
 when the user is online.</p>
 </li>
 <li>
@@ -2548,7 +2548,7 @@
 </li>
 <li>
 <p><code>pm_content_in_desktop_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Include content of private messages in desktop notifications.</p>
+<p>Include content of direct messages in desktop notifications.</p>
 </li>
 <li>
 <p><code>wildcard_mentions_notify</code>: <span class="api-field-type">boolean</span></p>
@@ -2566,7 +2566,7 @@
 <p>Unread count badge (appears in desktop sidebar and browser tab)</p>
 <ul>
 <li>1 - All unreads</li>
-<li>2 - Private messages and mentions</li>
+<li>2 - Direct messages and mentions</li>
 <li>3 - None</li>
 </ul>
 </li>
@@ -2617,8 +2617,8 @@
 <p><code>send_private_typing_notifications</code>: <span class="api-field-type">boolean</span></p>
 <p>Whether the user has chosen to send <a href="/help/typing-notifications">typing
 notifications</a>
-when composing private messages. The client should send typing
-notifications for private messages if and only if this setting is enabled.</p>
+when composing direct messages. The client should send typing
+notifications for direct messages if and only if this setting is enabled.</p>
 <p><strong>Changes</strong>: New in Zulip 5.0 (feature level 105).</p>
 </li>
 <li>
@@ -4167,26 +4167,26 @@
 </li>
 <li>
 <p><code>enable_desktop_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable visual desktop notifications for private messages and @-mentions.</p>
+<p>Enable visual desktop notifications for direct messages and @-mentions.</p>
 </li>
 <li>
 <p><code>enable_sounds</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable audible desktop notifications for private messages and
+<p>Enable audible desktop notifications for direct messages and
 @-mentions.</p>
 </li>
 <li>
 <p><code>enable_offline_email_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable email notifications for private messages and @-mentions received
+<p>Enable email notifications for direct messages and @-mentions received
 when the user is offline.</p>
 </li>
 <li>
 <p><code>enable_offline_push_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable mobile notification for private messages and @-mentions received
+<p>Enable mobile notification for direct messages and @-mentions received
 when the user is offline.</p>
 </li>
 <li>
 <p><code>enable_online_push_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Enable mobile notification for private messages and @-mentions received
+<p>Enable mobile notification for direct messages and @-mentions received
 when the user is online.</p>
 </li>
 <li>
@@ -4227,7 +4227,7 @@
 </li>
 <li>
 <p><code>pm_content_in_desktop_notifications</code>: <span class="api-field-type">boolean</span></p>
-<p>Include content of private messages in desktop notifications.</p>
+<p>Include content of direct messages in desktop notifications.</p>
 </li>
 <li>
 <p><code>wildcard_mentions_notify</code>: <span class="api-field-type">boolean</span></p>
@@ -4245,7 +4245,7 @@
 <p>Unread count badge (appears in desktop sidebar and browser tab)</p>
 <ul>
 <li>1 - All unreads</li>
-<li>2 - Private messages and mentions</li>
+<li>2 - Direct messages and mentions</li>
 <li>3 - None</li>
 </ul>
 </li>
@@ -4313,7 +4313,7 @@
 <li>
 <p><code>send_private_typing_notifications</code>: <span class="api-field-type">boolean</span></p>
 <p>Whether <a href="/help/typing-notifications">typing notifications</a> be sent when composing
-private messages.</p>
+direct messages.</p>
 <p><strong>Changes</strong>: New in Zulip 5.0 (feature level 105).</p>
 </li>
 <li>
diff -r -B -u current_api_html/update-realm-user-settings-defaults.html new_api_html/update-realm-user-settings-defaults.html
--- current_api_html/update-realm-user-settings-defaults.html	2023-06-19 18:50:28.579894455 +0200
+++ new_api_html/update-realm-user-settings-defaults.html	2023-06-19 19:18:48.832289447 +0200
@@ -529,7 +529,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable visual desktop notifications for private messages and @-mentions.</p></div>
+    <div class="api-description"><p>Enable visual desktop notifications for direct messages and @-mentions.</p></div>
     <hr>
 </div>
 <div class="api-argument" id="parameter-enable_sounds">
@@ -537,7 +537,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable audible desktop notifications for private messages and
+    <div class="api-description"><p>Enable audible desktop notifications for direct messages and
 @-mentions.</p></div>
     <hr>
 </div>
@@ -591,7 +591,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable email notifications for private messages and @-mentions received
+    <div class="api-description"><p>Enable email notifications for direct messages and @-mentions received
 when the user is offline.</p></div>
     <hr>
 </div>
@@ -600,7 +600,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable mobile notification for private messages and @-mentions received
+    <div class="api-description"><p>Enable mobile notification for direct messages and @-mentions received
 when the user is offline.</p></div>
     <hr>
 </div>
@@ -609,7 +609,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable mobile notification for private messages and @-mentions received
+    <div class="api-description"><p>Enable mobile notification for direct messages and @-mentions received
 when the user is online.</p></div>
     <hr>
 </div>
@@ -634,7 +634,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Include content of private messages in desktop notifications.</p></div>
+    <div class="api-description"><p>Include content of direct messages in desktop notifications.</p></div>
     <hr>
 </div>
 <div class="api-argument" id="parameter-wildcard_mentions_notify">
@@ -664,7 +664,7 @@
     <div class="api-description"><p>Unread count badge (appears in desktop sidebar and browser tab)</p>
 <ul>
 <li>1 - All unreads</li>
-<li>2 - Private messages and mentions</li>
+<li>2 - Direct messages and mentions</li>
 <li>3 - None</li>
 </ul>
 <p>Must be one of: <code>1</code>, <code>2</code>, <code>3</code>. </p></div>
@@ -722,7 +722,7 @@
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
     <div class="api-description"><p>Whether <a href="/help/typing-notifications">typing notifications</a> be sent when composing
-private messages.</p>
+direct messages.</p>
 <p><strong>Changes</strong>: New in Zulip 5.0 (feature level 105).</p></div>
     <hr>
 </div>
diff -r -B -u current_api_html/update-settings.html new_api_html/update-settings.html
--- current_api_html/update-settings.html	2023-06-19 18:50:25.643872947 +0200
+++ new_api_html/update-settings.html	2023-06-19 19:18:45.752253780 +0200
@@ -660,7 +660,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable visual desktop notifications for private messages and @-mentions.</p>
+    <div class="api-description"><p>Enable visual desktop notifications for direct messages and @-mentions.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
 the <code>PATCH /settings/notifications</code> endpoint.</p></div>
     <hr>
@@ -670,7 +670,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable audible desktop notifications for private messages and
+    <div class="api-description"><p>Enable audible desktop notifications for direct messages and
 @-mentions.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
 the <code>PATCH /settings/notifications</code> endpoint.</p></div>
@@ -691,7 +691,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable email notifications for private messages and @-mentions received
+    <div class="api-description"><p>Enable email notifications for direct messages and @-mentions received
 when the user is offline.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
 the <code>PATCH /settings/notifications</code> endpoint.</p></div>
@@ -702,7 +702,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable mobile notification for private messages and @-mentions received
+    <div class="api-description"><p>Enable mobile notification for direct messages and @-mentions received
 when the user is offline.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
 the <code>PATCH /settings/notifications</code> endpoint.</p></div>
@@ -713,7 +713,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Enable mobile notification for private messages and @-mentions received
+    <div class="api-description"><p>Enable mobile notification for direct messages and @-mentions received
 when the user is online.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
 the <code>PATCH /settings/notifications</code> endpoint.</p></div>
@@ -800,7 +800,7 @@
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
-    <div class="api-description"><p>Include content of private messages in desktop notifications.</p>
+    <div class="api-description"><p>Include content of direct messages in desktop notifications.</p>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
 the <code>PATCH /settings/notifications</code> endpoint.</p></div>
     <hr>
@@ -834,7 +834,7 @@
     <div class="api-description"><p>Unread count badge (appears in desktop sidebar and browser tab)</p>
 <ul>
 <li>1 - All unreads</li>
-<li>2 - Private messages and mentions</li>
+<li>2 - Direct messages and mentions</li>
 <li>3 - None</li>
 </ul>
 <p><strong>Changes</strong>: Before Zulip 5.0 (feature level 80), this setting was managed by
@@ -889,7 +889,7 @@
         <span class="api-argument-example-label">Example</span>: <code>true</code>
     </div>
     <div class="api-description"><p>Whether <a href="/help/typing-notifications">typing notifications</a> be sent when composing
-private messages.</p>
+direct messages.</p>
 <p><strong>Changes</strong>: New in Zulip 5.0 (feature level 105).</p></div>
     <hr>
 </div>
```
</details>

---

**Screenshots and screen captures:**

<details>
<summary>Must a user - main description</summary>

[Current documentation](https://zulip.com/api/mute-user)
![Screenshot from 2023-06-19 19-20-32](https://github.com/zulip/zulip/assets/63245456/c9b4e06a-5f9a-4c0e-990c-b20be296e6d7)
</details>

<details>
<summary>Register queue - recent_private_conversations</summary>

[Current documentation](https://zulip.com/api/register-queue)
![Screenshot from 2023-06-19 19-22-45](https://github.com/zulip/zulip/assets/63245456/9418507f-dc06-4070-b6f6-ac3494dc240e)
</details>

<details>
<summary>Register queue - unread_msgs</summary>

[Current documentation](https://zulip.com/api/register-queue)
![Screenshot from 2023-06-19 19-24-05](https://github.com/zulip/zulip/assets/63245456/632b2948-9c8b-4d76-a2bf-1d80c3f09ebb)
![Screenshot from 2023-06-19 19-25-11](https://github.com/zulip/zulip/assets/63245456/b2d4acd6-572c-4a9f-b762-2a96a39b4670)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
