### PR TITLE
api-docs: Update endpoints in streams section for permissions info.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8439,7 +8439,10 @@ paths:
 
         If any of the specified streams do not exist, they are automatically
         created. The initial [stream settings](/api/update-stream) will be determined
-        by the optional parameters like `invite_only` detailed below.
+        by the optional parameters, like `invite_only`, detailed below.
+
+        Note that the ability to subscribe oneself and/or other users to a specified
+        stream depends on the [stream's privacy settings](/help/stream-permissions).
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -15662,6 +15665,7 @@ paths:
       tags: ["streams"]
       description: |
         [Archive the stream](/help/archive-a-stream) with the ID `stream_id`.
+      x-requires-administrator: true
       parameters:
         - $ref: "#/components/parameters/StreamIdInPath"
       responses:
@@ -15695,6 +15699,10 @@ paths:
         - Stream [permissions](/help/stream-permissions), including
           [privacy](/help/change-the-privacy-of-a-stream) and [who can
           send](/help/stream-sending-policy).
+
+        Note that an organization administrator's ability to change a
+        [private stream's permissions](/help/stream-permissions#private-streams)
+        depends on them being subscribed to the stream.
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -15841,14 +15849,16 @@ paths:
         data structure), so deleting all the messages in the topic
         deletes the topic from Zulip.
 
-        **Changes**: Before Zulip 6.0 (feature level 147), this
-        request did a single atomic operation, which could time out
-        for very large topics. It now deletes messages in batches,
-        starting with the newest messages, so that progress will be
-        made even if the request times out.
+        **Changes**: As of Zulip 6.0 (feature level 154), in case
+        of timeout, a success response with "partially_completed"
+        result will now be returned.
 
-        As of feature level 154, in case of timeout, a success response
-        with "partially_completed" result will now be returned.
+        Before Zulip 6.0 (feature level 147), this request did a
+        single atomic operation, which could time out for very large
+        topics. It now deletes messages in batches, starting with
+        the newest messages, so that progress will be made even if
+        the request times out.
+      x-requires-administrator: true
       parameters:
         - $ref: "#/components/parameters/StreamIdInPath"
         - name: topic_name


### PR DESCRIPTION
Did a small audit of the **Streams** section in the API documentation for adding information about [stream permissions](https://zulip.com/help/stream-permissions) and about needing to be an organization administrator to use the endpoint.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/Peer.20subscribe.20permissions/near/1434182).

**Notes**:
- Updates the `api/subscribe` and `api/update-stream` endpoint docs to note that streams' permissions impact whether a user/admin can subscribe users and/or update a stream's permissions settings.
- Updates the `api/archive-stream` and `api/delete-topic` endpoint docs to note that they are only available to org admins.
- The `api/get-stream-topics` is updated in a separate pull request; see #26017.

---

**Screenshots and screen captures:**

<details>
<summary>Subscribe to a stream - main description</summary>

[Current documentation](https://zulip.com/api/subscribe)
![Screenshot from 2023-06-22 17-50-45](https://github.com/zulip/zulip/assets/63245456/ca6f3e12-a44e-4332-bc5c-798d18412928)
</details>
<details>
<summary>Update a stream - main description</summary>

[Current documentation](https://zulip.com/api/update-stream)
![Screenshot from 2023-06-22 17-50-54](https://github.com/zulip/zulip/assets/63245456/3d726292-a085-4d6d-9382-ed0a0f55f11b)
</details>
<details>
<summary>Archive a stream - main description</summary>

[Current documentation](https://zulip.com/api/archive-stream)
![Screenshot from 2023-06-22 17-51-03](https://github.com/zulip/zulip/assets/63245456/6d298967-259d-474a-a061-83596f59fca7)
</details>
<details>
<summary>Delete a topic - main description</summary>

[Current documentation](https://zulip.com/api/delete-topic)
![Screenshot from 2023-06-22 17-51-13](https://github.com/zulip/zulip/assets/63245456/18425d29-1277-4404-aec5-1f6c544dede0)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
