### PR TITLE
recent topics: Show recent topics view in stream narrow.

### DIFF
--- a/web/shared/src/internal_url.ts
+++ b/web/shared/src/internal_url.ts
@@ -57,6 +57,13 @@ export function by_stream_url(
     return `#narrow/stream/${encode_stream_id(stream_id, maybe_get_stream_name)}`;
 }
 
+export function recent_by_stream_url(
+    stream_id: number,
+    maybe_get_stream_name: MaybeGetStreamName,
+): string {
+    return `#recent/stream/${encode_stream_id(stream_id, maybe_get_stream_name)}`;
+}
+
 export function by_stream_topic_url(
     stream_id: number,
     topic: string,

--- a/web/src/hash_util.ts
+++ b/web/src/hash_util.ts
@@ -74,6 +74,11 @@ export function by_stream_url(stream_id: number): string {
     return internal_url.by_stream_url(stream_id, sub_store.maybe_get_stream_name);
 }
 
+export function recent_by_stream_url(stream_id: number): string {
+    // Wrapper for web use of internal_url.recent_by_stream_url
+    return internal_url.recent_by_stream_url(stream_id, sub_store.maybe_get_stream_name);
+}
+
 export function by_stream_topic_url(stream_id: number, topic: string): string {
     // Wrapper for web use of internal_url.by_stream_topic_url
     return internal_url.by_stream_topic_url(stream_id, topic, sub_store.maybe_get_stream_name);
@@ -82,11 +87,11 @@ export function by_stream_topic_url(stream_id: number, topic: string): string {
 // Encodes an operator list into the
 // corresponding hash: the # component
 // of the narrow URL
-export function operators_to_hash(operators?: Operator[]): string {
+export function operators_to_hash(operators?: Operator[], recent_view?: boolean): string {
     let hash = "#";
 
     if (operators !== undefined) {
-        hash = "#narrow";
+        hash = recent_view ? "#recent" : "#narrow";
 
         for (const elem of operators) {
             // Support legacy tuples.

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -124,7 +124,17 @@ function do_hashchange_normal(from_reload) {
     // be #ABCD.
     const hash = window.location.hash.split("/");
 
+    // Do this before the switch statement to differentiate between
+    // recent topics for all messages and recent topics for a specific
+    // stream.
+    if (hash.length === 1 && hash[0] === "#recent") {
+        maybe_hide_inbox();
+        recent_view_ui.show();
+        return false;
+    }
+
     switch (hash[0]) {
+        case "#recent":
         case "#narrow": {
             hide_non_message_list_views();
             let operators;
@@ -166,6 +176,7 @@ function do_hashchange_normal(from_reload) {
                 narrow_opts.then_select_id = location_data_for_hash.narrow_pointer;
                 narrow_opts.then_select_offset = location_data_for_hash.narrow_offset;
             }
+            narrow_opts.is_recent_view = hash[0] === "#recent";
             narrow.activate(operators, narrow_opts);
             return true;
         }
@@ -183,10 +194,6 @@ function do_hashchange_normal(from_reload) {
             // this detail in the browser's forward/back session history.
             recent_view_ui.show();
             window.location.replace("#recent");
-            break;
-        case "#recent":
-            maybe_hide_inbox();
-            recent_view_ui.show();
             break;
         case "#inbox":
             maybe_hide_recent_view();

--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -20,7 +20,7 @@ function get_formatted_sub_count(sub_count) {
 
 function make_message_view_header(filter) {
     const message_view_header = {};
-    if (recent_view_util.is_visible()) {
+    if (recent_view_util.is_main_view_visible()) {
         return {
             title: $t({defaultMessage: "Recent conversations"}),
             icon: "clock-o",
@@ -40,6 +40,9 @@ function make_message_view_header(filter) {
     }
     message_view_header.title = filter.get_title();
     filter.add_icon_data(message_view_header);
+    if (recent_view_util.is_stream_view_visible()) {
+        message_view_header.recent_view = true;
+    }
     if (filter.has_operator("stream") && !filter._sub) {
         message_view_header.sub_count = "0";
         message_view_header.formatted_sub_count = "0";
@@ -110,8 +113,8 @@ export function initialize() {
     render_title_area();
 }
 
-export function render_title_area() {
-    const filter = narrow_state.filter();
+export function render_title_area(narrow_filter = null) {
+    const filter = narrow_filter ?? narrow_state.filter();
     build_message_view_header(filter);
 }
 

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -81,14 +81,6 @@ export function save_narrow(operators) {
     changehash(new_hash);
 }
 
-function set_recent_view(operators) {
-    if (browser_history.state.changing_hash) {
-        return;
-    }
-    const new_hash = hash_util.operators_to_hash(operators, true);
-    changehash(new_hash);
-}
-
 export function activate(raw_operators, opts) {
     /* Main entry point for switching to a new view / message list.
        Note that for historical reasons related to the current
@@ -359,16 +351,6 @@ export function activate(raw_operators, opts) {
             const stream_name = operators[0].operand;
             const stream_id = stream_data.get_sub(stream_name).stream_id;
             recent_view_ui.show(stream_id);
-            compose_closed_ui.update_buttons_for_stream_views();
-            compose_closed_ui.update_reply_recipient_label();
-            left_sidebar_navigation_area.handle_narrow_activated(filter);
-            pm_list.handle_narrow_activated(filter);
-            stream_list.handle_narrow_activated(filter);
-            message_view_header.render_title_area(filter);
-            narrow_state.reset_current_filter();
-            if (opts.change_hash) {
-                set_recent_view(operators);
-            }
             return;
         }
 

--- a/web/src/recent_view_data.ts
+++ b/web/src/recent_view_data.ts
@@ -53,13 +53,24 @@ export function process_message(msg: Message): boolean {
     return conversation_data_updated;
 }
 
-function get_sorted_topics(): Map<string | undefined, TopicData> {
+function get_sorted_topics(topic_map: Map<string, TopicData>): Map<string | undefined, TopicData> {
     // Sort all recent topics by last message time.
-    return new Map([...topics.entries()].sort((a, b) => b[1].last_msg_id - a[1].last_msg_id));
+    return new Map([...topic_map.entries()].sort((a, b) => b[1].last_msg_id - a[1].last_msg_id));
 }
 
 export function get(): Map<string | undefined, TopicData> {
-    return get_sorted_topics();
+    return get_sorted_topics(topics);
+}
+
+export function get_topics_for_stream_id(stream_id: number): Map<string | undefined, TopicData> {
+    const stream_topics = new Map(
+        [...topics.entries()].filter(
+            (topic) =>
+                // TODO: It would be great if the map had the stream_id directly accessible.
+                topic[1].type === "stream" && topic[0].startsWith(`${stream_id.toString()}:`),
+        ),
+    );
+    return get_sorted_topics(stream_topics);
 }
 
 export function reify_message_id_if_available(opts: {old_id: number; new_id: number}): boolean {

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -10,6 +10,7 @@ import * as blueslip from "./blueslip";
 import * as buddy_data from "./buddy_data";
 import * as compose_closed_ui from "./compose_closed_ui";
 import * as compose_state from "./compose_state";
+import {Filter} from "./filter";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area";
@@ -38,6 +39,7 @@ import {
 import * as scroll_util from "./scroll_util";
 import * as sidebar_ui from "./sidebar_ui";
 import * as stream_data from "./stream_data";
+import * as stream_list from "./stream_list";
 import * as sub_store from "./sub_store";
 import * as timerender from "./timerender";
 import * as ui_util from "./ui_util";
@@ -1040,9 +1042,20 @@ export function show(for_stream_id = null) {
         highlight_view_in_left_sidebar() {
             if (for_stream_id === null) {
                 left_sidebar_navigation_area.highlight_recent_view();
+            } else {
+                const stream_name = sub_store.maybe_get_stream_name(for_stream_id);
+                if (stream_name) {
+                    const filter = new Filter([
+                        {
+                            negated: false,
+                            operator: "stream",
+                            operand: stream_name,
+                        },
+                    ]);
+                    left_sidebar_navigation_area.handle_narrow_activated(filter);
+                    stream_list.handle_narrow_activated(filter);
+                }
             }
-            // TODO: When showing for a specific stream, we might want to highlight
-            // the current stream in the left sidebar.
         },
         $view: $("#recent_view"),
         // We want to show `new stream message` instead of
@@ -1050,6 +1063,7 @@ export function show(for_stream_id = null) {
         // function. So, we reuse it here.
         update_compose: compose_closed_ui.update_buttons_for_non_stream_views,
         is_recent_view: true,
+        recent_view_stream_id: for_stream_id,
         is_visible: () =>
             for_stream_id ? is_stream_view_visible(for_stream_id) : is_main_view_visible(),
         reset_current_filter: for_stream_id === null,

--- a/web/src/recent_view_util.ts
+++ b/web/src/recent_view_util.ts
@@ -1,13 +1,31 @@
 import type {Message} from "./types";
 
 let is_view_visible = false;
+let current_stream_id: number | null = null;
 
-export function set_visible(value: boolean): void {
+export function set_visible(value: boolean, stream_id: number | null = null): void {
     is_view_visible = value;
+    current_stream_id = stream_id;
 }
 
 export function is_visible(): boolean {
     return is_view_visible;
+}
+
+export function is_main_view_visible(): boolean {
+    return is_view_visible && current_stream_id === null;
+}
+
+export function is_stream_view_visible(stream_id: number = -1): boolean {
+    // If no stream_id is provided, we return true if *any* stream view is visible.
+    if (stream_id !== -1) {
+        return is_view_visible && stream_id === current_stream_id;
+    }
+    return is_view_visible && current_stream_id !== null;
+}
+
+export function get_stream_view_id(): number | null {
+    return current_stream_id;
 }
 
 export function get_topic_key(stream_id: number, topic: string): string {

--- a/web/src/views_util.js
+++ b/web/src/views_util.js
@@ -23,9 +23,8 @@ export function show(opts) {
         return;
     }
 
-    // Hide selected elements in the left sidebar.
-    opts.highlight_view_in_left_sidebar();
     stream_list.handle_message_view_deactivated();
+    opts.highlight_view_in_left_sidebar();
     pm_list.handle_message_view_deactivated();
 
     // Hide "middle-column" which has html for rendering

--- a/web/src/views_util.js
+++ b/web/src/views_util.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 
 import * as compose_recipient from "./compose_recipient";
+import {Filter} from "./filter";
 import * as message_lists from "./message_lists";
 import * as message_view_header from "./message_view_header";
 import * as message_viewport from "./message_viewport";
@@ -10,6 +11,7 @@ import * as pm_list from "./pm_list";
 import * as resize from "./resize";
 import * as search from "./search";
 import * as stream_list from "./stream_list";
+import * as sub_store from "./sub_store";
 import * as unread_ui from "./unread_ui";
 
 export function show(opts) {
@@ -37,7 +39,20 @@ export function show(opts) {
     opts.update_compose();
     narrow_state.reset_current_filter();
     narrow_title.update_narrow_title(narrow_state.filter());
-    message_view_header.render_title_area();
+    if (opts.recent_view_stream_id) {
+        const stream_name = sub_store.maybe_get_stream_name(opts.recent_view_stream_id);
+        message_view_header.render_title_area(
+            new Filter([
+                {
+                    negated: false,
+                    operator: "stream",
+                    operand: stream_name,
+                },
+            ]),
+        );
+    } else {
+        message_view_header.render_title_area();
+    }
     compose_recipient.handle_middle_pane_transition();
     search.clear_search_form();
     opts.complete_rerender();

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2175,6 +2175,7 @@ div.focused-message-list {
             font-size: 14px;
             position: relative;
             top: 1px;
+            margin-right: 0;
         }
     }
 

--- a/web/templates/navbar_icon_and_title.hbs
+++ b/web/templates/navbar_icon_and_title.hbs
@@ -1,6 +1,15 @@
-{{#if zulip_icon}}
-<i class="zulip-icon zulip-icon-{{zulip_icon}}" aria-hidden="true"></i>
-{{else if icon}}
-<i class="fa fa-{{icon}}" aria-hidden="true"></i>
-{{/if}}
+{{#if recent_view}}
+{{#tr}}
+    Recent in <z-stream-name></z-stream-name>
+    {{#*inline "z-stream-name"}}
+        {{#if zulip_icon}}
+            <i class="zulip-icon zulip-icon-{{zulip_icon}}" aria-hidden="true"></i>
+        {{else if icon}}
+            <i class="fa fa-{{icon}}" aria-hidden="true"></i>
+        {{/if}}
+        {{title}}
+    {{/inline}}
+{{/tr}}
+{{else}}
 {{title}}
+{{/if}}

--- a/web/templates/recent_view_filters.hbs
+++ b/web/templates/recent_view_filters.hbs
@@ -1,5 +1,5 @@
 <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
-<button data-filter="include_private" type="button" class="btn btn-default btn-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="true">
+<button data-filter="include_private" type="button" class="btn btn-default btn-recent-filters include-private-filter {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="true">
     {{#if filter_pm}}
     <i class="fa fa-check-square-o"></i>
     {{else}}
@@ -23,7 +23,7 @@
     {{/if}}
     {{t 'Unread' }}
 </button>
-<button data-filter="participated" type="button" class="btn btn-default btn-recent-filters {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="false">
+<button data-filter="participated" type="button" class="btn btn-default btn-recent-filters include-participated-filter {{#if is_spectator}}fake_disabled_button{{/if}}" role="checkbox" aria-checked="false">
     {{#if filter_participated}}
     <i class="fa fa-check-square-o"></i>
     {{else}}

--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -9,7 +9,7 @@
                 <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
                     {{> stream_privacy }}
                 </span>
-                <a href="{{topic_url}}">{{stream_name}}</a>
+                <a href="{{stream_url}}">{{stream_name}}</a>
                 {{/if}}
             </div>
             {{!-- For presence/group indicator --}}

--- a/web/tests/internal_url.test.js
+++ b/web/tests/internal_url.test.js
@@ -45,6 +45,12 @@ run_test("test by_stream_url", () => {
     assert.equal(result, "#narrow/stream/123-a-test-stream");
 });
 
+run_test("test recent_by_stream_url", () => {
+    const maybe_get_stream_name = () => "a test stream";
+    const result = internal_url.recent_by_stream_url(123, maybe_get_stream_name);
+    assert.equal(result, "#recent/stream/123-a-test-stream");
+});
+
 run_test("test by_stream_topic_url", () => {
     const maybe_get_stream_name = () => "a test stream";
     const result = internal_url.by_stream_topic_url(123, "test topic", maybe_get_stream_name);

--- a/web/tests/recent_view.test.js
+++ b/web/tests/recent_view.test.js
@@ -93,6 +93,7 @@ mock_esm("../src/compose_closed_ui", {
 });
 mock_esm("../src/hash_util", {
     by_stream_url: test_url,
+    recent_by_stream_url: test_url,
     by_stream_topic_url: test_url,
     by_conversation_and_time_url: test_url,
 });
@@ -1007,6 +1008,14 @@ test("basic assertions", ({mock_template, override_rewire}) => {
     assert.equal(
         [...all_topics.keys()].toString(),
         "6:topic-12,6:topic-11,6:topic-8,4:topic-10,1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3,1:topic-2,1:topic-1",
+    );
+
+    // Test filtering by stream id, now only getting topics from stream 1
+    const stream_topics = rt_data.get_topics_for_stream_id(1);
+    assert.equal(stream_topics.size, 7);
+    assert.equal(
+        [...stream_topics.keys()].toString(),
+        "1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3,1:topic-2,1:topic-1",
     );
 
     // Process direct message


### PR DESCRIPTION
conversation about rollout plan [here](https://chat.zulip.org/#narrow/stream/101-design/topic/Add.20.22Recent.20Topics.22.20view.20for.20streams.20.28.2318549.29/near/1651468)

This creates a new Recent Conversations view for streams that only shows topics from the relevant stream.
    
This commit only introduces the view when the user clicks on a stream's name in the main Recent Conversations view. The idea is to introduce it there first and more widely later.
    
Fixes #18549.
    


I also have an open question about if it's worth the extra work to make each stream's filter defaults stored separately (see code comment).

<details>
<summary>screen capture</summary>

![Kapture 2023-10-05 at 15 00 03](https://github.com/zulip/zulip/assets/5634097/80120137-716c-4f3a-ab61-f796154411cb)
</details>

There's some weird stuff going on with the highlight of the buttons, but that's present on CZO as well.