### PR TITLE
message-viewport: Limit top/bottom scroll handler if popover is active.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -256,7 +256,7 @@ export function initialize_kitchen_sink_stuff() {
     const throttled_mousewheelhandler = _.throttle((_e, delta) => {
         // Most of the mouse wheel's work will be handled by the
         // scroll handler, but when we're at the top or bottom of the
-        // page, the pointer may still need to move.
+        // page, the selected message may still need to move.
 
         if (delta < 0 && message_viewport.at_top()) {
             navigate.up();
@@ -269,7 +269,11 @@ export function initialize_kitchen_sink_stuff() {
 
     message_viewport.$scroll_container.on("wheel", (e) => {
         const delta = e.originalEvent.deltaY;
-        if (!overlays.is_overlay_or_modal_open() && narrow_state.is_message_feed_visible()) {
+        if (
+            !overlays.is_overlay_or_modal_open() &&
+            !popovers.any_active() &&
+            narrow_state.is_message_feed_visible()
+        ) {
             // In the message view, we use a throttled mousewheel handler.
             throttled_mousewheelhandler(e, delta);
         }


### PR DESCRIPTION
Adds an additional check for calling `throttled_mousewheelhandler` on "wheel" scroll events so that, if the message viewport is at the top or bottom, the selected message doesn't change.

*Note that if the popover is open and the message viewport is at the bottom or top, and the user scrolls towards the opposite end of the feed while **not** hovering over the popover, then the popover will close and the message feed will scroll. If the user is in a view where both the top and bottom of the view are simultaneously visible, then scrolling anywhere on the screen with the mouse wheel will not close the popover. This is the current behavior and does not change with these updates; see screen captures below.*

Fixes #25980.

Also, fixes [issue discussed here on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/emoji.20popover.20scrolls.20in.20message.20feed.20as.20well/near/1608995):
> I was in a direct message conversation. The last message in the view was selected and the view was scrolled to the very bottom. I used the mouse to click on the emoji reaction for a message that wasn't selected, earlier in the conversation. The popover opened, but when I used the mouse wheel to scroll to the emoji I wanted, the selected message scrolled as well.
> 
> I didn't notice until I clicked the emoji and it showed up on the "wrong" message in that it wasn't the message I wanted to react to.
> 
> Only seems to reproduce for me when the view is scrolled all the way to the bottom. I can reproduce in both interleaved views and conversation views.

---

**Screenshots and screen captures:**

<details>
<summary>Current main - stream view where top/bottom both visible</summary>

[Screencast from 2023-07-13 17-57-41.webm](https://github.com/zulip/zulip/assets/63245456/6a03e4a7-dfd7-423f-b19c-19c9a6c0423d)
</details>
<details>
<summary>After changes - stream view where top/bottom both visible</summary>

[Screencast from 2023-07-13 17-56-38.webm](https://github.com/zulip/zulip/assets/63245456/30857864-d6d9-4f4d-83f3-62aba397a850)
</details>
<details>
<summary>Current main - stream view where bottom visible</summary>

[Screencast from 2023-07-13 17-58-54.webm](https://github.com/zulip/zulip/assets/63245456/ad8b9bfb-e1c5-4917-8f58-7edc56e8c012)
</details>
<details>
<summary>After changes - stream view where bottom visible</summary>

[Screencast from 2023-07-13 17-59-58.webm](https://github.com/zulip/zulip/assets/63245456/7ba13e42-1b11-4fd2-b5ee-273929f99eaa)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
