### PR TITLE
test-backend: Enable single-threaded profiling when thread count is unspecified.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -395,7 +395,12 @@ def main() -> None:
     # dynamic resolution of the test runner type with the django-stubs mypy plugin.
     TestRunner = cast("Type[Runner]", get_runner(settings))
 
-    parallel = default_parallel if options.processes is None else options.processes
+    if options.processes:
+        parallel = options.processes
+    elif options.profile:
+        parallel = 1
+    else:
+        parallel = default_parallel
     if parallel > 1:
         print(f"-- Running tests in parallel mode with {parallel} processes.", flush=True)
     else:


### PR DESCRIPTION
If the number of threads is not specified while profiling then use a single thread. This is because profiling across multiple threads (earlier default behaviour) may obscure the accurate measurement of which functions are the most costly due to thread blocking.

More context: https://chat.zulip.org/#narrow/stream/3-backend/topic/test-backend.20performance/near/1601293.