### PR TITLE
upload: Append file markdown to textarea when placeholder is missing.

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -189,7 +189,9 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
     // for details.
 
+    const old_text = $textarea.val();
     replace($textarea[0], old_syntax, () => new_syntax, "after-replacement");
+    const new_text = $textarea.val();
 
     // When replacing content in a textarea, we need to move the cursor
     // to preserve its logical position if and only if the content we
@@ -207,6 +209,9 @@ export function replace_syntax(old_syntax, new_syntax, $textarea = $("#compose-t
         // Otherwise we simply restore it to it's original position
         $textarea.caret(prev_caret);
     }
+
+    // Return if anything was actually replaced.
+    return old_text !== new_text;
 }
 
 export function compute_placeholder_text(opts) {

--- a/web/src/upload.js
+++ b/web/src/upload.js
@@ -318,12 +318,17 @@ export function setup_upload(config) {
         const split_url = url.split("/");
         const filename = split_url.at(-1);
         const filename_url = "[" + filename + "](" + url + ")";
-        compose_ui.replace_syntax(
+        const $text_area = get_item("textarea", config);
+        const replacement_successful = compose_ui.replace_syntax(
             get_translated_status(file),
             filename_url,
-            get_item("textarea", config),
+            $text_area,
         );
-        compose_ui.autosize_textarea(get_item("textarea", config));
+        if (!replacement_successful) {
+            compose_ui.insert_syntax_and_focus(filename_url, $text_area);
+        }
+
+        compose_ui.autosize_textarea($text_area);
 
         // The uploaded files should be removed since uppy doesn't allow files in the store
         // to be re-uploaded again.

--- a/web/tests/upload.test.js
+++ b/web/tests/upload.test.js
@@ -478,6 +478,7 @@ test("copy_paste", ({override, override_rewire}) => {
 test("uppy_events", ({override_rewire, mock_template}) => {
     $("#compose_banners .upload_banner .moving_bar").css = () => {};
     $("#compose_banners .upload_banner").length = 0;
+    override_rewire(compose_ui, "smart_insert_inline", () => {});
 
     const callbacks = {};
     let state = {};


### PR DESCRIPTION
Fixes #26037.

> If you are uploading something and you erase the placeholder from the textarea of the uploading file, the banner still remains and shows as if the upload is running. It even appears to finish until the last step, but nothing can be seen in the textarea. Consequently, the message can't be sent due to the empty textarea.
>
> The proposed solution: if an upload finishes and there's no placeholder text in the composebox, the file markdown is appended to the end of the message that's currently in the composebox.

Demo for composebox:

![Kapture 2023-06-25 at 16 59 50](https://github.com/zulip/zulip/assets/5634097/0ea9f106-b8b5-4797-8465-2a64f04f0b8a)

Demo for message edit:

![Kapture 2023-06-25 at 17 01 38](https://github.com/zulip/zulip/assets/5634097/e988393f-17be-4a5e-934d-8d2623f6a664)


I confirmed regular upload still inserts the file markdown as it did before.