### PR TITLE
poll_data: Revert to using "canned" instead of -1.

### DIFF
--- a/web/shared/src/poll_data.ts
+++ b/web/shared/src/poll_data.ts
@@ -21,7 +21,7 @@ export type PollOptionData = {
 
 type PollOption = {
     option: string;
-    user_id: number;
+    user_id: number | string;
     votes: Map<number, number>;
 };
 
@@ -40,7 +40,7 @@ export type PollHandle = {
     };
     new_option: {
         outbound: (option: string) => {type: string; idx: number; option: string};
-        inbound: (sender_id: number, data: InboundData) => void;
+        inbound: (sender_id: number | string, data: InboundData) => void;
     };
     question: {
         outbound: (question: string) => {type: string; question: string} | undefined;
@@ -238,7 +238,7 @@ export class PollData {
         };
 
         for (const [i, option] of options.entries()) {
-            this.handle.new_option.inbound(-1, {
+            this.handle.new_option.inbound("canned", {
                 idx: i,
                 option,
                 type: "new_option",


### PR DESCRIPTION
According to this [CZO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/poll.20responses.20removed.20or.20missing.3F) we have a bug in `poll_widget` which causes it to not show vote counts on old polls.

This was most probably introduced in this commit [ae6063807b64484a1162def4750037e341c75820](https://github.com/zulip/zulip/commit/ae6063807b64484a1162def4750037e341c75820).

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
