### PR TITLE
ts: Migrate `stream_data.js` module to TypeScript.

### DIFF
--- a/web/babel.config.js
+++ b/web/babel.config.js
@@ -15,6 +15,7 @@ module.exports = {
             "@babel/preset-env",
             {
                 corejs: "3.31",
+                include: ["transform-optional-chaining"],
                 shippedProposals: true,
                 useBuiltIns: "usage",
             },

--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -35,6 +35,7 @@ export const page_params: {
     realm_move_messages_between_streams_policy: number;
     realm_name_changes_disabled: boolean;
     realm_name: string;
+    realm_notifications_stream_id: number;
     realm_org_type: number;
     realm_plan_type: number;
     realm_private_message_policy: number;

--- a/web/src/page_params.ts
+++ b/web/src/page_params.ts
@@ -31,6 +31,7 @@ export const page_params: {
     realm_enable_spectator_access: boolean;
     realm_invite_to_realm_policy: number;
     realm_invite_to_stream_policy: number;
+    realm_is_zephyr_mirror_realm: boolean;
     realm_move_messages_between_streams_policy: number;
     realm_name_changes_disabled: boolean;
     realm_name: string;

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -740,28 +740,19 @@ export function create_sub_from_server_data(attrs) {
     delete attrs.subscribers;
 
     sub = {
-        name: attrs.name,
-        render_subscribers: !page_params.realm_is_zephyr_mirror_realm || attrs.invite_only === true,
-        subscribed: true,
+        render_subscribers: !page_params.realm_is_zephyr_mirror_realm || attrs.invite_only,
         newly_subscribed: false,
         is_muted: false,
-        invite_only: false,
         desktop_notifications: null,
         audible_notifications: null,
         push_notifications: null,
         email_notifications: null,
         wildcard_mentions_notify: null,
-        description: "",
-        rendered_description: "",
-        first_message_id: attrs.first_message_id,
+        color: attrs.color ?? color_data.pick_color(),
         ...attrs,
     };
 
     peer_data.set_subscribers(sub.stream_id, subscriber_user_ids);
-
-    if (!sub.color) {
-        sub.color = color_data.pick_color();
-    }
 
     clean_up_description(sub);
 

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -33,8 +33,8 @@ class BinaryDict {
             - autocomplete stream in compose
     */
 
-    trues = new FoldDict();
-    falses = new FoldDict();
+    trues = new Map();
+    falses = new Map();
 
     constructor(pred) {
         this.pred = pred;

--- a/web/src/stream_data.js
+++ b/web/src/stream_data.js
@@ -833,10 +833,13 @@ export function initialize(params) {
 
     function populate_subscriptions(subs, subscribed, previously_subscribed) {
         for (const sub of subs) {
-            sub.subscribed = subscribed;
-            sub.previously_subscribed = previously_subscribed;
+            const attrs = {
+                ...sub,
+                subscribed,
+                previously_subscribed,
+            };
 
-            create_sub_from_server_data(sub);
+            create_sub_from_server_data(attrs);
         }
     }
 

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -556,8 +556,8 @@ export function can_access_topic_history(sub: StreamSubscription): boolean {
     return sub.is_web_public || can_toggle_subscription(sub);
 }
 
-export function can_preview(sub: StreamSubscription): boolean | undefined {
-    return sub.subscribed || !sub.invite_only || sub.previously_subscribed;
+export function can_preview(sub: StreamSubscription): boolean {
+    return sub.subscribed || !sub.invite_only || sub.previously_subscribed === true;
 }
 
 export function can_change_permissions(sub: StreamSubscription): boolean {
@@ -650,14 +650,14 @@ export function can_post_messages_in_stream(stream: StreamSubscription): boolean
     return true;
 }
 
-export function is_subscribed_by_name(stream_name: string): boolean | undefined {
+export function is_subscribed_by_name(stream_name: string): boolean {
     const sub = get_sub(stream_name);
-    return sub?.subscribed;
+    return sub ? sub.subscribed : false;
 }
 
-export function is_subscribed(stream_id: number): boolean | undefined {
+export function is_subscribed(stream_id: number): boolean {
     const sub = sub_store.get(stream_id);
-    return sub?.subscribed;
+    return sub ? sub.subscribed : false;
 }
 
 export function get_stream_privacy_policy(stream_id: number): string {
@@ -675,9 +675,9 @@ export function get_stream_privacy_policy(stream_id: number): string {
     return stream_privacy_policy_values.private_with_public_history.code;
 }
 
-export function is_web_public(stream_id: number): boolean | undefined {
+export function is_web_public(stream_id: number): boolean {
     const sub = sub_store.get(stream_id);
-    return sub?.is_web_public;
+    return sub ? sub.is_web_public : false;
 }
 
 export function is_invite_only_by_stream_name(stream_name: string): boolean {

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -28,11 +28,10 @@ type StreamInitParams = {
 };
 
 // Type for the parameter of `create_sub_from_server_data` function.
-type ApiGenericStreamSubscription = (
-    | (NeverSubscribedStream & {previously_subscribed: boolean})
-    | (ApiStreamSubscription & {previously_subscribed: boolean})
-    | (Stream & {stream_weekly_traffic: number | null; subscribers: number[]})
-) & {subscribed: boolean};
+type ApiGenericStreamSubscription =
+    | NeverSubscribedStream
+    | ApiStreamSubscription
+    | (Stream & {stream_weekly_traffic: number | null; subscribers: number[]});
 
 type InviteStreamData = {
     name: string;
@@ -753,10 +752,9 @@ export function create_streams(streams: Stream[]): void {
         const attrs = {
             stream_weekly_traffic: null,
             subscribers: [],
-            subscribed: false,
             ...stream,
         };
-        create_sub_from_server_data(attrs);
+        create_sub_from_server_data(attrs, false, false);
     }
 }
 
@@ -768,6 +766,8 @@ export function clean_up_description(sub: StreamSubscription): void {
 
 export function create_sub_from_server_data(
     attrs: ApiGenericStreamSubscription,
+    subscribed: boolean,
+    previously_subscribed: boolean,
 ): StreamSubscription {
     if (!attrs.stream_id) {
         // fail fast
@@ -801,6 +801,8 @@ export function create_sub_from_server_data(
         email_notifications: null,
         wildcard_mentions_notify: null,
         color: "color" in attrs ? attrs.color : color_data.pick_color(),
+        subscribed,
+        previously_subscribed,
         ...attrs,
     };
 
@@ -880,13 +882,7 @@ export function initialize(params: StreamInitParams): void {
         previously_subscribed: boolean,
     ): void {
         for (const sub of subs) {
-            const attrs = {
-                ...sub,
-                subscribed,
-                previously_subscribed,
-            };
-
-            create_sub_from_server_data(attrs);
+            create_sub_from_server_data(sub, subscribed, previously_subscribed);
         }
     }
 

--- a/web/src/sub_store.ts
+++ b/web/src/sub_store.ts
@@ -54,7 +54,7 @@ export type ExtraStreamAttrs = {
     render_subscribers: boolean;
     newly_subscribed: boolean;
     subscribed: boolean;
-    previously_subscribed?: boolean;
+    previously_subscribed: boolean;
 };
 
 // This is the actual type of subscription objects we use in the app.


### PR DESCRIPTION
Migrates `stream_data` module to TypeScript and also refines the existing types for stream and subscription objects present in `sub_store` module.

The main crux of this module is `create_sub_from_server_data` which generates `sub` objects which we use in web client from the data we get from the server.

The type for it's parameter `attrs` which I called `StreamAttrs` is defined as union of three types:-
1)  `NeverSubscribedStream & Pick<ExtraStreamAttrs, "subscribed" | "previously_subscribed">`
2) `ApiStreamSubscription & Pick<ExtraStreamAttrs, "subscribed" | "previously_subscribed">`

Both of these types are inferred by me by looking at the `populate_subscriptions` method which calls this function with attrs confirming to the types mentioned above.

3) `Stream & {stream_weekly_traffic: number | null; subscribers: number[]; subscribed: boolean}`

This type is inferred from the `create_streams` function which calls this function with attrs having the above type.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
