### PR TITLE
print: Add print styles targeted at topics.

### DIFF
--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -57,6 +57,7 @@ import "../../styles/hotspots.css";
 import "../../styles/dark_theme.css";
 import "../../styles/user_status.css";
 import "../../styles/widgets.css";
+import "../../styles/print.css";
 
 // This should be last.
 import "../ui_init";

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -1,0 +1,74 @@
+@media print {
+    /* Hide unnecessary blocks. */
+    #navbar_alerts_wrapper,
+    #streamlist-toggle,
+    #left-sidebar-container,
+    #right-sidebar-container,
+    .top-messages-logo,
+    #userlist-toggle,
+    .message_length_controller,
+    #loading_older_messages_indicator,
+    #page_loading_indicator,
+    #message_feed_errors_container,
+    #bottom_whitespace,
+    #mark_read_on_scroll_state_banner,
+    #compose {
+        display: none;
+    }
+
+    /* Prevent headers from running on every page. */
+    #navbar-fixed-container,
+    .message_list .message_header {
+        position: static;
+    }
+
+    /* Save a bit of paper by removing padding. */
+    #message_feed_container {
+        padding-top: 0;
+    }
+
+    /* Hide unnecessary controls, but leave them
+       in the document flow. */
+    .search_icon,
+    .settings-dropdown-cog,
+    .recipient_bar_controls {
+        visibility: hidden;
+    }
+
+    /* Don't highlight the selected message. */
+    .selected_message .messagebox-content {
+        outline: 0;
+    }
+
+    /* Show collapsed content for printing. Note that
+       CSS Grid does not yet break very intelligently
+       in all browsers, so longer messages may sometimes
+       appear at the top of new pages. */
+    .message_content.collapsed,
+    .message_content.condensed {
+        max-height: unset !important;
+        min-height: unset !important;
+        overflow: auto !important;
+        height: auto !important;
+        mask-image: none;
+    }
+
+    /* Print links in the same color as text, with any
+       likely full URL values in parentheses. */
+    .message_content a {
+        color: inherit;
+
+        &[href^="http"]::after {
+            content: " (" attr(href) ")";
+        }
+    }
+
+    /* Ensure that emoji print. They are background-images,
+       which ordinarily do not print, so these properties
+       should ensure proper printing of inline, status, and
+       other emoji. */
+    .emoji {
+        color-adjust: exact;
+        print-color-adjust: exact;
+    }
+}


### PR DESCRIPTION
This adds some essential print styles via a new `print.css` stylesheet to ensure better printing especially of Zulip topics.

There are still things that could be improved, given enough time. In particular, there are slight differences when printing from light vs. dark mode; some additional work could be done on borders and things, but this PR is really about trying to faithfully present the content of topics and their messages as faithfully and accessibly as possible.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/printing.20Zulip.20conversations/near/1614108)

**Screenshots and screen captures:**

| Before, Emoji (invisible) | After |
| --- | --- |
| <img width="1136" alt="emoji-before" src="https://github.com/zulip/zulip/assets/170719/74a3aa96-dd82-4680-83d4-5682a357995b"> | <img width="1136" alt="emoji-after" src="https://github.com/zulip/zulip/assets/170719/5a955e74-bb0c-40f0-a05b-ea0dffe05bca"> |


| Before, Long Posts | After, Long Posts (print in their expanded form regardless of their state on screen) |
| --- | --- |
| <img width="1136" alt="long-post-before" src="https://github.com/zulip/zulip/assets/170719/fee11c98-31c8-45d7-a4ab-b2afe48baad4"> | <img width="1136" alt="long-post-after" src="https://github.com/zulip/zulip/assets/170719/e95c5c29-efca-47be-bbe3-93c8e75d48dd">


| Before, Links | After, Links (only links beginning with `http` are presented parenthetically after the link text) |
| --- | --- |
| <img width="1136" alt="links-before" src="https://github.com/zulip/zulip/assets/170719/8a20af71-dce2-4cfd-a54a-648d34a7eeff"> | <img width="1136" alt="links-after" src="https://github.com/zulip/zulip/assets/170719/323ed81d-9805-4bc5-8aa4-c8bd7bd4bd43"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>