### PR TITLE
gitea: Support missing head/base refs.

### DIFF
--- a/zerver/webhooks/gitea/view.py
+++ b/zerver/webhooks/gitea/view.py
@@ -31,8 +31,10 @@ def format_pull_request_event(payload: WildValue, include_title: bool = False) -
     target_branch = None
     base_branch = None
     if action != "edited":
-        target_branch = payload["pull_request"]["head"]["ref"].tame(check_string)
-        base_branch = payload["pull_request"]["base"]["ref"].tame(check_string)
+        if "head" in payload["pull_request"]:
+            target_branch = payload["pull_request"]["head"]["ref"].tame(check_string)
+        if "base" in payload["pull_request"]:
+            base_branch = payload["pull_request"]["base"]["ref"].tame(check_string)
     title = payload["pull_request"]["title"].tame(check_string) if include_title else None
     stringified_assignee = assignee["login"].tame(check_string) if assignee else None
 


### PR DESCRIPTION

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
