### PR TITLE
ts: Migrate `realm_playground.js` to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -143,7 +143,7 @@ EXEMPT_FILES = make_set(
         "web/src/ready.ts",
         "web/src/realm_icon.js",
         "web/src/realm_logo.js",
-        "web/src/realm_playground.js",
+        "web/src/realm_playground.ts",
         "web/src/realm_user_settings_defaults.ts",
         "web/src/recent_topics_ui.js",
         "web/src/recent_topics_util.js",

--- a/web/src/realm_playground.js
+++ b/web/src/realm_playground.js
@@ -2,7 +2,6 @@ import generated_pygments_data from "../generated/pygments_data.json";
 import * as typeahead from "../shared/src/typeahead";
 
 import {$t} from "./i18n";
-import * as typeahead_helper from "./typeahead_helper";
 
 const map_language_to_playground_info = new Map();
 const map_pygments_pretty_name_to_aliases = new Map();
@@ -28,9 +27,9 @@ export function get_playground_info_for_languages(lang) {
     return map_language_to_playground_info.get(lang);
 }
 
-export function sort_pygments_pretty_names_by_priority(generated_pygments_data) {
+function sort_pygments_pretty_names_by_priority(generated_pygments_data, comparator_func) {
     const priority_sorted_pygments_data = Object.keys(generated_pygments_data.langs).sort(
-        typeahead_helper.compare_language,
+        comparator_func,
     );
     for (const alias of priority_sorted_pygments_data) {
         const pretty_name = generated_pygments_data.langs[alias].pretty_name;
@@ -84,7 +83,7 @@ export function get_pygments_typeahead_list_for_settings(query) {
     return language_labels;
 }
 
-export function initialize(playground_data, generated_pygments_data) {
+export function initialize({playground_data, generated_pygments_data, pygments_comparator_func}) {
     update_playgrounds(playground_data);
-    sort_pygments_pretty_names_by_priority(generated_pygments_data);
+    sort_pygments_pretty_names_by_priority(generated_pygments_data, pygments_comparator_func);
 }

--- a/web/src/realm_playground.js
+++ b/web/src/realm_playground.js
@@ -27,7 +27,7 @@ export function get_playground_info_for_languages(lang) {
     return map_language_to_playground_info.get(lang);
 }
 
-function sort_pygments_pretty_names_by_priority(generated_pygments_data, comparator_func) {
+function sort_pygments_pretty_names_by_priority(comparator_func) {
     const priority_sorted_pygments_data = Object.keys(generated_pygments_data.langs).sort(
         comparator_func,
     );
@@ -83,7 +83,7 @@ export function get_pygments_typeahead_list_for_settings(query) {
     return language_labels;
 }
 
-export function initialize({playground_data, generated_pygments_data, pygments_comparator_func}) {
+export function initialize({playground_data, pygments_comparator_func}) {
     update_playgrounds(playground_data);
-    sort_pygments_pretty_names_by_priority(generated_pygments_data, pygments_comparator_func);
+    sort_pygments_pretty_names_by_priority(pygments_comparator_func);
 }

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -3,39 +3,58 @@ import * as typeahead from "../shared/src/typeahead";
 
 import {$t} from "./i18n";
 
-const map_language_to_playground_info = new Map();
-const map_pygments_pretty_name_to_aliases = new Map();
+type RealmPlayground = {
+    id: number;
+    name: string;
+    pygments_language: string;
+    url_prefix: string;
+};
 
-export function update_playgrounds(playgrounds_data) {
+const map_language_to_playground_info = new Map<
+    string,
+    Omit<RealmPlayground, "pygments_language">[]
+>();
+const map_pygments_pretty_name_to_aliases = new Map<string, string[]>();
+
+export function update_playgrounds(playgrounds_data: RealmPlayground[]): void {
     map_language_to_playground_info.clear();
 
     for (const data of Object.values(playgrounds_data)) {
-        const element_to_push = {
+        const element_to_push: Omit<RealmPlayground, "pygments_language"> = {
             id: data.id,
             name: data.name,
             url_prefix: data.url_prefix,
         };
         if (map_language_to_playground_info.has(data.pygments_language)) {
-            map_language_to_playground_info.get(data.pygments_language).push(element_to_push);
+            map_language_to_playground_info.get(data.pygments_language)!.push(element_to_push);
         } else {
             map_language_to_playground_info.set(data.pygments_language, [element_to_push]);
         }
     }
 }
 
-export function get_playground_info_for_languages(lang) {
+export function get_playground_info_for_languages(
+    lang: string,
+): Omit<RealmPlayground, "pygments_language">[] | undefined {
     return map_language_to_playground_info.get(lang);
 }
 
-function sort_pygments_pretty_names_by_priority(comparator_func) {
+function sort_pygments_pretty_names_by_priority(
+    comparator_func: (a: string, b: string) => number,
+): void {
     const priority_sorted_pygments_data = Object.keys(generated_pygments_data.langs).sort(
         comparator_func,
     );
     for (const alias of priority_sorted_pygments_data) {
-        const pretty_name = generated_pygments_data.langs[alias].pretty_name;
+        // This variable is just for type safety so that we can access
+        // generated_pygments_data.langs[lang].pretty_name without a type error.
+        // We know that alias is a valid key of generated_pygments_data.langs because
+        // we just got it from Object.keys(generated_pygments_data.langs).
+        const lang = alias as keyof typeof generated_pygments_data.langs;
+        const pretty_name = generated_pygments_data.langs[lang].pretty_name;
         // JS Map remembers the original order of insertion of keys.
         if (map_pygments_pretty_name_to_aliases.has(pretty_name)) {
-            map_pygments_pretty_name_to_aliases.get(pretty_name).push(alias);
+            map_pygments_pretty_name_to_aliases.get(pretty_name)!.push(alias);
         } else {
             map_pygments_pretty_name_to_aliases.set(pretty_name, [alias]);
         }
@@ -49,7 +68,7 @@ function sort_pygments_pretty_names_by_priority(comparator_func) {
 // May return duplicates, since it's common for playground languages
 // to also be pygments languages! retain_unique_language_aliases will
 // deduplicate them.
-export function get_pygments_typeahead_list_for_composebox() {
+export function get_pygments_typeahead_list_for_composebox(): string[] {
     const playground_pygment_langs = [...map_language_to_playground_info.keys()];
     const generated_pygment_langs = Object.keys(generated_pygments_data.langs);
 
@@ -58,8 +77,8 @@ export function get_pygments_typeahead_list_for_composebox() {
 
 // This gets the candidate list for showing autocomplete in settings when
 // adding a new Code Playground.
-export function get_pygments_typeahead_list_for_settings(query) {
-    const language_labels = new Map();
+export function get_pygments_typeahead_list_for_settings(query: string): Map<string, string> {
+    const language_labels = new Map<string, string>();
 
     // Adds a typeahead that allows selecting a custom language, by adding a
     // "Custom language" label in the first position of the typeahead list.
@@ -83,7 +102,13 @@ export function get_pygments_typeahead_list_for_settings(query) {
     return language_labels;
 }
 
-export function initialize({playground_data, pygments_comparator_func}) {
+export function initialize({
+    playground_data,
+    pygments_comparator_func,
+}: {
+    playground_data: RealmPlayground[];
+    pygments_comparator_func: (a: string, b: string) => number;
+}): void {
     update_playgrounds(playground_data);
     sort_pygments_pretty_names_by_priority(pygments_comparator_func);
 }

--- a/web/src/realm_playground.ts
+++ b/web/src/realm_playground.ts
@@ -19,7 +19,7 @@ const map_pygments_pretty_name_to_aliases = new Map<string, string[]>();
 export function update_playgrounds(playgrounds_data: RealmPlayground[]): void {
     map_language_to_playground_info.clear();
 
-    for (const data of Object.values(playgrounds_data)) {
+    for (const data of playgrounds_data) {
         const element_to_push: Omit<RealmPlayground, "pygments_language"> = {
             id: data.id,
             name: data.name,

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -715,7 +715,6 @@ export function initialize_everything() {
     linkifiers.initialize(page_params.realm_linkifiers);
     realm_playground.initialize({
         playground_data: page_params.realm_playgrounds,
-        generated_pygments_data,
         pygments_comparator_func: typeahead_helper.compare_language,
     });
     compose.initialize();

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -108,6 +108,7 @@ import * as top_left_corner from "./top_left_corner";
 import * as topic_list from "./topic_list";
 import * as topic_zoom from "./topic_zoom";
 import * as tutorial from "./tutorial";
+import * as typeahead_helper from "./typeahead_helper";
 import * as typing from "./typing";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
@@ -712,7 +713,11 @@ export function initialize_everything() {
     message_scroll.initialize();
     markdown.initialize(markdown_config.get_helpers());
     linkifiers.initialize(page_params.realm_linkifiers);
-    realm_playground.initialize(page_params.realm_playgrounds, generated_pygments_data);
+    realm_playground.initialize({
+        playground_data: page_params.realm_playgrounds,
+        generated_pygments_data,
+        pygments_comparator_func: typeahead_helper.compare_language,
+    });
     compose.initialize();
     // Typeahead must be initialized after compose.initialize()
     composebox_typeahead.initialize({

--- a/web/tests/realm_playground.test.js
+++ b/web/tests/realm_playground.test.js
@@ -30,7 +30,6 @@ run_test("get_pygments_typeahead_list_for_composebox", () => {
     ];
     realm_playground.initialize({
         playground_data,
-        generated_pygments_data: pygments_data,
         pygments_comparator_func: typeahead_helper.compare_language,
     });
 
@@ -70,7 +69,6 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
     ];
     realm_playground.initialize({
         playground_data,
-        generated_pygments_data: pygments_data,
         pygments_comparator_func: typeahead_helper.compare_language,
     });
 

--- a/web/tests/realm_playground.test.js
+++ b/web/tests/realm_playground.test.js
@@ -9,6 +9,7 @@ const pygments_data = zrequire("../generated/pygments_data.json");
 
 const {$t} = zrequire("i18n");
 const realm_playground = zrequire("realm_playground");
+const typeahead_helper = zrequire("typeahead_helper");
 
 run_test("get_pygments_typeahead_list_for_composebox", () => {
     // When no Code Playground is configured, the list of candidates should
@@ -27,7 +28,11 @@ run_test("get_pygments_typeahead_list_for_composebox", () => {
             url_prefix: "https://example.com/?q=",
         },
     ];
-    realm_playground.initialize(playground_data, pygments_data);
+    realm_playground.initialize({
+        playground_data,
+        generated_pygments_data: pygments_data,
+        pygments_comparator_func: typeahead_helper.compare_language,
+    });
 
     // Verify that Code Playground's pygments_language shows up in the result.
     // As well as all of pygments_data. Order doesn't matter and the result
@@ -63,7 +68,11 @@ run_test("get_pygments_typeahead_list_for_settings", () => {
             url_prefix: "https://example.com/?q=",
         },
     ];
-    realm_playground.initialize(playground_data, pygments_data);
+    realm_playground.initialize({
+        playground_data,
+        generated_pygments_data: pygments_data,
+        pygments_comparator_func: typeahead_helper.compare_language,
+    });
 
     let candidates = realm_playground.get_pygments_typeahead_list_for_settings("");
     let iterator = candidates.entries();


### PR DESCRIPTION
This PR migrates `realm_playground` module to TypeScript with some prep commits.
- Passes the comparator function for comparing `pygments_language` via the initialization function to remove direct dependency on `typeahead_helper.js` which was the only file blocking the conversion.
- Removes the parameter `generated_pygments_data`  for initialization function because `realm_playground.js` was already directly importing the data so it does not make sense to pass it around.
- Main conversion commit.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
