### PR TITLE
nginx: Remove gzip_disable "msie6"

### DIFF
--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -33,7 +33,6 @@ http {
     reset_timedout_connection on;
 
     gzip on;
-    gzip_disable "msie6";
     gzip_proxied any;
     gzip_types
       application/javascript


### PR DESCRIPTION
We don’t support IE 6.