### PR TITLE
bots_settings: Make "Download zuliprc" button keyboard focusable Fixes: #26198

### DIFF
--- a/web/templates/settings/bot_avatar_row.hbs
+++ b/web/templates/settings/bot_avatar_row.hbs
@@ -8,9 +8,9 @@
                 <button type="submit" class="btn open_edit_bot_form tippy-zulip-delayed-tooltip" data-sidebar-form="edit-bot" data-tippy-content="{{t 'Edit bot' }}" data-email="{{email}}">
                     <i class="fa fa-pencil blue" aria-hidden="true"></i>
                 </button>
-                <a type="submit" download="{{zuliprc}}" class="btn download_bot_zuliprc tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download zuliprc' }}" data-email="{{email}}">
+                <button type="submit" download="{{zuliprc}}" class="btn download_bot_zuliprc tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Download zuliprc' }}" data-email="{{email}}">
                     <i class="fa fa-download sea-green" aria-hidden="true"></i>
-                </a>
+                </button>
                 <button type="submit" id="copy_zuliprc" class="btn copy_zuliprc tippy-zulip-delayed-tooltip" data-tippy-content="{{t 'Copy zuliprc' }}">
                     <i class="fa fa-clipboard copy-gold"></i>
                 </button>


### PR DESCRIPTION
This PR modifies the bot_avatar_row.hbs template to include the download button in the keyboard navigation.
I changed the download button attribute from the anchor tag to the button tag which completely resolves the issue.

Fixes: https://github.com/zulip/zulip/issues/26198

**Screenshots and screen captures:**

<img width="257" alt="Screenshot 2023-07-10 212253" src="https://github.com/zulip/zulip/assets/112172255/f6ef2faf-237a-4c24-b65e-3e0c5c247158">


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [✅] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [✅] Each commit is a coherent idea.
- [✅] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
