### PR TITLE
docs: Document printable conversations.

### DIFF
--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -104,6 +104,7 @@
 * [View messages sent by a user](/help/view-messages-sent-by-a-user)
 * [Link to a message or conversation](/help/link-to-a-message-or-conversation)
 * [Searching for messages](/help/search-for-messages)
+* [Printing messages](/help/printing-messages)
 * [View message Markdown source](/help/view-the-markdown-source-of-a-message)
 * [View when message was sent](/help/view-the-exact-time-a-message-was-sent)
 * [View a message's edit history](/help/view-a-messages-edit-history)

--- a/help/printing-messages.md
+++ b/help/printing-messages.md
@@ -1,0 +1,37 @@
+# Printing messages
+
+Zulip [conversations](/help/recent-conversations) are printable from the
+Zulip web app. So is any other message feed view, including
+[searches](https://zulip.com/help/search-for-messages).
+
+{start_tabs}
+
+{tab|web}
+
+1. Navigate to a stream, topic, or direct message view.
+
+1. Ensure that all messages you wish to print from further back in time
+   have been loaded and can be scrolled to on screen (all loaded messages
+   will print).
+
+1. Use your browser's print feature (e.g., File > Print) to preview
+   and print your messages.
+
+{end_tabs}
+
+Messages will print beginning with the oldest loaded message you can see on
+screen. If you need your printout to include messages from further back in time,
+you'll need to scroll up through the message history until you can see the
+messages you wish to print.
+
+Conversation printouts exclude sidebars and other interface features that you
+otherwise see on screen. And whether you're viewing Zulip in the [light or dark
+theme](/help/dark-theme), Zulip message views will print with appropriate colors
+for paper or system-generated PDFs. Background colors will not be printed.
+
+## Related articles
+
+* [Reading topics](/help/reading-topics)
+* [Reading direct messages (DMs)](/help/reading-dms)
+* [Dark theme](/help/dark-theme)
+* [Supported browsers](/help/supported-browsers)


### PR DESCRIPTION
This adds a new page to the documentation for documenting the printing feature. It links to the documentation under the "Streams & topics" section.

This is ready to merge, now that #26374 has been merged.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/printing.20Zulip.20conversations/near/1616218)

**Screenshot**

<img width="1105" alt="Screenshot 2023-08-07 at 1 33 43 PM" src="https://github.com/zulip/zulip/assets/170719/4ea0249a-a520-4a1f-b96e-85d6baff526d">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
