### PR TITLE
recent_topics: Fix clear search button misaligned.

### DIFF
--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -123,10 +123,6 @@
             padding-top: 6px !important;
         }
 
-        #recent_topics_search_clear {
-            margin-top: -10px !important;
-        }
-
         .btn-recent-filters {
             border-radius: 40px;
             margin: 0 5px 10px 0;


### PR DESCRIPTION
Looks like some changes actually improved aligned of this icon so that we don't need this hacky margin.

before:
<img width="383" alt="Screenshot 2023-07-19 at 10 32 07 PM" src="https://github.com/zulip/zulip/assets/25124304/df4a134b-b730-4b7b-9696-8dafe0c02b42">


after:

<img width="383" alt="Screenshot 2023-07-19 at 10 31 56 PM" src="https://github.com/zulip/zulip/assets/25124304/46aafc86-db70-4122-ad16-2ee3324963e0">

