### PR TITLE
help: Add heading on linking to messages in "Writing messages" section.

### DIFF
--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -58,6 +58,7 @@
 ## Writing messages
 * [Message formatting](/help/format-your-message-using-markdown)
 * [Mention a user or group](/help/mention-a-user-or-group)
+* [Link to a stream, topic, or message](/help/link-to-a-message-or-conversation)
 * [Format a quote](/help/format-a-quote)
 * [Quote and reply](/help/quote-and-reply)
 * [Emoji and emoticons](/help/emoji-and-emoticons)


### PR DESCRIPTION
As discussed in [#user community > mentinoning users vs. linking to topics](https://chat.zulip.org/#narrow/stream/138-user-community/topic/mentinoning.20users.20vs.2E.20linking.20to.20topics), we should have a clear reference in the "Writing messages" sidebar section on linking to conversations below "Mention a user or group" to clarify mentioning users vs linking to conversations.

This adds a link to the "Link to a message or conversation" article with a different heading.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/0484855a-311a-4981-bcb9-e0466e4c1a22)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>