### PR TITLE
topic_mentions: Add @topic mention typeahead.

### DIFF
--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -877,7 +877,7 @@ export function content_typeahead_selected(item, event) {
                     item.user_id,
                     is_silent,
                 );
-                if (!is_silent) {
+                if (!is_silent && !item.is_broadcast) {
                     compose_validate.warn_if_mentioning_unsubscribed_user(item, $textbox);
                     mention_text = compose_validate.convert_mentions_to_silent_in_direct_messages(
                         mention_text,

--- a/web/src/composebox_typeahead.js
+++ b/web/src/composebox_typeahead.js
@@ -376,20 +376,26 @@ export function tokenize_compose_str(s) {
     return "";
 }
 
+function get_wildcard_string(mention) {
+    if (compose_state.get_message_type() === "private") {
+        return $t({defaultMessage: "Notify recipients"});
+    }
+    if (mention === "topic") {
+        return $t({defaultMessage: "Notify topic"});
+    }
+    return $t({defaultMessage: "Notify stream"});
+}
+
 export function broadcast_mentions() {
     if (!compose_validate.wildcard_mention_allowed()) {
         return [];
     }
     const wildcard_mention_array = ["all", "everyone"];
-    let wildcard_string = "";
-    if (compose_state.get_message_type() === "private") {
-        wildcard_string = $t({defaultMessage: "Notify recipients"});
-    } else {
-        wildcard_string = $t({defaultMessage: "Notify stream"});
-        wildcard_mention_array.push("stream");
+    if (compose_state.get_message_type() === "stream") {
+        wildcard_mention_array.push("stream", "topic");
     }
     return wildcard_mention_array.map((mention, idx) => ({
-        special_item_text: `${mention} (${wildcard_string})`,
+        special_item_text: `${mention} (${get_wildcard_string(mention)})`,
         email: mention,
 
         // Always sort above, under the assumption that names will

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -67,16 +67,20 @@ run_test("verify wildcard mentions typeahead for stream message", () => {
     const mention_all = ct.broadcast_mentions()[0];
     const mention_everyone = ct.broadcast_mentions()[1];
     const mention_stream = ct.broadcast_mentions()[2];
+    const mention_topic = ct.broadcast_mentions()[3];
     assert.equal(mention_all.email, "all");
     assert.equal(mention_all.full_name, "all");
     assert.equal(mention_everyone.email, "everyone");
     assert.equal(mention_everyone.full_name, "everyone");
     assert.equal(mention_stream.email, "stream");
     assert.equal(mention_stream.full_name, "stream");
+    assert.equal(mention_topic.email, "topic");
+    assert.equal(mention_topic.full_name, "topic");
 
     assert.equal(mention_all.special_item_text, "all (translated: Notify stream)");
     assert.equal(mention_everyone.special_item_text, "everyone (translated: Notify stream)");
     assert.equal(mention_stream.special_item_text, "stream (translated: Notify stream)");
+    assert.equal(mention_topic.special_item_text, "topic (translated: Notify topic)");
 
     compose_validate.wildcard_mention_allowed = () => false;
     const mentionNobody = ct.broadcast_mentions();

--- a/web/tests/composebox_typeahead.test.js
+++ b/web/tests/composebox_typeahead.test.js
@@ -63,6 +63,7 @@ const ct = composebox_typeahead;
 ct.__Rewire__("max_num_items", 15);
 
 run_test("verify wildcard mentions typeahead for stream message", () => {
+    compose_state.set_message_type("stream");
     const mention_all = ct.broadcast_mentions()[0];
     const mention_everyone = ct.broadcast_mentions()[1];
     const mention_stream = ct.broadcast_mentions()[2];

--- a/web/tests/typeahead_helper.test.js
+++ b/web/tests/typeahead_helper.test.js
@@ -588,7 +588,7 @@ test("sort broadcast mentions for stream message type", () => {
 
     assert.deepEqual(
         results.map((r) => r.email),
-        ["all", "everyone", "stream"],
+        ["all", "everyone", "stream", "topic"],
     );
 
     // Reverse the list to test actual sorting
@@ -602,7 +602,7 @@ test("sort broadcast mentions for stream message type", () => {
 
     assert.deepEqual(
         results2.map((r) => r.email),
-        ["all", "everyone", "stream", a_user.email, zman.email],
+        ["all", "everyone", "stream", "topic", a_user.email, zman.email],
     );
 });
 


### PR DESCRIPTION
Add a `@topic mention` typeahead that appears only in stream messages and not in private messages.

Fixes part of #22829

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
---
**Screenshots and screen captures:**

<details><summary>Typeahead menu</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/385ee202-1536-40bd-bede-7ba5bedfe572">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
