### PR TITLE
ts: Migrate `peer_data.js` module to TypeScript.

### DIFF
--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -1,28 +1,29 @@
 import * as blueslip from "./blueslip";
 import {LazySet} from "./lazy_set";
+import type {User} from "./people";
 import * as people from "./people";
 import * as sub_store from "./sub_store";
 
 // This maps a stream_id to a LazySet of user_ids who are subscribed.
-const stream_subscribers = new Map();
+const stream_subscribers = new Map<number, LazySet>();
 
-export function clear_for_testing() {
+export function clear_for_testing(): void {
     stream_subscribers.clear();
 }
 
-function assert_number(id) {
+function assert_number(id: number): void {
     if (typeof id !== "number") {
         blueslip.error("You must pass ids as numbers to peer_data", {id});
     }
 }
 
-function get_user_set(stream_id) {
+function get_user_set(stream_id: number): LazySet {
     // This is an internal function to get the LazySet of users.
     // We create one on the fly as necessary, but we warn in that case.
     assert_number(stream_id);
 
     if (!sub_store.get(stream_id)) {
-        blueslip.warn("We called get_user_set for an untracked stream: " + stream_id);
+        blueslip.warn(`We called get_user_set for an untracked stream: ${stream_id}`);
     }
 
     let subscribers = stream_subscribers.get(stream_id);
@@ -35,14 +36,14 @@ function get_user_set(stream_id) {
     return subscribers;
 }
 
-export function is_subscriber_subset(stream_id1, stream_id2) {
+export function is_subscriber_subset(stream_id1: number, stream_id2: number): boolean {
     const sub1_set = get_user_set(stream_id1);
     const sub2_set = get_user_set(stream_id2);
 
     return [...sub1_set.keys()].every((key) => sub2_set.has(key));
 }
 
-export function potential_subscribers(stream_id) {
+export function potential_subscribers(stream_id: number): User[] {
     /*
         This is a list of unsubscribed users
         for the current stream, who the current
@@ -62,7 +63,7 @@ export function potential_subscribers(stream_id) {
 
     const subscribers = get_user_set(stream_id);
 
-    function is_potential_subscriber(person) {
+    function is_potential_subscriber(person: User): boolean {
         // Use verbose style to force better test
         // coverage, plus we may add more conditions over
         // time.
@@ -76,12 +77,12 @@ export function potential_subscribers(stream_id) {
     return people.filter_all_users(is_potential_subscriber);
 }
 
-export function get_subscriber_count(stream_id) {
+export function get_subscriber_count(stream_id: number): number {
     const subscribers = get_user_set(stream_id);
     return subscribers.size;
 }
 
-export function get_subscribers(stream_id) {
+export function get_subscribers(stream_id: number): number[] {
     // This is our external interface for callers who just
     // want an array of user_ids who are subscribed to a stream.
     const subscribers = get_user_set(stream_id);
@@ -89,26 +90,26 @@ export function get_subscribers(stream_id) {
     return [...subscribers.keys()];
 }
 
-export function set_subscribers(stream_id, user_ids) {
-    const subscribers = new LazySet(user_ids || []);
+export function set_subscribers(stream_id: number, user_ids: number[]): void {
+    const subscribers = new LazySet(user_ids);
     stream_subscribers.set(stream_id, subscribers);
 }
 
-export function add_subscriber(stream_id, user_id) {
+export function add_subscriber(stream_id: number, user_id: number): void {
     // If stream_id/user_id are unknown to us, we will
     // still track it, but we will warn.
     const subscribers = get_user_set(stream_id);
     const person = people.maybe_get_user_by_id(user_id);
     if (person === undefined) {
-        blueslip.warn("We tried to add invalid subscriber: " + user_id);
+        blueslip.warn(`We tried to add invalid subscriber: ${user_id}`);
     }
     subscribers.add(user_id);
 }
 
-export function remove_subscriber(stream_id, user_id) {
+export function remove_subscriber(stream_id: number, user_id: number): boolean {
     const subscribers = get_user_set(stream_id);
     if (!subscribers.has(user_id)) {
-        blueslip.warn("We tried to remove invalid subscriber: " + user_id);
+        blueslip.warn(`We tried to remove invalid subscriber: ${user_id}`);
         return false;
     }
 
@@ -117,7 +118,13 @@ export function remove_subscriber(stream_id, user_id) {
     return true;
 }
 
-export function bulk_add_subscribers({stream_ids, user_ids}) {
+export function bulk_add_subscribers({
+    stream_ids,
+    user_ids,
+}: {
+    stream_ids: number[];
+    user_ids: number[];
+}): void {
     // We rely on our callers to validate stream_ids and user_ids.
     for (const stream_id of stream_ids) {
         const subscribers = get_user_set(stream_id);
@@ -127,7 +134,13 @@ export function bulk_add_subscribers({stream_ids, user_ids}) {
     }
 }
 
-export function bulk_remove_subscribers({stream_ids, user_ids}) {
+export function bulk_remove_subscribers({
+    stream_ids,
+    user_ids,
+}: {
+    stream_ids: number[];
+    user_ids: number[];
+}): void {
     // We rely on our callers to validate stream_ids and user_ids.
     for (const stream_id of stream_ids) {
         const subscribers = get_user_set(stream_id);
@@ -137,7 +150,7 @@ export function bulk_remove_subscribers({stream_ids, user_ids}) {
     }
 }
 
-export function is_user_subscribed(stream_id, user_id) {
+export function is_user_subscribed(stream_id: number, user_id: number): boolean {
     // Most callers should call stream_data.is_user_subscribed,
     // which does additional checks.
 

--- a/web/src/peer_data.ts
+++ b/web/src/peer_data.ts
@@ -11,17 +11,9 @@ export function clear_for_testing(): void {
     stream_subscribers.clear();
 }
 
-function assert_number(id: number): void {
-    if (typeof id !== "number") {
-        blueslip.error("You must pass ids as numbers to peer_data", {id});
-    }
-}
-
 function get_user_set(stream_id: number): LazySet {
     // This is an internal function to get the LazySet of users.
     // We create one on the fly as necessary, but we warn in that case.
-    assert_number(stream_id);
-
     if (!sub_store.get(stream_id)) {
         blueslip.warn(`We called get_user_set for an untracked stream: ${stream_id}`);
     }

--- a/web/tests/peer_data.test.js
+++ b/web/tests/peer_data.test.js
@@ -275,7 +275,6 @@ test("is_subscriber_subset", () => {
     blueslip.reset();
 
     // Warn about hypothetical undefined stream_ids.
-    blueslip.expect("error", "You must pass ids as numbers to peer_data");
     blueslip.expect("warn", "We called get_user_set for an untracked stream: undefined");
     peer_data.is_subscriber_subset(undefined, sub_a.stream_id);
     blueslip.reset();


### PR DESCRIPTION
This converts the module `peer_data.js` to TypeScript.

#### ~This is currently blocked by - people.js typescript migration which is progressing well in this PR #25539.~

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
