### PR TITLE
mailmap: Add evy@zulip.com.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -44,8 +44,9 @@ Dinesh <chdinesh1089@gmail.com>
 Dinesh <chdinesh1089@gmail.com> <chdinesh1089>
 Eeshan Garg <eeshan@zulip.com> <jerryguitarist@gmail.com>
 Eric Smith <erwsmith@gmail.com> <99841919+erwsmith@users.noreply.github.com>
-Evy Kassirer <evy.kassirer@gmail.com>
-Evy Kassirer <evy.kassirer@gmail.com> <evykassirer@users.noreply.github.com>
+Evy Kassirer <evy@zulip.com>
+Evy Kassirer <evy@zulip.com> <evy.kassirer@gmail.com>
+Evy Kassirer <evy@zulip.com> <evykassirer@users.noreply.github.com>
 Ganesh Pawar <pawarg256@gmail.com> <58626718+ganpa3@users.noreply.github.com>
 Greg Price <greg@zulip.com> <gnprice@gmail.com>
 Greg Price <greg@zulip.com> <greg@zulipchat.com>


### PR DESCRIPTION
I ran `git config --local user.email evy@zulip.com` locally and added a line to `.mailmap` to show that both my emails are the same person.