### PR TITLE
print: Hide closing X on search bar.

### DIFF
--- a/web/styles/print.css
+++ b/web/styles/print.css
@@ -44,6 +44,7 @@
     /* Hide unnecessary controls, but leave them
        in the document flow. */
     .search_icon,
+    #search_exit,
     .settings-dropdown-cog,
     .recipient_bar_controls {
         visibility: hidden;


### PR DESCRIPTION
This catches and hides a little piece of UI that was still printing: the X to close the search bar.

Note that this change will still be viable even after #24345 is merged.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="1257" alt="search-results-before" src="https://github.com/zulip/zulip/assets/170719/3b3d40bc-9d39-4baa-924e-37fa8ee4234d"> | <img width="1257" alt="search-results-after" src="https://github.com/zulip/zulip/assets/170719/bb3d2605-67eb-4ed8-8a4c-1772a9c86a0c"> |