### PR TITLE
message_edit: Suppress message controls popover in edit views.

### DIFF
--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -220,10 +220,13 @@ export function register_popover_menu(target, popover_props) {
 }
 
 export function toggle_message_actions_menu(message) {
-    if (message.locally_echoed) {
+    if (message.locally_echoed || message_edit.is_editing(message.id)) {
         // Don't open the popup for locally echoed messages for now.
         // It creates bugs with things like keyboard handlers when
         // we get the server response.
+        // We also suppress the popup for messages in an editing state,
+        // including previews, when a user tries to reach them from the
+        // keyboard.
         return true;
     }
 


### PR DESCRIPTION
This addresses an edge case where a user viewing a message in an edit mode (either as editable or source) triggers the `i` hotkey to trigger the message controls, which are not present and therefore not triggerable.

[CZO discussion](https://chat.zulip.org/#narrow/stream/464-kandra-js-errors/topic/Error.3A.20Expected.20one.20element.20in.20jQuery.20set.2C.20found.20more/near/1600194)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>