### PR TITLE
pgroonga: Remove 'GRANT USAGE' statement again.

### DIFF
--- a/scripts/setup/pgroonga-config
+++ b/scripts/setup/pgroonga-config
@@ -3,7 +3,6 @@ set -eux
 
 dbversion=$(crudini --get /etc/zulip/zulip.conf postgresql version)
 dbname=$(crudini --get /etc/zulip/zulip.conf postgresql database_name 2>/dev/null || echo zulip)
-dbuser=$(crudini --get /etc/zulip/zulip.conf postgresql database_user 2>/dev/null || echo zulip)
 
 sharedir="${1:-/usr/share/postgresql/$dbversion}"
 applied_file="$sharedir/pgroonga_setup.sql.applied"
@@ -11,7 +10,7 @@ applied_file="$sharedir/pgroonga_setup.sql.applied"
 installed_version=$(dpkg-query --show --showformat='${Version}' "postgresql-$dbversion-pgdg-pgroonga")
 
 if [ ! -f "$applied_file" ]; then
-    sql="CREATE EXTENSION PGROONGA; GRANT USAGE ON SCHEMA pgroonga TO $dbuser"
+    sql="CREATE EXTENSION PGROONGA"
 else
     sql="ALTER EXTENSION pgroonga UPDATE"
 fi


### PR DESCRIPTION
dc2726c81465 removed these statements, but c8ec3dfcf6dd accidentally brought one back.  Remove it.

Fixes: https://github.com/zulip/zulip/pull/26097#discussion_r1240435764

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
