### PR TITLE
compose: Fix the styles of the keyboard indicator in send shortcut.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -632,7 +632,6 @@ input.recipient_box {
     }
 
     & kbd {
-        height: 16px;
         padding: 0 4px;
     }
 

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -81,7 +81,6 @@
         & kbd {
             background-color: hsl(211deg 29% 14%);
             border-color: hsl(211deg 29% 14%);
-            box-shadow: inset 0 -1px 0 hsl(210deg 5% 34% / 20%);
             text-shadow: none;
             color: hsl(236deg 33% 90%);
         }


### PR DESCRIPTION
This PR aims to fix the styles of the keyboard indicator in send shortcut.

**Screenshots:**

<details>
<summary>Box shadow issue:</summary>

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/53193850/614bb9e2-06dc-416b-93a3-ef379ccda975) | ![image](https://github.com/zulip/zulip/assets/53193850/dd87ae7a-41ac-4841-a689-7b2378e938bc) | 
</details>

<details>
<summary>Vertical alignment issue:</summary>

| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip/assets/53193850/6fb0d96f-56b4-4748-9890-858447e347d5) | ![image](https://github.com/zulip/zulip/assets/53193850/280c7fc8-a684-48f7-88a8-6b9304386693) | 
</details>