### PR TITLE
emails: Send onboarding_zulip_guide only for unique organization type.

### DIFF
--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -458,7 +458,12 @@ class TestFollowupEmails(ZulipTestCase):
         scheduled_emails = ScheduledEmail.objects.filter(users=cordelia)
         self.assert_length(scheduled_emails, 0)
 
-    def test_followup_emails_for_regular_realms(self) -> None:
+    def test_emails_for_new_organization_with_existing_account(self) -> None:
+        # The initial account registered email is sent, and its content is for
+        # creating a new organization. Neither of the additional onboarding
+        # emails are scheduled because the user has a user account with the same
+        # email in another realm and that other realm has the same organization
+        # type as the new realm.
         cordelia = self.example_user("cordelia")
         with self.captureOnCommitCallbacks(execute=True) as callbacks:
             send_account_registered_email(self.example_user("cordelia"), realm_creation=True)
@@ -489,7 +494,12 @@ class TestFollowupEmails(ZulipTestCase):
         self.assertIn("you have created a new Zulip organization", message.body)
         self.assertNotIn("demo org", message.body)
 
-    def test_followup_emails_for_demo_realms(self) -> None:
+    def test_emails_for_new_demo_organization_with_existing_account(self) -> None:
+        # The initial account registered email is sent, and its content is for
+        # creating a new demo organization. Neither of the additional onboarding
+        # emails are scheduled because the user has a user account with the same
+        # email in another realm and that other realm has the same organization
+        # type as the new realm.
         cordelia = self.example_user("cordelia")
         cordelia.realm.demo_organization_scheduled_deletion_date = timezone_now() + timedelta(
             days=30


### PR DESCRIPTION
Only schedule the `onboarding_zulip_guide` email if the user is not also a member of any other Zulip organization of the same type on the server.

See [relevant CZO conversation](https://chat.zulip.org/#narrow/stream/138-user-community/topic/Zulip.20guide.20for.20open-source.20projects/near/1600880)

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
