### PR TITLE
topic_mentions: Highlight the @topic mention for topic participants.

### DIFF
--- a/web/src/rendered_markdown.js
+++ b/web/src/rendered_markdown.js
@@ -9,8 +9,10 @@ import view_code_in_playground from "../templates/view_code_in_playground.hbs";
 import * as blueslip from "./blueslip";
 import {show_copied_confirmation} from "./copied_tooltip";
 import {$t, $t_html} from "./i18n";
+import * as message_store from "./message_store";
 import * as people from "./people";
 import * as realm_playground from "./realm_playground";
+import * as rows from "./rows";
 import * as rtl from "./rtl";
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
@@ -134,6 +136,25 @@ export const update_elements = ($content) => {
                 // unpleasant corner cases involving data import.
                 set_name_in_mention_element(this, person.full_name, user_id);
             }
+        }
+    });
+
+    $content.find(".topic-mention").each(function () {
+        // TODO: This selector is designed to exclude drafts/scheduled
+        // messages. Arguably those settings should be unconditionally
+        // marked with user-mention-me, but rows.id doesn't support
+        // those elements, and we should address that quirk for
+        // mentions holistically.
+        const $message_row = $content.closest(".message_row");
+        if (!$message_row.length || $message_row.closest(".overlay-message-row").length) {
+            // There's no containing message when rendering a preview.
+            return;
+        }
+        const message_id = rows.id($message_row);
+        const message = message_store.get(message_id);
+
+        if (message.topic_wildcard_mentioned) {
+            $(this).addClass("user-mention-me");
         }
     });
 

--- a/web/src/rows.js
+++ b/web/src/rows.js
@@ -70,13 +70,13 @@ export function visible_range(start_id, end_id) {
     return rows;
 }
 
-export function is_draft_row($row) {
-    return $row.find("#drafts_table .restore-overlay-message").length >= 1;
+export function is_overlay_row($row) {
+    return $row.closest(".overlay-message-row").length >= 1;
 }
 
 export function id($message_row) {
-    if (is_draft_row($message_row)) {
-        blueslip.error("Drafts have no zid");
+    if (is_overlay_row($message_row)) {
+        blueslip.error("Drafts and scheduled messages have no zid");
         return undefined;
     }
 

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -178,8 +178,7 @@
         display: inline-block;
     }
 
-    .user-mention,
-    .topic-mention {
+    .user-mention {
         color: var(--color-text-other-mention);
         background-color: var(--color-background-text-direct-mention);
 
@@ -198,7 +197,8 @@
         }
     }
 
-    .user-group-mention {
+    .user-group-mention,
+    .topic-mention {
         color: var(--color-text-other-mention);
         background-color: var(--color-background-text-group-mention);
 
@@ -206,7 +206,9 @@
             color: var(--color-text-self-group-mention);
             font-weight: 600;
         }
+    }
 
+    .user-group-mention {
         &:hover {
             background-color: var(--color-background-text-hover-group-mention);
         }


### PR DESCRIPTION
Adds support to highlight the `@topic` wildcard mention text for the users who are both:
* subscribed to the stream
* a topic participant

Topic participants: Users who either sent or reacted to the messages in the topic.

Fixes part of #22829.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

---

**Screenshots and screen captures:**
<details><summary>Topic participant</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/7db24f46-b729-48d6-84c1-7afcddc5a052"></img>
</details> 
<details><summary>Not a topic participant</summary>
<img src="https://github.com/zulip/zulip/assets/56781761/59d11160-1465-431b-afb7-75a06d28971d">
</img>
</details> 

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
