### PR TITLE
settings: Add a saving-saved indicator to the 'SETTINGS/TOPICS' UI.

### DIFF
--- a/web/src/settings_user_topics.js
+++ b/web/src/settings_user_topics.js
@@ -69,7 +69,14 @@ export function set_up() {
 
         e.stopPropagation();
 
-        user_topics.set_user_topic_visibility_policy(stream_id, topic, visibility_policy);
+        user_topics.set_user_topic_visibility_policy(
+            stream_id,
+            topic,
+            visibility_policy,
+            false,
+            false,
+            $row.closest("#user-topic-settings").find(".alert-notification"),
+        );
     });
 
     populate_list();

--- a/web/templates/settings/user_topics_settings.hbs
+++ b/web/templates/settings/user_topics_settings.hbs
@@ -22,6 +22,7 @@
         {{else}}
             <h3>{{t "Topic settings"}}</h3>
         {{/if}}
+        {{> settings_save_discard_widget section_name="user-topics-settings" show_only_indicator=true }}
         <input id="user_topics_search" class="search filter_text_input" type="text" placeholder="{{t 'Filter topics' }}" aria-label="{{t 'Filter topics' }}"/>
     </div>
     <div class="progressive-table-wrapper" data-simplebar>

--- a/web/tests/settings_user_topics.test.js
+++ b/web/tests/settings_user_topics.test.js
@@ -67,6 +67,18 @@ run_test("settings", ({override}) => {
         assert.equal(opts, "tr");
         return $topic_tr_html;
     };
+    const $topics_panel_header = $.create("fake.topic_panel_header").attr(
+        "id",
+        "user-topic-settings",
+    );
+    const $status_element = $.create("fake.topics_panel_status_element").addClass(
+        "alert-notification",
+    );
+    $topics_panel_header.set_find_results(".alert-notification", $status_element);
+    $topic_tr_html.closest = (opts) => {
+        assert.equal(opts, "#user-topic-settings");
+        return $topics_panel_header;
+    };
 
     let topic_data_called = 0;
     $topic_tr_html.attr = (opts) => {


### PR DESCRIPTION
[#26016 (comment)](https://github.com/zulip/zulip/pull/26016#issuecomment-1639063408)

> I think the settings "topics" UI is missing a loading...saved indicator interaction to show you that your changes are saved; right now you get no feedback at all that your change works. But that feels like something that'd be OK as an immediate follow-up.

---

This commit adds a 'saving...' - 'saved' indicator to the 'SETTINGS/TOPICS' UI.

This improves the UX by reflecting that the changes are saved.

---
<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[screen-capture.webm](https://github.com/zulip/zulip/assets/56781761/fc0e4368-3fdc-4b96-a5bf-8191c5e180d1)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
