### PR TITLE
Remove bootstrap CSS for text type inputs.

### DIFF
--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -37,7 +37,7 @@
                     <div class="searchbar">
                         <div class="searchbar-reset">
                             <i class="fa fa-search" aria-hidden="true"></i>
-                            <input type="text" placeholder="{{ _('Search integrations') }}"/>
+                            <input type="text" class="search_input" placeholder="{{ _('Search integrations') }}"/>
                         </div>
                     </div>
                 </div>

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1026,3 +1026,19 @@ div.overlay {
         top: -1px;
     }
 }
+
+.filter_text_input {
+    padding: 4px 6px;
+    color: hsl(0deg 0% 33%);
+    border: 1px solid hsl(0deg 0% 80%);
+    transition: border linear 0.2s, box-shadow linear 0.2s;
+    box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+    border-radius: 4px;
+
+    &:focus {
+        border-color: hsl(206deg 80% 62% / 80%);
+        outline: 0;
+        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+            0 0 8px hsl(206deg 80% 62% / 60%);
+    }
+}

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -479,7 +479,8 @@
     .new-style .tab-switcher .ind-tab:not(.selected),
     select,
     .pill-container,
-    .user-status-content-wrapper {
+    .user-status-content-wrapper,
+    #custom-expiration-time-input {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
         color: inherit;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -480,7 +480,8 @@
     select,
     .pill-container,
     .user-status-content-wrapper,
-    #custom-expiration-time-input {
+    #custom-expiration-time-input,
+    #searchbox #search_query {
         background-color: hsl(0deg 0% 0% / 20%);
         border-color: hsl(0deg 0% 0% / 60%);
         color: inherit;

--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -355,13 +355,13 @@
     }
 }
 
-.dropdown-widget-button,
-.modal_text_input {
+.dropdown-widget-button {
     width: 206px;
 }
 
 .modal_password_input,
-.modal_url_input {
+.modal_url_input,
+.modal_text_input {
     padding: 4px 6px;
     color: hsl(0deg 0% 33%);
     border-radius: 4px;

--- a/web/styles/portico/activity.css
+++ b/web/styles/portico/activity.css
@@ -75,6 +75,20 @@ tr.admin td:first-child {
 
     & input {
         width: 206px;
+        padding: 4px 6px;
+        border-radius: 4px;
+        border: 1px solid hsl(0deg 0% 80%);
+        color: hsl(0deg 0% 33%);
+        margin-bottom: 10px;
+        transition: border linear 0.2s, box-shadow linear 0.2s;
+        box-shadow: inset 0 1px 1px hsla(0deg 0% 0% / 7.5%);
+
+        &:focus {
+            border-color: hsl(206deg 80% 62% / 80%);
+            outline: 0;
+            box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+                0 0 8px hsl(206.494deg 80% 62% / 60%);
+        }
     }
 }
 
@@ -92,23 +106,6 @@ tr.admin td:first-child {
 .support-discount-form {
     position: relative;
     top: -50px;
-
-    & input {
-        padding: 4px 6px;
-        border-radius: 4px;
-        border: 1px solid hsl(0deg 0% 80%);
-        color: hsl(0deg 0% 33%);
-        margin-bottom: 10px;
-        transition: border linear 0.2s, box-shadow linear 0.2s;
-        box-shadow: inset 0 1px 1px hsla(0deg 0 0 / 7.5%);
-
-        &:focus {
-            border-color: hsl(206deg 80% 62% / 80%);
-            outline: 0;
-            box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-                0 0 8px hsl(206.494deg 80% 62% / 60%);
-        }
-    }
 }
 
 .support-plan-type-form {
@@ -164,6 +161,20 @@ tr.admin td:first-child {
 
 .search-query.input-xxlarge {
     width: 530px;
+    padding: 4px 14px;
+    margin-bottom: 0;
+    border-radius: 15px;
+    border: 1px solid hsl(0deg 0% 80%);
+    box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+    transition: border linear 0.2s, box-shadow linear 0.2s;
+    color: hsl(0deg 0% 33%);
+
+    &:focus {
+        border-color: hsl(206deg 80% 62% / 80%);
+        outline: 0;
+        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+            0 0 8px hsl(206.494deg 80% 62% / 60%);
+    }
 }
 
 @media (width <= 767px) {

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -342,7 +342,8 @@ input[name="licenses"] {
 
 #license-manual-section,
 #licensechange-input-section,
-#sponsorship-form {
+#sponsorship-form,
+#invoice-form {
     & input {
         padding: 4px 6px;
         border-radius: 4px;

--- a/web/styles/portico/billing.css
+++ b/web/styles/portico/billing.css
@@ -328,26 +328,6 @@
     textarea {
         font-family: inherit;
     }
-
-    #license-manual-section,
-    #licensechange-input-section {
-        & input {
-            padding: 4px 6px;
-            border-radius: 4px;
-            border: 1px solid hsl(0deg 0% 80%);
-            color: hsl(0deg 0% 33%);
-            margin-bottom: 10px;
-            transition: border linear 0.2s, box-shadow linear 0.2s;
-            box-shadow: inset 0 1px 1px hsla(0deg 0 0 / 7.5%);
-
-            &:focus {
-                border-color: hsl(206deg 80% 62% / 80%);
-                outline: 0;
-                box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-                    0 0 8px hsl(206.494deg 80% 62% / 60%);
-            }
-        }
-    }
 }
 
 input[type="number"]::-webkit-outer-spin-button,
@@ -360,10 +340,30 @@ input[name="licenses"] {
     appearance: textfield;
 }
 
+#license-manual-section,
+#licensechange-input-section,
+#sponsorship-form {
+    & input {
+        padding: 4px 6px;
+        border-radius: 4px;
+        border: 1px solid hsl(0deg 0% 80%);
+        color: hsl(0deg 0% 33%);
+        margin-bottom: 10px;
+        transition: border linear 0.2s, box-shadow linear 0.2s;
+        box-shadow: inset 0 1px 1px hsla(0deg 0 0 / 7.5%);
+
+        &:focus {
+            border-color: hsl(206deg 80% 62% / 80%);
+            outline: 0;
+            box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+                0 0 8px hsl(206.494deg 80% 62% / 60%);
+        }
+    }
+}
+
 #sponsorship-form {
     & input {
         box-sizing: border-box;
-        height: 30px;
     }
 
     & textarea {

--- a/web/styles/portico/email_log.css
+++ b/web/styles/portico/email_log.css
@@ -34,6 +34,24 @@
                 outline-offset: -2px;
             }
         }
+
+        & input[type="text"] {
+            padding: 4px 6px;
+            color: hsl(0deg 0% 33%);
+            border-radius: 4px;
+            border: 1px solid hsl(0deg 0% 80%);
+            box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+            transition: border linear 0.2s, box-shadow linear 0.2s;
+            margin-bottom: 10px;
+            width: 206px;
+
+            &:focus {
+                border-color: hsl(206deg 80% 62% / 80%);
+                outline: 0;
+                box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+                    0 0 8px hsl(206deg 80% 62% / 60%);
+            }
+        }
     }
 
     & input[type="checkbox"] {

--- a/web/styles/portico/integrations.css
+++ b/web/styles/portico/integrations.css
@@ -108,7 +108,7 @@ $category-text: hsl(219deg 23% 33%);
             .searchbar-reset {
                 position: relative;
 
-                & input {
+                .search_input {
                     box-shadow: 0 0 7px 2px hsl(0deg 0% 0% / 3%);
 
                     font-size: 1em;
@@ -120,9 +120,13 @@ $category-text: hsl(219deg 23% 33%);
                     border-radius: 40px;
                     border: 1px solid $light-blue-border;
                     display: block;
+                    color: hsl(0deg 0% 33%);
+                    margin-bottom: 10px;
+                    transition: border linear 0.2s, box-shadow linear 0.2s;
 
                     &:focus {
                         border: 1px solid $border-green;
+                        outline: 0;
                     }
 
                     @media (width <= 768px) {

--- a/web/styles/portico/integrations_dev_panel.css
+++ b/web/styles/portico/integrations_dev_panel.css
@@ -57,6 +57,23 @@
         background-color: hsl(0deg 0% 100%);
         vertical-align: middle;
     }
+
+    & input {
+        padding: 4px 6px;
+        color: hsl(0deg 0% 33%);
+        border-radius: 4px;
+        border: 1px solid hsl(0deg 0% 80%);
+        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+        transition: border linear 0.2s, box-shadow linear 0.2s;
+        margin-bottom: 10px;
+
+        &:focus {
+            border-color: hsl(206deg 80% 62% / 80%);
+            outline: 0;
+            box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+                0 0 8px hsl(206deg 80% 62% / 60%);
+        }
+    }
 }
 
 #fixture_body {

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -77,6 +77,11 @@
         overflow: hidden;
         white-space: nowrap;
         padding-left: 35px;
+        color: hsl(0deg 0% 33%);
+
+        &:focus {
+            outline: 0;
+        }
 
         @media (width < $sm_min) {
             vertical-align: text-bottom;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1441,6 +1441,20 @@ $option_title_width: 180px;
     }
 }
 
+.time-limit-custom-input {
+    padding: 4px 6px;
+    color: hsl(0deg 0% 33%);
+    border: 1px solid hsl(0deg 0% 80%);
+    transition: border linear 0.2s, box-shadow linear 0.2s;
+
+    &:focus {
+        border-color: hsl(206deg 80% 62% / 80%);
+        outline: 0;
+        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+            0 0 8px hsl(206deg 80% 62% / 60%);
+    }
+}
+
 #profile-settings,
 #edit-user-form {
     .custom_user_field {

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1650,8 +1650,7 @@ $option_title_width: 180px;
     }
 }
 
-#payload_url_inputbox,
-#service_name_list {
+#payload_url_inputbox {
     & input[type="text"] {
         width: 340px;
     }

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -379,13 +379,6 @@ td .button {
     }
 }
 
-.settings_text_input,
-.settings_url_input {
-    /* 311px + 2 * 6px (padding) + 2 * 1px (border) = 325px (min width of select
-    elements in settings) */
-    width: 311px;
-}
-
 #admin-user-list,
 #admin-bot-list {
     .table tr:first-of-type td {
@@ -1967,7 +1960,8 @@ $option_title_width: 180px;
     }
 }
 
-.settings_url_input {
+.settings_url_input,
+.settings_text_input {
     padding: 4px 6px;
     color: hsl(0deg 0% 33%);
     border-radius: 4px;
@@ -1975,6 +1969,10 @@ $option_title_width: 180px;
     box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
     transition: border linear 0.2s, box-shadow linear 0.2s;
     margin-bottom: 10px;
+
+    /* 311px + 2 * 6px (padding) + 2 * 1px (border) = 325px (min width of select
+    elements in settings) */
+    width: 311px;
 
     &:focus {
         border-color: hsl(206deg 80% 62% / 80%);

--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -99,6 +99,21 @@
             width: 206px;
         }
     }
+
+    & input[type="text"] {
+        border: 1px solid hsl(0deg 0% 80%);
+        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+        transition: border linear 0.2s, box-shadow linear 0.2s;
+        border-radius: 4px;
+        color: hsl(0deg 0% 33%);
+
+        &:focus {
+            border-color: hsl(206deg 80% 62% / 80%);
+            outline: 0;
+            box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+                0 0 8px hsl(206deg 80% 62% / 60%);
+        }
+    }
 }
 
 .poll-widget {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1786,6 +1786,17 @@ div.focused_table {
         vertical-align: baseline;
         line-height: 0px;
         box-shadow: none;
+        color: hsl(0deg 0% 33%);
+        border-radius: 4px;
+        border: 1px solid hsl(0deg 0% 80%);
+        transition: border linear 0.2s, box-shadow linear 0.2s;
+
+        &:focus {
+            border-color: hsl(206deg 80% 62% / 80%);
+            outline: 0;
+            box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+                0 0 8px hsl(206deg 80% 62% / 60%);
+        }
     }
 }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2411,11 +2411,9 @@ textarea.invitee_emails {
     }
 }
 
-#invite-user-modal {
-    #custom-expiration-time-input,
-    #invite-user-form {
-        margin: 0;
-    }
+#custom-expiration-time-input,
+#invite-user-form {
+    margin: 0;
 }
 
 select.invite-expires-in,
@@ -2468,15 +2466,27 @@ select.invite-as {
     width: fit-content;
 }
 
-#custom-invite-expiration-time {
-    #custom-expiration-time-input {
-        width: 5ch;
-        margin-right: 15px;
-    }
+#custom-expiration-time-input {
+    width: 5ch;
+    margin-right: 15px;
 
-    #custom-expiration-time-unit {
-        width: auto;
+    padding: 4px 6px;
+    color: hsl(0deg 0% 33%);
+    border-radius: 4px;
+    border: 1px solid hsl(0deg 0% 80%);
+    box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%);
+    transition: border linear 0.2s, box-shadow linear 0.2s;
+
+    &:focus {
+        border-color: hsl(206deg 80% 62% / 80%);
+        outline: 0;
+        box-shadow: inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
+            0 0 8px hsl(206deg 80% 62% / 60%);
     }
+}
+
+#custom-expiration-time-unit {
+    width: auto;
 }
 
 .empty_feed_notice {

--- a/web/templates/dropdown_list_container.hbs
+++ b/web/templates/dropdown_list_container.hbs
@@ -1,6 +1,6 @@
 <div class="dropdown-list-container">
     <div class="dropdown-list-search">
-        <input class="dropdown-list-search-input" type="text" placeholder="{{t 'Filter' }}" autofocus/>
+        <input class="dropdown-list-search-input filter_text_input" type="text" placeholder="{{t 'Filter' }}" autofocus/>
     </div>
     <div class="dropdown-list-wrapper" data-simplebar>
         <ul class="dropdown-list"></ul>

--- a/web/templates/emoji_popover_content.hbs
+++ b/web/templates/emoji_popover_content.hbs
@@ -1,6 +1,6 @@
 <div class="emoji-popover">
     <div class="emoji-popover-top">
-        <input class="emoji-popover-filter" type="text" autofocus placeholder="{{t 'Search' }}" />
+        <input class="emoji-popover-filter filter_text_input" type="text" autofocus placeholder="{{t 'Search' }}" />
         <i class="fa fa-search" aria-hidden="true"></i>
     </div>
     <div class="emoji-popover-category-tabs">

--- a/web/templates/filter_topics.hbs
+++ b/web/templates/filter_topics.hbs
@@ -1,5 +1,5 @@
 <div class="input-append topic_search_section filter-topics">
-    <input class="topic-list-filter home-page-input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
+    <input class="topic-list-filter home-page-input filter_text_input" id="filter-topic-input" type="text" autocomplete="off" placeholder="{{t 'Filter topics'}}" />
     <button type="button" class="btn clear_search_button" id="clear_search_topic_button">
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -97,7 +97,7 @@
                 </span>
                 <i id="filter_streams_tooltip" class="streams_filter_icon fa fa-filter" aria-hidden="true" data-tooltip-template-id="filter-streams-tooltip-template"></i>
                 <div class="input-append notdisplayed stream_search_section">
-                    <input class="stream-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
+                    <input class="stream-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Filter streams' }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>

--- a/web/templates/recent_topics_table.hbs
+++ b/web/templates/recent_topics_table.hbs
@@ -3,7 +3,7 @@
         {{> recent_topics_filters}}
     </div>
     <div class="search_group" role="group">
-        <input type="text" id="recent_topics_search" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics (t)' }}" />
+        <input type="text" id="recent_topics_search" class="filter_text_input" value="{{ search_val }}" autocomplete="off" placeholder="{{t 'Filter topics (t)' }}" />
         <button type="button" class="btn clear_search_button" id="recent_topics_search_clear">
             <i class="fa fa-remove" aria-hidden="true"></i>
         </button>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -12,7 +12,7 @@
                 </i>
             </div>
             <div class="input-append notdisplayed" id="user_search_section">
-                <input class="user-list-filter home-page-input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />
+                <input class="user-list-filter home-page-input filter_text_input" type="text" autocomplete="off" placeholder="{{t 'Search people' }}" />
                 <button type="button" class="btn clear_search_button" id="clear_search_people_button">
                     <i class="fa fa-remove" aria-hidden="true"></i>
                 </button>

--- a/web/templates/set_status_overlay.hbs
+++ b/web/templates/set_status_overlay.hbs
@@ -2,7 +2,7 @@
     <div class="status-emoji-wrapper tippy-zulip-tooltip"  data-tippy-content="{{t 'Select emoji' }}" data-tippy-placement="top" aria-label="{{t 'Select emoji' }}"  tabindex="0" id="selected_emoji">
         {{> status_emoji_selector}}
     </div>
-    <input type="text" class="user-status" placeholder="{{t 'Your status' }}" maxlength="60"/>
+    <input type="text" class="user-status modal_text_input" placeholder="{{t 'Your status' }}" maxlength="60"/>
     <button type="button" class="btn clear_search_button" id="clear_status_message_button" disabled="disabled">
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>

--- a/web/templates/settings/add_new_bot_form.hbs
+++ b/web/templates/settings/add_new_bot_form.hbs
@@ -39,7 +39,7 @@
         <div id="payload_url_inputbox">
             <div class="input-group">
                 <label for="create_payload_url">{{t "Endpoint URL" }}</label>
-                <input type="text" name="payload_url" id="create_payload_url"
+                <input type="text" name="payload_url" id="create_payload_url" class="modal_text_input"
                   maxlength=2083 placeholder="https://hostname.example.com" value="" />
                 <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
             </div>

--- a/web/templates/settings/add_user_group_modal.hbs
+++ b/web/templates/settings/add_user_group_modal.hbs
@@ -5,6 +5,6 @@
     </div>
     <div>
         <label for="user_group_description">{{t "Description" }}</label>
-        <input type="text" name="description" id="user_group_description" maxlength="300" placeholder="{{t 'Marketing team' }}" />
+        <input type="text" name="description" id="user_group_description" class="modal_text_input" maxlength="300" placeholder="{{t 'Marketing team' }}" />
     </div>
 </form>

--- a/web/templates/settings/admin_linkifier_edit_form.hbs
+++ b/web/templates/settings/admin_linkifier_edit_form.hbs
@@ -2,12 +2,12 @@
     <form class="linkifier-edit-form">
         <div class="input-group name_change_container">
             <label for="edit-linkifier-pattern" >{{t "Pattern" }}</label>
-            <input type="text" autocomplete="off" id="edit-linkifier-pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" value="{{ pattern }}" />
+            <input type="text" autocomplete="off" id="edit-linkifier-pattern" class="modal_text_input" name="pattern" placeholder="#(?P<id>[0-9]+)" value="{{ pattern }}" />
             <div class="alert" id="edit-linkifier-pattern-status"></div>
         </div>
         <div class="input-group name_change_container">
             <label for="edit-linkifier-url-template" >{{t "URL template" }}</label>
-            <input type="text" autocomplete="off" id="edit-linkifier-url-template" name="url_template" placeholder="https://github.com/zulip/zulip/issues/{id}" value="{{ url_template }}" />
+            <input type="text" autocomplete="off" id="edit-linkifier-url-template" class="modal_text_input" name="url_template" placeholder="https://github.com/zulip/zulip/issues/{id}" value="{{ url_template }}" />
             <div class="alert" id="edit-linkifier-template-status"></div>
         </div>
     </form>

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -2,7 +2,7 @@
     <div id="attachment-stats-holder"></div>
     <div class="settings_panel_list_header">
         <h3>{{t "Uploaded files"}}</h3>
-        <input id="upload_file_search" class="search" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
+        <input id="upload_file_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter uploaded files' }}" aria-label="{{t 'Filter uploads' }}"/>
     </div>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -8,7 +8,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Bots"}}</h3>
         <div class="alert-notification" id="bot-field-status"></div>
-        <input type="text" class="search" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
+        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -6,7 +6,7 @@
             {{> ../help_link_widget link="/help/deactivate-or-reactivate-a-user" }}
         </h3>
         <div class="alert-notification" id="deactivated-user-field-status"></div>
-        <input type="text" class="search" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}"/>
+        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}"/>
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -7,7 +7,7 @@
             {{#if is_admin}}
                 <button type="submit" id="show-add-default-streams-modal" class="button rounded sea-green">{{t "Add stream" }}</button>
             {{/if}}
-            <input type="text" class="search" placeholder="{{t 'Filter default streams' }}" aria-label="{{t 'Filter streams' }}"/>
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter default streams' }}" aria-label="{{t 'Filter streams' }}"/>
         </div>
     </div>
 

--- a/web/templates/settings/dropdown_list_widget.hbs
+++ b/web/templates/settings/dropdown_list_widget.hbs
@@ -11,7 +11,7 @@
         </button>
         <ul class="dropdown-menu modal-bg" role="menu">
             <li class="dropdown-search" role="presentation">
-                <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{list_placeholder}}" autofocus/>
+                <input class="no-input-change-detection filter_text_input" type="text" role="menuitem" placeholder="{{list_placeholder}}" autofocus/>
             </li>
             <div class="dropdown-list-wrapper" data-simplebar>
                 <span class="dropdown-list-body"></span>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -11,7 +11,7 @@
 
     <div class="settings_panel_list_header">
         <h3>{{t "Custom emoji"}}</h3>
-        <input type="text" class="search" placeholder="{{t 'Filter emoji' }}"
+        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter emoji' }}"
           aria-label="{{t 'Filter emoji' }}"/>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -10,7 +10,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Invites"}}</h3>
         <div class="alert-notification" id="invites-field-status"></div>
-        <input type="text" class="search" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
+        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -59,7 +59,7 @@
         <div class="settings_panel_list_header">
             <h3>{{t "Linkifiers"}}</h3>
             <div class="alert-notification edit-linkifier-status" id="linkifier-field-status"></div>
-            <input type="text" class="search" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
         </div>
 
         <div class="progressive-table-wrapper" data-simplebar>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -40,12 +40,12 @@
                     <div class="alert" id="admin-linkifier-status"></div>
                     <div class="input-group">
                         <label for="linkifier_pattern">{{t "Pattern" }}</label>
-                        <input type="text" id="linkifier_pattern" name="pattern" placeholder="#(?P<id>[0-9]+)" />
+                        <input type="text" id="linkifier_pattern" class="settings_text_input" name="pattern" placeholder="#(?P<id>[0-9]+)" />
                         <div class="alert" id="admin-linkifier-pattern-status"></div>
                     </div>
                     <div class="input-group">
                         <label for="linkifier_template">{{t "URL template" }}</label>
-                        <input type="text" id="linkifier_template" name="url_template" placeholder="https://github.com/zulip/zulip/issues/{id}" />
+                        <input type="text" id="linkifier_template" class="settings_text_input" name="url_template" placeholder="https://github.com/zulip/zulip/issues/{id}" />
                         <div class="alert" id="admin-linkifier-template-status"></div>
                     </div>
                     <button type="submit" class="button rounded sea-green">

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -1,7 +1,7 @@
 <div id="muted-user-settings" class="settings-section" data-name="muted-users">
     <div class="settings_panel_list_header">
         <h3>{{t "Muted users"}}</h3>
-        <input id="muted_users_search" class="search" type="text" placeholder="{{t 'Filter muted users' }}" aria-label="{{t 'Filter muted users' }}"/>
+        <input id="muted_users_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter muted users' }}" aria-label="{{t 'Filter muted users' }}"/>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -45,15 +45,15 @@
                     <div class="alert" id="admin-playground-status"></div>
                     <div class="input-group">
                         <label for="playground_pygments_language"> {{t "Language" }}</label>
-                        <input type="text" id="playground_pygments_language" name="pygments_language" autocomplete="off" placeholder="Python" />
+                        <input type="text" id="playground_pygments_language" class="settings_text_input" name="pygments_language" autocomplete="off" placeholder="Python" />
                     </div>
                     <div class="input-group">
                         <label for="playground_name"> {{t "Name" }}</label>
-                        <input type="text" id="playground_name" name="playground_name" autocomplete="off" placeholder="Python3 playground" />
+                        <input type="text" id="playground_name" class="settings_text_input" name="playground_name" autocomplete="off" placeholder="Python3 playground" />
                     </div>
                     <div class="input-group">
                         <label for="playground_url_prefix"> {{t "URL prefix" }}</label>
-                        <input type="text" id="playground_url_prefix" name="url_prefix" placeholder="https://replit.com/languages/python3/?code=" />
+                        <input type="text" id="playground_url_prefix" class="settings_text_input" name="url_prefix" placeholder="https://replit.com/languages/python3/?code=" />
                     </div>
                     <button type="submit" id="submit_playground_button" class="button rounded sea-green">
                         {{t 'Add code playground' }}

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -65,7 +65,7 @@
 
         <div class="settings_panel_list_header">
             <h3>{{t "Code playgrounds"}}</h3>
-            <input type="text" class="search" placeholder="{{t 'Filter code playgrounds' }}" aria-label="{{t 'Filter code playgrounds' }}"/>
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter code playgrounds' }}" aria-label="{{t 'Filter code playgrounds' }}"/>
         </div>
 
         <div class="progressive-table-wrapper" data-simplebar>

--- a/web/templates/settings/profile_field_choice.hbs
+++ b/web/templates/settings/profile_field_choice.hbs
@@ -1,7 +1,7 @@
 <div class='choice-row movable-profile-field-row' data-value="{{value}}">
     <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
-    <input type='text' placeholder='{{t "New option" }}' value="{{ text }}" />
+    <input type='text' class="modal_text_input" placeholder='{{t "New option" }}' value="{{ text }}" />
 
     <button type='button' class="button rounded small delete-choice" title="{{t 'Delete' }}">
         <i class="fa fa-trash-o" aria-hidden="true"></i>

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -5,7 +5,7 @@
     <div class="settings_panel_list_header">
         <h3>{{t "Users"}}</h3>
         <div class="alert-notification" id="user-field-status"></div>
-        <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+        <input type="text" class="search filter_text_input" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
     </div>
 
     <div class="progressive-table-wrapper" data-simplebar>

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -9,7 +9,7 @@
     </p>
     <div class="settings_panel_list_header">
         <h3>{{t "Topic settings"}}</h3>
-        <input id="user_topics_search" class="search" type="text" placeholder="{{t 'Filter topics' }}" aria-label="{{t 'Filter topics' }}"/>
+        <input id="user_topics_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter topics' }}" aria-label="{{t 'Filter topics' }}"/>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table">

--- a/web/templates/stream_settings/new_stream_users.hbs
+++ b/web/templates/stream_settings/new_stream_users.hbs
@@ -13,7 +13,7 @@
 
 <div class="create_stream_subscriber_list_header">
     <h4 class="stream_setting_subsection_title">{{t 'Subscribers' }}</h4>
-    <input class="add-user-list-filter" name="user_list_filter" type="text"
+    <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter subscribers' }}" />
 </div>
 

--- a/web/templates/stream_settings/stream_members.hbs
+++ b/web/templates/stream_settings/stream_members.hbs
@@ -13,7 +13,7 @@
     <div>
         <h4 class="inline-block stream_setting_subsection_title">{{t "Subscribers"}}</h4>
         <span class="subscriber-search float-right">
-            <input type="text" class="search" placeholder="{{t 'Filter subscribers' }}" />
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter subscribers' }}" />
         </span>
     </div>
     <div class="subscriber-list-box">

--- a/web/templates/stream_settings/stream_settings_overlay.hbs
+++ b/web/templates/stream_settings/stream_settings_overlay.hbs
@@ -20,7 +20,7 @@
                     </div>
                 </div>
                 <div class="input-append stream_name_search_section" id="stream_filter">
-                    <input type="text" name="stream_name" id="search_stream_name" autocomplete="off"
+                    <input type="text" name="stream_name" id="search_stream_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter streams' }}" value=""/>
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>

--- a/web/templates/user_group_settings/new_user_group_users.hbs
+++ b/web/templates/user_group_settings/new_user_group_users.hbs
@@ -8,7 +8,7 @@
 
 <div class="create_member_list_header">
     <h4 class="user_group_setting_subsection_title">{{t 'Members' }}</h4>
-    <input class="add-user-list-filter" name="user_list_filter" type="text"
+    <input class="add-user-list-filter filter_text_input" name="user_list_filter" type="text"
       autocomplete="off" placeholder="{{t 'Filter members' }}" />
 </div>
 

--- a/web/templates/user_group_settings/user_group_creation_form.hbs
+++ b/web/templates/user_group_settings/user_group_creation_form.hbs
@@ -16,7 +16,7 @@
                 <label for="create_user_group_description">
                     {{t "User group description" }}
                 </label>
-                <input type="text" name="user_group_description" id="create_user_group_description"
+                <input type="text" name="user_group_description" id="create_user_group_description" class="settings_text_input"
                   placeholder="{{t 'User group description' }}" value="" autocomplete="off" />
             </section>
             <section class="block">

--- a/web/templates/user_group_settings/user_group_members.hbs
+++ b/web/templates/user_group_settings/user_group_members.hbs
@@ -12,7 +12,7 @@
     <div>
         <h4 class="inline-block user_group_setting_subsection_title">{{t "Members"}}</h4>
         <span class="member-search float-right">
-            <input type="text" class="search" placeholder="{{t 'Filter subscribers' }}" />
+            <input type="text" class="search filter_text_input" placeholder="{{t 'Filter subscribers' }}" />
         </span>
     </div>
     <div class="member-list-box">

--- a/web/templates/user_group_settings/user_group_settings_overlay.hbs
+++ b/web/templates/user_group_settings/user_group_settings_overlay.hbs
@@ -10,7 +10,7 @@
             </div>
             <div class="left">
                 <div class="input-append group_name_search_section" id="group_filter">
-                    <input type="text" name="group_name" id="search_group_name" autocomplete="off"
+                    <input type="text" name="group_name" id="search_group_name" class="filter_text_input" autocomplete="off"
                       placeholder="{{t 'Filter groups' }}" value=""/>
                     <button type="button" class="btn clear_search_button" id="clear_search_group_name">
                         <i class="fa fa-remove" aria-hidden="true"></i>

--- a/web/third/bootstrap/css/bootstrap.css
+++ b/web/third/bootstrap/css/bootstrap.css
@@ -540,14 +540,6 @@ input:focus:invalid:focus {
   -moz-border-radius: 0 4px 4px 0;
   border-radius: 0 4px 4px 0;
 }
-input.search-query {
-  padding-right: 14px;
-  padding-left: 14px;
-  margin-bottom: 0;
-  -webkit-border-radius: 15px;
-  -moz-border-radius: 15px;
-  border-radius: 15px;
-}
 .form-inline input,
 .form-inline .help-inline,
 .form-inline .input-append {

--- a/web/third/bootstrap/css/bootstrap.css
+++ b/web/third/bootstrap/css/bootstrap.css
@@ -420,37 +420,6 @@ label {
   display: block;
   margin-bottom: 5px;
 }
-input[type="text"] {
-  display: inline-block;
-  height: 20px;
-  padding: 4px 6px;
-  margin-bottom: 10px;
-  font-size: 14px;
-  line-height: 20px;
-  color: #555555;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
-  vertical-align: middle;
-}
-input[type="text"] {
-  background-color: #ffffff;
-  border: 1px solid #cccccc;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  -webkit-transition: border linear .2s, box-shadow linear .2s;
-  -moz-transition: border linear .2s, box-shadow linear .2s;
-  -o-transition: border linear .2s, box-shadow linear .2s;
-  transition: border linear .2s, box-shadow linear .2s;
-}
-input[type="text"]:focus {
-  border-color: rgba(82, 168, 236, 0.8);
-  outline: 0;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
-  -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
-}
 input:-moz-placeholder {
   color: #999999;
 }


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First commit is just to remove unnecessary CSS.
- Next two commits are to re-add the bootstrap CSS for text inputs in modals.
- Next four commits are to re-add bootstrap CSS for different text inputs like in invite modal, search, todo and poll widgetes and inline topic edit form.
- Next five commits are to re-add bootstrap CSS for text inputs in portico and dev server pages.
- Next three commits are to re-add the bootstrap CSS for text inputs in settings including stream and user group settings as well.
- Next commit is to re-add bootstrap CSS to various filter inputs across the app.
- Next commit is to remove CSS for text type inputs from `bootstrap.css`.
- Last commit is to fix the licenses input in "Pay by invoice" section of upgrade page.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
