### PR TITLE
docs: Correct scope of copied material from copy button.

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -30,17 +30,19 @@ function registerCodeSection($codeSection) {
     });
 }
 
-// Display the copy-to-clipboard button inside the markdown.pre element
+// Display the copy-to-clipboard button inside the .codehilite element
 // within the API and Help Center docs using clipboard.js
-function add_copy_to_clipboard_element($pre) {
+function add_copy_to_clipboard_element($codehilite) {
     const $copy_button = $("<button>").addClass("copy-codeblock");
     $copy_button.html(copy_to_clipboard_svg());
 
-    $($pre).append($copy_button);
+    $($codehilite).append($copy_button);
 
     const clipboard = new ClipboardJS($copy_button[0], {
         text(copy_element) {
-            return $(copy_element).siblings("code").text();
+            // trim to remove trailing whitespace introduced
+            // by additional elements inside <pre>
+            return $(copy_element).siblings("pre").text().trim();
         },
     });
 
@@ -90,8 +92,8 @@ function render_code_sections() {
         registerCodeSection($(this));
     });
 
-    // Add a copy-to-clipboard button for each pre element
-    $(".markdown pre").each(function () {
+    // Add a copy-to-clipboard button for each .codehilite element
+    $(".markdown .codehilite").each(function () {
         add_copy_to_clipboard_element($(this));
     });
 

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -381,11 +381,13 @@
         background-color: hsl(0deg 0% 93%);
     }
 
-    & pre {
+    .codehilite {
         /* Relative positioning is used to place the copy-to-clipboard button
            in the top-right corner. */
         position: relative;
+    }
 
+    & pre {
         & code {
             font-size: 14px;
             white-space: pre-wrap;


### PR DESCRIPTION
This traverses the DOM to the `<pre>` element containing the copyable material of interest.

The button is attached to the `.codehilite` element to ensure that the button does not move with horizontally-scrolling code content that exceeds the width of the content column, as happens frequently at mobile scales or for very long lines of content.

See [CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/copy.20code.20button.20on.20mobile)

Fixes #26093.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
