### PR TITLE
dropdown_widget: Show disabled if value not in options.

### DIFF
--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -1043,6 +1043,7 @@ export function init_dropdown_widgets() {
         },
         default_id: page_params.realm_notifications_stream_id,
         unique_id_type: dropdown_widget.DATA_TYPES.NUMBER,
+        show_disabled_if_current_value_not_in_options: true,
     });
     notifications_stream_widget.setup();
 
@@ -1062,6 +1063,7 @@ export function init_dropdown_widgets() {
         },
         default_id: page_params.realm_signup_notifications_stream_id,
         unique_id_type: dropdown_widget.DATA_TYPES.NUMBER,
+        show_disabled_if_current_value_not_in_options: true,
     });
     signup_notifications_stream_widget.setup();
 


### PR DESCRIPTION
It is possible that the current value of a dropdown widget is valid but not present in options since the current user doesn't have access it. So, we show [disabled] as value in that case.

This can be reproduced by setting a private stream for notifications in org settings and then opening org settings as a user which doesn't have access to the private stream.

discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/organisation.20settings.20dropdown.20widgets.20not.20initializing