### PR TITLE
Improve design of empty list view.

### DIFF
--- a/web/src/activity_ui.js
+++ b/web/src/activity_ui.js
@@ -75,7 +75,7 @@ export function searching() {
 }
 
 export function render_empty_user_list_message_if_needed($container) {
-    const empty_list_message = $container.data("empty");
+    const empty_list_message = $container.data("search-results-empty");
 
     if (!empty_list_message || $container.children().length) {
         return;

--- a/web/src/activity_ui.js
+++ b/web/src/activity_ui.js
@@ -1,5 +1,7 @@
 import _ from "lodash";
 
+import render_empty_list_widget_for_list from "../templates/empty_list_widget_for_list.hbs";
+
 import * as activity from "./activity";
 import * as blueslip from "./blueslip";
 import * as buddy_data from "./buddy_data";
@@ -72,6 +74,17 @@ export function searching() {
     return user_filter && user_filter.searching();
 }
 
+export function render_empty_user_list_message_if_needed($container) {
+    const empty_list_message = $container.data("empty");
+
+    if (!empty_list_message || $container.children().length) {
+        return;
+    }
+
+    const empty_list_widget = render_empty_list_widget_for_list({empty_list_message});
+    $container.append(empty_list_widget);
+}
+
 export function build_user_sidebar() {
     if (page_params.realm_presence_disabled) {
         return undefined;
@@ -82,6 +95,8 @@ export function build_user_sidebar() {
     const user_ids = buddy_data.get_filtered_and_sorted_user_ids(filter_text);
 
     buddy_list.populate({keys: user_ids});
+
+    render_empty_user_list_message_if_needed(buddy_list.$container);
 
     return user_ids; // for testing
 }

--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -189,8 +189,16 @@ function get_column_count_for_table($table: JQuery): number {
     return column_count;
 }
 
-export function render_empty_list_message_if_needed($container: JQuery): void {
-    const empty_list_message = $container.data("empty");
+export function render_empty_list_message_if_needed(
+    $container: JQuery,
+    filter_value: string,
+): void {
+    let empty_list_message = $container.data("empty");
+
+    const empty_search_results_message = $container.data("search-results-empty");
+    if (filter_value && empty_search_results_message) {
+        empty_list_message = empty_search_results_message;
+    }
 
     if (!empty_list_message || $container.children().length) {
         return;
@@ -290,7 +298,7 @@ export function create<Key = unknown, Item = Key>(
 
             // Stop once the offset reaches the length of the original list.
             if (meta.offset >= meta.filtered_list.length) {
-                render_empty_list_message_if_needed($container);
+                render_empty_list_message_if_needed($container, meta.filter_value);
                 return;
             }
 

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -293,8 +293,6 @@ export function hide_loading_indicator() {
     loading.destroy_indicator($("#recent_view_loading_messages_indicator"), {
         abs_positioned: false,
     });
-    // Show empty table text if there are no messages fetched.
-    $("#recent_view_table tbody").addClass("required-text");
 }
 
 export function process_messages(messages) {

--- a/web/src/settings_bots.js
+++ b/web/src/settings_bots.js
@@ -13,6 +13,7 @@ import {csrf_token} from "./csrf";
 import * as dialog_widget from "./dialog_widget";
 import {$t, $t_html} from "./i18n";
 import * as integration_url_modal from "./integration_url_modal";
+import * as list_widget from "./list_widget";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as settings_data from "./settings_data";
@@ -74,6 +75,9 @@ export function render_bots() {
         });
         user_owns_an_active_bot = user_owns_an_active_bot || elem.is_active;
     }
+
+    list_widget.render_empty_list_message_if_needed($("#active_bots_list"));
+    list_widget.render_empty_list_message_if_needed($("#inactive_bots_list"));
 }
 
 export function generate_zuliprc_url(bot_id) {

--- a/web/src/settings_emoji.ts
+++ b/web/src/settings_emoji.ts
@@ -109,8 +109,9 @@ export function populate_emoji(): void {
     }
 
     const emoji_data = emoji.get_server_realm_emoji_data();
+    const active_emoji_data = Object.values(emoji_data).filter((emoji) => !emoji.deactivated);
 
-    for (const emoji of Object.values(emoji_data)) {
+    for (const emoji of active_emoji_data) {
         // Add people.js data for the user here.
         if (emoji.author_id !== null) {
             emoji.author = people.maybe_get_user_by_id(emoji.author_id);
@@ -120,22 +121,19 @@ export function populate_emoji(): void {
     }
 
     const $emoji_table = $("#admin_emoji_table").expectOne();
-    ListWidget.create<ServerEmoji>($emoji_table, Object.values(emoji_data), {
+    ListWidget.create<ServerEmoji>($emoji_table, active_emoji_data, {
         name: "emoji_list",
         get_item: ListWidget.default_get_item,
         modifier_html(item) {
-            if (item.deactivated !== true) {
-                return render_admin_emoji_list({
-                    emoji: {
-                        name: item.name,
-                        display_name: item.name.replaceAll("_", " "),
-                        source_url: item.source_url,
-                        author: item.author || "",
-                        can_delete_emoji: can_delete_emoji(item),
-                    },
-                });
-            }
-            return "";
+            return render_admin_emoji_list({
+                emoji: {
+                    name: item.name,
+                    display_name: item.name.replaceAll("_", " "),
+                    source_url: item.source_url,
+                    author: item.author || "",
+                    can_delete_emoji: can_delete_emoji(item),
+                },
+            });
         },
         filter: {
             $element: $emoji_table

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -201,10 +201,18 @@ function render_user_stream_list(streams, user) {
         modifier_html(item) {
             return format_user_stream_list_item_html(item, user);
         },
+        callback_after_render() {
+            $container.parent().removeClass("empty-list");
+        },
         filter: {
             $element: $("#user-profile-streams-tab .stream-search"),
             predicate(item, value) {
                 return item && item.name.toLocaleLowerCase().includes(value);
+            },
+            onupdate() {
+                if ($container.find("#empty-table-message").length) {
+                    $container.parent().addClass("empty-list");
+                }
             },
         },
         $simplebar_container: $("#user-profile-modal .modal__body"),
@@ -218,6 +226,9 @@ function render_user_group_list(groups, user) {
     ListWidget.create($container, groups, {
         name: `user-${user.user_id}-group-list`,
         get_item: ListWidget.default_get_item,
+        callback_after_render() {
+            $container.parent().removeClass("empty-list");
+        },
         modifier_html(item) {
             return format_user_group_list_item_html(item);
         },

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -1163,6 +1163,15 @@ div.overlay {
     }
 }
 
+#empty-list-message,
+#empty-table-message {
+    background-color: inherit;
+    color: var(--color-text-default);
+    font-size: 1.5em;
+    padding: 3em 1em;
+    text-align: center;
+}
+
 .filter_text_input {
     padding: 4px 6px;
     color: hsl(0deg 0% 33%);

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -673,6 +673,14 @@ ul {
             }
         }
     }
+
+    .empty-list {
+        border: none;
+
+        #empty-table-message {
+            padding: 3em 1em;
+        }
+    }
 }
 
 @media (width < $md_min) {

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -636,20 +636,6 @@ ul {
                     }
                 }
             }
-
-            & tbody:empty::after,
-            &:empty::after {
-                content: attr(data-empty);
-                display: block;
-
-                text-align: center;
-                color: hsl(0deg 0% 67%);
-            }
-
-            &:empty {
-                display: block;
-                padding: 5px;
-            }
         }
     }
 

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -61,6 +61,11 @@
             position: absolute;
         }
 
+        #empty-table-message {
+            background-color: var(--color-background);
+            padding: 3em 1em;
+        }
+
         .fa-check-square-o,
         .fa-square-o {
             padding: 0 2px;

--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -53,14 +53,6 @@
             }
         }
 
-        .required-text:empty::after {
-            content: attr(data-empty);
-            display: block;
-            font-style: italic;
-            color: hsl(0deg 0% 67%);
-            position: absolute;
-        }
-
         #empty-table-message {
             background-color: var(--color-background);
             padding: 3em 1em;

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -85,6 +85,14 @@ $user_status_emoji_width: 24px;
         display: block;
     }
 
+    #empty-list-message {
+        font-size: 1.2em;
+
+        &:hover {
+            background-color: inherit;
+        }
+    }
+
     & a {
         color: inherit;
         margin-left: 0;

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1724,20 +1724,6 @@ $option_title_width: 180px;
     width: 100px;
 }
 
-.required-text {
-    &:empty::after {
-        content: attr(data-empty);
-        display: block;
-
-        font-style: italic;
-        color: hsl(0deg 0% 67%);
-    }
-
-    &.thick:empty::after {
-        width: 100%;
-    }
-}
-
 #payload_url_inputbox {
     & input[type="text"] {
         width: 340px;

--- a/web/templates/empty_list_widget_for_list.hbs
+++ b/web/templates/empty_list_widget_for_list.hbs
@@ -1,0 +1,1 @@
+<li id="empty-list-message">{{empty_list_message}}</li>

--- a/web/templates/empty_list_widget_for_table.hbs
+++ b/web/templates/empty_list_widget_for_table.hbs
@@ -1,0 +1,5 @@
+<tr>
+    <td id="empty-table-message" colspan="{{column_count}}">
+        {{empty_list_message}}
+    </td>
+</tr>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -18,7 +18,7 @@
                 </button>
             </div>
             <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar>
-                <ul id="user_presences" class="filters" data-empty="{{t 'No matching users.' }}"></ul>
+                <ul id="user_presences" class="filters" data-search-results-empty="{{t 'No matching users.' }}"></ul>
                 <div id="buddy_list_wrapper_padding"></div>
             </div>
         </div>

--- a/web/templates/right_sidebar.hbs
+++ b/web/templates/right_sidebar.hbs
@@ -18,7 +18,7 @@
                 </button>
             </div>
             <div id="buddy_list_wrapper" class="scrolling_list" data-simplebar>
-                <ul id="user_presences" class="filters required-text" data-empty="{{t 'No matching users.' }}"></ul>
+                <ul id="user_presences" class="filters" data-empty="{{t 'No matching users.' }}"></ul>
                 <div id="buddy_list_wrapper_padding"></div>
             </div>
         </div>

--- a/web/templates/settings/alert_word_settings.hbs
+++ b/web/templates/settings/alert_word_settings.hbs
@@ -23,7 +23,7 @@
                 <th data-sort="alphabetic" data-sort-prop="word">{{t "Word" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="alert-words-table" class="alert-words-table required-text thick"
+            <tbody id="alert-words-table" class="alert-words-table"
               data-empty="{{t 'There are no current alert words.' }}"></tbody>
         </table>
     </div>

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -15,8 +15,7 @@
                 <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
                 <th class="upload-actions actions">{{t "Actions" }}</th>
             </thead>
-            <tbody data-empty="{{t 'You have not uploaded any files.' }}"
-              id="uploaded_files_table"></tbody>
+            <tbody data-empty="{{t 'You have not uploaded any files.' }}" data-search-results-empty="{{t 'No uploaded files match your current filter.' }}" id="uploaded_files_table"></tbody>
         </table>
     </div>
     <div id="attachments_loading_indicator"></div>

--- a/web/templates/settings/attachments_settings.hbs
+++ b/web/templates/settings/attachments_settings.hbs
@@ -15,7 +15,7 @@
                 <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
                 <th class="upload-actions actions">{{t "Actions" }}</th>
             </thead>
-            <tbody class="required-text" data-empty="{{t 'You have not uploaded any files.' }}"
+            <tbody data-empty="{{t 'You have not uploaded any files.' }}"
               id="uploaded_files_table"></tbody>
         </table>
     </div>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -36,7 +36,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody id="admin_bots_table" class="admin_bot_table required-text thick"
+            <tbody id="admin_bots_table" class="admin_bot_table"
               data-empty="{{t 'No bots match your current filter.' }}"></tbody>
         </table>
     </div>

--- a/web/templates/settings/bot_list_admin.hbs
+++ b/web/templates/settings/bot_list_admin.hbs
@@ -37,7 +37,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_bots_table" class="admin_bot_table"
-              data-empty="{{t 'No bots match your current filter.' }}"></tbody>
+              data-empty="{{t 'No bots found.' }}" data-search-results-empty="{{t 'No bots match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_bots_loading_indicator"></div>

--- a/web/templates/settings/bot_settings.hbs
+++ b/web/templates/settings/bot_settings.hbs
@@ -26,10 +26,10 @@
             <li class="inactive-bots-tab"><a>{{t "Inactive bots" }}</a></li>
         </ul>
 
-        <ol class="bots_list required-text" id="active_bots_list" data-empty="{{t 'You have no active bots.' }}">
+        <ol class="bots_list" id="active_bots_list" data-empty="{{t 'You have no active bots.' }}">
         </ol>
 
-        <ol class="bots_list required-text" id="inactive_bots_list" data-empty="{{t 'You have no inactive bots.' }}">
+        <ol class="bots_list" id="inactive_bots_list" data-empty="{{t 'You have no inactive bots.' }}">
         </ol>
 
     </div>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -44,7 +44,7 @@
                 <th>{{t "Status" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_exports_table" class="required-text" data-empty="{{t 'No exports.' }}"></tbody>
+            <tbody id="admin_exports_table" data-empty="{{t 'No exports.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/data_exports_admin.hbs
+++ b/web/templates/settings/data_exports_admin.hbs
@@ -44,7 +44,7 @@
                 <th>{{t "Status" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_exports_table" data-empty="{{t 'No exports.' }}"></tbody>
+            <tbody id="admin_exports_table" data-empty="{{t 'No exports found.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -19,7 +19,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody id="admin_deactivated_users_table" class="required-text thick admin_user_table"
+            <tbody id="admin_deactivated_users_table" class="admin_user_table"
               data-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>
     </div>

--- a/web/templates/settings/deactivated_users_admin.hbs
+++ b/web/templates/settings/deactivated_users_admin.hbs
@@ -20,7 +20,7 @@
                 {{/if}}
             </thead>
             <tbody id="admin_deactivated_users_table" class="admin_user_table"
-              data-empty="{{t 'No users match your current filter.' }}"></tbody>
+              data-empty="{{t 'No deactivated users found.' }}" data-search-results-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_deactivated_users_loading_indicator"></div>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -19,7 +19,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody data-empty="{{t 'No default streams match you current filter.' }}"
+            <tbody data-empty="{{t 'No default streams found.' }}" data-search-results-empty="{{t 'No default streams match your current filter.' }}"
               id="admin_default_streams_table" class="admin_default_stream_table"></tbody>
         </table>
     </div>

--- a/web/templates/settings/default_streams_list_admin.hbs
+++ b/web/templates/settings/default_streams_list_admin.hbs
@@ -19,7 +19,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody class="required-text" data-empty="{{t 'No default streams match you current filter.' }}"
+            <tbody data-empty="{{t 'No default streams match you current filter.' }}"
               id="admin_default_streams_table" class="admin_default_stream_table"></tbody>
         </table>
     </div>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -22,7 +22,7 @@
                 <th class="image" data-sort="author_full_name">{{t "Author" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_emoji_table" data-empty="{{t 'No custom emoji.' }}"></tbody>
+            <tbody id="admin_emoji_table" data-empty="{{t 'No custom emoji.' }}" data-search-results-empty="{{t 'No custom emojis match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -22,7 +22,7 @@
                 <th class="image" data-sort="author_full_name">{{t "Author" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_emoji_table" class="required-text" data-empty="{{t 'No custom emoji.' }}"></tbody>
+            <tbody id="admin_emoji_table" data-empty="{{t 'No custom emoji.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/emoji_settings_admin.hbs
+++ b/web/templates/settings/emoji_settings_admin.hbs
@@ -22,7 +22,7 @@
                 <th class="image" data-sort="author_full_name">{{t "Author" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_emoji_table" data-empty="{{t 'No custom emoji.' }}" data-search-results-empty="{{t 'No custom emojis match your current filter.' }}"></tbody>
+            <tbody id="admin_emoji_table" data-empty="{{t 'No custom emojis found.' }}" data-search-results-empty="{{t 'No custom emojis match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -23,7 +23,7 @@
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_invites_table" class="required-text thick admin_invites_table" data-empty="{{t 'No invites match your current filter.' }}"></tbody>
+            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'No invites match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_invites_loading_indicator"></div>

--- a/web/templates/settings/invites_list_admin.hbs
+++ b/web/templates/settings/invites_list_admin.hbs
@@ -23,7 +23,7 @@
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'No invites match your current filter.' }}"></tbody>
+            <tbody id="admin_invites_table" class="admin_invites_table" data-empty="{{t 'No invites found.' }}" data-search-results-empty="{{t 'No invites match your current filter.' }}"></tbody>
         </table>
     </div>
     <div id="admin_page_invites_loading_indicator"></div>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -71,7 +71,7 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_linkifiers_table" class="required-text" data-empty="{{t 'No linkifiers set.' }}"></tbody>
+                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers set.' }}"></tbody>
             </table>
         </div>
     </div>

--- a/web/templates/settings/linkifier_settings_admin.hbs
+++ b/web/templates/settings/linkifier_settings_admin.hbs
@@ -71,7 +71,7 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers set.' }}"></tbody>
+                <tbody id="admin_linkifiers_table" data-empty="{{t 'No linkifiers set.' }}" data-search-results-empty="{{t 'No linkifiers match your current filter.' }}"></tbody>
             </table>
         </div>
     </div>

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -10,7 +10,7 @@
                 <th data-sort="numeric" data-sort-prop="date_muted">{{t "Date muted" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="muted_users_table" class="required-text" data-empty="{{t 'You have not muted any users yet.'}}"></tbody>
+            <tbody id="muted_users_table" data-empty="{{t 'You have not muted any users yet.'}}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/muted_users_settings.hbs
+++ b/web/templates/settings/muted_users_settings.hbs
@@ -10,7 +10,7 @@
                 <th data-sort="numeric" data-sort-prop="date_muted">{{t "Date muted" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="muted_users_table" data-empty="{{t 'You have not muted any users yet.'}}"></tbody>
+            <tbody id="muted_users_table" data-empty="{{t 'You have not muted any users yet.'}}" data-search-results-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -78,7 +78,7 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_playgrounds_table" class="required-text" data-empty="{{t 'No playgrounds configured.' }}"></tbody>
+                <tbody id="admin_playgrounds_table" data-empty="{{t 'No playgrounds configured.' }}"></tbody>
             </table>
         </div>
     </div>

--- a/web/templates/settings/playground_settings_admin.hbs
+++ b/web/templates/settings/playground_settings_admin.hbs
@@ -78,7 +78,7 @@
                     <th class="actions">{{t "Actions" }}</th>
                     {{/if}}
                 </thead>
-                <tbody id="admin_playgrounds_table" data-empty="{{t 'No playgrounds configured.' }}"></tbody>
+                <tbody id="admin_playgrounds_table" data-empty="{{t 'No playgrounds configured.' }}" data-search-results-empty="{{t 'No playgrounds match your current filter.' }}"></tbody>
             </table>
         </div>
     </div>

--- a/web/templates/settings/user_list_admin.hbs
+++ b/web/templates/settings/user_list_admin.hbs
@@ -19,7 +19,7 @@
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
             </thead>
-            <tbody id="admin_users_table" class="admin_user_table required-text thick"
+            <tbody id="admin_users_table" class="admin_user_table"
               data-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>
     </div>

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -33,7 +33,7 @@
                 <th data-sort="numeric" data-sort-prop="visibility_policy">{{t "Status" }}</th>
                 <th data-sort="numeric" data-sort-prop="date_updated" class="active topic_date_updated">{{t "Date updated" }}</th>
             </thead>
-            <tbody id="user_topics_table" data-empty="{{t 'You have not configured any topics yet.'}}"></tbody>
+            <tbody id="user_topics_table" data-empty="{{t 'You have not configured any topics yet.'}}" data-search-results-empty="{{t 'No topics match your current filter.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -33,7 +33,7 @@
                 <th data-sort="numeric" data-sort-prop="visibility_policy">{{t "Status" }}</th>
                 <th data-sort="numeric" data-sort-prop="date_updated" class="active topic_date_updated">{{t "Date updated" }}</th>
             </thead>
-            <tbody id="user_topics_table" class="required-text" data-empty="{{t 'You have not configured any topics yet.'}}"></tbody>
+            <tbody id="user_topics_table" data-empty="{{t 'You have not configured any topics yet.'}}"></tbody>
         </table>
     </div>
 </div>

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -110,7 +110,7 @@
                             </button>
                         </div>
                         <div class="subscription-stream-list empty-list">
-                            <table class="user-stream-list" data-empty="{{t 'No stream subscriptions.'}}"></table>
+                            <table class="user-stream-list" data-empty="{{t 'No stream subscriptions.'}}" data-search-results-empty="{{t 'No matching streams' }}"></table>
                         </div>
                     </div>
 

--- a/web/templates/user_profile_modal.hbs
+++ b/web/templates/user_profile_modal.hbs
@@ -109,13 +109,13 @@
                                 <i class="fa fa-remove" aria-hidden="true"></i>
                             </button>
                         </div>
-                        <div class="subscription-stream-list">
+                        <div class="subscription-stream-list empty-list">
                             <table class="user-stream-list" data-empty="{{t 'No stream subscriptions.'}}"></table>
                         </div>
                     </div>
 
                     <div class="tabcontent" id="user-profile-groups-tab">
-                        <div class="subscription-group-list">
+                        <div class="subscription-group-list empty-list">
                             <table class="user-group-list" data-empty="{{t 'No user group subscriptions.'}}"></table>
                         </div>
                     </div>

--- a/web/tests/activity.test.js
+++ b/web/tests/activity.test.js
@@ -449,6 +449,28 @@ test("first/prev/next", ({override, mock_template}) => {
     assert.ok(rendered_fred);
 });
 
+test("render_empty_user_list_message", ({override, mock_template}) => {
+    const empty_list_message = "No matching users.";
+    mock_template("empty_list_widget_for_list.hbs", false, (data) => {
+        assert.equal(data.empty_list_message, empty_list_message);
+        return empty_list_message;
+    });
+
+    let appended_data;
+    override(buddy_list, "$container", {
+        append(data) {
+            appended_data = data;
+        },
+        data() {
+            return empty_list_message;
+        },
+        children: () => [],
+    });
+
+    activity_ui.render_empty_user_list_message_if_needed(buddy_list.$container);
+    assert.equal(appended_data, empty_list_message);
+});
+
 test("insert_one_user_into_empty_list", ({override, mock_template}) => {
     user_settings.user_list_style = 2;
     mock_template("presence_row.hbs", true, (data, html) => {

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -46,6 +46,7 @@ const ListWidget = zrequire("list_widget");
 function make_container() {
     const $container = {};
     $container.empty = () => {};
+    $container.data = () => {};
 
     // Make our append function just set a field we can
     // check in our tests.

--- a/web/tests/user_search.test.js
+++ b/web/tests/user_search.test.js
@@ -9,6 +9,9 @@ const {page_params} = require("./lib/zpage_params");
 
 const fake_buddy_list = {
     scroll_container_sel: "#whatever",
+    $container: {
+        data() {},
+    },
     find_li() {},
     first_key() {},
     prev_key() {},


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Based on the discussion [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/.22No.20topics.20match.22.20on.20Recent.20conversations/near/1600888), we wanted to avoid using the `::after` pseudo-element for non-decorative content. As a solution, This PR adds a new function `render_empty_list_message_if_needed` to the list widget in `list_widget.js`. This function displays a message using the `data-empty` dataset when the list is empty, effectively replacing the need for the `::after` pseudo-element in rendering the empty list message.

Fixes: #23072<!-- Issue link, or clear description.-->

Related PR: #23134

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures</summary>

![image](https://github.com/zulip/zulip/assets/87542880/dd9b3c2b-eea3-4697-abd5-e6dee1d05d54)
![image](https://github.com/zulip/zulip/assets/87542880/1eed95b3-3c15-4284-8ec4-dd65742259d7)

![image](https://github.com/zulip/zulip/assets/87542880/e37279c7-169a-4090-956e-f4e9d6a7bd17)

![image](https://github.com/zulip/zulip/assets/87542880/97ad6c4c-1959-4eac-976e-e8058dbb3322)

![image](https://github.com/zulip/zulip/assets/87542880/02dfdab1-6ed6-47bc-9523-2044c561be6c)

![image](https://github.com/zulip/zulip/assets/87542880/1f50b998-272e-4c78-91d8-ed8f87074b6b)

![image](https://github.com/zulip/zulip/assets/87542880/83f2bd93-0a03-4d03-a006-7cded6d571f3)
![image](https://github.com/zulip/zulip/assets/87542880/55a73316-5864-42c7-8a1e-968b9e0e8588)

![image](https://github.com/zulip/zulip/assets/87542880/4d7e55a8-0bec-43c2-a36b-6d93f02b15cb)

![image](https://github.com/zulip/zulip/assets/87542880/8473a757-c818-4d25-b1c7-dfaaf31ffdbd)
![image](https://github.com/zulip/zulip/assets/87542880/95fcad68-95ac-4cbe-ae8c-27a75c7e32d3)

![image](https://github.com/zulip/zulip/assets/87542880/613ee677-37b9-4070-84e1-4b67eed36fef)

![image](https://github.com/zulip/zulip/assets/87542880/57e3f723-043a-44e2-8a41-a1fd31d40116)

![image](https://github.com/zulip/zulip/assets/87542880/a3c6ad2d-d56b-4610-8622-65c0f68b634b)


</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
