### PR TITLE
user_profile: Add subscribe widget to user profile.

### DIFF
--- a/web/src/dropdown_widget.js
+++ b/web/src/dropdown_widget.js
@@ -86,6 +86,16 @@ export class DropdownWidget {
         );
     }
 
+    show_empty_if_no_items($popper) {
+        const list_items = this.list_widget.get_current_list();
+        const $no_search_results = $popper.find(".no-dropdown-items");
+        if (list_items.length === 0) {
+            $no_search_results.show();
+        } else {
+            $no_search_results.hide();
+        }
+    }
+
     setup() {
         this.init();
         const delegate_container = this.$events_container.get(0);
@@ -123,13 +133,7 @@ export class DropdownWidget {
                 });
 
                 $search_input.on("input.list_widget_filter", () => {
-                    const list_items = this.list_widget.get_current_list();
-                    const $no_search_results = $popper.find(".no-dropdown-items");
-                    if (list_items.length === 0) {
-                        $no_search_results.show();
-                    } else {
-                        $no_search_results.hide();
-                    }
+                    this.show_empty_if_no_items($popper);
                 });
 
                 // Keyboard handler
@@ -232,6 +236,7 @@ export class DropdownWidget {
                 this.on_show_callback(instance);
             }.bind(this),
             onMount: function (instance) {
+                this.show_empty_if_no_items($(instance.popper));
                 this.on_mount_callback(instance);
             }.bind(this),
             onHidden: function (instance) {

--- a/web/src/subscriber_api.js
+++ b/web/src/subscriber_api.js
@@ -1,4 +1,5 @@
 import * as channel from "./channel";
+import * as people from "./people";
 
 /*
     This module simply encapsulates our legacy API for subscribing
@@ -10,6 +11,16 @@ import * as channel from "./channel";
 export function add_user_ids_to_stream(user_ids, sub, success, failure) {
     // TODO: use stream_id when backend supports it
     const stream_name = sub.name;
+    if (user_ids.length === 1 && people.is_my_user_id(Number(user_ids[0]))) {
+        // Self subscribe
+        const color = sub.color;
+        return channel.post({
+            url: "/json/users/me/subscriptions",
+            data: {subscriptions: JSON.stringify([{name: stream_name, color}])},
+            success,
+            error: failure,
+        });
+    }
     return channel.post({
         url: "/json/users/me/subscriptions",
         data: {

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -99,6 +99,17 @@ function change_state_of_subscribe_button(event, dropdown) {
     $subscribe_button.prop("disabled", false);
 }
 
+function reset_subscribe_widget() {
+    $("#user-profile-modal .add-subscription-button").prop("disabled", true);
+    stream_ui_updates.initialize_disable_btn_hint_popover(
+        $("#user-profile-modal .add-subscription-button-wrapper"),
+        $t({defaultMessage: "Select a stream to subscribe"}),
+    );
+    $("#user_profile_subscribe_widget .dropdown_widget_value").text(
+        $t({defaultMessage: "Select a stream"}),
+    );
+}
+
 export function get_user_unsub_streams() {
     const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id"), 10);
     return stream_data
@@ -342,11 +353,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     $elem.addClass("large allow-overflow");
     $("#tab-toggle").append($elem);
     if (show_user_subscribe_widget) {
-        $("#user-profile-modal .add-subscription-button").prop("disabled", true);
-        stream_ui_updates.initialize_disable_btn_hint_popover(
-            $("#user-profile-modal .add-subscription-button-wrapper"),
-            $t({defaultMessage: "Select a stream to subscribe"}),
-        );
+        reset_subscribe_widget();
     }
 }
 
@@ -381,6 +388,7 @@ export function register_click_handlers() {
         const $alert_box = $("#user-profile-streams-tab .stream_list_info");
         function addition_success(data) {
             if (Object.keys(data.subscribed).length > 0) {
+                reset_subscribe_widget();
                 ui_report.success(
                     $t_html({defaultMessage: "Subscribed successfully!"}),
                     $alert_box,

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -311,10 +311,7 @@ export function register_click_handlers() {
         const $stream_row = $(e.currentTarget).closest("[data-stream-id]");
         const stream_id = Number.parseInt($stream_row.attr("data-stream-id"), 10);
         const sub = sub_store.get(stream_id);
-        const target_user_id = Number.parseInt(
-            $stream_row.closest("#user-profile-modal").attr("data-user-id"),
-            10,
-        );
+        const target_user_id = Number.parseInt($("#user-profile-modal").attr("data-user-id"), 10);
         const $alert_box = $("#user-profile-streams-tab .stream_list_info");
 
         function removal_success(data) {

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -21,6 +21,7 @@ import * as settings_account from "./settings_account";
 import * as settings_bots from "./settings_bots";
 import * as settings_profile_fields from "./settings_profile_fields";
 import * as stream_data from "./stream_data";
+import * as stream_ui_updates from "./stream_ui_updates";
 import * as sub_store from "./sub_store";
 import * as subscriber_api from "./subscriber_api";
 import * as timerender from "./timerender";
@@ -94,6 +95,7 @@ function change_state_of_subscribe_button(event, dropdown) {
     event.stopPropagation();
     user_profile_subscribe_widget.render();
     const $subscribe_button = $("#user-profile-modal .add-subscription-button");
+    $subscribe_button.parent()[0]._tippy?.destroy();
     $subscribe_button.prop("disabled", false);
 }
 
@@ -341,6 +343,10 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     $("#tab-toggle").append($elem);
     if (show_user_subscribe_widget) {
         $("#user-profile-modal .add-subscription-button").prop("disabled", true);
+        stream_ui_updates.initialize_disable_btn_hint_popover(
+            $("#user-profile-modal .add-subscription-button-wrapper"),
+            $t({defaultMessage: "Select a stream to subscribe"}),
+        );
     }
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -526,6 +526,19 @@ ul {
         .filter-icon i {
             padding-right: 3px;
         }
+
+        .subscribe-widget-header {
+            margin: 0;
+            display: inline-block;
+            font-weight: inherit;
+        }
+
+        .user_profile_subscribe_widget {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            padding-top: 2px;
+        }
     }
 
     .stream-list-top-section {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -514,6 +514,13 @@ ul {
         margin-bottom: 20px;
     }
 
+    .stream-tab-element-header {
+        margin: 0;
+        display: inline-block;
+        font-weight: inherit;
+        font-size: 21px;
+    }
+
     #user-profile-streams-tab {
         .stream_list_info {
             margin-bottom: 8px;
@@ -527,12 +534,6 @@ ul {
             padding-right: 3px;
         }
 
-        .subscribe-widget-header {
-            margin: 0;
-            display: inline-block;
-            font-weight: inherit;
-        }
-
         .user_profile_subscribe_widget {
             display: flex;
             justify-content: space-between;
@@ -543,12 +544,7 @@ ul {
 
     .stream-list-top-section {
         display: flex;
-
-        .stream-list-header {
-            margin: 0;
-            display: inline-block;
-            font-weight: inherit;
-        }
+        margin-top: 12px;
 
         .stream-search {
             margin-left: auto;

--- a/web/templates/dropdown_list_container.hbs
+++ b/web/templates/dropdown_list_container.hbs
@@ -6,6 +6,6 @@
         <ul class="dropdown-list"></ul>
     </div>
     <div class="no-dropdown-items dropdown-list-item-common-styles">
-        {{t 'No search results'}}
+        {{t 'No matching results'}}
     </div>
 </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -93,13 +93,13 @@
                         <div class="alert stream_list_info"></div>
                         {{#if show_user_subscribe_widget}}
                             <div class="header-section">
-                                <h3 class="subscribe-widget-header">{{t 'Subscribe {full_name} to streams'}}</h3>
+                                <h3 class="stream-tab-element-header">{{t 'Subscribe {full_name} to streams'}}</h3>
                             </div>
                             {{> user_profile_subscribe_widget}}
                         {{/if}}
                         <div class="stream-list-top-section">
                             <div class="header-section">
-                                <h3 class="stream-list-header">{{t 'Subscribed streams' }}</h3>
+                                <h3 class="stream-tab-element-header">{{t 'Subscribed streams' }}</h3>
                             </div>
                             <input type="text" class="stream-search modal_text_input" placeholder="{{t 'Filter streams' }}" />
                             <button type="button" class="clear_search_button" id="clear_stream_search">

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -90,6 +90,13 @@
                     </div>
 
                     <div class="tabcontent" id="user-profile-streams-tab">
+                        <div class="alert stream_list_info"></div>
+                        {{#if show_user_subscribe_widget}}
+                            <div class="header-section">
+                                <h3 class="subscribe-widget-header">{{t 'Subscribe {full_name} to streams'}}</h3>
+                            </div>
+                            {{> user_profile_subscribe_widget}}
+                        {{/if}}
                         <div class="stream-list-top-section">
                             <div class="header-section">
                                 <h3 class="stream-list-header">{{t 'Subscribed streams' }}</h3>
@@ -99,7 +106,6 @@
                                 <i class="fa fa-remove" aria-hidden="true"></i>
                             </button>
                         </div>
-                        <div class="alert stream_list_info"></div>
                         <div class="subscription-stream-list">
                             <table class="user-stream-list" data-empty="{{t 'No stream subscriptions.'}}"></table>
                         </div>

--- a/web/templates/user_profile_subscribe_widget.hbs
+++ b/web/templates/user_profile_subscribe_widget.hbs
@@ -1,5 +1,5 @@
 <div class="user_profile_subscribe_widget">
-    {{> dropdown_widget widget_name="user_profile_subscribe" default_text=(t 'Select a stream')}}
+    {{> dropdown_widget widget_name="user_profile_subscribe"}}
     <div class="add-subscription-button-wrapper">
         <button type="button" name="subscribe" class="add-subscription-button button small rounded btn-success">
             {{t 'Subscribe' }}

--- a/web/templates/user_profile_subscribe_widget.hbs
+++ b/web/templates/user_profile_subscribe_widget.hbs
@@ -1,0 +1,6 @@
+<div class="user_profile_subscribe_widget">
+    {{> dropdown_widget widget_name="user_profile_subscribe" default_text=(t 'Select a stream')}}
+    <button type="button" name="subscribe" class="add-subscription-button button small rounded btn-success">
+        {{t 'Subscribe' }}
+    </button>
+</div>

--- a/web/templates/user_profile_subscribe_widget.hbs
+++ b/web/templates/user_profile_subscribe_widget.hbs
@@ -1,6 +1,8 @@
 <div class="user_profile_subscribe_widget">
     {{> dropdown_widget widget_name="user_profile_subscribe" default_text=(t 'Select a stream')}}
-    <button type="button" name="subscribe" class="add-subscription-button button small rounded btn-success">
-        {{t 'Subscribe' }}
-    </button>
+    <div class="add-subscription-button-wrapper">
+        <button type="button" name="subscribe" class="add-subscription-button button small rounded btn-success">
+            {{t 'Subscribe' }}
+        </button>
+    </div>
 </div>


### PR DESCRIPTION
- [x] Add subscribe widget to user profile model.
- [x] Don't show the subscribe widget of other users to non-admin users.
- [x] Hide the subscribe widget for generic bots and deactivated users.

-------------------

Fixes: #18883 
CZO: [Topic](https://chat.zulip.org/#narrow/stream/101-design/topic/User.20profile.20popover.3A.20Subscribe.20widget.2E)

-----------
**Screenshots and screen captures:**

<details>
<summary>SS:</summary>

<img width="522" alt="Screenshot 2023-09-09 at 1 39 22 PM" src="https://github.com/zulip/zulip/assets/66828942/2b05c5ea-d5e2-4182-bf39-8962fe517e0b">


</details>

<details>
<summary>Overall DEMO:</summary>

![overall_demo](https://github.com/zulip/zulip/assets/66828942/fbb59712-017d-4844-af45-ba292cd36f67)



</details>

------------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
