### PR TITLE
stream_settings: Fix height of select elements.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -1016,7 +1016,7 @@ div.settings-radio-input-parent {
         /* Match with select elements in settings page */
         min-width: 325px;
         max-width: 100%;
-        height: fit-content;
+        height: 30px;
     }
 
     & select.stream_post_policy_setting {


### PR DESCRIPTION
Previously, we used to have top and bottom paddings of 4px to the select elements but it was removed in a208da9c4d0 to make sure that text for the selected option is aligned properly.

All other select elements have height set to 30px, but the select elements in stream settings page had height set to "fit-content" and so they looked ugly after removing the padding.

This PR sets the height of select elements in stream settings to 30px.

<!-- Describe your pull request here.-->

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before -
![Screenshot from 2023-06-22 20-37-49](https://github.com/zulip/zulip/assets/35494118/a8935e69-d67a-4092-a677-a387c8cd138f)



After - 
![Screenshot from 2023-06-22 20-37-10](https://github.com/zulip/zulip/assets/35494118/de75671d-fc65-4e66-afb7-62b5d2a5089c)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
