### PR TITLE
test_users: Use 'do_change_user_setting' instead of '.save()'.

### DIFF
--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1177,14 +1177,18 @@ class UserProfileTest(ZulipTestCase):
         cordelia = self.example_user("cordelia")
         hamlet = self.example_user("hamlet")
 
-        cordelia.default_language = "de"
-        cordelia.default_view = "all_messages"
-        cordelia.emojiset = "twitter"
-        cordelia.timezone = "America/Phoenix"
-        cordelia.color_scheme = UserProfile.COLOR_SCHEME_NIGHT
-        cordelia.enable_offline_email_notifications = False
-        cordelia.enable_stream_push_notifications = True
-        cordelia.enter_sends = False
+        do_change_user_setting(cordelia, "default_language", "de", acting_user=None)
+        do_change_user_setting(cordelia, "default_view", "all_messages", acting_user=None)
+        do_change_user_setting(cordelia, "emojiset", "twitter", acting_user=None)
+        do_change_user_setting(cordelia, "timezone", "America/Phoenix", acting_user=None)
+        do_change_user_setting(
+            cordelia, "color_scheme", UserProfile.COLOR_SCHEME_NIGHT, acting_user=None
+        )
+        do_change_user_setting(
+            cordelia, "enable_offline_email_notifications", False, acting_user=None
+        )
+        do_change_user_setting(cordelia, "enable_stream_push_notifications", True, acting_user=None)
+        do_change_user_setting(cordelia, "enter_sends", False, acting_user=None)
         cordelia.avatar_source = UserProfile.AVATAR_FROM_USER
         cordelia.save()
 
@@ -1805,12 +1809,10 @@ class RecipientInfoTest(ZulipTestCase):
         # These tests were written with the old default for
         # enable_online_push_notifications; that default is better for
         # testing the full code path anyway.
-        hamlet.enable_online_push_notifications = False
-        cordelia.enable_online_push_notifications = False
-        othello.enable_online_push_notifications = False
-        hamlet.save()
-        cordelia.save()
-        othello.save()
+        for user in [hamlet, cordelia, othello]:
+            do_change_user_setting(
+                user, "enable_online_push_notifications", False, acting_user=None
+            )
 
         realm = hamlet.realm
 
@@ -1863,9 +1865,10 @@ class RecipientInfoTest(ZulipTestCase):
 
         self.assertEqual(info, expected_info)
 
-        hamlet.enable_offline_email_notifications = False
-        hamlet.enable_offline_push_notifications = False
-        hamlet.save()
+        do_change_user_setting(
+            hamlet, "enable_offline_email_notifications", False, acting_user=None
+        )
+        do_change_user_setting(hamlet, "enable_offline_push_notifications", False, acting_user=None)
         info = get_recipient_info(
             realm_id=realm.id,
             recipient=recipient,
@@ -1875,14 +1878,11 @@ class RecipientInfoTest(ZulipTestCase):
         )
         self.assertEqual(info.pm_mention_email_disabled_user_ids, {hamlet.id})
         self.assertEqual(info.pm_mention_push_disabled_user_ids, {hamlet.id})
-        hamlet.enable_offline_email_notifications = True
-        hamlet.enable_offline_push_notifications = True
-        hamlet.save()
+        do_change_user_setting(hamlet, "enable_offline_email_notifications", True, acting_user=None)
+        do_change_user_setting(hamlet, "enable_offline_push_notifications", True, acting_user=None)
 
-        cordelia.wildcard_mentions_notify = False
-        cordelia.save()
-        hamlet.enable_stream_push_notifications = True
-        hamlet.save()
+        do_change_user_setting(cordelia, "wildcard_mentions_notify", False, acting_user=None)
+        do_change_user_setting(hamlet, "enable_stream_push_notifications", True, acting_user=None)
         info = get_recipient_info(
             realm_id=realm.id,
             recipient=recipient,
@@ -1966,8 +1966,7 @@ class RecipientInfoTest(ZulipTestCase):
         )
         self.assertEqual(info.stream_push_user_ids, set())
 
-        hamlet.enable_stream_push_notifications = False
-        hamlet.save()
+        do_change_user_setting(hamlet, "enable_stream_push_notifications", False, acting_user=None)
         sub = get_subscription(stream_name, hamlet)
         sub.push_notifications = True
         sub.save()

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1176,7 +1176,6 @@ class UserProfileTest(ZulipTestCase):
         iago = self.example_user("iago")
         cordelia = self.example_user("cordelia")
         hamlet = self.example_user("hamlet")
-        hamlet.color_scheme = UserProfile.COLOR_SCHEME_LIGHT
 
         cordelia.default_language = "de"
         cordelia.default_view = "all_messages"
@@ -1225,7 +1224,7 @@ class UserProfileTest(ZulipTestCase):
 
         self.assertEqual(iago.color_scheme, UserProfile.COLOR_SCHEME_NIGHT)
         self.assertEqual(cordelia.color_scheme, UserProfile.COLOR_SCHEME_NIGHT)
-        self.assertEqual(hamlet.color_scheme, UserProfile.COLOR_SCHEME_LIGHT)
+        self.assertEqual(hamlet.color_scheme, UserProfile.COLOR_SCHEME_AUTOMATIC)
 
         self.assertEqual(iago.enable_offline_email_notifications, False)
         self.assertEqual(cordelia.enable_offline_email_notifications, False)


### PR DESCRIPTION
Follow-up : [#25828 (comment)](https://github.com/zulip/zulip/pull/25828#discussion_r1244652123)
> This should use `do_change_user_settings`.
(Maybe it would be nice to change all of this test in a sweep in a prep commit, since this test uses the `.save()` anti-pattern.)

While working on the follow-up, I noticed a small improvement, and the same has been included as a prep commit in this PR. The commit message explains the reasoning in detail. (Skipping to explain again in the PR description.)
 
<!-- Describe your pull request here.-->



<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
