### PR TITLE
compose: Don't select compose input field after focus.

### DIFF
--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -57,10 +57,12 @@ function get_focus_area(msg_type, opts) {
 export const _get_focus_area = get_focus_area;
 
 export function set_focus(msg_type, opts) {
+    // Called mainly when opening the compose box or switching the
+    // message type to set the focus in the first empty input in the
+    // compose box.
     if (window.getSelection().toString() === "" || opts.trigger !== "message click") {
         const focus_area = get_focus_area(msg_type, opts);
-        const $elt = $(focus_area);
-        $elt.trigger("focus").trigger("select");
+        $(focus_area).trigger("focus");
     }
 }
 


### PR DESCRIPTION
Fixes #25950.

Focus area is mostly determined by finding the first relevant field that is *empty*, and selecting empty fields has no effect.

The only situation where the field might not be empty is when the textarea already has text in it, since that's the default option. We don't want to select the composebox textarea because this can lead to people losing their messages if they start typing right away.

Screen capture of behavior after this change:

![Kapture 2023-07-04 at 12 47 16](https://github.com/zulip/zulip/assets/5634097/735fde54-00b3-4c80-b921-100988c6b8af)

