### PR TITLE
message fetch: Avoid cache complexity and ORM overhead

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -421,10 +421,6 @@ def display_recipient_cache_key(recipient_id: int) -> str:
     return f"display_recipient_dict:{recipient_id}"
 
 
-def single_user_display_recipient_cache_key(user_id: int) -> str:
-    return f"single_user_display_recipient:{user_id}"
-
-
 def user_profile_cache_key_id(email: str, realm_id: int) -> str:
     return f"user_profile:{hashlib.sha1(email.strip().encode()).hexdigest()}:{realm_id}"
 
@@ -536,7 +532,6 @@ def delete_display_recipient_cache(user_profile: "UserProfile") -> None:
         "recipient_id", flat=True
     )
     keys = [display_recipient_cache_key(rid) for rid in recipient_ids]
-    keys.append(single_user_display_recipient_cache_key(user_profile.id))
     cache_delete_many(keys)
 
 

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -76,7 +76,7 @@ class EditMessageTestCase(ZulipTestCase):
                 allow_edit_history=True,
             )
 
-        self.assert_length(queries, 1)
+        self.assert_length(queries, 2)
         for query in queries:
             self.assertNotIn("message", query.sql)
 
@@ -3700,7 +3700,7 @@ class EditMessageTest(EditMessageTestCase):
                     "topic": "new topic",
                 },
             )
-        self.assert_length(cache_tries, 13)
+        self.assert_length(cache_tries, 11)
 
         messages = get_topic_messages(user_profile, old_stream, "test")
         self.assert_length(messages, 1)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -947,7 +947,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        self.assert_length(cache_tries, 18)
+        self.assert_length(cache_tries, 17)
 
         user_profile = self.nonreg_user("test")
         self.assert_logged_in_user_id(user_profile.id)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -947,7 +947,7 @@ class LoginTest(ZulipTestCase):
         # seem to be any O(N) behavior.  Some of the cache hits are related
         # to sending messages, such as getting the welcome bot, looking up
         # the alert words for a realm, etc.
-        self.assert_length(cache_tries, 19)
+        self.assert_length(cache_tries, 18)
 
         user_profile = self.nonreg_user("test")
         self.assert_logged_in_user_id(user_profile.id)

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -18,10 +18,10 @@ class TestBasics(ZulipTestCase):
             stream_name=stream_name,
         )
 
+        self.assertEqual(SubMessage.get_raw_db_rows([]), [])
+
         def get_raw_rows() -> List[Dict[str, Any]]:
-            query = SubMessage.get_raw_db_rows([message_id])
-            rows = list(query)
-            return rows
+            return SubMessage.get_raw_db_rows([message_id])
 
         rows = get_raw_rows()
         self.assertEqual(rows, [])

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -800,7 +800,7 @@ class QueryCountTest(ZulipTestCase):
                         acting_user=None,
                     )
 
-        self.assert_length(cache_tries, 24)
+        self.assert_length(cache_tries, 22)
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]
 
         notifications = set()

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -800,7 +800,7 @@ class QueryCountTest(ZulipTestCase):
                         acting_user=None,
                     )
 
-        self.assert_length(cache_tries, 22)
+        self.assert_length(cache_tries, 21)
         peer_add_events = [event for event in events if event["event"].get("op") == "peer_add"]
 
         notifications = set()


### PR DESCRIPTION
Instead of doing some janky `.objects.filter(id__in=ids)` syntax to pull a couple of rows out of a single database table, we now use a simple helper with simple arguments that outperforms Django by about 500 microseconds.

And then we stop caching the results of queries that were already pretty fast to begin with.