### PR TITLE
Use stream_id (instead of name) for messages and drafts.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -131,7 +131,7 @@ export function create_message_object() {
         content: compose_state.message_content(),
         sender_id: page_params.user_id,
         queue_id: page_params.queue_id,
-        stream: "",
+        stream_id: "",
     };
     message.topic = "";
 
@@ -156,8 +156,6 @@ export function create_message_object() {
         const stream_id = compose_state.stream_id();
         message.stream_id = stream_id;
         message.to = stream_id;
-        const stream = stream_data.get_sub_by_id(stream_id);
-        message.stream = stream ? stream.name : "";
     }
     return message;
 }

--- a/web/src/compose_closed_ui.js
+++ b/web/src/compose_closed_ui.js
@@ -6,6 +6,7 @@ import * as message_lists from "./message_lists";
 import * as message_store from "./message_store";
 import * as narrow_state from "./narrow_state";
 import * as people from "./people";
+import * as stream_data from "./stream_data";
 
 export function get_recipient_label(message) {
     // TODO: This code path is bit of a type-checking disaster; we mix
@@ -19,8 +20,10 @@ export function get_recipient_label(message) {
             // i.e. stream+topic or a single direct message conversation,
             // we label the button as replying to the thread.
             if (narrow_state.narrowed_to_topic()) {
+                const stream = narrow_state.stream_sub();
+                const stream_id = stream?.stream_id;
                 message = {
-                    stream: narrow_state.stream_name(),
+                    stream_id,
                     topic: narrow_state.topic(),
                 };
             } else if (narrow_state.pm_ids_string()) {
@@ -44,8 +47,11 @@ export function get_recipient_label(message) {
     }
 
     if (message) {
-        if (message.stream && message.topic) {
-            return "#" + message.stream + " > " + message.topic;
+        if (message.stream_id && message.topic) {
+            const stream = stream_data.get_sub_by_id(message.stream_id);
+            if (stream) {
+                return "#" + stream.name + " > " + message.topic;
+            }
         } else if (message.display_reply_to) {
             return message.display_reply_to;
         }

--- a/web/src/desktop_integration.js
+++ b/web/src/desktop_integration.js
@@ -4,6 +4,7 @@ import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as message_store from "./message_store";
 import * as narrow from "./narrow";
+import * as stream_data from "./stream_data";
 
 if (window.electron_bridge !== undefined) {
     window.electron_bridge.on_event("logout", () => {
@@ -30,9 +31,13 @@ if (window.electron_bridge !== undefined) {
         const data = {
             type: message.type,
             content: reply,
-            to: message.type === "private" ? message.reply_to : message.stream,
             topic: message.topic,
         };
+        if (message.type === "private") {
+            data.to = message.reply_to;
+        } else {
+            data.to = stream_data.get_stream_name_from_id(message.stream_id);
+        }
 
         function success() {
             if (message.type === "stream") {

--- a/web/src/drafts.js
+++ b/web/src/drafts.js
@@ -200,8 +200,6 @@ export function snapshot_message() {
         message.private_message_recipient = recipient;
     } else {
         message.stream_id = compose_state.stream_id();
-        const sub = stream_data.get_sub_by_id(message.stream_id);
-        message.stream = sub ? sub.name : "";
         message.topic = compose_state.topic();
     }
     return message;
@@ -217,7 +215,7 @@ export function restore_message(draft) {
     if (draft.type === "stream") {
         compose_args = {
             type: "stream",
-            stream: draft.stream,
+            stream_id: draft.stream_id,
             topic: draft.topic,
             content: draft.content,
         };

--- a/web/src/echo.js
+++ b/web/src/echo.js
@@ -19,6 +19,7 @@ import * as popovers from "./popovers";
 import * as recent_topics_data from "./recent_topics_data";
 import * as rows from "./rows";
 import * as sent_messages from "./sent_messages";
+import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_topic_history from "./stream_topic_history";
 import * as transmit from "./transmit";
@@ -112,7 +113,7 @@ function resend_message(message, $row, on_send_message_success) {
 
 export function build_display_recipient(message) {
     if (message.type === "stream") {
-        return message.stream;
+        return stream_data.get_stream_name_from_id(message.stream_id);
     }
 
     // Build a display recipient with the full names of each

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -41,6 +41,7 @@ import * as search from "./search";
 import * as settings_data from "./settings_data";
 import * as spectators from "./spectators";
 import * as starred_messages_ui from "./starred_messages_ui";
+import * as stream_data from "./stream_data";
 import * as stream_list from "./stream_list";
 import * as stream_popover from "./stream_popover";
 import * as stream_settings_ui from "./stream_settings_ui";
@@ -1068,7 +1069,10 @@ export function process_hotkey(e, hotkey) {
                 case "stream":
                     narrow.activate(
                         [
-                            {operator: "stream", operand: msg.stream},
+                            {
+                                operator: "stream",
+                                operand: stream_data.get_stream_name_from_id(msg.stream_id),
+                            },
                             {operator: "topic", operand: msg.topic},
                             {operator: "near", operand: msg.id},
                         ],

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -32,6 +32,7 @@ import {page_params} from "./page_params";
 import * as resize from "./resize";
 import * as rows from "./rows";
 import * as settings_data from "./settings_data";
+import * as stream_data from "./stream_data";
 import * as timerender from "./timerender";
 import {show_copied_confirmation} from "./tippyjs";
 import * as ui_report from "./ui_report";
@@ -727,9 +728,10 @@ export function start_inline_topic_edit($recipient_row) {
     }
     const $inline_topic_edit_input = $form.find(".inline_topic_edit");
     $inline_topic_edit_input.val(topic).trigger("select").trigger("focus");
+    const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
     composebox_typeahead.initialize_topic_edit_typeahead(
         $inline_topic_edit_input,
-        message.stream,
+        stream_name,
         false,
     );
 }

--- a/web/src/message_events.js
+++ b/web/src/message_events.js
@@ -360,7 +360,6 @@ export function update_messages(events) {
                 if (stream_changed) {
                     const new_stream_name = sub_store.get(new_stream_id).name;
                     moved_message.stream_id = new_stream_id;
-                    moved_message.stream = new_stream_name;
                     moved_message.display_recipient = new_stream_name;
                 }
 

--- a/web/src/message_helper.js
+++ b/web/src/message_helper.js
@@ -43,7 +43,6 @@ export function process_new_message(message) {
     switch (message.type) {
         case "stream":
             message.is_stream = true;
-            message.stream = message.display_recipient;
             message.reply_to = message.sender_email;
 
             stream_topic_history.add_message({

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -190,7 +190,9 @@ function populate_group_from_message_container(group, message_container) {
         const color = stream_data.get_color(message_container.msg.stream_id);
         group.recipient_bar_color = stream_color.get_recipient_bar_color(color);
         group.stream_privacy_icon_color = stream_color.get_stream_privacy_icon_color(color);
-        group.invite_only = stream_data.is_invite_only_by_stream_name(message_container.msg.stream);
+        group.invite_only = stream_data.is_invite_only_by_stream_id(
+            message_container.msg.stream_id,
+        );
         group.is_web_public = stream_data.is_web_public(message_container.msg.stream_id);
         group.topic = message_container.msg.topic;
         group.match_topic = util.get_match_topic(message_container.msg);

--- a/web/src/message_list_view.js
+++ b/web/src/message_list_view.js
@@ -409,7 +409,7 @@ export class MessageListView {
         message_container.sender_is_guest = people.sender_is_guest(message_container.msg);
 
         message_container.small_avatar_url = people.small_avatar_url(message_container.msg);
-        if (message_container.msg.stream) {
+        if (message_container.msg.stream_id) {
             message_container.background_color = stream_data.get_color(
                 message_container.msg.stream_id,
             );
@@ -438,19 +438,20 @@ export class MessageListView {
 
         const last_subscribed = !last_msg_container.msg.historical;
         const first_subscribed = !first_msg_container.msg.historical;
-        const stream = first_msg_container.msg.stream;
+        const stream_id = first_msg_container.msg.stream_id;
+        const stream_name = stream_data.get_stream_name_from_id(stream_id);
 
         if (!last_subscribed && first_subscribed) {
             group.bookend_top = true;
             group.subscribed = true;
-            group.stream_name = stream;
+            group.stream_name = stream_name;
             return;
         }
 
         if (last_subscribed && !first_subscribed) {
             group.bookend_top = true;
             group.just_unsubscribed = true;
-            group.stream_name = stream;
+            group.stream_name = stream_name;
             return;
         }
     }
@@ -508,7 +509,7 @@ export class MessageListView {
 
                 this.maybe_add_subscription_marker(current_group, prev, message_container);
 
-                if (message_container.msg.stream) {
+                if (message_container.msg.stream_id) {
                     message_container.stream_url = hash_util.by_stream_url(
                         message_container.msg.stream_id,
                     );

--- a/web/src/message_store.js
+++ b/web/src/message_store.js
@@ -108,7 +108,6 @@ export function update_property(property, value, info) {
             for (const msg of stored_messages.values()) {
                 if (msg.stream_id && msg.stream_id === info.stream_id) {
                     msg.display_recipient = value;
-                    msg.stream = value;
                 }
             }
             break;

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -942,7 +942,7 @@ export function by_recipient(target_id, opts) {
                 // in the new view.
                 unread_ops.notify_server_message_read(message);
             }
-            by("stream", message.stream, opts);
+            by("stream", stream_data.get_stream_name_from_id(message.stream_id));
             break;
     }
 }

--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -231,7 +231,8 @@ export function process_notification(notification) {
             .slice(", ".length, -", ".length);
         notification_source = "pm";
     } else {
-        key = message.sender_full_name + " to " + message.stream + " > " + topic;
+        const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
+        key = message.sender_full_name + " to " + stream_name + " > " + topic;
         if (message.mentioned) {
             notification_source = "mention";
         } else if (message.alerted) {
@@ -277,7 +278,8 @@ export function process_notification(notification) {
     }
 
     if (message.type === "stream") {
-        title += " (to " + message.stream + " > " + topic + ")";
+        const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
+        title += " (to " + stream_name + " > " + topic + ")";
     }
 
     if (notification.desktop_notify) {
@@ -559,7 +561,8 @@ export function send_test_notification(content) {
 // Handlebars templates that will do further escaping.
 function get_message_header(message) {
     if (message.type === "stream") {
-        return `#${message.stream} > ${message.topic}`;
+        const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
+        return `#${stream_name} > ${message.topic}`;
     }
     if (message.display_recipient.length > 2) {
         return $t(

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -512,11 +512,11 @@ export function process_topic_edit(old_stream_id, old_topic, new_topic, new_stre
     process_messages(new_topic_msgs);
 }
 
-export function topic_in_search_results(keyword, stream, topic) {
+export function topic_in_search_results(keyword, stream_name, topic) {
     if (keyword === "") {
         return true;
     }
-    const text = (stream + " " + topic).toLowerCase();
+    const text = (stream_name + " " + topic).toLowerCase();
     const search_words = keyword.toLowerCase().split(/\s+/);
     return search_words.every((word) => text.includes(word));
 }

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -213,8 +213,10 @@ function set_table_focus(row, col, using_keyboard) {
             display_reply_to: $topic_row.find(".recent_topic_name a").text(),
         };
     } else {
+        const stream_name = $topic_row.find(".recent_topic_stream a").text();
+        const stream = stream_data.get_sub_by_name(stream_name);
         message = {
-            stream: $topic_row.find(".recent_topic_stream a").text(),
+            stream_id: stream?.stream_id,
             topic: $topic_row.find(".recent_topic_name a").text(),
         };
     }
@@ -382,7 +384,7 @@ function format_conversation(conversation_data) {
 
         // Stream info
         context.stream_id = last_msg.stream_id;
-        context.stream = last_msg.stream;
+        context.stream_name = stream_data.get_stream_name_from_id(last_msg.stream_id);
         context.stream_muted = stream_info.is_muted;
         context.stream_color = stream_info.color;
         context.stream_url = hash_util.by_stream_url(context.stream_id);
@@ -574,7 +576,8 @@ export function filters_should_hide_topic(topic_data) {
     }
 
     const search_keyword = $("#recent_topics_search").val();
-    if (!topic_in_search_results(search_keyword, msg.stream, msg.topic)) {
+    const stream_name = stream_data.get_stream_name_from_id(msg.stream_id);
+    if (!topic_in_search_results(search_keyword, stream_name, msg.topic)) {
         return true;
     }
 
@@ -723,7 +726,9 @@ function stream_sort(a, b) {
         const b_msg = message_store.get(b.last_msg_id);
 
         if (a.type === "stream") {
-            return sort_comparator(a_msg.stream, b_msg.stream);
+            const a_stream_name = stream_data.get_stream_name_from_id(a_msg.stream_id);
+            const b_stream_name = stream_data.get_stream_name_from_id(b_msg.stream_id);
+            return sort_comparator(a_stream_name, b_stream_name);
         }
         return sort_comparator(a_msg.display_reply_to, b_msg.display_reply_to);
     }

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -258,6 +258,10 @@ export function get_stream_id(name: string): number | undefined {
     return stream_id;
 }
 
+export function get_stream_name_from_id(stream_id: number): string {
+    return get_sub_by_id(stream_id)?.name ?? "";
+}
+
 export function get_sub_by_name(name: string): StreamSubscription | undefined {
     // Note: Only use this function for situations where
     // you are comfortable with a user dealing with an

--- a/web/src/stream_data.ts
+++ b/web/src/stream_data.ts
@@ -679,8 +679,8 @@ export function is_web_public(stream_id: number): boolean {
     return sub ? sub.is_web_public : false;
 }
 
-export function is_invite_only_by_stream_name(stream_name: string): boolean {
-    const sub = get_sub(stream_name);
+export function is_invite_only_by_stream_id(stream_id: number): boolean {
+    const sub = get_sub_by_id(stream_id);
     if (sub === undefined) {
         return false;
     }

--- a/web/src/transmit.js
+++ b/web/src/transmit.js
@@ -7,6 +7,7 @@ import * as people from "./people";
 import * as reload from "./reload";
 import * as reload_state from "./reload_state";
 import * as sent_messages from "./sent_messages";
+import * as stream_data from "./stream_data";
 
 export function send_message(request, on_success, error) {
     if (!request.resend) {
@@ -91,14 +92,14 @@ export function reply_message(opts) {
     });
 
     if (message.type === "stream") {
-        const stream = message.stream;
+        const stream_name = stream_data.get_stream_name_from_id(message.stream_id);
 
         const mention = people.get_mention_syntax(message.sender_full_name, message.sender_id);
 
         content = mention + " " + content;
 
         reply.type = "stream";
-        reply.to = stream;
+        reply.to = stream_name;
         reply.content = content;
         reply.topic = message.topic;
 

--- a/web/templates/recent_topic_row.hbs
+++ b/web/templates/recent_topic_row.hbs
@@ -9,7 +9,7 @@
                 <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
                     {{> stream_privacy }}
                 </span>
-                <a href="{{topic_url}}">{{stream}}</a>
+                <a href="{{topic_url}}">{{stream_name}}</a>
                 {{/if}}
             </div>
             {{!-- For presence/group indicator --}}

--- a/web/tests/compose.test.js
+++ b/web/tests/compose.test.js
@@ -198,7 +198,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
                 sender_id: new_user.user_id,
                 queue_id: undefined,
                 resend: false,
-                stream: "",
+                stream_id: "",
                 topic: "",
                 to: `[${alice.user_id}]`,
                 reply_to: "alice@example.com",

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -280,7 +280,6 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
 
     msg = {
         type: "stream",
-        stream: denmark.name,
         stream_id: denmark.stream_id,
         topic: "python",
     };
@@ -312,7 +311,6 @@ test("reply_with_mention", ({override, override_rewire, mock_template}) => {
 
     const msg = {
         type: "stream",
-        stream: denmark.name,
         stream_id: denmark.stream_id,
         topic: "python",
         sender_full_name: "Bob Roberts",
@@ -378,9 +376,15 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
         replaced = true;
     });
 
+    const denmark_stream = {
+        subscribed: false,
+        name: "Denmark",
+        stream_id: 20,
+    };
+
     selected_message = {
         type: "stream",
-        stream: "Denmark",
+        stream_id: denmark_stream.stream_id,
         topic: "python",
         sender_full_name: "Steve Stephenson",
         sender_id: 90,
@@ -419,7 +423,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
 
     selected_message = {
         type: "stream",
-        stream: "Denmark",
+        stream_id: denmark_stream.stream_id,
         topic: "test",
         sender_full_name: "Steve Stephenson",
         sender_id: 90,
@@ -433,7 +437,7 @@ test("quote_and_reply", ({disallow, override, override_rewire}) => {
 
     selected_message = {
         type: "stream",
-        stream: "Denmark",
+        stream_id: denmark_stream.stream_id,
         topic: "test",
         sender_full_name: "Steve Stephenson",
         sender_id: 90,

--- a/web/tests/compose_closed_ui.test.js
+++ b/web/tests/compose_closed_ui.test.js
@@ -24,6 +24,7 @@ function MessageListView() {
 mock_esm("../src/message_list_view", {
     MessageListView,
 });
+const stream_data = zrequire("stream_data");
 // Code we're actually using/testing
 const compose_closed_ui = zrequire("compose_closed_ui");
 const {Filter} = zrequire("filter");
@@ -48,25 +49,37 @@ run_test("reply_label", () => {
         filter,
     });
     message_lists.current = list;
+    const stream_one = {
+        subscribed: true,
+        name: "first_stream",
+        stream_id: 1,
+    };
+    stream_data.add_sub(stream_one);
+    const stream_two = {
+        subscribed: true,
+        name: "second_stream",
+        stream_id: 2,
+    };
+    stream_data.add_sub(stream_two);
     list.add_messages([
         {
             id: 0,
-            stream: "first_stream",
+            stream_id: stream_one.stream_id,
             topic: "first_topic",
         },
         {
             id: 1,
-            stream: "first_stream",
+            stream_id: stream_one.stream_id,
             topic: "second_topic",
         },
         {
             id: 2,
-            stream: "second_stream",
+            stream_id: stream_two.stream_id,
             topic: "third_topic",
         },
         {
             id: 3,
-            stream: "second_stream",
+            stream_id: stream_two.stream_id,
             topic: "second_topic",
         },
         {
@@ -105,8 +118,14 @@ run_test("reply_label", () => {
 });
 
 run_test("test_custom_message_input", () => {
+    const stream = {
+        subscribed: true,
+        name: "stream test",
+        stream_id: 10,
+    };
+    stream_data.add_sub(stream);
     compose_closed_ui.update_reply_recipient_label({
-        stream: "stream test",
+        stream_id: stream.stream_id,
         topic: "topic test",
     });
     test_reply_label("#stream test > topic test");

--- a/web/tests/compose_ui.test.js
+++ b/web/tests/compose_ui.test.js
@@ -249,9 +249,15 @@ run_test("compute_placeholder_text", () => {
 });
 
 run_test("quote_and_reply", ({override, override_rewire}) => {
+    const devel_stream = {
+        subscribed: false,
+        name: "devel",
+        stream_id: 20,
+    };
+
     const selected_message = {
         type: "stream",
-        stream: "devel",
+        stream_id: devel_stream.stream_id,
         topic: "python",
         sender_full_name: "Steve Stephenson",
         sender_id: 90,

--- a/web/tests/drafts.test.js
+++ b/web/tests/drafts.test.js
@@ -656,7 +656,7 @@ test("filter_drafts", ({override_rewire, mock_template}) => {
         updatedAt: date(-1),
     };
     const stream_draft_2 = {
-        stream: "stream 2",
+        stream: "stream 2", // TODO_STREAM_ID
         topic: "topic",
         type: "stream",
         content: "Test stream message 2",

--- a/web/tests/echo.test.js
+++ b/web/tests/echo.test.js
@@ -54,6 +54,14 @@ message_lists.all_rendered_message_lists = () => [message_lists.home, message_li
 const drafts = zrequire("drafts");
 const echo = zrequire("echo");
 const people = zrequire("people");
+const stream_data = zrequire("stream_data");
+
+const general_sub = {
+    stream_id: 101,
+    name: "general",
+    subscribed: true,
+};
+stream_data.add_sub(general_sub);
 
 run_test("process_from_server for un-echoed messages", () => {
     const waiting_for_ack = new Map();
@@ -138,7 +146,7 @@ run_test("build_display_recipient", () => {
 
     let message = {
         type: "stream",
-        stream: "general",
+        stream_id: general_sub.stream_id,
         sender_email: "iago@zulip.com",
         sender_full_name: "Iago",
         sender_id: 123,
@@ -237,7 +245,7 @@ run_test("insert_local_message streams", ({override}) => {
 
     const message_request = {
         type: "stream",
-        stream: "general",
+        stream_id: general_sub.stream_id,
         sender_email: "iago@zulip.com",
         sender_full_name: "Iago",
         sender_id: 123,
@@ -304,7 +312,7 @@ run_test("test reify_message_id", ({override}) => {
 
     const message_request = {
         type: "stream",
-        stream: "general",
+        stream_id: general_sub.stream_id,
         sender_email: "iago@zulip.com",
         sender_full_name: "Iago",
         sender_id: 123,

--- a/web/tests/message_events.test.js
+++ b/web/tests/message_events.test.js
@@ -142,7 +142,6 @@ run_test("update_messages", () => {
             sent_by_me: false,
             starred: false,
             status_emoji_info: undefined,
-            stream: denmark.name,
             stream_id: denmark.stream_id,
             topic: "lunch",
             type: "stream",

--- a/web/tests/message_list_view.test.js
+++ b/web/tests/message_list_view.test.js
@@ -417,7 +417,6 @@ test("merge_message_groups", () => {
             id: _.uniqueId("test_message_"),
             status_message: false,
             type: "stream",
-            stream: "Test stream 1",
             stream_id: 2,
             topic: "Test topic 1",
             sender_email: "test@example.com",

--- a/web/tests/message_store.test.js
+++ b/web/tests/message_store.test.js
@@ -149,7 +149,6 @@ test("process_new_message", () => {
     };
 
     message_helper.process_new_message(message);
-    assert.deepEqual(message.stream, message.display_recipient);
     assert.equal(message.reply_to, "denise@example.com");
     assert.deepEqual(message.flags, undefined);
     assert.equal(message.alerted, false);
@@ -292,7 +291,6 @@ test("update_property", () => {
         sender_id: alice.user_id,
         small_avatar_url: "alice_url",
         stream_id: devel.stream_id,
-        stream: devel.name,
         display_recipient: devel.name,
         id: 100,
     };
@@ -302,7 +300,6 @@ test("update_property", () => {
         sender_id: bob.user_id,
         small_avatar_url: "bob_url",
         stream_id: denmark.stream_id,
-        stream: denmark.name,
         display_recipient: denmark.name,
         id: 101,
     };
@@ -322,14 +319,14 @@ test("update_property", () => {
     assert.equal(message1.small_avatar_url, "alice_url");
     assert.equal(message2.small_avatar_url, "bobby_url");
 
-    assert.equal(message1.stream, devel.name);
+    assert.equal(message1.stream_id, devel.stream_id);
     assert.equal(message1.display_recipient, devel.name);
-    assert.equal(message2.stream, denmark.name);
+    assert.equal(message2.stream_id, denmark.stream_id);
     assert.equal(message2.display_recipient, denmark.name);
     message_store.update_property("stream_name", "Prod", {stream_id: devel.stream_id});
-    assert.equal(message1.stream, "Prod");
+    assert.equal(message1.stream_id, devel.stream_id);
     assert.equal(message1.display_recipient, "Prod");
-    assert.equal(message2.stream, denmark.name);
+    assert.equal(message2.stream_id, denmark.stream_id);
     assert.equal(message2.display_recipient, denmark.name);
 });
 

--- a/web/tests/notifications.test.js
+++ b/web/tests/notifications.test.js
@@ -79,7 +79,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "whatever",
     };
@@ -101,7 +100,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "whatever",
     };
@@ -120,7 +118,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "muted",
         stream_id: muted.stream_id,
         topic: "topic_three",
     };
@@ -140,7 +137,6 @@ test("message_is_notifiable", () => {
         mentioned: false,
         mentioned_me_directly: false,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "followed topic",
     };
@@ -169,7 +165,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "vanilla",
     };
@@ -188,7 +183,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: false,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "vanilla",
     };
@@ -223,7 +217,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: false,
         type: "stream",
-        stream: "muted",
         stream_id: muted.stream_id,
         topic: "whatever",
     };
@@ -242,7 +235,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "muted",
         stream_id: muted.stream_id,
         topic: "whatever",
     };
@@ -261,7 +253,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: false,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "muted topic",
     };
@@ -286,7 +277,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: false,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "followed topic",
     };
@@ -316,7 +306,6 @@ test("message_is_notifiable", () => {
         mentioned: true,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "whatever",
     };
@@ -340,7 +329,6 @@ test("message_is_notifiable", () => {
         mentioned: false,
         mentioned_me_directly: false,
         type: "stream",
-        stream: "general",
         stream_id: general.stream_id,
         topic: "whatever",
     };
@@ -387,8 +375,7 @@ test("basic_notifications", () => {
         notification_sent: false,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "general",
-        stream_id: muted.stream_id,
+        stream_id: general.stream_id,
         topic: "whatever",
     };
 
@@ -401,8 +388,7 @@ test("basic_notifications", () => {
         notification_sent: false,
         mentioned_me_directly: true,
         type: "stream",
-        stream: "general",
-        stream_id: muted.stream_id,
+        stream_id: general.stream_id,
         topic: "lunch",
     };
 

--- a/web/tests/recent_topics.test.js
+++ b/web/tests/recent_topics.test.js
@@ -132,6 +132,7 @@ mock_esm("../src/stream_data", {
         // We only test via muted topics for now.
         // TODO: Make muted streams and test them.
         false,
+    get_stream_name_from_id: () => "stream_name",
 });
 mock_esm("../src/stream_list", {
     handle_narrow_deactivated: noop,
@@ -211,7 +212,6 @@ let id = 0;
 const sample_messages = [];
 sample_messages[0] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic1,
     sender_id: sender1,
@@ -220,7 +220,6 @@ sample_messages[0] = {
 
 sample_messages[1] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic2,
     sender_id: sender1,
@@ -229,7 +228,6 @@ sample_messages[1] = {
 
 sample_messages[2] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic2,
     sender_id: sender2,
@@ -238,7 +236,6 @@ sample_messages[2] = {
 
 sample_messages[3] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic3,
     sender_id: sender2,
@@ -247,7 +244,6 @@ sample_messages[3] = {
 
 sample_messages[4] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic4,
     sender_id: sender2,
@@ -256,7 +252,6 @@ sample_messages[4] = {
 
 sample_messages[5] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic5,
     sender_id: sender1,
@@ -265,7 +260,6 @@ sample_messages[5] = {
 
 sample_messages[6] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic5,
     sender_id: sender2,
@@ -274,7 +268,6 @@ sample_messages[6] = {
 
 sample_messages[7] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic6,
     sender_id: sender1,
@@ -283,7 +276,6 @@ sample_messages[7] = {
 
 sample_messages[8] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic6,
     sender_id: sender2,
@@ -292,7 +284,6 @@ sample_messages[8] = {
 
 sample_messages[9] = {
     stream_id: stream1,
-    stream: "stream1",
     id: (id += 1),
     topic: topic7,
     sender_id: sender1,
@@ -302,7 +293,6 @@ sample_messages[9] = {
 // a message of stream4
 sample_messages[10] = {
     stream_id: stream4,
-    stream: "stream4",
     id: (id += 1),
     topic: topic10,
     sender_id: sender1,
@@ -355,7 +345,7 @@ function generate_topic_data(topic_info_array) {
             last_msg_url: "https://www.example.com",
             full_last_msg_date_time: "date at time",
             senders: people.sender_info_for_recent_topics_row([1, 2]),
-            stream: "stream" + stream_id,
+            stream_name: "stream_name",
             stream_color: "",
             stream_id,
             stream_muted: undefined,

--- a/web/tests/stream_data.test.js
+++ b/web/tests/stream_data.test.js
@@ -133,8 +133,9 @@ test("basics", () => {
     assert.ok(!stream_data.is_web_public_by_stream_name(social.name));
     assert.ok(!stream_data.is_web_public_by_stream_name("unknown"));
 
-    assert.ok(stream_data.is_invite_only_by_stream_name("social"));
-    assert.ok(!stream_data.is_invite_only_by_stream_name("unknown"));
+    assert.ok(stream_data.is_invite_only_by_stream_id(social.stream_id));
+    // Unknown stream id
+    assert.ok(!stream_data.is_invite_only_by_stream_id(1000));
 
     assert.equal(stream_data.get_color(social.stream_id), "red");
     assert.equal(stream_data.get_color(""), "#c2c2c2");

--- a/web/tests/transmit.test.js
+++ b/web/tests/transmit.test.js
@@ -20,6 +20,7 @@ const sent_messages = mock_esm("../src/sent_messages", {
 
 const people = zrequire("people");
 const transmit = zrequire("transmit");
+const stream_data = zrequire("stream_data");
 
 run_test("transmit_message_ajax", () => {
     let success_func_called;
@@ -97,9 +98,15 @@ run_test("transmit_message_ajax_reload_pending", () => {
 });
 
 run_test("reply_message_stream", ({override}) => {
+    const social_stream_id = 555;
+    stream_data.add_sub({
+        name: "social",
+        stream_id: social_stream_id,
+    });
+
     const stream_message = {
         type: "stream",
-        stream: "social",
+        stream_id: social_stream_id,
         topic: "lunch",
         sender_full_name: "Alice",
         sender_id: 123,


### PR DESCRIPTION
Continues from #26127, as part of an effort to reduce referencing streams by name, instead referencing them by id.

This should have no visual or functional changes.


