### PR TITLE
sentry: Reduce http timeout.

### DIFF
--- a/zerver/views/sentry.py
+++ b/zerver/views/sentry.py
@@ -17,7 +17,7 @@ from zerver.lib.validator import (
 
 class SentryTunnelSession(OutgoingSession):
     def __init__(self) -> None:
-        super().__init__(role="sentry_tunnel", timeout=5)
+        super().__init__(role="sentry_tunnel", timeout=1)
 
 
 @csrf_exempt


### PR DESCRIPTION
This helps reduce the impact on busy uwsgi processes in case there are slow timeout failures of Sentry servers.  The p99 is less than 300ms, and p99.9 per day peaks at around 1s, so this will not affect more than .1% of requests in normal operation.

This is not a complete solution (see #26229); it is merely stop-gap mitigation.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
