### PR TITLE
help: Link to /help/recent-conversations to define "conversation".

### DIFF
--- a/help/email-notifications.md
+++ b/help/email-notifications.md
@@ -33,10 +33,10 @@ helps in a few ways:
   the email would go out.
 * Edits made by the sender soon after sending a message will be
   reflected in the email.
-* Multiple messages in the same Zulip conversation are combined into
-  a single email. (Different conversations will always be
-  in separate emails, so that you can
-  [respond directly from your email][reply-from-email]).
+* Multiple messages in the same Zulip [conversation](/help/recent-conversations)
+  are combined into a single email. (Different conversations will always be in
+  separate emails, so that you can [respond directly from your
+  email][reply-from-email]).
 
 [reply-from-email]: /help/using-zulip-via-email
 

--- a/help/inbox.md
+++ b/help/inbox.md
@@ -1,8 +1,9 @@
 # Inbox
 
 The **Inbox** is the default view in the Zulip mobile app. It's a great way to
-get an overview of all the unmuted conversations where you have unread messages,
-excluding [inactive streams](/help/manage-inactive-streams).
+get an overview of all the unmuted [conversations](/help/recent-conversations)
+where you have unread messages, excluding [inactive
+streams](/help/manage-inactive-streams).
 
 The **Inbox** view shows your unread direct message conversations, followed by
 all topics with unread messages, grouped by stream. The list of streams is

--- a/help/include/streams-and-topics.md
+++ b/help/include/streams-and-topics.md
@@ -9,9 +9,9 @@ conversational thread. Here is what it looks like in Zulip.
 
 Topics are one of the most wonderful aspects of using Zulip:
 
-* Lots of conversations can happen in the same stream at the same time, each in
-  its own topic. You never have to worry about interrupting — each
-  conversation has its own space.
+* Lots of [conversations](/help/recent-conversations) can happen in the same
+  stream at the same time, each in its own topic. You never have to worry about
+  interrupting — each conversation has its own space.
 * Conversations can last many hours or days, letting everyone respond in their
   own time. Don't worry about replying long after a message is sent —
   everyone will see your reply in context.

--- a/help/link-to-a-message-or-conversation.md
+++ b/help/link-to-a-message-or-conversation.md
@@ -1,8 +1,9 @@
 # Link to a message or conversation
 
 Zulip makes it easy to share links to messages, topics, and streams. You can
-link from one Zulip conversation to another, or share links to Zulip conversations
-in issue trackers, emails, or other external tools.
+link from one Zulip [conversation](/help/recent-conversations) to another, or
+share links to Zulip conversations in issue trackers, emails, or other external
+tools.
 
 ## Link to a stream or topic within Zulip
 

--- a/help/manage-your-uploaded-files.md
+++ b/help/manage-your-uploaded-files.md
@@ -13,8 +13,9 @@ uploaded.
 
 !!! tip ""
 
-    You can also view a file in the context of the conversations where it
-    was mentioned by clicking on a message ID in the **Mentioned in** column.
+    You can also view a file in the context of the
+    [conversations](/help/recent-conversations) where it was
+    mentioned by clicking on a message ID in the **Mentioned in** column.
 
 {end_tabs}
 

--- a/help/mastering-the-compose-box.md
+++ b/help/mastering-the-compose-box.md
@@ -2,10 +2,10 @@
 
 ## Composing to a different conversation
 
-When composing a message, Zulip lets you view a different conversation from the
-one you are composing to. For example, you can start a new topic without
-changing your narrow, send a direct message about the topic you're viewing, or
-look up a related discussion.
+When composing a message, Zulip lets you view a different
+[conversation](/help/recent-conversations) from the one you are composing to.
+For example, you can start a new topic without changing your narrow, send a
+direct message about the topic you're viewing, or look up a related discussion.
 
 In this context, the parts of the message view that are outside of the
 conversation you are composing to are faded for clarity.
@@ -43,8 +43,8 @@ will be sent.
 
 ### Go to conversation
 
-Zulip lets you narrow the message view to the conversation you're currently
-composing to.
+Zulip lets you narrow the message view to the
+[conversation](/help/recent-conversations) you're currently composing to.
 
 {start_tabs}
 

--- a/help/view-your-mentions.md
+++ b/help/view-your-mentions.md
@@ -18,7 +18,7 @@ the messages where you were mentioned from a dedicated tab.
 1. Click **Mentions** in the left sidebar.
 
 1. Browse your mentions. You can click on a message recipient bar to go
-   to the conversation where you were mentioned.
+   to the [conversation](/help/recent-conversations) where you were mentioned.
 
 !!! tip ""
     You can also [search your mentions](/help/search-for-messages) using the


### PR DESCRIPTION
This PR replaces #25839.

- Adds a link to the "Recent conversations" article whenever we use the term **conversation** as a technical term referring to **topic** or **DM thread**. This can help clarify meaning when the term is used in this specific way.

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>