### PR TITLE
scheduled_messages: Update datatype from array to dictionary

### DIFF
--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -18,7 +18,8 @@ import * as timerender from "./timerender";
 export const MINIMUM_SCHEDULED_MESSAGE_DELAY_SECONDS = 5 * 60;
 export const SCHEDULING_MODAL_UPDATE_INTERVAL_IN_MILLISECONDS = 60 * 1000;
 
-export let scheduled_messages_data = [];
+// scheduled_messages_data is a dictionary where key=scheduled_message_id and value=scheduled_messages
+export const scheduled_messages_data = {};
 
 function compute_send_times(now = new Date()) {
     const send_times = {};
@@ -59,12 +60,6 @@ export function is_send_later_timestamp_missing_or_expired(
     return false;
 }
 
-function sort_scheduled_messages_data() {
-    scheduled_messages_data.sort(
-        (msg1, msg2) => msg1.scheduled_delivery_timestamp - msg2.scheduled_delivery_timestamp,
-    );
-}
-
 function hide_scheduled_message_success_compose_banner(scheduled_message_id) {
     $(
         `.message_scheduled_success_compose_banner[data-scheduled-message-id=${scheduled_message_id}]`,
@@ -72,31 +67,24 @@ function hide_scheduled_message_success_compose_banner(scheduled_message_id) {
 }
 
 export function add_scheduled_messages(scheduled_messages) {
-    scheduled_messages_data.push(...scheduled_messages);
-    sort_scheduled_messages_data();
+    for (const scheduled_message of scheduled_messages) {
+        scheduled_messages_data[scheduled_message.scheduled_message_id] = scheduled_message;
+    }
 }
 
 export function remove_scheduled_message(scheduled_message_id) {
-    const msg_index = scheduled_messages_data.findIndex(
-        (msg) => msg.scheduled_message_id === scheduled_message_id,
-    );
-    if (msg_index !== undefined) {
-        scheduled_messages_data.splice(msg_index, 1);
+    if (scheduled_messages_data[scheduled_message_id] !== undefined) {
+        delete scheduled_messages_data[scheduled_message_id];
         hide_scheduled_message_success_compose_banner(scheduled_message_id);
     }
 }
 
 export function update_scheduled_message(scheduled_message) {
-    const msg_index = scheduled_messages_data.findIndex(
-        (msg) => msg.scheduled_message_id === scheduled_message.scheduled_message_id,
-    );
-
-    if (msg_index === undefined) {
+    if (scheduled_messages_data[scheduled_message.scheduled_message_id] === undefined) {
         return;
     }
 
-    scheduled_messages_data[msg_index] = scheduled_message;
-    sort_scheduled_messages_data();
+    scheduled_messages_data[scheduled_message.scheduled_message_id] = scheduled_message;
 }
 
 function narrow_via_edit_scheduled_message(compose_args) {
@@ -168,9 +156,7 @@ function show_message_unscheduled_banner(scheduled_delivery_timestamp) {
 }
 
 export function edit_scheduled_message(scheduled_message_id, should_narrow_to_recipient = true) {
-    const scheduled_msg = scheduled_messages_data.find(
-        (msg) => msg.scheduled_message_id === scheduled_message_id,
-    );
+    const scheduled_msg = scheduled_messages_data[scheduled_message_id];
     delete_scheduled_message(scheduled_message_id, () => {
         open_scheduled_message_in_compose(scheduled_msg, should_narrow_to_recipient);
         show_message_unscheduled_banner(scheduled_msg.scheduled_delivery_timestamp);
@@ -185,7 +171,7 @@ export function delete_scheduled_message(scheduled_msg_id, success = () => {}) {
 }
 
 export function get_count() {
-    return scheduled_messages_data.length;
+    return Object.keys(scheduled_messages_data).length;
 }
 
 export function get_filtered_send_opts(date) {
@@ -296,7 +282,7 @@ export function get_filtered_send_opts(date) {
 }
 
 export function initialize(scheduled_messages_params) {
-    scheduled_messages_data = scheduled_messages_params.scheduled_messages;
+    add_scheduled_messages(scheduled_messages_params.scheduled_messages);
 
     $("body").on("click", ".undo_scheduled_message", (e) => {
         const scheduled_message_id = Number.parseInt(

--- a/web/src/scheduled_messages_overlay_ui.js
+++ b/web/src/scheduled_messages_overlay_ui.js
@@ -16,7 +16,8 @@ import * as timerender from "./timerender";
 export const keyboard_handling_context = {
     get_items_ids() {
         const scheduled_messages_ids = [];
-        for (const message of scheduled_messages.scheduled_messages_data) {
+        const sorted_messages = sort_scheduled_messages(scheduled_messages.scheduled_messages_data);
+        for (const message of sorted_messages) {
             scheduled_messages_ids.push(message.scheduled_message_id);
         }
         return scheduled_messages_ids;
@@ -47,13 +48,21 @@ export const keyboard_handling_context = {
     id_attribute_name: "data-scheduled-message-id",
 };
 
+function sort_scheduled_messages(scheduled_messages) {
+    const sorted_messages = Object.values(scheduled_messages).sort(
+        (msg1, msg2) => msg1.scheduled_delivery_timestamp - msg2.scheduled_delivery_timestamp,
+    );
+    return sorted_messages;
+}
+
 export function handle_keyboard_events(e, event_key) {
     messages_overlay_ui.modals_handle_events(e, event_key, keyboard_handling_context);
 }
 
 function format(scheduled_messages) {
     const formatted_msgs = [];
-    for (const msg of scheduled_messages) {
+    const sorted_messages = sort_scheduled_messages(scheduled_messages);
+    for (const msg of sorted_messages) {
         const msg_render_context = {...msg};
         if (msg.type === "stream") {
             msg_render_context.is_stream = true;


### PR DESCRIPTION
This PR changes the datatype of scheduled_messages from an array to a dictionary type.
The aim of this PR is to reduce the higher cost of updation & deletion in array type.
With the dictionary datatype, we can perform operations on the data with the use of the message_id.
The dictionary stores a message object which is referenced by a key.
The key format is "message-<scheduled_message_id>".

Fixes: #25557 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
