### PR TITLE
user_profile: Render the streams list dynamically.

### DIFF
--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -589,7 +589,7 @@ export function dispatch_normal_event(event) {
                     const user_ids = people.validate_user_ids(event.user_ids);
 
                     peer_data.bulk_add_subscribers({stream_ids, user_ids});
-                    stream_events.process_subscriber_update(stream_ids);
+                    stream_events.process_subscriber_update(user_ids, stream_ids);
                     break;
                 }
                 case "peer_remove": {
@@ -597,7 +597,7 @@ export function dispatch_normal_event(event) {
                     const user_ids = people.validate_user_ids(event.user_ids);
 
                     peer_data.bulk_remove_subscribers({stream_ids, user_ids});
-                    stream_events.process_subscriber_update(stream_ids);
+                    stream_events.process_subscriber_update(user_ids, stream_ids);
                     break;
                 }
                 case "remove":

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -9,7 +9,6 @@ import * as bot_data from "./bot_data";
 import * as browser_history from "./browser_history";
 import {buddy_list} from "./buddy_list";
 import * as compose from "./compose";
-import * as compose_fade from "./compose_fade";
 import * as compose_pm_pill from "./compose_pm_pill";
 import * as compose_recipient from "./compose_recipient";
 import * as composebox_typeahead from "./composebox_typeahead";
@@ -590,13 +589,7 @@ export function dispatch_normal_event(event) {
                     const user_ids = people.validate_user_ids(event.user_ids);
 
                     peer_data.bulk_add_subscribers({stream_ids, user_ids});
-
-                    for (const stream_id of stream_ids) {
-                        const sub = sub_store.get(stream_id);
-                        stream_settings_ui.update_subscribers_ui(sub);
-                    }
-
-                    compose_fade.update_faded_users();
+                    stream_events.process_subscriber_update(stream_ids);
                     break;
                 }
                 case "peer_remove": {
@@ -604,13 +597,7 @@ export function dispatch_normal_event(event) {
                     const user_ids = people.validate_user_ids(event.user_ids);
 
                     peer_data.bulk_remove_subscribers({stream_ids, user_ids});
-
-                    for (const stream_id of stream_ids) {
-                        const sub = sub_store.get(stream_id);
-                        stream_settings_ui.update_subscribers_ui(sub);
-                    }
-
-                    compose_fade.update_faded_users();
+                    stream_events.process_subscriber_update(stream_ids);
                     break;
                 }
                 case "remove":

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -384,11 +384,15 @@ export function muted_stream_ids(): number[] {
         .map((sub) => sub.stream_id);
 }
 
-export function get_subscribed_streams_for_user(user_id: number): StreamSubscription[] {
+export function get_streams_for_user(user_id: number): {
+    subscribed: StreamSubscription[];
+    can_subscribe: StreamSubscription[];
+} {
     // Note that we only have access to subscribers of some streams
     // depending on our role.
     const all_subs = get_unsorted_subs();
     const subscribed_subs = [];
+    const can_subscribe_subs = [];
     for (const sub of all_subs) {
         if (!can_view_subscribers(sub)) {
             // Private streams that we have been removed from appear
@@ -398,10 +402,15 @@ export function get_subscribed_streams_for_user(user_id: number): StreamSubscrip
         }
         if (is_user_subscribed(sub.stream_id, user_id)) {
             subscribed_subs.push(sub);
+        } else if (can_subscribe_others(sub)) {
+            can_subscribe_subs.push(sub);
         }
     }
 
-    return subscribed_subs;
+    return {
+        subscribed: subscribed_subs,
+        can_subscribe: can_subscribe_subs,
+    };
 }
 
 export function get_invite_stream_data(): InviteStreamData[] {

--- a/web/src/stream_events.js
+++ b/web/src/stream_events.js
@@ -9,6 +9,7 @@ import * as message_view_header from "./message_view_header";
 import * as narrow_state from "./narrow_state";
 import * as overlays from "./overlays";
 import * as peer_data from "./peer_data";
+import * as people from "./people";
 import * as recent_topics_ui from "./recent_topics_ui";
 import * as settings_notifications from "./settings_notifications";
 import * as stream_color from "./stream_color";
@@ -18,6 +19,7 @@ import * as stream_muting from "./stream_muting";
 import * as stream_settings_ui from "./stream_settings_ui";
 import * as sub_store from "./sub_store";
 import * as unread_ui from "./unread_ui";
+import * as user_profile from "./user_profile";
 
 // In theory, this function should apply the account-level defaults,
 // however, they are only called after a manual override, so
@@ -152,6 +154,7 @@ export function mark_subscribed(sub, subscribers, color) {
 
     stream_list.add_sidebar_row(sub);
     stream_list.update_subscribe_to_more_streams_link();
+    user_profile.update_user_profile_streams_list_for_users([people.my_current_user_id()]);
 }
 
 export function mark_unsubscribed(sub) {
@@ -186,6 +189,7 @@ export function mark_unsubscribed(sub) {
 
     stream_list.remove_sidebar_row(sub.stream_id);
     stream_list.update_subscribe_to_more_streams_link();
+    user_profile.update_user_profile_streams_list_for_users([people.my_current_user_id()]);
 }
 
 export function remove_deactivated_user_from_all_streams(user_id) {
@@ -199,10 +203,11 @@ export function remove_deactivated_user_from_all_streams(user_id) {
     }
 }
 
-export function process_subscriber_update(stream_ids) {
+export function process_subscriber_update(user_ids, stream_ids) {
     for (const stream_id of stream_ids) {
         const sub = sub_store.get(stream_id);
         stream_settings_ui.update_subscribers_ui(sub);
     }
     compose_fade.update_faded_users();
+    user_profile.update_user_profile_streams_list_for_users(user_ids);
 }

--- a/web/src/stream_events.js
+++ b/web/src/stream_events.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import * as blueslip from "./blueslip";
 import * as color_data from "./color_data";
+import * as compose_fade from "./compose_fade";
 import * as compose_recipient from "./compose_recipient";
 import * as message_lists from "./message_lists";
 import * as message_view_header from "./message_view_header";
@@ -196,4 +197,12 @@ export function remove_deactivated_user_from_all_streams(user_id) {
             stream_settings_ui.update_subscribers_ui(sub);
         }
     }
+}
+
+export function process_subscriber_update(stream_ids) {
+    for (const stream_id of stream_ids) {
+        const sub = sub_store.get(stream_id);
+        stream_settings_ui.update_subscribers_ui(sub);
+    }
+    compose_fade.update_faded_users();
 }

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -197,7 +197,7 @@ export function show_user_profile(user, default_tab_key = "profile-tab") {
     const profile_data = page_params.custom_profile_fields
         .map((f) => get_custom_profile_field_data(user, f, field_types))
         .filter((f) => f.name !== undefined);
-    const user_streams = stream_data.get_subscribed_streams_for_user(user.user_id);
+    const user_streams = stream_data.get_streams_for_user(user.user_id).subscribed;
     const groups_of_user = user_groups.get_user_groups_of_user(user.user_id);
     const args = {
         user_id: user.user_id,

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -28,6 +28,8 @@ import * as user_groups from "./user_groups";
 import * as user_pill from "./user_pill";
 import * as util from "./util";
 
+let user_streams_list_widget;
+
 function compare_by_name(a, b) {
     return util.strcmp(a.name, b.name);
 }
@@ -38,6 +40,14 @@ export function get_user_id_if_user_profile_modal_open() {
         return user_id;
     }
     return undefined;
+}
+
+export function update_user_profile_streams_list_for_users(user_ids) {
+    const user_id = get_user_id_if_user_profile_modal_open();
+    if (user_id && user_ids.includes(user_id) && user_streams_list_widget !== undefined) {
+        const user_streams = stream_data.get_streams_for_user(user_id).subscribed;
+        user_streams_list_widget.replace_list_data(user_streams);
+    }
 }
 
 function initialize_bot_owner(element_id, bot_id) {
@@ -89,7 +99,7 @@ function render_user_stream_list(streams, user) {
     streams.sort(compare_by_name);
     const $container = $("#user-profile-modal .user-stream-list");
     $container.empty();
-    ListWidget.create($container, streams, {
+    user_streams_list_widget = ListWidget.create($container, streams, {
         name: `user-${user.user_id}-stream-list`,
         get_item: ListWidget.default_get_item,
         modifier(item) {
@@ -172,6 +182,7 @@ export function get_custom_profile_field_data(user, field, field_types) {
 }
 
 export function hide_user_profile() {
+    user_streams_list_widget = undefined;
     overlays.close_modal_if_open("user-profile-modal");
 }
 

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -32,6 +32,14 @@ function compare_by_name(a, b) {
     return util.strcmp(a.name, b.name);
 }
 
+export function get_user_id_if_user_profile_modal_open() {
+    if (overlays.is_modal_open() && overlays.active_modal() === "#user-profile-modal") {
+        const user_id = $("#user-profile-modal").data("user-id");
+        return user_id;
+    }
+    return undefined;
+}
+
 function initialize_bot_owner(element_id, bot_id) {
     const user_pills = new Map();
     const bot = people.get_by_user_id(bot_id);

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -318,13 +318,6 @@ export function register_click_handlers() {
 
         function removal_success(data) {
             if (data.removed.length > 0) {
-                // Most of the work for handling the unsubscribe is done
-                // by the subscription -> remove event we will get.
-                // However, the user profile component has not yet
-                // implemented live update, so we do update its
-                // UI manually here by removing the stream from this list.
-                $stream_row.remove();
-
                 ui_report.success(
                     $t_html({defaultMessage: "Unsubscribed successfully!"}),
                     $alert_box,

--- a/web/tests/dispatch_subs.test.js
+++ b/web/tests/dispatch_subs.test.js
@@ -12,7 +12,6 @@ const {page_params} = require("./lib/zpage_params");
 const event_fixtures = events.fixtures;
 const test_user = events.test_user;
 
-const compose_fade = mock_esm("../src/compose_fade");
 const message_lists = mock_esm("../src/message_lists");
 const narrow_state = mock_esm("../src/narrow_state");
 const overlays = mock_esm("../src/overlays");
@@ -80,22 +79,17 @@ test("peer add/remove", ({override}) => {
         stream_id: event.stream_ids[0],
     });
 
-    const subs_stub = make_stub();
-    override(stream_settings_ui, "update_subscribers_ui", subs_stub.f);
-
-    const compose_fade_stub = make_stub();
-    override(compose_fade, "update_faded_users", compose_fade_stub.f);
+    const stream_stub = make_stub();
+    override(stream_events, "process_subscriber_update", stream_stub.f);
 
     dispatch(event);
-    assert.equal(compose_fade_stub.num_calls, 1);
-    assert.equal(subs_stub.num_calls, 1);
+    assert.equal(stream_stub.num_calls, 1);
 
     assert.ok(peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
 
     event = event_fixtures.subscription__peer_remove;
     dispatch(event);
-    assert.equal(compose_fade_stub.num_calls, 2);
-    assert.equal(subs_stub.num_calls, 2);
+    assert.equal(stream_stub.num_calls, 2);
 
     assert.ok(!peer_data.is_user_subscribed(event.stream_ids[0], event.user_ids[0]));
 });
@@ -143,7 +137,7 @@ test("add error handling", () => {
 });
 
 test("peer event error handling (bad stream_ids/user_ids)", ({override}) => {
-    override(compose_fade, "update_faded_users", () => {});
+    override(stream_events, "process_subscriber_update", () => {});
 
     const add_event = {
         type: "subscription",

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -200,7 +200,7 @@ test("basics", () => {
     ]);
 });
 
-test("get_subscribed_streams_for_user", () => {
+test("get_streams_for_user", () => {
     const denmark = {
         subscribed: true,
         color: "blue",
@@ -226,7 +226,16 @@ test("get_subscribed_streams_for_user", () => {
         is_muted: true,
         invite_only: true,
     };
-    const subs = [denmark, social, test];
+    const world = {
+        color: "blue",
+        name: "world",
+        stream_id: 4,
+        is_muted: false,
+        invite_only: false,
+        history_public_to_subscribers: false,
+        stream_post_policy: stream_data.stream_post_policy_values.admins.code,
+    };
+    const subs = [denmark, social, test, world];
     for (const sub of subs) {
         stream_data.add_sub(sub);
     }
@@ -234,6 +243,7 @@ test("get_subscribed_streams_for_user", () => {
     peer_data.set_subscribers(denmark.stream_id, [me.user_id, test_user.user_id]);
     peer_data.set_subscribers(social.stream_id, [test_user.user_id]);
     peer_data.set_subscribers(test.stream_id, [test_user.user_id]);
+    peer_data.set_subscribers(world.stream_id, [me.user_id]);
 
     // test_user is subscribed to all three streams, but current user (me)
     // gets only two because of subscriber visibility policy of stream:
@@ -242,10 +252,15 @@ test("get_subscribed_streams_for_user", () => {
     //          user is a guest.
     // #test: current user is no longer subscribed to a private stream, so
     //        he can not see whether test_user is subscribed to it.
-    assert.deepEqual(stream_data.get_subscribed_streams_for_user(test_user.user_id), [
+    assert.deepEqual(stream_data.get_streams_for_user(test_user.user_id).subscribed, [
         denmark,
         social,
     ]);
+    assert.deepEqual(stream_data.get_streams_for_user(test_user.user_id).can_subscribe, []);
+    // Verify can subscribe if we're an administrator.
+    page_params.is_admin = true;
+    assert.deepEqual(stream_data.get_streams_for_user(test_user.user_id).can_subscribe, [world]);
+    page_params.is_admin = false;
 });
 
 test("renames", () => {

--- a/web/tests/stream_events.test.js
+++ b/web/tests/stream_events.test.js
@@ -42,6 +42,7 @@ const people = zrequire("people");
 const stream_data = zrequire("stream_data");
 const stream_events = zrequire("stream_events");
 const compose_recipient = zrequire("compose_recipient");
+const compose_fade = zrequire("compose_fade");
 
 const george = {
     email: "george@zulip.com",
@@ -441,4 +442,24 @@ test("remove_deactivated_user_from_all_streams", () => {
 
     // verify that we issue a call to update subscriber count/list UI
     assert.equal(subs_stub.num_calls, 1);
+});
+
+test("process_subscriber_update", () => {
+    const subsStub = make_stub();
+    stream_settings_ui.update_subscribers_ui = subsStub.f;
+
+    const fadedUsersStub = make_stub();
+    compose_fade.update_faded_users = fadedUsersStub.f;
+
+    // Sample stream IDs
+    const streamIds = [1, 2, 3];
+
+    // Call the function being tested
+    stream_events.process_subscriber_update(streamIds);
+
+    // Assert that update_subscribers_ui is called for each stream ID
+    assert.equal(subsStub.num_calls, streamIds.length);
+
+    // Assert that update_faded_users is called once
+    assert.equal(fadedUsersStub.num_calls, 1);
 });


### PR DESCRIPTION
- [x] Update the streams list of the user profile dynamically.
- This is a prep PR to continue to work further on #26183.
------------

Fixes: https://github.com/zulip/zulip/pull/26183#discussion_r1262884954

-----------

**Screenshots and screen captures:**

![user_profile_updates](https://github.com/zulip/zulip/assets/66828942/e8a8a27e-d8f7-4ae6-bcbe-a7ef8a9aca18)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
