### PR TITLE
Breaks import cycles.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -21,11 +21,14 @@ import * as channel from "./channel";
 import * as click_handlers from "./click_handlers";
 import * as common from "./common";
 import * as compose from "./compose";
+import * as compose_actions from "./compose_actions";
+import * as compose_banner from "./compose_banner";
 import * as compose_closed_ui from "./compose_closed_ui";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_recipient from "./compose_recipient";
 import * as compose_textarea from "./compose_textarea";
 import * as compose_tooltips from "./compose_tooltips";
+import * as compose_ui from "./compose_ui";
 import * as composebox_typeahead from "./composebox_typeahead";
 import * as condense from "./condense";
 import * as copy_and_paste from "./copy_and_paste";
@@ -480,6 +483,32 @@ function initialize_unread_ui() {
     unread_ui.initialize({notify_server_messages_read: unread_ops.notify_server_messages_read});
 }
 
+function initialize_scheduled_messages(scheduled_message_params) {
+    // Add required hooks.
+    scheduled_messages.register_post_open_scheduled_message_hook(
+        "compose",
+        compose.clear_compose_box,
+    );
+    scheduled_messages.register_post_open_scheduled_message_hook(
+        "compose_banner",
+        compose_banner.clear_message_sent_banners,
+    );
+    scheduled_messages.register_post_open_scheduled_message_hook(
+        "compose_actions",
+        compose_actions.start,
+    );
+    scheduled_messages.register_post_open_scheduled_message_hook(
+        "compose_ui",
+        compose_ui.autosize_textarea,
+    );
+    scheduled_messages.register_post_open_scheduled_message_hook(
+        "popover_menus",
+        popover_menus.set_selected_schedule_timestamp,
+    );
+
+    scheduled_messages.initialize(scheduled_message_params);
+}
+
 export function initialize_everything() {
     /*
         When we initialize our various modules, a lot
@@ -619,8 +648,8 @@ export function initialize_everything() {
     tippyjs.initialize();
     compose_tooltips.initialize();
     message_list_tooltips.initialize();
-    // This populates data for scheduled messages.
-    scheduled_messages.initialize(scheduled_messages_params);
+    // This populates data for scheduled messages and sets up the required hooks.
+    initialize_scheduled_messages(scheduled_messages_params);
     popovers.initialize();
     popover_menus.initialize();
 


### PR DESCRIPTION
~This is work in progress, I am planning to break some more cycles in this PR.~
This is ready for a review now @PIG208 , @andersk 

So far I have added ~two~ six commits - 
- Breaks cycle `echo.js -> message_events.js`.
- Breaks cycle `muted_topics_ui.js -> recent_topics_ui.js`.
- Breaks cycle `reactions.js -> emoji_picker.js`.
- Introduced a hook pattern for scheduling messages breaking import cycles related to `scheduled_messages.js` module..
- Breaks cycle `search.js -> narrow.js`.
- Breaks cycle `narrow.js -> message_scroll.js`.
- ~Add hooks for post zoom-in and zoom-out methods for `topic_zoom.js` module.~

So far the metrics measured by [Cycle-Analysis tool](https://github.com/andersk/cycle-analysis) are down to ~`116, 64`~ ~`104, 57`~ `111, 59` from the current `118, 66`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
