### PR TITLE
message feed: Redesign empty feed notice.

### DIFF
--- a/web/src/narrow_banner.js
+++ b/web/src/narrow_banner.js
@@ -84,7 +84,7 @@ function pick_empty_narrow_banner() {
                   },
               ),
     };
-    const default_banner_for_multiple_filters = $t({defaultMessage: "No search results."});
+    const default_banner_for_multiple_filters = $t({defaultMessage: "No search results"});
 
     const current_filter = narrow_state.filter();
 
@@ -283,7 +283,7 @@ function pick_empty_narrow_banner() {
         case "search": {
             // You are narrowed to empty search results.
             return {
-                title: $t({defaultMessage: "No search results."}),
+                title: $t({defaultMessage: "No search results"}),
                 search_data: retrieve_search_query_data(),
             };
         }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1349,11 +1349,6 @@
         }
     }
 
-    .history-limited-box,
-    .all-messages-search-caution {
-        background-color: hsl(0deg 0% 0% / 20%);
-    }
-
     #feedback_container,
     code,
     .typeahead.dropdown-menu {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -289,26 +289,12 @@ p.n-margin {
 
 .history-limited-box {
     color: hsl(16deg 60% 45%);
-    border: 1px solid hsl(16deg 60% 45%);
-    box-shadow: 0 0 2px hsl(16deg 60% 45%);
-}
-
-.all-messages-search-caution {
-    border: 1px solid hsl(192deg 19% 75% / 20%);
-    box-shadow: 0 0 2px hsl(192deg 19% 75% / 20%);
 }
 
 .history-limited-box,
 .all-messages-search-caution {
-    border-radius: 4px;
     display: none;
     font-size: 16px;
-    margin: 0 auto 12px;
-    padding: 5px;
-    /* Difference should be 16px to accommodate the icon. */
-    /* This emulates hanging indent. */
-    padding-left: 26px;
-    text-indent: -10px;
 
     & i {
         margin: 0 3px 0 1px;
@@ -2307,6 +2293,12 @@ nav {
     border-radius: 6px;
 }
 
+#message_feed_errors_container {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+}
+
 #create_stream_subscribers {
     margin-top: 10px;
 
@@ -2471,7 +2463,6 @@ select.invite-as {
 }
 
 .empty_feed_notice {
-    padding: 3em 1em;
     text-align: center;
 }
 

--- a/web/templates/empty_feed_notice.hbs
+++ b/web/templates/empty_feed_notice.hbs
@@ -1,23 +1,6 @@
 <div class="empty_feed_notice">
     <h4> {{ title }} </h4>
-    {{#if search_data}}
-    <div>
-        {{#if search_data.has_stop_word}}{{t "Some common words were excluded from your search." }} <br/>{{/if}}{{t "You searched for:" }}
-        {{#if search_data.stream_query}}
-        <span>stream: {{search_data.stream_query}}</span>
-        {{/if}}
-        {{#if search_data.topic_query}}
-        <span>topic: {{search_data.topic_query}}</span>
-        {{/if}}
-        {{#each search_data.query_words}}
-            {{#if is_stop_word}}
-            <del>{{query_word}}</del>
-            {{else}}
-            <span>{{query_word}}</span>
-            {{/if}}
-        {{/each}}
-    </div>
-    {{else}}
+    {{#if html}}
     {{{ html }}}
     {{/if}}
 </div>

--- a/web/templates/message_feed_errors.hbs
+++ b/web/templates/message_feed_errors.hbs
@@ -9,16 +9,15 @@
         {{/tr}}
     </p>
 </div>
+<div class="empty_feed_notice_main"></div>
 <div class="all-messages-search-caution hidden-for-spectators" hidden>
     <p>
-        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
         {{#tr}}
         End of results from your
         <z-link>history</z-link>.
         {{#*inline "z-link"}}<a href="/help/search-for-messages#searching-shared-history"
           target="_blank" rel="noopener noreferrer">{{> @partial-block}}</a>{{/inline}}
         {{/tr}}
-        &nbsp;
         <span>
             {{#tr}}
             Consider <z-link>searching all public streams</z-link>.
@@ -27,4 +26,3 @@
         </span>
     </p>
 </div>
-<div class="empty_feed_notice_main"></div>

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -100,13 +100,6 @@ run_test("empty_narrow_html", ({mock_template}) => {
         actual_html,
         `<div class="empty_feed_notice">
     <h4> This is a title </h4>
-    <div>
-        Some common words were excluded from your search. <br/>You searched for:
-        <span>stream: new</span>
-        <span>topic: test</span>
-            <span>search</span>
-            <del>a</del>
-    </div>
 </div>
 `,
     );
@@ -125,11 +118,6 @@ run_test("empty_narrow_html", ({mock_template}) => {
         actual_html,
         `<div class="empty_feed_notice">
     <h4> This is a title </h4>
-    <div>
-        You searched for:
-        <span>stream: hello world</span>
-            <span>searchA</span>
-    </div>
 </div>
 `,
     );
@@ -148,11 +136,6 @@ run_test("empty_narrow_html", ({mock_template}) => {
         actual_html,
         `<div class="empty_feed_notice">
     <h4> This is a title </h4>
-    <div>
-        You searched for:
-        <span>topic: hello</span>
-            <span>searchB</span>
-    </div>
 </div>
 `,
     );
@@ -263,7 +246,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", ""),
+        empty_narrow_html("translated: No search results", ""),
     );
     page_params.is_spectator = false;
 
@@ -482,7 +465,7 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results."),
+        empty_narrow_html("translated: No search results"),
     );
 
     set_filter([["is", "invalid"]]);
@@ -520,17 +503,6 @@ run_test("show_empty_narrow_message", ({mock_template}) => {
     );
 });
 
-run_test("show_empty_narrow_message_with_search", ({mock_template}) => {
-    page_params.stop_words = [];
-
-    mock_template("empty_feed_notice.hbs", true, (data, html) => html);
-
-    narrow_state.reset_current_filter();
-    set_filter([["search", "grail"]]);
-    narrow_banner.show_empty_narrow_message();
-    assert.match($(".empty_feed_notice_main").html(), /<span>grail<\/span>/);
-});
-
 run_test("hide_empty_narrow_message", () => {
     narrow_banner.hide_empty_narrow_message();
     assert.equal($(".empty_feed_notice").text(), "never-been-set");
@@ -554,7 +526,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", undefined, expected_search_data),
+        empty_narrow_html("translated: No search results", undefined, expected_search_data),
     );
 
     const expected_stream_search_data = {
@@ -573,7 +545,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
     narrow_banner.show_empty_narrow_message();
     assert.equal(
         $(".empty_feed_notice_main").html(),
-        empty_narrow_html("translated: No search results.", undefined, expected_stream_search_data),
+        empty_narrow_html("translated: No search results", undefined, expected_stream_search_data),
     );
 
     const expected_stream_topic_search_data = {
@@ -595,7 +567,7 @@ run_test("show_search_stopwords", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results.",
+            "translated: No search results",
             undefined,
             expected_stream_topic_search_data,
         ),
@@ -617,7 +589,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results.",
+            "translated: No search results",
             "translated HTML: <p>You are searching for messages that belong to more than one stream, which is not possible.</p>",
         ),
     );
@@ -630,7 +602,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results.",
+            "translated: No search results",
             "translated HTML: <p>You are searching for messages that belong to more than one topic, which is not possible.</p>",
         ),
     );
@@ -646,7 +618,7 @@ run_test("show_invalid_narrow_message", ({mock_template}) => {
     assert.equal(
         $(".empty_feed_notice_main").html(),
         empty_narrow_html(
-            "translated: No search results.",
+            "translated: No search results",
             "translated HTML: <p>You are searching for messages that are sent by more than one person, which is not possible.</p>",
         ),
     );


### PR DESCRIPTION
Part of #24345 (redesigning the search bar)

* [CZO thread discussing this change](https://chat.zulip.org/#narrow/stream/101-design/topic/search.20empty.20results)
* [Figma for the empty search screen](https://www.figma.com/file/jbNOiBWvbtLuHaiTj4CW0G/Zulip-Web-App?type=design&node-id=1700-137541&mode=design&t=UhuV7tXTigUjuQQA-0)

This changes the design of the screen that shows when there are no search results, as well as the banner that shows when the user reaches the end of search results if there are possiby more results in a public stream search or results in messages not searchable because the organization has limited history.

<details>
<summary>before</summary>

<img width="769" alt="image" src="https://github.com/zulip/zulip/assets/5634097/5af71233-0519-4614-8c84-248581b9b462">


</details>

<details>
<summary>after</summary>

<img width="737" alt="image" src="https://github.com/zulip/zulip/assets/5634097/6310d3d9-1ab7-415d-b8b1-9d6a7b625992">

<img width="756" alt="image" src="https://github.com/zulip/zulip/assets/5634097/d5860705-74aa-4e68-ab8c-369c14031780">

also visible for when there are some search results:

<img width="742" alt="image" src="https://github.com/zulip/zulip/assets/5634097/be074ce4-5514-4bfa-9077-0d2a5a8ea7cb">
</details>
