### PR TITLE
Improve api doc tests by eliminating 218 Zephyr-related checks

### DIFF
--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -135,6 +135,7 @@ class DocPageTest(ZulipTestCase):
         for endpoint in endpoint_list:
             self._test(endpoint, "", doc_html_str=True)
 
+    def test_api_doc_404_status_codes(self) -> None:
         result = self.client_get(
             "/api/nonexistent-page",
             follow=True,
@@ -150,7 +151,7 @@ class DocPageTest(ZulipTestCase):
         )
         self.assertEqual(result.status_code, 404)
 
-        # Test some API doc endpoints for specific content and metadata.
+    def test_specific_api_endpoints_for_content(self) -> None:
         self._test("/api/", "The Zulip API")
         self._test("/api/api-keys", "be careful with it")
         self._test("/api/installation-instructions", "No download required!")

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -173,13 +173,15 @@ class DocPageTest(ZulipTestCase):
         api_page_raw = str(self.client_get("/api/").content)
         ENDPOINT_REGEXP = re.compile(r"href=\"/api/\s*(.*?)\"")
         endpoint_list_set = set(re.findall(ENDPOINT_REGEXP, api_page_raw))
-        endpoint_list = [f"/api/{endpoint}" for endpoint in endpoint_list_set]
+        endpoint_list = sorted(endpoint_list_set)
+
         # Validate that the parsing logic isn't broken, since if it
         # broke, the below would become a noop.
         self.assertGreater(len(endpoint_list), 70)
 
         for endpoint in endpoint_list:
-            self._test(endpoint, "", doc_html_str=True)
+            url = f"/api/{endpoint}"
+            self._test(url, "", doc_html_str=True)
 
     def test_api_doc_404_status_codes(self) -> None:
         result = self.client_get(

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -198,9 +198,16 @@ class DocPageTest(ZulipTestCase):
             "/api/update-message": "propagate_mode",
         }
 
-        # Validate that the parsing logic isn't broken, since if it
-        # broke, the below would become a noop.
-        self.assertGreater(len(endpoint_list), 70)
+        """
+        We have 110 endpoints as of June 2023.  If the
+        way we represent links changes, or the way we put links
+        into the main /api page changes, or if somebody simply introduces
+        a bug into the test, there is a danger of losing coverage,
+        although this is mitigated by other factors such as line
+        coverage checks.  For that reason, as well as developer convenience,
+        we don't make the check here super precise.
+        """
+        self.assertGreater(len(endpoint_list), 100)
 
         for endpoint in endpoint_list:
             url = f"/api/{endpoint}"

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -181,7 +181,15 @@ class DocPageTest(ZulipTestCase):
 
         for endpoint in endpoint_list:
             url = f"/api/{endpoint}"
-            self._test(url, "", doc_html_str=True)
+            self._test_normal_path(
+                url=url,
+                expected_content="",
+                extra_strings=[],
+                landing_missing_strings=[],
+                landing_page=True,
+                doc_html_str=True,
+                search_disabled=False,
+            )
 
     def test_api_doc_404_status_codes(self) -> None:
         result = self.client_get(


### PR DESCRIPTION
I also do some general cleanup.