### PR TITLE
compose: Return focus to DM input after pill selection.

### DIFF
--- a/web/src/compose_pm_pill.js
+++ b/web/src/compose_pm_pill.js
@@ -29,6 +29,7 @@ export function initialize({on_pill_create_or_remove}) {
 
     widget.onPillCreate(() => {
         on_pill_create_or_remove();
+        $("#private_message_recipient").trigger("focus");
     });
 
     widget.onPillRemove(() => {


### PR DESCRIPTION
Before this change, the cursor left the DM recipient box after selecting a pill from the typeahead. This was only the case with mouse clicks and not with keyboard selection.

This change ensures we always return focus to the input field after selection.

![Kapture 2023-07-25 at 14 55 42](https://github.com/zulip/zulip/assets/5634097/90da3aa9-f71d-4835-a2f3-df58ad5c4832)
