### PR TITLE
Message Feed: Fix collapsed messages for highlighted texts.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -195,6 +195,35 @@ $time_column_min_width: 50px; /* + padding */
             all single paragraphs the same.
             */
             padding: 2px 0;
+            color: var(--color-text-message-default);
+            line-height: var(--message-box-line-height);
+            min-height: 17px;
+            display: block;
+            position: relative;
+            overflow: hidden;
+
+            &:empty {
+                display: none;
+            }
+
+            &.condensed {
+                max-height: 8.5em;
+                min-height: 0;
+                overflow: hidden;
+                mask-image: linear-gradient(
+                    to top,
+                    hsl(0deg 0% 100% / 0%) 0%,
+                    hsl(0deg 0% 100%) 60px
+                );
+                mask-size: cover;
+            }
+
+            &.collapsed {
+                padding: 0;
+                max-height: 0;
+                min-height: 0;
+                overflow: hidden;
+            }
         }
 
         .message_reactions {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1695,37 +1695,6 @@ div.focused_table {
     display: block;
 }
 
-.message_content {
-    color: var(--color-text-message-default);
-    line-height: var(--message-box-line-height);
-    min-height: 17px;
-    display: block;
-    position: relative;
-    overflow: hidden;
-
-    &:empty {
-        display: none;
-    }
-
-    &.condensed {
-        max-height: 8.5em;
-        min-height: 0;
-        overflow: hidden;
-        mask-image: linear-gradient(
-            to top,
-            hsl(0deg 0% 100% / 0%) 0%,
-            hsl(0deg 0% 100%) 60px
-        );
-        mask-size: cover;
-    }
-
-    &.collapsed {
-        max-height: 0;
-        min-height: 0;
-        overflow: hidden;
-    }
-}
-
 .rtl {
     direction: rtl;
 }


### PR DESCRIPTION
### Description
As @timabbott pointed it out in #26346 highlighted messages when collapsed by `-`  it gets unusual line-like artifact. This PR fixes that issue.

<!-- Describe your pull request here.-->

Fixes: #26346<!-- Issue link, or clear description.-->

**To Discuss** : 

- If the blank line above "Show More" should be removed or not, the screen recording below has blank line removed and the code doesn't.

- If a user sends multiple message and one of the message in between is collapsed it still leaves a blank line, if removed I figured it was looking kind of cluttery so I've not removed that blank line in this pr. 

![image](https://github.com/zulip/zulip/assets/91622060/e4f7a6bf-d124-4c7e-8558-8c4dce4a88c0)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/91622060/4768c9db-a5c9-43d3-97b1-18b665048288


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
