### PR TITLE
me_messages: Sender-name cleanup.

### DIFF
--- a/web/src/info_overlay.js
+++ b/web/src/info_overlay.js
@@ -128,7 +128,8 @@ def zulip():
     },
     {
         markdown: "/me is busy working",
-        output_html: '<p><span class="sender_name-in-status">Iago</span> is busy working</p>',
+        output_html:
+            '<p><span class="sender_name">Iago</span> <span class="status-message">is busy working</span></p>',
     },
     {
         markdown: "<time:2023-05-28T13:30:00+05:30>",

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -730,17 +730,13 @@ export function hide_playground_links_popover() {
 }
 
 export function register_click_handlers() {
-    $("#main_div").on(
-        "click",
-        ".sender_name, .sender_name-in-status, .message-avatar",
-        function (e) {
-            const $row = $(this).closest(".message_row");
-            e.stopPropagation();
-            const message = message_lists.current.get(rows.id($row));
-            const user = people.get_by_user_id(message.sender_id);
-            show_user_info_popover_for_message(this, user, message);
-        },
-    );
+    $("#main_div").on("click", ".sender_name, .message-avatar", function (e) {
+        const $row = $(this).closest(".message_row");
+        e.stopPropagation();
+        const message = message_lists.current.get(rows.id($row));
+        const user = people.get_by_user_id(message.sender_id);
+        show_user_info_popover_for_message(this, user, message);
+    });
 
     $("#main_div").on("click", ".user-mention", function (e) {
         const id_string = $(this).attr("data-user-id");

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -342,8 +342,7 @@ $time_column_min_width: 50px; /* + padding */
                     padding: $message_box_margin 0 0 5px;
                 }
 
-                .sender_name,
-                .sender_name-in-status {
+                .sender_name {
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1577,21 +1577,11 @@ td.pointer {
 .sender_name {
     display: inline-block;
     font-weight: 700;
-}
-
-.sender_name-in-status {
-    margin-right: 3px;
-    font-weight: 700;
-}
-
-.sender_name,
-.sender_name-in-status {
     color: var(--color-text-sender-name);
 }
 
 .sender_name_hovered {
-    .sender_name,
-    .sender_name-in-status {
+    .sender_name {
         color: hsl(200deg 100% 40%);
     }
 }

--- a/web/tests/popovers.test.js
+++ b/web/tests/popovers.test.js
@@ -111,7 +111,7 @@ test_ui("sender_hover", ({override, mock_template}) => {
     page_params.is_spectator = false;
     override($.fn, "popover", noop);
 
-    const selection = ".sender_name, .sender_name-in-status, .message-avatar";
+    const selection = ".sender_name, .message-avatar";
     const handler = $("#main_div").get_on_handler("click", selection);
 
     const message = {


### PR DESCRIPTION
This PR removes remaining references to a class (`.sender_name-in-status`) that was eliminated as part of #25997.

It also aligns the info-overlay example for me-messages to use the `.sender_name` class, along with the `status-message` class, so that the example always remains in concord with live code. (In the screenshots below, you can see the extra space after Iago's name is no longer present because of how usernames are now run inline with the me-message text.)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![info-overlay-before](https://github.com/zulip/zulip/assets/170719/45e843fa-d45b-453e-8a8e-8c191aa7e34e) | ![info-overlay-after](https://github.com/zulip/zulip/assets/170719/75e00f93-0bd3-45a6-a6c5-bdd70d1cef07) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>