### PR TITLE
navbar: Fix background-color inconsistency in dark theme.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -196,15 +196,14 @@
     #userlist-toggle-button,
     .header,
     #message_view_header {
-        background-color: hsl(0deg 0% 13%);
+        background-color: var(--color-background-navbar);
     }
 
     & body,
     .app-main,
     .column-middle,
     #streams_header,
-    .private_messages_container,
-    .header {
+    .private_messages_container {
         background-color: var(--color-background);
     }
 


### PR DESCRIPTION
CZO thread: https://chat.zulip.org/#narrow/stream/9-issues/topic/top.20navbar.20bottom.20border/near/1598791


<img width="986" alt="image" src="https://github.com/zulip/zulip/assets/5634097/adb27a27-8c93-472b-9911-1df36b7045b7">

