### PR TITLE
puppeteer: Use `stream_name` instead of `stream` for clarity.

### DIFF
--- a/web/e2e-tests/compose.test.ts
+++ b/web/e2e-tests/compose.test.ts
@@ -6,7 +6,7 @@ import * as common from "./lib/common";
 
 async function check_compose_form_empty(page: Page): Promise<void> {
     await common.check_compose_state(page, {
-        stream: "",
+        stream_name: "",
         topic: "",
         content: "",
     });
@@ -31,7 +31,7 @@ async function test_send_messages(page: Page): Promise<void> {
     const initial_msgs_count = (await page.$$("#zhome .message_row")).length;
 
     await common.send_multiple_messages(page, [
-        {stream: "Verona", topic: "Reply test", content: "Compose stream reply test"},
+        {stream_name: "Verona", topic: "Reply test", content: "Compose stream reply test"},
         {recipient: "cordelia@zulip.com", content: "Compose direct message reply test"},
     ]);
 
@@ -64,7 +64,7 @@ async function test_reply_by_click_prepopulates_stream_topic_names(page: Page): 
     // we chose only the last element make sure we don't click on any duplicates.
     await stream_message.click();
     await common.check_compose_state(page, {
-        stream: "Verona",
+        stream_name: "Verona",
         topic: "Reply test",
         content: "",
     });
@@ -91,7 +91,7 @@ async function test_reply_with_r_shortcut(page: Page): Promise<void> {
     await page.keyboard.press("KeyK");
     await page.keyboard.press("KeyR");
     await common.check_compose_state(page, {
-        stream: "Verona",
+        stream_name: "Verona",
         topic: "Reply test",
         content: "",
     });

--- a/web/e2e-tests/copy-and-paste.test.ts
+++ b/web/e2e-tests/copy-and-paste.test.ts
@@ -133,19 +133,19 @@ async function copy_paste_test(page: Page): Promise<void> {
     await page.waitForSelector("#zhome .message_row", {visible: true});
 
     await common.send_multiple_messages(page, [
-        {stream: "Verona", topic: "copy-paste-topic #1", content: "copy paste test A"},
+        {stream_name: "Verona", topic: "copy-paste-topic #1", content: "copy paste test A"},
 
-        {stream: "Verona", topic: "copy-paste-topic #1", content: "copy paste test B"},
+        {stream_name: "Verona", topic: "copy-paste-topic #1", content: "copy paste test B"},
 
-        {stream: "Verona", topic: "copy-paste-topic #2", content: "copy paste test C"},
+        {stream_name: "Verona", topic: "copy-paste-topic #2", content: "copy paste test C"},
 
-        {stream: "Verona", topic: "copy-paste-topic #2", content: "copy paste test D"},
+        {stream_name: "Verona", topic: "copy-paste-topic #2", content: "copy paste test D"},
 
-        {stream: "Verona", topic: "copy-paste-topic #2", content: "copy paste test E"},
+        {stream_name: "Verona", topic: "copy-paste-topic #2", content: "copy paste test E"},
 
-        {stream: "Verona", topic: "copy-paste-topic #3", content: "copy paste test F"},
+        {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test F"},
 
-        {stream: "Verona", topic: "copy-paste-topic #3", content: "copy paste test G"},
+        {stream_name: "Verona", topic: "copy-paste-topic #3", content: "copy paste test G"},
     ]);
 
     await common.check_messages_sent(page, "zhome", [

--- a/web/e2e-tests/drafts.test.ts
+++ b/web/e2e-tests/drafts.test.ts
@@ -117,7 +117,7 @@ async function test_restore_message_draft_via_draft_overlay(page: Page): Promise
     await page.waitForSelector("#stream_message_recipient_topic", {visible: true});
     await page.waitForSelector("#preview_message_area", {hidden: true});
     await common.check_compose_state(page, {
-        stream: "Denmark",
+        stream_name: "Denmark",
         topic: "tests",
         content: "Test stream message.",
     });

--- a/web/e2e-tests/edit.test.ts
+++ b/web/e2e-tests/edit.test.ts
@@ -31,7 +31,7 @@ async function edit_stream_message(page: Page, content: string): Promise<void> {
 
 async function test_stream_message_edit(page: Page): Promise<void> {
     await common.send_message(page, "stream", {
-        stream: "Verona",
+        stream_name: "Verona",
         topic: "edits",
         content: "test editing",
     });
@@ -45,7 +45,7 @@ async function test_edit_message_with_slash_me(page: Page): Promise<void> {
     const last_message_xpath = `(//*[@id="zhome"]//*[${common.has_class_x("messagebox")}])[last()]`;
 
     await common.send_message(page, "stream", {
-        stream: "Verona",
+        stream_name: "Verona",
         topic: "edits",
         content: "/me test editing a message with me",
     });

--- a/web/e2e-tests/lib/common.ts
+++ b/web/e2e-tests/lib/common.ts
@@ -17,7 +17,7 @@ const puppeteer_dir = path.join(root_dir, "var/puppeteer");
 type Message = Record<string, string | boolean> & {
     recipient?: string;
     content: string;
-    stream?: string;
+    stream_name?: string;
 };
 
 let browser: Browser | null = null;
@@ -208,13 +208,13 @@ export async function check_compose_state(
     params: Record<string, string>,
 ): Promise<void> {
     const form_params: Record<string, string> = {content: params.content};
-    if (params.stream) {
+    if (params.stream_name) {
         assert.equal(
             await get_text_from_selector(
                 page,
                 "#compose_select_recipient_widget .dropdown_widget_value",
             ),
-            params.stream,
+            params.stream_name,
         );
     }
     if (params.topic) {
@@ -433,9 +433,9 @@ export async function send_message(
         assert.fail("`send_message` got invalid message type");
     }
 
-    if (params.stream) {
-        await select_stream_in_compose_via_dropdown(page, params.stream);
-        delete params.stream;
+    if (params.stream_name) {
+        await select_stream_in_compose_via_dropdown(page, params.stream_name);
+        delete params.stream_name;
     }
 
     if (params.topic) {
@@ -464,7 +464,7 @@ export async function send_message(
 
 export async function send_multiple_messages(page: Page, msgs: Message[]): Promise<void> {
     for (const msg of msgs) {
-        await send_message(page, msg.stream !== undefined ? "stream" : "private", msg);
+        await send_message(page, msg.stream_name !== undefined ? "stream" : "private", msg);
     }
 }
 

--- a/web/e2e-tests/message-basics.test.ts
+++ b/web/e2e-tests/message-basics.test.ts
@@ -482,14 +482,14 @@ async function message_basic_tests(page: Page): Promise<void> {
 
     console.log("Sending messages");
     await common.send_multiple_messages(page, [
-        {stream: "Verona", topic: "test", content: "verona test a"},
-        {stream: "Verona", topic: "test", content: "verona test b"},
-        {stream: "Verona", topic: "other topic", content: "verona other topic c"},
-        {stream: "Denmark", topic: "test", content: "denmark message"},
+        {stream_name: "Verona", topic: "test", content: "verona test a"},
+        {stream_name: "Verona", topic: "test", content: "verona test b"},
+        {stream_name: "Verona", topic: "other topic", content: "verona other topic c"},
+        {stream_name: "Denmark", topic: "test", content: "denmark message"},
         {recipient: "cordelia@zulip.com, hamlet@zulip.com", content: "group direct message a"},
         {recipient: "cordelia@zulip.com, hamlet@zulip.com", content: "group direct message b"},
         {recipient: "cordelia@zulip.com", content: "direct message c"},
-        {stream: "Verona", topic: "test", content: "verona test d"},
+        {stream_name: "Verona", topic: "test", content: "verona test d"},
         {recipient: "cordelia@zulip.com, hamlet@zulip.com", content: "group direct message d"},
         {recipient: "cordelia@zulip.com", content: "direct message e"},
     ]);

--- a/web/e2e-tests/stars.test.ts
+++ b/web/e2e-tests/stars.test.ts
@@ -41,7 +41,7 @@ async function stars_test(page: Page): Promise<void> {
     await page.click(".top_left_all_messages");
     await page.waitForSelector("#zhome .message_row", {visible: true});
     await common.send_message(page, "stream", {
-        stream: "Verona",
+        stream_name: "Verona",
         topic: "stars",
         content: message,
     });


### PR DESCRIPTION
Doing this as part of my work to move towards `stream_id` -- though this should stay as a name because end-to-end tests do things visually and need to look for the string on the screen.