### PR TITLE
message-list-view: Update sticky header in rerender_messages.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -1208,7 +1208,9 @@ export class MessageListView {
 
     _rerender_header(message_containers) {
         // Given a list of messages that are in the **same** message group,
-        // rerender the header / recipient bar of the messages
+        // rerender the header / recipient bar of the messages. This method
+        // should only be called with rerender_messages as the rerendered
+        // header may need to be updated for the "sticky_header" class.
         if (message_containers.length === 0) {
             return;
         }
@@ -1314,6 +1316,10 @@ export class MessageListView {
 
         for (const messages_in_group of message_groups) {
             this._rerender_header(messages_in_group, message_content_edited);
+        }
+
+        if (message_lists.current === this.list && narrow_state.is_message_feed_visible()) {
+            this.update_sticky_recipient_headers();
         }
     }
 


### PR DESCRIPTION
When a message list view rerenders a locally echoed message the message recipient header is also rerendered, which then removes the `"sticky_header"` class if it was present. If rerendering the message triggers a scroll event, then the `"sticky_header"` class is updated.

<details>
<summary>console trace on message_list_view._rerender_header</summary>

![Screenshot from 2023-06-28 15-54-43](https://github.com/zulip/zulip/assets/63245456/0757657e-69da-4a56-a61b-88262ba7aebc)
</details>

But it is possible that the rerendering of the message will not trigger a scroll event, which means the recipient header is no longer updated and the next calculation for the message list view's `_scroll_limit` for the top of the feed will not include the sticky header and the currently selected message may be scrolled partially or completely under the message header recipient bar.

Here we add a check for the current message list and whether it is visible after we rerender messages in `echo.process_from_server`, and update the sticky recipient headers even if there is no scroll event.

---

**Questions/Notes**:
- Manually tested in direct messages with self view, all direct messages view, direct messages with other user view, stream view, stream/topic view and all messages view. Can reproduce current behavior / changes on Firefox and Chrome on Linux.
- There are a few other places where `message_list.view.rerender_messages` is called. See `git-grep` search below. Though this particular case is only triggered by `process_from_server` in `web/src/echo.js`, it might be worth checking for similar cases in the other instances?

```console
$ git grep '[.]rerender_messages(' web/
web/src/echo.js:        msg_list.view.rerender_messages([message]);
web/src/echo.js:            msg_list.view.rerender_messages(msgs_to_rerender);
web/src/message_events.js:            list.view.rerender_messages(messages_to_rerender, any_message_content_edited);
web/src/message_live_update.js:        list.view.rerender_messages(messages_to_render);
web/src/message_live_update.js:        list.view.rerender_messages(messages);
```

---

**Screenshots**:
<details>
<summary>Dev tools showing overlap of message and recipient header - current main</summary>

![Screenshot from 2023-06-28 12-20-27](https://github.com/zulip/zulip/assets/63245456/cbec386f-cf5e-4d3c-ab06-bc1dee35ac5d)
</details>
<details>
<summary>Dev tools showing no overlap of message and recipient header - after changes</summary>

![Screenshot from 2023-06-28 15-32-46](https://github.com/zulip/zulip/assets/63245456/e5cf32c5-d11e-4072-b59c-6e88486e2fac)

</details>

**Screen captures:**

<details>
<summary>One person - All messages view - current main</summary>

[Screencast from 28-06-23 15:18:40.webm](https://github.com/zulip/zulip/assets/63245456/5124ad2c-0cd9-4d1d-940b-842725b2f6df)
</details>
<details>
<summary>One person - All messages view - after changes</summary>

[Screencast from 28-06-23 15:19:48.webm](https://github.com/zulip/zulip/assets/63245456/aa40ca3f-4341-4c60-a664-88e17cd530f5)
</details>
<details>
<summary>Two people - Stream and stream/topic views - current main</summary>

[Screencast from 28-06-23 15:10:12.webm](https://github.com/zulip/zulip/assets/63245456/685d3a12-7a7f-43ca-8514-7bee37dd454f)
</details>
<details>
<summary>Two people - Stream and stream/topic views - after changes</summary>

[Screencast from 28-06-23 15:06:58.webm](https://github.com/zulip/zulip/assets/63245456/ac34e763-4657-44d8-be6e-d4a36310a007)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
