### PR TITLE
welcome-emails: Separate followup_day1 email from welcome emails.

### DIFF
--- a/help/disable-welcome-emails.md
+++ b/help/disable-welcome-emails.md
@@ -2,10 +2,12 @@
 
 {!admin-only.md!}
 
-Zulip sends a handful of emails to new users when they join, telling them their
-Zulip account details, and introducing them to the Zulip app. You can disable
-these emails if they don't make sense for your organization. If you do so, you
-will need to inform users how to log in to their Zulip accounts.
+Zulip sends a handful of emails to new users, introducing them to the Zulip
+app, when they join an organization. If these emails don't make sense for
+your organization, you can disable them.
+
+Note that regardless of this setting, users will receive an initial account
+email notifying them about their new Zulip account and how to log in.
 
 ## Disable welcome emails
 

--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -19,7 +19,7 @@ from zerver.actions.users import change_user_is_active, get_service_dicts_for_bo
 from zerver.lib.avatar import avatar_url
 from zerver.lib.create_user import create_user
 from zerver.lib.default_streams import get_slim_realm_default_streams
-from zerver.lib.email_notifications import enqueue_welcome_emails
+from zerver.lib.email_notifications import enqueue_welcome_emails, send_account_registered_email
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.send_email import clear_scheduled_invitation_emails
 from zerver.lib.stream_subscription import bulk_get_subscriber_peer_info
@@ -277,7 +277,11 @@ def process_new_human_user(
     # from being sent after the user is created.
     clear_scheduled_invitation_emails(user_profile.delivery_email)
     if realm.send_welcome_emails:
-        enqueue_welcome_emails(user_profile, realm_creation)
+        enqueue_welcome_emails(user_profile)
+
+    # Schedule an initial email with the user's
+    # new account details and log-in information.
+    send_account_registered_email(user_profile, realm_creation)
 
     # We have an import loop here; it's intentional, because we want
     # to keep all the onboarding code in zerver/lib/onboarding.py.

--- a/zerver/management/commands/deliver_scheduled_emails.py
+++ b/zerver/management/commands/deliver_scheduled_emails.py
@@ -1,7 +1,6 @@
 """\
 Send email messages that have been queued for later delivery by
-various things (at this time invitation reminders and day1/day2
-followup emails).
+various things (e.g. invitation reminders and welcome emails).
 
 This management command is run via supervisor.
 """

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -403,7 +403,7 @@ class TestDevelopmentEmailsLog(ZulipTestCase):
             )  # Generates emails and redirects to /emails/
             self.assertEqual("/emails/", result["Location"])  # Make sure redirect URL is correct.
 
-            # The above call to /emails/generate/ creates 15 emails and
+            # The above call to /emails/generate/ creates the emails and
             # logs the below line for every email.
             output_log = (
                 "INFO:root:Emails sent in development are available at http://testserver/emails"

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -323,7 +323,7 @@ class RealmTest(ZulipTestCase):
     def test_do_deactivate_realm_clears_scheduled_jobs(self) -> None:
         user = self.example_user("hamlet")
         send_future_email(
-            "zerver/emails/followup_day1",
+            "zerver/emails/followup_day2",
             user.realm,
             to_user_ids=[user.id],
             delay=datetime.timedelta(hours=1),

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1134,9 +1134,9 @@ class EmailUnsubscribeTests(ZulipTestCase):
         click even when logged out to stop receiving them.
         """
         user_profile = self.example_user("hamlet")
-        # Simulate a new user signing up, which enqueues 3 welcome e-mails.
+        # Simulate scheduling welcome e-mails for a new user.
         enqueue_welcome_emails(user_profile)
-        self.assertEqual(3, ScheduledEmail.objects.filter(users=user_profile).count())
+        self.assertEqual(2, ScheduledEmail.objects.filter(users=user_profile).count())
 
         # Simulate unsubscribing from the welcome e-mails.
         unsubscribe_link = one_click_unsubscribe_link(user_profile, "welcome")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1618,7 +1618,7 @@ class ActivateTest(ZulipTestCase):
     def test_clear_scheduled_jobs(self) -> None:
         user = self.example_user("hamlet")
         send_future_email(
-            "zerver/emails/followup_day1",
+            "zerver/emails/followup_day2",
             user.realm,
             to_user_ids=[user.id],
             delay=datetime.timedelta(hours=1),
@@ -1631,7 +1631,7 @@ class ActivateTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
         send_future_email(
-            "zerver/emails/followup_day1",
+            "zerver/emails/followup_day2",
             iago.realm,
             to_user_ids=[hamlet.id, iago.id],
             delay=datetime.timedelta(hours=1),
@@ -1647,7 +1647,7 @@ class ActivateTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         iago = self.example_user("iago")
         send_future_email(
-            "zerver/emails/followup_day1",
+            "zerver/emails/followup_day2",
             iago.realm,
             to_user_ids=[hamlet.id, iago.id],
             delay=datetime.timedelta(hours=1),
@@ -1662,7 +1662,7 @@ class ActivateTest(ZulipTestCase):
         iago = self.example_user("iago")
         hamlet = self.example_user("hamlet")
         send_future_email(
-            "zerver/emails/followup_day1",
+            "zerver/emails/followup_day2",
             iago.realm,
             to_user_ids=[hamlet.id, iago.id],
             delay=datetime.timedelta(hours=1),
@@ -1688,7 +1688,7 @@ class ActivateTest(ZulipTestCase):
         hamlet = self.example_user("hamlet")
         to_user_ids = [hamlet.id, iago.id]
         send_future_email(
-            "zerver/emails/followup_day1",
+            "zerver/emails/followup_day2",
             iago.realm,
             to_user_ids=to_user_ids,
             delay=datetime.timedelta(hours=1),
@@ -1711,7 +1711,7 @@ class ActivateTest(ZulipTestCase):
             [
                 f"WARNING:zulip.send_email:ScheduledEmail {email_id} at {scheduled_at} "
                 "had empty users and address attributes: "
-                "{'template_prefix': 'zerver/emails/followup_day1', 'from_name': None, "
+                "{'template_prefix': 'zerver/emails/followup_day2', 'from_name': None, "
                 "'from_address': None, 'language': None, 'context': {}}"
             ],
         )

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -13,7 +13,7 @@ from confirmation.models import Confirmation, confirmation_url
 from zerver.actions.realm_settings import do_send_realm_reactivation_email
 from zerver.actions.user_settings import do_change_user_delivery_email
 from zerver.actions.users import change_user_is_active
-from zerver.lib.email_notifications import enqueue_welcome_emails
+from zerver.lib.email_notifications import enqueue_welcome_emails, send_account_registered_email
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
 from zerver.models import Realm, get_realm, get_realm_stream, get_user_by_delivery_email
@@ -137,11 +137,17 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     # Reset the email value so we can run this again
     do_change_user_delivery_email(user_profile, registered_email)
 
-    # Follow up day1 day2 emails for normal user
+    # Initial email with new account information for normal user.
+    send_account_registered_email(user_profile)
+
+    # Follow up day2 and onboarding zulip guide emails for normal user
     enqueue_welcome_emails(user_profile)
 
-    # Follow up day1 day2 emails for admin user
-    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm), realm_creation=True)
+    # Initial email with new account information for admin user
+    send_account_registered_email(get_user_by_delivery_email("iago@zulip.com", realm))
+
+    # Follow up day2 and onboarding zulip guide emails for admin user
+    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm))
 
     # Realm reactivation email
     do_send_realm_reactivation_email(realm, acting_user=None)

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -587,7 +587,7 @@ i18n_urls = [
         name="confirm_email_change",
     ),
     # Email unsubscription endpoint. Allows for unsubscribing from various types of emails,
-    # including the welcome emails (day 1 & 2), missed PMs, etc.
+    # including welcome emails, missed direct messages, etc.
     path(
         "accounts/unsubscribe/<email_type>/<confirmation_key>",
         email_unsubscribe,


### PR DESCRIPTION
Separates the `followup_day1` email from the scheduled welcome emails, and instead sends the email directly when a new user account is created.

Fixes #25268.

**Notes**:
- There are 4 small prep commits with minor updates to tests and code comments.
- Did the changes to `followup_day1` email in two steps:
  - First, I removed it from `enqueue_welcome_emails`, creating a specific function for the `followup_day1` email and always scheduling it (without delay) when a new (human) user is created/processed.
  - Then, I switched it from being scheduled (without delay) to being sent via `send_email` in a separate commit. If we want to keep the email as a scheduled email, then it is easy to drop this commit, but it seemed cleaner for the implementation to make this change.
- I didn't change the email template name in these changes even though `followup_day1` is probably not the best name for this email.
  - Doing so will impact translations, and I wasn't sure how renaming the template might impact existing scheduled emails with the current template name (though they should be at the top of the send email queue).
  - I thought that renaming the template could be a follow-up task if people feel it's important to change. After these changes there are two remaining instances of `followup_day1` in the `zerver` directory: when we send the email as we reference the template name there, and a currently commented out translated string test in `test_i18n.py`.
- The final commit is an update to the help center article on disabling welcome emails in an organization.
- Note there is no change to the `followup_day1` email content / subject / sender / etc. in these changes.

**Questions**:
- Is this a change that we would want to inform organization administrators of?
  - I don't know how many Zulip Cloud organizations have sending welcome emails disabled, but I can see it being worth a heads up that we now send this email for all new user accounts created.
  - And noting it in the next major release for self-hosted organizations might make sense as well?

**Screenshots and screen captures:**

<details>
<summary>Help center: Disable welcome emails</summary>

[Current documentation](https://zulip.com/help/disable-welcome-emails)
![Screenshot from 2023-07-04 13-06-47](https://github.com/zulip/zulip/assets/63245456/95f8c334-908c-4d99-bd63-c4b466b15fa8)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
