### PR TITLE
search: Bold text in first search suggestion

### DIFF
--- a/web/src/search.js
+++ b/web/src/search.js
@@ -46,8 +46,7 @@ export function initialize() {
 
     $search_query_box.typeahead({
         source(query) {
-            const base_query = "";
-            const suggestions = search_suggestion.get_suggestions(base_query, query);
+            const suggestions = search_suggestion.get_suggestions(query);
             // Update our global search_map hash
             search_map = suggestions.lookup_table;
             return suggestions.strings;

--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -705,7 +705,7 @@ class Attacher {
     }
 }
 
-export function get_search_result(_base_query, query) {
+export function get_search_result(query) {
     let suggestion;
 
     // search_operators correspond to the operators for the query in the input.
@@ -808,8 +808,8 @@ export function get_search_result(_base_query, query) {
     return attacher.result.slice(0, max_items);
 }
 
-export function get_suggestions(base_query, query) {
-    const result = get_search_result(base_query, query);
+export function get_suggestions(query) {
+    const result = get_search_result(query);
     return finalize_search_result(result);
 }
 

--- a/web/src/search_suggestion.js
+++ b/web/src/search_suggestion.js
@@ -749,7 +749,16 @@ export function get_search_result(query) {
     // `has` and `is` operators work only on predefined categories. Default suggestion
     // is not displayed in that case. e.g. `messages that contain abc` as
     // a suggestion for `has:abc`does not make sense.
-    if (last.operator !== "" && last.operator !== "has" && last.operator !== "is") {
+    if (last.operator === "search") {
+        suggestion = {
+            search_string: last.operand,
+            description_html: `search for <strong>${Handlebars.Utils.escapeExpression(
+                last.operand,
+            )}</strong>`,
+        };
+        attacher.prepend_base(suggestion);
+        attacher.push(suggestion);
+    } else if (last.operator !== "" && last.operator !== "has" && last.operator !== "is") {
         suggestion = get_default_suggestion(search_operators);
         attacher.push(suggestion);
     }

--- a/web/templates/search_description.hbs
+++ b/web/templates/search_description.hbs
@@ -1,0 +1,42 @@
+{{~#each parts ~}}
+
+    {{#if (eq this.type "plain_text")~}}
+        {{~this.content~}}
+    {{else if (eq this.type "stream_topic")}}
+        {{~!-- squash whitespace --~}}
+        stream {{this.stream}} > {{this.topic}}
+        {{~!-- squash whitespace --~}}
+    {{else if (eq this.type "invalid_has")}}
+        {{~!-- squash whitespace --~}}
+        invalid {{this.operand}} operand for has operator
+        {{~!-- squash whitespace --~}}
+    {{else if (eq this.type "prefix_for_operator")}}
+        {{~!-- squash whitespace --~}}
+        {{this.prefix_for_operator}} {{this.operand}}
+        {{~!-- squash whitespace --~}}
+    {{else if (eq this.type "is_operator")}}
+        {{#if (eq this.operand "mentioned")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}@-mentions
+            {{~!-- squash whitespace --~}}
+        {{else if (or (eq this.operand "starred") (eq this.operand "alerted") (eq this.operand "unread"))}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}{{this.operand}} messages
+            {{~!-- squash whitespace --~}}
+        {{else if (or (eq this.operand "dm") (eq this.operand "private"))}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}direct messages
+            {{~!-- squash whitespace --~}}
+        {{else if (eq this.operand "resolved")}}
+            {{~!-- squash whitespace --~}}
+            {{this.verb}}topics marked as resolved
+            {{~!-- squash whitespace --~}}
+        {{else}}
+            {{~!-- squash whitespace --~}}
+            invalid {{this.operand}} operand for is operator
+            {{~!-- squash whitespace --~}}
+        {{~/if~}}
+    {{~/if~}}
+    {{~#if (not @last)~}}, {{/if~}}
+
+{{~/each~}}

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1156,9 +1156,10 @@ test("unparse", () => {
     assert.deepEqual(Filter.unparse(operators), string);
 });
 
-test("describe", () => {
+test("describe", ({mock_template}) => {
     let narrow;
     let string;
+    mock_template("search_description.hbs", true, (_data, html) => html);
 
     narrow = [{operator: "streams", operand: "public"}];
     string = "streams public";
@@ -1186,7 +1187,7 @@ test("describe", () => {
         {operator: "stream", operand: "devel"},
         {operator: "topic", operand: "JS"},
     ];
-    string = "stream devel &gt; JS";
+    string = "stream devel > JS";
     assert.equal(Filter.search_description_as_html(narrow), string);
 
     narrow = [

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -68,8 +68,8 @@ function init() {
     stream_data.clear_subscriptions();
 }
 
-function get_suggestions(base_query, query) {
-    return search.get_suggestions(base_query, query);
+function get_suggestions(query) {
+    return search.get_suggestions(query);
 }
 
 function test(label, f) {
@@ -84,7 +84,7 @@ test("basic_get_suggestions", ({override}) => {
 
     override(narrow_state, "stream", () => "office");
 
-    const suggestions = get_suggestions("", query);
+    const suggestions = get_suggestions(query);
 
     const expected = ["fred"];
     assert.deepEqual(suggestions.strings, expected);
@@ -94,7 +94,7 @@ test("basic_get_suggestions_for_spectator", () => {
     page_params.is_spectator = true;
 
     const query = "";
-    const suggestions = get_suggestions("", query);
+    const suggestions = get_suggestions(query);
     assert.deepEqual(suggestions.strings, ["", "has:link", "has:image", "has:attachment"]);
     page_params.is_spectator = false;
 });
@@ -102,7 +102,7 @@ test("basic_get_suggestions_for_spectator", () => {
 test("subset_suggestions", () => {
     const query = "stream:Denmark topic:Hamlet shakespeare";
 
-    const suggestions = get_suggestions("", query);
+    const suggestions = get_suggestions(query);
 
     const expected = [
         "stream:Denmark topic:Hamlet shakespeare",
@@ -115,7 +115,7 @@ test("subset_suggestions", () => {
 
 test("dm_suggestions", ({override}) => {
     let query = "is:dm";
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     let expected = [
         "is:dm",
         "dm:alice@zulip.com",
@@ -127,7 +127,7 @@ test("dm_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:dm al";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "is:dm al",
         "is:dm is:alerted",
@@ -142,75 +142,75 @@ test("dm_suggestions", ({override}) => {
     // we suggest "is:dm" to anyone with "is:private"
     // in their muscle memory.
     query = "is:pr";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:dm"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:private";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:dm"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "dm:t";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:t", "dm:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-dm:t";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-dm:t", "is:dm -dm:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "dm:ted@zulip.com";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:ted";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["sender:ted", "sender:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:te";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["sender:te", "sender:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-sender:te";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-sender:te", "-sender:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:ted@zulip.com";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["sender:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:unread from:ted";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:unread from:ted", "is:unread from:ted@zulip.com", "is:unread"];
     assert.deepEqual(suggestions.strings, expected);
 
     // Users can enter bizarre queries, and if they do, we want to
     // be conservative with suggestions.
     query = "is:dm near:3";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:dm near:3", "is:dm"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "dm:ted@zulip.com near:3";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:ted@zulip.com near:3", "dm:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     // Make sure suggestions still work if preceding tokens
     query = "is:alerted sender:ted@zulip.com";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:alerted sender:ted@zulip.com", "is:alerted"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:starred has:link is:dm al";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "is:starred has:link is:dm al",
         "is:starred has:link is:dm is:alerted",
@@ -225,12 +225,12 @@ test("dm_suggestions", ({override}) => {
 
     // Make sure it handles past context correctly
     query = "stream:Denmark dm:";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["stream:Denmark dm:", "stream:Denmark"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:ted@zulip.com sender:";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["sender:ted@zulip.com sender:", "sender:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -238,12 +238,12 @@ test("dm_suggestions", ({override}) => {
     // and "dm" operator as a suggestions
     override(narrow_state, "stream", () => undefined);
     query = "pm-with";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["pm-with", "dm:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "pm-with:t";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["pm-with:t", "dm:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -252,7 +252,7 @@ test("group_suggestions", () => {
     // Entering a comma in a "dm:" query should immediately
     // generate suggestions for the next person.
     let query = "dm:bob@zulip.com,";
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     let expected = [
         "dm:bob@zulip.com,",
         "dm:bob@zulip.com,alice@zulip.com",
@@ -264,25 +264,25 @@ test("group_suggestions", () => {
     // Only the last part of a comma-separated "dm" query
     // should be used to generate suggestions.
     query = "dm:bob@zulip.com,t";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:bob@zulip.com,t", "dm:bob@zulip.com,ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     // Smit should also generate ted@zulip.com (Ted Smith) as a suggestion.
     query = "dm:bob@zulip.com,Smit";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:bob@zulip.com,Smit", "dm:bob@zulip.com,ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     // Do not suggest "myself@zulip.com" (the name of the current user)
     query = "dm:ted@zulip.com,my";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:ted@zulip.com,my"];
     assert.deepEqual(suggestions.strings, expected);
 
     // No superfluous suggestions should be generated.
     query = "dm:bob@zulip.com,red";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:bob@zulip.com,red"];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -290,7 +290,7 @@ test("group_suggestions", () => {
     // if the "dm" operator is negated.
 
     query = "-dm:bob@zulip.com,";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "-dm:bob@zulip.com,",
         "is:dm -dm:bob@zulip.com,alice@zulip.com",
@@ -300,17 +300,17 @@ test("group_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-dm:bob@zulip.com,t";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-dm:bob@zulip.com,t", "is:dm -dm:bob@zulip.com,ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-dm:bob@zulip.com,Smit";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-dm:bob@zulip.com,Smit", "is:dm -dm:bob@zulip.com,ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-dm:bob@zulip.com,red";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-dm:bob@zulip.com,red"];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -318,7 +318,7 @@ test("group_suggestions", () => {
     // show suggestions for group direct messages with the "dm"
     // operator.
     query = "pm-with:bob@zulip.com,";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "pm-with:bob@zulip.com,",
         "dm:bob@zulip.com,alice@zulip.com",
@@ -329,7 +329,7 @@ test("group_suggestions", () => {
 
     // Test multiple operators
     query = "is:starred has:link dm:bob@zulip.com,Smit";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "is:starred has:link dm:bob@zulip.com,Smit",
         "is:starred has:link dm:bob@zulip.com,ted@zulip.com",
@@ -339,7 +339,7 @@ test("group_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 
     query = "stream:Denmark has:link dm:bob@zulip.com,Smit";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "stream:Denmark has:link dm:bob@zulip.com,Smit",
         "stream:Denmark has:link",
@@ -365,7 +365,7 @@ test("group_suggestions", () => {
     // Simulate a past group direct message which should now
     // prioritize ted over alice
     query = "dm:bob@zulip.com,";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "dm:bob@zulip.com,",
         "dm:bob@zulip.com,ted@zulip.com",
@@ -377,7 +377,7 @@ test("group_suggestions", () => {
     // bob, ted, and jeff are already an existing group direct message,
     // so prioritize this one
     query = "dm:bob@zulip.com,ted@zulip.com,";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "dm:bob@zulip.com,ted@zulip.com,",
         "dm:bob@zulip.com,ted@zulip.com,jeff@zulip.com",
@@ -389,7 +389,7 @@ test("group_suggestions", () => {
     // but if we start with just jeff, then don't prioritize ted over
     // alice because it doesn't complete the full group direct message.
     query = "dm:jeff@zulip.com,";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "dm:jeff@zulip.com,",
         "dm:jeff@zulip.com,alice@zulip.com",
@@ -399,7 +399,7 @@ test("group_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 
     query = "dm:jeff@zulip.com,ted@zulip.com hi";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["dm:jeff@zulip.com,ted@zulip.com hi", "dm:jeff@zulip.com,ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -410,7 +410,7 @@ test("empty_query_suggestions", () => {
     stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
 
-    const suggestions = get_suggestions("", query);
+    const suggestions = get_suggestions(query);
 
     const expected = [
         "",
@@ -454,7 +454,7 @@ test("has_suggestions", ({override}) => {
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
     override(narrow_state, "stream", () => {});
 
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     let expected = ["h", "has:link", "has:image", "has:attachment"];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -467,7 +467,7 @@ test("has_suggestions", ({override}) => {
     assert.equal(describe("has:attachment"), "Messages that contain attachments");
 
     query = "-h";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-h", "-has:link", "-has:image", "-has:attachment"];
     assert.deepEqual(suggestions.strings, expected);
     assert.equal(describe("-has:link"), "Exclude messages that contain links");
@@ -477,27 +477,27 @@ test("has_suggestions", ({override}) => {
     // operand suggestions follow.
 
     query = "has:";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["has:link", "has:image", "has:attachment"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "has:im";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["has:image"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-has:im";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-has:image"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "att";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["att", "has:attachment"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "stream:Denmark is:alerted has:lin";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "stream:Denmark is:alerted has:link",
         "stream:Denmark is:alerted",
@@ -512,7 +512,7 @@ test("check_is_suggestions", ({override}) => {
     override(narrow_state, "stream", () => {});
 
     let query = "i";
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     let expected = [
         "i",
         "is:dm",
@@ -540,7 +540,7 @@ test("check_is_suggestions", ({override}) => {
     assert.equal(describe("is:resolved"), "Topics marked as resolved");
 
     query = "-i";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "-i",
         "-is:dm",
@@ -562,27 +562,27 @@ test("check_is_suggestions", ({override}) => {
     // operand suggestions follow.
 
     query = "is:";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:dm", "is:starred", "is:mentioned", "is:alerted", "is:unread", "is:resolved"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:st";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:starred"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-is:st";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-is:starred"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "st";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["st", "streams:public", "is:starred", "stream:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "stream:Denmark has:link is:sta";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["stream:Denmark has:link is:starred", "stream:Denmark has:link", "stream:Denmark"];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -591,7 +591,7 @@ test("sent_by_me_suggestions", ({override}) => {
     override(narrow_state, "stream", () => {});
 
     let query = "";
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     assert.ok(suggestions.strings.includes("sender:myself@zulip.com"));
     assert.equal(
         suggestions.lookup_table.get("sender:myself@zulip.com").description_html,
@@ -599,47 +599,47 @@ test("sent_by_me_suggestions", ({override}) => {
     );
 
     query = "sender";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     let expected = ["sender", "sender:myself@zulip.com", "sender:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-sender";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-sender", "-sender:myself@zulip.com", "-sender:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "from";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["from", "from:myself@zulip.com", "from:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-from";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-from", "-from:myself@zulip.com", "-from:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:bob@zulip.com";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["sender:bob@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "from:bob@zulip.com";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["from:bob@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sent";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["sent", "sender:myself@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-sent";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-sent", "-sender:myself@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "stream:Denmark topic:Denmark1 sent";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "stream:Denmark topic:Denmark1 sent",
         "stream:Denmark topic:Denmark1 sender:myself@zulip.com",
@@ -649,12 +649,12 @@ test("sent_by_me_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 
     query = "is:starred sender:m";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["is:starred sender:m", "is:starred sender:myself@zulip.com", "is:starred"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:alice@zulip.com sender:";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["sender:alice@zulip.com sender:", "sender:alice@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -672,7 +672,7 @@ test("topic_suggestions", ({override}) => {
     stream_data.add_sub({stream_id: devel_id, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: office_id, name: "office", subscribed: true});
 
-    suggestions = get_suggestions("", "te");
+    suggestions = get_suggestions("te");
     expected = ["te", "sender:ted@zulip.com", "dm:ted@zulip.com", "dm-including:ted@zulip.com"];
     assert.deepEqual(suggestions.strings, expected);
 
@@ -688,7 +688,7 @@ test("topic_suggestions", ({override}) => {
         });
     }
 
-    suggestions = get_suggestions("", "te");
+    suggestions = get_suggestions("te");
     expected = [
         "te",
         "sender:ted@zulip.com",
@@ -705,23 +705,23 @@ test("topic_suggestions", ({override}) => {
     assert.equal(describe("te"), "Search for te");
     assert.equal(describe("stream:office topic:team"), "Stream office &gt; team");
 
-    suggestions = get_suggestions("", "topic:staplers stream:office");
+    suggestions = get_suggestions("topic:staplers stream:office");
     expected = ["topic:staplers stream:office", "topic:staplers"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("", "stream:devel topic:");
+    suggestions = get_suggestions("stream:devel topic:");
     expected = ["stream:devel topic:", "stream:devel topic:REXX", "stream:devel"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("", "stream:devel -topic:");
+    suggestions = get_suggestions("stream:devel -topic:");
     expected = ["stream:devel -topic:", "stream:devel -topic:REXX", "stream:devel"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("", "-topic:te");
+    suggestions = get_suggestions("-topic:te");
     expected = ["-topic:te", "stream:office -topic:team", "stream:office -topic:test"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("", "is:alerted stream:devel is:starred topic:");
+    suggestions = get_suggestions("is:alerted stream:devel is:starred topic:");
     expected = [
         "is:alerted stream:devel is:starred topic:",
         "is:alerted stream:devel is:starred topic:REXX",
@@ -731,11 +731,11 @@ test("topic_suggestions", ({override}) => {
     ];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("", "is:dm stream:devel topic:");
+    suggestions = get_suggestions("is:dm stream:devel topic:");
     expected = ["is:dm stream:devel topic:", "is:dm stream:devel", "is:dm"];
     assert.deepEqual(suggestions.strings, expected);
 
-    suggestions = get_suggestions("", "topic:REXX stream:devel topic:");
+    suggestions = get_suggestions("topic:REXX stream:devel topic:");
     expected = ["topic:REXX stream:devel topic:", "topic:REXX stream:devel", "topic:REXX"];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -789,7 +789,7 @@ test("whitespace_glitch", ({override}) => {
     override(stream_topic_history_util, "get_server_history", () => {});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
 
-    const suggestions = get_suggestions("", query);
+    const suggestions = get_suggestions(query);
 
     const expected = ["stream:office"];
 
@@ -803,17 +803,17 @@ test("stream_completion", ({override}) => {
     override(narrow_state, "stream", () => {});
 
     let query = "stream:of";
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     let expected = ["stream:of", "stream:office"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-stream:of";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-stream:of", "-stream:office"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "hel";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["hel", "stream:dev+help"];
     assert.deepEqual(suggestions.strings, expected);
 });
@@ -845,7 +845,7 @@ test("people_suggestions", ({override}) => {
     people.add_active_user(bob);
     people.add_active_user(alice);
 
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
 
     let expected = [
         "te",
@@ -898,7 +898,7 @@ test("people_suggestions", ({override}) => {
     assert.equal(get_avatar_url("sender:bob@zulip.com"), expectedString);
     assert.equal(get_avatar_url("dm-including:bob@zulip.com"), expectedString);
 
-    suggestions = get_suggestions("", "Ted "); // note space
+    suggestions = get_suggestions("Ted "); // note space
 
     expected = ["Ted", "sender:ted@zulip.com", "dm:ted@zulip.com", "dm-including:ted@zulip.com"];
 
@@ -906,17 +906,17 @@ test("people_suggestions", ({override}) => {
 
     query = "sender:ted sm";
     expected = ["sender:ted+sm", "sender:ted@zulip.com"];
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:ted@zulip.com new";
     expected = ["sender:ted@zulip.com new", "sender:ted@zulip.com"];
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     assert.deepEqual(suggestions.strings, expected);
 
     query = "sender:ted@tulip.com new";
     expected = ["sender:ted@tulip.com+new"];
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     assert.deepEqual(suggestions.strings, expected);
 });
 
@@ -925,22 +925,22 @@ test("operator_suggestions", ({override}) => {
 
     // Completed operator should return nothing
     let query = "stream:";
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     let expected = ["stream:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "st";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["st", "streams:public", "is:starred", "stream:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "-s";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["-s", "-streams:public", "-sender:myself@zulip.com", "-stream:", "-sender:"];
     assert.deepEqual(suggestions.strings, expected);
 
     query = "stream:Denmark is:alerted -f";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = [
         "stream:Denmark is:alerted -f",
         "stream:Denmark is:alerted -from:myself@zulip.com",
@@ -957,19 +957,19 @@ test("queries_with_spaces", () => {
 
     // test allowing spaces with quotes surrounding operand
     let query = 'stream:"dev he"';
-    let suggestions = get_suggestions("", query);
+    let suggestions = get_suggestions(query);
     let expected = ["stream:dev+he", "stream:dev+help"];
     assert.deepEqual(suggestions.strings, expected);
 
     // test mismatched quote
     query = 'stream:"dev h';
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["stream:dev+h", "stream:dev+help"];
     assert.deepEqual(suggestions.strings, expected);
 
     // test extra space after operator still works
     query = "stream: offi";
-    suggestions = get_suggestions("", query);
+    suggestions = get_suggestions(query);
     expected = ["stream:offi", "stream:office"];
     assert.deepEqual(suggestions.strings, expected);
 });

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -79,7 +79,9 @@ function test(label, f) {
     });
 }
 
-test("basic_get_suggestions", ({override}) => {
+test("basic_get_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (data, html) => html);
+
     const query = "fred";
 
     override(narrow_state, "stream", () => "office");
@@ -99,7 +101,9 @@ test("basic_get_suggestions_for_spectator", () => {
     page_params.is_spectator = false;
 });
 
-test("subset_suggestions", () => {
+test("subset_suggestions", ({mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     const query = "stream:Denmark topic:Hamlet shakespeare";
 
     const suggestions = get_suggestions(query);
@@ -113,7 +117,9 @@ test("subset_suggestions", () => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("dm_suggestions", ({override}) => {
+test("dm_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     let query = "is:dm";
     let suggestions = get_suggestions(query);
     let expected = [
@@ -248,7 +254,9 @@ test("dm_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("group_suggestions", () => {
+test("group_suggestions", ({mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     // Entering a comma in a "dm:" query should immediately
     // generate suggestions for the next person.
     let query = "dm:bob@zulip.com,";
@@ -446,7 +454,9 @@ test("empty_query_suggestions", () => {
     assert.equal(describe("has:attachment"), "Messages that contain attachments");
 });
 
-test("has_suggestions", ({override}) => {
+test("has_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     // Checks that category wise suggestions are displayed instead of a single
     // default suggestion when suggesting `has` operator.
     let query = "h";
@@ -506,7 +516,9 @@ test("has_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("check_is_suggestions", ({override}) => {
+test("check_is_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     stream_data.add_sub({stream_id: 44, name: "devel", subscribed: true});
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
     override(narrow_state, "stream", () => {});
@@ -587,7 +599,9 @@ test("check_is_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("sent_by_me_suggestions", ({override}) => {
+test("sent_by_me_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     override(narrow_state, "stream", () => {});
 
     let query = "";
@@ -659,7 +673,8 @@ test("sent_by_me_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("topic_suggestions", ({override}) => {
+test("topic_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
     let suggestions;
     let expected;
 
@@ -703,7 +718,7 @@ test("topic_suggestions", ({override}) => {
         return suggestions.lookup_table.get(q).description_html;
     }
     assert.equal(describe("te"), "Search for te");
-    assert.equal(describe("stream:office topic:team"), "Stream office &gt; team");
+    assert.equal(describe("stream:office topic:team"), "Stream office > team");
 
     suggestions = get_suggestions("topic:staplers stream:office");
     expected = ["topic:staplers stream:office", "topic:staplers"];
@@ -783,7 +798,9 @@ test("topic_suggestions (limits)", () => {
     assert_result("z", []);
 });
 
-test("whitespace_glitch", ({override}) => {
+test("whitespace_glitch", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     const query = "stream:office "; // note trailing space
 
     override(stream_topic_history_util, "get_server_history", () => {});
@@ -796,7 +813,9 @@ test("whitespace_glitch", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("stream_completion", ({override}) => {
+test("stream_completion", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
     stream_data.add_sub({stream_id: 88, name: "dev help", subscribed: true});
 
@@ -818,7 +837,9 @@ test("stream_completion", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("people_suggestions", ({override}) => {
+test("people_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     let query = "te";
 
     override(narrow_state, "stream", () => {});
@@ -920,7 +941,9 @@ test("people_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("operator_suggestions", ({override}) => {
+test("operator_suggestions", ({override, mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     override(narrow_state, "stream", () => undefined);
 
     // Completed operator should return nothing
@@ -951,7 +974,9 @@ test("operator_suggestions", ({override}) => {
     assert.deepEqual(suggestions.strings, expected);
 });
 
-test("queries_with_spaces", () => {
+test("queries_with_spaces", ({mock_template}) => {
+    mock_template("search_description.hbs", true, (_data, html) => html);
+
     stream_data.add_sub({stream_id: 77, name: "office", subscribed: true});
     stream_data.add_sub({stream_id: 88, name: "dev help", subscribed: true});
 

--- a/web/tests/search_suggestion.test.js
+++ b/web/tests/search_suggestion.test.js
@@ -79,9 +79,7 @@ function test(label, f) {
     });
 }
 
-test("basic_get_suggestions", ({override, mock_template}) => {
-    mock_template("search_description.hbs", true, (data, html) => html);
-
+test("basic_get_suggestions", ({override}) => {
     const query = "fred";
 
     override(narrow_state, "stream", () => "office");
@@ -717,7 +715,7 @@ test("topic_suggestions", ({override, mock_template}) => {
     function describe(q) {
         return suggestions.lookup_table.get(q).description_html;
     }
-    assert.equal(describe("te"), "Search for te");
+    assert.equal(describe("te"), "Search for <strong>te</strong>");
     assert.equal(describe("stream:office topic:team"), "Stream office > team");
 
     suggestions = get_suggestions("topic:staplers stream:office");


### PR DESCRIPTION
This comes out of a request Vlad had in #24345

before:

<img width="670" alt="image" src="https://github.com/zulip/zulip/assets/5634097/eb240d69-5f80-4fa7-90ac-74bed153569b">

after:

<img width="542" alt="image" src="https://github.com/zulip/zulip/assets/5634097/47c4c0f7-d317-4378-9364-dbca3e59741c">
