### PR TITLE
notifications: Remove the stray notification trigger strings.

### DIFF
--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -80,6 +80,7 @@ from zerver.lib.widget import do_widget_post_save_actions
 from zerver.models import (
     Client,
     Message,
+    NotificationTriggers,
     Realm,
     Recipient,
     Stream,
@@ -516,7 +517,7 @@ def get_service_bot_events(
             trigger = "mention"
         # Direct message triggers for personal and huddle messages
         elif (not is_stream) and (user_profile_id in active_user_ids):
-            trigger = "private_message"
+            trigger = NotificationTriggers.PRIVATE_MESSAGE
         else:
             return
 

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -451,28 +451,29 @@ def do_send_missedmessage_events_reply_in_zulip(
     unique_triggers = set(triggers)
 
     personal_mentioned = any(
-        message["trigger"] == "mentioned" and message["mentioned_user_group_id"] is None
+        message["trigger"] == NotificationTriggers.MENTION
+        and message["mentioned_user_group_id"] is None
         for message in missed_messages
     )
 
     mention = (
-        "mentioned" in unique_triggers
-        or "topic_wildcard_mentioned" in unique_triggers
-        or "stream_wildcard_mentioned" in unique_triggers
-        or "topic_wildcard_mentioned_in_followed_topic" in unique_triggers
-        or "stream_wildcard_mentioned_in_followed_topic" in unique_triggers
+        NotificationTriggers.MENTION in unique_triggers
+        or NotificationTriggers.TOPIC_WILDCARD_MENTION in unique_triggers
+        or NotificationTriggers.STREAM_WILDCARD_MENTION in unique_triggers
+        or NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC in unique_triggers
+        or NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC in unique_triggers
     )
 
     context.update(
         mention=mention,
         personal_mentioned=personal_mentioned,
-        topic_wildcard_mentioned="topic_wildcard_mentioned" in unique_triggers,
-        stream_wildcard_mentioned="stream_wildcard_mentioned" in unique_triggers,
-        stream_email_notify="stream_email_notify" in unique_triggers,
-        followed_topic_email_notify="followed_topic_email_notify" in unique_triggers,
-        topic_wildcard_mentioned_in_followed_topic="topic_wildcard_mentioned_in_followed_topic"
+        topic_wildcard_mentioned=NotificationTriggers.TOPIC_WILDCARD_MENTION in unique_triggers,
+        stream_wildcard_mentioned=NotificationTriggers.STREAM_WILDCARD_MENTION in unique_triggers,
+        stream_email_notify=NotificationTriggers.STREAM_EMAIL in unique_triggers,
+        followed_topic_email_notify=NotificationTriggers.FOLLOWED_TOPIC_EMAIL in unique_triggers,
+        topic_wildcard_mentioned_in_followed_topic=NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC
         in unique_triggers,
-        stream_wildcard_mentioned_in_followed_topic="stream_wildcard_mentioned_in_followed_topic"
+        stream_wildcard_mentioned_in_followed_topic=NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC
         in unique_triggers,
         mentioned_user_group_name=mentioned_user_group_name,
     )

--- a/zerver/lib/notification_data.py
+++ b/zerver/lib/notification_data.py
@@ -323,7 +323,10 @@ def get_mentioned_user_group_name(
     messages instead.
     """
     for message in messages:
-        if message["mentioned_user_group_id"] is None and message["trigger"] == "mentioned":
+        if (
+            message["mentioned_user_group_id"] is None
+            and message["trigger"] == NotificationTriggers.MENTION
+        ):
             # The user has also been personally mentioned, so that gets prioritized.
             return None
 

--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -14,6 +14,7 @@ from zerver.lib.queue import queue_json_publish
 from zerver.lib.utils import assert_is_not_none
 from zerver.models import (
     Message,
+    NotificationTriggers,
     Realm,
     RealmAuditLog,
     Recipient,
@@ -417,11 +418,16 @@ def soft_reactivate_if_personal_notification(
     if not user_profile.long_term_idle:
         return
 
-    private_message = "private_message" in unique_triggers
-    personal_mention = "mentioned" in unique_triggers and mentioned_user_group_name is None
+    private_message = NotificationTriggers.PRIVATE_MESSAGE in unique_triggers
+    personal_mention = (
+        NotificationTriggers.MENTION in unique_triggers and mentioned_user_group_name is None
+    )
     topic_wildcard_mention = any(
         trigger in unique_triggers
-        for trigger in ["topic_wildcard_mentioned", "topic_wildcard_mentioned_in_followed_topic"]
+        for trigger in [
+            NotificationTriggers.TOPIC_WILDCARD_MENTION,
+            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
+        ]
     )
     if not private_message and not personal_mention and not topic_wildcard_mention:
         return

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -8,7 +8,7 @@ from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.push_notifications import get_apns_badge_count, get_apns_badge_count_future
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import mock_queue_publish
-from zerver.models import Subscription, UserPresence, UserTopic, get_stream
+from zerver.models import NotificationTriggers, Subscription, UserPresence, UserTopic, get_stream
 from zerver.tornado.event_queue import maybe_enqueue_notifications
 
 
@@ -203,13 +203,13 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         mobile_event = queue_messages[0]["event"]
 
         self.assertEqual(mobile_event["user_profile_id"], cordelia.id)
-        self.assertEqual(mobile_event["trigger"], "mentioned")
+        self.assertEqual(mobile_event["trigger"], NotificationTriggers.MENTION)
 
         self.assertEqual(queue_messages[1]["queue_name"], "missedmessage_emails")
         email_event = queue_messages[1]["event"]
 
         self.assertEqual(email_event["user_profile_id"], cordelia.id)
-        self.assertEqual(email_event["trigger"], "mentioned")
+        self.assertEqual(email_event["trigger"], NotificationTriggers.MENTION)
 
     def test_second_mention_is_ignored(self) -> None:
         original_content = "hello @**Cordelia, Lear's daughter**"

--- a/zerver/tests/test_notification_data.py
+++ b/zerver/tests/test_notification_data.py
@@ -2,6 +2,7 @@ from zerver.actions.user_groups import check_add_user_group
 from zerver.lib.mention import MentionBackend, MentionData
 from zerver.lib.notification_data import UserMessageNotificationsData, get_user_group_mentions_data
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.models import NotificationTriggers
 
 
 class TestNotificationData(ZulipTestCase):
@@ -26,7 +27,7 @@ class TestNotificationData(ZulipTestCase):
         user_data = self.create_user_notifications_data_object(user_id=user_id, pm_push_notify=True)
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "private_message",
+            NotificationTriggers.PRIVATE_MESSAGE,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -36,7 +37,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "mentioned",
+            NotificationTriggers.MENTION,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -46,7 +47,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "topic_wildcard_mentioned",
+            NotificationTriggers.TOPIC_WILDCARD_MENTION,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -56,7 +57,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "stream_wildcard_mentioned",
+            NotificationTriggers.STREAM_WILDCARD_MENTION,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -66,7 +67,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "stream_push_notify",
+            NotificationTriggers.STREAM_PUSH,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -76,7 +77,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "followed_topic_push_notify",
+            NotificationTriggers.FOLLOWED_TOPIC_PUSH,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -86,7 +87,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "topic_wildcard_mentioned_in_followed_topic",
+            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -96,7 +97,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "stream_wildcard_mentioned_in_followed_topic",
+            NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -115,7 +116,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_push_notification_trigger(acting_user_id=acting_user_id, idle=False),
-            "private_message",
+            NotificationTriggers.PRIVATE_MESSAGE,
         )
         self.assertTrue(user_data.is_push_notifiable(acting_user_id=acting_user_id, idle=False))
 
@@ -194,7 +195,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "private_message",
+            NotificationTriggers.PRIVATE_MESSAGE,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -204,7 +205,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "mentioned",
+            NotificationTriggers.MENTION,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -214,7 +215,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "topic_wildcard_mentioned",
+            NotificationTriggers.TOPIC_WILDCARD_MENTION,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -224,7 +225,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "stream_wildcard_mentioned",
+            NotificationTriggers.STREAM_WILDCARD_MENTION,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -234,7 +235,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "stream_email_notify",
+            NotificationTriggers.STREAM_EMAIL,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -244,7 +245,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "followed_topic_email_notify",
+            NotificationTriggers.FOLLOWED_TOPIC_EMAIL,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -254,7 +255,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "topic_wildcard_mentioned_in_followed_topic",
+            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 
@@ -264,7 +265,7 @@ class TestNotificationData(ZulipTestCase):
         )
         self.assertEqual(
             user_data.get_email_notification_trigger(acting_user_id=acting_user_id, idle=True),
-            "stream_wildcard_mentioned_in_followed_topic",
+            NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
         )
         self.assertTrue(user_data.is_email_notifiable(acting_user_id=acting_user_id, idle=True))
 

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -11,7 +11,14 @@ from zerver.lib.outgoing_webhook import get_service_interface_class, process_suc
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.topic import TOPIC_NAME
-from zerver.models import SLACK_INTERFACE, Message, get_realm, get_stream, get_user
+from zerver.models import (
+    SLACK_INTERFACE,
+    Message,
+    NotificationTriggers,
+    get_realm,
+    get_stream,
+    get_user,
+)
 from zerver.openapi.openapi import validate_against_openapi_schema
 
 
@@ -174,7 +181,7 @@ class TestSlackOutgoingWebhookService(ZulipTestCase):
             "user_profile_id": 24,
             "service_name": "test-service",
             "command": "test content",
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
             "message": {
                 "sender_id": 3,
                 "sender_realm_str": "zulip",

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1106,7 +1106,7 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         with mock.patch(
             "zerver.lib.push_notifications.gcm_client"
@@ -1168,7 +1168,7 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         with mock.patch(
             "zerver.lib.push_notifications.gcm_client"
@@ -1227,7 +1227,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         missed_message = {
             "user_profile_id": self.user_profile.id,
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         assert settings.PUSH_NOTIFICATION_BOUNCER_URL is not None
         URL = settings.PUSH_NOTIFICATION_BOUNCER_URL + "/api/v1/remotes/push/notify"
@@ -1257,7 +1257,7 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
 
         # If the message is unread, we should send push notifications.
@@ -1297,7 +1297,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         )
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         # Now, delete the message the normal way
         do_delete_messages(user_profile.realm, [message])
@@ -1330,7 +1330,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         )
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         # Now delete the message forcefully, so it just doesn't exist.
         message.delete()
@@ -1366,7 +1366,7 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=True), mock.patch(
             "zerver.lib.push_notifications.get_message_payload_apns", return_value={"apns": True}
@@ -1416,7 +1416,7 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         with mock.patch(
             "zerver.lib.push_notifications.get_message_payload_apns", return_value={"apns": True}
@@ -1614,7 +1614,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         message_id = self.send_stream_message(sender, "public_stream", "test")
         missed_message = {
             "message_id": message_id,
-            "trigger": "stream_push_notify",
+            "trigger": NotificationTriggers.STREAM_PUSH,
         }
 
         android_devices = list(
@@ -1665,7 +1665,10 @@ class HandlePushNotificationTest(PushNotificationTest):
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_push_notification(
                 self.user_profile.id,
-                {"message_id": stream_mentioned_message_id, "trigger": "mentioned"},
+                {
+                    "message_id": stream_mentioned_message_id,
+                    "trigger": NotificationTriggers.MENTION,
+                },
             )
 
         # Direct message should soft reactivate the user
@@ -1674,7 +1677,10 @@ class HandlePushNotificationTest(PushNotificationTest):
             personal_message_id = self.send_personal_message(othello, self.user_profile, "Message")
             handle_push_notification(
                 self.user_profile.id,
-                {"message_id": personal_message_id, "trigger": "private_message"},
+                {
+                    "message_id": personal_message_id,
+                    "trigger": NotificationTriggers.PRIVATE_MESSAGE,
+                },
             )
 
         # User FOLLOWS the topic.
@@ -1700,7 +1706,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                 self.user_profile.id,
                 {
                     "message_id": stream_mentioned_message_id,
-                    "trigger": "topic_wildcard_mentioned_in_followed_topic",
+                    "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
                 },
             )
 
@@ -1712,7 +1718,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                 self.user_profile.id,
                 {
                     "message_id": stream_mentioned_message_id,
-                    "trigger": "stream_wildcard_mentioned_in_followed_topic",
+                    "trigger": NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
                 },
             )
 
@@ -1733,7 +1739,10 @@ class HandlePushNotificationTest(PushNotificationTest):
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_push_notification(
                 self.user_profile.id,
-                {"message_id": stream_mentioned_message_id, "trigger": "topic_wildcard_mentioned"},
+                {
+                    "message_id": stream_mentioned_message_id,
+                    "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION,
+                },
             )
 
         # Stream Wildcard mention should NOT soft reactivate the user
@@ -1742,7 +1751,10 @@ class HandlePushNotificationTest(PushNotificationTest):
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_push_notification(
                 self.user_profile.id,
-                {"message_id": stream_mentioned_message_id, "trigger": "stream_wildcard_mentioned"},
+                {
+                    "message_id": stream_mentioned_message_id,
+                    "trigger": NotificationTriggers.STREAM_WILDCARD_MENTION,
+                },
             )
 
         # Group mention should NOT soft reactivate the user
@@ -1753,7 +1765,7 @@ class HandlePushNotificationTest(PushNotificationTest):
                 self.user_profile.id,
                 {
                     "message_id": stream_mentioned_message_id,
-                    "trigger": "mentioned",
+                    "trigger": NotificationTriggers.MENTION,
                     "mentioned_user_group_id": large_user_group.id,
                 },
             )
@@ -1777,7 +1789,7 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         missed_message = {
             "message_id": message.id,
-            "trigger": "private_message",
+            "trigger": NotificationTriggers.PRIVATE_MESSAGE,
         }
         handle_push_notification(user_profile.id, missed_message)
         mock_push_notifications.assert_called_once()
@@ -2345,14 +2357,14 @@ class TestGetGCMPayload(PushNotificationTest):
 
     def test_get_message_payload_gcm_personal_mention(self) -> None:
         self._test_get_message_payload_gcm_mentions(
-            "mentioned", "King Hamlet mentioned you in #Verona"
+            NotificationTriggers.MENTION, "King Hamlet mentioned you in #Verona"
         )
 
     def test_get_message_payload_gcm_user_group_mention(self) -> None:
         # Note that the @mobile_team user group doesn't actually
         # exist; this test is just verifying the formatting logic.
         self._test_get_message_payload_gcm_mentions(
-            "mentioned",
+            NotificationTriggers.MENTION,
             "King Hamlet mentioned @mobile_team in #Verona",
             mentioned_user_group_id=3,
             mentioned_user_group_name="mobile_team",
@@ -2360,23 +2372,24 @@ class TestGetGCMPayload(PushNotificationTest):
 
     def test_get_message_payload_gcm_topic_wildcard_mention_in_followed_topic(self) -> None:
         self._test_get_message_payload_gcm_mentions(
-            "topic_wildcard_mentioned_in_followed_topic", "TODO - 2"
+            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC, "TODO - 2"
         )
 
     def test_get_message_payload_gcm_stream_wildcard_mention_in_followed_topic(self) -> None:
         self._test_get_message_payload_gcm_mentions(
-            "stream_wildcard_mentioned_in_followed_topic", "TODO"
+            NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC, "TODO"
         )
 
     def test_get_message_payload_gcm_topic_wildcard_mention(self) -> None:
         self._test_get_message_payload_gcm_mentions(
-            "topic_wildcard_mentioned",
+            NotificationTriggers.TOPIC_WILDCARD_MENTION,
             "King Hamlet mentioned all topic participants in #Verona > Test topic",
         )
 
     def test_get_message_payload_gcm_stream_wildcard_mention(self) -> None:
         self._test_get_message_payload_gcm_mentions(
-            "stream_wildcard_mentioned", "King Hamlet mentioned everyone in #Verona"
+            NotificationTriggers.STREAM_WILDCARD_MENTION,
+            "King Hamlet mentioned everyone in #Verona",
         )
 
     def test_get_message_payload_gcm_private_message(self) -> None:

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -15,7 +15,7 @@ from zerver.lib.bot_storage import StateError
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import mock_queue_publish
 from zerver.lib.validator import check_string
-from zerver.models import Recipient, UserProfile, get_realm
+from zerver.models import NotificationTriggers, Recipient, UserProfile, get_realm
 
 BOT_TYPE_TO_QUEUE_NAME = {
     UserProfile.OUTGOING_WEBHOOK_BOT: "outgoing_webhooks",
@@ -56,7 +56,7 @@ class TestServiceBotBasics(ZulipTestCase):
 
         expected = dict(
             outgoing_webhooks=[
-                dict(trigger="private_message", user_profile_id=outgoing_bot.id),
+                dict(trigger=NotificationTriggers.PRIVATE_MESSAGE, user_profile_id=outgoing_bot.id),
             ],
         )
 
@@ -533,7 +533,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             assert self.bot_profile.bot_type
             self.assertEqual(queue_name, BOT_TYPE_TO_QUEUE_NAME[self.bot_profile.bot_type])
             self.assertEqual(trigger_event["user_profile_id"], self.bot_profile.id)
-            self.assertEqual(trigger_event["trigger"], "private_message")
+            self.assertEqual(trigger_event["trigger"], NotificationTriggers.PRIVATE_MESSAGE)
             self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
             display_recipients = [
                 trigger_event["message"]["display_recipient"][0]["email"],
@@ -576,7 +576,7 @@ class TestServiceBotEventTriggers(ZulipTestCase):
             self.assertEqual(queue_name, BOT_TYPE_TO_QUEUE_NAME[self.bot_profile.bot_type])
             self.assertIn(trigger_event["user_profile_id"], profile_ids)
             profile_ids.remove(trigger_event["user_profile_id"])
-            self.assertEqual(trigger_event["trigger"], "private_message")
+            self.assertEqual(trigger_event["trigger"], NotificationTriggers.PRIVATE_MESSAGE)
             self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
             self.assertEqual(trigger_event["message"]["type"], "private")
 


### PR DESCRIPTION
[#25828 (comment)](https://github.com/zulip/zulip/pull/25828#discussion_r1259828715)

> Would be great if we didn't have any stray trigger strings in this file, as well as in test_notification_data.py, although not a blocker :)

> Included in my TODO list. -- stray trigger strings have been used in a lot of places in this file and a few others. I'll change all of them in a separate mini PR.

---

This commit removes the stray strings used to refer to various types of notification triggers.

We use the attributes of the `NotificationTriggers` class instead.

<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
