### PR TITLE
ts: Migrate `user_group_pill` module to TypeScript.

### DIFF
--- a/web/src/input_pill.ts
+++ b/web/src/input_pill.ts
@@ -58,7 +58,7 @@ type InputPillRenderingDetails = {
 };
 
 // These are the functions that are exposed to other modules.
-type InputPillContainer<T> = {
+export type InputPillContainer<T> = {
     appendValue: (text: string) => void;
     appendValidatedData: (item: InputPillItem<T>) => void;
     getByElement: (element: HTMLElement) => InputPill<T> | undefined;

--- a/web/src/user_group_pill.ts
+++ b/web/src/user_group_pill.ts
@@ -1,10 +1,22 @@
+import type {InputPillContainer, InputPillItem} from "./input_pill";
+import type {UserGroup} from "./user_groups";
 import * as user_groups from "./user_groups";
 
-function display_pill(group) {
-    return group.name + ": " + group.members.size + " users";
+type UserGroupPill = {
+    id: number;
+    group_name: string;
+};
+
+type UserGroupPillWidget = InputPillContainer<UserGroupPill>;
+
+function display_pill(group: UserGroup): string {
+    return `${group.name}: ${group.members.size} users`;
 }
 
-export function create_item_from_group_name(group_name, current_items) {
+export function create_item_from_group_name(
+    group_name: string,
+    current_items: InputPillItem<UserGroupPill>[],
+): InputPillItem<UserGroupPill> | undefined {
     group_name = group_name.trim();
     const group = user_groups.get_user_group_from_name(group_name);
     if (!group) {
@@ -26,18 +38,18 @@ export function create_item_from_group_name(group_name, current_items) {
     return item;
 }
 
-export function get_group_name_from_item(item) {
+export function get_group_name_from_item(item: InputPillItem<UserGroupPill>): string {
     return item.group_name;
 }
 
-function get_user_ids_from_user_groups(items) {
+function get_user_ids_from_user_groups(items: InputPillItem<UserGroupPill>[]): number[] {
     const group_ids = items.map((item) => item.id).filter(Boolean);
     return group_ids.flatMap((group_id) => [
         ...user_groups.get_user_group_from_id(group_id).members,
     ]);
 }
 
-export function get_user_ids(pill_widget) {
+export function get_user_ids(pill_widget: UserGroupPillWidget): number[] {
     const items = pill_widget.items();
     let user_ids = get_user_ids_from_user_groups(items);
     user_ids = [...new Set(user_ids)];
@@ -47,18 +59,17 @@ export function get_user_ids(pill_widget) {
     return user_ids;
 }
 
-export function append_user_group(group, pill_widget) {
-    if (group !== undefined && group !== null) {
-        pill_widget.appendValidatedData({
-            type: "user_group",
-            display_value: display_pill(group),
-            id: group.id,
-        });
-        pill_widget.clear_text();
-    }
+export function append_user_group(group: UserGroup, pill_widget: UserGroupPillWidget): void {
+    pill_widget.appendValidatedData({
+        type: "user_group",
+        display_value: display_pill(group),
+        id: group.id,
+        group_name: group.name,
+    });
+    pill_widget.clear_text();
 }
 
-export function get_group_ids(pill_widget) {
+export function get_group_ids(pill_widget: UserGroupPillWidget): number[] {
     const items = pill_widget.items();
     let group_ids = items.map((item) => item.id);
     group_ids = group_ids.filter(Boolean);
@@ -66,13 +77,16 @@ export function get_group_ids(pill_widget) {
     return group_ids;
 }
 
-export function filter_taken_groups(items, pill_widget) {
+export function filter_taken_groups(
+    items: UserGroup[],
+    pill_widget: UserGroupPillWidget,
+): UserGroup[] {
     const taken_group_ids = get_group_ids(pill_widget);
     items = items.filter((item) => !taken_group_ids.includes(item.id));
     return items;
 }
 
-export function typeahead_source(pill_widget) {
+export function typeahead_source(pill_widget: UserGroupPillWidget): UserGroup[] {
     const groups = user_groups.get_realm_user_groups();
     return filter_taken_groups(groups, pill_widget);
 }

--- a/web/src/user_groups.ts
+++ b/web/src/user_groups.ts
@@ -5,7 +5,7 @@ import {page_params} from "./page_params";
 import * as settings_config from "./settings_config";
 import type {User, UserGroupUpdateEvent} from "./types";
 
-type UserGroup = {
+export type UserGroup = {
     description: string;
     id: number;
     name: string;

--- a/web/tests/user_group_pill.test.js
+++ b/web/tests/user_group_pill.test.js
@@ -70,3 +70,21 @@ run_test("get_group_ids", () => {
     const group_ids = user_group_pill.get_group_ids(widget);
     assert.deepEqual(group_ids, [101, 102]);
 });
+
+run_test("append_user_group", () => {
+    const items = [admins_pill];
+    const widget = {
+        appendValidatedData(group) {
+            assert.deepEqual(group, testers_pill);
+            items.push(testers_pill);
+        },
+        clear_text() {},
+    };
+
+    const group = {
+        ...testers,
+        members: new Set(testers.members),
+    };
+    user_group_pill.append_user_group(group, widget);
+    assert.deepEqual(items, [admins_pill, testers_pill]);
+});


### PR DESCRIPTION
Converts `user_group_pill` widget to typescript. Uses generic type definitions from `input_pill` widget module.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
