### PR TITLE
compose: Add warning banner for search views.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -507,6 +507,27 @@ export function initialize() {
         },
     );
 
+    $("body").on(
+        "click",
+        `.${CSS.escape(
+            compose_banner.CLASSNAMES.compose_in_search_view,
+        )} .main-view-banner-action-button`,
+        (event) => {
+            event.preventDefault();
+
+            const $target = $(event.target).parents(".main-view-banner");
+            const stream_id = Number.parseInt($target.attr("data-stream-id"), 10);
+            const topic_name = $target.attr("data-topic-name");
+            const sub = sub_store.get(stream_id);
+            narrow.activate([
+                {operator: "stream", operand: sub.name},
+                {operator: "topic", operand: topic_name},
+            ]);
+
+            $(`.${CSS.escape(compose_banner.CLASSNAMES.compose_in_search_view)}`).remove();
+        },
+    );
+
     const user_not_subscribed_selector = `.${CSS.escape(
         compose_banner.CLASSNAMES.user_not_subscribed,
     )}`;

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -4,6 +4,7 @@ import autosize from "autosize";
 import $ from "jquery";
 
 import * as fenced_code from "../shared/src/fenced_code";
+import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 
 import * as channel from "./channel";
 import * as compose_banner from "./compose_banner";
@@ -70,6 +71,35 @@ function show_compose_box(msg_type, opts) {
     // When changing this, edit the 42px in _maybe_autoscroll
     $(".new_message_textarea").css("min-height", "3em");
     compose_ui.set_focus(msg_type, opts);
+    const filter = narrow_state.filter();
+    if (!filter.is_common_narrow()) {
+        show_compose_in_search_view_banner();
+    }
+}
+
+function show_compose_in_search_view_banner() {
+    // TODO: use compose_state.stream_id() when #25785 merges.
+    let stream_id = "";
+    const stream_name = compose_state.stream_name();
+    if (stream_name) {
+        const sub = stream_data.get_sub(stream_name);
+        if (sub) {
+            stream_id = sub.stream_id;
+        }
+    }
+
+    const search_view_banner = render_compose_banner({
+        banner_type: compose_banner.WARNING,
+        classname: compose_banner.CLASSNAMES.compose_in_search_view,
+        stream_id,
+        topic_name: compose_state.topic(),
+        banner_text: $t({
+            defaultMessage:
+                "You are composing a message from a search view, which may not include the latest messages in the conversation.",
+        }),
+        button_text: $t({defaultMessage: "Go to conversation"}),
+    });
+    compose_banner.append_compose_banner_to_banner_list(search_view_banner, $("#compose_banners"));
 }
 
 export function clear_textarea() {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -34,6 +34,7 @@ export const CLASSNAMES = {
     wildcard_warning: "wildcard_warning",
     private_stream_warning: "private_stream_warning",
     unscheduled_message: "unscheduled_message",
+    compose_in_search_view: "compose_in_search_view",
     // errors
     wildcards_not_allowed: "wildcards_not_allowed",
     subscription_error: "subscription_error",

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -37,6 +37,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
 const hash_util = mock_esm("../src/hash_util");
 const narrow_state = mock_esm("../src/narrow_state", {
     set_compose_defaults: noop,
+    filter: () => ({is_common_narrow: () => true}),
 });
 
 mock_esm("../src/reload_state", {


### PR DESCRIPTION
Added a warning compose banner when composing a message in a search view that doesn't include all the messages in a conversation.

This is helpful in a situation where a user sends a message without the full context and forgets they are in a narrowed search view.

Fixes: #25893.

![issue-25893-rec](https://github.com/zulip/zulip/assets/71205057/d4a01fc9-2dab-44d3-bd3b-2f42af87cbac)

Need to confirm the following:
- The condition for a narrow that doesn't show all messages in a conversation is based on the function is_common_narrow() in filter.js. I thought this might be more appropriate than supports_collapsing_recipients() but just wanted to confirm.
- Similarly, the "Go to conversation" button uses parameters defined in get_url_encoding() in filter.js, which I also think is appropriate but would like to double-check.


<details>
<summary>Self-review checklist</summary>


- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
