### PR TITLE
help: Add gear menu icons to relative links.

### DIFF
--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -18,16 +18,25 @@ gear_info = {
     # key is from REGEXP: `{relative|gear|key}`
     # name is what the item is called in the gear menu: `Select **name**.`
     # link is used for relative links: `Select [name](link).`
-    "manage-streams": ["Manage streams", "/#streams/subscribed"],
-    "settings": ["Personal Settings", "/#settings/profile"],
-    "organization-settings": ["Organization settings", "/#organization/organization-profile"],
-    "integrations": ["Integrations", "/integrations/"],
-    "stats": ["Usage statistics", "/stats"],
-    "plans": ["Plans and pricing", "/plans/"],
-    "billing": ["Billing", "/billing/"],
-    "keyboard-shortcuts": ["Keyboard shortcuts (?)", "/#keyboard-shortcuts"],
-    "message-formatting": ["Message formatting", "/#message-formatting"],
-    "search-filters": ["Search filters", "/#search-operators"],
+    "manage-streams": ['<i class="fa fa-exchange"></i> Manage streams', "/#streams/subscribed"],
+    "settings": ['<i class="fa fa-wrench"></i> Personal Settings', "/#settings/profile"],
+    "organization-settings": [
+        '<i class="fa fa-bolt"></i> Organization settings',
+        "/#organization/organization-profile",
+    ],
+    "integrations": ['<i class="fa fa-github"></i> Integrations', "/integrations/"],
+    "stats": ['<i class="fa fa-bar-chart"></i> Usage statistics', "/stats"],
+    "plans": ['<i class="fa fa-rocket"></i> Plans and pricing', "/plans/"],
+    "billing": ['<i class="fa fa-credit-card"></i> Billing', "/billing/"],
+    "keyboard-shortcuts": [
+        '<i class="fa fa-keyboard-o"></i> Keyboard shortcuts (?)',
+        "/#keyboard-shortcuts",
+    ],
+    "message-formatting": [
+        '<i class="fa fa-pencil"></i> Message formatting',
+        "/#message-formatting",
+    ],
+    "search-filters": ['<i class="fa fa-search"></i> Search filters', "/#search-operators"],
     "about-zulip": ["About Zulip", "/#about-zulip"],
 }
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -388,13 +388,18 @@ class HelpTest(ZulipTestCase):
 
     def test_help_relative_links_for_gear(self) -> None:
         result = self.client_get("/help/analytics")
-        self.assertIn('<a href="/stats">Usage statistics</a>', str(result.content))
+        self.assertIn(
+            '<a href="/stats"><i class="fa fa-bar-chart"></i> Usage statistics</a>',
+            str(result.content),
+        )
         self.assertEqual(result.status_code, 200)
 
         with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
             result = self.client_get("/help/analytics", subdomain="")
         self.assertEqual(result.status_code, 200)
-        self.assertIn("<strong>Usage statistics</strong>", str(result.content))
+        self.assertIn(
+            '<strong><i class="fa fa-bar-chart"></i> Usage statistics</strong>', str(result.content)
+        )
         self.assertNotIn("/stats", str(result.content))
 
     def test_help_relative_links_for_stream(self) -> None:


### PR DESCRIPTION
As discussed in , https://github.com/zulip/zulip/pull/26313#issuecomment-1646130071 this PR adds icons to the following relative help links:

```
{relative|gear|manage-streams}
{relative|gear|settings}
{relative|gear|organization-settings}
{relative|gear|stats}
{relative|gear|keyboard-shortcuts}
{relative|gear|message-formatting}
{relative|gear|search-filters}
{relative|gear|integrations}
{relative|gear|plans}
{relative|gear|billing}
```

**Screenshots and screen captures:**

<img width="300" alt="image" src="https://github.com/zulip/zulip/assets/2343554/e94010d0-c0e6-4511-b631-68027dd74c39">

<img width="280" alt="image" src="https://github.com/zulip/zulip/assets/2343554/095f046a-42a5-46a2-b355-098a0a3bb830">


**Notes:**
- I also tested not including the icon as part of the link, but I think it looks better the other way around as shown above.
![stats-gear-icon-docs](https://github.com/zulip/zulip/assets/2343554/fd10c561-d5e0-4c07-b876-64fc2c62ee61)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>