### PR TITLE
header: Fix dark mode header box-shadow.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -195,7 +195,7 @@
 
     #navbar-middle .column-middle-inner,
     #userlist-toggle-button,
-    .header-main,
+    .header,
     #message_view_header {
         background-color: hsl(0deg 0% 13%);
     }


### PR DESCRIPTION
Followup to 239b6737c0a58e3d86d2c0d1c9e684fe994ad72b

I forgot to add darkmode support to my previous followup, sorry about that.

Current state of main:

![image](https://github.com/zulip/zulip/assets/5634097/76b46456-b5d2-4db0-8d83-a2d6d0e79772)

with this PR:

<img width="638" alt="image" src="https://github.com/zulip/zulip/assets/5634097/249b78f3-a7d0-4552-b4d1-51546cb3e624">
