### PR TITLE
widgets: Rename confusing variable name in `tabbed_instructions.ts`.

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -14,13 +14,13 @@ function registerCodeSection($codeSection) {
     const $blocks = $codeSection.find(".blocks div");
 
     $li.on("click", function () {
-        const language = this.dataset.language;
+        const tab_key = this.dataset.tabKey;
 
         $li.removeClass("active");
-        $li.filter("[data-language=" + language + "]").addClass("active");
+        $li.filter("[data-tab-key=" + tab_key + "]").addClass("active");
 
         $blocks.removeClass("active");
-        $blocks.filter("[data-language=" + language + "]").addClass("active");
+        $blocks.filter("[data-tab-key=" + tab_key + "]").addClass("active");
     });
 
     $li.on("keydown", (e) => {

--- a/web/src/portico/tabbed-instructions.ts
+++ b/web/src/portico/tabbed-instructions.ts
@@ -31,25 +31,25 @@ export function activate_correct_tab($codeSection: JQuery): void {
     const $blocks = $codeSection.find(".blocks div");
 
     $li.each(function () {
-        const language = this.dataset.language;
+        const tab_key = this.dataset.tabKey;
         $(this).removeClass("active");
-        if (language === user_os) {
+        if (tab_key === user_os) {
             $(this).addClass("active");
         }
 
-        if (desktop_os.has(user_os) && language === "desktop-web") {
+        if (desktop_os.has(user_os) && tab_key === "desktop-web") {
             $(this).addClass("active");
         }
     });
 
     $blocks.each(function () {
-        const language = this.dataset.language;
+        const tab_key = this.dataset.tabKey;
         $(this).removeClass("active");
-        if (language === user_os) {
+        if (tab_key === user_os) {
             $(this).addClass("active");
         }
 
-        if (desktop_os.has(user_os) && language === "desktop-web") {
+        if (desktop_os.has(user_os) && tab_key === "desktop-web") {
             $(this).addClass("active");
         }
     });
@@ -58,9 +58,9 @@ export function activate_correct_tab($codeSection: JQuery): void {
     const $active_list_items = $li.filter(".active");
     if (!$active_list_items.length) {
         $li.first().addClass("active");
-        const language = $li.first()[0].dataset.language;
-        if (language) {
-            $blocks.filter("[data-language=" + language + "]").addClass("active");
+        const tab_key = $li.first()[0].dataset.tabKey;
+        if (tab_key) {
+            $blocks.filter("[data-tab-key=" + tab_key + "]").addClass("active");
         } else {
             blueslip.error("Tabbed instructions widget has no tabs to activate!");
         }

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -27,11 +27,11 @@ NAV_BAR_TEMPLATE = """
 """.strip()
 
 NAV_LIST_ITEM_TEMPLATE = """
-<li data-tab-key="{data_language}" tabindex="0">{label}</li>
+<li data-tab-key="{data_tab_key}" tabindex="0">{label}</li>
 """.strip()
 
 DIV_TAB_CONTENT_TEMPLATE = """
-<div data-tab-key="{data_language}" markdown="1">
+<div data-tab-key="{data_tab_key}" markdown="1">
 {content}
 </div>
 """.strip()
@@ -125,7 +125,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
                 tab_class = "no-tabs"
                 tab_section["tabs"] = [
                     {
-                        "tab_name": "instructions-for-all-platforms",
+                        "tab_key": "instructions-for-all-platforms",
                         "start": tab_section["start_tabs_index"],
                     }
                 ]
@@ -155,7 +155,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
 
             content = "\n".join(lines[start_index:end_index]).strip()
             tab_content_block = DIV_TAB_CONTENT_TEMPLATE.format(
-                data_language=tab["tab_name"],
+                data_tab_key=tab["tab_key"],
                 # Wrapping the content in two newlines is necessary here.
                 # If we don't do this, the inner Markdown does not get
                 # rendered properly.
@@ -167,14 +167,14 @@ class TabbedSectionsPreprocessor(Preprocessor):
     def generate_nav_bar(self, tab_section: Dict[str, Any]) -> str:
         li_elements = []
         for tab in tab_section["tabs"]:
-            tab_name = tab.get("tab_name")
-            tab_label = TAB_SECTION_LABELS.get(tab_name)
+            tab_key = tab.get("tab_key")
+            tab_label = TAB_SECTION_LABELS.get(tab_key)
             if tab_label is None:
                 raise ValueError(
-                    f"Tab '{tab_name}' is not present in TAB_SECTION_LABELS in zerver/lib/markdown/tabbed_sections.py"
+                    f"Tab '{tab_key}' is not present in TAB_SECTION_LABELS in zerver/lib/markdown/tabbed_sections.py"
                 )
 
-            li = NAV_LIST_ITEM_TEMPLATE.format(data_language=tab_name, label=tab_label)
+            li = NAV_LIST_ITEM_TEMPLATE.format(data_tab_key=tab_key, label=tab_label)
             li_elements.append(li)
 
         return NAV_BAR_TEMPLATE.format(tabs="\n".join(li_elements))
@@ -189,7 +189,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
             tab_content_match = TAB_CONTENT_REGEX.search(line)
             if tab_content_match:
                 block.setdefault("tabs", [])
-                tab = {"start": index, "tab_name": tab_content_match.group(1)}
+                tab = {"start": index, "tab_key": tab_content_match.group(1)}
                 block["tabs"].append(tab)
 
             end_match = END_TABBED_SECTION_REGEX.search(line)

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -27,11 +27,11 @@ NAV_BAR_TEMPLATE = """
 """.strip()
 
 NAV_LIST_ITEM_TEMPLATE = """
-<li data-language="{data_language}" tabindex="0">{label}</li>
+<li data-tab-key="{data_language}" tabindex="0">{label}</li>
 """.strip()
 
 DIV_TAB_CONTENT_TEMPLATE = """
-<div data-language="{data_language}" markdown="1">
+<div data-tab-key="{data_language}" markdown="1">
 {content}
 </div>
 """.strip()

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -38,14 +38,14 @@ header
 <p>
   <div class="code-section has-tabs" markdown="1">
     <ul class="nav">
-      <li data-language="ios" tabindex="0">iOS</li>
-      <li data-language="desktop-web" tabindex="0">Desktop/Web</li>
+      <li data-tab-key="ios" tabindex="0">iOS</li>
+      <li data-tab-key="desktop-web" tabindex="0">Desktop/Web</li>
     </ul>
     <div class="blocks">
-      <div data-language="ios" markdown="1"></p>
+      <div data-tab-key="ios" markdown="1"></p>
         <p>iOS instructions</p>
       <p></div>
-      <div data-language="desktop-web" markdown="1"></p>
+      <div data-tab-key="desktop-web" markdown="1"></p>
         <p>Desktop/browser instructions</p>
       <p></div>
     </div>
@@ -56,14 +56,14 @@ header
 <p>
   <div class="code-section has-tabs" markdown="1">
     <ul class="nav">
-      <li data-language="desktop-web" tabindex="0">Desktop/Web</li>
-      <li data-language="android" tabindex="0">Android</li>
+      <li data-tab-key="desktop-web" tabindex="0">Desktop/Web</li>
+      <li data-tab-key="android" tabindex="0">Android</li>
     </ul>
     <div class="blocks">
-      <div data-language="desktop-web" markdown="1"></p>
+      <div data-tab-key="desktop-web" markdown="1"></p>
         <p>Desktop/browser instructions</p>
       <p></div>
-      <div data-language="android" markdown="1"></p>
+      <div data-tab-key="android" markdown="1"></p>
         <p>Android instructions</p>
       <p></div>
     </div>
@@ -74,10 +74,10 @@ header
 <p>
   <div class="code-section no-tabs" markdown="1">
     <ul class="nav">
-      <li data-language="instructions-for-all-platforms" tabindex="0">Instructions for all platforms</li>
+      <li data-tab-key="instructions-for-all-platforms" tabindex="0">Instructions for all platforms</li>
     </ul>
     <div class="blocks">
-      <div data-language="instructions-for-all-platforms" markdown="1"></p>
+      <div data-tab-key="instructions-for-all-platforms" markdown="1"></p>
         <p>Instructions for all platforms</p>
       <p></div>
     </div>


### PR DESCRIPTION
The `tabbed_instructions` widget used for both language toggles in our API documentation and app toggles in our Help Center documentation misleadingly calls the identifier for the tab `language` in local variables and its interface.

- Renames local variable `language` -> `tab_key`.
- Renames HTML data attributes `data-language` -> `data-tab-key`.
- Updates variable names in `tabbed_sections.py`.

Fixes #24669.
Replaces #25007 and #24760.

**Remarks**
I split the work into two commits to make the PR a bit easier to review, but maybe it would be better to put all the changes in a single commit?

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] End-to-end functionality of buttons, interactions and flows.
</details>