### PR TITLE
use stream_id instead of stream_name as much as possible

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -6,7 +6,6 @@ import _ from "lodash";
 
 import render_success_message_scheduled_banner from "../templates/compose_banner/success_message_scheduled_banner.hbs";
 
-import * as blueslip from "./blueslip";
 import * as channel from "./channel";
 import * as compose_actions from "./compose_actions";
 import * as compose_banner from "./compose_banner";
@@ -153,21 +152,12 @@ export function create_message_object() {
             message.to = people.user_ids_string_to_ids_array(message.to_user_ids);
         }
     } else {
-        const stream_name = compose_state.stream_name();
-        message.stream = stream_name;
-        if (stream_name) {
-            message.stream_id = compose_recipient.selected_recipient_id;
-            message.to = compose_recipient.selected_recipient_id;
-        } else {
-            // We should be validating streams in calling code.  We'll
-            // try to fall back to stream_name here just in case the
-            // user started composing to the old stream name and
-            // manually entered the stream name, and it got past
-            // validation. We should try to kill this code off eventually.
-            blueslip.error("Trying to send message with bad stream name.");
-            message.to = stream_name;
-        }
         message.topic = topic;
+        const stream_id = compose_state.stream_id();
+        message.stream_id = stream_id;
+        message.to = stream_id;
+        const stream = stream_data.get_sub_by_id(stream_id);
+        message.stream = stream ? stream.name : "";
     }
     return message;
 }

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -403,7 +403,7 @@ export function on_topic_narrow() {
         return;
     }
 
-    if (compose_state.stream_name() !== narrow_state.stream()) {
+    if (compose_state.stream_name() !== narrow_state.stream_name()) {
         // If we changed streams, then we only leave the
         // compose box open if there is content or if the recipient was edited.
         if (compose_state.has_message_content() || compose_state.is_recipient_edited_manually()) {

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -119,7 +119,10 @@ export function complete_starting_tasks(msg_type, opts) {
 
     maybe_scroll_up_selected_message();
     compose_fade.start_compose(msg_type);
-    stream_bar.decorate(opts.stream, $("#stream_message_recipient_topic .message_header_stream"));
+    stream_bar.decorate(
+        opts.stream_id,
+        $("#stream_message_recipient_topic .message_header_stream"),
+    );
     $(document).trigger(new $.Event("compose_started.zulip", opts));
     compose_recipient.update_placeholder_text();
     compose_recipient.update_narrow_to_recipient_visibility();
@@ -153,7 +156,7 @@ export function maybe_scroll_up_selected_message() {
 function fill_in_opts_from_current_narrowed_view(msg_type, opts) {
     return {
         message_type: msg_type,
-        stream: "",
+        stream_id: "",
         topic: "",
         private_message_recipient: "",
         trigger: "unknown",
@@ -171,7 +174,7 @@ function same_recipient_as_before(msg_type, opts) {
     return (
         compose_state.get_message_type() === msg_type &&
         ((msg_type === "stream" &&
-            opts.stream === compose_state.stream_name() &&
+            opts.stream_id === compose_state.stream_id() &&
             opts.topic === compose_state.topic()) ||
             (msg_type === "private" &&
                 opts.private_message_recipient === compose_state.private_message_recipient()))
@@ -216,7 +219,7 @@ export function start(msg_type, opts) {
         (opts.trigger === "new topic button" ||
             (opts.trigger === "compose_hotkey" && msg_type === "stream"))
     ) {
-        opts.stream = subbed_streams[0].name;
+        opts.stream_id = subbed_streams[0].stream_id;
     }
 
     if (compose_state.composing() && !same_recipient_as_before(msg_type, opts)) {
@@ -227,12 +230,12 @@ export function start(msg_type, opts) {
     const $stream_header_colorblock = $(
         "#compose_select_recipient_widget_wrapper .stream_header_colorblock",
     );
-    stream_bar.decorate(opts.stream, $stream_header_colorblock);
+    stream_bar.decorate(opts.stream_id, $stream_header_colorblock);
 
     if (msg_type === "private") {
         compose_state.set_compose_recipient_id(compose_recipient.DIRECT_MESSAGE_ID);
-    } else if (opts.stream) {
-        compose_state.set_stream_name(opts.stream);
+    } else if (opts.stream_id) {
+        compose_state.set_stream_id(opts.stream_id);
     } else {
         // Open stream selection dropdown if no stream is selected.
         compose_recipient.open_compose_recipient_dropdown();
@@ -361,11 +364,11 @@ export function respond_to_message(opts) {
         msg_type = message.type;
     }
 
-    let stream = "";
+    let stream_id = "";
     let topic = "";
     let pm_recipient = "";
     if (msg_type === "stream") {
-        stream = message.stream;
+        stream_id = message.stream_id;
         topic = message.topic;
     } else {
         pm_recipient = message.reply_to;
@@ -380,7 +383,7 @@ export function respond_to_message(opts) {
     }
 
     start(msg_type, {
-        stream,
+        stream_id,
         topic,
         private_message_recipient: pm_recipient,
         trigger: opts.trigger,

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -20,7 +20,7 @@ export function get_recipient_label(message) {
             // we label the button as replying to the thread.
             if (narrow_state.narrowed_to_topic()) {
                 message = {
-                    stream: narrow_state.stream(),
+                    stream: narrow_state.stream_name(),
                     topic: narrow_state.topic(),
                 };
             } else if (narrow_state.pm_ids_string()) {

--- a/web/src/compose_fade.js
+++ b/web/src/compose_fade.js
@@ -9,7 +9,6 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as people from "./people";
 import * as rows from "./rows";
-import * as stream_data from "./stream_data";
 import * as util from "./util";
 
 let normal_display = false;
@@ -26,12 +25,10 @@ export function set_focused_recipient(msg_type) {
     };
 
     if (focused_recipient.type === "stream") {
-        const stream_name = compose_state.stream_name();
+        const stream_id = compose_state.stream_id();
         focused_recipient.topic = compose_state.topic();
-        focused_recipient.stream = stream_name;
-        const sub = stream_data.get_sub(stream_name);
-        if (sub) {
-            focused_recipient.stream_id = sub.stream_id;
+        if (stream_id) {
+            focused_recipient.stream_id = stream_id;
         }
     } else {
         // Normalize the recipient list so it matches the one used when

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -36,7 +36,7 @@ export function set_selected_recipient_id(recipient_id) {
 
 function composing_to_current_topic_narrow() {
     return (
-        util.lower_same(compose_state.stream_name(), narrow_state.stream() || "") &&
+        util.lower_same(compose_state.stream_name(), narrow_state.stream_name() || "") &&
         util.lower_same(compose_state.topic(), narrow_state.topic() || "")
     );
 }

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -153,7 +153,7 @@ function switch_message_type(message_type) {
 
     const opts = {
         message_type,
-        stream: compose_state.stream_name(),
+        stream_id: compose_state.stream_id(),
         topic: compose_state.topic(),
         private_message_recipient: compose_state.private_message_recipient(),
     };
@@ -162,8 +162,8 @@ function switch_message_type(message_type) {
     compose_ui.set_focus(message_type, opts);
 }
 
-function update_recipient_label(stream_name) {
-    const stream = stream_data.get_sub_by_name(stream_name);
+function update_recipient_label(stream_id) {
+    const stream = stream_data.get_sub_by_id(stream_id);
     if (stream === undefined) {
         $("#compose_select_recipient_widget .dropdown_widget_value").text(
             $t({defaultMessage: "Select a stream"}),
@@ -182,7 +182,7 @@ export function update_compose_for_message_type(message_type, opts) {
         $("#stream_toggle").addClass("active");
         $("#private_message_toggle").removeClass("active");
         $("#compose-recipient").removeClass("compose-recipient-direct-selected");
-        update_recipient_label(opts.stream);
+        update_recipient_label(opts.stream_id);
     } else {
         $("#compose-direct-recipient").show();
         $("#stream_message_recipient_topic").hide();
@@ -220,9 +220,9 @@ export function on_compose_select_recipient_update() {
         const $stream_header_colorblock = $(
             "#compose_select_recipient_widget_wrapper .stream_header_colorblock",
         );
-        const stream_name = compose_state.stream_name();
-        update_recipient_label(stream_name);
-        stream_bar.decorate(stream_name, $stream_header_colorblock);
+        const stream_id = compose_state.stream_id();
+        update_recipient_label(stream_id);
+        stream_bar.decorate(stream_id, $stream_header_colorblock);
     }
 
     check_posting_policy_for_compose_box();
@@ -351,7 +351,7 @@ export function update_placeholder_text() {
 
     const opts = {
         message_type: compose_state.get_message_type(),
-        stream: compose_state.stream_name(),
+        stream_id: compose_state.stream_id(),
         topic: compose_state.topic(),
         // TODO: to remove a circular import, direct message recipient needs
         // to be calculated in compose_state instead of compose_pm_pill.

--- a/web/src/compose_state.js
+++ b/web/src/compose_state.js
@@ -163,7 +163,7 @@ export function focus_in_empty_compose(consider_start_of_whitespace_message_empt
         case "stream_message_recipient_topic":
             return topic() === "";
         case "compose_select_recipient_widget_wrapper":
-            return stream_name() === "";
+            return stream_id() === "";
     }
 
     return false;
@@ -183,7 +183,7 @@ export function has_message_content() {
 
 export function has_full_recipient() {
     if (message_type === "stream") {
-        return stream_name() !== "" && topic() !== "";
+        return stream_id() !== "" && topic() !== "";
     }
     return private_message_recipient() !== "";
 }

--- a/web/src/compose_state.js
+++ b/web/src/compose_state.js
@@ -1,9 +1,7 @@
 import $ from "jquery";
 
-import * as blueslip from "./blueslip";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_recipient from "./compose_recipient";
-import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 
 let message_type = false; // 'stream', 'private', or false-y
@@ -88,20 +86,7 @@ export function stream_name() {
     return "";
 }
 
-export function set_stream_name(stream_name) {
-    if (!stream_name) {
-        compose_recipient.set_selected_recipient_id("");
-        return;
-    }
-
-    // If we fail to select a stream that the caller expects
-    // us to do successfully, we should throw an error.
-    const stream_id = stream_data.get_stream_id(stream_name);
-    if (stream_id === undefined) {
-        blueslip.error("Unable to select stream: " + stream_name);
-        compose_recipient.set_selected_recipient_id("");
-        return;
-    }
+export function set_stream_id(stream_id) {
     compose_recipient.set_selected_recipient_id(stream_id);
 }
 

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -11,6 +11,7 @@ import * as loading from "./loading";
 import * as people from "./people";
 import * as popover_menus from "./popover_menus";
 import * as rtl from "./rtl";
+import * as stream_data from "./stream_data";
 import * as user_status from "./user_status";
 
 export let compose_spinner_visible = false;
@@ -35,10 +36,10 @@ export function autosize_textarea($textarea) {
 
 function get_focus_area(msg_type, opts) {
     // Set focus to "Topic" when narrowed to a stream+topic and "New topic" button clicked.
-    if (msg_type === "stream" && opts.stream && !opts.topic) {
+    if (msg_type === "stream" && opts.stream_id && !opts.topic) {
         return "#stream_message_recipient_topic";
     } else if (
-        (msg_type === "stream" && opts.stream) ||
+        (msg_type === "stream" && opts.stream_id) ||
         (msg_type === "private" && opts.private_message_recipient)
     ) {
         if (opts.trigger === "new topic button") {
@@ -224,13 +225,16 @@ export function compute_placeholder_text(opts) {
     // because the caller is expected to insert this into the
     // placeholder field in a way that does HTML escaping.
     if (opts.message_type === "stream") {
-        if (opts.topic) {
+        const stream = stream_data.get_sub_by_id(opts.stream_id);
+        const stream_name = stream ? stream.name : "";
+
+        if (stream_name && opts.topic) {
             return $t(
                 {defaultMessage: "Message #{stream_name} > {topic_name}"},
-                {stream_name: opts.stream, topic_name: opts.topic},
+                {stream_name, topic_name: opts.topic},
             );
-        } else if (opts.stream) {
-            return $t({defaultMessage: "Message #{stream_name}"}, {stream_name: opts.stream});
+        } else if (stream_name) {
+            return $t({defaultMessage: "Message #{stream_name}"}, {stream_name});
         }
     }
 

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -68,8 +68,7 @@ export function update_emoji_data() {
     }
 }
 
-export function topics_seen_for(stream_name) {
-    const stream_id = stream_data.get_stream_id(stream_name);
+export function topics_seen_for(stream_id) {
     if (!stream_id) {
         return [];
     }
@@ -729,7 +728,8 @@ export function get_candidates(query) {
                     return false;
                 }
 
-                const topic_list = topics_seen_for(stream_name);
+                const stream_id = stream_data.get_stream_id(stream_name);
+                const topic_list = topics_seen_for(stream_id);
                 if (should_show_custom_query(this.token, topic_list)) {
                     topic_list.push(this.token);
                 }
@@ -1017,7 +1017,8 @@ export function initialize_topic_edit_typeahead(form_field, stream_name, dropup)
             return sorted;
         },
         source() {
-            return topics_seen_for(stream_name);
+            const stream_id = stream_data.get_stream_id(stream_name);
+            return topics_seen_for(stream_id);
         },
         items: 5,
     };
@@ -1094,8 +1095,7 @@ export function initialize({on_enter_send}) {
 
     $("#stream_message_recipient_topic").typeahead({
         source() {
-            const stream_name = compose_state.stream_name();
-            return topics_seen_for(stream_name);
+            return topics_seen_for(compose_state.stream_id());
         },
         items: 3,
         fixed: true,

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -436,7 +436,7 @@ export function get_pm_people(query) {
     const opts = {
         want_broadcast: false,
         filter_pills: true,
-        stream: compose_state.stream_name(),
+        stream_id: compose_state.stream_id(),
         topic: compose_state.topic(),
     };
     return get_person_suggestions(query, opts);
@@ -509,7 +509,7 @@ export function get_person_suggestions(query, opts) {
     return typeahead_helper.sort_recipients({
         users: filtered_persons,
         query,
-        current_stream: opts.stream,
+        current_stream_id: opts.stream_id,
         current_topic: opts.topic,
         groups: filtered_groups,
         max_num_items,
@@ -520,14 +520,14 @@ export function get_stream_topic_data(hacky_this) {
     const opts = {};
     const $message_row = hacky_this.$element.closest(".message_row");
     if ($message_row.length === 1) {
-        // we are editing a message so we try to use it's keys.
+        // we are editing a message so we try to use its keys.
         const msg = message_store.get(rows.id($message_row));
         if (msg.type === "stream") {
-            opts.stream = msg.stream;
+            opts.stream_id = msg.stream_id;
             opts.topic = msg.topic;
         }
     } else {
-        opts.stream = compose_state.stream_name();
+        opts.stream_id = compose_state.stream_id();
         opts.topic = compose_state.topic();
     }
     return opts;

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -199,11 +199,9 @@ export function snapshot_message() {
         message.reply_to = recipient;
         message.private_message_recipient = recipient;
     } else {
-        message.stream = compose_state.stream_name();
-        const sub = stream_data.get_sub(message.stream);
-        if (sub) {
-            message.stream_id = sub.stream_id;
-        }
+        message.stream_id = compose_state.stream_id();
+        const sub = stream_data.get_sub_by_id(message.stream_id);
+        message.stream = sub ? sub.name : "";
         message.topic = compose_state.topic();
     }
     return message;

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -451,7 +451,7 @@ function current_recipient_data() {
     // Prioritize recipients from the compose box first. If the compose
     // box isn't open, just return data from the current narrow.
     if (!compose_state.composing()) {
-        const stream_name = narrow_state.stream();
+        const stream_name = narrow_state.stream_name();
         return {
             stream_name,
             topic: narrow_state.topic(),

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -360,9 +360,14 @@ export function format_draft(draft) {
                     draft_model.editDraft(id, draft);
                 }
             }
+        } else {
+            const sub = stream_data.get_sub(stream_name);
+            if (sub !== undefined) {
+                draft.stream_id = sub.stream_id;
+            }
         }
         const draft_topic = draft.topic || compose.empty_topic_placeholder();
-        const draft_stream_color = stream_data.get_color(stream_name);
+        const draft_stream_color = stream_data.get_color(draft.stream_id);
 
         formatted = {
             draft_id: draft.id,

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -268,8 +268,7 @@ export function update_messages(events) {
                 event.propagate_mode,
             );
 
-            const stream_name = stream_archived ? undefined : old_stream.name;
-            const compose_stream_name = compose_state.stream_name();
+            const compose_stream_id = compose_state.stream_id();
             const orig_topic = util.get_edit_event_orig_topic(event);
 
             const current_filter = narrow_state.filter();
@@ -289,9 +288,9 @@ export function update_messages(events) {
 
             if (
                 going_forward_change &&
-                stream_name &&
-                compose_stream_name &&
-                stream_name.toLowerCase() === compose_stream_name.toLowerCase() &&
+                !stream_archived &&
+                compose_stream_id &&
+                old_stream.stream_id === compose_stream_id &&
                 orig_topic === compose_state.topic()
             ) {
                 changed_compose = true;
@@ -373,6 +372,7 @@ export function update_messages(events) {
                 });
             }
 
+            const old_stream_name = stream_archived ? undefined : old_stream.name;
             if (
                 going_forward_change &&
                 // This logic is a bit awkward.  What we're trying to
@@ -390,7 +390,7 @@ export function update_messages(events) {
                 // messages within a narrow.
                 selection_changed_topic &&
                 current_filter &&
-                current_filter.has_topic(stream_name, orig_topic)
+                current_filter.has_topic(old_stream_name, orig_topic)
             ) {
                 let new_filter = current_filter;
                 if (new_filter && stream_changed) {

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -326,7 +326,7 @@ export class MessageList {
         if (!this.narrowed) {
             return;
         }
-        const stream_name = narrow_state.stream();
+        const stream_name = narrow_state.stream_name();
         if (stream_name === undefined) {
             return;
         }

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -927,7 +927,7 @@ export class MessageListView {
                 last_message_group.message_containers.at(-1).msg.historical;
         }
 
-        const stream_name = narrow_state.stream();
+        const stream_name = narrow_state.stream_name();
         if (stream_name !== undefined) {
             // If user narrows to a stream, doesn't update
             // trailing bookend if user is subscribed.

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -187,7 +187,7 @@ function populate_group_from_message_container(group, message_container) {
     group.is_private = message_container.msg.is_private;
 
     if (group.is_stream) {
-        const color = stream_data.get_color(message_container.msg.stream);
+        const color = stream_data.get_color(message_container.msg.stream_id);
         group.recipient_bar_color = stream_color.get_recipient_bar_color(color);
         group.stream_privacy_icon_color = stream_color.get_stream_privacy_icon_color(color);
         group.invite_only = stream_data.is_invite_only_by_stream_name(message_container.msg.stream);
@@ -409,7 +409,7 @@ export class MessageListView {
         message_container.small_avatar_url = people.small_avatar_url(message_container.msg);
         if (message_container.msg.stream) {
             message_container.background_color = stream_data.get_color(
-                message_container.msg.stream,
+                message_container.msg.stream_id,
             );
         }
 

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -958,11 +958,11 @@ export function to_compose_target() {
     };
 
     if (compose_state.get_message_type() === "stream") {
-        const stream_name = compose_state.stream_name();
-        const stream_id = stream_data.get_stream_id(stream_name);
+        const stream_id = compose_state.stream_id();
         if (!stream_id) {
             return;
         }
+        const stream_name = stream_data.get_sub_by_id(stream_id).name;
         // If we are composing to a new topic, we narrow to the stream but
         // grey-out the message view instead of narrowing to an empty view.
         const operators = [{operator: "stream", operand: stream_name}];

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -801,7 +801,7 @@ export function activate_stream_for_cycle_hotkey(stream_name) {
 }
 
 export function stream_cycle_backward() {
-    const curr_stream = narrow_state.stream();
+    const curr_stream = narrow_state.stream_name();
 
     if (!curr_stream) {
         return;
@@ -817,7 +817,7 @@ export function stream_cycle_backward() {
 }
 
 export function stream_cycle_forward() {
-    const curr_stream = narrow_state.stream();
+    const curr_stream = narrow_state.stream_name();
 
     if (!curr_stream) {
         return;
@@ -834,7 +834,7 @@ export function stream_cycle_forward() {
 
 export function narrow_to_next_topic(opts = {}) {
     const curr_info = {
-        stream: narrow_state.stream(),
+        stream: narrow_state.stream_name(),
         topic: narrow_state.topic(),
     };
 

--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -243,7 +243,7 @@ function pick_empty_narrow_banner() {
                 }
 
                 function can_toggle_narrowed_stream() {
-                    const stream_name = narrow_state.stream();
+                    const stream_name = narrow_state.stream_name();
 
                     if (!stream_name) {
                         return false;

--- a/web/src/narrow_state.js
+++ b/web/src/narrow_state.js
@@ -93,7 +93,7 @@ export function set_compose_defaults() {
         // So we look up the resolved stream and return that if appropriate.
         const sub = stream_sub();
         if (sub !== undefined) {
-            opts.stream = sub.name;
+            opts.stream_id = sub.stream_id;
         }
     }
 

--- a/web/src/narrow_state.js
+++ b/web/src/narrow_state.js
@@ -110,7 +110,7 @@ export function set_compose_defaults() {
     return opts;
 }
 
-export function stream() {
+export function stream_name() {
     if (current_filter === undefined) {
         return undefined;
     }

--- a/web/src/pill_typeahead.js
+++ b/web/src/pill_typeahead.js
@@ -112,7 +112,7 @@ export function set_up($input, pills, opts) {
             return typeahead_helper.sort_recipients({
                 users,
                 query,
-                current_stream: "",
+                current_stream_id: "",
                 current_topic: undefined,
                 groups,
                 max_num_items: undefined,

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -70,7 +70,7 @@ function format(scheduled_messages) {
             msg_render_context.stream_name = sub_store.maybe_get_stream_name(
                 msg_render_context.stream_id,
             );
-            const color = stream_data.get_color(msg_render_context.stream_name);
+            const color = stream_data.get_color(msg_render_context.stream_id);
             msg_render_context.recipient_bar_color = stream_color.get_recipient_bar_color(color);
             msg_render_context.stream_privacy_icon_color =
                 stream_color.get_stream_privacy_icon_color(color);

--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -401,7 +401,7 @@ function get_topic_suggestions(last, operators) {
             if (filter.has_operator("stream")) {
                 stream = filter.operands("stream")[0];
             } else {
-                stream = narrow_state.stream();
+                stream = narrow_state.stream_name();
                 suggest_operators.push({operator: "stream", operand: stream});
             }
             break;

--- a/web/src/stream_bar.js
+++ b/web/src/stream_bar.js
@@ -4,10 +4,10 @@ import * as stream_data from "./stream_data";
 // color look like the stream being used.
 // (In particular, if there's a color associated with it,
 //  have that color be reflected here too.)
-export function decorate(stream_name, $element) {
-    if (stream_name === undefined) {
+export function decorate(stream_id, $element) {
+    if (stream_id === undefined) {
         return;
     }
-    const color = stream_data.get_color(stream_name);
+    const color = stream_data.get_color(stream_id);
     $element.css("background-color", color);
 }

--- a/web/src/stream_color.js
+++ b/web/src/stream_color.js
@@ -11,18 +11,16 @@ import * as row from "./rows";
 import * as settings_data from "./settings_data";
 import * as stream_data from "./stream_data";
 import * as stream_settings_ui from "./stream_settings_ui";
-import * as sub_store from "./sub_store";
 
 extend([lchPlugin, mixPlugin]);
 
 export function update_stream_recipient_color($stream_header) {
     if ($stream_header.length) {
         const stream_id = Number.parseInt($($stream_header).attr("data-stream-id"), 10);
-        const stream_name = sub_store.maybe_get_stream_name(stream_id);
-        if (!stream_name) {
+        if (!stream_id) {
             return;
         }
-        const stream_color = stream_data.get_color(stream_name);
+        const stream_color = stream_data.get_color(stream_id);
         const recipient_bar_color = get_recipient_bar_color(stream_color);
         $stream_header
             .find(".message-header-contents")

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -453,8 +453,8 @@ export function canonicalized_name(stream_name) {
     return stream_name.toString().toLowerCase();
 }
 
-export function get_color(stream_name) {
-    const sub = get_sub(stream_name);
+export function get_color(stream_id) {
+    const sub = get_sub_by_id(stream_id);
     if (sub === undefined) {
         return DEFAULT_COLOR;
     }

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -135,7 +135,7 @@ function show_subscription_settings(sub) {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
 
     const $colorpicker = $edit_container.find(".colorpicker");
-    const color = stream_data.get_color(sub.name);
+    const color = stream_data.get_color(sub.stream_id);
     stream_color.set_colorpicker_color($colorpicker, color);
     stream_ui_updates.update_add_subscriptions_elements(sub);
 

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -334,11 +334,9 @@ export function build_move_topic_to_stream_popover(
     }
 
     function render_selected_stream() {
-        const stream_name = sub_store.maybe_get_stream_name(
-            Number.parseInt(stream_widget_value, 10),
-        );
-        stream_bar.decorate(stream_name, $stream_header_colorblock);
-        const stream = stream_data.get_sub_by_name(stream_name);
+        const stream_id = Number.parseInt(stream_widget_value, 10);
+        stream_bar.decorate(stream_id, $stream_header_colorblock);
+        const stream = stream_data.get_sub_by_id(stream_id);
         if (stream === undefined) {
             $("#move_topic_to_stream_widget .dropdown_widget_value").text(
                 $t({defaultMessage: "Select a stream"}),

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -13,6 +13,7 @@ import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as components from "./components";
+import * as compose_recipient from "./compose_recipient";
 import * as compose_state from "./compose_state";
 import * as confirm_dialog from "./confirm_dialog";
 import * as dropdown_widget from "./dropdown_widget";
@@ -167,8 +168,6 @@ export function is_subscribed_stream_tab_active() {
 }
 
 export function update_stream_name(sub, new_name) {
-    const old_name = sub.name;
-
     // Rename the stream internally.
     stream_data.rename_sub(sub, new_name);
     const stream_id = sub.stream_id;
@@ -186,9 +185,9 @@ export function update_stream_name(sub, new_name) {
     // Update the message feed.
     message_live_update.update_stream_name(stream_id, new_name);
 
-    // Update compose_state if needed
-    if (compose_state.stream_name() === old_name) {
-        compose_state.set_stream_name(new_name);
+    // Update compose UI if needed
+    if (compose_state.stream_id() === stream_id) {
+        compose_recipient.on_compose_select_recipient_update();
     }
 
     // Update navbar if needed

--- a/web/src/typeahead_helper.js
+++ b/web/src/typeahead_helper.js
@@ -233,26 +233,29 @@ export function compare_people_for_relevance(
     return tertiary_compare(person_a, person_b);
 }
 
-export function sort_people_for_relevance(objs, current_stream_name, current_topic) {
+export function sort_people_for_relevance(objs, current_stream_id, current_topic) {
     // If sorting for recipientbox typeahead and not viewing a stream / topic, then current_stream = ""
-    let current_stream = false;
-    if (current_stream_name) {
-        current_stream = stream_data.get_sub(current_stream_name);
+    let current_stream = null;
+    if (current_stream_id) {
+        current_stream = stream_data.get_sub_by_id(current_stream_id);
     }
     if (!current_stream) {
         objs.sort((person_a, person_b) =>
             compare_people_for_relevance(person_a, person_b, compare_by_pms),
         );
     } else {
-        const stream_id = current_stream.stream_id;
-
         objs.sort((person_a, person_b) =>
             compare_people_for_relevance(
                 person_a,
                 person_b,
                 (user_a, user_b) =>
-                    recent_senders.compare_by_recency(user_a, user_b, stream_id, current_topic),
-                current_stream.stream_id,
+                    recent_senders.compare_by_recency(
+                        user_a,
+                        user_b,
+                        current_stream_id,
+                        current_topic,
+                    ),
+                current_stream_id,
             ),
         );
     }
@@ -348,13 +351,13 @@ export function sort_languages(matches, query) {
 export function sort_recipients({
     users,
     query,
-    current_stream,
+    current_stream_id,
     current_topic,
     groups = [],
     max_num_items = 20,
 }) {
     function sort_relevance(items) {
-        return sort_people_for_relevance(items, current_stream, current_topic);
+        return sort_people_for_relevance(items, current_stream_id, current_topic);
     }
 
     const users_name_results = typeahead.triage(query, users, (p) => p.full_name);

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -738,14 +738,6 @@ test_ui("create_message_object", ({override, override_rewire}) => {
     assert.equal(message.topic, "lunch");
     assert.equal(message.content, "burrito");
 
-    blueslip.expect("error", "Unable to select stream: BOGUS STREAM");
-    compose_state.set_stream_name("BOGUS STREAM");
-    blueslip.expect("error", "Trying to send message with bad stream name.");
-    message = compose.create_message_object();
-    assert.equal(message.to, "");
-    assert.equal(message.topic, "lunch");
-    assert.equal(message.content, "burrito");
-
     compose_state.set_message_type("private");
     override(compose_pm_pill, "get_emails", () => "alice@example.com,bob@example.com");
 

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -9,7 +9,6 @@ const {mock_banners} = require("./lib/compose_banner");
 const {$t} = require("./lib/i18n");
 const {mock_esm, set_global, zrequire} = require("./lib/namespace");
 const {run_test} = require("./lib/test");
-const blueslip = require("./lib/zblueslip");
 const $ = require("./lib/zjquery");
 const {page_params, user_settings} = require("./lib/zpage_params");
 
@@ -318,7 +317,7 @@ test_ui("enter_with_preview_open", ({override, override_rewire}) => {
 
     // Test sending a message with content.
     compose_state.set_message_type("stream");
-    compose_state.set_stream_name("social");
+    compose_state.set_stream_id(social.stream_id);
 
     $("#compose-textarea").val("message me");
     $("#compose-textarea").hide();
@@ -727,7 +726,7 @@ test_ui("create_message_object", ({override, override_rewire}) => {
     mock_banners();
     override_rewire(compose_recipient, "on_compose_select_recipient_update", noop);
 
-    compose_state.set_stream_name("social");
+    compose_state.set_stream_id(social.stream_id);
     $("#stream_message_recipient_topic").val("lunch");
     $("#compose-textarea").val("burrito");
 

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -127,7 +127,7 @@ test("start", ({override, override_rewire, mock_template}) => {
 
     // Start stream message
     compose_defaults = {
-        stream: "",
+        stream_id: "",
         topic: "topic1",
     };
 
@@ -177,7 +177,7 @@ test("start", ({override, override_rewire, mock_template}) => {
     };
     stream_data.add_sub(social);
 
-    compose_state.set_stream_name("");
+    compose_state.set_stream_id("");
     // More than 1 subscription, do not autofill
     opts = {};
     start("stream", opts);
@@ -270,12 +270,6 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
     assert.equal(compose_state.private_message_recipient(), "alice@example.com");
 
     // Test stream
-    msg = {
-        type: "stream",
-        stream: "Denmark",
-        topic: "python",
-    };
-
     const denmark = {
         subscribed: true,
         color: "blue",
@@ -283,6 +277,14 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
         stream_id: 1,
     };
     stream_data.add_sub(denmark);
+
+    msg = {
+        type: "stream",
+        stream: denmark.name,
+        stream_id: denmark.stream_id,
+        topic: "python",
+    };
+
     opts = {};
 
     respond_to_message(opts);
@@ -310,7 +312,8 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
 
     const msg = {
         type: "stream",
-        stream: "Denmark",
+        stream: denmark.name,
+        stream_id: denmark.stream_id,
         topic: "python",
         sender_full_name: "Bob Roberts",
         sender_id: 40,

--- a/web/tests/compose_fade.test.js
+++ b/web/tests/compose_fade.test.js
@@ -71,7 +71,7 @@ run_test("set_focused_recipient", ({override_rewire}) => {
     assert.equal(compose_fade_helper.would_receive_message(bob.user_id), true);
 
     stream_data.add_sub(sub);
-    compose_state.set_stream_name("social");
+    compose_state.set_stream_id(sub.stream_id);
     peer_data.set_subscribers(sub.stream_id, [me.user_id, alice.user_id]);
     compose_fade.set_focused_recipient("stream");
 

--- a/web/tests/compose_state.test.js
+++ b/web/tests/compose_state.test.js
@@ -41,7 +41,7 @@ run_test("has_full_recipient", ({override, override_rewire}) => {
     override(compose_pm_pill, "get_emails", () => emails);
 
     compose_state.set_message_type("stream");
-    compose_state.set_stream_name("");
+    compose_state.set_stream_id("");
     compose_state.topic("");
     assert.equal(compose_state.has_full_recipient(), false);
 
@@ -49,7 +49,7 @@ run_test("has_full_recipient", ({override, override_rewire}) => {
     assert.equal(compose_state.has_full_recipient(), false);
 
     stream_data.add_sub({name: "bar", stream_id: 99});
-    compose_state.set_stream_name("bar");
+    compose_state.set_stream_id(99);
     assert.equal(compose_state.has_full_recipient(), true);
 
     compose_state.set_message_type("private");

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -20,6 +20,7 @@ mock_esm("../src/message_lists", {
 });
 
 const compose_ui = zrequire("compose_ui");
+const stream_data = zrequire("stream_data");
 const people = zrequire("people");
 const user_status = zrequire("user_status");
 const hash_util = mock_esm("../src/hash_util");
@@ -184,7 +185,7 @@ run_test("replace_syntax", ({override}) => {
 run_test("compute_placeholder_text", () => {
     let opts = {
         message_type: "stream",
-        stream: "",
+        stream_id: "",
         topic: "",
         private_message_recipient: "",
     };
@@ -195,7 +196,13 @@ run_test("compute_placeholder_text", () => {
         $t({defaultMessage: "Compose your message here"}),
     );
 
-    opts.stream = "all";
+    const stream_all = {
+        subscribed: true,
+        name: "all",
+        stream_id: 2,
+    };
+    stream_data.add_sub(stream_all);
+    opts.stream_id = stream_all.stream_id;
     assert.equal(compose_ui.compute_placeholder_text(opts), $t({defaultMessage: "Message #all"}));
 
     opts.topic = "Test";
@@ -207,7 +214,7 @@ run_test("compute_placeholder_text", () => {
     // direct message narrows
     opts = {
         message_type: "private",
-        stream: "",
+        stream_id: "",
         topic: "",
         private_message_recipient: "",
     };
@@ -748,10 +755,20 @@ run_test("get_focus_area", () => {
         "#compose-textarea",
     );
     assert.equal(get_focus_area("stream", {}), "#compose_select_recipient_widget_wrapper");
-    assert.equal(get_focus_area("stream", {stream: "fun"}), "#stream_message_recipient_topic");
-    assert.equal(get_focus_area("stream", {stream: "fun", topic: "more"}), "#compose-textarea");
     assert.equal(
-        get_focus_area("stream", {stream: "fun", topic: "more", trigger: "new topic button"}),
+        get_focus_area("stream", {stream_name: "fun", stream_id: 4}),
+        "#stream_message_recipient_topic",
+    );
+    assert.equal(
+        get_focus_area("stream", {stream_name: "fun", stream_id: 4, topic: "more"}),
+        "#compose-textarea",
+    );
+    assert.equal(
+        get_focus_area("stream", {
+            stream_id: 4,
+            topic: "more",
+            trigger: "new topic button",
+        }),
         "#stream_message_recipient_topic",
     );
 });

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -744,7 +744,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
             return sweden_topics_to_show;
         });
 
-        compose_state.set_stream_name("Sweden");
+        compose_state.set_stream_id(sweden_stream.stream_id);
         let actual_value = options.source();
         // Topics should be sorted alphabetically, not by addition order.
         let expected_value = sweden_topics_to_show;
@@ -800,8 +800,8 @@ test("initialize", ({override, override_rewire, mock_template}) => {
 
         topic_typeahead_called = true;
 
-        // Unset the stream name.
-        compose_state.set_stream_name("");
+        // Unset the stream.
+        compose_state.set_stream_id("");
     };
 
     let pm_recipient_typeahead_called = false;
@@ -881,7 +881,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
             return typeahead_helper.sort_recipients({
                 users: people,
                 query,
-                current_stream: compose_state.stream_name(),
+                current_stream_id: compose_state.stream_id(),
                 current_topic: compose_state.topic(),
             });
         }
@@ -1139,7 +1139,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     assert.equal($("#private_message_recipient").val(), "othello@zulip.com");
 
     // the UI of selecting a stream is tested in puppeteer tests.
-    compose_state.set_stream_name("Sweden");
+    compose_state.set_stream_id(sweden_stream.stream_id);
 
     let event = {
         type: "keydown",
@@ -1199,7 +1199,7 @@ test("initialize", ({override, override_rewire, mock_template}) => {
     $("form#send_message_form").trigger(event);
 
     // the UI of selecting a stream is tested in puppeteer tests.
-    compose_state.set_stream_name("Sweden");
+    compose_state.set_stream_id(sweden_stream.stream_id);
     // handle_keyup()
     event = {
         type: "keydown",
@@ -1800,12 +1800,12 @@ test("direct message recipients sorted according to stream / topic being viewed"
     override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
 
     // When viewing no stream, sorting is alphabetical
-    compose_state.set_stream_name("");
+    compose_state.set_stream_id("");
     results = ct.get_pm_people("li");
     assert.deepEqual(results, [ali, alice, cordelia]);
 
     // When viewing denmark stream, subscriber cordelia is placed higher
-    compose_state.set_stream_name("Denmark");
+    compose_state.set_stream_id(denmark_stream.stream_id);
     results = ct.get_pm_people("li");
     assert.deepEqual(results, [cordelia, ali, alice]);
 

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -407,14 +407,14 @@ test("topics_seen_for", ({override, override_rewire}) => {
         assert.equal(stream_id, denmark_stream.stream_id);
     });
 
-    assert.deepEqual(ct.topics_seen_for("Denmark"), [
+    assert.deepEqual(ct.topics_seen_for(denmark_stream.stream_id), [
         "With Twisted Metal",
         "acceptance",
         "civil fears",
     ]);
 
     // Test when the stream doesn't exist (there are no topics)
-    assert.deepEqual(ct.topics_seen_for("non-existing-stream"), []);
+    assert.deepEqual(ct.topics_seen_for(""), []);
 });
 
 test("content_typeahead_selected", ({override}) => {

--- a/web/tests/dispatch_subs.test.js
+++ b/web/tests/dispatch_subs.test.js
@@ -275,7 +275,7 @@ test("stream delete (stream is selected in compose)", ({override, override_rewir
     }
 
     stream_data.subscribe_myself(event.streams[0]);
-    compose_state.set_stream_name(event.streams[0].name);
+    compose_state.set_stream_id(event.streams[0].stream_id);
 
     override(settings_streams, "update_default_streams_table", noop);
 

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -81,6 +81,7 @@ const draft_2 = {
 };
 const short_msg = {
     stream: "stream",
+    stream_id: 30,
     topic: "topic",
     type: "stream",
     content: "a",
@@ -159,11 +160,6 @@ test("snapshot_message", ({override_rewire}) => {
     override_rewire(compose_recipient, "on_compose_select_recipient_update", () => {});
     mock_banners();
 
-    override_rewire(stream_data, "get_sub", (stream_name) => {
-        assert.equal(stream_name, "stream");
-        return {stream_id: 30};
-    });
-
     $(".narrow_to_compose_recipients").toggleClass = noop;
 
     mock_stream_header_colorblock();
@@ -176,7 +172,7 @@ test("snapshot_message", ({override_rewire}) => {
         if (curr_draft.type === "private") {
             compose_state.set_compose_recipient_id(compose_recipient.DIRECT_MESSAGE_ID);
         } else {
-            compose_state.set_stream_name(curr_draft.stream);
+            compose_state.set_stream_id(curr_draft.stream_id);
         }
         compose_state.topic(curr_draft.topic);
         compose_state.private_message_recipient(curr_draft.private_message_recipient);
@@ -187,7 +183,7 @@ test("snapshot_message", ({override_rewire}) => {
         name: draft_1.stream,
     };
     stream_data.add_sub(stream);
-    compose_state.set_stream_name("stream");
+    compose_state.set_stream_id(stream.stream_id);
 
     curr_draft = draft_1;
     set_compose_state();

--- a/web/tests/example3.test.js
+++ b/web/tests/example3.test.js
@@ -79,7 +79,7 @@ run_test("narrow_state", () => {
     // As we often do, first make assertions about the starting
     // state:
 
-    assert.equal(narrow_state.stream(), undefined);
+    assert.equal(narrow_state.stream_name(), undefined);
 
     // Now set up a Filter object.
     const filter_terms = [
@@ -92,6 +92,6 @@ run_test("narrow_state", () => {
     // And here is where we actually change state.
     narrow_state.set_current_filter(filter);
 
-    assert.equal(narrow_state.stream(), "Denmark");
+    assert.equal(narrow_state.stream_name(), "Denmark");
     assert.equal(narrow_state.topic(), "copenhagen");
 });

--- a/web/tests/message_list.test.js
+++ b/web/tests/message_list.test.js
@@ -332,7 +332,7 @@ run_test("bookend", ({override}) => {
     list.view.clear_trailing_bookend = noop;
     list.narrowed = true;
 
-    override(narrow_state, "stream", () => "IceCream");
+    override(narrow_state, "stream_name", () => "IceCream");
 
     let is_subscribed = true;
     let invite_only = false;

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -662,7 +662,7 @@ run_test("narrow_to_compose_target errors", ({override_rewire, disallow_rewire})
 
     // No-op when empty stream.
     compose_state.set_message_type("stream");
-    compose_state.set_stream_name("");
+    compose_state.set_stream_id("");
     narrow.to_compose_target();
 });
 
@@ -677,7 +677,7 @@ run_test("narrow_to_compose_target streams", ({override_rewire}) => {
 
     compose_state.set_message_type("stream");
     stream_data.add_sub({name: "ROME", stream_id: 99});
-    compose_state.set_stream_name("ROME");
+    compose_state.set_stream_id(99);
 
     // Test with existing topic
     compose_state.topic("one");

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -176,13 +176,13 @@ test("set_compose_defaults", () => {
 
     // First try with a stream that doesn't exist.
     let stream_and_topic = narrow_state.set_compose_defaults();
-    assert.equal(stream_and_topic.stream, undefined);
+    assert.equal(stream_and_topic.stream_id, undefined);
     assert.equal(stream_and_topic.topic, "Bar");
 
     const test_stream = {name: "Foo", stream_id: 72};
     stream_data.add_sub(test_stream);
     stream_and_topic = narrow_state.set_compose_defaults();
-    assert.equal(stream_and_topic.stream, "Foo");
+    assert.equal(stream_and_topic.stream_id, 72);
     assert.equal(stream_and_topic.topic, "Bar");
 
     set_filter([["dm", "foo@bar.com"]]);
@@ -217,7 +217,7 @@ test("set_compose_defaults", () => {
     set_filter([["stream", "rome"]]);
 
     const stream_test = narrow_state.set_compose_defaults();
-    assert.equal(stream_test.stream, "ROME");
+    assert.equal(stream_test.stream_id, 99);
 });
 
 test("update_email", () => {

--- a/web/tests/narrow_state.test.js
+++ b/web/tests/narrow_state.test.js
@@ -42,7 +42,7 @@ test("stream", () => {
     ]);
     assert.ok(narrow_state.active());
 
-    assert.equal(narrow_state.stream(), "Test");
+    assert.equal(narrow_state.stream_name(), "Test");
     assert.equal(narrow_state.stream_sub().stream_id, test_stream.stream_id);
     assert.equal(narrow_state.topic(), "Bar");
     assert.ok(narrow_state.is_for_stream_id(test_stream.stream_id));
@@ -268,14 +268,14 @@ test("topic", () => {
 
 test("stream_sub", () => {
     set_filter([]);
-    assert.equal(narrow_state.stream(), undefined);
+    assert.equal(narrow_state.stream_name(), undefined);
     assert.equal(narrow_state.stream_sub(), undefined);
 
     set_filter([
         ["stream", "Foo"],
         ["topic", "Bar"],
     ]);
-    assert.equal(narrow_state.stream(), "Foo");
+    assert.equal(narrow_state.stream_name(), "Foo");
     assert.equal(narrow_state.stream_sub(), undefined);
 
     const sub = {name: "Foo", stream_id: 55};
@@ -286,7 +286,7 @@ test("stream_sub", () => {
         ["sender", "someone"],
         ["topic", "random"],
     ]);
-    assert.equal(narrow_state.stream(), undefined);
+    assert.equal(narrow_state.stream_name(), undefined);
 });
 
 test("pm_ids_string", () => {

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -82,7 +82,7 @@ function test(label, f) {
 test("basic_get_suggestions", ({override}) => {
     const query = "fred";
 
-    override(narrow_state, "stream", () => "office");
+    override(narrow_state, "stream_name", () => "office");
 
     const suggestions = get_suggestions(query);
 
@@ -240,7 +240,7 @@ test("dm_suggestions", ({override, mock_template}) => {
 
     // "pm-with" operator returns search result
     // and "dm" operator as a suggestions
-    override(narrow_state, "stream", () => undefined);
+    override(narrow_state, "stream_name", () => undefined);
     query = "pm-with";
     suggestions = get_suggestions(query);
     expected = ["pm-with", "dm:"];
@@ -460,7 +460,7 @@ test("has_suggestions", ({override, mock_template}) => {
     let query = "h";
     stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
-    override(narrow_state, "stream", () => {});
+    override(narrow_state, "stream_name", () => {});
 
     let suggestions = get_suggestions(query);
     let expected = ["h", "has:link", "has:image", "has:attachment"];
@@ -519,7 +519,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
 
     stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
-    override(narrow_state, "stream", () => {});
+    override(narrow_state, "stream_name", () => {});
 
     let query = "i";
     let suggestions = get_suggestions(query);
@@ -600,7 +600,7 @@ test("check_is_suggestions", ({override, mock_template}) => {
 test("sent_by_me_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 
-    override(narrow_state, "stream", () => {});
+    override(narrow_state, "stream_name", () => {});
 
     let query = "";
     let suggestions = get_suggestions(query);
@@ -678,7 +678,7 @@ test("topic_suggestions", ({override, mock_template}) => {
 
     override(stream_topic_history_util, "get_server_history", () => {});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
-    override(narrow_state, "stream", () => "office");
+    override(narrow_state, "stream_name", () => "office");
 
     const devel_id = 44;
     const office_id = 77;
@@ -817,7 +817,7 @@ test("stream_completion", ({override, mock_template}) => {
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
     stream_data.add_sub({stream_id: 88, name: "dev help", subscribed: true});
 
-    override(narrow_state, "stream", () => {});
+    override(narrow_state, "stream_name", () => {});
 
     let query = "stream:of";
     let suggestions = get_suggestions(query);
@@ -840,7 +840,7 @@ test("people_suggestions", ({override, mock_template}) => {
 
     let query = "te";
 
-    override(narrow_state, "stream", () => {});
+    override(narrow_state, "stream_name", () => {});
 
     const ted = {
         email: "ted@zulip.com",
@@ -942,7 +942,7 @@ test("people_suggestions", ({override, mock_template}) => {
 test("operator_suggestions", ({override, mock_template}) => {
     mock_template("search_description.hbs", true, (_data, html) => html);
 
-    override(narrow_state, "stream", () => undefined);
+    override(narrow_state, "stream_name", () => undefined);
 
     // Completed operator should return nothing
     let query = "stream:";

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -136,8 +136,8 @@ test("basics", () => {
     assert.ok(stream_data.is_invite_only_by_stream_name("social"));
     assert.ok(!stream_data.is_invite_only_by_stream_name("unknown"));
 
-    assert.equal(stream_data.get_color("social"), "red");
-    assert.equal(stream_data.get_color("unknown"), "#c2c2c2");
+    assert.equal(stream_data.get_color(social.stream_id), "red");
+    assert.equal(stream_data.get_color(""), "#c2c2c2");
 
     assert.equal(stream_data.get_name("denMARK"), "Denmark");
     assert.equal(stream_data.get_name("unknown Stream"), "unknown Stream");


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: #25742

Followup to #25785.

This should have no visual or functional changes.

This PR changes a lot of code area, especially the last commit, and should ideally be QA'd by people other than me to catch bugs. I've opened the composebox, selected streams from the dropdown, and interacted with the draft menu. I can write up a more thorough list of test cases (TODO).

The last commit is large and felt like it needed to be done all at once, but I welcome suggestions on how to break it up so I can learn more about breaking up big commits.

Note that there are some uses of `stream_name` remaining -- notably things that interact with `narrow` and the search filters, since those are user input and aren't associated with stream ids.