### PR TITLE
search: Remove unused `search_open` classname.

### DIFF
--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -18,7 +18,7 @@
                     <div id="searchbox">
                         <form id="searchbox_form" class="navbar-search">
                             <div id="search_arrows" class="input-append">
-                                <span class="search_icon search_open"><i class="zulip-icon zulip-icon-search tippy-zulip-delayed-tooltip" data-tooltip-template-id="search-query-tooltip-template"></i></span>
+                                <span class="search_icon"><i class="zulip-icon zulip-icon-search tippy-zulip-delayed-tooltip" data-tooltip-template-id="search-query-tooltip-template"></i></span>
                                 <input class="search-query input-block-level home-page-input" id="search_query" type="text" placeholder="{{t 'Search' }}"
                                   autocomplete="off"/>
                                 <button class="btn search_close_button tippy-zulip-delayed-tooltip" type="button" id="search_exit" aria-label="{{t 'Exit search' }}" data-tippy-content="Close"><i class="zulip-icon zulip-icon-close" aria-hidden="true"></i></button>


### PR DESCRIPTION
A little cleanup commit that came out of https://github.com/zulip/zulip/pull/24345