### PR TITLE
tests: Disable flaky test_edit_bot_form test.

### DIFF
--- a/web/e2e-tests/settings.test.ts
+++ b/web/e2e-tests/settings.test.ts
@@ -188,7 +188,12 @@ async function test_botserverrc(page: Page): Promise<void> {
     assert.match(botserverrc_decoded_url, botserverrc_regex, "Incorrect botserverrc format.");
 }
 
+// Disabled the below test due to non-deterministic failures.
+// The test often fails to close the modal, as does the
+// test_invalid_edit_bot_form above.
+// TODO: Debug this and re-enable with a fix.
 async function test_edit_bot_form(page: Page): Promise<void> {
+    return;
     const bot1_email = "1-bot@zulip.testserver";
     const bot1_edit_btn = `.open_edit_bot_form[data-email="${CSS.escape(bot1_email)}"]`;
     await page.click(bot1_edit_btn);


### PR DESCRIPTION
This disables the `test_edit_bot_form` Puppeteer test that, like its already-disabled `test_invalid_edit_bot_form` cousin, is failing nondeterministically, including on GitHub CI runs.

[CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/flaky.20settings.2Etest.2Ets.3F/near/1619848)

I opened issue #26442 to track the proper debugging of these tests so they're not simply disabled and forgotten about.
