### PR TITLE
WIP message-viewport: Stop propagation of selected message change in popovers/message edit.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -210,11 +210,15 @@ export function initialize_kitchen_sink_stuff() {
 
         // Most of the mouse wheel's work will be handled by the
         // scroll handler, but when we're at the top or bottom of the
-        // page, the pointer may still need to move.
+        // page, the selected message may still need to move. And
+        // popovers may still need to be closed to be consistent
+        // with message view behavior in the middle of the feed.
 
         if (delta < 0 && message_viewport.at_rendered_top()) {
+            popovers.hide_all();
             navigate.up();
         } else if (delta > 0 && message_viewport.at_rendered_bottom()) {
+            popovers.hide_all();
             navigate.down();
         }
 

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -238,7 +238,20 @@ export function initialize_kitchen_sink_stuff() {
 
     $(window).on("resize", _.throttle(resize_handler.handler, 50));
 
-    // Scrolling in overlays. input boxes, and other elements that
+    // Stop propagation of the previous "wheel" event handler for popovers
+    // with scrollable content (e.g. emoji picker, stream picker, giphy) and
+    // message edit form preview/textarea. These aren't handled by the event
+    // handler below because they aren't in the DOM when the web-app is
+    // initialized.
+    message_viewport.$scroll_container.on(
+        "wheel",
+        ".simplebar-content, .scrolling_list, textarea",
+        (e) => {
+            e.stopPropagation();
+        },
+    );
+
+    // Scrolling in overlays, input boxes, and other elements that
     // explicitly scroll should not scroll the main view.  Stop
     // propagation in all cases.  Also, ignore the event if the
     // element is already at the top or bottom.  Otherwise we get a


### PR DESCRIPTION
After the `message_viewport.$scroll_container` was changed to be the entire page (`"html"`), the "wheel" event handler for the main message feed (that continues to move the selected message at the top and bottom of the feed) was now bubbling up when scrolling on popovers (in the message feed and in the compose box) and on the message edit form.

See [relevant CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/emoji.20popover.20scrolls.20in.20message.20feed.20as.20well/near/1608995).

Addresses the issue in two commits:
- Adds a "wheel" event handler with specific selectors for these popover / form elements that stops propagation so that the event doesn't bubble up to the event handler for moving the selected message.
- Adds a `popovers.hide_all()` call to the "wheel" event handler for moving the selected message so that the behavior for closing popovers is consistent overall in the message feed view.

**Notes/Questions**:
- There is another "wheel" event handler that is stopping propagation in the stream list, buddy list and compose box text/preview area. But this isn't covering the popovers or message edit form because those don't exist in the DOM when the web-app is initialized.
  - That event handler also includes some more logic to prevent the default behavior as well, which I wasn't sure if we wanted/needed to also handle for these popovers and the message edit form. So that may still need to be done.
  - Also, there may be some clean-up that can be done here as I don't think the "modal-body" selector is doing anything here as those are in overlays, which do not trigger the "wheel" event for changing the selected message 
- The kitchen sink function in `ui_init.js` has a `TODO` comment of potentially moving some of the function's content to more specific modules. These event handlers could potentially be moved to `message_viewport.js`, but I thought that could be done as a follow-up and I didn't investigate if that change would cause any import cycles / dependencies in that module.
- Fixing the popover actions to not reference the selected message, but rather the message ID data on the popover element, would be addressed in separate pull requests. See CZO discussion for more on this point, which is a related bug.

Fixes #25980. Marking this here because the popovers will either close or (if scrollable) scroll their content. This is different than the behavior noted prior to the change to the message feed scroll container, but it more consistent with the scrolling / popover behavior in general.

---

**Screencasts**:

<details>
<summary>Popovers - current behavior on main</summary>

[Screencast from 2023-08-09 15-47-20.webm](https://github.com/zulip/zulip/assets/63245456/d8b90271-839e-405c-b367-0cb015825293)
</details>
<details>
<summary>Popovers - after changes</summary>

[Screencast from 2023-08-09 15-48-45.webm](https://github.com/zulip/zulip/assets/63245456/18a9ecb7-3d03-439e-8fa7-ba0bacaa270a)
</details>
<details>
<summary>Edit message - current behavior on main</summary>

[Screencast from 2023-08-09 17-27-30.webm](https://github.com/zulip/zulip/assets/63245456/6a1b06aa-9202-4107-85cb-3962aa7217e8)
</details>
<details>
<summary>Edit message - after changes</summary>

*Note that the selected message doesn't move if we're at the top and bottom of the feed. This is where I'm not sure if the new behavior is much better than the current main.*

[Screencast from 2023-08-09 17-28-54.webm](https://github.com/zulip/zulip/assets/63245456/d84f28a8-2544-4a3f-80bb-e9cfed9e0508)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
