### PR TITLE
alert_messages: Use a background color to obscure controls and time.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -407,10 +407,6 @@
         color: inherit !important;
     }
 
-    .private-message .alert-msg {
-        background-color: hsl(208deg 17% 29%);
-    }
-
     .active_private_messages_section {
         #private_messages_section,
         #private_messages_list,

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -215,6 +215,10 @@ $time_column_min_width: 50px; /* + padding */
             /* Span both the controls and time columns */
             grid-row: controls-start;
             grid-column: controls-start / time-end;
+            /* Use 1px of margin on the right to keep the alert message's
+               background color from overlapping the selected-message
+               outline. */
+            margin-right: 1px;
         }
 
         .message_length_controller {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1128,11 +1128,13 @@ td.pointer {
     animation: rotate 1s infinite linear;
 }
 
-/* The way this overrides the menus with a background-color and a high
-   z-index is kinda hacky, and requires some annoying color-matching,
-   but it works. */
 .alert-msg {
     color: hsl(170deg 48% 54%);
+    /* Duplicate the message-content background color so as to hide
+       the hover controls and time marker. */
+    background-color: var(--color-background-stream-message-content);
+    /* The z-index is necessary to ensure that alert messages fully
+       overlay the hover controls and time marker. */
     z-index: 999;
     font-weight: 400;
     display: none;
@@ -1548,10 +1550,7 @@ td.pointer {
 .message_row.private-message {
     background-color: var(--color-background-private-message-content);
 
-    .alert-msg {
-        background-color: hsl(192deg 20% 95%);
-    }
-
+    .alert-msg,
     .date_row {
         background-color: var(--color-background-private-message-content);
     }


### PR DESCRIPTION
This commit duplicates the background color for streams and private messages on alert messages to hide the controls and time.

See [CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/inconsistent.20Copied!.20alerts/near/1609936)

**Screenshots and screen captures:**

| Private Messages Before | Private Messages After |
| --- | --- |
| ![private-light-before](https://github.com/zulip/zulip/assets/170719/5e904844-9f07-4190-af0c-2cfa0055d505) | ![private-light-after](https://github.com/zulip/zulip/assets/170719/a92a3637-8e75-4b9c-9a6c-2d5605319017) |
| ![private-dark-before](https://github.com/zulip/zulip/assets/170719/01fc5c10-9eb7-4bd3-b2ab-95e140b7166e) | ![private-dark-after](https://github.com/zulip/zulip/assets/170719/5481f876-57ae-4994-b1a9-62d6ae198a71) |

| Stream Messages Before | Stream Messages After |
| --- | --- |
| ![stream-light-before](https://github.com/zulip/zulip/assets/170719/f3321bb1-b135-4be2-97c7-b97b737d7021) | ![stream-light-after](https://github.com/zulip/zulip/assets/170719/325a3550-172b-413a-bdc5-5473f525b7d4) |
| ![stream-dark-before](https://github.com/zulip/zulip/assets/170719/3f8481b1-49e8-451d-8099-78c4ea941f8d) | ![stream-dark-after](https://github.com/zulip/zulip/assets/170719/c6c6f6a4-29df-45ea-ad2c-a6880627bb53) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>