### PR TITLE
Polish UI for portico pages copy-codeblock button

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -47,14 +47,14 @@ function add_copy_to_clipboard_element($codehilite) {
     });
 
     // Show a tippy tooltip when the button is hovered
-    const tooltipCopy = tippy($copy_button[0], {
+    const tooltip_copy = tippy($copy_button[0], {
         content: "Copy code",
         trigger: "mouseenter",
         placement: "top",
     });
 
     // Show a tippy tooltip when the code is copied
-    const tooltipCopied = tippy($copy_button[0], {
+    const tooltip_copied = tippy($copy_button[0], {
         content: "Copied!",
         trigger: "manual",
         placement: "top",
@@ -67,12 +67,12 @@ function add_copy_to_clipboard_element($codehilite) {
 
     // Show "Copied!" tooltip when code is successfully copied
     clipboard.on("success", () => {
-        tooltipCopy.hide();
-        tooltipCopied.show();
+        tooltip_copy.hide();
+        tooltip_copied.show();
 
         // Hide the "Copied!" tooltip after 1 second
         setTimeout(() => {
-            tooltipCopied.hide();
+            tooltip_copied.hide();
         }, 1000);
     });
 }

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -46,19 +46,33 @@ function add_copy_to_clipboard_element($codehilite) {
         },
     });
 
+    // Show a tippy tooltip when the button is hovered
+    const tooltipCopy = tippy($copy_button[0], {
+        content: "Copy code",
+        trigger: "mouseenter",
+        placement: "top",
+    });
+
     // Show a tippy tooltip when the code is copied
+    const tooltipCopied = tippy($copy_button[0], {
+        content: "Copied!",
+        trigger: "manual",
+        placement: "top",
+    });
+
+    // Copy code on button click
+    $copy_button.on("click", () => {
+        clipboard.onClick({currentTarget: $copy_button[0]});
+    });
+
+    // Show "Copied!" tooltip when code is successfully copied
     clipboard.on("success", () => {
-        const tooltip = tippy($copy_button[0], {
-            content: "Copied!",
-            trigger: "manual",
-            placement: "top",
-        });
+        tooltipCopy.hide();
+        tooltipCopied.show();
 
-        tooltip.show();
-
-        // Show the tooltip for 1s
+        // Hide the "Copied!" tooltip after 1 second
         setTimeout(() => {
-            tooltip.hide();
+            tooltipCopied.hide();
         }, 1000);
     });
 }

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -9,9 +9,9 @@ import * as common from "../common";
 import * as google_analytics from "./google-analytics";
 import {activate_correct_tab} from "./tabbed-instructions";
 
-function registerCodeSection($codeSection) {
-    const $li = $codeSection.find("ul.nav li");
-    const $blocks = $codeSection.find(".blocks div");
+function register_code_section($code_section) {
+    const $li = $code_section.find("ul.nav li");
+    const $blocks = $code_section.find(".blocks div");
 
     $li.on("click", function () {
         const tab_key = this.dataset.tabKey;
@@ -103,7 +103,7 @@ function highlight_current_article() {
 function render_code_sections() {
     $(".code-section").each(function () {
         activate_correct_tab($(this));
-        registerCodeSection($(this));
+        register_code_section($(this));
     });
 
     // Add a copy-to-clipboard button for each .codehilite element

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -399,6 +399,7 @@
     }
 
     .copy-codeblock {
+        cursor: pointer;
         /* Invisible default button */
         background: none;
         border: none;

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -414,6 +414,10 @@
             outline-offset: -1px;
             outline-color: hsl(176deg 46% 41%);
         }
+
+        &:hover svg path {
+            fill: hsl(200deg 100% 40%);
+        }
     }
 
     .code-section {


### PR DESCRIPTION
<!-- Describe your pull request here.-->
In this PR, I set the cursor style of the copy code button in portico pages to pointer, added a hover effect and added a "Copy code" tooltip to the button.

Fixes: https://github.com/zulip/zulip/issues/25962<!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
Before:
![gifAntes](https://github.com/zulip/zulip/assets/83559250/04ecbb21-3ddb-4d52-968b-135afc1b4353)

After:
![gifDepois](https://github.com/zulip/zulip/assets/83559250/2b7c4eea-62ac-408f-86f0-7d48afe7f98f)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
