### PR TITLE
compose: Add warning banner for search views.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -510,6 +510,7 @@ export function initialize() {
     const user_not_subscribed_selector = `.${CSS.escape(
         compose_banner.CLASSNAMES.user_not_subscribed,
     )}`;
+
     $("body").on(
         "click",
         `${user_not_subscribed_selector} .main-view-banner-action-button`,
@@ -540,6 +541,25 @@ export function initialize() {
                 message_edit.toggle_resolve_topic(message_id, topic_name, true);
                 compose_validate.clear_topic_resolved_warning(true);
             });
+        },
+    );
+
+    $("body").on(
+        "click",
+        `.${CSS.escape(
+            compose_banner.CLASSNAMES.compose_in_search_view,
+        )} .main-view-banner-action-button`,
+        (event) => {
+            event.preventDefault();
+            const $target = $(event.target).parents(".main-view-banner");
+            const stream_id = Number.parseInt($target.attr("data-stream-id"), 10);
+            const topic_name = $target.attr("data-topic-name");
+            const sub = sub_store.get(stream_id);
+            narrow.activate([
+                {operator: "stream", operand: sub.name},
+                {operator: "topic", operand: topic_name},
+            ]);
+            $(`.${CSS.escape(compose_banner.CLASSNAMES.compose_in_search_view)}`).remove();
         },
     );
 

--- a/web/src/compose_actions.js
+++ b/web/src/compose_actions.js
@@ -4,6 +4,7 @@ import autosize from "autosize";
 import $ from "jquery";
 
 import * as fenced_code from "../shared/src/fenced_code";
+import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 
 import * as channel from "./channel";
 import * as compose_banner from "./compose_banner";
@@ -70,6 +71,35 @@ function show_compose_box(msg_type, opts) {
     // When changing this, edit the 42px in _maybe_autoscroll
     $(".new_message_textarea").css("min-height", "3em");
     compose_ui.set_focus(msg_type, opts);
+    const filter = narrow_state.filter();
+    if (!filter.is_common_narrow()) {
+        show_compose_in_search_view_banner();
+    }
+}
+
+function show_compose_in_search_view_banner() {
+    // TODO: use compose_state.stream_id() when #25785 merges.
+    let stream_id = "";
+    const stream_name = compose_state.stream_name();
+    if (stream_name) {
+        const sub = stream_data.get_sub(stream_name);
+        if (sub) {
+            stream_id = sub.stream_id;
+        }
+    }
+
+    const search_view_banner = render_compose_banner({
+        banner_type: compose_banner.WARNING,
+        classname: compose_banner.CLASSNAMES.compose_in_search_view,
+        stream_id,
+        topic_name: compose_state.topic(),
+        banner_text: $t({
+            defaultMessage:
+                "You are composing a message from a search view, which may not include the latest messages in the conversation.",
+        }),
+        button_text: $t({defaultMessage: "Go to conversation"}),
+    });
+    compose_banner.append_compose_banner_to_banner_list(search_view_banner, $("#compose_banners"));
 }
 
 export function clear_textarea() {

--- a/web/src/compose_banner.ts
+++ b/web/src/compose_banner.ts
@@ -34,6 +34,7 @@ export const CLASSNAMES = {
     wildcard_warning: "wildcard_warning",
     private_stream_warning: "private_stream_warning",
     unscheduled_message: "unscheduled_message",
+    compose_in_search_view: "compose_in_search_view",
     // errors
     wildcards_not_allowed: "wildcards_not_allowed",
     subscription_error: "subscription_error",
@@ -104,6 +105,10 @@ export function clear_errors(): void {
 
 export function clear_warnings(): void {
     $(`#compose_banners .${CSS.escape(WARNING)}`).remove();
+}
+
+export function clear_in_search_view(): void {
+    $(`#compose_banners .${CSS.escape("compose_in_search_view")}`).remove();
 }
 
 export function clear_uploads(): void {

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -37,6 +37,7 @@ const compose_ui = mock_esm("../src/compose_ui", {
 const hash_util = mock_esm("../src/hash_util");
 const narrow_state = mock_esm("../src/narrow_state", {
     set_compose_defaults: noop,
+    filter: () => ({is_common_narrow: () => true}),
 });
 
 mock_esm("../src/reload_state", {

--- a/web/tests/lib/compose_banner.js
+++ b/web/tests/lib/compose_banner.js
@@ -32,4 +32,10 @@ exports.mock_banners = () => {
     $cb.set_find_results(".missing_private_message_recipient", $stub);
     $cb.set_find_results(".subscription_error", $stub);
     $cb.set_find_results(".generic_compose_error", $stub);
+
+    // Mock `not.remove` which excludes a classname from `remove`.
+    const className = CSS.escape(compose_banner.WARNING);
+    $(`#compose_banners .${className}`).not = () => ({
+        remove() {},
+    });
 };


### PR DESCRIPTION
This commit adds a warning compose banner when composing a message in a search view that doesn't include all the messages in a conversation.

This is helpful if a user sends a message without the full context and forgets they are in a narrowed search view.

Fixes: #25893.

Continuation of work done in #26100.

![Kapture 2023-07-06 at 13 55 40](https://github.com/zulip/zulip/assets/5634097/2f6470ce-69ea-447b-a707-c846f71f0096)
