### PR TITLE
settings: Remove bot-email field from edit-bot modal.

### DIFF
--- a/web/templates/settings/edit_bot_form.hbs
+++ b/web/templates/settings/edit_bot_form.hbs
@@ -5,10 +5,6 @@
             <input type="text" autocomplete="off" name="full_name" id="edit_bot_full_name" class="modal_text_input" value="{{ full_name }}" />
         </div>
         <input type="hidden" name="is_full_name" value="true" />
-        <div class="input-group email_change_container">
-            <label for="email">{{t "Email" }}</label>
-            <input type="text" autocomplete="off" name="email" class="modal_text_input" value="{{ email }}" readonly/>
-        </div>
         <div class="input-group user_id_container">
             <label for="user_id">{{t "User ID" }}</label>
             <input type="text" autocomplete="off" name="user_id" class="modal_text_input" value="{{ user_id }}" readonly/>


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR removes the BOT EMAIL field from the *Mange Bot* modal.  The issue had 4 points with 2 marked as completed. I observed the third has also been completed with USERNAME now written as BOT EMAIL.(https://github.com/zulip/zulip/issues/13162).  This PR addresses the 4th point which is to remove the BOT EMAIL field from the Edit bot modal now. I noticed this is now Manage Bot while working.

Fixes: <!-- Issue link, or clear description.-->
https://github.com/zulip/zulip/issues/10617

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
<p align="center"><p>This has always been this way</p>
<img src="https://github.com/zulip/zulip/assets/74251163/5760e2c4-c502-4908-994d-bc936abca59b" width="500px" alt="bot-profile" />
</p>

<table>
 <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
<td><img src="https://github.com/zulip/zulip/assets/74251163/206d00c4-ccf5-4cf4-a7f3-8c66ca6daaf8" width="400px" alt="Before"></td>
    <td><img src="https://github.com/zulip/zulip/assets/74251163/a1435f24-1010-42a2-92dc-7b171597bc5d" width="400px" alt="After"></td>
    
  </tr>
</table>



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x ] Explains differences from previous plans (e.g., issue description).
- [x ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x ] Each commit is a coherent idea.
- [x ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x ] Visual appearance of the changes.
- [x ] Responsiveness and internationalization.
- [x ] Strings and tooltips.
- [x ] End-to-end functionality of buttons, interactions and flows.
- [x ] Corner cases, error conditions, and easily imagined bugs.
</details>
