### PR TITLE
scheduled messages: Allow user to reschedule quickly from edit window.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -569,6 +569,18 @@ export function initialize() {
     $("body").on(
         "click",
         `.${CSS.escape(
+            compose_banner.CLASSNAMES.unscheduled_message,
+        )} .main-view-banner-action-button`,
+        (event) => {
+            event.preventDefault();
+            const send_at_timestamp = popover_menus.get_selected_send_later_timestamp();
+            popover_menus.do_schedule_message(send_at_timestamp);
+        },
+    );
+
+    $("body").on(
+        "click",
+        `.${CSS.escape(
             compose_banner.CLASSNAMES.recipient_not_subscribed,
         )} .main-view-banner-action-button`,
         (event) => {

--- a/web/src/scheduled_messages.js
+++ b/web/src/scheduled_messages.js
@@ -144,12 +144,10 @@ function show_message_unscheduled_banner(scheduled_delivery_timestamp) {
     );
     const unscheduled_banner = render_compose_banner({
         banner_type: compose_banner.WARNING,
-        banner_text: $t(
-            {
-                defaultMessage: "This message is no longer scheduled for {deliver_at}.",
-            },
-            {deliver_at},
-        ),
+        banner_text: $t({
+            defaultMessage: "This message is no longer scheduled to be sent.",
+        }),
+        button_text: $t({defaultMessage: "Schedule for {deliver_at}"}, {deliver_at}),
         classname: compose_banner.CLASSNAMES.unscheduled_message,
     });
     compose_banner.append_compose_banner_to_banner_list(unscheduled_banner, $("#compose_banners"));


### PR DESCRIPTION
Currently we unschedule messages as soon as they're opened for editing. Users have requested a way to easily reschedule, especially for situations where they didn't end up wanting to edit the messages in the first place.

This commit adds an action button to reschedule the message for the time it was originally scheduled for.

CZO:
https://chat.zulip.org/#narrow/stream/9-issues/topic/Scheduled.20message.20sent.20to.20draft.20if.20no.20changes

<img width="916" alt="image" src="https://github.com/zulip/zulip/assets/5634097/d3980005-09ab-44fa-abd7-90494d232365">

