### PR TITLE
emails: Update subject for confirm_new_email to have realm information.

### DIFF
--- a/templates/zerver/emails/confirm_new_email.subject.txt
+++ b/templates/zerver/emails/confirm_new_email.subject.txt
@@ -1,1 +1,1 @@
-{{ _("Verify your new email address") }}
+{% trans %}Verify your new email address for {{ organization_host }}{% endtrans %}

--- a/zerver/actions/user_settings.py
+++ b/zerver/actions/user_settings.py
@@ -150,6 +150,7 @@ def do_start_email_change_process(user_profile: UserProfile, new_email: str) -> 
         old_email=old_email,
         new_email=new_email,
         activate_url=activation_url,
+        organization_host=user_profile.realm.host,
     )
     language = user_profile.default_language
     send_email(

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -39,7 +39,7 @@ class EmailChangeTestCase(ZulipTestCase):
         email_message = mail.outbox[0]
         self.assertEqual(
             email_message.subject,
-            "Verify your new email address",
+            "Verify your new email address for zulip.testserver",
         )
         body = email_message.body
         self.assertIn("We received a request to change the email", body)
@@ -168,7 +168,7 @@ class EmailChangeTestCase(ZulipTestCase):
         email_message = mail.outbox[0]
         self.assertEqual(
             email_message.subject,
-            "Verify your new email address",
+            "Verify your new email address for zulip.testserver",
         )
         body = email_message.body
         self.assertIn("We received a request to change the email", body)


### PR DESCRIPTION
Updates the email subject for confirming an email change to include the realm information.

Noted in demo organization work in [this comment in #22666](https://github.com/zulip/zulip/pull/22666#issuecomment-1438816323):

> For the confirm email change subject, maybe the following would work well?
> 
> 1. For non-demo orgs, change it to: "Verify your new email address for `<organization name>`"

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
