### PR TITLE
link preview: Remove max-height and bottom shadow for link previews.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -363,14 +363,6 @@
         }
     }
 
-    .message_embed .data-container::after {
-        background: linear-gradient(
-            0deg,
-            hsl(212deg 28% 18%),
-            transparent 100%
-        );
-    }
-
     .column-left .left-sidebar,
     .stream_name_search_section,
     .group_name_search_section,

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -474,7 +474,6 @@
         margin: 5px 0;
         border: none;
         border-left: 3px solid hsl(0deg 0% 93%);
-        height: 80px;
         padding: 5px;
         z-index: 1;
         text-shadow: hsl(0deg 0% 0% / 1%) 0 0 1px;
@@ -499,10 +498,11 @@
 
         .message_embed_image {
             display: inline-block;
-            width: 70px;
-            height: 70px;
             background-size: cover;
             background-position: center;
+            max-width: 300px;
+            height: 100px;
+            width: 100%;
         }
 
         .data-container {
@@ -510,28 +510,12 @@
             padding: 0 5px;
             display: inline-block;
             vertical-align: top;
-            max-width: calc(100% - 115px);
-            max-height: 80px;
             overflow: hidden;
         }
 
         .data-container div {
             display: block;
             border: none;
-        }
-
-        .data-container::after {
-            content: " ";
-            position: absolute;
-            width: 100%;
-            height: 10%;
-            bottom: 0;
-
-            background: linear-gradient(
-                0deg,
-                hsl(0deg 0% 100%),
-                transparent 100%
-            );
         }
     }
 
@@ -673,11 +657,6 @@
 @media (width < $sm_min) {
     .rendered_markdown .message_embed {
         height: auto;
-
-        .message_embed_image {
-            width: 100%;
-            height: 100px;
-        }
 
         .data-container {
             display: block;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1695,6 +1695,12 @@ div.focused_table {
 
     &.condensed {
         max-height: 8.5em;
+        /* Narrower screens need a bit more preview space because there is less space.
+           This is also important for link previews, since otherwise they would get cut
+           off halfway through the image. */
+        @media (width < $sm_min) {
+            max-height: 25em;
+        }
         min-height: 0;
         overflow: hidden;
     }


### PR DESCRIPTION
Previously, we cut off link previews at a fixed height, and also displayed a linear-gradient ishadow at the bottom of the preview to transition the message into the background where it cut off.

But there were several issues present. The shadow faded to the default message color, which broke for dark mode when the background color changed. But it would have already been broken for light and dark mode with messages other than the default color (i.e. mention highlights). The shadow was also displayed in every link preview, even if it wasn't cut off.

This change removes the shadow for every message, and allows link previews to be displayed in full. This removes the visual bugs, removes the need for the shadow, and allows users to view the full preview text.

Long preview messages can be condensed with our existing condense message infrastructure. Very narrow messages needed to be changed to be taller so that the full link preview would be visible.

CZO conversation: https://chat.zulip.org/#narrow/stream/101-design/topic/shadow.20at.20bottom.20of.20link.20preview/near/1605298

<details>
<summary>Screenshots before</summary>

<img width="776" alt="image" src="https://github.com/zulip/zulip/assets/5634097/c72453cd-edab-4026-a87b-6c58e81efc8c">

<img width="456" alt="image" src="https://github.com/zulip/zulip/assets/5634097/de67fda2-bbf6-4f41-b646-1c1946b7e0d1">

![image](https://github.com/zulip/zulip/assets/5634097/764a0096-3a6c-402f-b2b0-9ef94ba9caaa)


<img width="370" alt="image" src="https://github.com/zulip/zulip/assets/5634097/0ec7ba48-c606-4201-8a50-bcb1fd544447">

<img width="356" alt="image" src="https://github.com/zulip/zulip/assets/5634097/55d81fe4-8ac7-4d58-9945-14b3aca33ab8">


</details>


<details>
<summary>Screenshots after</summary>

<img width="477" alt="image" src="https://github.com/zulip/zulip/assets/5634097/bf0b10dc-9f84-41f4-8799-08f2bc02e2bd">

<img width="466" alt="image" src="https://github.com/zulip/zulip/assets/5634097/33a91052-4a82-4a9c-887c-394c540af931">

<img width="711" alt="image" src="https://github.com/zulip/zulip/assets/5634097/3a44de96-724a-427f-95c2-fa71f61b403c">

<img width="710" alt="image" src="https://github.com/zulip/zulip/assets/5634097/9d2c309b-bb6c-4e6d-9478-63761f8455d0">



</details>