### PR TITLE
messages: Fix first unread message being marked as read on reload.

### DIFF
--- a/web/src/message_fetch.js
+++ b/web/src/message_fetch.js
@@ -469,6 +469,7 @@ export function initialize(home_view_loaded) {
             message_lists.home.select_id(data.anchor, {
                 then_scroll: true,
                 use_closest: true,
+                mark_read: false,
                 target_scroll_offset: page_params.initial_offset,
             });
         }

--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -129,7 +129,11 @@ export class MessageList {
             // message. Regardless of whether the messages are new or
             // old, we want to select a message as though we just
             // entered this view.
-            this.select_id(this.first_unread_message_id(), {then_scroll: true, use_closest: true});
+            this.select_id(this.first_unread_message_id(), {
+                then_scroll: true,
+                use_closest: true,
+                mark_read: false,
+            });
         }
 
         return render_info;

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -782,6 +782,7 @@ export function update_selection(opts) {
     message_lists.current.select_id(msg_id, {
         then_scroll,
         use_closest: true,
+        mark_read: false,
         force_rerender: true,
     });
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
As @laurynmm pointed out [here in CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/messages.20marked.20as.20read.20in.20open.20tabs.20when.20page.20reloaded/near/1611162)  when a pinned tab (not on focus) that is set to a narrowed view is reloaded, the first unread message in the list is marked as read. 

So while trying to debug this and I found out that the select_id() function was getting called with the  message_id  of first unread message three times and since the default opts of select_id is ```mark_read: true``` so I explicitly set mark_read to false (specifically in message_fetch.js, message_list.js and narrow.js) and now the problem is solved !

Fixes: #26299 <!-- Issue link, or clear description.-->

Note: 
- I am not aware of any specific case when the messages should be marked as read when the function is being called but if there are any kindly mention them.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


https://github.com/zulip/zulip/assets/91622060/aace88e1-2dc1-4c03-90a5-6ed27f18c7f9


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
