### PR TITLE
bot_icon: Correct vertical alignment.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -350,7 +350,7 @@ $time_column_min_width: 50px; /* + padding */
 
                 .zulip-icon.zulip-icon-bot {
                     align-self: center;
-                    padding: $message_box_margin 0 0 5px;
+                    padding: 0 0 0 5px;
                 }
 
                 .sender_name {


### PR DESCRIPTION
This PR removes some margin that became unnecessary as of #25997, but went unfixed until now.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/bot.20icon.20alignment.20in.20messages/near/1616249)

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![bot-icon-align-before](https://github.com/zulip/zulip/assets/170719/4a767272-7246-4266-b908-84ff4932f1c5) | ![bot-icon-align-after](https://github.com/zulip/zulip/assets/170719/a00d3c45-ecde-48a3-b9d1-7d63f9ee0e8b) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>