### PR TITLE
events: Add test for removing custom profile field data.

### DIFF
--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1093,7 +1093,7 @@ custom_profile_field_type = DictType(
     required_keys=[
         # vertical formatting
         ("id", int),
-        ("value", str),
+        ("value", OptionalType(str)),
     ],
     optional_keys=[
         # vertical formatting

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -948,26 +948,30 @@ def apply_event(
                 for field in p:
                     if field in person:
                         p[field] = person[field]
-                    if "role" in person:
-                        p["is_admin"] = is_administrator_role(person["role"])
-                        p["is_owner"] = person["role"] == UserProfile.ROLE_REALM_OWNER
-                        p["is_guest"] = person["role"] == UserProfile.ROLE_GUEST
-                    if "is_billing_admin" in person:
-                        p["is_billing_admin"] = person["is_billing_admin"]
-                    if "custom_profile_field" in person:
-                        custom_field_id = person["custom_profile_field"]["id"]
-                        custom_field_new_value = person["custom_profile_field"]["value"]
-                        if "rendered_value" in person["custom_profile_field"]:
-                            p["profile_data"][str(custom_field_id)] = {
-                                "value": custom_field_new_value,
-                                "rendered_value": person["custom_profile_field"]["rendered_value"],
-                            }
-                        else:
-                            p["profile_data"][str(custom_field_id)] = {
-                                "value": custom_field_new_value,
-                            }
-                    if "new_email" in person:
-                        p["email"] = person["new_email"]
+
+                if "role" in person:
+                    p["is_admin"] = is_administrator_role(person["role"])
+                    p["is_owner"] = person["role"] == UserProfile.ROLE_REALM_OWNER
+                    p["is_guest"] = person["role"] == UserProfile.ROLE_GUEST
+
+                if "is_billing_admin" in person:
+                    p["is_billing_admin"] = person["is_billing_admin"]
+
+                if "custom_profile_field" in person:
+                    custom_field_id = person["custom_profile_field"]["id"]
+                    custom_field_new_value = person["custom_profile_field"]["value"]
+                    if "rendered_value" in person["custom_profile_field"]:
+                        p["profile_data"][str(custom_field_id)] = {
+                            "value": custom_field_new_value,
+                            "rendered_value": person["custom_profile_field"]["rendered_value"],
+                        }
+                    else:
+                        p["profile_data"][str(custom_field_id)] = {
+                            "value": custom_field_new_value,
+                        }
+
+                if "new_email" in person:
+                    p["email"] = person["new_email"]
         else:
             raise AssertionError("Unexpected event type {type}/{op}".format(**event))
     elif event["type"] == "realm_bot":

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -958,15 +958,17 @@ def apply_event(
                     p["is_billing_admin"] = person["is_billing_admin"]
 
                 if "custom_profile_field" in person:
-                    custom_field_id = person["custom_profile_field"]["id"]
+                    custom_field_id = str(person["custom_profile_field"]["id"])
                     custom_field_new_value = person["custom_profile_field"]["value"]
-                    if "rendered_value" in person["custom_profile_field"]:
-                        p["profile_data"][str(custom_field_id)] = {
+                    if custom_field_new_value is None and "profile_data" in p:
+                        p["profile_data"].pop(custom_field_id, None)
+                    elif "rendered_value" in person["custom_profile_field"]:
+                        p["profile_data"][custom_field_id] = {
                             "value": custom_field_new_value,
                             "rendered_value": person["custom_profile_field"]["rendered_value"],
                         }
                     else:
-                        p["profile_data"][str(custom_field_id)] = {
+                        p["profile_data"][custom_field_id] = {
                             "value": custom_field_new_value,
                         }
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -24,6 +24,7 @@ from zerver.actions.bots import (
 )
 from zerver.actions.create_user import do_create_user, do_reactivate_user
 from zerver.actions.custom_profile_fields import (
+    check_remove_custom_profile_field_value,
     do_remove_realm_custom_profile_field,
     do_update_user_custom_profile_data_if_changed,
     try_add_realm_custom_profile_field,
@@ -1122,6 +1123,13 @@ class NormalActionsTest(BaseAction):
         }
         events = self.verify_action(
             lambda: do_update_user_custom_profile_data_if_changed(self.user_profile, [field])
+        )
+        check_realm_user_update("events[0]", events[0], "custom_profile_field")
+        self.assertEqual(events[0]["person"]["custom_profile_field"].keys(), {"id", "value"})
+
+        # Test event for removing custom profile data
+        events = self.verify_action(
+            lambda: check_remove_custom_profile_field_value(self.user_profile, field_id)
         )
         check_realm_user_update("events[0]", events[0], "custom_profile_field")
         self.assertEqual(events[0]["person"]["custom_profile_field"].keys(), {"id", "value"})


### PR DESCRIPTION
Follow-up noted in #22103, see [this comment](https://github.com/zulip/zulip/pull/22103#issuecomment-1138853085) for particular context.

Adds a test for removing the value set for a user's custom profile setting without adding another value.

When adding the test coverage, found two bugs in the events logic for the "realm_user" case in `apply_event`:
- First, the updates to these custom profile fields, as well as other fields in the event's `"person"` object, were being done in a loop over the fields in the state's `"raw_user"` object, which was unnecessarily making the same update multiple times.
  - So the first commit unnests those updates so that they are only updated once.
  - The commit that introduced the nesting was  https://github.com/zulip/zulip/commit/649fccde6ba438a213c6c43688462e3506563019
- Second, in the case that the field value was being removed, the user object's `"profile_data"` was being updated to have `None` as the value, instead of removing the field ID from the `"profile_data"`.
  - So the second commit, fixes that logic to remove the field ID from the `"profile_data"` if present. And adds the test coverage for these events.
  - A similar bug in the events logic was fixed in commit https://github.com/zulip/zulip/commit/96c61a1a41ecc911fc442513a6164a911b15f700 for when a custom profile field is removed from a realm.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
