### PR TITLE
compose: Allow URLs to be pasted onto selected text.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "handlebars-loader": "^1.7.1",
     "html-webpack-plugin": "^5.3.2",
     "intl-messageformat": "^10.3.0",
+    "is-url": "^1.2.4",
     "jquery": "^3.6.3",
     "jquery-caret-plugin": "^1.5.2",
     "jquery-validation": "^1.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ dependencies:
   intl-messageformat:
     specifier: ^10.3.0
     version: 10.5.0
+  is-url:
+    specifier: ^1.2.4
+    version: 1.2.4
   jquery:
     specifier: ^3.6.3
     version: 3.7.0
@@ -7453,6 +7456,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       unc-path-regex: 0.1.2
+    dev: false
+
+  /is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
     dev: false
 
   /is-utf8@0.2.1:

--- a/web/src/compose_ui.js
+++ b/web/src/compose_ui.js
@@ -339,7 +339,7 @@ export function handle_keyup(_event, $textarea) {
     rtl.set_rtl_class_for_textarea($textarea);
 }
 
-export function format_text($textarea, type) {
+export function format_text($textarea, type, inserted_content) {
     const italic_syntax = "*";
     const bold_syntax = "**";
     const bold_and_italic_syntax = "***";
@@ -501,6 +501,14 @@ export function format_text($textarea, type) {
             const new_start = range.end + "[](".length;
             const new_end = new_start + "url".length;
             field.setSelectionRange(new_start, new_end);
+            break;
+        }
+        case "linked": {
+            // From a paste event with a URL as inserted content
+            wrapSelection(field, "[", `](${inserted_content})`);
+            // Put the cursor at the end of the selection range
+            // and all wrapped material
+            $textarea.caret(range.end + `[](${inserted_content})`.length);
             break;
         }
     }


### PR DESCRIPTION
This PR enables URL-pasting onto selected compose text. The logic checks for the presence of a URL on the clipboard following a `"paste"` event, and equally for a text selection in the compose area. Absent either of those things, no action is taken. Otherwise, a Markdown string of the selected text is formatted using the selection in the textarea, and the cursor is placed at the end of the new Markdown string.

The PR opens with a testing-related prep commit to remove brittle, self-referential event-testing logic from the copy-and-paste tests, which will break anyway once there is need to reach into the event object--as this PR does in retrieving the textarea in question.

Fixes: #18692

[Recent CZO discussion](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Linkify.20text.20when.20pasting.20an.20url/near/1608530)

**Compose area:**
![copy-and-paste-compose](https://github.com/zulip/zulip/assets/170719/758d5f28-680b-4d7a-8351-2c1b2192668d)

**Edit area:**
![copy-and-paste-edit](https://github.com/zulip/zulip/assets/170719/9f9f8efb-0b14-445a-a347-f58da2c5989c)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>

