### PR TITLE
message list: Preserve selected message when navigating back to search results.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -59,6 +59,7 @@ EXEMPT_FILES = make_set(
         "web/src/billing/upgrade.ts",
         "web/src/blueslip.ts",
         "web/src/blueslip_stacktrace.ts",
+        "web/src/browser_history.js",
         "web/src/click_handlers.js",
         "web/src/compose.js",
         "web/src/compose_actions.js",

--- a/web/src/browser_history.js
+++ b/web/src/browser_history.js
@@ -2,6 +2,8 @@
 
 import * as blueslip from "./blueslip";
 import * as hash_util from "./hash_util";
+import * as message_lists from "./message_lists";
+import * as narrow_state from "./narrow_state";
 import * as ui_util from "./ui_util";
 import {user_settings} from "./user_settings";
 
@@ -95,4 +97,25 @@ export function update_hash_internally_if_required(hash) {
 
 export function return_to_web_public_hash() {
     window.location.hash = state.spectator_old_hash;
+}
+
+export const hash_to_page_location = {};
+
+export function save_narrow() {
+    const narrow_data = {};
+    if (!narrow_state.active()) {
+        return;
+    }
+
+    const narrow_pointer = message_lists.current.selected_id();
+    if (narrow_pointer === -1) {
+        return;
+    }
+    narrow_data.narrow_pointer = narrow_pointer;
+    const $narrow_row = message_lists.current.selected_row();
+    if ($narrow_row.length === 0) {
+        return;
+    }
+    narrow_data.narrow_offset = $narrow_row.get_offset_to_window().top;
+    hash_to_page_location[window.location.hash] = narrow_data;
 }

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -196,6 +196,7 @@ export function initialize() {
                 // This might happen for locally echoed messages, for example.
                 return;
             }
+            browser_history.save_narrow();
             window.location = hash_util.by_conversation_and_time_url(message);
             return;
         }

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -201,6 +201,12 @@ function do_hashchange_normal(from_reload) {
                     narrow_opts.then_select_offset = page_params.initial_narrow_offset;
                 }
             }
+            const location_data_for_hash =
+                browser_history.hash_to_page_location[window.location.hash];
+            if (location_data_for_hash !== undefined) {
+                narrow_opts.then_select_id = location_data_for_hash.narrow_pointer;
+                narrow_opts.then_select_offset = location_data_for_hash.narrow_offset;
+            }
             narrow.activate(operators, narrow_opts);
             return true;
         }


### PR DESCRIPTION
Fixes #20066.
    
![Kapture-2023-07-17-at-07 17 10](https://github.com/zulip/zulip/assets/5634097/ebbdc1d1-c55c-4eab-9163-f5c7245363c3)


This commit replicates some of the logic in reload.preserve_state
to save scroll position and selected message in search views, so
that if the user navigates back to the search results we can put
them in the same position they were when they navigated away.

This saves one position per search result, so if there are two
searches for the same string in search history they'll both
load the same position and selected message.

Fresh searches always load at the bottom of the search results
instead of loading the previously saved position because
`narrow.activate` changes the window.location *after* a search
is completed.

For a behind-the-scenes look at thoughts while working on this
change: https://chat.zulip.org/#narrow/stream/6-frontend/topic/back.20navigation.20from.20search.20.5Blivestream.5D