### PR TITLE
hotkeys: Explicitly handle "home" and "end" key events.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -768,9 +768,13 @@ export function process_hotkey(e, hotkey) {
             // don't return, as we still want it to be picked up by the code below
         } else {
             switch (event_name) {
+                // home and page up both move the cursor
+                case "home":
                 case "page_up":
                     $(":focus").caret(0).animate({scrollTop: 0}, "fast");
                     return true;
+                // end and page down both move the cursor
+                case "end":
                 case "page_down": {
                     // so that it always goes to the end of the text box.
                     const height = $(":focus")[0].scrollHeight;


### PR DESCRIPTION
This fixes a case with Google Chrome on macOS where the Home and End keys caused scrolling in the message area/viewport, rather than being confined to the compose box--even when the compose box contained text and had focus.

The fix is somewhat heavy-handed in that it introduces different behavior for Home and End within a textarea from what the browser default is (on Firefox, the default is to do nothing; on Chrome, Home and End move to the beginning or end of the current line, respectively--at least when not exhibiting the bug on macOS that this PR is trying to address).

That said, Zulip already introduces novel behavior for PageUp and PageDown in the textarea, so this fix is in line with that precedent.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/Home.2FEnd.20in.20message.20editing/near/1614683)

| Before, hitting Home and End keys | After, hitting Home and End keys |
| --- | --- |
| ![chrome-home-end-before](https://github.com/zulip/zulip/assets/170719/564526b7-4cae-4291-ae0d-3649c6157775) | ![chrome-home-end-after](https://github.com/zulip/zulip/assets/170719/f0a44e2b-fbf5-47fd-bab4-8e27da36b2ef) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
