### PR TITLE
WIP: Compose box clean up

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -82,7 +82,7 @@ export function update_audio_and_video_chat_button_display() {
 
 export function update_video_chat_button_display() {
     const show_video_chat_button = compute_show_video_chat_button();
-    $("compose_bottom_top_container .video_link").toggle(show_video_chat_button);
+    $(".compose-buttons-container .video_link").toggle(show_video_chat_button);
     $(".message-edit-feature-group .video_link").toggle(show_video_chat_button);
 }
 
@@ -452,8 +452,8 @@ export function initialize() {
     // Register hooks for compose_actions.
     setup_compose_actions_hooks();
 
-    $("compose_bottom_top_container .video_link").toggle(compute_show_video_chat_button());
-    $("compose_bottom_top_container .audio_link").toggle(compute_show_audio_chat_button());
+    $(".compose-buttons-container .video_link").toggle(compute_show_video_chat_button());
+    $(".compose-buttons-container .audio_link").toggle(compute_show_audio_chat_button());
 
     $("#compose-textarea").on("keydown", (event) => {
         compose_ui.handle_keydown(event, $("#compose-textarea").expectOne());

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -82,7 +82,7 @@ export function update_audio_and_video_chat_button_display() {
 
 export function update_video_chat_button_display() {
     const show_video_chat_button = compute_show_video_chat_button();
-    $("#below-compose-content .video_link").toggle(show_video_chat_button);
+    $("compose_bottom_top_container .video_link").toggle(show_video_chat_button);
     $(".message-edit-feature-group .video_link").toggle(show_video_chat_button);
 }
 
@@ -452,8 +452,8 @@ export function initialize() {
     // Register hooks for compose_actions.
     setup_compose_actions_hooks();
 
-    $("#below-compose-content .video_link").toggle(compute_show_video_chat_button());
-    $("#below-compose-content .audio_link").toggle(compute_show_audio_chat_button());
+    $("compose_bottom_top_container .video_link").toggle(compute_show_video_chat_button());
+    $("compose_bottom_top_container .audio_link").toggle(compute_show_audio_chat_button());
 
     $("#compose-textarea").on("keydown", (event) => {
         compose_ui.handle_keydown(event, $("#compose-textarea").expectOne());

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -133,7 +133,7 @@ export function get_posting_policy_error_message() {
 export function check_posting_policy_for_compose_box() {
     const banner_text = get_posting_policy_error_message();
     if (banner_text === "") {
-        $(".compose_right_float_container").removeClass("disabled-compose-send-button-container");
+        $(".compose-send-button-container").removeClass("disabled-compose-send-button-container");
         compose_banner.clear_errors();
         return;
     }
@@ -142,7 +142,7 @@ export function check_posting_policy_for_compose_box() {
     if (selected_recipient_id === "direct") {
         banner_classname = compose_banner.CLASSNAMES.private_messages_disabled;
     }
-    $(".compose_right_float_container").addClass("disabled-compose-send-button-container");
+    $(".compose-send-button-container").addClass("disabled-compose-send-button-container");
     compose_banner.show_error_message(banner_text, banner_classname, $("#compose_banners"));
 }
 

--- a/web/src/compose_tooltips.js
+++ b/web/src/compose_tooltips.js
@@ -33,8 +33,7 @@ export function initialize() {
         // Only display Tippy content on classes accompanied by a `data-` attribute.
         target: `
         .compose_control_button[data-tooltip-template-id],
-        .compose_control_button[data-tippy-content],
-        .compose_control_button_container
+        .compose_control_button[data-tippy-content]
         `,
         // Add some additional delay when they open
         // so that regular users don't have to see

--- a/web/src/compose_validate.js
+++ b/web/src/compose_validate.js
@@ -618,7 +618,7 @@ export function check_overflow_text() {
     // expensive.
     const text = compose_state.message_content();
     const max_length = page_params.max_message_length;
-    const $indicator = $("#compose_limit_indicator");
+    const $indicator = $("#compose-limit-indicator");
 
     if (text.length > max_length) {
         $indicator.addClass("over_limit");

--- a/web/src/giphy.js
+++ b/web/src/giphy.js
@@ -184,7 +184,7 @@ function get_popover_content() {
 }
 
 export function initialize() {
-    popover_menus.register_popover_menu(".compose_control_button.compose_gif_icon", {
+    popover_menus.register_popover_menu(".compose_control_button .compose_gif_icon", {
         placement: "top",
         onCreate(instance) {
             instance.setContent(ui_util.parse_html(get_popover_content()));

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -178,21 +178,15 @@
     }
 }
 
-#below-compose-content {
+.compose_bottom_top_container {
     display: flex;
-    flex-direction: column;
-    width: 100%;
+    align-items: center;
     margin-top: 6px;
-    margin-bottom: -2px;
+}
 
-    .compose_bottom_top_container {
-        display: flex;
-    }
-
-    .compose_bottom_bottom_container {
-        display: flex;
-        justify-content: space-between;
-    }
+.compose_bottom_bottom_container {
+    display: flex;
+    justify-content: space-between;
 }
 
 #compose-limit-indicator {
@@ -746,7 +740,6 @@ input.recipient_box {
     display: flex;
     flex-direction: row;
     white-space: nowrap;
-    margin-top: 2px;
     height: 24px;
 
     &.disabled-compose-send-button-container {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -655,15 +655,6 @@ input.recipient_box {
     gap: 4px;
     align-items: center;
 
-    /* We use the selector in this manner to maintain specificity. */
-    .compose_control_button_container .compose_gif_icon {
-        font-size: 22px;
-
-        /* Remove top and bottom padding. This is necessary
-         * because `compose_gif_icon` is no longer a flex item.  */
-        padding: 0 5px;
-    }
-
     .compose_control_button {
         padding: 1px 5px 0;
         opacity: 0.7;
@@ -678,6 +669,12 @@ input.recipient_box {
 
     .markdown_preview {
         padding-top: 0;
+    }
+
+    .compose_gif_icon {
+        display: block;
+        font-size: 22px;
+        margin-top: -1.5px;
     }
 
     .compose_control_menu {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -173,22 +173,6 @@
     margin: 0;
     height: 100%;
 
-    .messagebox-wrapper {
-        flex: 1;
-    }
-
-    .messagebox {
-        /* normally 5px 14px; pull in the right and bottom a bit */
-        cursor: default;
-        padding: 0;
-        background: none;
-        box-shadow: none;
-        border: none;
-        height: 100%;
-        display: flex;
-        flex-flow: column;
-    }
-
     .message_content {
         margin-right: 0;
     }

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -676,7 +676,7 @@ input.recipient_box {
     min-height: var(--compose-recipient-box-min-height);
 }
 
-.compose_control_buttons_container {
+.compose-control-buttons-container {
     margin-right: auto;
     display: flex;
     gap: 4px;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -190,7 +190,6 @@
 }
 
 #compose-limit-indicator {
-    margin-right: 8px;
     font-size: 12px;
     color: hsl(39deg 100% 50%);
     align-self: center;
@@ -605,12 +604,7 @@ input.recipient_box {
 
 .open_enter_sends_dialog {
     font-size: 12px;
-    height: 14px;
-    padding-left: 4px;
     opacity: 0.7;
-    margin-bottom: 5px;
-    position: relative;
-    top: -2px;
     cursor: pointer;
 
     @media (width < $mm_min) {
@@ -619,6 +613,7 @@ input.recipient_box {
 
     & kbd {
         padding: 0 4px;
+        margin: 0.1em 0.1em 0;
     }
 
     &:hover {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -665,21 +665,19 @@ input.recipient_box {
     }
 
     .compose_control_button {
-        padding: 5px;
+        padding: 1px 5px 0;
         opacity: 0.7;
         color: inherit;
         text-decoration: none;
         font-size: 17px;
-        text-align: center;
 
         &:hover {
             opacity: 1;
         }
     }
 
-    .fa-eye {
-        position: relative;
-        top: -0.7px;
+    .markdown_preview {
+        padding-top: 0;
     }
 
     .compose_control_menu {
@@ -706,7 +704,6 @@ input.recipient_box {
         display: flex;
         align-items: center;
         gap: 4px;
-        padding: 0;
         margin: 0;
     }
 
@@ -720,14 +717,12 @@ input.recipient_box {
         font-size: 15px;
         font-weight: 600;
         font-family: "Source Sans 3 VF", sans-serif;
-        padding: 0 5px;
-        position: relative;
-        top: 0.7px;
     }
 
     .compose_help_button {
         font-size: 20px;
         line-height: 17px;
+        padding-top: 0;
     }
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -211,7 +211,7 @@
     }
 }
 
-#compose_limit_indicator {
+#compose-limit-indicator {
     margin-right: 8px;
     font-size: 12px;
     color: hsl(39deg 100% 50%);

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -178,13 +178,13 @@
     }
 }
 
-.compose_bottom_top_container {
+.compose-buttons-container {
     display: flex;
     align-items: center;
     margin-top: 6px;
 }
 
-.compose_bottom_bottom_container {
+.enter-sends-container {
     display: flex;
     justify-content: space-between;
 }
@@ -736,7 +736,7 @@ input.recipient_box {
     }
 }
 
-.compose_right_float_container {
+.compose-send-button-container {
     display: flex;
     flex-direction: row;
     white-space: nowrap;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -872,6 +872,12 @@ input.recipient_box {
     }
 }
 
+@media (width < $sm_min) {
+    .compose-control-buttons-container {
+        margin-bottom: 1.5px;
+    }
+}
+
 @media (width < $mm_min) {
     #compose-content {
         margin-right: 5px;

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -550,7 +550,9 @@ input.recipient_box {
 }
 
 #compose-send-button {
-    padding: 3px 12px;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
     margin-bottom: 0;
     font-weight: 600;
     font-size: 0.9em;
@@ -558,8 +560,6 @@ input.recipient_box {
 
     .loader {
         display: none;
-        position: relative;
-        top: -6px;
     }
 }
 
@@ -733,8 +733,6 @@ input.recipient_box {
 
 .compose-send-button-container {
     display: flex;
-    flex-direction: row;
-    white-space: nowrap;
     height: 24px;
 
     &.disabled-compose-send-button-container {
@@ -850,11 +848,8 @@ input.recipient_box {
 #send_later {
     display: flex;
     align-items: center;
-    float: right;
-    color: hsl(0deg 0% 100%);
     border-radius: 0 4px 4px 0;
     padding: 0;
-    margin: 0;
 
     .zulip-icon {
         padding: 5px 9px;

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -597,7 +597,7 @@
         border-color: hsl(0deg 0% 0% / 90%);
     }
 
-    .compose_control_buttons_container .divider {
+    .compose-control-buttons-container .divider {
         color: hsl(236deg 33% 90% / 50%);
     }
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -75,8 +75,8 @@
                         <div class="preview_content rendered_markdown"></div>
                     </div>
                     <div class="drag"></div>
-                    <div class="compose_bottom_top_container">
-                        <div class="compose_right_float_container order-3">
+                    <div class="compose-buttons-container">
+                        <div class="compose-send-button-container order-3">
                             <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
                                 <img class="loader" alt="" src="" />
                                 <span>{{t 'Send' }}</span>
@@ -88,7 +88,7 @@
                         </div>
                         {{> compose_control_buttons }}
                     </div>
-                    <div class="compose_bottom_bottom_container">
+                    <div class="enter-sends-container">
                         <span id="compose-limit-indicator"></span>
                         <div class="open_enter_sends_dialog">
                             <span class="enter_sends_true">

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -69,46 +69,42 @@
                             </div>
                         </div>
                     </div>
-                    <div class="messagebox-wrapper">
-                        <div class="messagebox">
-                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
-                            <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
-                                <div class="markdown_preview_spinner"></div>
-                                <div class="preview_content rendered_markdown"></div>
+                    <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
+                    <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
+                        <div class="markdown_preview_spinner"></div>
+                        <div class="preview_content rendered_markdown"></div>
+                    </div>
+                    <div class="drag"></div>
+                    <div id="below-compose-content">
+                        <div class="compose_bottom_top_container">
+                            <div class="compose_right_float_container order-3">
+                                <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
+                                    <img class="loader" alt="" src="" />
+                                    <span>{{t 'Send' }}</span>
+                                </button>
+                                <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
+                                    <div class="separator-line"></div>
+                                    <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
+                                </button>
                             </div>
-                            <div class="drag"></div>
-                            <div id="below-compose-content">
-                                <div class="compose_bottom_top_container">
-                                    <div class="compose_right_float_container order-3">
-                                        <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
-                                            <img class="loader" alt="" src="" />
-                                            <span>{{t 'Send' }}</span>
-                                        </button>
-                                        <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
-                                            <div class="separator-line"></div>
-                                            <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
-                                        </button>
-                                    </div>
-                                    {{> compose_control_buttons }}
-                                </div>
-                                <div class="compose_bottom_bottom_container">
-                                    <span id="compose-limit-indicator"></span>
-                                    <div class="open_enter_sends_dialog">
-                                        <span class="enter_sends_true">
-                                            {{#tr}}
-                                                <z-shortcut></z-shortcut> to send
-                                                {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
-                                            {{/tr}}
-                                        </span>
-                                        <span class="enter_sends_false">
-                                            {{#tr}}
-                                                <z-shortcut></z-shortcut> to send
-                                                {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
-                                            {{/tr}}
-                                        </span>
-                                        <i class="fa fa-caret-down" aria-hidden="true"></i>
-                                    </div>
-                                </div>
+                            {{> compose_control_buttons }}
+                        </div>
+                        <div class="compose_bottom_bottom_container">
+                            <span id="compose-limit-indicator"></span>
+                            <div class="open_enter_sends_dialog">
+                                <span class="enter_sends_true">
+                                    {{#tr}}
+                                        <z-shortcut></z-shortcut> to send
+                                        {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
+                                    {{/tr}}
+                                </span>
+                                <span class="enter_sends_false">
+                                    {{#tr}}
+                                        <z-shortcut></z-shortcut> to send
+                                        {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
+                                    {{/tr}}
+                                </span>
+                                <i class="fa fa-caret-down" aria-hidden="true"></i>
                             </div>
                         </div>
                     </div>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -75,37 +75,35 @@
                         <div class="preview_content rendered_markdown"></div>
                     </div>
                     <div class="drag"></div>
-                    <div id="below-compose-content">
-                        <div class="compose_bottom_top_container">
-                            <div class="compose_right_float_container order-3">
-                                <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
-                                    <img class="loader" alt="" src="" />
-                                    <span>{{t 'Send' }}</span>
-                                </button>
-                                <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
-                                    <div class="separator-line"></div>
-                                    <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
-                                </button>
-                            </div>
-                            {{> compose_control_buttons }}
+                    <div class="compose_bottom_top_container">
+                        <div class="compose_right_float_container order-3">
+                            <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
+                                <img class="loader" alt="" src="" />
+                                <span>{{t 'Send' }}</span>
+                            </button>
+                            <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
+                                <div class="separator-line"></div>
+                                <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
+                            </button>
                         </div>
-                        <div class="compose_bottom_bottom_container">
-                            <span id="compose-limit-indicator"></span>
-                            <div class="open_enter_sends_dialog">
-                                <span class="enter_sends_true">
-                                    {{#tr}}
-                                        <z-shortcut></z-shortcut> to send
-                                        {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
-                                    {{/tr}}
-                                </span>
-                                <span class="enter_sends_false">
-                                    {{#tr}}
-                                        <z-shortcut></z-shortcut> to send
-                                        {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
-                                    {{/tr}}
-                                </span>
-                                <i class="fa fa-caret-down" aria-hidden="true"></i>
-                            </div>
+                        {{> compose_control_buttons }}
+                    </div>
+                    <div class="compose_bottom_bottom_container">
+                        <span id="compose-limit-indicator"></span>
+                        <div class="open_enter_sends_dialog">
+                            <span class="enter_sends_true">
+                                {{#tr}}
+                                    <z-shortcut></z-shortcut> to send
+                                    {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
+                                {{/tr}}
+                            </span>
+                            <span class="enter_sends_false">
+                                {{#tr}}
+                                    <z-shortcut></z-shortcut> to send
+                                    {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
+                                {{/tr}}
+                            </span>
+                            <i class="fa fa-caret-down" aria-hidden="true"></i>
                         </div>
                     </div>
                 </div>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -92,7 +92,7 @@
                                     {{> compose_control_buttons }}
                                 </div>
                                 <div class="compose_bottom_bottom_container">
-                                    <span id="compose_limit_indicator"></span>
+                                    <span id="compose-limit-indicator"></span>
                                     <div class="open_enter_sends_dialog">
                                         <span class="enter_sends_true">
                                             {{#tr}}

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -9,9 +9,9 @@
     <a role="button" class="compose_control_button audio_link" aria-label="{{t 'Add audio call' }}" tabindex=0 data-tippy-content="{{t 'Add audio call' }}"><i class="fa fa-phone"></i> </a>
     <a role="button" class="compose_control_button" data-tippy-content="{{t 'Add emoji' }}"> <i class="fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0></i> </a>
     <a role="button" class="compose_control_button time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"> <i class="fa fa-clock-o"></i> </a>
-    <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}}" data-tippy-content="{{t 'Add GIF' }}">
-        <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
-    </div>
+    <a role="button" class="compose_control_button {{#unless giphy_enabled }}hide{{/unless}}" data-tippy-content="{{t 'Add GIF' }}">
+        <i class="zulip-icon zulip-icon-gif compose_gif_icon" aria-label="{{t 'Add GIF' }}" tabindex=0></i>
+    </a>
     <div class="divider hide-sm">|</div>
     <div class="{{#if message_id}}hide-lg{{else}}hide-sm{{/if}}">
         {{> compose_control_buttons_in_popover}}

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -1,4 +1,4 @@
-<div class="compose_control_buttons_container order-1">
+<div class="compose-control-buttons-container order-1">
     <input type="file" class="file_input notvisible" multiple />
     {{#if file_upload_enabled }}
     <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -1,15 +1,14 @@
 <div class="compose-control-buttons-container order-1">
     <input type="file" class="file_input notvisible" multiple />
     {{#if file_upload_enabled }}
-    <a role="button" class="compose_control_button compose_upload_file fa fa-paperclip notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"></a>
+    <a role="button" class="compose_control_button compose_upload_file notdisplayed" aria-label="{{t 'Upload files' }}" tabindex=0 data-tippy-content="{{t 'Upload files' }}"> <i class="fa fa-paperclip"></i> </a>
     {{/if}}
-    <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
-    <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
-    <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
-    <div class="compose_control_button_container" data-tippy-content="{{t 'Add emoji' }}">
-        <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0></a>
-    </div>
-    <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"></a>
+    <a role="button" class="compose_control_button markdown_preview" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"> <i class="fa fa-eye"></i> </a>
+    <a role="button" class="compose_control_button undo_markdown_preview" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"> <i class="fa fa-edit"></i> </a>
+    <a role="button" class="compose_control_button video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"> <i class="fa fa-video-camera"></i> </a>
+    <a role="button" class="compose_control_button audio_link" aria-label="{{t 'Add audio call' }}" tabindex=0 data-tippy-content="{{t 'Add audio call' }}"><i class="fa fa-phone"></i> </a>
+    <a role="button" class="compose_control_button" data-tippy-content="{{t 'Add emoji' }}"> <i class="fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0></i> </a>
+    <a role="button" class="compose_control_button time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"> <i class="fa fa-clock-o"></i> </a>
     <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}}" data-tippy-content="{{t 'Add GIF' }}">
         <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>
     </div>

--- a/web/templates/compose_control_buttons_in_popover.hbs
+++ b/web/templates/compose_control_buttons_in_popover.hbs
@@ -1,5 +1,5 @@
-<a role="button" data-format-type="bold" class="compose_control_button fa fa-bold formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"></a>
-<a role="button" data-format-type="italic" class="compose_control_button fa fa-italic formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"></a>
-<a role="button" data-format-type="link" class="compose_control_button fa fa-link formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"></a>
+<a role="button" data-format-type="bold" class="compose_control_button formatting_button" aria-label="{{t 'Bold' }}" tabindex=0 data-tippy-content="{{t 'Bold' }}"> <i class="fa fa-bold"></i> </a>
+<a role="button" data-format-type="italic" class="compose_control_button formatting_button" aria-label="{{t 'Italic' }}" tabindex=0 data-tippy-content="{{t 'Italic' }}"> <i class="fa fa-italic"></i> </a>
+<a role="button" data-format-type="link" class="compose_control_button formatting_button" aria-label="{{t 'Link' }}" tabindex=0 data-tippy-content="{{t 'Link' }}"> <i class="fa fa-link"></i> </a>
 <div class="divider hide-sm">|</div>
-<a role="button" class="compose_control_button compose_help_button fa fa-question" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"></a>
+<a role="button" class="compose_control_button compose_help_button" tabindex=0 data-tippy-content="{{t 'Message formatting' }}" data-overlay-trigger="message-formatting"> <i class="fa fa-question"></i> </a>

--- a/web/templates/compose_control_buttons_popover.hbs
+++ b/web/templates/compose_control_buttons_popover.hbs
@@ -1,3 +1,3 @@
-<div class="compose_control_buttons_container order-1">
+<div class="compose-control-buttons-container order-1">
     {{> compose_control_buttons_in_popover}}
 </div>

--- a/web/tests/compose_validate.test.js
+++ b/web/tests/compose_validate.test.js
@@ -562,7 +562,7 @@ test_ui("test_check_overflow_text", ({mock_template}) => {
     page_params.max_message_length = 10000;
 
     const $textarea = $("#compose-textarea");
-    const $indicator = $("#compose_limit_indicator");
+    const $indicator = $("#compose-limit-indicator");
     const $send_button = $("#compose-send-button");
     let banner_rendered = false;
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -29,7 +29,7 @@ set_global(
 const server_events_dispatch = zrequire("server_events_dispatch");
 const compose = zrequire("compose");
 function stub_out_video_calls() {
-    const $elem = $("compose_bottom_top_container .video_link");
+    const $elem = $(".compose-buttons-container .video_link");
     $elem.toggle = (show) => {
         /* istanbul ignore if */
         if (show) {
@@ -234,7 +234,7 @@ test("test_video_chat_button_toggle disabled", ({override}) => {
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
     compose.initialize();
-    assert.equal($("compose_bottom_top_container .video_link").visible(), false);
+    assert.equal($(".compose-buttons-container .video_link").visible(), false);
 });
 
 test("test_video_chat_button_toggle no url", ({override}) => {
@@ -244,7 +244,7 @@ test("test_video_chat_button_toggle no url", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = null;
     compose.initialize();
-    assert.equal($("compose_bottom_top_container .video_link").visible(), false);
+    assert.equal($(".compose-buttons-container .video_link").visible(), false);
 });
 
 test("test_video_chat_button_toggle enabled", ({override}) => {
@@ -254,5 +254,5 @@ test("test_video_chat_button_toggle enabled", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = "https://meet.jit.si";
     compose.initialize();
-    assert.equal($("compose_bottom_top_container .video_link").visible(), true);
+    assert.equal($(".compose-buttons-container .video_link").visible(), true);
 });

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -29,7 +29,7 @@ set_global(
 const server_events_dispatch = zrequire("server_events_dispatch");
 const compose = zrequire("compose");
 function stub_out_video_calls() {
-    const $elem = $("#below-compose-content .video_link");
+    const $elem = $("compose_bottom_top_container .video_link");
     $elem.toggle = (show) => {
         /* istanbul ignore if */
         if (show) {
@@ -234,7 +234,7 @@ test("test_video_chat_button_toggle disabled", ({override}) => {
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
     compose.initialize();
-    assert.equal($("#below-compose-content .video_link").visible(), false);
+    assert.equal($("compose_bottom_top_container .video_link").visible(), false);
 });
 
 test("test_video_chat_button_toggle no url", ({override}) => {
@@ -244,7 +244,7 @@ test("test_video_chat_button_toggle no url", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = null;
     compose.initialize();
-    assert.equal($("#below-compose-content .video_link").visible(), false);
+    assert.equal($("compose_bottom_top_container .video_link").visible(), false);
 });
 
 test("test_video_chat_button_toggle enabled", ({override}) => {
@@ -254,5 +254,5 @@ test("test_video_chat_button_toggle enabled", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = "https://meet.jit.si";
     compose.initialize();
-    assert.equal($("#below-compose-content .video_link").visible(), true);
+    assert.equal($("compose_bottom_top_container .video_link").visible(), true);
 });


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This is a Prep commit for #24878.
This works in parallel with #26194.

Changes made in this PR:
- The `messagebox`, `messagebox-wrapper`, and `below-compose-content` divs have been removed. These divs were simply container elements and could be easily removed without affecting the layout. Their removal was done to clean up unnecessary divs and facilitate the conversion of the compose box to a grid layout for the redesign.

- Renamed some divs to more descriptive names:
    - `compose_bottom_top_container` to `compose-buttons-container`
    - `compose_right_float_container` to `compose-send-button-container`
    - `compose_bottom_bottom_container` to `enter-sends-container`

- Improves the alignment and consistency of button icons within the `compose_control_buttons_container` section. Previously,
icons were aligned using hardcoded top values, but they have now been restructured. Icons are no longer directly placed within the buttons; Instead, an <i> element with the class `fa fa-icon-name` has been added inside each button. This change will have two future benefits:
    - In the redesign of the compose box, we will incorporate custom SVGs using the "zulip-icon-*" class. It would be more convenient to use them as <i> elements.
    - Some of the popovers are being converted to Tippy. Since "Tippy tooltip" and "Tippy popover" cannot coexist on the same
element, we will need to split them into two separate elements just like gif icon. So, doing this helps maintain consistency across icons.

- Remove unnecessary CSS for `compose_send_button_container` and `enter_sends_container`. 


Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
- Now the new layout looks like this:
![image](https://github.com/zulip/zulip/assets/64723994/0bbc006f-0a5f-48e6-a588-c73cef282c66)


- Before vs After (This is a refactor PR keeping the same design):
![image](https://github.com/zulip/zulip/assets/64723994/d1e4361d-874d-49b7-a5c0-f63bdbde5097) 
vs
![image](https://github.com/zulip/zulip/assets/64723994/0e514a82-7d18-4eef-8e3f-2a0e850aedf6)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
