### PR TITLE
[WIP] compose box: Establish compose box within the middle-column layout.

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -262,9 +262,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="compose" {% if embedded %}data-embedded{% endif %}>
-                    <div id="compose-container"></div>
-                </div>
+                <div id="compose" {% if embedded %}data-embedded{% endif %}></div>
             </div><!--/tab-content-->
         </div>
         <div class="column-right" id="right-sidebar-container">

--- a/web/src/resize.js
+++ b/web/src/resize.js
@@ -115,7 +115,8 @@ export function reset_compose_message_max_height(bottom_whitespace_height) {
         // subtract 10 for the selected message border.
         bottom_whitespace_height - compose_non_textarea_height - 10,
     );
-    $("#scroll-to-bottom-button-container").css("bottom", compose_height);
+    // Capture the compose box's height for use in CSS
+    $("html").css("--compose-box-height", `${compose_height}px`);
 }
 
 export function resize_bottom_whitespace() {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -231,7 +231,7 @@ function initialize_navbar() {
 }
 
 function initialize_compose_box() {
-    $("#compose-container").append(
+    $("#compose").append(
         render_compose({
             embedded: $("#compose").attr("data-embedded") === "",
             file_upload_enabled: page_params.max_file_upload_size_mib > 0,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -223,9 +223,18 @@
 }
 
 #compose {
-    position: fixed;
+    /* .column-middle is set to `position: relative`,
+       so it acts as the positioning context for
+       sticky positioning. */
+    position: sticky;
+    /* The element will render by default at the far
+       left of `.column-middle`, so only the bottom
+       positioning property is needed here. */
     bottom: 0;
-    left: 0;
+    /* TODO: Set establish and reference this value
+       using a CSS variable */
+    max-width: 870px;
+    width: 100%;
     z-index: 4;
 }
 
@@ -894,6 +903,9 @@ input.recipient_box {
 
 #compose.compose-fullscreen {
     z-index: 99;
+    height: calc(
+        100vh - var(--navbar-alerts-wrapper-height) - var(--header-height)
+    );
 
     .message_comp {
         flex: 1;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -230,13 +230,6 @@
     z-index: 4;
 }
 
-#compose-container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    margin: auto;
-}
-
 #compose_top {
     display: flex;
     justify-content: space-between;
@@ -922,10 +915,6 @@ input.recipient_box {
 
 #compose.compose-fullscreen {
     z-index: 99;
-
-    #compose-container {
-        height: 100%;
-    }
 
     .message_comp {
         flex: 1;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -50,7 +50,6 @@
     }
 }
 
-/* Main geometry for this element is in zulip.css */
 #compose-content {
     background-color: hsl(232deg 30% 92%);
     transition: background-color 200ms linear;
@@ -890,26 +889,6 @@ input.recipient_box {
     &:hover,
     &:focus {
         box-shadow: none;
-    }
-}
-
-@media (width < $xl_min) {
-    #compose-content {
-        margin-right: 7px;
-    }
-}
-
-@media (width < $md_min) {
-    #compose-content {
-        margin-right: 7px;
-        margin-left: 7px;
-    }
-}
-
-@media (width < $mm_min) {
-    #compose-content {
-        margin-right: 5px;
-        margin-left: 5px;
     }
 }
 

--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -4,7 +4,7 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    max-height: 100vh;
+    max-height: calc(100vh - var(--compose-box-height));
 
     #recent_topics_table {
         max-width: 100%;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3077,7 +3077,7 @@ select.invite-as {
 #scroll-to-bottom-button-container {
     display: block;
     position: absolute;
-    bottom: 41px;
+    bottom: var(--compose-box-height);
     right: 0;
     visibility: hidden;
     opacity: 0;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -31,15 +31,13 @@ body {
 
     /* Implementation for fluid layout width setting. */
     .header-main,
-    .app .app-main,
-    #compose-container {
+    .app .app-main {
         max-width: 1400px;
     }
 
     &.fluid_layout_width {
         .header-main,
-        .app .app-main,
-        #compose-container {
+        .app .app-main {
             max-width: inherit;
         }
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -750,8 +750,7 @@ body.has-overlay-scrollbar {
     }
 }
 
-.column-middle,
-#compose-content {
+.column-middle {
     margin-right: var(--right-sidebar-width);
     margin-left: calc(
         var(--left-sidebar-width) + var(--left-sidebar-collapse-widget-gutter)


### PR DESCRIPTION
This PR eliminates the use of fixed positioning to jimmy the compose box into the layout, and instead makes it a first-class citizen of the middle column.

This represents a long-term project, meaning it will not be part of the compose-box work slated for the 8.0 release.