### PR TITLE
wal-g: Use "start_time" field, not "time" which is S3 modified-at.

### DIFF
--- a/puppet/zulip/files/postgresql/wal-g-exporter
+++ b/puppet/zulip/files/postgresql/wal-g-exporter
@@ -106,7 +106,7 @@ class WalGPrometheusServer(BaseHTTPRequestHandler):
             )
 
             if len(data) > 0:
-                data.sort(key=lambda e: e["time"], reverse=True)
+                data.sort(key=lambda e: e["start_time"], reverse=True)
                 latest = data[0]
                 labels = {
                     "host": latest["hostname"],


### PR DESCRIPTION
The `time` field is based on the file metadata in S3, which means that touching the file contents in S3 can move backups around in the list.

Switch to using `start_time` as the sort key, which is based on the contents of the JSON file stored as part of the backup, so is not affected by changes in S3 metadata.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
