### PR TITLE
grid: Remove unnecessary mobile-scale padding.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2995,18 +2995,10 @@ select.invite-as {
         top: -8px;
     }
 
-    .messagebox-content {
-        padding-right: 15px;
-    }
-
     .include-sender .message_controls {
         background: none !important;
         padding: 0 !important;
         border: none !important;
-    }
-
-    .message_content {
-        padding-right: 50px;
     }
 }
 


### PR DESCRIPTION
This PR removes unnecessary right padding from the message box; this will give 15px back to displaying message content at mobile scales.

This also removes padding on .message_content that wasn't actually rendered due to its low specificity. It was likely also leftover from an earlier, non-grid-based layout.

**Screenshots and screen captures:**

| Mobile Before | Mobile After |
| --- | --- |
| ![mobile-time-before](https://github.com/zulip/zulip/assets/170719/ba39eac1-0198-4bb1-8cf6-20963fec7e51) | ![mobile-time-after](https://github.com/zulip/zulip/assets/170719/a7f463b6-63cd-4cbc-aca2-1ccdd160aaa6) |

| Medium Before | Medium After (no change) |
| --- | --- |
| ![medium-time-before](https://github.com/zulip/zulip/assets/170719/54681a30-5eb3-41c9-a3f4-3ab8bfecb443) | ![medium-time-after](https://github.com/zulip/zulip/assets/170719/cc91c742-9a0c-4560-9872-9f4cd0d988da) |

This also works well with other languages with longer timestamps (both After shots here):

| Mobile After | Medium After |
| --- | --- |
| ![simplified-chinese-mobile-after](https://github.com/zulip/zulip/assets/170719/0ae572c4-5cd1-4a69-8ee4-3cf6341241f6) | ![simplified-chinese-medium-after](https://github.com/zulip/zulip/assets/170719/8f09f9d2-fee1-4b5c-a94c-5a71da7299ae) |







<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
