### PR TITLE
theme: Change recipient bar color and theme in the same paint.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -847,15 +847,19 @@ export function initialize() {
     $("body").on("click", "#gear-menu .dark-theme", (e) => {
         // Allow propagation to close gear menu.
         e.preventDefault();
-        dark_theme.enable();
-        message_lists.update_recipient_bar_background_color();
+        requestAnimationFrame(() => {
+            dark_theme.enable();
+            message_lists.update_recipient_bar_background_color();
+        });
     });
 
     $("body").on("click", "#gear-menu .light-theme", (e) => {
         // Allow propagation to close gear menu.
         e.preventDefault();
-        dark_theme.disable();
-        message_lists.update_recipient_bar_background_color();
+        requestAnimationFrame(() => {
+            dark_theme.disable();
+            message_lists.update_recipient_bar_background_color();
+        });
     });
 
     $("body").on("click", "#header-container .brand", (e) => {

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -746,7 +746,7 @@ export function dispatch_normal_event(event) {
                 unread_ui.update_unread_banner();
             }
             if (event.property === "color_scheme") {
-                setTimeout(() => {
+                requestAnimationFrame(() => {
                     if (event.value === settings_config.color_scheme_values.night.code) {
                         dark_theme.enable();
                         realm_logo.render();
@@ -758,7 +758,7 @@ export function dispatch_normal_event(event) {
                         realm_logo.render();
                     }
                     message_lists.update_recipient_bar_background_color();
-                }, 300);
+                });
             }
             if (event.property === "starred_message_counts") {
                 starred_messages_ui.rerender_ui();

--- a/web/src/zcommand.js
+++ b/web/src/zcommand.js
@@ -61,8 +61,10 @@ export function switch_to_light_theme() {
     send({
         command: "/day",
         on_success(data) {
-            dark_theme.disable();
-            message_lists.update_recipient_bar_background_color();
+            requestAnimationFrame(() => {
+                dark_theme.disable();
+                message_lists.update_recipient_bar_background_color();
+            });
             feedback_widget.show({
                 populate($container) {
                     const rendered_msg = markdown.parse_non_message(data.msg);
@@ -84,8 +86,10 @@ export function switch_to_dark_theme() {
     send({
         command: "/night",
         on_success(data) {
-            dark_theme.enable();
-            message_lists.update_recipient_bar_background_color();
+            requestAnimationFrame(() => {
+                dark_theme.enable();
+                message_lists.update_recipient_bar_background_color();
+            });
             feedback_widget.show({
                 populate($container) {
                     const rendered_msg = markdown.parse_non_message(data.msg);

--- a/web/tests/dispatch.test.js
+++ b/web/tests/dispatch.test.js
@@ -17,7 +17,7 @@ const test_message = events.test_message;
 const test_user = events.test_user;
 const typing_person1 = events.typing_person1;
 
-set_global("setTimeout", (func) => func());
+set_global("requestAnimationFrame", (func) => func());
 
 const activity = mock_esm("../src/activity");
 const alert_words_ui = mock_esm("../src/alert_words_ui");


### PR DESCRIPTION
`update_recipient_bar_background_color` changes in a paint after change in theme without using `requestAnimationFrame` to make sure they happen in the same paint.

I am not able to capture this change in my GIF tool properly but color changes are definitely happening together now with the message header.

discussion: https://github.com/zulip/zulip/pull/25777#issuecomment-1564652487