### PR TITLE
pgroonga: Run upgrade SQL when pgroonga package is updated.

### DIFF
--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -89,20 +89,10 @@ class zulip::postgresql_base {
     }
 
     $dbname = zulipconf('postgresql', 'database_name', 'zulip')
-    $dbuser = zulipconf('postgresql', 'database_user', 'zulip')
-    file { $pgroonga_setup_sql_path:
-      ensure  => file,
-      require => Package["${postgresql}-pgdg-pgroonga"],
-      owner   => 'postgres',
-      group   => 'postgres',
-      mode    => '0640',
-      content => template('zulip/postgresql/pgroonga_setup.sql.template.erb'),
-    }
-
     exec{'create_pgroonga_extension':
-      require => File[$pgroonga_setup_sql_path],
+      require => Package["${postgresql}-pgdg-pgroonga"],
       # lint:ignore:140chars
-      command => "bash -c 'cat ${pgroonga_setup_sql_path} | su postgres -c \"psql -v ON_ERROR_STOP=1 ${dbname}\" && touch ${pgroonga_setup_sql_path}.applied'",
+      command => "bash -c 'echo \"CREATE EXTENSION PGROONGA\" | su postgres -c \"psql -v ON_ERROR_STOP=1 ${dbname}\" && touch ${pgroonga_setup_sql_path}.applied'",
       # lint:endignore
       creates => "${pgroonga_setup_sql_path}.applied",
     }

--- a/puppet/zulip/manifests/postgresql_base.pp
+++ b/puppet/zulip/manifests/postgresql_base.pp
@@ -83,18 +83,20 @@ class zulip::postgresql_base {
     }
 
     package{"${postgresql}-pgdg-pgroonga":
-      ensure  => installed,
-      require => [Package[$postgresql],
-                  Exec[$setup_system_deps]],
+      ensure  => latest,
+      require => [
+        Package[$postgresql],
+        Exec[$setup_system_deps]
+      ],
     }
-
-    $dbname = zulipconf('postgresql', 'database_name', 'zulip')
-    exec{'create_pgroonga_extension':
+    exec { 'pgroonga-config':
       require => Package["${postgresql}-pgdg-pgroonga"],
-      # lint:ignore:140chars
-      command => "bash -c 'echo \"CREATE EXTENSION PGROONGA\" | su postgres -c \"psql -v ON_ERROR_STOP=1 ${dbname}\" && touch ${pgroonga_setup_sql_path}.applied'",
-      # lint:endignore
-      creates => "${pgroonga_setup_sql_path}.applied",
+      unless  => @("EOT"/$),
+          test -f ${pgroonga_setup_sql_path}.applied &&
+          test "$(dpkg-query --show --showformat='\${Version}' "${postgresql}-pgdg-pgroonga")" \
+             = "$(cat ${pgroonga_setup_sql_path}.applied)"
+          | EOT
+      command => "${::zulip_scripts_path}/setup/pgroonga-config ${postgresql_sharedir}",
     }
   }
 

--- a/puppet/zulip/templates/postgresql/pgroonga_setup.sql.template.erb
+++ b/puppet/zulip/templates/postgresql/pgroonga_setup.sql.template.erb
@@ -1,2 +1,0 @@
-CREATE EXTENSION PGROONGA;
-GRANT USAGE ON SCHEMA pgroonga TO <%= @dbuser %>;

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -28,6 +28,7 @@ from scripts.lib.zulip_tools import (
     DEPLOYMENTS_DIR,
     assert_running_as_root,
     get_config,
+    get_config_bool,
     get_config_file,
     get_zulip_pwent,
     listening_publicly,
@@ -205,6 +206,7 @@ def shutdown_server() -> None:
 
 # postgresql.version is required for database servers, but wasn't
 # previously; fill it in based on what the OS provides.
+postgresql_version = None
 if os.path.exists("/etc/init.d/postgresql"):
     postgresql_version = get_config(config_file, "postgresql", "version")
     django_pg_version = subprocess.check_output(
@@ -269,9 +271,20 @@ if glob.glob("/usr/share/postgresql/*/extension/tsearch_extras.control"):
     subprocess.check_call(["apt-get", "remove", "-y", "postgresql-*-tsearch-extras"])
 
 if not (minimal_change or args.skip_puppet):
+    # We need to temporarily hold pgroonga, if installed -- upgrading
+    # it without running the appropriate upgrade SQL can cause
+    # PostgreSQL to crash
+    if postgresql_version is not None and get_config_bool(config_file, "machine", "pgroonga"):
+        subprocess.check_call(
+            ["apt-mark", "hold", f"postgresql-{postgresql_version}-pgdg-pgroonga"]
+        )
     logging.info("Upgrading system packages...")
     subprocess.check_call(["apt-get", "update"])
     subprocess.check_call(["apt-get", "-y", "--with-new-pkgs", "upgrade"])
+    if postgresql_version is not None and get_config_bool(config_file, "machine", "pgroonga"):
+        subprocess.check_call(
+            ["apt-mark", "unhold", f"postgresql-{postgresql_version}-pgdg-pgroonga"]
+        )
 
 # To bootstrap zulip-puppet-apply, we need to install the system yaml
 # package; new installs get this, but old installs may not have it.

--- a/scripts/setup/create-pgroonga.sql
+++ b/scripts/setup/create-pgroonga.sql
@@ -1,3 +1,2 @@
 \connect zulip
 CREATE EXTENSION pgroonga;
-GRANT USAGE ON SCHEMA pgroonga TO zulip;

--- a/scripts/setup/pgroonga-config
+++ b/scripts/setup/pgroonga-config
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -eux
+
+dbversion=$(crudini --get /etc/zulip/zulip.conf postgresql version)
+dbname=$(crudini --get /etc/zulip/zulip.conf postgresql database_name 2>/dev/null || echo zulip)
+dbuser=$(crudini --get /etc/zulip/zulip.conf postgresql database_user 2>/dev/null || echo zulip)
+
+sharedir="${1:-/usr/share/postgresql/$dbversion}"
+applied_file="$sharedir/pgroonga_setup.sql.applied"
+
+installed_version=$(dpkg-query --show --showformat='${Version}' "postgresql-$dbversion-pgdg-pgroonga")
+
+if [ ! -f "$applied_file" ]; then
+    sql="CREATE EXTENSION PGROONGA; GRANT USAGE ON SCHEMA pgroonga TO $dbuser"
+else
+    sql="ALTER EXTENSION pgroonga UPDATE"
+fi
+
+echo "$sql" | su postgres -c "psql -v ON_ERROR_STOP=1 $dbname"
+
+echo "$installed_version" >"$applied_file"

--- a/tools/setup/postgresql-init-dev-db
+++ b/tools/setup/postgresql-init-dev-db
@@ -116,8 +116,6 @@ SELECT unnest(
         ARRAY['ALTER SYSTEM SET pgroonga.enable_wal = ''on''', 'SELECT pg_reload_conf()']
     END
 ) \gexec
-
-GRANT USAGE ON SCHEMA pgroonga TO $USERNAME;
 EOF
 
 psql -v ON_ERROR_STOP=1 -e -h localhost postgres "$USERNAME" <<EOF


### PR DESCRIPTION
Updating the pgroonga package is not sufficient to upgrade the extension in PostgreSQL -- an `ALTER EXTENSION pgroonga UPDATE` must explicitly be run[^1].  Failure to do so can lead to unexpected behavior, including crashes of PostgreSQL.

Expand on the existing `pgroonga_setup.sql.applied` file, to track which version of the PostgreSQL extension has been configured.  If the file exists but is empty, we run `ALTER EXTENSION pgroonga UPDATE` regardless -- if it is a no-op, it still succeeds with a `NOTICE`:

```
zulip=# ALTER EXTENSION pgroonga UPDATE;
NOTICE:  version "3.0.8" of extension "pgroonga" is already installed
ALTER EXTENSION
```

The simple `ALTER EXTENSION` is sufficient for the backwards-compatible case[^1] -- which, for our usage, is every upgrade since 0.9 -> 1.0.  Since version 1.0 was released in 2015, before pgroonga support was added to Zulip in 2016, we can assume for the moment that all pgroonga upgrades are backwards-compatible, and not bother regenerating indexes.

Fixes: #25989.

[^1]: https://pgroonga.github.io/upgrade/

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
