### PR TITLE
giphy: Set focus to the query input after clearing it.

### DIFF
--- a/web/src/giphy.js
+++ b/web/src/giphy.js
@@ -214,7 +214,7 @@ export function initialize() {
 
     $("body").on("click", "#giphy_search_clear", async (e) => {
         e.stopPropagation();
-        $("#giphy-search-query").val("");
+        $("#giphy-search-query").val("").trigger("focus");
         await update_grid_with_search_term();
     });
 


### PR DESCRIPTION
These changes improve keyboard navigation in the Giphy popover.

Fixes: #26096.