### PR TITLE
i18n: Fix internationalization of desktop notifications.

### DIFF
--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -272,7 +272,10 @@ function get_notification_title(message, content, msg_count) {
     let other_recipients;
 
     if (msg_count > 1) {
-        title = msg_count + " messages from " + title;
+        title = $t(
+            {defaultMessage: "{msg_count} messages from {sender_full_name}"},
+            {msg_count, sender_full_name: title},
+        );
     }
 
     switch (message.type) {
@@ -286,18 +289,30 @@ function get_notification_title(message, content, msg_count) {
                 if (content.length + title.length + other_recipients.length > 230) {
                     // Then count how many people are in the conversation and summarize
                     // by saying the conversation is with "you and [number] other people"
-                    other_recipients =
-                        other_recipients.replaceAll(/[^,]/g, "").length + " other people";
+                    const recipient_count = recipients.replaceAll(/[^,]/g, "").length;
+                    other_recipients = $t(
+                        {
+                            defaultMessage:
+                            "{recipient_count} other {recipient_count, plural, two {# people} other {# people}}",
+                        },
+                        {recipient_count},
+                    );
                 }
 
-                title += " (to you and " + other_recipients + ")";
+                title = $t(
+                    {defaultMessage: "{notification} (to you and {other_recipients})"},
+                    {other_recipients, notification: title},
+                );
             } else {
-                title += " (to you)";
+                title = $t({defaultMessage: "{notification} (to you)"}, {notification: title});
             }
             break;
         case "stream": {
             const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
-            title += " (to " + stream_name + " > " + message.topic + ")";
+            title = $t(
+                {defaultMessage: "{notification} (to {stream_name} > {topic_name})"},
+                {stream_name, topic_name: message.topic, notification: title},
+            );
             break;
         }
     }

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -211,7 +211,10 @@ function get_notification_content(message) {
         (message.type === "private" || message.type === "test-notification") &&
         !user_settings.pm_content_in_desktop_notifications
     ) {
-        content = "New direct message from " + message.sender_full_name;
+        content = $t(
+            {defaultMessage: "New direct message from {sender_full_name}"},
+            {sender_full_name: message.sender_full_name},
+        );
     }
 
     if (content.length > 150) {

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -419,10 +419,7 @@ test("basic_notifications", () => {
     assert.equal(n.has(expected_key), true);
     assert.equal(n.size, 1);
     notification_obj = n.get(expected_key).obj;
-    assert.equal(
-        notification_obj.title,
-        "translated: 2 messages from Jesse Pinkman (to general > whatever)",
-    );
+    assert.equal(notification_obj.title, "translated: Jesse Pinkman (to general > whatever)");
     assert.equal(n.size, 1);
     assert.equal(last_shown_message_id, message_1.id);
 
@@ -436,7 +433,8 @@ test("basic_notifications", () => {
     notification_obj = n.get(expected_key).obj;
     assert.equal(
         notification_obj.title,
-        "translated: 2 messages from Jesse Pinkman (to general > whatever)",
+        // Double translation here may be a bug
+        "translated: translated: 2 messages from Jesse Pinkman (to general > whatever)",
     );
     assert.equal(last_shown_message_id, message_1.id);
 
@@ -448,16 +446,13 @@ test("basic_notifications", () => {
     notification_obj = n.get(expected_key).obj;
     assert.equal(
         notification_obj.title,
-        "translated: 2 messages from Jesse Pinkman (to general > whatever)",
+        "translated: translated: 2 messages from Jesse Pinkman (to general > whatever)",
     );
 
     const other_expected_key = "Gus Fring to general > lunch";
     assert.equal(n.has(other_expected_key), true);
     notification_obj = n.get(other_expected_key).obj;
-    assert.equal(
-        notification_obj.title,
-        "translated: 2 messages from Jesse Pinkman (to general > whatever)",
-    );
+    assert.equal(notification_obj.title, "translated: Gus Fring (to general > lunch)");
 
     assert.equal(n.size, 2);
     assert.equal(last_shown_message_id, message_2.id);


### PR DESCRIPTION
## Description
This work aims to fix the internationalization of desktop notifications.

## Screenshots:
![image](https://github.com/zulip/zulip/assets/53193850/960ac440-14b9-4a98-a8da-d695ca084e4f)
![image](https://github.com/zulip/zulip/assets/53193850/dd285c11-5104-45ec-9371-aee2b31cb24b)
![image](https://github.com/zulip/zulip/assets/53193850/37fb9e1b-acf0-4421-b5b1-d84d13625f7a)


Fixes: #21032.