### PR TITLE
left sidebar: Add mark all messages as unread in topic popover.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -529,6 +529,11 @@ export function initialize() {
                 instance.hide();
             });
 
+            $popper.one("click", ".sidebar-popover-mark-topic-unread", () => {
+                unread_ops.mark_topic_as_unread(stream_id, topic_name);
+                instance.hide();
+            });
+
             $popper.one("click", ".sidebar-popover-delete-topic-messages", () => {
                 const html_body = render_delete_topic_modal({topic_name});
 

--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -14,6 +14,7 @@ import * as settings_data from "./settings_data";
 import * as starred_messages from "./starred_messages";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
+import * as unread from "./unread";
 import * as user_topics from "./user_topics";
 
 export function get_actions_popover_content_context(message_id) {
@@ -130,6 +131,7 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
     const has_starred_messages = starred_messages.get_count_in_topic(sub.stream_id, topic_name) > 0;
     const can_move_topic = settings_data.user_can_move_messages_between_streams();
     const can_rename_topic = settings_data.user_can_move_messages_to_another_topic();
+    const unread_count = unread.num_unread_for_topic(stream_id, topic_name) > 0;
     return {
         stream_name: sub.name,
         stream_id: sub.stream_id,
@@ -144,5 +146,6 @@ export function get_topic_popover_content_context({stream_id, topic_name, url}) 
         color: sub.color,
         has_starred_messages,
         url,
+        unread_count,
     };
 }

--- a/web/templates/topic_sidebar_actions.hbs
+++ b/web/templates/topic_sidebar_actions.hbs
@@ -50,14 +50,21 @@
         </a>
     </li>
     {{/if}}
-
+    {{#if unread_count }}
     <li class="hidden-for-spectators">
         <a tabindex="0" class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
     </li>
-
+    {{else}}
+    <li class="hidden-for-spectators">
+        <a tabindex="0" class="sidebar-popover-mark-topic-unread" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-book" aria-hidden="true"></i>
+            {{t "Mark all messages as unread"}}
+        </a>
+    </li>
+    {{/if}}
     <li>
         <a tabindex="0" class="sidebar-popover-copy-link-to-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}" data-clipboard-text="{{ url }}">
             <i class="fa fa-link" aria-hidden="true"></i>


### PR DESCRIPTION
This will enable users to check messages in a topic at later time by marking them as unread. New rest endpoint is introduced: "mark_topic_as_unread".
Fixes #25085




**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/39624400/1c40764b-4401-4d80-8ef8-d536e52fe941)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
