### PR TITLE
pm_list: Show empty conversations in left sidebar.

### DIFF
--- a/web/src/pm_conversations.ts
+++ b/web/src/pm_conversations.ts
@@ -37,6 +37,32 @@ class RecentDirectMessages {
     recent_message_ids = new FoldDict<PMConversation>(); // key is user_ids_string
     recent_private_messages: PMConversation[] = [];
 
+    remove_empty_dm(): void {
+        const convoList = this.recent_private_messages;
+        for (let i = 0; i < convoList.length; i += 1) {
+            if (convoList[i].max_message_id < 0) {
+                convoList.splice(i, i + 1);
+                break;
+            }
+        }
+    }
+
+    insert_empty_dm(user_ids: number[]): void {
+        const user_ids_string = user_ids.join(",");
+        // adds to top of recent private messages list, if not already present.
+        if (
+            !this.recent_private_messages
+                .map((obj) => obj.user_ids_string)
+                .includes(user_ids_string)
+        ) {
+            const conversation = {
+                user_ids_string,
+                max_message_id: -1,
+            };
+            this.recent_private_messages.unshift(conversation);
+        }
+    }
+
     insert(user_ids: number[], message_id: number): void {
         if (user_ids.length === 0) {
             // The server sends [] for direct messages to oneself.

--- a/web/src/pm_list.js
+++ b/web/src/pm_list.js
@@ -161,7 +161,7 @@ export function handle_narrow_activated(filter) {
         unhighlight_all_private_messages_view();
     }
     if (narrow_to_private_messages_section) {
-        const current_user_ids_string = pm_list_data.get_active_user_ids_string();
+        const {user_ids_string: current_user_ids_string} = pm_list_data.get_active_user_ids();
         const $active_filter_li = $(
             `li[data-user-ids-string='${CSS.escape(current_user_ids_string)}']`,
         );

--- a/web/src/pm_list_data.js
+++ b/web/src/pm_list_data.js
@@ -12,20 +12,29 @@ const max_conversations_to_show = 8;
 // Maximum number of conversation threads to show in default view with unreads.
 const max_conversations_to_show_with_unreads = 15;
 
-export function get_active_user_ids_string() {
+export function get_active_user_ids() {
     const filter = narrow_state.filter();
 
     if (!filter) {
-        return undefined;
+        return {
+            user_ids_string: undefined,
+            user_ids_array: undefined,
+        };
     }
 
     const emails = filter.operands("dm")[0];
 
     if (!emails) {
-        return undefined;
+        return {
+            user_ids_string: undefined,
+            user_ids_array: undefined,
+        };
     }
 
-    return people.emails_strings_to_user_ids_string(emails);
+    return {
+        user_ids_string: people.emails_strings_to_user_ids_string(emails),
+        user_ids_array: people.emails_strings_to_user_ids_array(emails),
+    };
 }
 
 export function get_conversations() {
@@ -33,7 +42,7 @@ export function get_conversations() {
     const display_objects = [];
 
     // The user_ids_string for the current view, if any.
-    const active_user_ids_string = get_active_user_ids_string();
+    const active_user_ids_string = get_active_user_ids().user_ids_string;
 
     for (const conversation of private_messages) {
         const user_ids_string = conversation.user_ids_string;

--- a/web/tests/pm_conversations.test.js
+++ b/web/tests/pm_conversations.test.js
@@ -101,3 +101,53 @@ test("muted_users", () => {
     ]);
     assert.deepEqual(pmc.recent.get_strings(), ["3", "1,2,3", "15"]);
 });
+
+test("insert_empty_dm", () => {
+    pmc.recent.initialize(params);
+
+    // Base data
+    assert.deepEqual(pmc.recent.get(), [
+        {user_ids_string: "1", max_message_id: 100},
+        {user_ids_string: "3", max_message_id: 99},
+        {user_ids_string: "1,2", max_message_id: 98},
+        {user_ids_string: "1,2,3", max_message_id: 97},
+        {user_ids_string: "15", max_message_id: 96},
+    ]);
+
+    // Insert an empty conversation
+    const user_ids1 = [1, 5];
+    pmc.recent.insert_empty_dm(user_ids1);
+
+    // Check if the empty conversation is added
+    assert.deepEqual(pmc.recent.get(), [
+        {user_ids_string: "1,5", max_message_id: -1},
+        {user_ids_string: "1", max_message_id: 100},
+        {user_ids_string: "3", max_message_id: 99},
+        {user_ids_string: "1,2", max_message_id: 98},
+        {user_ids_string: "1,2,3", max_message_id: 97},
+        {user_ids_string: "15", max_message_id: 96},
+    ]);
+
+    // Try inserting an existing conversation, should not affect the order
+    const user_ids2 = [1, 5];
+    pmc.recent.insert_empty_dm(user_ids2);
+
+    // Check if the order remains the same
+    assert.deepEqual(pmc.recent.get(), [
+        {user_ids_string: "1,5", max_message_id: -1},
+        {user_ids_string: "1", max_message_id: 100},
+        {user_ids_string: "3", max_message_id: 99},
+        {user_ids_string: "1,2", max_message_id: 98},
+        {user_ids_string: "1,2,3", max_message_id: 97},
+        {user_ids_string: "15", max_message_id: 96},
+    ]);
+
+    pmc.recent.remove_empty_dm();
+    assert.deepEqual(pmc.recent.get(), [
+        {user_ids_string: "1", max_message_id: 100},
+        {user_ids_string: "3", max_message_id: 99},
+        {user_ids_string: "1,2", max_message_id: 98},
+        {user_ids_string: "1,2,3", max_message_id: 97},
+        {user_ids_string: "15", max_message_id: 96},
+    ]);
+});

--- a/web/tests/pm_list_data.test.js
+++ b/web/tests/pm_list_data.test.js
@@ -179,15 +179,22 @@ test("get_conversations bot", ({override}) => {
     assert.deepEqual(pm_data, expected_data);
 });
 
-test("get_active_user_ids_string", () => {
-    assert.equal(pm_list_data.get_active_user_ids_string(), undefined);
+test("get_active_user_ids", () => {
+    assert.deepEqual(pm_list_data.get_active_user_ids(), {
+        user_ids_string: undefined,
+        user_ids_array: undefined,
+    });
 
     const stream_filter = new Filter([{operator: "stream", operand: "test"}]);
     narrow_state.set_current_filter(stream_filter);
-    assert.equal(pm_list_data.get_active_user_ids_string(), undefined);
+    assert.deepEqual(pm_list_data.get_active_user_ids(), {
+        user_ids_string: undefined,
+        user_ids_array: undefined,
+    });
 
     set_pm_with_filter("bob@zulip.com,alice@zulip.com");
-    assert.equal(pm_list_data.get_active_user_ids_string(), "101,102");
+    assert.equal(pm_list_data.get_active_user_ids().user_ids_string, "101,102");
+    assert.deepEqual(pm_list_data.get_active_user_ids().user_ids_array, [101, 102]);
 });
 
 test("get_list_info_unread_messages", ({override}) => {


### PR DESCRIPTION
- [x] Show a empty conversation in left sidebar, when the user is in view of the new conversation.

----------

Fixes: #22769
CZO: [Thread](https://chat.zulip.org/#narrow/stream/101-design/topic/Show.20empty.20conversations.20in.20left.20sidebar.20.2322769)

-----------

**Screenshots and screen captures:**

<details>
<summary>Demo:</summary>
<br>

![pm_conversation](https://github.com/zulip/zulip/assets/66828942/d35798d5-cddb-443c-b0ee-5e08f3bb3202)
</details>

-------------------
ToDo:

- Complete the similar implementation for topics also.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
