### PR TITLE
blueslip: Simplify expectOne error message.

### DIFF
--- a/web/src/setup.js
+++ b/web/src/setup.js
@@ -41,7 +41,7 @@ $(() => {
 
     $.fn.expectOne = function () {
         if (blueslip && this.length !== 1) {
-            blueslip.error("Expected one element in jQuery set, found more", {length: this.length});
+            blueslip.error("Expected one element in jQuery set", {length: this.length});
         }
         return this;
     };


### PR DESCRIPTION
This error is logged if there are 0 or 2+ elements, so the generic language here is meant to cover both cases.

[CZO discussion](https://chat.zulip.org/#narrow/stream/464-kandra-js-errors/topic/Error.3A.20Expected.20one.20element.20in.20jQuery.20set.2C.20found.20more/near/1600194)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>