### PR TITLE
search: Rename search_arrows to search_input.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -523,7 +523,7 @@
         background-color: hsl(0deg 0% 0% / 20%);
     }
 
-    #search_arrows .pill,
+    #searchbox-input-container .pill,
     #compose-direct-recipient.pill-container .pill {
         color: inherit;
         border: 1px solid hsl(0deg 0% 0% / 50%);
@@ -531,7 +531,7 @@
         font-weight: 600;
     }
 
-    #search_arrows .pill:focus,
+    #searchbox-input-container .pill:focus,
     #compose-direct-recipient.pill-container .pill:focus {
         color: hsl(0deg 0% 100%);
         border: 1px solid hsl(176deg 78% 28% / 60%);

--- a/web/styles/search.css
+++ b/web/styles/search.css
@@ -88,7 +88,7 @@
         }
     }
 
-    #search_arrows:focus {
+    #searchbox-input-container:focus {
         box-shadow: inset 0 0 0 2px hsl(204deg 20% 74%);
     }
 
@@ -132,7 +132,7 @@
         left: 0;
     }
 
-    #search_arrows {
+    #searchbox-input-container {
         font-size: 90%;
         letter-spacing: normal;
         padding-left: 0;

--- a/web/templates/navbar.hbs
+++ b/web/templates/navbar.hbs
@@ -17,7 +17,7 @@
                     </div>
                     <div id="searchbox">
                         <form id="searchbox_form" class="navbar-search">
-                            <div id="search_arrows" class="input-append">
+                            <div id="searchbox-input-container" class="input-append">
                                 <span class="search_icon"><i class="zulip-icon zulip-icon-search tippy-zulip-delayed-tooltip" data-tooltip-template-id="search-query-tooltip-template"></i></span>
                                 <input class="search-query input-block-level home-page-input" id="search_query" type="text" placeholder="{{t 'Search' }}"
                                   autocomplete="off"/>


### PR DESCRIPTION
The terminology "arrows" comes from historical functionality that is no longer relevant, so search_input is a more clear and accurate name.

No functional changes.
