### PR TITLE
wal-g: Support alternate S3 storage classes.

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -908,6 +908,19 @@ may wish to increase this if you are taking backups on a replica, so can afford
 to affect other disk I/O, and have an SSD which is good at parallel random
 reads.
 
+#### `backups_storage_class`
+
+What [storage class](https://aws.amazon.com/s3/storage-classes/) to use when
+uploading database backups. Defaults to `STANDARD`, meaning "[S3
+standard][s3-standard]", but many deployments will have overall lower costs if
+"[S3 Standard - Infrequent Access][s3-ia]" is used, via the `STANDARD_IA`
+value. Also supported is "[S3 Reduced Redundancy][s3-rr]", by setting
+`REDUCED_REDUNDANCY`, but this is not suggested for production use.
+
+[s3-standard]: https://aws.amazon.com/s3/storage-classes/#General_purpose
+[s3-ia]: https://aws.amazon.com/s3/storage-classes/#Infrequent_access
+[s3-rr]: https://aws.amazon.com/s3/reduced-redundancy/
+
 #### `missing_dictionaries`
 
 If set to a true value during initial database creation, uses PostgreSQL's

--- a/puppet/zulip/files/postgresql/env-wal-g
+++ b/puppet/zulip/files/postgresql/env-wal-g
@@ -22,4 +22,9 @@ if ! s3_backups_bucket=$(crudini --get "$ZULIP_SECRETS_CONF" secrets s3_backups_
     exit 1
 fi
 export WALG_S3_PREFIX="s3://$s3_backups_bucket"
+
+if storage_class=$(crudini --get /etc/zulip/zulip.conf postgresql backups_storage_class 2>&1); then
+    export WALG_S3_STORAGE_CLASS="$storage_class"
+fi
+
 exec /usr/local/bin/wal-g "$@"

--- a/puppet/zulip/files/postgresql/env-wal-g
+++ b/puppet/zulip/files/postgresql/env-wal-g
@@ -21,5 +21,5 @@ if ! s3_backups_bucket=$(crudini --get "$ZULIP_SECRETS_CONF" secrets s3_backups_
     echo "Could not determine which s3 bucket to use:" "$s3_backups_bucket"
     exit 1
 fi
-export WALE_S3_PREFIX="s3://$s3_backups_bucket"
+export WALG_S3_PREFIX="s3://$s3_backups_bucket"
 exec /usr/local/bin/wal-g "$@"


### PR DESCRIPTION
Using S3's "infrequent access" storage class can save some money on larger backups.

Tested in a test production instance.  Note that this changes the storage class for _new_ backups but does not adjust old ones.  You can `aws cp --storage-class STANDARD_IA --recursive s3://some-bucket-name/ s3://some-bucket-name/` to adjust the storage class on existing files.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
