### PR TITLE
settings(user): Display Setting changed to Preferences.

### DIFF
--- a/docs/documentation/helpcenter.md
+++ b/docs/documentation/helpcenter.md
@@ -55,7 +55,7 @@ There are over 100 feature articles and longer guides in the
 the current documentation as a resource and guide as you begin.
 
 - Use the list on [Zulip help center home](https://zulip.com/help/)
-  to find the section of the docs (e.g. Display settings, Sending
+  to find the section of the docs (e.g. Preferences, Sending
   messages, Reading messages, etc.) that relates to the new feature
   you're documenting.
 

--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -483,7 +483,7 @@ Do these tasks as Cordelia.
   - Change full name (Hamlet should see the name change)
   - Customize profile picture
   - Deactivate account (and then log in as Iago to re-activate Cordelia)
-- Display settings
+- Preferences
   - Right now, these unfortunately require reloads to take effect.
   - Default language (change to Spanish)
   - 24-hour time (and then test going back to AM/PM)

--- a/help/change-the-time-format.md
+++ b/help/change-the-time-format.md
@@ -7,7 +7,7 @@ format (e.g. 5:00 PM) or a 24-hour format (e.g. 17:00).
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **General**, select your preferred option from the
 **Time format** dropdown.

--- a/help/change-your-language.md
+++ b/help/change-your-language.md
@@ -11,7 +11,7 @@ messages you receive.
 
 {tab|desktop-web}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **General**, click the button under **Language**.
 

--- a/help/configure-default-new-user-settings.md
+++ b/help/configure-default-new-user-settings.md
@@ -15,7 +15,7 @@ preference settings, including the following:
 * Privacy settings, including:
     * [Displaying availability to other users](/help/status-and-availability)
     * [Allowing others to see when the user has read messages](/help/read-receipts)
-* Display settings, including:
+* Preferences, including:
     * Default view ([Recent conversations](/help/recent-conversations) vs.
       [All messages](/help/reading-strategies#all-messages))
     * [Light theme vs. dark theme](/help/dark-theme)

--- a/help/configure-default-view.md
+++ b/help/configure-default-view.md
@@ -29,7 +29,7 @@ organization settings:
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Advanced**, click on the **Default view** dropdown
    and select a view.
@@ -57,7 +57,7 @@ shortcut.
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Advanced**, toggle **Escape key navigates to
    default view**, as desired.

--- a/help/configure-emoticon-translations.md
+++ b/help/configure-emoticon-translations.md
@@ -19,7 +19,7 @@ by Zulip.
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Emoji**, toggle **Convert emoticons before sending**.
 

--- a/help/dark-theme.md
+++ b/help/dark-theme.md
@@ -9,7 +9,7 @@ for working in a dark space.
 
 {tab|desktop-web}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 
 1. Under **General**, select the desired color scheme from the **Theme** dropdown.

--- a/help/emoji-and-emoticons.md
+++ b/help/emoji-and-emoticons.md
@@ -55,7 +55,7 @@ will be displayed as
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Emoji settings**, select **Convert emoticons before sending**.
 
@@ -80,7 +80,7 @@ you send. Zulip emoji are compatible with screen readers and other accessibility
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Emoji**, select **Google**,
    **Twitter**, **Plain text**, or **Google blobs** for the emoji theme.

--- a/help/emoji-reactions.md
+++ b/help/emoji-reactions.md
@@ -97,7 +97,7 @@ so](#toggle-whether-names-of-reacting-users-are-displayed) is enabled.
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Emoji**, toggle **Display names of reacting users when few users have
    reacted to a message**.

--- a/help/enable-full-width-display.md
+++ b/help/enable-full-width-display.md
@@ -11,7 +11,7 @@ You can instead configure Zulip to use the full width of wide screens.
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Advanced**, select **Use full width on wide screens**.
 

--- a/help/high-contrast-mode.md
+++ b/help/high-contrast-mode.md
@@ -5,9 +5,9 @@ buttons, links and unread counts) are intentionally light. **High contrast mode*
 increases the contrast of these elements to meet the AA level of the
 W3C's Web Content Accessibility Guidelines.
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
-2. Under **Display settings**, select **High contrast mode**.
+2. Under **Preferences**, select **High contrast mode**.
 
 ## Related articles
 

--- a/help/import-your-settings.md
+++ b/help/import-your-settings.md
@@ -14,7 +14,7 @@ The import will include your:
 
 - [Name and avatar](/#settings/profile)
 - [Privacy settings](/#settings/account-and-privacy)
-- [Display settings](/#settings/display-settings)
+- [Preferences](/#settings/preferences)
 - [Notification settings](/#settings/notifications)
 - Tutorial completion status.
 

--- a/help/include/set-up-your-account.md
+++ b/help/include/set-up-your-account.md
@@ -10,7 +10,7 @@
   [edit your profile information](/help/edit-your-profile) to tell others
   about yourself.
 
-- [Review your display settings](/help/review-your-settings#review-your-display-settings).
+- [Review your Preferences](/help/review-your-settings#review-your-preferences).
   You can [switch between light and dark theme](/help/dark-theme),
   [pick your favorite emoji theme](/help/emoji-and-emoticons#change-your-emoji-set),
   [change your language](/help/change-your-language), and make other tweaks to your Zulip experience.

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -45,7 +45,7 @@
 * [Review your settings](/help/review-your-settings)
 * [Deactivate your account](/help/deactivate-your-account)
 
-## Display settings
+## Preferences
 * [Dark theme](/help/dark-theme)
 * [Change your language](/help/change-your-language)
 * [Change your time zone](/help/change-your-timezone)

--- a/help/manage-inactive-streams.md
+++ b/help/manage-inactive-streams.md
@@ -13,7 +13,7 @@ is your first time using Zulip.
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 2. Under **Advanced**, configure **Demote inactive streams**.
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -19,7 +19,7 @@ are at your computer. You will still be able to
 
 {tab|desktop-web}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Advanced**, click on the **Automatically mark messages as
    read** dropdown, and select **Always**, **Never** or **Only in

--- a/help/review-your-settings.md
+++ b/help/review-your-settings.md
@@ -14,13 +14,13 @@ you use Zulip.
 
 {end_tabs}
 
-## Review your display settings
+## Review your preferences
 
 {start_tabs}
 
 {relative|gear|settings}
 
-1. Click on the **Display settings** tab on the left.
+1. Click on the **Preferences** tab on the left.
 
 {end_tabs}
 

--- a/help/star-a-message.md
+++ b/help/star-a-message.md
@@ -37,7 +37,7 @@ can disable that feature.
 
 {start_tabs}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Advanced**, toggle **Show counts for starred messages**.
 

--- a/help/status-and-availability.md
+++ b/help/status-and-availability.md
@@ -85,7 +85,7 @@ With the compact option, only status emoji are shown.
 
 {tab|desktop-web}
 
-{settings_tab|display-settings}
+{settings_tab|preferences}
 
 1. Under **Advanced**, select **Compact** or **Show status and text** for the
    user list style.

--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -347,28 +347,28 @@ async function test_alert_words_section(page: Page): Promise<void> {
 }
 
 async function change_language(page: Page, language_data_code: string): Promise<void> {
-    await page.waitForSelector("#user-display-settings .language_selection_button", {
+    await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,
     });
-    await page.click("#user-display-settings .language_selection_button");
+    await page.click("#user-preferences .language_selection_button");
     await common.wait_for_micromodal_to_open(page);
     const language_selector = `a[data-code="${CSS.escape(language_data_code)}"]`;
     await page.click(language_selector);
 }
 
 async function check_language_setting_status(page: Page): Promise<void> {
-    await page.waitForSelector("#user-display-settings .general-settings-status .reload_link", {
+    await page.waitForSelector("#user-preferences .general-settings-status .reload_link", {
         visible: true,
     });
 }
 
 async function assert_language_changed_to_chinese(page: Page): Promise<void> {
-    await page.waitForSelector("#user-display-settings .language_selection_button", {
+    await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,
     });
     const default_language = await common.get_text_from_selector(
         page,
-        "#user-display-settings .language_selection_button",
+        "#user-preferences .language_selection_button",
     );
     assert.strictEqual(
         default_language,
@@ -386,7 +386,7 @@ async function test_i18n_language_precedence(page: Page): Promise<void> {
 }
 
 async function test_default_language_setting(page: Page): Promise<void> {
-    const display_settings_section = '[data-section="display-settings"]';
+    const display_settings_section = '[data-section="preferences"]';
     await page.click(display_settings_section);
 
     const chinese_language_data_code = "zh-hans";
@@ -394,7 +394,7 @@ async function test_default_language_setting(page: Page): Promise<void> {
     // Check that the saved indicator appears
     await check_language_setting_status(page);
     await page.click(".reload_link");
-    await page.waitForSelector("#user-display-settings .language_selection_button", {
+    await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,
     });
     await assert_language_changed_to_chinese(page);
@@ -410,10 +410,10 @@ async function test_default_language_setting(page: Page): Promise<void> {
     await page.goto("http://zulip.zulipdev.com:9981/#settings"); // get back to normal language.
     await page.waitForSelector(display_settings_section, {visible: true});
     await page.click(display_settings_section);
-    await page.waitForSelector("#user-display-settings .general-settings-status", {
+    await page.waitForSelector("#user-preferences .general-settings-status", {
         visible: true,
     });
-    await page.waitForSelector("#user-display-settings .language_selection_button", {
+    await page.waitForSelector("#user-preferences .language_selection_button", {
         visible: true,
     });
 }

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -251,7 +251,7 @@ function do_hashchange_overlay(old_hash) {
     }
     const base = hash_util.get_current_hash_category();
     const old_base = hash_util.get_hash_category(old_hash);
-    const section = hash_util.get_current_hash_section();
+    let section = hash_util.get_current_hash_section();
 
     if (base === "groups" && (!page_params.development_environment || page_params.is_guest)) {
         // The #groups settings page is unfinished, and disabled in production.
@@ -260,7 +260,11 @@ function do_hashchange_overlay(old_hash) {
     }
 
     const coming_from_overlay = hash_util.is_overlay_hash(old_hash);
-
+    if (section === "display-settings") {
+        // Since display-settings was deprecated and replaced with preferences
+        // #settings/display-settings is being redirected to #settings/preferences.
+        section = "preferences";
+    }
     if ((base === "settings" || base === "organization") && !section) {
         let settings_panel_object = settings_panel_menu.normal_settings;
         if (base === "organization") {

--- a/web/src/settings_display.js
+++ b/web/src/settings_display.js
@@ -92,9 +92,9 @@ function user_default_language_modal_post_render() {
             const data = {default_language: setting_value};
 
             const new_language = $link.attr("data-name");
-            $(
-                "#user-display-settings .language_selection_widget .language_selection_button span",
-            ).text(new_language);
+            $("#user-preferences .language_selection_widget .language_selection_button span").text(
+                new_language,
+            );
 
             change_display_setting(
                 data,
@@ -320,7 +320,7 @@ export function initialize() {
     const user_language_name = get_language_name(user_settings.default_language);
     set_default_language_name(user_language_name);
 
-    user_settings_panel.container = "#user-display-settings";
+    user_settings_panel.container = "#user-preferences";
     user_settings_panel.settings_object = user_settings;
     user_settings_panel.for_realm_settings = false;
 }

--- a/web/src/settings_sections.js
+++ b/web/src/settings_sections.js
@@ -51,7 +51,7 @@ export function get_group(section) {
 export function initialize() {
     // personal
     load_func_dict.set("your-account", settings_account.set_up);
-    load_func_dict.set("display-settings", () => {
+    load_func_dict.set("preferences", () => {
         settings_display.set_up(settings_display.user_settings_panel);
     });
     load_func_dict.set("notifications", () => {

--- a/web/templates/settings/user_display_settings.hbs
+++ b/web/templates/settings/user_display_settings.hbs
@@ -1,3 +1,3 @@
-<div id="user-display-settings" class="settings-section" data-name="display-settings">
+<div id="user-preferences" class="settings-section" data-name="preferences">
     {{> display_settings prefix="user_" for_realm_settings=false}}
 </div>

--- a/web/templates/settings_overlay.hbs
+++ b/web/templates/settings_overlay.hbs
@@ -20,9 +20,9 @@
                         <i class="icon fa fa-lock" aria-hidden="true"></i>
                         <div class="text">{{t "Account & privacy" }}</div>
                     </li>
-                    <li tabindex="0" data-section="display-settings">
+                    <li tabindex="0" data-section="preferences">
                         <i class="icon fa fa-clock-o" aria-hidden="true"></i>
-                        <div class="text">{{t "Display settings" }}</div>
+                        <div class="text">{{t "Preferences" }}</div>
                     </li>
                     <li tabindex="0" data-section="notifications">
                         <i class="icon fa fa-exclamation-triangle" aria-hidden="true"></i>

--- a/web/templates/unread_banner/mark_as_read_disabled_banner.hbs
+++ b/web/templates/unread_banner/mark_as_read_disabled_banner.hbs
@@ -2,7 +2,7 @@
     <p id="mark_as_read_turned_off_content" class="banner_content">
         {{#tr}}
             Messages will not be automatically marked as read. <z-link>Change setting</z-link>
-            {{#*inline "z-link"}}<a href='/#settings/display-settings'>{{> @partial-block}}</a>{{/inline}}
+            {{#*inline "z-link"}}<a href='/#settings/preferences'>{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </p>
     <button id="mark_view_read" class="main-view-banner-action-button">

--- a/web/templates/unread_banner/mark_as_read_only_in_conversation_view.hbs
+++ b/web/templates/unread_banner/mark_as_read_only_in_conversation_view.hbs
@@ -2,7 +2,7 @@
     <p id="mark_as_read_turned_off_content" class="banner_content">
         {{#tr}}
             Messages will not be automatically marked as read because this is not a conversation view. <z-link>Change setting</z-link>
-            {{#*inline "z-link"}}<a href='/#settings/display-settings'>{{> @partial-block}}</a>{{/inline}}
+            {{#*inline "z-link"}}<a href='/#settings/preferences'>{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
     </p>
     <button id="mark_view_read" class="main-view-banner-action-button">

--- a/web/tests/hash_util.test.js
+++ b/web/tests/hash_util.test.js
@@ -52,7 +52,7 @@ run_test("hash_util", () => {
 
 run_test("test_get_hash_category", () => {
     assert.deepEqual(hash_util.get_hash_category("streams/subscribed"), "streams");
-    assert.deepEqual(hash_util.get_hash_category("#settings/display-settings"), "settings");
+    assert.deepEqual(hash_util.get_hash_category("#settings/preferences"), "settings");
     assert.deepEqual(hash_util.get_hash_category("#drafts"), "drafts");
     assert.deepEqual(hash_util.get_hash_category("invites"), "invites");
 

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -24,7 +24,7 @@ link_mapping = {
         "Account & privacy",
         "/#settings/account-and-privacy",
     ],
-    "display-settings": ["Personal settings", "Display settings", "/#settings/display-settings"],
+    "preferences": ["Personal settings", "Preferences", "/#settings/preferences"],
     "notifications": ["Personal settings", "Notifications", "/#settings/notifications"],
     "your-bots": ["Personal settings", "Bots", "/#settings/your-bots"],
     "alert-words": ["Personal settings", "Alert words", "/#settings/alert-words"],

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -164,7 +164,7 @@ def select_welcome_bot_response(human_response_lower: str) -> str:
         )
     elif human_response_lower == "theme":
         return _(
-            "Go to [Display settings](#settings/display-settings) "
+            "Go to [Preferences](#settings/preferences) "
             "to [switch between the light and dark themes](/help/dark-theme), "
             "[pick your favorite emoji theme](/help/emoji-and-emoticons#change-your-emoji-set), "
             "[change your language](/help/change-your-language), "

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -376,16 +376,14 @@ class HelpTest(ZulipTestCase):
     def test_help_settings_links(self) -> None:
         result = self.client_get("/help/change-the-time-format")
         self.assertEqual(result.status_code, 200)
-        self.assertIn(
-            'Go to <a href="/#settings/display-settings">Display settings</a>', str(result.content)
-        )
+        self.assertIn('Go to <a href="/#settings/preferences">Preferences</a>', str(result.content))
         # Check that the sidebar was rendered properly.
         self.assertIn("Getting started with Zulip", str(result.content))
 
         with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
             result = self.client_get("/help/change-the-time-format", subdomain="")
         self.assertEqual(result.status_code, 200)
-        self.assertIn("<strong>Display settings</strong>", str(result.content))
+        self.assertIn("<strong>Preferences</strong>", str(result.content))
         self.assertNotIn("/#settings", str(result.content))
 
     def test_help_relative_links_for_gear(self) -> None:

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -75,7 +75,7 @@ class TutorialTests(ZulipTestCase):
         for content in messages:
             self.send_personal_message(user, bot, content)
             expected_response = (
-                "Go to [Display settings](#settings/display-settings) "
+                "Go to [Preferences](#settings/preferences) "
                 "to [switch between the light and dark themes](/help/dark-theme), "
                 "[pick your favorite emoji theme](/help/emoji-and-emoticons#change-your-emoji-set), "
                 "[change your language](/help/change-your-language), and make other tweaks to your Zulip experience."


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Changed "Display Settings" to "Preferences"  in the User Settings tab and changed the url to `#settings/preferences` with a redirect from  `#settings/display-settings` and updated the documentation as  discussed in [Community](https://chat.zulip.org/#narrow/stream/101-design/topic/Renaming.20display.20settings/near/1577713). 

### Changing to Display-Settings to  Preferences : 
 - changed data name and div id in `web/templates/settings/user_display_settings.hbs`
 - changed initialize() in  `web/src/settings_sections.js` that sets dict as preferences 
 - changed data-section to preferences in `web/templates/settings_overlay.hbs` 

### Redirecting : 
- In function hash_change_overlays in `web/src/hashchange.js` added if statement that checks if the section is "display-settings" and sets preferences section as active

### Documentation:
-  Edited the help_setting_links.py 
-  Changed in every django.po to refer it as Preferences
-  Edited in all help/ .md files from "display-settings" to "preferences"

Fixes: #25945 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/91622060/c01622b1-c9c4-4a73-8da5-bb8ba5195a4c

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
