### PR TITLE
streams: Add stream traffic data to `Stream` objects.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,14 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 199**
+
+* [`POST /register`](/api/register-queue), [`GET /events`][/api/get-events],
+  [`GET /streams`](/api/get-streams),
+  [`GET /streams/{stream_id}`](/api/get-stream-by-id): Stream objects now
+  include a `stream_weekly_traffic` field indicating the stream's level of
+  traffic.
+
 **Feature level 198**
 
 * [`GET /events`](/api/get-events), [`POST /register`](/api/register-queue),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 198
+API_FEATURE_LEVEL = 199
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/tests/lib/events.js
+++ b/web/tests/lib/events.js
@@ -650,13 +650,31 @@ exports.fixtures = {
     stream__create: {
         type: "stream",
         op: "create",
-        streams: [streams.devel, streams.test],
+        streams: [
+            {
+                ...streams.devel,
+                stream_weekly_traffic: null,
+            },
+            {
+                ...streams.test,
+                stream_weekly_traffic: null,
+            },
+        ],
     },
 
     stream__delete: {
         type: "stream",
         op: "delete",
-        streams: [streams.devel, streams.test],
+        streams: [
+            {
+                ...streams.devel,
+                stream_weekly_traffic: null,
+            },
+            {
+                ...streams.test,
+                stream_weekly_traffic: null,
+            },
+        ],
     },
 
     stream__update: {

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -44,6 +44,7 @@ from zerver.lib.streams import (
     get_stream_permission_policy_name,
     render_stream_description,
     send_stream_creation_event,
+    stream_to_dict,
 )
 from zerver.lib.subscription_info import get_subscribers_query
 from zerver.lib.types import APISubscriptionDict
@@ -117,7 +118,7 @@ def do_deactivate_stream(stream: Stream, *, acting_user: Optional[UserProfile]) 
     for group in default_stream_groups_for_stream:
         do_remove_streams_from_default_stream_group(stream.realm, group, [stream])
 
-    stream_dict = stream.to_dict()
+    stream_dict = stream_to_dict(stream)
     stream_dict.update(dict(name=old_name, invite_only=was_invite_only))
     event = dict(type="stream", op="delete", streams=[stream_dict])
     send_event_on_commit(stream.realm, event, affected_user_ids)
@@ -354,7 +355,7 @@ def send_subscription_add_events(
             stream = sub_info.stream
             stream_info = stream_info_dict[stream.id]
             subscription = sub_info.sub
-            stream_dict = stream.to_dict()
+            stream_dict = stream_to_dict(stream)
             # This is verbose as we cannot unpack existing TypedDict
             # to initialize another TypedDict while making mypy happy.
             # https://github.com/python/mypy/issues/5382

--- a/zerver/lib/default_streams.py
+++ b/zerver/lib/default_streams.py
@@ -1,6 +1,6 @@
 from typing import List, Set
 
-from zerver.lib.types import APIStreamDict
+from zerver.lib.types import DefaultStreamDict
 from zerver.models import DefaultStream, Stream
 
 
@@ -22,7 +22,7 @@ def get_default_stream_ids_for_realm(realm_id: int) -> Set[int]:
     return set(DefaultStream.objects.filter(realm_id=realm_id).values_list("stream_id", flat=True))
 
 
-def get_default_streams_for_realm_as_dicts(realm_id: int) -> List[APIStreamDict]:
+def get_default_streams_for_realm_as_dicts(realm_id: int) -> List[DefaultStreamDict]:
     """
     Return all the default streams for a realm using a list of dictionaries sorted
     by stream name.

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -49,7 +49,7 @@ from zerver.models import Realm, RealmUserDefault, Stream, UserProfile
 
 # These fields are used for "stream" events, and are included in the
 # larger "subscription" events that also contain personal settings.
-basic_stream_fields = [
+default_stream_fields = [
     ("can_remove_subscribers_group", int),
     ("date_created", int),
     ("description", str),
@@ -65,6 +65,11 @@ basic_stream_fields = [
     ("stream_post_policy", int),
 ]
 
+basic_stream_fields = [
+    *default_stream_fields,
+    ("stream_weekly_traffic", OptionalType(int)),
+]
+
 subscription_fields: Sequence[Tuple[str, object]] = [
     *basic_stream_fields,
     ("audible_notifications", OptionalType(bool)),
@@ -76,7 +81,6 @@ subscription_fields: Sequence[Tuple[str, object]] = [
     ("is_muted", bool),
     ("pin_to_top", bool),
     ("push_notifications", OptionalType(bool)),
-    ("stream_weekly_traffic", OptionalType(int)),
     # We may try to remove subscribers from some events in
     # the future for clients that don't want subscriber
     # info.
@@ -185,7 +189,7 @@ _check_stream_group = DictType(
         ("name", str),
         ("id", int),
         ("description", str),
-        ("streams", ListType(DictType(basic_stream_fields))),
+        ("streams", ListType(DictType(default_stream_fields))),
     ]
 )
 
@@ -200,7 +204,7 @@ check_default_stream_groups = make_checker(default_stream_groups_event)
 default_streams_event = event_dict_type(
     required_keys=[
         ("type", Equals("default_streams")),
-        ("default_streams", ListType(DictType(basic_stream_fields))),
+        ("default_streams", ListType(DictType(default_stream_fields))),
     ]
 )
 check_default_streams = make_checker(default_streams_event)

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -998,12 +998,6 @@ def apply_event(
                     if include_subscribers:
                         stream_data["subscribers"] = []
 
-                    # We know the stream has no traffic, and this
-                    # field is not present in the event.
-                    #
-                    # TODO: Probably this should just be added to the event.
-                    stream_data["stream_weekly_traffic"] = None
-
                     # Add stream to never_subscribed (if not invite_only)
                     state["never_subscribed"].append(stream_data)
                 if "streams" in state:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -17,6 +17,7 @@ from zerver.lib.stream_subscription import (
     get_subscribed_stream_ids_for_user,
 )
 from zerver.lib.string_validation import check_stream_name
+from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.types import APIStreamDict
 from zerver.lib.user_groups import is_user_in_group
 from zerver.models import (
@@ -111,7 +112,7 @@ def render_stream_description(text: str, realm: Realm) -> str:
 
 
 def send_stream_creation_event(realm: Realm, stream: Stream, user_ids: List[int]) -> None:
-    event = dict(type="stream", op="create", streams=[stream.to_dict()])
+    event = dict(type="stream", op="create", streams=[stream_to_dict(stream)])
     send_event(realm, event, user_ids)
 
 
@@ -823,6 +824,24 @@ def get_occupied_streams(realm: Realm) -> QuerySet[Stream]:
         .filter(occupied=True)
     )
     return occupied_streams
+
+
+def stream_to_dict(stream: Stream) -> APIStreamDict:
+    return APIStreamDict(
+        can_remove_subscribers_group=stream.can_remove_subscribers_group_id,
+        date_created=datetime_to_timestamp(stream.date_created),
+        description=stream.description,
+        first_message_id=stream.first_message_id,
+        history_public_to_subscribers=stream.history_public_to_subscribers,
+        invite_only=stream.invite_only,
+        is_web_public=stream.is_web_public,
+        message_retention_days=stream.message_retention_days,
+        name=stream.name,
+        rendered_description=stream.rendered_description,
+        stream_id=stream.id,
+        stream_post_policy=stream.stream_post_policy,
+        is_announcement_only=stream.stream_post_policy == Stream.STREAM_POST_POLICY_ADMINS,
+    )
 
 
 def get_web_public_streams(realm: Realm) -> List[APIStreamDict]:  # nocoverage

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -217,7 +217,7 @@ class NeverSubscribedStreamDict(TypedDict):
     subscribers: NotRequired[List[int]]
 
 
-class APIStreamDict(TypedDict):
+class DefaultStreamDict(TypedDict):
     """Stream information provided to Zulip clients as a dictionary via API.
     It should contain all the fields specified in `zerver.models.Stream.API_FIELDS`
     with few exceptions and possible additional fields.
@@ -240,6 +240,10 @@ class APIStreamDict(TypedDict):
     is_default: NotRequired[bool]
 
 
+class APIStreamDict(DefaultStreamDict):
+    stream_weekly_traffic: Optional[int]
+
+
 class APISubscriptionDict(APIStreamDict):
     """Similar to StreamClientDict, it should contain all the fields specified in
     `zerver.models.Subscription.API_FIELDS` and several additional fields.
@@ -256,7 +260,6 @@ class APISubscriptionDict(APIStreamDict):
     # Computed fields not specified in `Subscription.API_FIELDS`
     email_address: str
     in_home_view: bool
-    stream_weekly_traffic: Optional[int]
     subscribers: List[int]
 
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -86,7 +86,7 @@ from zerver.lib.exceptions import JsonableError, RateLimitedError
 from zerver.lib.pysa import mark_sanitized
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.types import (
-    APIStreamDict,
+    DefaultStreamDict,
     DisplayRecipientT,
     ExtendedFieldElement,
     ExtendedValidator,
@@ -2701,8 +2701,8 @@ class Stream(models.Model):
         "can_remove_subscribers_group_id",
     ]
 
-    def to_dict(self) -> APIStreamDict:
-        return APIStreamDict(
+    def to_dict(self) -> DefaultStreamDict:
+        return DefaultStreamDict(
             can_remove_subscribers_group=self.can_remove_subscribers_group_id,
             date_created=datetime_to_timestamp(self.date_created),
             description=self.description,

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2701,11 +2701,6 @@ class Stream(models.Model):
         "can_remove_subscribers_group_id",
     ]
 
-    @staticmethod
-    def get_client_data(query: QuerySet["Stream"]) -> List[APIStreamDict]:
-        query = query.only(*Stream.API_FIELDS)
-        return [row.to_dict() for row in query]
-
     def to_dict(self) -> APIStreamDict:
         return APIStreamDict(
             can_remove_subscribers_group=self.can_remove_subscribers_group_id,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11584,8 +11584,8 @@ paths:
                                   type: integer
                                   nullable: true
                                   description: |
-                                    The average number of messages sent to the stream in recent weeks,
-                                    rounded to the nearest integer.
+                                    The average number of messages sent to the stream per week, as
+                                    estimated based on recent weeks, rounded to the nearest integer.
 
                                     If `null`, the stream was recently created and there is
                                     insufficient data to estimate the average traffic.
@@ -17745,8 +17745,8 @@ components:
           type: integer
           nullable: true
           description: |
-            The average number of messages sent to the stream in recent weeks,
-            rounded to the nearest integer.
+            The average number of messages sent to the stream per week, as
+            estimated based on recent weeks, rounded to the nearest integer.
 
             If `null`, the stream was recently created and there is
             insufficient data to estimate the average traffic.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1884,7 +1884,7 @@ paths:
                                     An array of dictionaries where each dictionary
                                     contains details about a single default stream.
                                   items:
-                                    $ref: "#/components/schemas/BasicStream"
+                                    $ref: "#/components/schemas/DefaultStream"
                               example:
                                 {
                                   "type": "default_streams",
@@ -11766,7 +11766,7 @@ paths:
                       realm_default_streams:
                         type: array
                         items:
-                          $ref: "#/components/schemas/BasicStream"
+                          $ref: "#/components/schemas/DefaultStream"
                         description: |
                           Present if `default_streams` is present in `fetch_event_types`.
 
@@ -15689,6 +15689,21 @@ paths:
                                   nullable: true
                                 is_announcement_only: {}
                                 can_remove_subscribers_group: {}
+                                stream_weekly_traffic:
+                                  type: integer
+                                  nullable: true
+                                  description: |
+                                    The average number of messages sent to the stream per week, as
+                                    estimated based on recent weeks, rounded to the nearest integer.
+
+                                    If `null`, no information is provided on the average traffic.
+                                    This can be because the stream was recently created and there
+                                    is insufficient data to make an estimate, or because the server
+                                    wishes to omit this information for this client, this realm, or
+                                    this endpoint or type of event.
+
+                                    **Changes**: New in Zulip 8.0 (feature level 199). Previously,
+                                    this statistic was available only in subscription objects.
                                 is_default:
                                   type: boolean
                                   description: |
@@ -16995,6 +17010,41 @@ components:
               nullable: true
             is_announcement_only: {}
             can_remove_subscribers_group: {}
+            stream_weekly_traffic:
+              type: integer
+              nullable: true
+              description: |
+                The average number of messages sent to the stream per week, as
+                estimated based on recent weeks, rounded to the nearest integer.
+
+                If `null`, no information is provided on the average traffic.
+                This can be because the stream was recently created and there
+                is insufficient data to make an estimate, or because the server
+                wishes to omit this information for this client, this realm, or
+                this endpoint or type of event.
+
+                **Changes**: New in Zulip 8.0 (feature level 199). Previously, this
+                statistic was available only in subscription objects.
+    DefaultStream:
+      allOf:
+        - $ref: "#/components/schemas/BasicStreamBase"
+        - additionalProperties: false
+          properties:
+            stream_id: {}
+            name: {}
+            description: {}
+            date_created: {}
+            invite_only: {}
+            rendered_description: {}
+            is_web_public: {}
+            stream_post_policy: {}
+            message_retention_days:
+              nullable: true
+            history_public_to_subscribers: {}
+            first_message_id:
+              nullable: true
+            is_announcement_only: {}
+            can_remove_subscribers_group: {}
     BasicStreamBase:
       type: object
       description: |
@@ -17786,7 +17836,7 @@ components:
             Array containing details about the streams
             in the default stream group.
           items:
-            $ref: "#/components/schemas/BasicStream"
+            $ref: "#/components/schemas/DefaultStream"
     EmailAddressVisibility:
       type: integer
       description: |

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -1249,7 +1249,7 @@ class FetchQueriesTest(ZulipTestCase):
         self.login_user(user)
 
         flush_per_request_caches()
-        with self.assert_database_query_count(38):
+        with self.assert_database_query_count(39):
             with mock.patch("zerver.lib.events.always_want") as want_mock:
                 fetch_initial_state_data(user)
 
@@ -1279,7 +1279,7 @@ class FetchQueriesTest(ZulipTestCase):
             recent_private_conversations=1,
             scheduled_messages=1,
             starred_messages=1,
-            stream=2,
+            stream=3,
             stop_words=0,
             subscription=4,
             update_display_settings=0,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2476,6 +2476,7 @@ class NormalActionsTest(BaseAction):
             action = lambda: do_deactivate_stream(stream, acting_user=None)
             events = self.verify_action(action, include_streams=include_streams)
             check_stream_delete("events[0]", events[0])
+            self.assertIsNone(events[0]["streams"][0]["stream_weekly_traffic"])
 
     def test_subscribe_other_user_never_subscribed(self) -> None:
         for i, include_streams in enumerate([True, False]):
@@ -3266,6 +3267,7 @@ class SubscribeActionTest(BaseAction):
             events[0]["streams"][0]["message_retention_days"],
             10,
         )
+        self.assertIsNone(events[0]["streams"][0]["stream_weekly_traffic"])
 
         stream.invite_only = False
         stream.save()

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -70,6 +70,7 @@ from zerver.lib.streams import (
     filter_stream_authorization,
     get_stream_permission_policy_name,
     list_to_streams,
+    stream_to_dict,
 )
 from zerver.lib.string_validation import check_stream_name
 from zerver.lib.subscription_info import gather_subscriptions
@@ -873,7 +874,7 @@ def get_stream_backend(
     stream_id: int,
 ) -> HttpResponse:
     (stream, sub) = access_stream_by_id(user_profile, stream_id, allow_realm_admin=True)
-    return json_success(request, data={"stream": stream.to_dict()})
+    return json_success(request, data={"stream": stream_to_dict(stream)})
 
 
 @has_request_variables


### PR DESCRIPTION
<!-- Describe your pull request here.-->
- First two commits are prep commits to include stream traffic information in `Stream` objects.
- Last commit adds stream traffic information to `Stream` objects.

 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
