### PR TITLE
popovers: Migrate emoji popover to Tippy.

### DIFF
--- a/web/e2e-tests/user-status.test.ts
+++ b/web/e2e-tests/user-status.test.ts
@@ -52,7 +52,7 @@ async function test_user_status(page: Page): Promise<void> {
     // Wait until emoji popover is opened.
     await page.waitForSelector(`.emoji-popover  ${tada_emoji_selector}`, {visible: true});
     await page.click(`.emoji-popover  ${tada_emoji_selector}`);
-    await page.waitForSelector(".emoji-info-popover", {hidden: true});
+    await page.waitForSelector(".emoji-picker-popover", {hidden: true});
     await page.waitForSelector(`.selected-emoji${tada_emoji_selector}`);
 
     await page.click("#set-user-status-modal .dialog_submit_button");

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -897,7 +897,7 @@ export function initialize() {
         // Dismiss popovers if the user has clicked outside them
         if (
             $(
-                '.popover-inner, #user-profile-modal, .emoji-info-popover, .app-main [class^="column-"].expanded',
+                '.popover-inner, #user-profile-modal, .emoji-picker-popover, .app-main [class^="column-"].expanded',
             ).has(e.target).length === 0
         ) {
             // Since tippy instance can handle outside clicks on their own,

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -619,7 +619,12 @@ function register_popover_events($popover) {
     });
 }
 
-export function build_emoji_popover($elt, id) {
+export function build_emoji_popover(element, id) {
+    const $elt = $(element);
+    if (id !== undefined) {
+        message_lists.current.select_id(id);
+    }
+
     let placement = popovers.compute_placement($elt, APPROX_HEIGHT, APPROX_WIDTH, true);
 
     if (placement === "viewport_center") {
@@ -649,6 +654,8 @@ export function build_emoji_popover($elt, id) {
         fixed: true,
     });
     $elt.popover("show");
+    $elt.addClass("reaction_button_visible");
+    $elt.closest(".message_row").toggleClass("has_popover has_emoji_popover");
 
     const $popover = $elt.data("popover").$tip;
     $popover.find(".emoji-popover-filter").trigger("focus");
@@ -659,12 +666,13 @@ export function build_emoji_popover($elt, id) {
         index: 0,
     };
     show_emoji_catalog();
+    reset_emoji_showcase();
 
     $(() => refill_section_head_offsets($popover));
     register_popover_events($popover);
 }
 
-export function toggle_emoji_popover(element, id, coming_from_actions_popover) {
+export function toggle_emoji_popover(element, id) {
     const $last_popover_elem = $current_message_emoji_popover_elem;
     popovers.hide_all();
     if ($last_popover_elem !== undefined && $last_popover_elem.get()[0] === element) {
@@ -673,20 +681,7 @@ export function toggle_emoji_popover(element, id, coming_from_actions_popover) {
         return;
     }
 
-    const $elt = $(element);
-    $elt.closest(".message_row").toggleClass("has_popover has_emoji_popover");
-    if (id !== undefined) {
-        message_lists.current.select_id(id);
-    }
-
-    if (user_status_ui.user_status_picker_open()) {
-        build_emoji_popover($elt, id);
-    } else if ($elt.data("popover") === undefined || coming_from_actions_popover) {
-        // Keep the element over which the popover is based off visible.
-        $elt.addClass("reaction_button_visible");
-        build_emoji_popover($elt, id);
-    }
-    reset_emoji_showcase();
+    build_emoji_popover(element, id);
 }
 
 export function register_click_handlers() {

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -756,7 +756,7 @@ export function register_click_handlers() {
         e.stopPropagation();
         e.preventDefault();
 
-        const $popover = $(e.currentTarget).closest(".emoji-info-popover").expectOne();
+        const $popover = $(e.currentTarget).closest(".emoji-picker-popover").expectOne();
         const $emoji_map = $popover.find(".emoji-popover-emoji-map");
 
         const offset = section_head_offsets.find(

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -187,12 +187,12 @@ function refill_section_head_offsets($popover) {
     });
 }
 
-export function reactions_popped() {
+export function is_open() {
     return Boolean(emoji_popover_instance);
 }
 
 export function hide_emoji_popover() {
-    if (!reactions_popped()) {
+    if (!is_open()) {
         return;
     }
     current_message_id = null;
@@ -447,7 +447,7 @@ function change_focus_to_filter() {
 export function navigate(event_name, e) {
     if (
         event_name === "toggle_reactions_popover" &&
-        reactions_popped() &&
+        is_open() &&
         (search_is_active === false || search_results.length === 0)
     ) {
         hide_emoji_popover();
@@ -792,7 +792,7 @@ export function register_click_handlers() {
         e.preventDefault();
         e.stopPropagation();
         toggle_emoji_popover(e.target, undefined, {placement: "bottom"});
-        if (reactions_popped()) {
+        if (is_open()) {
             // Because the emoji picker gets drawn on top of the user
             // status modal, we need this hack to make clicking outside
             // the emoji picker only close the emoji picker, and not the

--- a/web/src/emoji_picker.js
+++ b/web/src/emoji_picker.js
@@ -202,8 +202,8 @@ export function hide_emoji_popover() {
         // handler that opens the "user status modal" emoji picker.
         $(".app, .header, .modal__overlay, #set-user-status-modal").css("pointer-events", "all");
     }
-    $(emoji_popover_instance.reference).removeClass("reaction_button_visible");
-    $(emoji_popover_instance.reference).parent().removeClass("reaction_button_visible");
+    $(emoji_popover_instance.reference).removeClass("active-emoji-picker-reference");
+    $(emoji_popover_instance.reference).parent().removeClass("active-emoji-picker-reference");
     emoji_popover_instance.destroy();
     emoji_popover_instance = null;
 }
@@ -657,8 +657,8 @@ function get_default_emoji_popover_options() {
         },
         onShow(instance) {
             const $reference = $(instance.reference);
-            $reference.addClass("reaction_button_visible");
-            $reference.parent().addClass("reaction_button_visible");
+            $reference.addClass("active-emoji-picker-reference");
+            $reference.parent().addClass("active-emoji-picker-reference");
         },
         onMount(instance) {
             const $popover = $(instance.popper);

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -1000,8 +1000,11 @@ export function process_hotkey(e, hotkey) {
         case "toggle_reactions_popover": {
             const $row = message_lists.current.selected_row();
             emoji_picker.toggle_emoji_popover(
-                msg.sent_by_me ? $row.find(".actions_hover")[0] : $row.find(".reaction_button")[0],
+                msg.sent_by_me
+                    ? $row.find(".message-actions-menu-button")[0]
+                    : $row.find(".emoji-message-control-button-container")[0],
                 msg.id,
+                {placement: "bottom"},
             );
             return true;
         }

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -292,7 +292,7 @@ export function process_escape_key(e) {
         }
 
         // Emoji picker goes before compose so compose emoji picker is closed properly.
-        if (emoji_picker.reactions_popped()) {
+        if (emoji_picker.is_open()) {
             emoji_picker.hide_emoji_popover();
             return true;
         }
@@ -404,7 +404,7 @@ export function process_enter_key(e) {
         return false;
     }
 
-    if (emoji_picker.reactions_popped()) {
+    if (emoji_picker.is_open()) {
         return emoji_picker.navigate("enter", e);
     }
 
@@ -557,7 +557,7 @@ export function process_tab_key() {
         return true;
     }
 
-    if (emoji_picker.reactions_popped()) {
+    if (emoji_picker.is_open()) {
         return emoji_picker.navigate("tab");
     }
 
@@ -593,7 +593,7 @@ export function process_shift_tab_key() {
     }
 
     // Shift-Tabbing from emoji catalog/search results takes you back to search textbox.
-    if (emoji_picker.reactions_popped()) {
+    if (emoji_picker.is_open()) {
         return emoji_picker.navigate("shift_tab");
     }
 
@@ -647,7 +647,7 @@ export function process_hotkey(e, hotkey) {
 
     // This block needs to be before the open modals check, because
     // the "user status" modal can show the emoji picker.
-    if (emoji_picker.reactions_popped()) {
+    if (emoji_picker.is_open()) {
         return emoji_picker.navigate(event_name);
     }
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -191,18 +191,13 @@ function on_show_prep(instance) {
 }
 
 function get_props_for_popover_centering(popover_props) {
-    // We should put the reference element in the viewport,
-    // otherwise Tippy will think that the reference is
-    // hidden and hide the popover too.
-    const reference_offset = 1;
-
     return {
         arrow: false,
         getReferenceClientRect: () => ({
             width: 0,
             height: 0,
-            left: reference_offset,
-            top: reference_offset,
+            left: 0,
+            top: 0,
         }),
         placement: "top",
         popperOptions: {
@@ -212,15 +207,25 @@ function get_props_for_popover_centering(popover_props) {
                     options: {
                         offset({popper}) {
                             // Calculate the offset needed to place the reference in the center
-                            const x_offset_to_center = window.innerWidth / 2 - reference_offset;
-                            const y_offset_to_center =
-                                window.innerHeight / 2 - popper.height / 2 - reference_offset;
+                            const x_offset_to_center = window.innerWidth / 2;
+                            const y_offset_to_center = window.innerHeight / 2 - popper.height / 2;
 
                             return [x_offset_to_center, y_offset_to_center];
                         },
                     },
                 },
             ],
+        },
+        onShow(instance) {
+            // By default, Tippys with the `data-reference-hidden` attribute aren't displayed.
+            // But when we render them as centered overlays on mobile and use
+            // `getReferenceClientRect` for a virtual reference, Tippy slaps this
+            // hidden attribute on our element, making it invisible. We want to bypass
+            // this in scenarios where we're centering popovers on mobile screens.
+            $(instance.popper).find(".tippy-box").addClass("show-when-reference-hidden");
+            if (popover_props.onShow) {
+                popover_props.onShow(instance);
+            }
         },
         onMount(instance) {
             $("body").append($("<div>").attr("id", "popover-overlay-background"));

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -895,11 +895,9 @@ export function initialize() {
                 // emoji_picker which we don't want to hide after actions popover is hidden.
                 e.stopPropagation();
                 e.preventDefault();
-                emoji_picker.toggle_emoji_popover(
-                    instance.reference.parentElement,
-                    message_id,
-                    true,
-                );
+                emoji_picker.toggle_emoji_popover(instance.reference.parentElement, message_id, {
+                    placement: "bottom",
+                });
                 instance.hide();
             });
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -204,6 +204,7 @@ function get_props_for_popover_centering(popover_props) {
             left: reference_offset,
             top: reference_offset,
         }),
+        placement: "top",
         popperOptions: {
             modifiers: [
                 {

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -223,11 +223,15 @@ function get_props_for_popover_centering(popover_props) {
         },
         onMount(instance) {
             $("body").append($("<div>").attr("id", "popover-overlay-background"));
-            popover_props.onMount(instance);
+            if (popover_props.onMount) {
+                popover_props.onMount(instance);
+            }
         },
         onHidden(instance) {
             $("#popover-overlay-background").remove();
-            popover_props.onHidden(instance);
+            if (popover_props.onHidden) {
+                popover_props.onHidden(instance);
+            }
         },
     };
 }

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1070,7 +1070,7 @@ export function any_active() {
         stream_popover.stream_popped() ||
         message_info_popped() ||
         user_info_popped() ||
-        emoji_picker.reactions_popped() ||
+        emoji_picker.is_open() ||
         $("[class^='column-'].expanded").length
     );
 }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -547,7 +547,7 @@
         border-color: hsl(0deg 0% 0% / 60%);
     }
 
-    .emoji-info-popover
+    .emoji-picker-popover
         .emoji-popover
         .emoji-popover-category-tabs
         .emoji-popover-tab-item.active {
@@ -642,7 +642,7 @@
         #user-group-creation
         #user_group_creation_form
         #user_group_creating_indicator:not(:empty),
-    .emoji-info-popover
+    .emoji-picker-popover
         .emoji-popover
         .emoji-popover-emoji:not(.reacted):focus {
         background-color: hsl(212deg 28% 8% / 75%);
@@ -804,9 +804,9 @@
 
     .group-row.active,
     .stream-row.active,
-    .emoji-info-popover .emoji-showcase-container,
-    .emoji-info-popover .emoji-popover .emoji-popover-category-tabs,
-    .emoji-info-popover .emoji-popover .emoji-popover-top {
+    .emoji-picker-popover .emoji-showcase-container,
+    .emoji-picker-popover .emoji-popover .emoji-popover-category-tabs,
+    .emoji-picker-popover .emoji-popover .emoji-popover-top {
         background-color: hsl(0deg 0% 0% / 20%);
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -738,7 +738,8 @@ ul {
     left: -1px;
 }
 
-.giphy-popover {
+.giphy-popover,
+.emoji-popover-root {
     .tippy-content {
         /* We remove the default padding from this container
            as it is not necessary for the Giphy popover. */
@@ -747,6 +748,18 @@ ul {
         /* By resetting to the default color from the `body`,
            we can ignore the colors applied from `tippy-box`. */
         color: var(--color-text-default);
+    }
+}
+
+.emoji-popover-root {
+    /* The emoji popover has a different background color for the
+       header and footer, so we customize the arrow to match this color. */
+    .tippy-box[data-placement="top"] .tippy-arrow::before {
+        border-top-color: hsl(0deg 0% 93%);
+    }
+
+    .tippy-box[data-placement="bottom"] .tippy-arrow::before {
+        border-bottom-color: hsl(0deg 0% 93%);
     }
 }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -710,7 +710,7 @@ ul {
         }
     }
 
-    .emoji-info-popover {
+    .emoji-picker-popover {
         position: static;
         margin-right: 0;
     }

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -81,10 +81,13 @@
         background-color: hsl(0deg 0% 98%);
     }
 
-    .reaction_button {
+    .reaction_button,
+    .emoji-message-control-button-container {
         display: flex;
         align-items: center;
+    }
 
+    .reaction_button {
         & i {
             font-size: 1em;
         }
@@ -170,7 +173,7 @@
 
             background-color: hsl(0deg 0% 93%);
 
-            border-radius: 5px 5px 0 0;
+            border-radius: 3px 3px 0 0;
 
             .fa-search {
                 position: absolute;
@@ -277,6 +280,7 @@
         background-color: hsl(0deg 0% 93%);
         min-height: 44px;
         width: 250px;
+        border-radius: 0 0 3px 3px;
 
         .emoji-preview {
             position: absolute;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -140,7 +140,7 @@
     opacity: 1 !important;
 }
 
-.emoji-info-popover {
+.emoji-picker-popover {
     padding: 0;
     height: 370px;
     user-select: none;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -134,7 +134,7 @@
     }
 }
 
-.reaction_button_visible {
+.active-emoji-picker-reference {
     visibility: visible !important;
     pointer-events: all !important;
     opacity: 1 !important;

--- a/web/styles/tooltips.css
+++ b/web/styles/tooltips.css
@@ -97,7 +97,7 @@
 
        See https://github.com/atomiks/tippyjs/issues/555 for some discussion on this.
     */
-    [data-reference-hidden] {
+    [data-reference-hidden]:not(.show-when-reference-hidden) {
         display: none;
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1203,7 +1203,7 @@ td.pointer {
         text-align: center;
         color: var(--color-message-action-visible);
 
-        > i {
+        & i {
             vertical-align: middle;
             /* TODO: Math for these values, possibly with variables.
                In short, the icon body is 16px square; the current

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -6,8 +6,9 @@
     <a role="button" class="markdown_preview compose_control_button fa fa-eye" aria-label="{{t 'Preview' }}" tabindex=0 data-tippy-content="{{t 'Preview' }}"></a>
     <a role="button" class="undo_markdown_preview compose_control_button fa fa-edit" aria-label="{{t 'Write' }}" tabindex=0 style="display:none;" data-tippy-content="{{t 'Write' }}"></a>
     <a role="button" class="compose_control_button fa fa-video-camera video_link" aria-label="{{t 'Add video call' }}" tabindex=0 data-tippy-content="{{t 'Add video call' }}"></a>
-    <a role="button" class="compose_control_button fa fa-phone audio_link" aria-label="{{t 'Add audio call' }}" tabindex=0 data-tippy-content="{{t 'Add audio call' }}"></a>
-    <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0 data-tippy-content="{{t 'Add emoji' }}"></a>
+    <div class="compose_control_button_container" data-tippy-content="{{t 'Add emoji' }}">
+        <a role="button" class="compose_control_button fa fa-smile-o emoji_map" aria-label="{{t 'Add emoji' }}" tabindex=0></a>
+    </div>
     <a role="button" class="compose_control_button fa fa-clock-o time_pick" aria-label="{{t 'Add global time' }}" tabindex=0 data-tooltip-template-id="add-global-time-tooltip" data-tippy-maxWidth="none"></a>
     <div class="compose_control_button_container {{#unless giphy_enabled }}hide{{/unless}}" data-tippy-content="{{t 'Add GIF' }}">
         <a role="button" class="compose_control_button compose_gif_icon zulip-icon zulip-icon-gif" aria-label="{{t 'Add GIF' }}" tabindex=0></a>

--- a/web/templates/emoji_popover.hbs
+++ b/web/templates/emoji_popover.hbs
@@ -1,7 +1,4 @@
-<div class="popover emoji-info-popover">
-    <div class="arrow"></div>
-    <div class="popover-content">
-        <div></div>
-    </div>
+<div class="emoji-info-popover">
+    <div class="popover-content"></div>
     <div class="emoji-showcase-container"></div>
 </div>

--- a/web/templates/emoji_popover.hbs
+++ b/web/templates/emoji_popover.hbs
@@ -1,4 +1,4 @@
-<div class="emoji-info-popover">
+<div class="emoji-picker-popover">
     <div class="popover-content"></div>
     <div class="emoji-showcase-container"></div>
 </div>

--- a/web/templates/message_controls.hbs
+++ b/web/templates/message_controls.hbs
@@ -5,7 +5,9 @@
 
     {{#unless msg/sent_by_me}}
     <div class="reaction_button message_control_button" data-tooltip-template-id="add-emoji-tooltip-template">
-        <i class="zulip-icon zulip-icon-smile" aria-label="{{t 'Add emoji reaction' }} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
+        <div class="emoji-message-control-button-container">
+            <i class="zulip-icon zulip-icon-smile" aria-label="{{t 'Add emoji reaction' }} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
+        </div>
     </div>
     {{/unless}}
 

--- a/web/templates/message_reactions.hbs
+++ b/web/templates/message_reactions.hbs
@@ -2,6 +2,8 @@
     {{> message_reaction}}
 {{/each}}
 <div class="reaction_button" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
-    <i class="zulip-icon zulip-icon-smile" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
-    <div class="message_reaction_count">+</div>
+    <div class="emoji-message-control-button-container">
+        <i class="zulip-icon zulip-icon-smile" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
+        <div class="message_reaction_count">+</div>
+    </div>
 </div>

--- a/web/templates/message_reactions.hbs
+++ b/web/templates/message_reactions.hbs
@@ -1,9 +1,9 @@
 {{#each this/msg/message_reactions}}
     {{> message_reaction}}
 {{/each}}
-<div class="reaction_button" role="button" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
+<div class="reaction_button" role="button" aria-haspopup="true" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
     <div class="emoji-message-control-button-container">
-        <i class="zulip-icon zulip-icon-smile" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
+        <i class="zulip-icon zulip-icon-smile" tabindex="0"></i>
         <div class="message_reaction_count">+</div>
     </div>
 </div>

--- a/web/templates/message_reactions.hbs
+++ b/web/templates/message_reactions.hbs
@@ -1,9 +1,9 @@
 {{#each this/msg/message_reactions}}
     {{> message_reaction}}
 {{/each}}
-<div class="reaction_button" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
+<div class="reaction_button" role="button" data-tippy-content="{{t 'Add emoji reaction' }}" aria-label="{{t 'Add emoji reaction' }} (:)">
     <div class="emoji-message-control-button-container">
-        <i class="zulip-icon zulip-icon-smile" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
+        <i class="zulip-icon zulip-icon-smile" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
         <div class="message_reaction_count">+</div>
     </div>
 </div>

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -37,7 +37,7 @@ const compose_actions = mock_esm("../src/compose_actions");
 const condense = mock_esm("../src/condense");
 const drafts = mock_esm("../src/drafts");
 const emoji_picker = mock_esm("../src/emoji_picker", {
-    reactions_popped: () => false,
+    is_open: () => false,
     toggle_emoji_popover() {},
 });
 const gear_menu = mock_esm("../src/gear_menu", {
@@ -418,7 +418,7 @@ run_test("v w/no overlays", ({override}) => {
 });
 
 run_test("emoji picker", ({override}) => {
-    override(emoji_picker, "reactions_popped", () => true);
+    override(emoji_picker, "is_open", () => true);
     assert_mapping(":", emoji_picker, "navigate", true);
 });
 

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -101,7 +101,7 @@ message_lists.current = {
     },
     selected_row() {
         const $row = $.create("selected-row-stub");
-        $row.set_find_results(".actions_hover", []);
+        $row.set_find_results(".message-actions-menu-button", []);
         return $row;
     },
     selected_message() {


### PR DESCRIPTION
## Description:
This PR is part of our ongoing effort to migrate from Bootstrap-based popovers to Tippy.

## Known issues:
- [x] The arrow color is incorrect in the light theme.
- [x] The popover opens on the second click in the compose section.
    _I've spent a lot of time trying to debug why it only opens on the second click, but I haven't had any results. I would really appreciate any help here._
- [x] The popover doesn't open in places other than the compose box.
- [x] The popover used to open in overlay mode for screens with a width less than 768px, but it's currently not working as intended.
---
### Fixes part of #23632.