### PR TITLE
Fix exception exiting "more topics" after losing access to a stream

### DIFF
--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -147,14 +147,13 @@ function get_search_term() {
 
 export function add_sidebar_row(sub) {
     create_sidebar_row(sub);
-    build_stream_list();
-    stream_cursor.redraw();
+    update_streams_sidebar();
 }
 
 export function remove_sidebar_row(stream_id) {
     stream_sidebar.remove_row(stream_id);
-    build_stream_list();
-    stream_cursor.redraw();
+    const force_rerender = stream_id === topic_list.active_stream_id();
+    update_streams_sidebar(force_rerender);
 }
 
 export function create_initial_sidebar_rows() {

--- a/web/src/stream_list.js
+++ b/web/src/stream_list.js
@@ -198,7 +198,7 @@ export function build_stream_list(force_rerender) {
         elems.push(sidebar_row.get_li());
     }
 
-    topic_list.clear();
+    topic_zoom.clear_topics();
     $parent.empty();
 
     const any_pinned_streams =

--- a/web/tests/stream_list.test.js
+++ b/web/tests/stream_list.test.js
@@ -142,6 +142,8 @@ test_ui("create_sidebar_row", ({override_rewire, mock_template}) => {
     create_social_sidebar_row({mock_template});
     create_stream_subheader({mock_template});
 
+    topic_list.get_stream_li = noop;
+
     const $pinned_subheader = $("<pinned-subheader-stub>");
     const $active_subheader = $("<active-subheader-stub>");
     const $devel_sidebar = $("<devel-sidebar-row-stub>");
@@ -152,14 +154,14 @@ test_ui("create_sidebar_row", ({override_rewire, mock_template}) => {
         appended_elems = elems;
     };
 
-    let topic_list_cleared;
-    topic_list.clear = () => {
-        topic_list_cleared = true;
+    let topics_closed;
+    topic_list.close = () => {
+        topics_closed = true;
     };
 
     stream_list.build_stream_list();
 
-    assert.ok(topic_list_cleared);
+    assert.ok(topics_closed);
     const expected_elems = [
         $pinned_subheader.html(), // separator
         $devel_sidebar, // pinned


### PR DESCRIPTION
The `stream_list.build_stream_list()` function is responsible for rendering the stream list in the left sidebar. Previously, it uses `topic_list.clear()` to clear the `active_widgets` that tracks active stream(s) in the left sidebar. This led to a bug where rendering stream list after adding or removing a stream through `build_stream_list()` while a stream was zoomed in ("more topics" clicked) didn't fully exit the "more topics" view. So clicking "BACK TO STREAMS" throws an exception with the message "Error: Unexpected number of topic lists to zoom out" because `active_widgets`, cleared by `topic_list.clear()`, became inaccessible.

To address this issue, instead of clearing the topics list with `topic_list.clear()`, the code now ensures the closure of the zoomed stream by using `topic_zoom.clear_topics()`. This change ensures a proper exit from the "more topics" view and avoids the exception.

Fixes #25670.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Before</summary>

https://github.com/zulip/zulip/assets/87542880/65936a26-9601-4cbf-b201-aee536b541ab

</details>

<details>
<summary>After</summary>

https://github.com/zulip/zulip/assets/87542880/c84f5470-ef2e-43fa-881a-8c7c281d026a

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
