### PR TITLE
help: Fix "Typing notifications" intro paragraph.

### DIFF
--- a/help/direct-messages.md
+++ b/help/direct-messages.md
@@ -82,6 +82,12 @@ If using Zulip in a browser or desktop, there are several ways to access an exis
 
 {relative|message|direct}
 
+{tab|mobile}
+
+1. Tap the **Direct messages**
+   ( <img src="/static/images/help/mobile-dm-tab-icon.svg" alt="direct messages" class="mobile-icon"/> )
+   tab at the bottom of the app.
+
 {end_tabs}
 
 ## Related articles

--- a/help/direct-messages.md
+++ b/help/direct-messages.md
@@ -74,6 +74,16 @@ If using Zulip in a browser or desktop, there are several ways to access an exis
 * Open the compose box, and enter a list of users on the **To:**
   line. Type <kbd>Ctrl</kbd> + <kbd>.</kbd> to open that conversation.
 
+## View all direct messages
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{relative|message|direct}
+
+{end_tabs}
+
 ## Related articles
 
 * [Typing notifications](/help/typing-notifications)

--- a/help/direct-messages.md
+++ b/help/direct-messages.md
@@ -74,7 +74,7 @@ If using Zulip in a browser or desktop, there are several ways to access an exis
 * Open the compose box, and enter a list of users on the **To:**
   line. Type <kbd>Ctrl</kbd> + <kbd>.</kbd> to open that conversation.
 
-## View all direct messages
+## Access all DMs
 
 {start_tabs}
 

--- a/help/typing-notifications.md
+++ b/help/typing-notifications.md
@@ -2,12 +2,15 @@
 
 Zulip displays typing notifications when viewing a direct message or
 group direct message conversation to which one of the other
-participants is currently composing a message.
+participants is currently composing a message. In the web and desktop apps,
+typing notifications are also displayed in the
+[all direct messages view](/help/direct-messages#access-all-dms).
 
-Typing notifications are only sent while one is actively editing text
-in the compose box, and they disappear if typing is paused for about
-15 seconds.  Just having the compose box open will not send a typing
-notification.
+Typing notifications are only sent while one is actively editing text in
+the compose box. They disappear if typing is paused for several seconds,
+if all the content of the message is erased, or if the message is
+[saved as a draft](/help/view-and-edit-your-message-drafts#save-a-draft).
+Just having the compose box open will not send a typing notification.
 
 ### Disable typing notifications
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -101,12 +101,20 @@ starred_instructions = """
    sidebar, or by [searching](/help/search-for-messages) for `is:starred`.
 """
 
+direct_instructions = """
+1. In the left sidebar, click the **All direct messages**
+   (<i class="fa fa-align-right"></i>) icon to the right of the
+   **Direct messages** label, or use the <kbd>Shift</kbd> + <kbd>P</kbd>
+   keyboard shortcut.
+"""
+
 message_info = {
     "drafts": ["Drafts", "/#drafts", draft_instructions],
     "scheduled": ["Scheduled messages", "/#scheduled", scheduled_instructions],
     "recent": ["Recent conversations", "/#recent", recent_instructions],
     "all": ["All messages", "/#all_messages", all_instructions],
     "starred": ["Starred messages", "/#narrow/is/starred", starred_instructions],
+    "direct": ["All direct messages", "/#narrow/is/dm", direct_instructions],
 }
 
 


### PR DESCRIPTION
- Corrects documentation to reflect that [typing notifications](https://zulip.com/help/typing-notifications) work when narrowing to all direct messages as well, adding a link to a new section in [Direct messages](https://zulip.com/help/direct-messages).

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/2343554/36a5dd90-f326-4a42-94c0-9dec261538d6)

![view-all-dms-relative-link](https://github.com/zulip/zulip/assets/2343554/d57adb99-682a-46eb-a123-3d8d3b6d35fe)
![view-all-dms-instructions](https://github.com/zulip/zulip/assets/2343554/fbb282e9-d761-4409-93d1-25d6a621cdbe)
![image](https://github.com/zulip/zulip/assets/2343554/5965e1cb-9355-4b5b-8538-72af4f45584f)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>