### PR TITLE
print: Fix dark mode, opacity issues.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1553,11 +1553,13 @@
     }
 }
 
-:root.dark-theme {
-    @extend %dark-theme;
+@media screen {
+    :root.dark-theme {
+        @extend %dark-theme;
+    }
 }
 
-@media (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
     :root.color-scheme-automatic {
         @extend %dark-theme;
     }

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -49,6 +49,12 @@
         visibility: hidden;
     }
 
+    /* Try to keep the message header with the messages
+       that follow in interleaved views. */
+    .message_header_stream {
+        break-after: avoid;
+    }
+
     /* Don't highlight the selected message. */
     .selected_message .messagebox-content {
         outline: 0;

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -22,7 +22,13 @@
         position: static;
     }
 
-    /* Save a bit of paper by removing padding. */
+    /* Save a bit of paper by removing height, which
+       otherwise creates a blank final page, and padding. */
+    html,
+    body {
+        height: auto;
+    }
+
     #message_feed_container {
         padding-top: 0;
     }

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -4,6 +4,7 @@
     #streamlist-toggle,
     #left-sidebar-container,
     #right-sidebar-container,
+    .column-left,
     .top-messages-logo,
     #userlist-toggle,
     .message_length_controller,
@@ -12,8 +13,15 @@
     #message_feed_errors_container,
     #bottom_whitespace,
     #mark_read_on_scroll_state_banner,
+    .trailing_bookend,
     #compose {
         display: none;
+    }
+
+    /* Allow printer to set the margins, and
+       prevent Safari from using screen-based ones. */
+    .column-middle {
+        margin: 0;
     }
 
     /* Prevent headers from running on every page. */

--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -40,6 +40,17 @@
         outline: 0;
     }
 
+    .messagebox-content {
+        .message_edit_notice,
+        .message_time {
+            /* Firefox seems to have a bug that fuzzes out
+               small text with opacity; this unsets that
+               value, and replaces with a matching gray. */
+            opacity: unset;
+            color: hsl(0deg 0% 0% / 48%);
+        }
+    }
+
     /* Show collapsed content for printing. Note that
        CSS Grid does not yet break very intelligently
        in all browsers, so longer messages may sometimes

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -251,11 +251,13 @@ body {
     --color-background-text-hover-group-mention: hsl(183deg 52% 40% / 30%);
 }
 
-:root.dark-theme {
-    @extend %dark-theme;
+@media screen {
+    :root.dark-theme {
+        @extend %dark-theme;
+    }
 }
 
-@media (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
     :root.color-scheme-automatic {
         @extend %dark-theme;
     }


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR improves topic-printing in multiple ways:

1) it isolates all dark-mode CSS to screen media only (`@media screen`), meaning that printed topics should always only ever apply the light mode--keeping the print CSS free from a whole bunch of adjustments that we'd have to make otherwise.
2) it fixes a bug with Firefox, where print output can appear pixelated/fuzzed out on text with opacity set, such as the EDITED/MOVED messages and timestamps.
3) it saves paper by setting `height: auto` in the print styles for `html` and `body`, which were otherwise creating a blank N+1th page--even on topics with a single short message.
4) it overrides some additional things (primarily margins) that Safari was accounting for, based on how wide the viewport was at the time of printing.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/printing.20Zulip.20conversations/near/1616218)

| Before ([Actual PDF](https://github.com/zulip/zulip/files/12195874/dark-mode-print-before.pdf)) | After ([Actual PDF](https://github.com/zulip/zulip/files/12195878/dark-mode-print-after.pdf))|
| --- | --- |
| <img width="1113" alt="print-before" src="https://github.com/zulip/zulip/assets/170719/7d33a44f-049c-4317-ae3d-fe2af83f00ab"> | <img width="1113" alt="print-after" src="https://github.com/zulip/zulip/assets/170719/da49fc2c-3fe1-4ae7-a879-5abfabc02ab9"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>