### PR TITLE
Move browser navigation code into `browser_history.js`

### DIFF
--- a/docs/subsystems/hashchange-system.md
+++ b/docs/subsystems/hashchange-system.md
@@ -59,7 +59,7 @@ The main external API lives in `web/src/browser_history.js`:
 - `browser_history.update` is used to update the browser
   history, and it should be called when the app code is taking care
   of updating the UI directly
-- `browser_history.go_to_location` is used when you want the `hashchange`
+- `browser_history.go_to_hash` is used when you want the `hashchange`
   module to actually dispatch building the next page
 
 Internally you have these functions:

--- a/web/src/browser_history.js
+++ b/web/src/browser_history.js
@@ -70,7 +70,7 @@ export function update(new_hash) {
 
     state.old_hash = old_hash;
     state.is_internal_change = true;
-    go_to_location(new_hash);
+    go_to_hash(new_hash);
 }
 
 export function exit_overlay() {
@@ -81,7 +81,7 @@ export function exit_overlay() {
     }
 }
 
-export function go_to_location(hash) {
+export function go_to_hash(hash) {
     // Call this function when you WANT the hashchanged
     // function to run.
     window.location.hash = hash;
@@ -94,5 +94,5 @@ export function update_hash_internally_if_required(hash) {
 }
 
 export function return_to_web_public_hash() {
-    go_to_location(state.spectator_old_hash);
+    go_to_hash(state.spectator_old_hash);
 }

--- a/web/src/browser_history.js
+++ b/web/src/browser_history.js
@@ -70,7 +70,7 @@ export function update(new_hash) {
 
     state.old_hash = old_hash;
     state.is_internal_change = true;
-    window.location.hash = new_hash;
+    go_to_location(new_hash);
 }
 
 export function exit_overlay() {
@@ -94,5 +94,5 @@ export function update_hash_internally_if_required(hash) {
 }
 
 export function return_to_web_public_hash() {
-    window.location.hash = state.spectator_old_hash;
+    go_to_location(state.spectator_old_hash);
 }

--- a/web/src/browser_history.js
+++ b/web/src/browser_history.js
@@ -87,6 +87,10 @@ export function go_to_hash(hash) {
     window.location.hash = hash;
 }
 
+export function go_to_location(href) {
+    window.location.href = href;
+}
+
 export function update_hash_internally_if_required(hash) {
     if (window.location.hash !== hash) {
         update(hash);

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -196,7 +196,7 @@ export function initialize() {
                 // This might happen for locally echoed messages, for example.
                 return;
             }
-            window.location = hash_util.by_conversation_and_time_url(message);
+            browser_history.go_to_location(hash_util.by_conversation_and_time_hash(message));
             return;
         }
 

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -780,7 +780,7 @@ export function initialize() {
             e.preventDefault();
             e.stopPropagation();
 
-            window.location.hash = "narrow/is/dm";
+            browser_history.go_to_location("narrow/is/dm");
         },
     );
 

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -196,7 +196,7 @@ export function initialize() {
                 // This might happen for locally echoed messages, for example.
                 return;
             }
-            browser_history.go_to_location(hash_util.by_conversation_and_time_hash(message));
+            browser_history.go_to_hash(hash_util.by_conversation_and_time_hash(message));
             return;
         }
 
@@ -272,7 +272,7 @@ export function initialize() {
         // so we re-encode the hash.
         const stream_id = Number.parseInt($(this).attr("data-stream-id"), 10);
         if (stream_id) {
-            browser_history.go_to_location(hash_util.by_stream_url(stream_id));
+            browser_history.go_to_hash(hash_util.by_stream_url(stream_id));
             return;
         }
         window.location.href = $(this).attr("href");
@@ -690,7 +690,7 @@ export function initialize() {
 
     $("body").on("click", "[data-overlay-trigger]", function () {
         const target = $(this).attr("data-overlay-trigger");
-        browser_history.go_to_location(target);
+        browser_history.go_to_hash(target);
     });
 
     function handle_compose_click(e) {
@@ -780,7 +780,7 @@ export function initialize() {
             e.preventDefault();
             e.stopPropagation();
 
-            browser_history.go_to_location("narrow/is/dm");
+            browser_history.go_to_hash("narrow/is/dm");
         },
     );
 

--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -275,7 +275,7 @@ export function initialize() {
             browser_history.go_to_hash(hash_util.by_stream_url(stream_id));
             return;
         }
-        window.location.href = $(this).attr("href");
+        browser_history.go_to_location($(this).attr("href"));
     });
 
     $("body").on("click", "#scroll-to-bottom-button-clickable-area", (e) => {
@@ -473,7 +473,7 @@ export function initialize() {
     $("body").on("click", ".login_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        window.location.href = hash_util.build_login_link();
+        browser_history.go_to_location(hash_util.build_login_link());
     });
 
     $("#userlist-toggle-button").on("click", (e) => {

--- a/web/src/desktop_integration.js
+++ b/web/src/desktop_integration.js
@@ -11,11 +11,11 @@ if (window.electron_bridge !== undefined) {
     });
 
     window.electron_bridge.on_event("show-keyboard-shortcuts", () => {
-        browser_history.go_to_location("keyboard-shortcuts");
+        browser_history.go_to_hash("keyboard-shortcuts");
     });
 
     window.electron_bridge.on_event("show-notification-settings", () => {
-        browser_history.go_to_location("settings/notifications");
+        browser_history.go_to_hash("settings/notifications");
     });
 
     // The code below is for sending a message received from notification reply which

--- a/web/src/gear_menu.ts
+++ b/web/src/gear_menu.ts
@@ -76,7 +76,7 @@ The "info:" items use our info overlay system
 in web/src/info_overlay.js.  They are dispatched
 using a click handler in web/src/click_handlers.js.
 The click handler uses "[data-overlay-trigger]" as
-the selector and then calls browser_history.go_to_location.
+the selector and then calls browser_history.go_to_hash.
 */
 
 export function version_display_string(): string {

--- a/web/src/hash_util.js
+++ b/web/src/hash_util.js
@@ -144,6 +144,16 @@ export function huddle_with_url(user_ids_string) {
     return "#narrow/dm/" + user_ids_string + "-group";
 }
 
+export function by_conversation_and_time_hash(message) {
+    const suffix = "/near/" + internal_url.encodeHashComponent(message.id);
+
+    if (message.type === "stream") {
+        return by_stream_topic_url(message.stream_id, message.topic) + suffix;
+    }
+
+    return people.pm_perma_link(message) + suffix;
+}
+
 export function by_conversation_and_time_url(message) {
     const absolute_url =
         window.location.protocol +
@@ -152,13 +162,7 @@ export function by_conversation_and_time_url(message) {
         "/" +
         window.location.pathname.split("/")[1];
 
-    const suffix = "/near/" + internal_url.encodeHashComponent(message.id);
-
-    if (message.type === "stream") {
-        return absolute_url + by_stream_topic_url(message.stream_id, message.topic) + suffix;
-    }
-
-    return absolute_url + people.pm_perma_link(message) + suffix;
+    return absolute_url + by_conversation_and_time_hash(message);
 }
 
 export function stream_edit_url(sub) {

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -79,7 +79,7 @@ function set_hash(hash) {
         }
 
         blueslip.error("browser does not support pushState");
-        window.location.hash = hash;
+        browser_history.go_to_location(hash);
     }
 }
 
@@ -152,7 +152,7 @@ function show_default_view() {
         // go back in browser history. See
         // https://chat.zulip.org/#narrow/stream/9-issues/topic/Browser.20back.20button.20on.20RT
         // for detailed description of the issue.
-        window.location.hash = user_settings.default_view;
+        browser_history.go_to_location(user_settings.default_view);
     }
 }
 

--- a/web/src/hashchange.js
+++ b/web/src/hashchange.js
@@ -79,7 +79,7 @@ function set_hash(hash) {
         }
 
         blueslip.error("browser does not support pushState");
-        browser_history.go_to_location(hash);
+        browser_history.go_to_hash(hash);
     }
 }
 
@@ -152,7 +152,7 @@ function show_default_view() {
         // go back in browser history. See
         // https://chat.zulip.org/#narrow/stream/9-issues/topic/Browser.20back.20button.20on.20RT
         // for detailed description of the issue.
-        browser_history.go_to_location(user_settings.default_view);
+        browser_history.go_to_hash(user_settings.default_view);
     }
 }
 

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -513,7 +513,7 @@ export function process_enter_key(e) {
             return false;
         }
 
-        window.location = hash_util.by_conversation_and_time_url(message);
+        browser_history.go_to_location(hash_util.by_conversation_and_time_hash(message));
         return true;
     }
 
@@ -1053,7 +1053,7 @@ export function process_hotkey(e, hotkey) {
         }
         case "zoom_to_message_near": {
             // The following code is essentially equivalent to
-            // `window.location = hashutil.by_conversation_and_time_url(msg)`
+            // `browser_history.go_to_location(hash_util.hash_by_conversation_and_time_url(msg))`
             // but we use `narrow.activate` to pass in the `trigger` parameter
             switch (msg.type) {
                 case "private":

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -513,7 +513,7 @@ export function process_enter_key(e) {
             return false;
         }
 
-        browser_history.go_to_location(hash_util.by_conversation_and_time_hash(message));
+        browser_history.go_to_hash(hash_util.by_conversation_and_time_hash(message));
         return true;
     }
 
@@ -854,7 +854,7 @@ export function process_hotkey(e, hotkey) {
             gear_menu.open();
             return true;
         case "show_shortcuts": // Show keyboard shortcuts page
-            browser_history.go_to_location("keyboard-shortcuts");
+            browser_history.go_to_hash("keyboard-shortcuts");
             return true;
         case "stream_cycle_backward":
             narrow.stream_cycle_backward();
@@ -869,10 +869,10 @@ export function process_hotkey(e, hotkey) {
             narrow.narrow_to_next_pm_string({trigger: "hotkey"});
             return true;
         case "open_recent_topics":
-            browser_history.go_to_location("#recent");
+            browser_history.go_to_hash("#recent");
             return true;
         case "all_messages":
-            browser_history.go_to_location("#all_messages");
+            browser_history.go_to_hash("#all_messages");
             return true;
     }
 
@@ -894,7 +894,7 @@ export function process_hotkey(e, hotkey) {
             }
             return true;
         case "open_drafts":
-            browser_history.go_to_location("drafts");
+            browser_history.go_to_hash("drafts");
             return true;
         case "C_deprecated":
             deprecated_feature_notice.maybe_show_deprecation_notice("Shift + C");
@@ -1053,7 +1053,7 @@ export function process_hotkey(e, hotkey) {
         }
         case "zoom_to_message_near": {
             // The following code is essentially equivalent to
-            // `browser_history.go_to_location(hash_util.hash_by_conversation_and_time_url(msg))`
+            // `browser_history.go_to_hash(hash_util.hash_by_conversation_and_time_url(msg))`
             // but we use `narrow.activate` to pass in the `trigger` parameter
             switch (msg.type) {
                 case "private":

--- a/web/src/message_view_header.js
+++ b/web/src/message_view_header.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 
 import render_message_view_header from "../templates/message_view_header.hbs";
 
+import * as browser_history from "./browser_history";
 import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
 import * as peer_data from "./peer_data";
@@ -155,7 +156,7 @@ export function exit_search() {
         close_search_bar_and_open_narrow_description();
     } else {
         // for "searching narrows", we redirect
-        window.location.href = filter.generate_redirect_url();
+        browser_history.go_to_location(filter.generate_redirect_url());
     }
     $(".app").trigger("focus");
 }

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -1005,7 +1005,7 @@ function handle_post_narrow_deactivate_processes() {
 
 export function deactivate(coming_from_recent_topics = false, is_actively_scrolling = false) {
     // NOTE: Never call this function independently,
-    // always use browser_history.go_to_location("#all_messages") to
+    // always use browser_history.go_to_hash("#all_messages") to
     // activate All message narrow.
     /*
       Switches message_lists.current from narrowed_msg_list to

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -6,6 +6,7 @@ import tippy from "tippy.js";
 import copy_to_clipboard_svg from "../../templates/copy_to_clipboard_svg.hbs";
 import * as common from "../common";
 
+import * as browser_history from "./browser_history";
 import * as google_analytics from "./google-analytics";
 import {activate_correct_tab} from "./tabbed-instructions";
 
@@ -210,7 +211,7 @@ $(document).on(
     "click",
     ".markdown .content h1, .markdown .content h2, .markdown .content h3",
     function () {
-        window.location.hash = $(this).attr("id");
+        browser_history.go_to_location($(this).attr("id"));
         scrollToHash(markdownSB);
     },
 );

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -211,7 +211,7 @@ $(document).on(
     "click",
     ".markdown .content h1, .markdown .content h2, .markdown .content h3",
     function () {
-        browser_history.go_to_location($(this).attr("id"));
+        browser_history.go_to_hash($(this).attr("id"));
         scrollToHash(markdownSB);
     },
 );

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -7,6 +7,7 @@ import render_recent_topics_body from "../templates/recent_topics_table.hbs";
 import render_user_with_status_icon from "../templates/user_with_status_icon.hbs";
 
 import * as blueslip from "./blueslip";
+import * as browser_history from "./browser_history";
 import * as buddy_data from "./buddy_data";
 import * as compose_closed_ui from "./compose_closed_ui";
 import * as hash_util from "./hash_util";
@@ -1364,7 +1365,7 @@ export function initialize() {
         e.stopPropagation();
         const topic_row_index = $(e.target).closest("tr").index();
         focus_clicked_element(topic_row_index, COLUMNS.stream);
-        window.location.href = $(e.currentTarget).find("a").attr("href");
+        browser_history.go_to_location($(e.currentTarget).find("a").attr("href"));
     });
 
     $("body").on("click", "td.recent_topic_name", (e) => {
@@ -1375,7 +1376,7 @@ export function initialize() {
         const topic_key = $topic_row.attr("id").slice("recent_conversation:".length);
         const topic_row_index = $topic_row.index();
         focus_clicked_element(topic_row_index, COLUMNS.topic, topic_key);
-        window.location.href = $(e.currentTarget).find("a").attr("href");
+        browser_history.go_to_location($(e.currentTarget).find("a").attr("href"));
     });
 
     // Search for all table rows (this combines stream & topic names)

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -320,7 +320,7 @@ export function dispatch_normal_event(event) {
                     // with this code, if they didn't have an active
                     // longpoll waiting at the moment the realm was
                     // deactivated.
-                    window.location.href = "/accounts/deactivated/";
+                    browser_history.go_to_location("/accounts/deactivated/");
                     break;
             }
             if (page_params.is_admin) {

--- a/web/src/settings_account.js
+++ b/web/src/settings_account.js
@@ -9,6 +9,7 @@ import render_settings_dev_env_email_access from "../templates/settings/dev_env_
 
 import * as avatar from "./avatar";
 import * as blueslip from "./blueslip";
+import * as browser_history from "./browser_history";
 import * as channel from "./channel";
 import * as common from "./common";
 import * as confirm_dialog from "./confirm_dialog";
@@ -783,7 +784,7 @@ export function set_up() {
                 success() {
                     dialog_widget.hide_dialog_spinner();
                     dialog_widget.close_modal();
-                    window.location.href = "/login/";
+                    browser_history.go_to_location("/login/");
                 },
                 error(xhr) {
                     const error_last_owner = $t_html({

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -457,7 +457,7 @@ export function register_stream_handlers() {
         hide_stream_popover();
 
         const stream_edit_hash = hash_util.stream_edit_url(sub);
-        browser_history.go_to_location(stream_edit_hash);
+        browser_history.go_to_hash(stream_edit_hash);
     });
 
     // Pin/unpin

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -925,7 +925,7 @@ export function view_stream() {
     if (row_data) {
         const stream_narrow_hash =
             "#narrow/stream/" + hash_util.encode_stream_name(row_data.object.name);
-        browser_history.go_to_location(stream_narrow_hash);
+        browser_history.go_to_hash(stream_narrow_hash);
     }
 }
 

--- a/web/src/user_profile.js
+++ b/web/src/user_profile.js
@@ -340,7 +340,7 @@ export function register_click_handlers() {
         if (sub.invite_only && people.is_my_user_id(target_user_id)) {
             const new_hash = hash_util.stream_edit_url(sub);
             hide_user_profile();
-            browser_history.go_to_location(new_hash);
+            browser_history.go_to_hash(new_hash);
             return;
         }
         handle_remove_stream_subscription(target_user_id, sub, removal_success, removal_failure);

--- a/web/tests/browser_history.test.js
+++ b/web/tests/browser_history.test.js
@@ -24,7 +24,7 @@ function test(label, f) {
 test("basics", () => {
     const hash1 = "#settings/profile";
     const hash2 = "#narrow/is/dm";
-    browser_history.go_to_location(hash1);
+    browser_history.go_to_hash(hash1);
     assert.equal(window.location.hash, hash1);
 
     browser_history.update(hash2);

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -310,7 +310,7 @@ run_test("streams", ({override}) => {
 });
 
 run_test("basic mappings", () => {
-    assert_mapping("?", browser_history, "go_to_location");
+    assert_mapping("?", browser_history, "go_to_hash");
     assert_mapping("/", search, "initiate_search");
     assert_mapping_rewire("w", activity, "initiate_search");
     assert_mapping("q", stream_list, "initiate_search");
@@ -338,7 +338,7 @@ run_test("drafts closed w/other overlay", ({override}) => {
 
 run_test("drafts closed launch", ({override}) => {
     override(overlays, "is_active", () => false);
-    assert_mapping("d", browser_history, "go_to_location");
+    assert_mapping("d", browser_history, "go_to_hash");
 });
 
 run_test("modal open", ({override}) => {

--- a/web/tests/lib/index.js
+++ b/web/tests/lib/index.js
@@ -9,6 +9,7 @@ const Sentry = require("@sentry/browser");
 const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 
+const browser_history = require("./browser_history");
 const handlebars = require("./handlebars");
 const stub_i18n = require("./i18n");
 const namespace = require("./namespace");
@@ -104,7 +105,7 @@ test.set_verbose(files.length === 1);
         namespace.start();
         namespace.set_global("window", window);
         namespace.set_global("location", dom.window.location);
-        window.location.href = "http://zulip.zulipdev.com/#";
+        browser_history.go_to_location("http://zulip.zulipdev.com/#");
         namespace.set_global("setTimeout", noop);
         namespace.set_global("setInterval", noop);
         namespace.set_global("localStorage", localStorage);


### PR DESCRIPTION
We'd like to move towards using `history.pushState` for browser navigation, and this PR helps us move in that direction by containing browser navigation to happen within `browser_history.js`. The next step will be to change the code in `browser_history` to use the `history` module instead.

Relevant CZO conversation: https://chat.zulip.org/#narrow/stream/6-frontend/topic/browser.20navigation/near/1621488

Related issue: #20066 

Notably this doesn't:

* do anything with instances of `window.location.replace` -- I wasn't sure if we should change anything here.
* touch some related code in `src/portico` -- is code there relevant? There's an instance of `window.location.href = ` in `desktop-login.js` and `window.location = ` in `integrations.js` but the portico code seems very different than most of the rest of our code.