### PR TITLE
page load: Replace expensive default streams query with a sane query.

### DIFF
--- a/zerver/actions/create_user.py
+++ b/zerver/actions/create_user.py
@@ -11,7 +11,6 @@ from django.utils.translation import override as override_language
 
 from analytics.lib.counts import COUNT_STATS, do_increment_logging_stat
 from confirmation import settings as confirmation_settings
-from zerver.actions.default_streams import get_default_streams_for_realm
 from zerver.actions.invites import notify_invites_changed
 from zerver.actions.message_send import internal_send_private_message, internal_send_stream_message
 from zerver.actions.streams import bulk_add_subscriptions, send_peer_subscriber_events
@@ -19,6 +18,7 @@ from zerver.actions.user_groups import do_send_user_group_members_update_event
 from zerver.actions.users import change_user_is_active, get_service_dicts_for_bot
 from zerver.lib.avatar import avatar_url
 from zerver.lib.create_user import create_user
+from zerver.lib.default_streams import get_default_streams_for_realm
 from zerver.lib.email_notifications import enqueue_welcome_emails
 from zerver.lib.mention import silent_mention_syntax_for_user
 from zerver.lib.send_email import clear_scheduled_invitation_emails

--- a/zerver/actions/default_streams.py
+++ b/zerver/actions/default_streams.py
@@ -137,16 +137,18 @@ def do_add_streams_to_default_stream_group(
 def do_remove_streams_from_default_stream_group(
     realm: Realm, group: DefaultStreamGroup, streams: List[Stream]
 ) -> None:
+    group_stream_ids = {stream.id for stream in group.streams.all()}
     for stream in streams:
-        if stream not in group.streams.all():
+        if stream.id not in group_stream_ids:
             raise JsonableError(
                 _(
                     "Stream '{stream_name}' is not present in default stream group '{group_name}'",
                 ).format(stream_name=stream.name, group_name=group.name)
             )
-        group.streams.remove(stream)
 
-    group.save()
+    delete_stream_ids = {stream.id for stream in streams}
+
+    group.streams.remove(*delete_stream_ids)
     notify_default_stream_groups(realm)
 
 

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -68,9 +68,7 @@ from zerver.tornado.django_api import send_event, send_event_on_commit
 
 
 @transaction.atomic(savepoint=False)
-def do_deactivate_stream(
-    stream: Stream, log: bool = True, *, acting_user: Optional[UserProfile]
-) -> None:
+def do_deactivate_stream(stream: Stream, *, acting_user: Optional[UserProfile]) -> None:
     # If the stream is already deactivated, this is a no-op
     if stream.deactivated is True:
         raise JsonableError(_("Stream is already deactivated"))

--- a/zerver/lib/default_streams.py
+++ b/zerver/lib/default_streams.py
@@ -1,0 +1,25 @@
+from typing import List, Set
+
+from zerver.lib.types import APIStreamDict
+from zerver.models import DefaultStream, Stream
+
+
+def get_default_streams_for_realm(realm_id: int) -> List[Stream]:
+    return [
+        default.stream
+        for default in DefaultStream.objects.select_related().filter(realm_id=realm_id)
+    ]
+
+
+def streams_to_dicts_sorted(streams: List[Stream]) -> List[APIStreamDict]:
+    return sorted((stream.to_dict() for stream in streams), key=lambda elt: elt["name"])
+
+
+def get_default_stream_ids_for_realm(realm_id: int) -> Set[int]:
+    return set(DefaultStream.objects.filter(realm_id=realm_id).values_list("stream_id", flat=True))
+
+
+def get_default_streams_for_realm_as_dicts(realm_id: int) -> List[APIStreamDict]:
+    # returns default streams in JSON serializable format, sorted by stream name
+    streams = get_default_streams_for_realm(realm_id)
+    return streams_to_dicts_sorted(streams)

--- a/zerver/lib/default_streams.py
+++ b/zerver/lib/default_streams.py
@@ -5,14 +5,13 @@ from zerver.models import DefaultStream, Stream
 
 
 def get_default_streams_for_realm(realm_id: int) -> List[Stream]:
+    # TODO: Deprecate this extremely expensive query. We can't immediately
+    #       just improve it by removing select_related(), because then you
+    #       may get the opposite problem of multiple round trips.
     return [
         default.stream
         for default in DefaultStream.objects.select_related().filter(realm_id=realm_id)
     ]
-
-
-def streams_to_dicts_sorted(streams: List[Stream]) -> List[APIStreamDict]:
-    return sorted((stream.to_dict() for stream in streams), key=lambda elt: elt["name"])
 
 
 def get_default_stream_ids_for_realm(realm_id: int) -> Set[int]:
@@ -20,6 +19,15 @@ def get_default_stream_ids_for_realm(realm_id: int) -> Set[int]:
 
 
 def get_default_streams_for_realm_as_dicts(realm_id: int) -> List[APIStreamDict]:
-    # returns default streams in JSON serializable format, sorted by stream name
-    streams = get_default_streams_for_realm(realm_id)
-    return streams_to_dicts_sorted(streams)
+    """
+    Return all the default streams for a realm using a list of dictionaries sorted
+    by stream name.
+    """
+
+    # This slightly convoluted construction makes it so that the Django ORM gets
+    # all the data it needs to serialize default streams as a list of dictionaries
+    # using a single query without using select_related().
+    # This is enforced by test_query_count in test_subs.py.
+    stream_ids = DefaultStream.objects.filter(realm_id=realm_id).values_list("stream_id")
+    streams = Stream.objects.filter(id__in=stream_ids)
+    return sorted((stream.to_dict() for stream in streams), key=lambda elt: elt["name"])

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -10,8 +10,6 @@ from django.utils.translation import gettext as _
 from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
 from zerver.actions.default_streams import (
     default_stream_groups_to_dicts_sorted,
-    get_default_streams_for_realm,
-    streams_to_dicts_sorted,
 )
 from zerver.actions.users import get_owned_bot_dicts
 from zerver.lib import emoji
@@ -19,6 +17,7 @@ from zerver.lib.alert_words import user_alert_words
 from zerver.lib.avatar import avatar_url
 from zerver.lib.bot_config import load_bot_config_template
 from zerver.lib.compatibility import is_outdated_server
+from zerver.lib.default_streams import get_default_streams_for_realm_as_dicts
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.external_accounts import get_default_external_accounts
 from zerver.lib.hotspots import get_next_hotspots
@@ -583,9 +582,8 @@ def fetch_initial_state_data(
             # doesn't have any.
             state["realm_default_streams"] = []
         else:
-            state["realm_default_streams"] = streams_to_dicts_sorted(
-                get_default_streams_for_realm(realm.id)
-            )
+            state["realm_default_streams"] = get_default_streams_for_realm_as_dicts(realm.id)
+
     if want("default_stream_groups"):
         if settings_user.is_guest:
             state["realm_default_stream_groups"] = []
@@ -898,8 +896,8 @@ def apply_event(
                     if state["is_guest"]:
                         state["realm_default_streams"] = []
                     else:
-                        state["realm_default_streams"] = streams_to_dicts_sorted(
-                            get_default_streams_for_realm(user_profile.realm_id)
+                        state["realm_default_streams"] = get_default_streams_for_realm_as_dicts(
+                            user_profile.realm_id
                         )
 
                 for field in ["delivery_email", "email", "full_name", "is_billing_admin"]:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -5,7 +5,7 @@ from django.db.models import Exists, OuterRef, Q, QuerySet
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import gettext as _
 
-from zerver.actions.default_streams import get_default_streams_for_realm
+from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.exceptions import (
     JsonableError,
     OrganizationAdministratorRequiredError,
@@ -889,11 +889,8 @@ def do_get_streams(
     streams.sort(key=lambda elt: elt["name"])
 
     if include_default:
-        is_default = {}
-        default_streams = get_default_streams_for_realm(user_profile.realm_id)
-        for default_stream in default_streams:
-            is_default[default_stream.id] = True
+        default_stream_ids = get_default_stream_ids_for_realm(user_profile.realm_id)
         for stream in streams:
-            stream["is_default"] = is_default.get(stream["stream_id"], False)
+            stream["is_default"] = stream["stream_id"] in default_stream_ids
 
     return streams

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -25,7 +25,6 @@ from confirmation.models import (
 from corporate.lib.stripe import get_latest_seat_count
 from zerver.actions.create_realm import do_change_realm_subdomain, do_create_realm
 from zerver.actions.create_user import do_create_user, process_new_human_user
-from zerver.actions.default_streams import get_default_streams_for_realm
 from zerver.actions.invites import (
     do_create_multiuse_invite_link,
     do_get_invites_controlled_by_user,
@@ -37,6 +36,7 @@ from zerver.actions.realm_settings import do_change_realm_plan_type, do_set_real
 from zerver.actions.user_settings import do_change_full_name
 from zerver.actions.users import change_user_is_active
 from zerver.context_processors import common_context
+from zerver.lib.default_streams import get_default_streams_for_realm_as_dicts
 from zerver.lib.send_email import (
     FromAddress,
     deliver_scheduled_emails,
@@ -708,7 +708,7 @@ class InviteUserTest(InviteUserBase):
         self.assert_json_success(self.invite(invitee, []))
         self.assertTrue(find_key_by_email(invitee))
 
-        default_streams = get_default_streams_for_realm(realm.id)
+        default_streams = get_default_streams_for_realm_as_dicts(realm.id)
         self.assert_length(default_streams, 1)
 
         self.submit_reg_form_for_user(invitee, "password")
@@ -2294,7 +2294,7 @@ class MultiuseInviteTest(ZulipTestCase):
         invite_link = self.generate_multiuse_invite_link(streams=streams)
         self.check_user_able_to_register(email3, invite_link)
         # User is not subscribed to default streams as well.
-        self.assert_length(get_default_streams_for_realm(self.realm.id), 1)
+        self.assert_length(get_default_streams_for_realm_as_dicts(self.realm.id), 1)
         self.check_user_subscribed_only_to_streams(name3, [])
 
     def test_multiuse_link_different_realms(self) -> None:
@@ -2363,7 +2363,7 @@ class MultiuseInviteTest(ZulipTestCase):
         invite_link = self.assert_json_success(result)["invite_link"]
         self.check_user_able_to_register(self.nonreg_email("alice"), invite_link)
         # User is not subscribed to default streams as well.
-        self.assert_length(get_default_streams_for_realm(self.realm.id), 1)
+        self.assert_length(get_default_streams_for_realm_as_dicts(self.realm.id), 1)
         self.check_user_subscribed_only_to_streams("alice", [])
 
     def test_only_admin_can_create_multiuse_link_api_call(self) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -268,10 +268,11 @@ class AddNewUserHistoryTest(ZulipTestCase):
             self.example_user("hamlet"), streams[0].name, "test"
         )
 
-        # Overwrite ONBOARDING_UNREAD_MESSAGES to 2
-        ONBOARDING_UNREAD_MESSAGES = 2
+        # Overwrite MAX_NUM_ONBOARDING_UNREAD_MESSAGES to 2
+        MAX_NUM_ONBOARDING_UNREAD_MESSAGES = 2
         with patch(
-            "zerver.actions.create_user.ONBOARDING_UNREAD_MESSAGES", ONBOARDING_UNREAD_MESSAGES
+            "zerver.actions.create_user.MAX_NUM_ONBOARDING_UNREAD_MESSAGES",
+            MAX_NUM_ONBOARDING_UNREAD_MESSAGES,
         ):
             add_new_user_history(user_profile, streams)
 
@@ -291,7 +292,7 @@ class AddNewUserHistoryTest(ZulipTestCase):
             ).flags.read.is_set
         )
 
-        # Verify that the ONBOARDING_UNREAD_MESSAGES latest messages
+        # Verify that the MAX_NUM_ONBOARDING_UNREAD_MESSAGES latest messages
         # that weren't the race message are marked as unread.
         latest_messages = (
             UserMessage.objects.filter(
@@ -299,7 +300,7 @@ class AddNewUserHistoryTest(ZulipTestCase):
                 message__recipient__type=Recipient.STREAM,
             )
             .exclude(message_id=race_message_id)
-            .order_by("-message_id")[0:ONBOARDING_UNREAD_MESSAGES]
+            .order_by("-message_id")[0:MAX_NUM_ONBOARDING_UNREAD_MESSAGES]
         )
         self.assert_length(latest_messages, 2)
         for msg in latest_messages:
@@ -312,7 +313,9 @@ class AddNewUserHistoryTest(ZulipTestCase):
                 message__recipient__type=Recipient.STREAM,
             )
             .exclude(message_id=race_message_id)
-            .order_by("-message_id")[ONBOARDING_UNREAD_MESSAGES : ONBOARDING_UNREAD_MESSAGES + 1]
+            .order_by("-message_id")[
+                MAX_NUM_ONBOARDING_UNREAD_MESSAGES : MAX_NUM_ONBOARDING_UNREAD_MESSAGES + 1
+            ]
         )
         self.assertGreater(len(older_messages), 0)
         for msg in older_messages:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -27,7 +27,6 @@ from zerver.actions.create_user import add_new_user_history
 from zerver.actions.default_streams import (
     do_add_default_stream,
     do_create_default_stream_group,
-    get_default_streams_for_realm,
 )
 from zerver.actions.realm_settings import (
     do_deactivate_realm,
@@ -38,6 +37,7 @@ from zerver.actions.realm_settings import (
 from zerver.actions.users import change_user_is_active, do_change_user_role, do_deactivate_user
 from zerver.decorator import do_two_factor_login
 from zerver.forms import HomepageForm, check_subdomain_available
+from zerver.lib.default_streams import get_default_streams_for_realm_as_dicts
 from zerver.lib.email_notifications import enqueue_welcome_emails
 from zerver.lib.i18n import get_default_language_for_new_user
 from zerver.lib.initial_password import initial_password
@@ -3690,9 +3690,10 @@ class UserSignUpTest(ZulipTestCase):
         stream_name = "Rome"
         realm = get_realm("zulip")
         stream = get_stream(stream_name, realm)
-        default_streams = get_default_streams_for_realm(realm.id)
-        default_streams_name = [stream.name for stream in default_streams]
-        self.assertNotIn(stream_name, default_streams_name)
+        default_stream_names = {
+            stream["name"] for stream in get_default_streams_for_realm_as_dicts(realm.id)
+        }
+        self.assertNotIn(stream_name, default_stream_names)
 
         # Invite user.
         self.ldap_invite_and_signup_as(

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -22,7 +22,6 @@ from zerver.actions.default_streams import (
     do_remove_default_stream,
     do_remove_default_stream_group,
     do_remove_streams_from_default_stream_group,
-    get_default_streams_for_realm,
     lookup_default_stream_groups,
 )
 from zerver.actions.realm_settings import do_change_realm_plan_type, do_set_realm_property
@@ -35,6 +34,7 @@ from zerver.actions.streams import (
 )
 from zerver.actions.user_groups import add_subgroups_to_user_group, check_add_user_group
 from zerver.actions.users import do_change_user_role, do_deactivate_user
+from zerver.lib.default_streams import get_default_streams_for_realm_as_dicts
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import UnreadStreamInfo, aggregate_unread_data, get_raw_unread_data
 from zerver.lib.response import json_success
@@ -2673,9 +2673,8 @@ class StreamAdminTest(ZulipTestCase):
 
 class DefaultStreamTest(ZulipTestCase):
     def get_default_stream_names(self, realm: Realm) -> Set[str]:
-        streams = get_default_streams_for_realm(realm.id)
-        stream_names = [s.name for s in streams]
-        return set(stream_names)
+        streams = get_default_streams_for_realm_as_dicts(realm.id)
+        return {s["name"] for s in streams}
 
     def test_add_and_remove_default_stream(self) -> None:
         realm = get_realm("zulip")

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2818,7 +2818,14 @@ class DefaultStreamGroupTest(ZulipTestCase):
 
         # Test adding streams to existing default stream group
         group = lookup_default_stream_groups(["group1"], realm)[0]
-        new_stream_names = ["stream4", "stream5"]
+        new_stream_names = [
+            "stream4",
+            "stream5",
+            "stream6",
+            "stream7",
+            "stream8",
+            "stream9",
+        ]
         new_streams = []
         for new_stream_name in new_stream_names:
             new_stream = ensure_stream(realm, new_stream_name, acting_user=None)
@@ -2832,7 +2839,8 @@ class DefaultStreamGroupTest(ZulipTestCase):
         self.assertEqual(get_streams(default_stream_groups[0]), streams)
 
         # Test removing streams from existing default stream group
-        do_remove_streams_from_default_stream_group(realm, group, new_streams)
+        with self.assert_database_query_count(16):
+            do_remove_streams_from_default_stream_group(realm, group, new_streams)
         remaining_streams = streams[0:3]
         default_stream_groups = get_default_stream_groups(realm)
         self.assert_length(default_stream_groups, 1)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2839,7 +2839,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         self.assertEqual(get_streams(default_stream_groups[0]), streams)
 
         # Test removing streams from existing default stream group
-        with self.assert_database_query_count(16):
+        with self.assert_database_query_count(5):
             do_remove_streams_from_default_stream_group(realm, group, new_streams)
         remaining_streams = streams[0:3]
         default_stream_groups = get_default_stream_groups(realm)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -19,7 +19,6 @@ from zerver.actions.default_streams import (
     do_remove_default_stream,
     do_remove_default_stream_group,
     do_remove_streams_from_default_stream_group,
-    get_default_streams_for_realm,
 )
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_send import (
@@ -47,6 +46,7 @@ from zerver.decorator import (
     require_post,
     require_realm_admin,
 )
+from zerver.lib.default_streams import get_default_stream_ids_for_realm
 from zerver.lib.exceptions import (
     ErrorCode,
     JsonableError,
@@ -317,7 +317,7 @@ def update_stream_backend(
 
     if is_private is not None:
         # Default streams cannot be made private.
-        default_stream_ids = {s.id for s in get_default_streams_for_realm(stream.realm_id)}
+        default_stream_ids = get_default_stream_ids_for_realm(stream.realm_id)
         if is_private and stream.id in default_stream_ids:
             raise JsonableError(_("Default streams cannot be made private."))
 


### PR DESCRIPTION
This improves `test_events.py` by about 10%, and it does so by fixing the actual app.