### PR TITLE
streams: Warn when archiving a notification stream.

### DIFF
--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -603,8 +603,19 @@ export function initialize() {
         const stream = sub_store.get(stream_id);
 
         const stream_name_with_privacy_symbol_html = render_inline_decorated_stream_name({stream});
+
+        const is_new_stream_notification_stream =
+            stream_id === page_params.realm_notifications_stream_id;
+        const is_signup_notification_stream =
+            stream_id === page_params.realm_signup_notifications_stream_id;
+        const is_notification_stream =
+            is_new_stream_notification_stream || is_signup_notification_stream;
+
         const html_body = render_settings_deactivation_stream_modal({
             stream_name_with_privacy_symbol_html,
+            is_new_stream_notification_stream,
+            is_signup_notification_stream,
+            is_notification_stream,
         });
 
         confirm_dialog.launch({

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -148,6 +148,10 @@
     margin-bottom: 10px;
 }
 
+#archive-stream-modal .notification_stream_archive_warning {
+    margin-bottom: 0;
+}
+
 #read_receipts_modal {
     .modal__container {
         width: 360px;

--- a/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
+++ b/web/templates/confirm_dialog/confirm_deactivate_stream.hbs
@@ -1,4 +1,17 @@
-{{#tr}}
-    Archiving stream <z-stream></z-stream> will immediately unsubscribe everyone. This action cannot be undone.
-    {{#*inline "z-stream"}}<strong>{{{stream_name_with_privacy_symbol_html}}}</strong>{{/inline}}
-{{/tr}}
+<p>
+    {{#tr}}
+        Archiving stream <z-stream></z-stream> will immediately unsubscribe everyone. This action cannot be undone.
+        {{#*inline "z-stream"}}<strong>{{{stream_name_with_privacy_symbol_html}}}</strong>{{/inline}}
+    {{/tr}}
+</p>
+{{#if is_notification_stream}}
+<p class="notification_stream_archive_warning">{{#tr}}Archiving this stream will also disable settings that were configured to use this stream:{{/tr}}</p>
+<ul>
+    {{#if is_new_stream_notification_stream}}
+        <li>{{#tr}}New stream notifications{{/tr}}</li>
+    {{/if}}
+    {{#if is_signup_notification_stream}}
+        <li>{{#tr}}New user notifications{{/tr}}</li>
+    {{/if}}
+</ul>
+{{/if}}


### PR DESCRIPTION
Archiving a user/stream notification stream disables user/stream notifications.This commit adds a warning that notifications will be disabled while archiving any notification stream.

This PR address the review comments of #23735.

Fixes: #22110.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot from 2023-07-03 16-51-19](https://github.com/zulip/zulip/assets/99073049/6930617f-694e-45b8-b085-1216ab1e6fae)
![Screenshot from 2023-07-03 16-50-50](https://github.com/zulip/zulip/assets/99073049/ada5b822-9c60-4e73-acf3-45aaaee70ea2)
![Screenshot from 2023-07-03 16-50-37](https://github.com/zulip/zulip/assets/99073049/faef1887-522f-42b9-81c5-a0838a1945f6)
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
