### PR TITLE
topic generator test: Use strings for stream name instead of numbers.

### DIFF
--- a/web/tests/topic_generator.test.js
+++ b/web/tests/topic_generator.test.js
@@ -41,12 +41,12 @@ run_test("streams", () => {
 });
 
 run_test("topics", ({override}) => {
-    const streams = [1, 2, 3, 4];
+    const streams = ["stream1", "stream2", "stream3", "stream4"];
     const topics = new Map([
-        [1, ["read", "read", "1a", "1b", "read", "1c"]],
-        [2, []],
-        [3, ["3a", "read", "read", "3b", "read"]],
-        [4, ["4a"]],
+        ["stream1", ["read", "read", "1a", "1b", "read", "1c"]],
+        ["stream2", []],
+        ["stream3", ["3a", "read", "read", "3b", "read"]],
+        ["stream4", ["4a"]],
     ]);
 
     function has_unread_messages(_stream, topic) {
@@ -61,15 +61,15 @@ run_test("topics", ({override}) => {
         return tg.next_topic(streams, get_topics, has_unread_messages, curr_stream, curr_topic);
     }
 
-    assert.deepEqual(next_topic(1, "1a"), {stream: 1, topic: "1b"});
-    assert.deepEqual(next_topic(1, undefined), {stream: 1, topic: "1a"});
-    assert.deepEqual(next_topic(2, "bogus"), {stream: 3, topic: "3a"});
-    assert.deepEqual(next_topic(3, "3b"), {stream: 3, topic: "3a"});
-    assert.deepEqual(next_topic(4, "4a"), {stream: 1, topic: "1a"});
-    assert.deepEqual(next_topic(undefined, undefined), {stream: 1, topic: "1a"});
+    assert.deepEqual(next_topic("stream1", "1a"), {stream: "stream1", topic: "1b"});
+    assert.deepEqual(next_topic("stream1", undefined), {stream: "stream1", topic: "1a"});
+    assert.deepEqual(next_topic("stream2", "bogus"), {stream: "stream3", topic: "3a"});
+    assert.deepEqual(next_topic("stream3", "3b"), {stream: "stream3", topic: "3a"});
+    assert.deepEqual(next_topic("stream4", "4a"), {stream: "stream1", topic: "1a"});
+    assert.deepEqual(next_topic(undefined, undefined), {stream: "stream1", topic: "1a"});
 
     assert.deepEqual(
-        tg.next_topic(streams, get_topics, () => false, 1, "1a"),
+        tg.next_topic(streams, get_topics, () => false, "stream1", "1a"),
         undefined,
     );
 


### PR DESCRIPTION
This function takes the stream name (a string) and using numbers makes it seem like it's actually using a stream id, which is confusing. This change adjusts `stream` to always be a string.