### PR TITLE
message_feed: Fix edited notice to appear for disabled edit_history.

### DIFF
--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -58,7 +58,7 @@ function same_recipient(a, b) {
     return util.same_recipient(a.msg, b.msg);
 }
 
-function analyze_edit_history(message) {
+function analyze_edit_history(message, last_edit_timestr) {
     // Returns a dict of booleans that describe the message's history:
     //   * edited: if the message has had its content edited
     //   * moved: if the message has had its stream/topic edited
@@ -100,6 +100,12 @@ function analyze_edit_history(message) {
                 moved = true;
             }
         }
+    } else if (last_edit_timestr !== undefined) {
+        // When the edit_history is disabled for the organization, we do not receive the edit_history
+        // variable in the message object. In this case, we will check if the last_edit_timestr is
+        // available or not. Since we don't have the edit_history, we can't determine if the message
+        // was moved or edited. Therefore, we simply mark the messages as edited.
+        edited = true;
     }
     return {edited, moved, resolve_toggled};
 }
@@ -307,7 +313,7 @@ export class MessageListView {
         const include_sender = message_container.include_sender;
         const is_hidden = message_container.is_hidden;
         const status_message = Boolean(message_container.status_message);
-        const edit_history_details = analyze_edit_history(message_container.msg);
+        const edit_history_details = analyze_edit_history(message_container.msg, last_edit_timestr);
 
         if (
             last_edit_timestr === undefined ||


### PR DESCRIPTION
This PR fixes the bug where the edited notice is not displayed for edited/moved messages when the edit_history is disabled for the organization. However, this is incorrect because the edited notice should still be shown for messages that are edited/moved, even if the edit_history is disabled. This issue occurred because the edit_history variable was not set in the message object when the edit_history is disabled. Therefore, in this case, we check for the availability of last_edit_timestr. If it is available, we display the edited notice. Since we cannot determine if the message was moved or edited, we show the edited notice for both cases.

-----------------

Fixes: [CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/edited.20notice.20disappears.20on.20refreshing)


-------------

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
