### PR TITLE
stream_ui_updates: Check if sub/unsub button is rendered.

### DIFF
--- a/web/src/stream_ui_updates.js
+++ b/web/src/stream_ui_updates.js
@@ -76,6 +76,12 @@ export function update_settings_button_for_sub(sub) {
 
     // This is for the Subscribe/Unsubscribe button in the right panel.
     const $settings_button = stream_settings_ui.settings_button_for_sub(sub);
+
+    if (!$settings_button.length) {
+        // `subscribe` button hasn't been rendered yet while we are processing the event.
+        return;
+    }
+
     if (sub.subscribed) {
         $settings_button.text($t({defaultMessage: "Unsubscribe"})).removeClass("unsubscribed");
     } else {


### PR DESCRIPTION
It might be possible that an event can come while we are in the middle of rendering the stream settings overlay. This can cause `hash_util.is_editing_stream(sub.stream_id)` to be `true` while the `sub/unsub` button still hasn't been rendered yet.
