### PR TITLE
dropdown-list-widget: Remove "dropdown-list-body" class and reference.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -302,11 +302,8 @@ export function initialize_kitchen_sink_stuff() {
 
     // Ignore wheel events in the compose area which weren't already handled above.
     $("#compose").on("wheel", (e) => {
-        // Except for the stream select dropdown and compose banners, which still needs scroll events.
-        if (
-            $(e.target).closest(".dropdown-list-body").length ||
-            $(e.target).closest("#compose_banners").length
-        ) {
+        // Except for the compose banners, which still need scroll events.
+        if ($(e.target).closest("#compose_banners").length) {
             return;
         }
         e.stopPropagation();

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -1586,44 +1586,6 @@ $option_title_width: 180px;
         margin-top: 0;
         display: block;
     }
-
-    .dropdown-list-body {
-        position: relative;
-        margin-top: 0;
-        display: block;
-
-        /* In bootstrap v2.3.2, we strictly need
-        .dropdown-menu > li > a as the order of the elements
-        for the bootstrap style to be applied.
-        Since we use a combination of dropdown + simplebar here,
-        the structure cannot be possible since simplebar inserts
-        elements of its own, so we copy over that style
-        from bootstrap to here. */
-        & li a {
-            display: block;
-            padding: 3px 20px;
-            clear: both;
-            font-weight: normal;
-            line-height: 20px;
-            color: hsl(0deg 0% 20%);
-            white-space: nowrap;
-
-            &:hover {
-                color: hsl(0deg 0% 100%);
-                text-decoration: none;
-                background-color: hsl(200deg 100% 38%);
-                background-image: linear-gradient(
-                    to bottom,
-                    hsl(200deg 100% 40%),
-                    hsl(200deg 100% 35%)
-                );
-            }
-
-            &:focus {
-                text-decoration: none;
-            }
-        }
-    }
 }
 
 .subsection-failed-status p {


### PR DESCRIPTION
Removes the "dropdown-list-body" CSS class and reference in event handler in `ui_init.js` as it is no longer used in the new `DropdownWidget`.

The previous uses of the class were removed in commit 875d564f2d. A `git-grep` for "dropdown-list-body" after these changes returns nothing.

@amanagr - Could you double-check that I'm not missing anything here since you did the migration to the new `DropdownWidget`?

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
