### PR TITLE
rendered-markdown: Update reference to "private message" in comment.

### DIFF
--- a/web/src/rendered_markdown.js
+++ b/web/src/rendered_markdown.js
@@ -98,7 +98,7 @@ export const update_elements = ($content) => {
                     $(this).addClass("user-mention-me");
                 }
             } else {
-                // Always highlight wildcard mentions in private message.
+                // Always highlight wildcard mentions in direct messages.
                 $(this).addClass("user-mention-me");
             }
         }


### PR DESCRIPTION
Updates a new code comment to use "direct message" instead of "private message" in `web/src/rendered_markdown.js`. 

After this change, `git grep 'private message web/` returns no matches. This was missed in the original audit done in #26060 because the changes that added the comment were not merged yet.