### PR TITLE
message view: Don't mark message as read in mentions view.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -527,10 +527,6 @@ export class Filter {
             return true;
         }
 
-        if (_.isEqual(term_types, ["is-mentioned"])) {
-            return true;
-        }
-
         if (_.isEqual(term_types, ["is-resolved"])) {
             return true;
         }
@@ -568,15 +564,19 @@ export class Filter {
         // can_mark_messages_read tests the following filters:
         // stream, stream + topic,
         // is:dm, dm,
-        // is:mentioned, is:resolved
+        // is:resolved
         if (this.can_mark_messages_read()) {
             return true;
         }
         // that leaves us with checking:
         // is: starred
-        // (which can_mark_messages_read_does not check as starred messages are always read)
+        // (which can_mark_messages_read does not check as starred messages are always read)
+        // is: mentioned
+        // (for which can_mark_messages_read returns false, since they don't have conversation context)
         const term_types = this.sorted_term_types();
-
+        if (_.isEqual(term_types, ["is-mentioned"])) {
+            return true;
+        }
         if (_.isEqual(term_types, ["is-starred"])) {
             return true;
         }

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -213,7 +213,7 @@ test("basics", () => {
     operators = [{operator: "is", operand: "mentioned"}];
     filter = new Filter(operators);
     assert.ok(!filter.contains_only_private_messages());
-    assert.ok(filter.can_mark_messages_read());
+    assert.ok(!filter.can_mark_messages_read());
     assert.ok(!filter.supports_collapsing_recipients());
     assert.ok(!filter.has_operator("search"));
     assert.ok(filter.can_apply_locally());
@@ -361,11 +361,7 @@ function assert_not_mark_read_with_is_operands(additional_operators_to_test) {
 
     is_operator = [{operator: "is", operand: "mentioned"}];
     filter = new Filter([...additional_operators_to_test, ...is_operator]);
-    if (additional_operators_to_test.length === 0) {
-        assert.ok(filter.can_mark_messages_read());
-    } else {
-        assert.ok(!filter.can_mark_messages_read());
-    }
+    assert.ok(!filter.can_mark_messages_read());
 
     is_operator = [{operator: "is", operand: "mentioned", negated: true}];
     filter = new Filter([...additional_operators_to_test, ...is_operator]);


### PR DESCRIPTION
[CZO conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/mentions.20narrow)

Reverts 399dc5046b27ecd92e4fe2885064cda2e14eb5b5 which reverted 5e97ec9ad95ea8ab6810b2fea7ce423f5a4462a2, which we can bring back now that we display a banner when messages can't be marked as read.

<img width="1453" alt="image" src="https://github.com/zulip/zulip/assets/5634097/070ee664-4b9c-4514-a38f-05b7e89dc5b1">

<img width="1434" alt="image" src="https://github.com/zulip/zulip/assets/5634097/b4680344-b5fd-4f4c-ad43-91d5d96699ff">

