### PR TITLE
replace the variable `$http_host` to `$host` in nginx conf example

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -483,7 +483,7 @@ that your Zulip server sits at `https://10.10.10.10:443`; see
            location / {
                    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
                    proxy_set_header        X-Forwarded-Proto $scheme;
-                   proxy_set_header        Host $http_host;
+                   proxy_set_header        Host $host;
                    proxy_http_version      1.1;
                    proxy_buffering         off;
                    proxy_read_timeout      20m;

--- a/scripts/lib/sharding.py
+++ b/scripts/lib/sharding.py
@@ -44,7 +44,7 @@ def write_updated_configs() -> None:
             sharding_json_f.write("{}\n")
             return
 
-        nginx_sharding_conf_f.write("map $http_host $tornado_server {\n")
+        nginx_sharding_conf_f.write("map $host $tornado_server {\n")
         nginx_sharding_conf_f.write("    default http://tornado9800;\n")
         shard_map: Dict[str, Union[int, List[int]]] = {}
         shard_regexes: List[Tuple[str, Union[int, List[int]]]] = []


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes:
The value of variable `$http_host` header will be empty string when using http/3: https://github.com/nginx-quic/nginx-quic/issues/3
Anyone using a browser that supports http/3 requests the nginx for the first time with http/2 will get an expected HTTP 200, but any succeeding requests will fail with HTTP 400 response by the zulip since the browser has chosen to upgrade to http/3 then the zulip reject with an empty value for `Host` header: https://github.com/zulip/zulip/issues/9552#issuecomment-392219083

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
