### PR TITLE
ruff: Collapse short multi-line import statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,3 +178,4 @@ extend-function-names = ["gettext_lazy"]
 
 [tool.ruff.isort]
 known-third-party = ["zulip"]
+split-on-trailing-comma = false

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -69,10 +69,7 @@ from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.streams import access_stream_for_send_message, ensure_stream
 from zerver.lib.string_validation import check_stream_name
 from zerver.lib.timestamp import timestamp_to_datetime
-from zerver.lib.topic import (
-    filter_by_exact_message_topic,
-    participants_for_topic,
-)
+from zerver.lib.topic import filter_by_exact_message_topic, participants_for_topic
 from zerver.lib.url_preview.types import UrlEmbedData
 from zerver.lib.user_message import UserMessageLite, bulk_insert_ums
 from zerver.lib.validator import check_widget_content

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -23,13 +23,7 @@ from zerver.lib.cache import (
 from zerver.lib.safe_session_cached_db import SessionStore
 from zerver.lib.sessions import session_engine
 from zerver.lib.users import get_all_api_keys
-from zerver.models import (
-    Client,
-    Huddle,
-    UserProfile,
-    get_client_cache_key,
-    huddle_hash_cache_key,
-)
+from zerver.models import Client, Huddle, UserProfile, get_client_cache_key, huddle_hash_cache_key
 
 
 def user_cache_items(

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -8,9 +8,7 @@ from django.conf import settings
 from django.utils.translation import gettext as _
 
 from version import API_FEATURE_LEVEL, ZULIP_MERGE_BASE, ZULIP_VERSION
-from zerver.actions.default_streams import (
-    default_stream_groups_to_dicts_sorted,
-)
+from zerver.actions.default_streams import default_stream_groups_to_dicts_sorted
 from zerver.actions.users import get_owned_bot_dicts
 from zerver.lib import emoji
 from zerver.lib.alert_words import user_alert_words

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -13,11 +13,7 @@ from django_otp.middleware import is_verified
 from zulip_bots.custom_exceptions import ConfigValidationError
 
 from zerver.lib.avatar import avatar_url, get_avatar_field
-from zerver.lib.cache import (
-    cache_with_key,
-    get_cross_realm_dicts_key,
-    realm_user_dict_fields,
-)
+from zerver.lib.cache import cache_with_key, get_cross_realm_dicts_key, realm_user_dict_fields
 from zerver.lib.exceptions import (
     JsonableError,
     OrganizationAdministratorRequiredError,

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -43,11 +43,7 @@ from zerver.actions.users import change_user_is_active
 from zerver.context_processors import common_context
 from zerver.lib.create_user import create_user
 from zerver.lib.default_streams import get_default_streams_for_realm_as_dicts
-from zerver.lib.send_email import (
-    FromAddress,
-    deliver_scheduled_emails,
-    send_future_email,
-)
+from zerver.lib.send_email import FromAddress, deliver_scheduled_emails, send_future_email
 from zerver.lib.streams import ensure_stream
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import find_key_by_email

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -18,16 +18,10 @@ from django.utils import translation
 from django.utils.translation import gettext as _
 
 from confirmation import settings as confirmation_settings
-from confirmation.models import (
-    Confirmation,
-    one_click_unsubscribe_link,
-)
+from confirmation.models import Confirmation, one_click_unsubscribe_link
 from zerver.actions.create_realm import do_change_realm_subdomain, do_create_realm
 from zerver.actions.create_user import add_new_user_history
-from zerver.actions.default_streams import (
-    do_add_default_stream,
-    do_create_default_stream_group,
-)
+from zerver.actions.default_streams import do_add_default_stream, do_create_default_stream_group
 from zerver.actions.realm_settings import (
     do_deactivate_realm,
     do_set_realm_authentication_methods,
@@ -50,11 +44,7 @@ from zerver.lib.mobile_auth_otp import (
     xor_hex_strings,
 )
 from zerver.lib.name_restrictions import is_disposable_domain
-from zerver.lib.send_email import (
-    EmailNotDeliveredError,
-    FromAddress,
-    send_future_email,
-)
+from zerver.lib.send_email import EmailNotDeliveredError, FromAddress, send_future_email
 from zerver.lib.stream_subscription import get_stream_subscriptions_for_user
 from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.subdomains import is_root_domain_available

--- a/zerver/tests/test_upload_local.py
+++ b/zerver/tests/test_upload_local.py
@@ -10,10 +10,7 @@ from PIL import Image
 import zerver.lib.upload
 from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.test_classes import UploadSerializeMixin, ZulipTestCase
-from zerver.lib.test_helpers import (
-    get_test_image_file,
-    read_test_image_file,
-)
+from zerver.lib.test_helpers import get_test_image_file, read_test_image_file
 from zerver.lib.upload import (
     all_message_attachments,
     delete_export_tarball,
@@ -24,18 +21,9 @@ from zerver.lib.upload import (
     upload_export_tarball,
     upload_message_attachment,
 )
-from zerver.lib.upload.base import (
-    DEFAULT_EMOJI_SIZE,
-    MEDIUM_AVATAR_SIZE,
-    resize_avatar,
-)
+from zerver.lib.upload.base import DEFAULT_EMOJI_SIZE, MEDIUM_AVATAR_SIZE, resize_avatar
 from zerver.lib.upload.local import write_local_file
-from zerver.models import (
-    Attachment,
-    RealmEmoji,
-    get_realm,
-    get_system_bot,
-)
+from zerver.models import Attachment, RealmEmoji, get_realm, get_system_bot
 
 
 class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):

--- a/zerver/tests/test_upload_s3.py
+++ b/zerver/tests/test_upload_s3.py
@@ -36,13 +36,7 @@ from zerver.lib.upload.base import (
     resize_avatar,
 )
 from zerver.lib.upload.s3 import S3UploadBackend
-from zerver.models import (
-    Attachment,
-    RealmEmoji,
-    UserProfile,
-    get_realm,
-    get_system_bot,
-)
+from zerver.models import Attachment, RealmEmoji, UserProfile, get_realm, get_system_bot
 
 
 class S3Test(ZulipTestCase):

--- a/zerver/tests/test_user_topics.py
+++ b/zerver/tests/test_user_topics.py
@@ -7,10 +7,7 @@ from django.utils.timezone import now as timezone_now
 from zerver.actions.user_topics import do_set_user_topic_visibility_policy
 from zerver.lib.stream_topic import StreamTopicTarget
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.lib.user_topics import (
-    get_topic_mutes,
-    topic_has_visibility_policy,
-)
+from zerver.lib.user_topics import get_topic_mutes, topic_has_visibility_policy
 from zerver.models import UserProfile, UserTopic, get_stream
 
 

--- a/zerver/views/message_send.py
+++ b/zerver/views/message_send.py
@@ -22,13 +22,7 @@ from zerver.lib.topic import REQ_topic
 from zerver.lib.validator import check_string_in, to_float
 from zerver.lib.zcommand import process_zcommands
 from zerver.lib.zephyr import compute_mit_user_fullname
-from zerver.models import (
-    Client,
-    Message,
-    RealmDomain,
-    UserProfile,
-    get_user_including_cross_realm,
-)
+from zerver.models import Client, Message, RealmDomain, UserProfile, get_user_including_cross_realm
 
 
 class InvalidMirrorInputError(Exception):

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -7,11 +7,7 @@ from django.views.decorators.http import require_POST
 
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
-from zerver.lib.validator import (
-    WildValue,
-    check_string,
-    to_wild_value,
-)
+from zerver.lib.validator import WildValue, check_string, to_wild_value
 
 
 @csrf_exempt

--- a/zerver/views/sentry.py
+++ b/zerver/views/sentry.py
@@ -9,10 +9,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.outgoing_http import OutgoingSession
-from zerver.lib.validator import (
-    check_url,
-    to_wild_value,
-)
+from zerver.lib.validator import check_url, to_wild_value
 
 
 class SentryTunnelSession(OutgoingSession):

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -130,9 +130,7 @@ from zerver.views.registration import (
     realm_register,
     signup_send_confirm,
 )
-from zerver.views.report import (
-    report_csp_violations,
-)
+from zerver.views.report import report_csp_violations
 from zerver.views.scheduled_messages import (
     create_scheduled_message_backend,
     delete_scheduled_messages,


### PR DESCRIPTION
isort did this by default, though it’s unclear whether that was intended; see https://github.com/astral-sh/ruff/issues/4153.