### PR TITLE
api-docs: Fixes errors in example events and adds test coverage for documented events.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1241,8 +1241,10 @@ field with an integer field `invite_to_realm_policy`.
 
 **Feature level 35**
 
-* The peer_add and peer_remove subscription events now have plural
-  versions of `user_ids` and `stream_ids`.
+* [`GET /events`](/api/get-events): The `subscription` events for
+  `peer_add` and `peer_remove` now include `user_ids` and `stream_ids`
+  arrays. Previously, these events included singular `user_id` and
+  `stream_id` integers.
 
 **Feature level 34**
 
@@ -1349,9 +1351,9 @@ No changes; feature level used for Zulip 3.0 release.
 
 **Feature level 19**
 
-* [`GET /events`](/api/get-events): `subscriptions` event with
-  `op="peer_add"` and `op="peer_remove"` now identify the modified
-  stream by a `stream_id` field, replacing the old `name` field.
+* [`GET /events`](/api/get-events): The `subscription` events for
+  `peer_add` and `peer_remove` now identify the modified
+  stream by the `stream_id` field, replacing the old `name` field.
 
 **Feature level 18**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1296,8 +1296,9 @@ releases.
 
 **Feature level 26**
 
-* [`GET /messages`](/api/get-messages): `sender_short_name` field is no
-  longer included in return values for this endpoint.
+* [`GET /messages`](/api/get-messages), [`GET /events`](/api/get-events):
+  The `sender_short_name` field is no longer included in message objects
+  returned by these endpoints.
 * [`GET /messages`](/api/get-messages) : Removed `short_name` field from
   `display_recipient` array objects.
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -1599,11 +1599,15 @@ def test_streams(client: Client, nonadmin_client: Client) -> None:
 
 
 def test_queues(client: Client) -> None:
-    # Note that the example for api/get-events is not tested.
+    # Note that the example for api/get-events is not tested here.
+    #
     # Since, methods such as client.get_events() or client.call_on_each_message
     # are blocking calls and since the event queue backend is already
     # thoroughly tested in zerver/tests/test_event_queue.py, it is not worth
     # the effort to come up with asynchronous logic for testing those here.
+    #
+    # We do validate endpoint example responses in zerver/tests/test_openapi.py,
+    # as well as the example events returned by api/get-events.
     queue_id = register_queue(client)
     get_queue(client, queue_id)
     deregister_queue(client, queue_id)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -846,6 +846,10 @@ paths:
                             - type: object
                               description: |
                                 Event type for messages.
+
+                                **Changes**: In Zulip 3.1 (feature level 26), the
+                                `sender_short_name` field was removed from message
+                                objects.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -888,7 +892,6 @@ paths:
                                       "reactions": [],
                                       "submessages": [],
                                       "sender_full_name": "King Hamlet",
-                                      "sender_short_name": "hamlet",
                                       "sender_email": "user10@zulip.testserver",
                                       "sender_realm_str": "zulip",
                                       "display_recipient": "Denmark",
@@ -5791,8 +5794,11 @@ paths:
                       messages:
                         type: array
                         description: |
-                          An array of `message` objects, each containing the following
-                          fields:
+                          An array of `message` objects.
+
+                          **Changes**: In Zulip 3.1 (feature level 26), the
+                          `sender_short_name` field was removed from message
+                          objects.
                         items:
                           allOf:
                             - $ref: "#/components/schemas/MessagesBase"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -771,6 +771,15 @@ paths:
                                 Event sent to other users when users have been subscribed to
                                 streams. Sent to all users if the stream is public or to only
                                 the existing subscribers if the stream is private.
+
+                                **Changes**: In Zulip 4.0 (feature level 35), the singular
+                                `user_id` and `stream_id` integers included in this event
+                                were replaced with plural `user_ids` and `stream_ids` integer
+                                arrays.
+
+                                In Zulip 3.0 (feature level 19), the `stream_id` field was
+                                added to identify the stream the user subscribed to,
+                                replacing the `name` field.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -787,12 +796,18 @@ paths:
                                   type: array
                                   description: |
                                     The IDs of the streams to which the user has subscribed.
+
+                                    **Changes**: New in Zulip 4.0 (feature level 35), replacing
+                                    the `stream_id` integer.
                                   items:
                                     type: integer
                                 user_ids:
                                   type: array
                                   description: |
                                     The IDs of the users who subscribed.
+
+                                    **Changes**: New in Zulip 4.0 (feature level 35), replacing
+                                    the `user_id` integer.
                                   items:
                                     type: integer
                               additionalProperties: false
@@ -800,8 +815,8 @@ paths:
                                 {
                                   "type": "subscription",
                                   "op": "peer_add",
-                                  "stream_id": 9,
-                                  "user_id": 12,
+                                  "stream_ids": [9],
+                                  "user_ids": [12],
                                   "id": 0,
                                 }
                             - type: object
@@ -809,6 +824,15 @@ paths:
                                 Event sent to other users when users have been unsubscribed
                                 from streams. Sent to all users if the stream is public or to only
                                 the existing subscribers if the stream is private.
+
+                                **Changes**: In Zulip 4.0 (feature level 35), the singular
+                                `user_id` and `stream_id` integers included in this event
+                                were replaced with plural `user_ids` and `stream_ids` integer
+                                arrays.
+
+                                In Zulip 3.0 (feature level 19), the `stream_id` field was
+                                added to identify the stream the user unsubscribed from,
+                                replacing the `name` field.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -826,12 +850,18 @@ paths:
                                   description: |
                                     The IDs of the streams from which the users have been
                                     unsubscribed from.
+
+                                    **Changes**: New in Zulip 4.0 (feature level 35), replacing
+                                    the `stream_id` integer.
                                   items:
                                     type: integer
                                 user_ids:
                                   type: array
                                   description: |
                                     The IDs of the users who have been unsubscribed.
+
+                                    **Changes**: New in Zulip 4.0 (feature level 35), replacing
+                                    the `user_id` integer.
                                   items:
                                     type: integer
                               additionalProperties: false
@@ -839,8 +869,8 @@ paths:
                                 {
                                   "type": "subscription",
                                   "op": "peer_remove",
-                                  "stream_id": 9,
-                                  "user_id": 12,
+                                  "stream_ids": [9],
+                                  "user_ids": [12],
                                   "id": 0,
                                 }
                             - type: object

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4448,7 +4448,7 @@ paths:
                               example:
                                 {
                                   "type": "drafts",
-                                  "op": "update",
+                                  "op": "remove",
                                   "draft_id": 17,
                                 }
                             - type: object

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2781,7 +2781,8 @@ paths:
                                   additionalProperties:
                                     type: object
                                     description: |
-                                      Additional properties.
+                                      `{message_id}`: Object containing details about the
+                                      message with the specified ID.
                                     additionalProperties: false
                                     required: ["type"]
                                     properties:
@@ -2836,7 +2837,7 @@ paths:
                                   "messages": [63],
                                   "message_details":
                                     {
-                                      63:
+                                      "63":
                                         {
                                           "type": "stream",
                                           "stream_id": 22,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3623,8 +3623,7 @@ paths:
                                 {
                                   "type": "realm_bot",
                                   "op": "delete",
-                                  "bot":
-                                    {"user_id": 35, "full_name": "Foo Bot"},
+                                  "bot": {"user_id": 35},
                                   "id": 1,
                                 }
                             - type: object


### PR DESCRIPTION
As noted in [this discussion on CZO](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/peer_add.2Fremove.20examples.20.26.20changes/near/1595427), the examples for the different events returned in the [`GET /events`](https://zulip.com/api/get-events) endpoint documentation were not being tested, and therefore prone to becoming out-of-date when/if the API for a particular event was changed/updated.

Here we add test coverage that validates the event example in the documentation against the event schema in the documentation. There are 5 prep commits with updates/fixes that were found through adding the test coverage.

**Notes**:
- If there was an API feature level changelog entry or **Changes** note that also needed to be updated/added for the example event that was being updated, then I went ahead and included those changes in the commit for completeness.
- The test coverage will catch errors and typos in new events added to the documentation and if fields/objects are updated or removed from existing events in the API. If new fields/objects are added to an existing event, then it would only be caught by the test if it was marked as required in the event schema.
- The documented event schemas are thoroughly tested against the backend code that generates the events in `test_events.py`, so here we're just extending using those tested event schemas to check the examples of the events in the documentation.

---

**Screenshots and screen captures:**

*These are in commit order*

<details>
<summary>API changelog feature level 26 entry - first bullet point</summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-31)
![Screenshot from 2023-06-21 21-56-03](https://github.com/zulip/zulip/assets/63245456/f38cd8a7-112e-4368-acee-457f90862e6c)
</details>
<details>
<summary> Get messages response - message object </summary>

[Current documentation](https://zulip.com/api/get-messages#response)
![Screenshot from 2023-06-21 21-57-22](https://github.com/zulip/zulip/assets/63245456/83f0ebf2-379f-457a-83db-0b0b4263f86f)
</details>
<details>
<summary>Get events - message event </summary>

[Current documentation](https://zulip.com/api/get-events#message)
![Screenshot from 2023-06-21 21-58-28](https://github.com/zulip/zulip/assets/63245456/14ce20e1-0346-47a6-897a-05d8318ff05e)
![Screenshot from 2023-06-21 21-59-58](https://github.com/zulip/zulip/assets/63245456/5ff51bbd-1878-447b-bf26-86dc0ea7bb03)
</details>
<details>
<summary>Get events - update_message_flags remove event </summary>

**Note that the example was being rendered correctly here, but was incorrect in zulip.yaml**
[Current documentation](https://zulip.com/api/get-events#update_message_flags-remove)
![Screenshot from 2023-06-21 22-02-57](https://github.com/zulip/zulip/assets/63245456/7116167b-a9eb-4562-9873-b9eea1959793)
</details>
<details>
<summary>Get events - realm_bot delete event </summary>

[Current documentation](https://zulip.com/api/get-events#realm_bot-delete)
![Screenshot from 2023-06-21 22-04-47](https://github.com/zulip/zulip/assets/63245456/5cf8f9c0-5cc2-4261-b94a-00fdc04bb19f)
</details>
<details>
<summary>Get events - drafts remove event </summary>

[Current documentation](https://zulip.com/api/get-events#drafts-remove)
![Screenshot from 2023-06-21 22-06-58](https://github.com/zulip/zulip/assets/63245456/4ad78d9e-5990-401a-af11-0a14a597e48e)
</details>
<details>
<summary>API changelog feature level 35 entry </summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-40)
![Screenshot from 2023-06-21 22-09-34](https://github.com/zulip/zulip/assets/63245456/db07caaa-545a-4834-980c-d5121299784d)

</details>
<details>
<summary>API changelog feature level 19 entry </summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-30)
![Screenshot from 2023-06-21 22-10-51](https://github.com/zulip/zulip/assets/63245456/c38e5f77-d1f8-4ca7-a994-b0ec6b349239)

</details>
<details>
<summary>Get events - subscription peer_add and peer_remove events </summary>

[Current documentation](https://zulip.com/api/get-events#subscription-peer_add)
![Screenshot from 2023-06-21 22-12-23](https://github.com/zulip/zulip/assets/63245456/38602253-5ab9-4727-8315-6aea55504c5e)
![Screenshot from 2023-06-21 22-12-43](https://github.com/zulip/zulip/assets/63245456/a25ba250-c3b7-4f70-900f-c69eb366af5c)

</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
