### PR TITLE
ts: Migrate `schema.js` to TypeScript.

### DIFF
--- a/web/src/schema.ts
+++ b/web/src/schema.ts
@@ -7,23 +7,36 @@ side validators in zerver/lib/validator.py.
 
 */
 
-export function check_string(var_name, val) {
+type CheckData = (var_name: string, val: unknown) => string | undefined;
+type RecordFields = {
+    short_name: CheckData;
+    long_name: CheckData;
+    reply: CheckData;
+    heading: CheckData;
+    choices: CheckData;
+};
+
+export function check_string(var_name: string, val: unknown): string | undefined {
     if (typeof val !== "string") {
         return var_name + " is not a string";
     }
     return undefined;
 }
 
-export function check_record(var_name, val, fields) {
+export function check_record(
+    var_name: string,
+    val: unknown,
+    fields: RecordFields,
+): string | undefined {
     if (typeof val !== "object") {
         return var_name + " is not a record";
     }
 
     const field_results = Object.entries(fields).map(([field_name, f]) => {
-        if (val[field_name] === undefined) {
+        if ((val as Record<string, unknown>)[field_name] === undefined) {
             return field_name + " is missing";
         }
-        return f(field_name, val[field_name]);
+        return f(field_name, (val as Record<string, unknown>)[field_name]);
     });
 
     const msg = field_results.filter(Boolean).sort().join(", ");
@@ -35,7 +48,11 @@ export function check_record(var_name, val, fields) {
     return undefined;
 }
 
-export function check_array(var_name, val, checker) {
+export function check_array(
+    var_name: string,
+    val: unknown,
+    checker: CheckData,
+): string | undefined {
     if (!Array.isArray(val)) {
         return var_name + " is not an array";
     }


### PR DESCRIPTION
Added type annotations. Many types are infered from `zform.js`.


<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
