### PR TITLE
navbar: Fix background-color in Dark theme.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -196,7 +196,7 @@
     #userlist-toggle-button,
     .header,
     #message_view_header {
-        background-color: hsl(0deg 0% 13%);
+        background-color: var(--color-background-navbar);
     }
 
     & body,

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -180,7 +180,7 @@ body {
     --color-message-list-border: hsl(0deg 0% 0% / 40%);
     --color-background: hsl(0deg 0% 11%);
     --color-background-dropdown-input: hsl(225deg 6% 10%);
-    --color-background-navbar: hsl(0deg 0% 13%);
+    --color-background-navbar: hsl(0deg 0% 11%);
     --color-background-active-narrow-filter: hsl(200deg 17% 18%);
     --color-background-hover-narrow-filter: hsl(136deg 25% 73% / 20%);
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);


### PR DESCRIPTION
CZO: https://chat.zulip.org/#narrow/stream/9-issues/topic/top.20navbar.20bottom.20border/near/1598791

Fix the background color for the #userlist-toggle-button and the middle part of the navbar to match the overall navbar color in the Dark theme. This resolves the inconsistency in the background colors.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
![image](https://github.com/zulip/zulip/assets/64723994/fe10256d-e13d-4680-ac76-5bec308c02f9)

After:
![image](https://github.com/zulip/zulip/assets/64723994/2cbbe222-0da5-4cf2-99fd-662d37bb31db)

Before:
![image](https://github.com/zulip/zulip/assets/64723994/a202c6b9-7293-4b53-ae55-274f1451ec9f)

After:
![image](https://github.com/zulip/zulip/assets/64723994/5c4940ed-9d62-4682-9bd3-afc28e211dae)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
