### PR TITLE
retention: Prevent deletion of partially-archived messages.

### DIFF
--- a/zerver/actions/uploads.py
+++ b/zerver/actions/uploads.py
@@ -74,11 +74,17 @@ def do_delete_old_unclaimed_attachments(weeks_ago: int) -> None:
         weeks_ago
     )
 
+    # An attachment may be removed from Attachments and
+    # ArchiveAttachments in the same run; prevent warnings from the
+    # backing store by only removing it from there once.
+    already_removed = set()
     for attachment in old_unclaimed_attachments:
         delete_message_attachment(attachment.path_id)
+        already_removed.add(attachment.path_id)
         attachment.delete()
     for archived_attachment in old_unclaimed_archived_attachments:
-        delete_message_attachment(archived_attachment.path_id)
+        if archived_attachment.path_id not in already_removed:
+            delete_message_attachment(archived_attachment.path_id)
         archived_attachment.delete()
 
 

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -478,7 +478,9 @@ def move_messages_to_archive(
     archived_attachments = ArchivedAttachment.objects.filter(
         messages__id__in=message_ids
     ).distinct()
-    Attachment.objects.filter(messages__isnull=True, id__in=archived_attachments).delete()
+    Attachment.objects.filter(
+        messages__isnull=True, scheduled_messages__isnull=True, id__in=archived_attachments
+    ).delete()
 
 
 def restore_messages_from_archive(archive_transaction_id: int) -> List[int]:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3739,9 +3739,9 @@ def get_old_unclaimed_attachments(
     )
     old_archived_attachments = ArchivedAttachment.objects.annotate(
         has_other_messages=Exists(
-            Attachment.objects.filter(id=OuterRef("id"))
-            .exclude(messages=None)
-            .exclude(scheduled_messages=None)
+            Attachment.objects.filter(id=OuterRef("id")).exclude(
+                messages=None, scheduled_messages=None
+            )
         )
     ).filter(messages=None, create_time__lt=delta_weeks_ago, has_other_messages=False)
 

--- a/zerver/tests/test_delete_unclaimed_attachments.py
+++ b/zerver/tests/test_delete_unclaimed_attachments.py
@@ -1,0 +1,345 @@
+import os
+import re
+from datetime import datetime, timedelta
+from io import StringIO
+from typing import Optional
+
+import time_machine
+from django.conf import settings
+from django.utils.timezone import now as timezone_now
+
+from zerver.actions.message_delete import do_delete_messages
+from zerver.actions.scheduled_messages import check_schedule_message, delete_scheduled_message
+from zerver.actions.uploads import do_delete_old_unclaimed_attachments
+from zerver.lib.retention import clean_archived_data
+from zerver.lib.test_classes import UploadSerializeMixin, ZulipTestCase
+from zerver.models import (
+    ArchivedAttachment,
+    Attachment,
+    Message,
+    UserProfile,
+    get_client,
+)
+
+
+class UnclaimedAttachmentTest(UploadSerializeMixin, ZulipTestCase):
+    def make_attachment(
+        self, filename: str, when: Optional[datetime] = None, uploader: Optional[UserProfile] = None
+    ) -> Attachment:
+        if when is None:
+            when = timezone_now() - timedelta(weeks=2)
+        if uploader is None:
+            uploader = self.example_user("hamlet")
+        self.login_user(uploader)
+
+        with time_machine.travel(when):
+            file_obj = StringIO("zulip!")
+            file_obj.name = filename
+            response = self.assert_json_success(
+                self.client_post("/json/user_uploads", {"file": file_obj})
+            )
+            path_id = re.sub("/user_uploads/", "", response["uri"])
+            return Attachment.objects.get(path_id=path_id)
+
+    def assert_exists(
+        self,
+        attachment: Attachment,
+        *,
+        has_file: bool,
+        has_attachment: bool,
+        has_archived_attachment: bool,
+    ) -> None:
+        assert settings.LOCAL_FILES_DIR
+        self.assertEqual(  # File existence on disk
+            os.path.isfile(os.path.join(settings.LOCAL_FILES_DIR, attachment.path_id)), has_file
+        )
+        self.assertEqual(  # Attachment row
+            Attachment.objects.filter(id=attachment.id).exists(), has_attachment
+        )
+        self.assertEqual(  # ArchivedAttachment row
+            ArchivedAttachment.objects.filter(id=attachment.id).exists(), has_archived_attachment
+        )
+
+    def test_delete_unused_upload(self) -> None:
+        unused_attachment = self.make_attachment("unused.txt")
+        self.assert_exists(
+            unused_attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+        # If we have 3 weeks of grace, nothing happens
+        do_delete_old_unclaimed_attachments(3)
+        self.assert_exists(
+            unused_attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+        # If we have 1 weeks of grace, the Attachment is deleted, and so is the file on disk
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            unused_attachment, has_file=False, has_attachment=False, has_archived_attachment=False
+        )
+
+    def test_delete_used_upload(self) -> None:
+        hamlet = self.example_user("hamlet")
+        attachment = self.make_attachment("used.txt")
+
+        # Send message referencing that message
+        self.subscribe(hamlet, "Denmark")
+        body = f"Some files here ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{attachment.path_id})"
+        self.send_stream_message(hamlet, "Denmark", body, "test")
+
+        # Because the message is claimed, it is not removed
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+    def test_delete_upload_archived_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        attachment = self.make_attachment("used.txt")
+
+        # Send message referencing that message
+        self.subscribe(hamlet, "Denmark")
+        body = f"Some files here ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{attachment.path_id})"
+        message_id = self.send_stream_message(hamlet, "Denmark", body, "test")
+
+        # Delete that message; this moves it to ArchivedAttachment but leaves the file on disk
+        do_delete_messages(hamlet.realm, [Message.objects.get(id=message_id)])
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=False, has_archived_attachment=True
+        )
+
+        # Removing unclaimed attachments leaves the file, since it is
+        # attached to an existing ArchivedAttachment
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=False, has_archived_attachment=True
+        )
+
+        # Now purge the ArchivedMessage
+        with self.settings(ARCHIVED_DATA_VACUUMING_DELAY_DAYS=0):
+            clean_archived_data()
+
+        # The attachment still exists as an unclaimed ArchivedAttachment
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=False, has_archived_attachment=True
+        )
+
+        # Removing unclaimed attachments now cleans it out
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=False, has_attachment=False, has_archived_attachment=False
+        )
+
+    def test_delete_one_message(self) -> None:
+        hamlet = self.example_user("hamlet")
+        attachment = self.make_attachment("used.txt")
+
+        # Send message referencing that message
+        self.subscribe(hamlet, "Denmark")
+        body = f"Some files here ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{attachment.path_id})"
+        first_message_id = self.send_stream_message(hamlet, "Denmark", body, "test")
+        second_message_id = self.send_stream_message(hamlet, "Denmark", body, "test")
+
+        # Delete the second message; this leaves an Attachment and an
+        # ArchivedAttachment, both associated with a message
+        do_delete_messages(hamlet.realm, [Message.objects.get(id=first_message_id)])
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Removing unclaimed attachments leaves the file, since it is
+        # attached to an existing Attachment and ArchivedAttachment
+        # which have Messages and ArchivedMessages, respectively
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Purging the ArchivedMessage does not affect the Attachment
+        # or ArchivedAttachment
+        with self.settings(ARCHIVED_DATA_VACUUMING_DELAY_DAYS=0):
+            clean_archived_data()
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Removing unclaimed attachments still does nothing, because
+        # the ArchivedAttachment is protected by the existing
+        # Attachment.
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Deleting the other message now leaves just an ArchivedAttachment
+        do_delete_messages(hamlet.realm, [Message.objects.get(id=second_message_id)])
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=False, has_archived_attachment=True
+        )
+
+        # Cleaning out the archived message and purging unclaimed
+        # attachments now finally removes it.
+        with self.settings(ARCHIVED_DATA_VACUUMING_DELAY_DAYS=0):
+            clean_archived_data()
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=False, has_attachment=False, has_archived_attachment=False
+        )
+
+    def test_delete_with_scheduled_messages(self) -> None:
+        hamlet = self.example_user("hamlet")
+        attachment = self.make_attachment("used.txt")
+
+        # Schedule a future send with the attachment
+        self.subscribe(hamlet, "Denmark")
+        body = f"Some files here ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{attachment.path_id})"
+        scheduled_message_id = check_schedule_message(
+            hamlet,
+            get_client("website"),
+            "stream",
+            [self.get_stream_id("Denmark")],
+            "Test topic",
+            body,
+            timezone_now() + timedelta(days=365),
+            hamlet.realm,
+        )
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+        # The ScheduledMessage protects the attachment from being removed
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+        # Deleting the ScheduledMessage leaves the attachment dangling
+        delete_scheduled_message(hamlet, scheduled_message_id)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+        # Having no referents, it is now a target for removal
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=False, has_attachment=False, has_archived_attachment=False
+        )
+
+    def test_delete_with_scheduled_message_and_archive(self) -> None:
+        hamlet = self.example_user("hamlet")
+        attachment = self.make_attachment("used.txt")
+
+        # Schedule a message, and also send one now
+        self.subscribe(hamlet, "Denmark")
+        body = f"Some files here ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{attachment.path_id})"
+        scheduled_message_id = check_schedule_message(
+            hamlet,
+            get_client("website"),
+            "stream",
+            [self.get_stream_id("Denmark")],
+            "Test topic",
+            body,
+            timezone_now() + timedelta(days=365),
+            hamlet.realm,
+        )
+        sent_message_id = self.send_stream_message(hamlet, "Denmark", body, "test")
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+        # Deleting the sent message leaves us with an Attachment
+        # attached to the scheduled message, and an archived
+        # attachment with an archived message
+        do_delete_messages(hamlet.realm, [Message.objects.get(id=sent_message_id)])
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Expiring the archived message leaves a dangling
+        # ArchivedAttachment and a protected Attachment
+        with self.settings(ARCHIVED_DATA_VACUUMING_DELAY_DAYS=0):
+            clean_archived_data()
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Removing unclaimed attachments deletes nothing, since the
+        # the ArchivedAttachment is protected by the Attachment which
+        # is still protected by the scheduled message
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Deleting the ScheduledMessage leaves the attachment fully dangling
+        delete_scheduled_message(hamlet, scheduled_message_id)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Having no referents, it is now a target for removal
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=False, has_attachment=False, has_archived_attachment=False
+        )
+
+    def test_delete_with_unscheduled_message_and_archive(self) -> None:
+        # This is subtly different from the test above -- we delete
+        # the scheduled message first, which is the only way to get an
+        # Attachment with not referents as well as an
+        # ArchivedAttachment which does have references.  Normally,
+        # the process of archiving prunes Attachments which have no
+        # references.
+        hamlet = self.example_user("hamlet")
+        attachment = self.make_attachment("used.txt")
+
+        # Schedule a message, and also send one now
+        self.subscribe(hamlet, "Denmark")
+        body = f"Some files here ...[zulip.txt](http://{hamlet.realm.host}/user_uploads/{attachment.path_id})"
+        scheduled_message_id = check_schedule_message(
+            hamlet,
+            get_client("website"),
+            "stream",
+            [self.get_stream_id("Denmark")],
+            "Test topic",
+            body,
+            timezone_now() + timedelta(days=365),
+            hamlet.realm,
+        )
+        sent_message_id = self.send_stream_message(hamlet, "Denmark", body, "test")
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=False
+        )
+
+        # Delete the message and then unschedule the scheduled message
+        # before expiring the ArchivedMessages.
+        do_delete_messages(hamlet.realm, [Message.objects.get(id=sent_message_id)])
+        delete_scheduled_message(hamlet, scheduled_message_id)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Attempting to expire unclaimed attachments leaves the
+        # unreferenced Attachment which is protected by the
+        # ArchivedAttachment which has archived messages referencing
+        # it.
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Expiring archived messages leaves us with a dangling
+        # Attachment and ArchivedAttachment, with neither having
+        # referents.
+        with self.settings(ARCHIVED_DATA_VACUUMING_DELAY_DAYS=0):
+            clean_archived_data()
+        self.assert_exists(
+            attachment, has_file=True, has_attachment=True, has_archived_attachment=True
+        )
+
+        # Having no referents in either place, it is now a target for
+        # removal
+        do_delete_old_unclaimed_attachments(1)
+        self.assert_exists(
+            attachment, has_file=False, has_attachment=False, has_archived_attachment=False
+        )

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -9,6 +9,7 @@ from zerver.actions.create_realm import do_create_realm
 from zerver.actions.message_delete import do_delete_messages
 from zerver.actions.message_send import internal_send_private_message
 from zerver.actions.realm_settings import do_set_realm_property
+from zerver.actions.scheduled_messages import check_schedule_message, delete_scheduled_message
 from zerver.actions.submessage import do_add_submessage
 from zerver.lib.retention import (
     archive_messages,
@@ -35,6 +36,7 @@ from zerver.models import (
     Stream,
     SubMessage,
     UserMessage,
+    get_client,
     get_realm,
     get_stream,
     get_system_bot,
@@ -802,6 +804,70 @@ class MoveMessageToArchiveGeneral(MoveMessageToArchiveBase):
         restore_all_data_from_archive()
         self.assertEqual(
             set(Attachment.objects.filter(messages__id=msg_id).values_list("id", flat=True)),
+            set(attachment_ids),
+        )
+
+    def test_archiving_message_with_scheduled_message(self) -> None:
+        # Make sure that attachments referenced by scheduledmessages do't get deleted
+        self._create_attachments()
+        realm_id = get_realm("zulip").id
+        host = get_realm("zulip").host
+        body = """Some files here ...[zulip.txt](
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt)
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py ....
+            Some more.... http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py ...
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/new.py ....
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/hello.txt ....
+        """.format(
+            id=realm_id, host=host
+        )
+
+        msg_id = self.send_personal_message(self.sender, self.recipient, body)
+
+        # Schedule a message with the same contents
+        scheduled_msg_id = check_schedule_message(
+            sender=self.sender,
+            client=get_client("website"),
+            recipient_type_name="private",
+            message_to=[self.recipient.id],
+            topic_name=None,
+            message_content=body,
+            deliver_at=timezone_now() + timedelta(hours=1),
+        )
+
+        usermsg_ids = self._get_usermessage_ids([msg_id])
+        attachment_ids = list(
+            Attachment.objects.filter(messages__id=msg_id).values_list("id", flat=True),
+        )
+
+        self._assert_archive_empty()
+        # Archive one of the messages:
+        move_messages_to_archive(message_ids=[msg_id])
+        self._verify_archive_data([msg_id], usermsg_ids)
+        # Attachments shouldn't have been deleted, as the scheduled message links to them:
+        self.assertEqual(Attachment.objects.count(), 5)
+
+        self.assertEqual(
+            set(
+                ArchivedAttachment.objects.filter(messages__id=msg_id).values_list("id", flat=True)
+            ),
+            set(attachment_ids),
+        )
+
+        # Delete the ScheduledMessage
+        delete_scheduled_message(self.sender, scheduled_msg_id)
+
+        # The Attachment object exists, with no message or scheduledmessage attached
+        self.assertEqual(Attachment.objects.count(), 5)
+        self.assertEqual(
+            Attachment.objects.filter(messages=None, scheduled_messages=None).count(), 5
+        )
+
+        # There is also the ArchivedAttachment for each of them
+        self.assertEqual(
+            set(
+                ArchivedAttachment.objects.filter(messages__id=msg_id).values_list("id", flat=True)
+            ),
             set(attachment_ids),
         )
 


### PR DESCRIPTION
Previously, this code:
```python3
old_archived_attachments = ArchivedAttachment.objects.annotate(
    has_other_messages=Exists(
        Attachment.objects.filter(id=OuterRef("id"))
        .exclude(messages=None)
        .exclude(scheduled_messages=None)
    )
).filter(messages=None, create_time__lt=delta_weeks_ago, has_other_messages=False)
```

...protected from removal any ArchivedAttachment objects where there
was an Attachment which had _both_ a message _and_ a scheduled
message, instead of _either_ a message _or_ a scheduled message.
Since files are removed from disk when the ArchivedAttachment rows are
deleted, this meant that if an upload was referenced in two messages,
and one was deleted, the file was permanently deleted when the
ArchivedMessage and ArchivedAttachment were cleaned up, despite being
still referenced in live Messages and Attachments.

Switch from `.exclude(messages=None).exclude(scheduled_messages=None)`
to `.exclude(messages=None, scheduled_messages=None)` which "OR"s
those conditions appropriately.

Pull the relevant test into its own file, and expand it significantly
to cover this, and other, corner cases.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
