### PR TITLE
server-events: Remove unused "home_view_loaded.zulip" event trigger.

### DIFF
--- a/web/src/server_events.js
+++ b/web/src/server_events.js
@@ -264,7 +264,6 @@ export function force_get_events() {
 export function home_view_loaded() {
     waiting_on_homeview_load = false;
     get_events_success([]);
-    $(document).trigger("home_view_loaded.zulip");
 }
 
 export function initialize() {

--- a/web/tests/server_events.test.js
+++ b/web/tests/server_events.test.js
@@ -9,13 +9,6 @@ const {page_params} = require("./lib/zpage_params");
 
 const noop = () => {};
 
-set_global("document", {
-    to_$() {
-        return {
-            trigger() {},
-        };
-    },
-});
 set_global("addEventListener", noop);
 
 const channel = mock_esm("../src/channel");


### PR DESCRIPTION
In commit 92ad98814429c8, we removed the local echo code that tried to re-render locally echoed messages that were rendered right before a server/browser restart. These changes removed the only event triggered by `"home_view_loaded.zulip"`.

This removes the remaining `"home_view_loaded.zulip"` event trigger in `web/src/server_events.js` since it no longer triggers any events.

This is was noted when working on #26023.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
