### PR TITLE
compose: Show wildcard mentions according to policy.

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -336,6 +336,9 @@ export function tokenize_compose_str(s) {
 }
 
 export function broadcast_mentions() {
+    if (!compose_validate.wildcard_mention_allowed()) {
+        return [];
+    }
     const wildcard_mention_array = ["all", "everyone"];
     let wildcard_string = "";
     if (compose_state.get_message_type() === "private") {

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -14,6 +14,7 @@ const noop = () => {};
 const compose_validate = mock_esm("../src/compose_validate", {
     validate_message_length: () => true,
     warn_if_topic_resolved: noop,
+    wildcard_mention_allowed: () => true,
 });
 const input_pill = mock_esm("../src/input_pill");
 const message_user_ids = mock_esm("../src/message_user_ids", {
@@ -70,6 +71,11 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
     assert.equal(mention_all.special_item_text, "all (translated: Notify stream)");
     assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify stream)");
     assert.equal(mention_stream.special_item_text, "stream (translated: Notify stream)");
+
+    compose_validate.wildcard_mention_allowed = () => false;
+    const mentionNobody = ct.broadcast_mentions();
+    assert.equal(mentionNobody.length, 0);
+    compose_validate.wildcard_mention_allowed = () => true;
 });
 
 run_test("verify wildcard mentions typeahead for private message", () => {


### PR DESCRIPTION
Users are permitted to see  wildcard mentions for all/everyone during message composition in large streams according to `restrict wildcard mentions` policy.
Fixes #25429



**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/39624400/41c5b2c7-dd7f-4d3f-bfb5-61832519a8ba)


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
