### PR TITLE
hashchange: Remove hiding of recent topics.

### DIFF
--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -95,7 +95,6 @@ export function changehash(newhash) {
     if (browser_history.state.changing_hash) {
         return;
     }
-    maybe_hide_recent_topics();
     message_viewport.stop_auto_scrolling();
     set_hash(newhash);
 }


### PR DESCRIPTION
Recent Topics is hidden when we switch to a narrow view or the All Messages view, so this call is not needed. It will also become actively unhelpful when we build a stream-specific recent topics page, because then it will be possible to have a hash change that shouldn't close the recent topics view.

Manually tested switching between All Messages, Recent Topics, and narrow views.