### PR TITLE
people: Revert to using `ignore_missing` parameter.

### DIFF
--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -121,8 +121,8 @@ export function get_by_user_id(user_id: number): User {
 }
 
 // This is type unsafe version of get_by_user_id for the callers that expects undefined values.
-export function maybe_get_user_by_id(user_id: number): User | undefined {
-    if (!people_by_user_id_dict.has(user_id)) {
+export function maybe_get_user_by_id(user_id: number, ignore_missing = false): User | undefined {
+    if (!people_by_user_id_dict.has(user_id) && !ignore_missing) {
         blueslip.error("Unknown user_id in maybe_get_user_by_id", {user_id});
         return undefined;
     }

--- a/web/src/presence.js
+++ b/web/src/presence.js
@@ -175,7 +175,7 @@ export function set_info(presences, server_timestamp) {
         // reload_state.is_in_progress, because races where presence
         // returns data on users not yet received via the server_events
         // system are common in both situations.
-        const person = people.maybe_get_user_by_id(user_id);
+        const person = people.maybe_get_user_by_id(user_id, true);
         if (person === undefined) {
             if (!(watchdog.suspects_user_is_offline() || reload_state.is_in_progress())) {
                 // If we're online, and we get a user who we don't

--- a/web/src/rendered_markdown.js
+++ b/web/src/rendered_markdown.js
@@ -107,7 +107,7 @@ export const update_elements = ($content) => {
             // mention text to show the user's current name,
             // assuming that you're not searching for text
             // inside the highlight.
-            const person = people.maybe_get_user_by_id(user_id);
+            const person = people.maybe_get_user_by_id(user_id, true);
             if (person !== undefined) {
                 // Note that person might be undefined in some
                 // unpleasant corner cases involving data import.

--- a/web/tests/presence.test.js
+++ b/web/tests/presence.test.js
@@ -95,7 +95,6 @@ test("unknown user", ({override}) => {
     const presences = {};
     presences[unknown_user_id.toString()] = "does-not-matter";
 
-    blueslip.expect("error", "Unknown user_id in maybe_get_user_by_id", 3);
     blueslip.expect("error", "Unknown user ID in presence data");
     presence.set_info(presences, now);
 


### PR DESCRIPTION
We revert to use `ignore_missing` parameter for `maybe_get_user_by_id` function to avoid sending unnecessary `blueslip.error()` calls to sentry.

This bug was introduced in the commit [1c8bf4f050475073d641f6f4b5f27b143e8b1dd6](https://github.com/zulip/zulip/commit/1c8bf4f050475073d641f6f4b5f27b143e8b1dd6).

Discussion - [CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/people.2Ejs.20typescript.20migration/near/1618488)

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
