### PR TITLE
settings_emoji: Fix file upload bug in upload emoji modal.

### DIFF
--- a/web/src/settings_emoji.js
+++ b/web/src/settings_emoji.js
@@ -290,6 +290,7 @@ function show_modal() {
         html_body,
         html_submit_button: $t_html({defaultMessage: "Confirm"}),
         id: "add-custom-emoji-modal",
+        form_id: "add-custom-emoji-form",
         loading_spinner: true,
         on_click: add_custom_emoji,
         post_render: add_custom_emoji_post_render,

--- a/web/templates/settings/add_emoji.hbs
+++ b/web/templates/settings/add_emoji.hbs
@@ -2,8 +2,8 @@
     <div>
         <input type="file" name="emoji_file_input" class="notvisible"
           id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
-        <button class="button white rounded" style="display: none;" id="emoji_image_clear_button">{{t "Clear image" }}</button>
-        <button class="button rounded" id="emoji_upload_button">{{t "Upload image or GIF" }}</button>
+        <button type="button" class="button white rounded" style="display: none;" id="emoji_image_clear_button">{{t "Clear image" }}</button>
+        <button type="button" class="button rounded" id="emoji_upload_button">{{t "Upload image or GIF" }}</button>
         <div style="display: none;" id="emoji_preview_text">
             Preview: <i id="emoji_placeholder_icon" class="fa fa-file-image-o" aria-hidden="true"></i><img class="emoji" id="emoji_preview_image" src=""/>
         </div>


### PR DESCRIPTION
Before this commit if a user pressed enter to submit the add emoji form the uploaded emoji was getting cleared.

This was happening because when we pressed enter the browser tried to submit the form, because we had two buttons inside that form one for clearing uploaded emoji and one for uploading emoji they were being treated as "submit" button and hence their callback ran which in result was responsible for the bug.

Fixed this by explicitly setting the `type` attribute for those buttons to `type=button` so that they will not be treated as "submit" button. Also added the `form_id` option for `dialog_widget` which is needed if we do want to correctly submit the form by pressing enter.

Fixes: #24972

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

#### Before
![before](https://github.com/zulip/zulip/assets/84276404/6ead32a6-f31a-488e-aa36-abc8d19f8d29)

#### After
![after](https://github.com/zulip/zulip/assets/84276404/b1960bba-90b4-4ef8-b7bf-9d6a8841127b)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
