### PR TITLE
dark_theme: Remove Firefox override for dropdown appearance

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1568,12 +1568,6 @@
     }
 }
 
-@supports (-moz-appearance: none) {
-    %dark-theme #settings_page select {
-        background-color: hsl(0deg 0% 0% / 20%);
-    }
-}
-
 :root.dark-theme {
     @extend %dark-theme;
 }


### PR DESCRIPTION
Followup to #26340.

We get the right background-color from line 487 in the same way as Chrome.