### PR TITLE
stream settings: Warn users before locking them out of a stream.

### DIFF
--- a/web/src/settings_org.js
+++ b/web/src/settings_org.js
@@ -1,11 +1,13 @@
 import $ from "jquery";
 
 import pygments_data from "../generated/pygments_data.json";
+import render_compose_banner from "../templates/compose_banner/compose_banner.hbs";
 import render_settings_deactivate_realm_modal from "../templates/confirm_dialog/confirm_deactivate_realm.hbs";
 import render_settings_admin_auth_methods_list from "../templates/settings/admin_auth_methods_list.hbs";
 
 import * as blueslip from "./blueslip";
 import * as channel from "./channel";
+import * as compose_banner from "./compose_banner";
 import {csrf_token} from "./csrf";
 import * as dialog_widget from "./dialog_widget";
 import * as dropdown_widget from "./dropdown_widget";
@@ -995,6 +997,19 @@ export function check_property_changed(elem, for_realm_default_settings, sub) {
     return current_val !== proposed_val;
 }
 
+function switching_to_private(properties_elements, for_realm_default_settings) {
+    for (const elem of properties_elements) {
+        const $elem = $(elem);
+        const property_name = extract_property_name($elem, for_realm_default_settings);
+        if (property_name !== "stream_privacy") {
+            continue;
+        }
+        const proposed_val = get_input_element_value($elem, "radio-group");
+        return proposed_val === "invite-only-public-history" || proposed_val === "invite-only";
+    }
+    return false;
+}
+
 export function save_discard_widget_status_handler($subsection, for_realm_default_settings, sub) {
     $subsection.find(".subsection-failed-status p").hide();
     $subsection.find(".save-button").show();
@@ -1006,6 +1021,39 @@ export function save_discard_widget_status_handler($subsection, for_realm_defaul
     const $save_btn_controls = $subsection.find(".subsection-header .save-button-controls");
     const button_state = show_change_process_button ? "unsaved" : "discarded";
     change_save_button_state($save_btn_controls, button_state);
+
+    // If this widget is for a stream, and the stream isn't currently private
+    // but being changed to private, and the user changing this setting isn't
+    // subscribed, we show a warning that they won't be able to access the
+    // stream after making it private unless they subscribe.
+    if (!sub) {
+        return;
+    }
+    if (
+        button_state === "unsaved" &&
+        !sub.invite_only &&
+        !sub.subscribed &&
+        switching_to_private(properties_elements, for_realm_default_settings)
+    ) {
+        if ($("#stream_permission_settings .stream_privacy_warning").length > 0) {
+            return;
+        }
+        const context = {
+            banner_type: compose_banner.WARNING,
+            banner_text: $t({
+                defaultMessage:
+                    "Only subscribers can access or join private streams, so you will lose access to this stream if you convert it to a private stream while not subscribed to it.",
+            }),
+            button_text: $t({defaultMessage: "Subscribe"}),
+            classname: "stream_privacy_warning",
+            stream_id: sub.stream_id,
+        };
+        $("#stream_permission_settings .stream-permissions-warning-banner").append(
+            render_compose_banner(context),
+        );
+    } else {
+        $("#stream_permission_settings .stream-permissions-warning-banner").empty();
+    }
 }
 
 export function init_dropdown_widgets() {

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -465,6 +465,36 @@ export function initialize() {
         return true;
     });
 
+    $("#streams_overlay_container").on(
+        "click",
+        ".stream-permissions-warning-banner .main-view-banner-close-button",
+        (event) => {
+            event.preventDefault();
+            $("#stream_permission_settings .stream-permissions-warning-banner").empty();
+        },
+    );
+
+    $("#streams_overlay_container").on(
+        "click",
+        ".stream-permissions-warning-banner .main-view-banner-action-button",
+        (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            const $target = $(event.target).parents(".main-view-banner");
+            const stream_id = Number.parseInt($target.attr("data-stream-id"), 10);
+            // Makes sure we take the correct stream_row.
+            const $stream_row = $(
+                `#streams_overlay_container div.stream-row[data-stream-id='${CSS.escape(
+                    stream_id,
+                )}']`,
+            );
+            const sub = sub_store.get(stream_id);
+            stream_settings_ui.sub_or_unsub(sub, $stream_row);
+            $("#stream_permission_settings .stream-permissions-warning-banner").empty();
+        },
+    );
+
     function save_stream_info(e) {
         const sub = get_sub_for_target(e.currentTarget);
 

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -52,6 +52,8 @@
                     {{> ../settings/settings_save_discard_widget section_name="stream-permissions" }}
                 </div>
 
+                <div class="stream-permissions-warning-banner"></div>
+
                 {{> stream_types
                   stream_post_policy_values=../stream_post_policy_values
                   stream_privacy_policy_values=../stream_privacy_policy_values


### PR DESCRIPTION
Organization owners can make streams private even if they're not subscribed to them, but cannot access private streams they're not subscribed to. This means they're able to lock themself out of streams.

This change warns users of this and give them a chance to subscribe.

Fixes #26437.

Things I've tested:

* Clicking subscribe updates the button at the top of the stream settings menu and the checkmark on the left menu, and closes the banner.
* Close button closes the banner.
* Banner shows up under the correct conditions.

Pending UI feedback [on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Owner.20locked.20out.20from.20private.20stream)

![image](https://github.com/zulip/zulip/assets/5634097/2ce8546b-0ee4-4e3f-8c89-b894f47fe992)
