### PR TITLE
Migrate stream selection dropdown in move topic modal to use tippy dropdown library.

### DIFF
--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -246,22 +246,7 @@ function item_click_callback(event, dropdown) {
 }
 
 function get_options_for_recipient_widget() {
-    const options = stream_data
-        .subscribed_subs()
-        .map((stream) => ({
-            name: stream.name,
-            unique_id: stream.stream_id,
-            stream,
-        }))
-        .sort((a, b) => {
-            if (a.name.toLowerCase() < b.name.toLowerCase()) {
-                return -1;
-            }
-            if (a.name.toLowerCase() > b.name.toLowerCase()) {
-                return 1;
-            }
-            return 0;
-        });
+    const options = stream_data.get_options_for_dropdown_widget();
 
     const direct_messages_option = {
         is_direct_message: true,

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -32,7 +32,6 @@ import {page_params} from "./page_params";
 import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
-import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
@@ -408,31 +407,6 @@ function create_copy_to_clipboard_handler($row, source, message_id) {
             $(".tooltip").hide();
         }
     });
-}
-
-export function get_available_streams_for_moving_messages(current_stream_id) {
-    return stream_data
-        .subscribed_subs()
-        .filter((stream) => {
-            if (stream.stream_id === current_stream_id) {
-                return true;
-            }
-            return stream_data.can_post_messages_in_stream(stream);
-        })
-        .map((stream) => ({
-            name: stream.name,
-            value: stream.stream_id.toString(),
-            stream,
-        }))
-        .sort((a, b) => {
-            if (a.name.toLowerCase() < b.name.toLowerCase()) {
-                return -1;
-            }
-            if (a.name.toLowerCase() > b.name.toLowerCase()) {
-                return 1;
-            }
-            return 0;
-        });
 }
 
 function edit_message($row, raw_content) {

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -849,3 +849,25 @@ export function initialize(params) {
 export function remove_default_stream(stream_id) {
     default_stream_ids.delete(stream_id);
 }
+
+export function get_options_for_dropdown_widget() {
+    return (
+        subscribed_subs()
+            .map((stream) => ({
+                name: stream.name,
+                unique_id: stream.stream_id,
+                stream,
+            }))
+            // eslint-disable-next-line consistent-return, array-callback-return
+            .sort((a, b) => {
+                if (a.name.toLowerCase() < b.name.toLowerCase()) {
+                    return -1;
+                }
+                if (a.name.toLowerCase() > b.name.toLowerCase()) {
+                    return 1;
+                }
+                // Not possible since two streams cannot have same name.
+                // return 0;
+            })
+    );
+}

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -851,23 +851,11 @@ export function remove_default_stream(stream_id) {
 }
 
 export function get_options_for_dropdown_widget() {
-    return (
-        subscribed_subs()
-            .map((stream) => ({
-                name: stream.name,
-                unique_id: stream.stream_id,
-                stream,
-            }))
-            // eslint-disable-next-line consistent-return, array-callback-return
-            .sort((a, b) => {
-                if (a.name.toLowerCase() < b.name.toLowerCase()) {
-                    return -1;
-                }
-                if (a.name.toLowerCase() > b.name.toLowerCase()) {
-                    return 1;
-                }
-                // Not possible since two streams cannot have same name.
-                // return 0;
-            })
-    );
+    return subscribed_subs()
+        .map((stream) => ({
+            name: stream.name,
+            unique_id: stream.stream_id,
+            stream,
+        }))
+        .sort((a, b) => util.strcmp(a.name.toLowerCase(), b.name.toLowerCase()));
 }

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 
+import render_inline_decorated_stream_name from "../templates/inline_decorated_stream_name.hbs";
 import render_move_topic_to_stream from "../templates/move_topic_to_stream.hbs";
 import render_stream_sidebar_actions from "../templates/stream_sidebar_actions.hbs";
 
@@ -8,16 +9,16 @@ import * as browser_history from "./browser_history";
 import * as compose_actions from "./compose_actions";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as dialog_widget from "./dialog_widget";
-import {DropdownListWidget} from "./dropdown_list_widget";
+import * as dropdown_widget from "./dropdown_widget";
 import * as hash_util from "./hash_util";
 import {$t, $t_html} from "./i18n";
-import * as keydown_util from "./keydown_util";
 import * as message_edit from "./message_edit";
 import * as popovers from "./popovers";
 import * as resize from "./resize";
 import * as settings_data from "./settings_data";
 import * as stream_bar from "./stream_bar";
 import * as stream_color from "./stream_color";
+import * as stream_data from "./stream_data";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as ui_report from "./ui_report";
@@ -26,7 +27,7 @@ import * as unread_ops from "./unread_ops";
 // We handle stream popovers and topic popovers in this
 // module.  Both are popped up from the left sidebar.
 let current_stream_sidebar_elem;
-let stream_widget;
+let stream_widget_value;
 let $stream_header_colorblock;
 
 // Keep the menu icon over which the popover is based off visible.
@@ -251,7 +252,7 @@ export function build_move_topic_to_stream_popover(
         if (only_topic_edit) {
             select_stream_id = undefined;
         } else {
-            select_stream_id = stream_widget.value();
+            select_stream_id = stream_widget_value;
         }
 
         let {
@@ -326,15 +327,37 @@ export function build_move_topic_to_stream_popover(
 
     function set_stream_topic_typeahead() {
         const $topic_input = $("#move_topic_form .move_messages_edit_topic");
-        const new_stream_id = Number(stream_widget.value(), 10);
+        const new_stream_id = Number(stream_widget_value, 10);
         const new_stream_name = sub_store.get(new_stream_id).name;
         $topic_input.data("typeahead").unlisten();
         composebox_typeahead.initialize_topic_edit_typeahead($topic_input, new_stream_name, false);
     }
 
-    function move_topic_on_update() {
-        update_submit_button_disabled_state(stream_widget.value());
+    function render_selected_stream() {
+        const stream_name = sub_store.maybe_get_stream_name(
+            Number.parseInt(stream_widget_value, 10),
+        );
+        stream_bar.decorate(stream_name, $stream_header_colorblock);
+        const stream = stream_data.get_sub_by_name(stream_name);
+        if (stream === undefined) {
+            $("#move_topic_stream_name").text($t({defaultMessage: "Select a stream"}));
+        } else {
+            $("#move_topic_stream_name").html(
+                render_inline_decorated_stream_name({stream, show_colored_icon: true}),
+            );
+        }
+    }
+
+    function move_topic_on_update(event, dropdown) {
+        stream_widget_value = $(event.currentTarget).attr("data-unique-id");
+
+        update_submit_button_disabled_state(stream_widget_value);
         set_stream_topic_typeahead();
+        render_selected_stream();
+
+        dropdown.hide();
+        event.preventDefault();
+        event.stopPropagation();
     }
 
     function move_topic_post_render() {
@@ -360,24 +383,36 @@ export function build_move_topic_to_stream_popover(
         $stream_header_colorblock = $("#dialog_widget_modal .topic_stream_edit_header").find(
             ".stream_header_colorblock",
         );
-        stream_bar.decorate(current_stream_name, $stream_header_colorblock);
-        const streams_list =
-            message_edit.get_available_streams_for_moving_messages(current_stream_id);
-        const opts = {
-            widget_name: "select_stream",
-            data: streams_list,
-            default_text: $t({defaultMessage: "No streams"}),
-            include_current_item: false,
-            value: current_stream_id,
-            on_update: move_topic_on_update,
-        };
-        stream_widget = new DropdownListWidget(opts);
+        stream_widget_value = current_stream_id;
+        const streams_list_options = () =>
+            stream_data.get_options_for_dropdown_widget().filter((stream) => {
+                if (stream.stream_id === current_stream_id) {
+                    return true;
+                }
+                return stream_data.can_post_messages_in_stream(stream);
+            });
+        dropdown_widget.setup(
+            {
+                target: "#move_topic_stream_widget",
+                // Overlap dropdown search input with stream selection button.
+                placement: "bottom-start",
+                offset: [0, -30],
+            },
+            streams_list_options,
+            move_topic_on_update,
+        );
 
-        stream_widget.setup();
-
+        render_selected_stream();
         $("#select_stream_widget .dropdown-toggle").prop("disabled", disable_stream_input);
         $("#move_topic_modal .move_messages_edit_topic").on("input", () => {
-            update_submit_button_disabled_state(stream_widget.value());
+            update_submit_button_disabled_state(stream_widget_value);
+        });
+        $(".move-topic-dropdown").on("keydown", (e) => {
+            if (e.key === "Enter") {
+                $("#move_topic_stream_widget").trigger("click");
+                e.stopPropagation();
+                e.preventDefault();
+            }
         });
     }
 
@@ -413,21 +448,6 @@ export function register_click_handlers() {
             elt,
             stream_id,
         });
-    });
-
-    $("body").on("click keypress", ".move-topic-dropdown .list_item", (e) => {
-        // We want the dropdown to collapse once any of the list item is pressed
-        // and thus don't want to kill the natural bubbling of event.
-        e.preventDefault();
-
-        if (e.type === "keypress" && !keydown_util.is_enter_event(e)) {
-            return;
-        }
-        const stream_name = sub_store.maybe_get_stream_name(
-            Number.parseInt(stream_widget.value(), 10),
-        );
-
-        stream_bar.decorate(stream_name, $stream_header_colorblock);
     });
 
     register_stream_handlers();

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -853,7 +853,6 @@ input.recipient_box {
     }
 
     .fa-chevron-down {
-        float: right;
         padding-left: 5px;
         color: hsl(0deg 0% 58%);
         font-weight: lighter;

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -850,14 +850,46 @@ ul {
         margin: 0;
     }
 
-    /* Override the default border-radius to properly align
-       the button corners with `stream_header_colorblock`. */
-    .dropdown-toggle {
-        border-radius: 1px 4px 4px 1px !important;
+    .move-topic-dropdown {
+        display: flex;
+        margin-bottom: 10px;
+
+        .dropdown-widget-button {
+            /* Override the default border-radius to properly align
+            the button corners with `stream_header_colorblock`. */
+            border-radius: 1px 4px 4px 1px !important;
+            outline: none;
+            line-height: 24px;
+            width: auto;
+            max-width: 206px;
+        }
+
+        .stream_header_colorblock {
+            margin: 0;
+        }
+
+        #move_topic_stream_name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            color: var(--color-text-default);
+
+            .stream-privacy-type-icon {
+                font-size: 13px;
+                width: 13px;
+                height: 13px;
+                position: relative;
+                top: 2px;
+            }
+        }
+
+        .fa-chevron-down {
+            padding-left: 5px;
+            color: hsl(0deg 0% 58%);
+            font-weight: lighter;
+        }
     }
 
-    .dropdown-list-widget,
-    .stream_header_colorblock,
     .move_messages_edit_topic {
         margin-bottom: 10px;
     }

--- a/web/templates/move_topic_to_stream.hbs
+++ b/web/templates/move_topic_to_stream.hbs
@@ -9,11 +9,14 @@
     {{/if}}
     <div class="topic_stream_edit_header">
         {{#unless only_topic_edit}}
-        <div class="stream_header_colorblock"></div>
-        <div class="move-topic-dropdown">
-            {{> settings/dropdown_list_widget
-              widget_name="select_stream"
-              list_placeholder=(t 'Filter streams')}}
+        <div class="move-topic-dropdown" tabindex="0">
+            <div class="stream_header_colorblock"></div>
+            <button id="move_topic_stream_widget" class="dropdown-widget-button" type="button" tabindex="-1">
+                <span id="move_topic_stream_name">
+                    {{t 'Select a stream'}}
+                </span>
+                <i class="fa fa-chevron-down"></i>
+            </button>
         </div>
         <i class="fa fa-angle-right" aria-hidden="true"></i>
         {{/unless}}

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -169,6 +169,35 @@ test("basics", () => {
     assert.equal(sub_store.get(-3), undefined);
     assert.equal(sub_store.get(undefined), undefined);
     assert.equal(sub_store.get(1), denmark);
+
+    assert.deepEqual(stream_data.get_options_for_dropdown_widget(), [
+        {
+            name: "social",
+            stream: {
+                color: "red",
+                history_public_to_subscribers: false,
+                invite_only: true,
+                is_muted: false,
+                name: "social",
+                stream_id: 2,
+                stream_post_policy: 2,
+                subscribed: true,
+            },
+            unique_id: 2,
+        },
+        {
+            name: "test",
+            stream: {
+                color: "yellow",
+                invite_only: false,
+                is_muted: true,
+                name: "test",
+                stream_id: 3,
+                subscribed: true,
+            },
+            unique_id: 3,
+        },
+    ]);
 });
 
 test("get_subscribed_streams_for_user", () => {
@@ -980,4 +1009,104 @@ test("can_unsubscribe_others", () => {
     assert.equal(stream_data.can_unsubscribe_others(sub), true);
     page_params.is_admin = false;
     assert.equal(stream_data.can_unsubscribe_others(sub), false);
+});
+
+test("options for dropdown widget", () => {
+    const denmark = {
+        subscribed: true,
+        color: "blue",
+        name: "Denmark",
+        stream_id: 1,
+        is_muted: true,
+        invite_only: true,
+        history_public_to_subscribers: true,
+    };
+    const social = {
+        subscribed: true,
+        color: "red",
+        name: "social",
+        stream_id: 2,
+        is_muted: false,
+        invite_only: true,
+        history_public_to_subscribers: false,
+        stream_post_policy: stream_data.stream_post_policy_values.admins.code,
+    };
+    const test = {
+        subscribed: true,
+        color: "yellow",
+        name: "test",
+        stream_id: 3,
+        is_muted: true,
+        invite_only: false,
+    };
+    const web_public_stream = {
+        subscribed: true,
+        color: "yellow",
+        name: "web_public_stream",
+        stream_id: 4,
+        is_muted: false,
+        invite_only: false,
+        history_public_to_subscribers: true,
+        is_web_public: true,
+    };
+    stream_data.add_sub(denmark);
+    stream_data.add_sub(social);
+    stream_data.add_sub(web_public_stream);
+    stream_data.add_sub(test);
+
+    assert.deepEqual(stream_data.get_options_for_dropdown_widget(), [
+        {
+            name: "Denmark",
+            stream: {
+                subscribed: true,
+                color: "blue",
+                name: "Denmark",
+                stream_id: 1,
+                is_muted: true,
+                invite_only: true,
+                history_public_to_subscribers: true,
+            },
+            unique_id: 1,
+        },
+        {
+            name: "social",
+            stream: {
+                color: "red",
+                history_public_to_subscribers: false,
+                invite_only: true,
+                is_muted: false,
+                name: "social",
+                stream_id: 2,
+                stream_post_policy: 2,
+                subscribed: true,
+            },
+            unique_id: 2,
+        },
+        {
+            name: "test",
+            stream: {
+                color: "yellow",
+                invite_only: false,
+                is_muted: true,
+                name: "test",
+                stream_id: 3,
+                subscribed: true,
+            },
+            unique_id: 3,
+        },
+        {
+            name: "web_public_stream",
+            stream: {
+                subscribed: true,
+                color: "yellow",
+                name: "web_public_stream",
+                stream_id: 4,
+                is_muted: false,
+                invite_only: false,
+                history_public_to_subscribers: true,
+                is_web_public: true,
+            },
+            unique_id: 4,
+        },
+    ]);
 });


### PR DESCRIPTION
I was trying to abstract and migrate everything at once but it was driving me insane, so instead a better approach would be to just migrate everyone one by one and then abstract it so that the abstraction can benefit from all the use cases and it is easier to do.

<img width="186" alt="image" src="https://github.com/zulip/zulip/assets/25124304/39c6cb80-4103-48b2-8032-db28f301e7e1">
