### PR TITLE
open-source: Convert deleted tweet into a quote.

### DIFF
--- a/templates/corporate/for/communities.md
+++ b/templates/corporate/for/communities.md
@@ -73,7 +73,9 @@ many busy individuals can happily participate in.
 
 &nbsp;
 
-<blockquote class="twitter-tweet" data-cards="hidden"><p lang="en" dir="ltr">We just moved the Lichess team (~100 persons) to <a href="https://twitter.com/zulip?ref_src=twsrc%5Etfw">@zulip</a>, and I&#39;m loving it. The topics in particular make it vastly superior to slack &amp; discord, when it comes to dealing with many conversations.<br>Zulip is also open-source! <a href="https://t.co/lxHjf3YPMe">https://t.co/lxHjf3YPMe</a></p>&mdash; Thibault D (@ornicar) <a href="https://twitter.com/ornicar/status/1412672302601457664?ref_src=twsrc%5Etfw">July 7, 2021</a></blockquote>
+> "We just moved the Lichess team (~100 persons) to <a href="https://twitter.com/zulip?ref_src=twsrc%5Etfw">@zulip</a>, and I&#39;m loving it. The topics in particular make it vastly superior to slack &amp; discord, when it comes to dealing with many conversations. Zulip is also open-source!"
+
+> — <a href="https://twitter.com/ornicar">Thibault D (@ornicar)</a>
 
 &nbsp;
 

--- a/templates/corporate/for/open-source.html
+++ b/templates/corporate/for/open-source.html
@@ -98,7 +98,14 @@
                         </div>
                     </li>
                 </ul>
-                <blockquote class="twitter-tweet" data-cards="hidden"><p lang="en" dir="ltr">We just moved the Lichess team (~100 persons) to <a href="https://twitter.com/zulip?ref_src=twsrc%5Etfw">@zulip</a>, and I&#39;m loving it. The topics in particular make it vastly superior to slack &amp; discord, when it comes to dealing with many conversations.<br />Zulip is also open-source! <a href="https://t.co/lxHjf3YPMe">https://t.co/lxHjf3YPMe</a></p>&mdash; Thibault D (@ornicar) <a href="https://twitter.com/ornicar/status/1412672302601457664?ref_src=twsrc%5Etfw">July 7, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js"></script>
+                <div class="quote">
+                    <blockquote>
+                        We just moved the Lichess team (~100 persons) to <a href="https://twitter.com/zulip?ref_src=twsrc%5Etfw">@zulip</a>, and I&#39;m loving it. The topics in particular make it vastly superior to slack &amp; discord, when it comes to dealing with many conversations.<br />Zulip is also open-source!
+                    </blockquote>
+                    <div class="author">
+                        — <a href="https://twitter.com/ornicar">Thibault D (@ornicar)</a>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="feature-half">


### PR DESCRIPTION
Reference https://github.com/zulip/zulip/pull/26304#issuecomment-1646979611

This tweet was deleted since user moved to mastodon from twitter and used a tool to delete all their tweets.

- In `/for/open-source` page-

before:
![Screenshot from 2023-07-20 21-57-26](https://github.com/zulip/zulip/assets/35494118/059b3f0e-a8f2-4fb8-8ef3-8853b3be5206)
after:
<img width="976" alt="image" src="https://github.com/zulip/zulip/assets/25124304/572b0757-b547-4016-93f6-6d2cd46371a2">


- In `/for/communities` page-
before:
![Screenshot from 2023-07-20 21-59-45](https://github.com/zulip/zulip/assets/35494118/3f6032f6-d14b-4e6e-9fc3-f9ef8197cd72)
after:
<img width="538" alt="image" src="https://github.com/zulip/zulip/assets/25124304/00847db5-cfea-4ec4-b965-acefa5ee0822">
