### PR TITLE
help: Update "Star a message" and document mobile features.

### DIFF
--- a/help/star-a-message.md
+++ b/help/star-a-message.md
@@ -12,17 +12,25 @@ tasks you need to go back to or documents you reference often.
 
 1. Click the **star** (<i class="fa fa-star-o"></i>) icon.
 
+!!! tip ""
+
+    Starred messages have a filled in star (<i class="fa fa-star"></i>) to their
+    right. You can unstar a message using the same instructions used to star it.
+
 {tab|mobile}
 
-1. Long press on a message.
+{!message-long-press-menu.md!}
 
-1. Select **Star message** in the menu that appears.
+1. Tap **Star message**.
+
+!!! tip ""
+
+    Starred messages have a "starred" label in the bottom right corner of the
+    message. You can unstar a message by tapping **Unstar message** in the
+    long-press menu.
 
 {end_tabs}
 
-Starred messages have a filled in star (<i class="fa fa-star"></i>) to
-their right.  You can unstar a message using the same instructions
-used to star it.
 
 ## View your starred messages
 

--- a/help/star-a-message.md
+++ b/help/star-a-message.md
@@ -39,6 +39,12 @@ tasks you need to go back to or documents you reference often.
 
 {relative|message|starred}
 
+{tab|mobile}
+
+1. Tap the **Starred messages**
+   (<img src="/static/images/help/mobile-star-icon.svg" alt="star" class="mobile-icon"/>)
+   tab at the top of the app.
+
 {end_tabs}
 
 ## Toggle starred messages counter

--- a/help/star-a-message.md
+++ b/help/star-a-message.md
@@ -31,11 +31,17 @@ tasks you need to go back to or documents you reference often.
 
 {end_tabs}
 
-
 ## View your starred messages
 
-You can view your starred messages by clicking **Starred messages** in the
-left sidebar, or by [searching](/help/search-for-messages) for `is:starred`.
+{start_tabs}
+
+{tab|desktop}
+
+{relative|message|starred}
+
+{end_tabs}
+
+## Toggle starred messages counter
 
 By default, Zulip displays the number of starred messages in the left
 sidebar; this allows you to use them as an inbox of messages you'd
@@ -44,6 +50,8 @@ else and would prefer not to see the count in your left sidebar, you
 can disable that feature.
 
 {start_tabs}
+
+{tab|desktop-web}
 
 {settings_tab|preferences}
 
@@ -55,3 +63,4 @@ can disable that feature.
 
 * [Marking messages as unread](/help/marking-messages-as-unread)
 * [Reading strategies](/help/reading-strategies)
+* [Searching for messages](/help/search-for-messages)

--- a/static/images/help/mobile-star-icon.svg
+++ b/static/images/help/mobile-star-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-star">
+    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+</svg>

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -96,11 +96,17 @@ all_instructions = """
    sidebar or use the <kbd>A</kbd> keyboard shortcut.
 """
 
+starred_instructions = """
+1. Click on <i class="fa fa-star"></i> **Starred messages** in the left
+   sidebar, or by [searching](/help/search-for-messages) for `is:starred`.
+"""
+
 message_info = {
     "drafts": ["Drafts", "/#drafts", draft_instructions],
     "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
     "recent": ["Recent conversations", "/#recent", recent_instructions],
     "all": ["All messages", "/#all_messages", all_instructions],
+    "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
 }
 
 


### PR DESCRIPTION
- Updates [Star a message](https://zulip.com/help/star-a-message) mobile instructions.
- Updates "View your starred messages" section.
- Adds instructions block and relative link to Starred messages.
- Adds "Toggle starred messages counter" subheading.
-  Documents "Starred messages" mobile feature.
- Adds "Searching for messages" as a related article.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/a18da506-44d1-4be9-8ef6-b6d306675ef4)

![image](https://github.com/zulip/zulip/assets/2343554/b6c141e2-c1ac-473d-acb4-4868bf300e67)

<img width="250" alt="image" src="https://github.com/zulip/zulip/assets/2343554/3cbad16f-0361-4d8b-882e-84df645e6c45">

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>