### PR TITLE
me_message: Lighten me-messages to 0.6 opacity.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -294,6 +294,7 @@ $time_column_min_width: 50px; /* + padding */
 
             .status-message {
                 font-weight: normal;
+                opacity: 0.6;
             }
 
             .message_content {


### PR DESCRIPTION
This PR lightens the text of me-messages to 0.6 opacity, as [specified by Vlad on CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/me-message.20layout/near/1594028).

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![me-message-before](https://github.com/zulip/zulip/assets/170719/10a6f44e-cc29-4222-ab2b-5b8d52ebb725) | ![me-message-after](https://github.com/zulip/zulip/assets/170719/f0c5629b-6792-4ead-8063-b24c5a16f325) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>