### PR TITLE
narrow: Hide inconsequential buttons while renaming topic.

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -405,6 +405,10 @@ export class MessageList {
         $recipient_row.find(".stream_topic").hide();
         $recipient_row.find(".topic_edit").show();
         $recipient_row.find(".always_visible_topic_edit").hide();
+        $recipient_row.find(".on_hover_topic_resolve").hide();
+        $recipient_row.find(".on_hover_topic_unresolve").hide();
+        $recipient_row.find(".on_hover_topic_mute").hide();
+        $recipient_row.find(".on_hover_topic_unmute").hide();
     }
 
     hide_edit_topic_on_recipient_row($recipient_row) {
@@ -414,6 +418,10 @@ export class MessageList {
         $recipient_row.find(".topic_edit_form").empty();
         $recipient_row.find(".topic_edit").hide();
         $recipient_row.find(".always_visible_topic_edit").show();
+        $recipient_row.find(".on_hover_topic_resolve").show();
+        $recipient_row.find(".on_hover_topic_unresolve").show();
+        $recipient_row.find(".on_hover_topic_mute").show();
+        $recipient_row.find(".on_hover_topic_unmute").show();
     }
 
     reselect_selected_id() {


### PR DESCRIPTION
Users won't press accidentally "mark topic as resolved" and "mute this topic" buttons while renaming topic.
Fixes #25840




**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/39624400/ba02c5b8-bf2f-410d-a4f6-8c6f367814aa)


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
