### PR TITLE
Polish UI for portico pages copy-codeblock button #25962

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -782,6 +782,7 @@ li,
     width: 10px;
     padding: 6px;
     display: block;
+    cursor: pointer;
     /* The below two avoids the padded element from displaying
     its own border and background color */
     border: none;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -791,9 +791,29 @@ li,
     icon is clickable and is needed because of reduced
     opacity of readonly textarea */
     z-index: 2;
+    transition: transform 0.3s ease;
 
     &:hover svg path {
         fill: hsl(200deg 100% 40%);
+        animation: pulse 1s infinite;
+    }
+}
+
+.copy_button_base svg path {
+    transition: transform 0.3s ease;
+}
+
+@keyframes pulse {
+    0% {
+        transform: scale(1);
+    }
+
+    50% {
+        transform: scale(1.1);
+    }
+
+    100% {
+        transform: scale(1);
     }
 }
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
In this PR, I set the cursor style of the copy code button to pointer and enhanced the hover effect, making it pulse as well as turning blue.
Most of the items requested in the issue was already implemented, such as the tooltips and basic hover effect. I made this changes trying to improve the UI for copy code button, but maybe this issue could already be closed. However, I'm making this PR as a suggestion, trying to contribute the best way I could.

Fixes: https://github.com/zulip/zulip/issues/25962<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
![WhatsApp Video 2023-07-02 at 16 39 50](https://github.com/zulip/zulip/assets/83559250/a351e6a9-29ea-4edd-82cd-9e2ae8ab8d97)


After:
![#Venice - Zulip Dev - Zulip - Google Chrome 2023-07-02 16-36-09 (1)](https://github.com/zulip/zulip/assets/83559250/5e955850-f0df-49d2-81c8-86e8a8692007)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
