### PR TITLE
message_feed: Remove the view edit history option from the three-dot menu & add shortcut.

### DIFF
--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -150,6 +150,10 @@ in the Zulip app to add more to your repertoire as needed.
 
 * **Move message and (optionally) other messages in the same topic**: <kbd>M</kbd>
 
+* **View message edit and move history**: <kbd>Shift</kbd> +
+  <kbd>H</kbd>. Message edit history [must be
+  enabled](/help/disable-message-edit-history).
+
 * **Star message**: <kbd>Ctrl</kbd> + <kbd>S</kbd>
 
 * **React with <img alt=":thumbs_up:" class="emoji"

--- a/help/view-a-messages-edit-history.md
+++ b/help/view-a-messages-edit-history.md
@@ -16,23 +16,14 @@ Organization administrators can
 
 {start_tabs}
 
-1. Click on the message's **EDITED** or **MOVED** label.
+1. Click on the message's **EDITED** or **MOVED** label shown next to
+   a user's name or to the left of each message in the message feed.
 
-{end_tabs}
+!!! tip ""
 
-### Via the message menu (alternate method)
-
-{start_tabs}
-
-{!message-actions-menu.md!}
-
-1. Click **View edit history**.
-
-!!! warn ""
-
-    You will only see **View edit history** in the dropdown
-    menu if the message has been moved or edited, and
-    message edit history is enabled in the organization.
+    In organizations where message edit history is disabled, you will
+    never see a **MOVED** label; messages that have been moved will be
+    marked as **EDITED** just like those whose content has been edited.
 
 {end_tabs}
 

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -24,6 +24,7 @@ import * as hotspots from "./hotspots";
 import * as lightbox from "./lightbox";
 import * as list_util from "./list_util";
 import * as message_edit from "./message_edit";
+import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as narrow from "./narrow";
@@ -77,6 +78,7 @@ const keydown_shift_mappings = {
     39: {name: "right_arrow", message_view_only: false}, // right arrow
     38: {name: "up_arrow", message_view_only: false}, // up arrow
     40: {name: "down_arrow", message_view_only: false}, // down arrow
+    72: {name: "view_edit_history", message_view_only: true}, // 'H'
 };
 
 const keydown_unshift_mappings = {
@@ -1043,6 +1045,14 @@ export function process_hotkey(e, hotkey) {
             const $row = message_lists.current.get_row(msg.id);
             message_edit.start($row);
             return true;
+        }
+        case "view_edit_history": {
+            if (page_params.realm_allow_edit_history) {
+                message_edit_history.show_history(msg);
+                $("#message-history-cancel").trigger("focus");
+                return true;
+            }
+            return false;
         }
         case "move_message": {
             if (!message_edit.can_move_message(msg)) {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -34,7 +34,6 @@ import * as flatpickr from "./flatpickr";
 import * as giphy from "./giphy";
 import {$t_html} from "./i18n";
 import * as message_edit from "./message_edit";
-import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
@@ -800,17 +799,6 @@ export function initialize() {
                 if ($row && !message_container.is_hidden) {
                     message_lists.current.view.hide_revealed_message(message_id);
                 }
-                e.preventDefault();
-                e.stopPropagation();
-                instance.hide();
-            });
-
-            $popper.one("click", ".view_edit_history", (e) => {
-                const message_id = $(e.currentTarget).data("message-id");
-                const $row = message_lists.current.get_row(message_id);
-                const message = message_lists.current.get(rows.id($row));
-                message_edit_history.show_history(message);
-                $("#message-history-cancel").trigger("focus");
                 e.preventDefault();
                 e.stopPropagation();
                 instance.hide();

--- a/web/src/popover_menus_data.js
+++ b/web/src/popover_menus_data.js
@@ -65,17 +65,6 @@ export function get_actions_popover_content_context(message_id) {
     const should_display_mark_as_unread =
         !message.unread && not_spectator && (not_stream_message || subscribed_to_stream);
 
-    const should_display_edit_history_option =
-        message.edit_history &&
-        message.edit_history.some(
-            (entry) =>
-                entry.prev_content !== undefined ||
-                entry.prev_stream !== undefined ||
-                entry.prev_topic !== undefined,
-        ) &&
-        page_params.realm_allow_edit_history &&
-        not_spectator;
-
     // Disabling this for /me messages is a temporary workaround
     // for the fact that we don't have a styling for how that
     // should look.  See also condense.js.
@@ -113,7 +102,6 @@ export function get_actions_popover_content_context(message_id) {
         should_display_collapse,
         should_display_uncollapse,
         should_display_add_reaction_option,
-        should_display_edit_history_option,
         should_display_hide_option,
         conversation_time_url,
         narrowed: narrow_state.active(),

--- a/web/templates/actions_popover_content.hbs
+++ b/web/templates/actions_popover_content.hbs
@@ -101,15 +101,6 @@
     </li>
     {{/if}}
 
-    {{#if should_display_edit_history_option}}
-    <li>
-        <a class="view_edit_history" data-message-id="{{message_id}}" tabindex="0">
-            <i class="fa fa-clock-o" aria-hidden="true"></i>
-            {{t "View edit history" }}
-        </a>
-    </li>
-    {{/if}}
-
     {{#if should_display_read_receipts_option}}
     <li>
         <a class="view_read_receipts" data-message-id="{{message_id}}" tabindex="0">

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -229,6 +229,10 @@
                     <td><span class="hotkey"><kbd>M</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{{t 'View edit and move history' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>H</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{{t 'Star selected message' }}</td>
                     <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>
                 </tr>
@@ -257,10 +261,6 @@
                 <tr>
                     <td class="definition">{{t 'Toggle topic mute' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>M</kbd></span></td>
-                </tr>
-                <tr>
-                    <td class="definition">{{t 'View edit history' }}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>H</kbd></span></td>
                 </tr>
             </table>
         </div>

--- a/web/templates/keyboard_shortcuts.hbs
+++ b/web/templates/keyboard_shortcuts.hbs
@@ -258,6 +258,10 @@
                     <td class="definition">{{t 'Toggle topic mute' }}</td>
                     <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>M</kbd></span></td>
                 </tr>
+                <tr>
+                    <td class="definition">{{t 'View edit history' }}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>H</kbd></span></td>
+                </tr>
             </table>
         </div>
         <div>


### PR DESCRIPTION
- [x] Remove "View edit history" from the three-dot menu.
- [x] Update https://zulip.com/help/view-a-messages-edit-history accordingly
- [x] Add `Shift+H` as a keyboard shortcut to open the message edit history dialog.

--------------

Fixes: #23077

-------------

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>
<br>

<img width="243" alt="Screenshot 2023-07-12 at 10 37 58 PM" src="https://github.com/zulip/zulip/assets/66828942/de3e786d-08f1-420a-a4a4-49acf4a68a81">

<br>

<img width="779" alt="Screenshot 2023-07-12 at 10 37 34 PM" src="https://github.com/zulip/zulip/assets/66828942/48c8658a-fb70-4136-81dc-4e6b06c4648b">


</details>

<details>
<summary>After:</summary>
<br>

<img width="249" alt="Screenshot 2023-07-12 at 10 27 45 PM" src="https://github.com/zulip/zulip/assets/66828942/2a6ad194-df72-482d-9990-becd8c9b74db">

<br>

<img width="743" alt="Screenshot 2023-08-14 at 1 52 38 AM" src="https://github.com/zulip/zulip/assets/66828942/8b443d7f-c48c-4ece-8558-ac5441a37fee">



</details>

<details>
<summary>Keyboard Shortcuts dialog:</summary>
<br>

<img width="547" alt="Screenshot 2023-07-28 at 5 35 05 AM" src="https://github.com/zulip/zulip/assets/66828942/33578755-c601-4ffa-a6f0-beaaef6a291c">



</details>


---------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
