### PR TITLE
docs: Update help center links to "Edit a message" and "Delete a message".

### DIFF
--- a/templates/corporate/features.html
+++ b/templates/corporate/features.html
@@ -195,10 +195,10 @@
             <p>Enjoy the benefits of threaded conversations while
             controlling your audience and privacy.</p>
         </a>
-        <a class="feature-block" href="/help/edit-or-delete-a-message" target="_blank" rel="noopener noreferrer">
+        <a class="feature-block" href="/help/edit-a-message" target="_blank" rel="noopener noreferrer">
             <h3>MESSAGE EDITING</h3>
             <p>Don’t worry, you can always fix that typo, either in
-            the body of message or its topic.</p>
+            the body of a message or its topic.</p>
         </a>
         <a class="feature-block" href="/help/move-content-to-another-stream" target="_blank" rel="noopener noreferrer">
             <h3>MOVING MESSAGES</h3>

--- a/templates/corporate/for/business.html
+++ b/templates/corporate/for/business.html
@@ -333,7 +333,7 @@
                     <li>
                         <div class="list-content">
                             If you made a mistake, no worries! You
-                            can <a href="/help/edit-or-delete-a-message">edit your
+                            can <a href="/help/edit-a-message">edit your
                             message</a>, or move it to a
                             different <a href="/help/move-content-to-another-topic">topic</a>
                             or <a href="/help/move-content-to-another-stream">stream</a>.

--- a/templates/corporate/for/events.html
+++ b/templates/corporate/for/events.html
@@ -203,7 +203,7 @@
                     <li><div class="list-content"><a href="/help/format-your-message-using-markdown#latex">Type LaTeX</a> directly into your Zulip message, and see it beautifully rendered.</div></li>
                     <li><div class="list-content"><a href="/help/code-blocks">Zulip code blocks</a> come with syntax highlighting for over 250 languages, and integrated <a href="/help/code-blocks#code-playgrounds">code playgrounds.</a></div></li>
                     <li><div class="list-content">Structure your ideas with bulleted and numbered <a href="/help/format-your-message-using-markdown#lists">lists</a>.</div></li>
-                    <li><div class="list-content">If you made a mistake, no worries! You can <a href="/help/edit-or-delete-a-message">edit your message</a>, or move it to a different <a href="/help/move-content-to-another-topic">topic</a> or <a href="/help/move-content-to-another-stream">stream</a>.</div></li>
+                    <li><div class="list-content">If you made a mistake, no worries! You can <a href="/help/edit-a-message">edit your message</a>, or move it to a different <a href="/help/move-content-to-another-topic">topic</a> or <a href="/help/move-content-to-another-stream">stream</a>.</div></li>
                 </ul>
             </div>
         </div>

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -360,7 +360,7 @@
                     <li>
                         <div class="list-content">
                             If you made a mistake, no worries! You
-                            can <a href="/help/edit-or-delete-a-message">edit your
+                            can <a href="/help/edit-a-message">edit your
                             message</a>, or move it to a
                             different <a href="/help/move-content-to-another-topic">topic</a>
                             or <a href="/help/move-content-to-another-stream">stream</a>.

--- a/templates/corporate/for/research.html
+++ b/templates/corporate/for/research.html
@@ -197,7 +197,7 @@
                     <li>
                         <div class="list-content">
                             If you made a mistake, no worries! You
-                            can <a href="/help/edit-or-delete-a-message">edit your
+                            can <a href="/help/edit-a-message">edit your
                             message</a>, or move it to a
                             different <a href="/help/move-content-to-another-topic">topic</a>
                             or <a href="/help/move-content-to-another-stream">stream</a>.

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1118,7 +1118,7 @@ export function delete_message(msg_id) {
     confirm_dialog.launch({
         html_heading: $t_html({defaultMessage: "Delete message?"}),
         html_body,
-        help_link: "/help/edit-or-delete-a-message#delete-a-message",
+        help_link: "/help/delete-a-message#delete-a-message-completely",
         on_click: do_delete_message,
         loading_spinner: true,
     });

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -236,7 +236,7 @@
         <div id="org-msg-deletion" class="settings-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Message deletion" }}
-                    {{> ../help_link_widget link="/help/edit-or-delete-a-message#delete-a-message" }}
+                    {{> ../help_link_widget link="/help/delete-a-message" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="msg-deletion" }}
             </div>

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7357,7 +7357,7 @@ paths:
         [delete a message completely][delete-completely] feature documented in
         the Zulip Help Center.
 
-        [delete-completely]: /help/edit-or-delete-a-message#delete-a-message-completely
+        [delete-completely]: /help/delete-a-message#delete-a-message-completely
       x-requires-administrator: true
       parameters:
         - $ref: "#/components/parameters/MessageId"


### PR DESCRIPTION
This PR is a follow-up to #26166.