### PR TITLE
added try catch block in scrollToHash function

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -121,18 +121,21 @@ function render_code_sections() {
 }
 
 function scrollToHash(simplebar) {
-    const hash = window.location.hash;
-    const scrollbar = simplebar.getScrollElement();
-    if (hash !== "" && $(hash).length > 0) {
-        const position = $(hash).position().top - $(scrollbar.firstChild).position().top;
-        // Preserve a reference to the scroll target, so it is not lost (and the highlight
-        // along with it) when the page is updated via fetch
-        const $scroll_target = $(hash);
-        $scroll_target.addClass("scroll-target");
-        scrollbar.scrollTop = position;
-    } else {
-        scrollbar.scrollTop = 0;
+    try {
+        const hash = window.location.hash;
+        const scrollbar = simplebar.getScrollElement();
+        if (hash !== "" && $(hash).length > 0) {
+            const position = $(hash).position().top - $(scrollbar.firstChild).position().top;
+            // Preserve a reference to the scroll target, so it is not lost (and the highlight
+            // along with it) when the page is updated via fetch
+            const $scroll_target = $(hash);
+            $scroll_target.addClass("scroll-target");
+            scrollbar.scrollTop = position;
+        } else {
+            scrollbar.scrollTop = 0;
+        }
     }
+    catch(e){}
 }
 
 const cache = new Map();


### PR DESCRIPTION
<!-- Describe your pull request here.-->
added try-catch block in scrollToHash function for exception handling
Fixes: <!-- Issue link, or clear description.-->
https://github.com/zulip/zulip/issues/26249
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
