### PR TITLE
streams: Send stream creation events when subscribing guests.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 192**
+
+* [`GET /events`](/api/get-events): Stream creation events are now
+  sent when guest users gain access to a public stream by being
+  subscribed. Guest users previously only received these events when
+  subscribed to private streams.
+
 **Feature level 191**
 
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 191
+API_FEATURE_LEVEL = 192
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1168,6 +1168,11 @@ paths:
                                 the new stream exists (for private streams, only subscribers and
                                 organization administrators will receive this event).
 
+                                This event is also sent when a user gains access to a stream they
+                                previously [could not access](/help/stream-permissions), such as
+                                when a private stream is made public, or when a user is subscribed
+                                to a private stream.
+
                                 Note that organization administrators who are not subscribed will
                                 not be able to see content on the stream; just that it exists.
                               properties:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1170,11 +1170,15 @@ paths:
 
                                 This event is also sent when a user gains access to a stream they
                                 previously [could not access](/help/stream-permissions), such as
-                                when a private stream is made public, or when a user is subscribed
-                                to a private stream.
+                                when a private stream is made public, or when a [guest user](/help/roles-and-permissions)
+                                is subscribed to a public (or private) stream.
 
                                 Note that organization administrators who are not subscribed will
                                 not be able to see content on the stream; just that it exists.
+
+                                **Changes**: Prior to Zulip 8.0 (feature level 192), this event was
+                                not sent when guest users gained access to a public stream by being
+                                subscribed.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3261,6 +3261,18 @@ class SubscribeActionTest(BaseAction):
             10,
         )
 
+        stream.invite_only = False
+        stream.save()
+
+        # Subscribe as a guest to a public stream.
+        self.user_profile = self.example_user("polonius")
+        action = lambda: bulk_add_subscriptions(
+            user_profile.realm, [stream], [self.user_profile], acting_user=None
+        )
+        events = self.verify_action(action, include_subscribers=include_subscribers, num_events=2)
+        check_stream_create("events[0]", events[0])
+        check_subscription_add("events[1]", events[1])
+
 
 class DraftActionTest(BaseAction):
     def do_enable_drafts_synchronization(self, user_profile: UserProfile) -> None:


### PR DESCRIPTION
We did not send the stream creation events when subscribing guests to public streams while we do send them when subscribing non-admin users to private streams.

This commit adds code to send the stream creation events when subscribing guests to public streams, so the clients can know that stream exists and fixes the bug where client tries to process a subscription add event for a stream which it does not know about.

<!-- Describe your pull request here.-->
 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
