### PR TITLE
alerts: Display copied alerts with Tippy.

### DIFF
--- a/web/src/about_zulip.js
+++ b/web/src/about_zulip.js
@@ -6,6 +6,7 @@ import render_about_zulip from "../templates/about_zulip.hbs";
 import * as browser_history from "./browser_history";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import {show_copied_confirmation} from "./tippyjs";
 
 export function launch() {
     overlays.open_overlay({
@@ -16,7 +17,11 @@ export function launch() {
         },
     });
 
-    new ClipboardJS("#about-zulip .fa-copy");
+    const clipboard = new ClipboardJS("#about-zulip .fa-copy");
+
+    clipboard.on("success", () => {
+        show_copied_confirmation($("#about-zulip .fa-copy")[0]);
+    });
 }
 
 export function initialize() {

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -33,6 +33,7 @@ import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
 import * as timerender from "./timerender";
+import {show_copied_confirmation} from "./tippyjs";
 import * as ui_report from "./ui_report";
 import * as upload from "./upload";
 import * as util from "./util";
@@ -399,13 +400,15 @@ function create_copy_to_clipboard_handler($row, source, message_id) {
     });
 
     clipboard.on("success", () => {
-        end_message_row_edit($row);
-        $row.find(".alert-msg").text($t({defaultMessage: "Copied!"}));
-        $row.find(".alert-msg").css("display", "block");
-        $row.find(".alert-msg").delay(1000).fadeOut(300);
-        if ($(".tooltip").is(":visible")) {
-            $(".tooltip").hide();
-        }
+        // Hide the Tippy and source box after a 600ms delay
+        const tippy_timeout_in_ms = 600;
+        show_copied_confirmation(
+            $row.find(".copy_message")[0],
+            () => {
+                end_message_row_edit($row);
+            },
+            tippy_timeout_in_ms,
+        );
     });
 }
 

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -31,7 +31,7 @@ import * as drafts from "./drafts";
 import * as emoji_picker from "./emoji_picker";
 import * as flatpickr from "./flatpickr";
 import * as giphy from "./giphy";
-import {$t, $t_html} from "./i18n";
+import {$t_html} from "./i18n";
 import * as message_edit from "./message_edit";
 import * as message_edit_history from "./message_edit_history";
 import * as message_lists from "./message_lists";
@@ -48,6 +48,7 @@ import * as starred_messages from "./starred_messages";
 import * as starred_messages_ui from "./starred_messages_ui";
 import * as stream_popover from "./stream_popover";
 import * as timerender from "./timerender";
+import {show_copied_confirmation} from "./tippyjs";
 import {parse_html} from "./ui_util";
 import * as unread_ops from "./unread_ops";
 import {user_settings} from "./user_settings";
@@ -784,16 +785,8 @@ export function initialize() {
                 instance.hide();
             });
 
-            new ClipboardJS($popper.find(".copy_link")[0]).on("success", (e) => {
-                // e.trigger returns the DOM element triggering the copy action
-                const message_id = e.trigger.dataset.messageId;
-                const $row = $(`[zid='${CSS.escape(message_id)}']`);
-                $row.find(".alert-msg")
-                    .text($t({defaultMessage: "Copied!"}))
-                    .css("display", "block")
-                    .delay(1000)
-                    .fadeOut(300);
-
+            new ClipboardJS($popper.find(".copy_link")[0]).on("success", () => {
+                show_copied_confirmation($(instance.reference).closest(".message_controls")[0]);
                 setTimeout(() => {
                     // The Clipboard library works by focusing to a hidden textarea.
                     // We unfocus this so keyboard shortcuts, etc., will work again.

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -368,13 +368,18 @@ export function initialize() {
     });
 }
 
-export function show_copied_confirmation($copy_button) {
+export function show_copied_confirmation($copy_button, on_hide_callback, timeout_in_ms = 1000) {
     // Display a tooltip to notify the user the message or code was copied.
     const instance = tippy($copy_button, {
         placement: "top",
         appendTo: () => document.body,
         onUntrigger() {
             remove_instance();
+        },
+        onHide() {
+            if (on_hide_callback) {
+                on_hide_callback();
+            }
         },
     });
     instance.setContent($t({defaultMessage: "Copied!"}));
@@ -384,5 +389,5 @@ export function show_copied_confirmation($copy_button) {
             instance.destroy();
         }
     }
-    setTimeout(remove_instance, 1000);
+    setTimeout(remove_instance, timeout_in_ms);
 }

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -409,10 +409,6 @@
         color: inherit !important;
     }
 
-    .private-message .alert-msg {
-        background-color: hsl(208deg 17% 29%);
-    }
-
     .active_private_messages_section {
         #private_messages_section,
         #private_messages_list,

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -243,12 +243,6 @@ $time_column_min_width: 50px; /* + padding */
             margin-top: $distance_of_non_text_elements_from_message_box;
         }
 
-        .alert-msg {
-            /* Span both the controls and time columns */
-            grid-row: controls-start;
-            grid-column: controls-start / time-end;
-        }
-
         .message_length_controller {
             grid-area: more;
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1161,16 +1161,6 @@ td.pointer {
     animation: rotate 1s infinite linear;
 }
 
-/* The way this overrides the menus with a background-color and a high
-   z-index is kinda hacky, and requires some annoying color-matching,
-   but it works. */
-.alert-msg {
-    color: hsl(170deg 48% 54%);
-    z-index: 999;
-    font-weight: 400;
-    display: none;
-}
-
 .status-time {
     top: 8px !important;
 }
@@ -1582,10 +1572,6 @@ td.pointer {
 
 .message_row.private-message {
     background-color: var(--color-background-private-message-content);
-
-    .alert-msg {
-        background-color: hsl(192deg 20% 95%);
-    }
 
     .date_row {
         background-color: var(--color-background-private-message-content);

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -26,8 +26,6 @@
     {{/if}}
 </span>
 
-<span class="alert-msg"></span>
-
 <a {{#unless msg/locally_echoed}}href="{{ msg/url }}"{{/unless}} class="message_time{{#if status_message}} status-time{{/if}}">
     {{#unless include_sender}}
     <span class="copy-paste-text">&nbsp;</span>


### PR DESCRIPTION
This PR properly displays Tippy Copied! alerts in three cases:

1) On the clipboard icon when copying message source.
2) On the hover controls when copying the link to a message.
3) In the About Zulip modal when copying the Zulip version number.

With those complete, the PR removes the `.alert-msg` styles and fragment of the message-body template, which are no longer needed.

Fixes: #21036, #23210.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/inconsistent.20Copied!.20alerts/near/1615056)

**Screenshots and screen captures:**

| Copy message source, before | Copy message source, after |
| --- | --- |
| ![copy-source-before](https://github.com/zulip/zulip/assets/170719/0f033ec6-9f49-4433-9e38-eb75ba381c3b) | ![copy-source-after](https://github.com/zulip/zulip/assets/170719/67680537-dac5-42d2-93ac-201c5ef2500d) |

| Copy message link, before | Copy message link, after |
| --- | --- |
| ![copy-link-before](https://github.com/zulip/zulip/assets/170719/e53263e5-dba6-4033-93c1-2239e57cf371) | ![copy-link-after](https://github.com/zulip/zulip/assets/170719/7437272e-7182-430d-bffc-ecdcd87bb16e) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>