### PR TITLE
message view header: Don't initalize multiple times.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -549,7 +549,7 @@ export function activate(raw_operators, opts) {
         pm_list.handle_narrow_activated(current_filter);
         stream_list.handle_narrow_activated(current_filter);
         typing_events.render_notifications_for_narrow();
-        message_view_header.initialize();
+        message_view_header.render_title_area();
         unread_ui.update_unread_banner();
 
         // It is important to call this after other important updates
@@ -991,7 +991,7 @@ function handle_post_narrow_deactivate_processes() {
     message_edit.handle_narrow_deactivated();
     widgetize.set_widgets_for_list();
     typing_events.render_notifications_for_narrow();
-    message_view_header.initialize();
+    message_view_header.render_title_area();
     update_narrow_title(narrow_state.filter());
     message_feed_top_notices.update_top_of_narrow_notices(message_lists.home);
 }

--- a/web/tests/narrow_activate.test.js
+++ b/web/tests/narrow_activate.test.js
@@ -90,7 +90,7 @@ function test_helper() {
     stub(notifications, "redraw_title");
     stub(search, "update_button_visibility");
     stub(stream_list, "handle_narrow_activated");
-    stub(message_view_header, "initialize");
+    stub(message_view_header, "render_title_area");
     stub(top_left_corner, "handle_narrow_activated");
     stub(typing_events, "render_notifications_for_narrow");
     stub(compose_recipient, "update_narrow_to_recipient_visibility");
@@ -198,7 +198,7 @@ run_test("basics", () => {
         [top_left_corner, "handle_narrow_activated"],
         [stream_list, "handle_narrow_activated"],
         [typing_events, "render_notifications_for_narrow"],
-        [message_view_header, "initialize"],
+        [message_view_header, "render_title_area"],
         [compose_recipient, "update_narrow_to_recipient_visibility"],
     ]);
 


### PR DESCRIPTION
The `initialize` function registers a click handler, and previously it was being registered another time each time one of these calls to `initialize()` happened. The only other thing that happens in `initialize` is a call to `render_title_area`, so this commit replaces the extra calls to initialize with that.
