### PR TITLE
help: Offer relative links to in-app overlays for logged in users.

### DIFF
--- a/help/format-your-message-using-markdown.md
+++ b/help/format-your-message-using-markdown.md
@@ -130,10 +130,13 @@ A summary of the formatting syntax above is available in the Zulip app.
 
 {start_tabs}
 
-{!start-composing.md!}
+{relative|gear|message-formatting}
 
-1. Click the **question mark** (<i class="fa fa-question"></i>) icon at the
-   bottom of the compose box.
+!!! tip ""
+
+    You can also [open the compose box](/help/open-the-compose-box), and click
+    the **question mark** (<i class="fa fa-question"></i>) icon at the bottom of
+    the compose box.
 
 {end_tabs}
 

--- a/help/include/all-messages.md
+++ b/help/include/all-messages.md
@@ -9,8 +9,7 @@ view](/help/configure-default-view#configure-default-view) for the Zulip web app
 
 {tab|desktop-web}
 
-1. Open **All messages** from the left sidebar or with the
-   <kbd>A</kbd> keyboard shortcut.
+{relative|message|all}
 
 {tab|mobile}
 

--- a/help/include/invite-users.md
+++ b/help/include/invite-users.md
@@ -1,0 +1,4 @@
+1. Click on the **gear** (<i class="fa fa-cog"></i>) icon in the upper
+   right corner of the web or desktop app.
+
+1. Select <i class="fa fa-user-plus"></i> **Invite users**.

--- a/help/include/open-recent-conversations.md
+++ b/help/include/open-recent-conversations.md
@@ -1,1 +1,0 @@
-1. Click **Recent conversations** in the left sidebar.

--- a/help/include/reading-topics.md
+++ b/help/include/reading-topics.md
@@ -2,7 +2,7 @@
 
 {tab|via-recent-conversations}
 
-{!open-recent-conversations.md!}
+{relative|message|recent}
 
 1. Click on the name of a topic in the **Topic** column.
 

--- a/help/include/recent-conversations.md
+++ b/help/include/recent-conversations.md
@@ -6,7 +6,7 @@ for catching up on messages sent while you were away.
 
 {start_tabs}
 
-{!open-recent-conversations.md!}
+{relative|message|recent}
 
 1. The filters at the top help you quickly find relevant conversations.
    For example, select **Participated** to narrow to the topics you

--- a/help/invite-new-users.md
+++ b/help/invite-new-users.md
@@ -29,7 +29,7 @@ permission to invite users.
 
 {start_tabs}
 
-{relative|gear|invite}
+{!invite-users.md!}
 
 1. Click **Send an email**.
 
@@ -61,7 +61,7 @@ permission to invite users.
 
 {start_tabs}
 
-{relative|gear|invite}
+{!invite-users.md!}
 
 1. Click **Generate invite link**.
 

--- a/help/keyboard-shortcuts.md
+++ b/help/keyboard-shortcuts.md
@@ -232,8 +232,12 @@ A summary of the keyboard shortcuts above is available in the Zulip app.
 
 {start_tabs}
 
-1. Click the **keyboard** (<i class="fa fa-keyboard-o"></i>) icon at the bottom
-   of the app, just below the right sidebar.
+{relative|gear|keyboard-shortcuts}
+
+!!! tip ""
+
+    You can also click the **keyboard** (<i class="fa fa-keyboard-o"></i>)
+    icon at the bottom of the app, just below the right sidebar.
 
 {end_tabs}
 

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -73,7 +73,7 @@ stream or topic as read**.
 
 {tab|via-recent-conversations}
 
-{!open-recent-conversations.md!}
+{relative|message|recent}
 
 1. Click on an unread messages counter in the **Topic** column to mark all
    messages in that topic as read.

--- a/help/search-for-messages.md
+++ b/help/search-for-messages.md
@@ -154,10 +154,7 @@ A summary of the search filters above is available in the Zulip app.
 
 {start_tabs}
 
-1. Click the **keyboard** (<i class="fa fa-keyboard-o"></i>) icon at the bottom
-   of the app, just below the right sidebar.
-
-1. Switch to the **Search filters** tab.
+{relative|gear|search-filters}
 
 {end_tabs}
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -27,6 +27,7 @@ gear_info = {
     "billing": ["Billing", "/billing/"],
     "invite": ["Invite users", "/#invite"],
     "keyboard-shortcuts": ["Keyboard shortcuts (?)", "/#keyboard-shortcuts"],
+    "message-formatting": ["Message formatting", "/#message-formatting"],
     "about-zulip": ["About Zulip", "/#about-zulip"],
 }
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -75,9 +75,15 @@ scheduled_instructions = """
    sidebar. If you do not see this link, you have no scheduled messages.
 """
 
+recent_instructions = """
+1. Click on <i class="fa fa-clock-o"></i> **Recent conversations** in the left
+   sidebar.
+"""
+
 message_info = {
     "drafts": ["Drafts", "/#drafts", draft_instructions],
     "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
+    "recent": ["Recent conversations", "/#recent", recent_instructions],
 }
 
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -80,10 +80,16 @@ recent_instructions = """
    sidebar.
 """
 
+all_instructions = """
+1. Click on <i class="fa fa-align-left"></i> **All messages** in the left
+   sidebar or use the <kbd>A</kbd> keyboard shortcut.
+"""
+
 message_info = {
     "drafts": ["Drafts", "/#drafts", draft_instructions],
     "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
     "recent": ["Recent conversations", "/#recent", recent_instructions],
+    "all": ["All messages", "/#all_messages", all_instructions],
 }
 
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -26,6 +26,7 @@ gear_info = {
     "plans": ["Plans and pricing", "/plans/"],
     "billing": ["Billing", "/billing/"],
     "invite": ["Invite users", "/#invite"],
+    "keyboard-shortcuts": ["Keyboard shortcuts (?)", "/#keyboard-shortcuts"],
     "about-zulip": ["About Zulip", "/#about-zulip"],
 }
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -25,7 +25,6 @@ gear_info = {
     "stats": ["Usage statistics", "/stats"],
     "plans": ["Plans and pricing", "/plans/"],
     "billing": ["Billing", "/billing/"],
-    "invite": ["Invite users", "/#invite"],
     "keyboard-shortcuts": ["Keyboard shortcuts (?)", "/#keyboard-shortcuts"],
     "message-formatting": ["Message formatting", "/#message-formatting"],
     "search-filters": ["Search filters", "/#search-operators"],

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -28,6 +28,7 @@ gear_info = {
     "invite": ["Invite users", "/#invite"],
     "keyboard-shortcuts": ["Keyboard shortcuts (?)", "/#keyboard-shortcuts"],
     "message-formatting": ["Message formatting", "/#message-formatting"],
+    "search-filters": ["Search filters", "/#search-operators"],
     "about-zulip": ["About Zulip", "/#about-zulip"],
 }
 


### PR DESCRIPTION
As discussed in https://github.com/zulip/zulip/pull/26124#discussion_r1252000330, this PR adds the following relative help links:

`{relative|message|recent}`
`{relative|message|all}`
`{relative|gear|keyboard-shortcuts}`
`{relative|gear|message-formatting}`
`{relative|gear|search-filters}`

and replaces `{relative|gear|invite}` with a Markdown include since we no longer use the `#invite` hash in the web-app.

**Notes:**
- Maybe we should add the corresponding gear menu icon to each item name in `gear_info`? If so, we could add all of them as a separate commit.

**Screenshots and screen captures:**
- https://zulip.com/help/recent-conversations
![image](https://github.com/zulip/zulip/assets/2343554/78f0e3fc-af76-402c-bbee-5bef98dc3e11)
![image](https://github.com/zulip/zulip/assets/2343554/c0d454fb-0ec6-47cc-bfa4-b5bf5a0c6f88)

- https://zulip.com/help/all-messages
![image](https://github.com/zulip/zulip/assets/2343554/c90795fd-18bf-4098-89a6-5bd2d04da4fa)
![image](https://github.com/zulip/zulip/assets/2343554/efcdf3d3-7d97-4e2f-82af-1a4c12c9f2c6)

- https://zulip.com/help/keyboard-shortcuts#keyboard-shortcuts-reference
![image](https://github.com/zulip/zulip/assets/2343554/a3330d7b-510d-4b8b-9d45-1b2023d3d612)
![image](https://github.com/zulip/zulip/assets/2343554/47193497-2537-4cfb-8dfc-3424250575b7)

- http://zulip.com/help/format-your-message-using-markdown#message-formatting-reference
![image](https://github.com/zulip/zulip/assets/2343554/aae3e9a9-2c91-46bb-912c-115c7f2f0fb5)
![image](https://github.com/zulip/zulip/assets/2343554/e71257da-b6ee-441e-9df0-1e503405e424)

- http://zulip.com/help/search-for-messages#search-filters-reference
![image](https://github.com/zulip/zulip/assets/2343554/179eec49-4dc0-4e23-9b77-492c3c36254c)
![image](https://github.com/zulip/zulip/assets/2343554/fe196ec0-9747-49c6-af64-085ebc4173ad)

- http://zulip.com/help/invite-new-users
![image](https://github.com/zulip/zulip/assets/2343554/23eefba6-a665-48fb-bdaf-3016458abaec)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>