### PR TITLE
grid: Handle layout across multiple message modes.

### DIFF
--- a/web/src/message_list.js
+++ b/web/src/message_list.js
@@ -382,11 +382,7 @@ export class MessageList {
             return;
         }
         $row.find(".message_edit_form").append(edit_obj.$form);
-        // Hide the original message with visibility: hidden,
-        // so its baseline is still detectable on other columns
-        // in the grid for a consistent layout in the edit state
-        $row.find(".message_content").css("visibility", "hidden");
-        $row.find(".status-message, .message_controls").hide();
+        $row.find(".message_content, .status-message, .message_controls").hide();
         $row.find(".sender-status").toggleClass("sender-status-edit");
         $row.find(".messagebox-content").addClass("content_edit_mode");
         $row.find(".message_edit").css("display", "block");
@@ -394,8 +390,7 @@ export class MessageList {
     }
 
     hide_edit_message($row) {
-        $row.find(".message_content").css("visibility", "visible");
-        $row.find(".status-message, .message_controls").show();
+        $row.find(".message_content, .status-message, .message_controls").show();
         $row.find(".sender-status").toggleClass("sender-status-edit");
         $row.find(".message_edit_form").empty();
         $row.find(".messagebox-content").removeClass("content_edit_mode");

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -167,6 +167,25 @@ $time_column_min_width: 50px; /* + padding */
         .message_time {
             justify-self: end;
             padding-right: 5px;
+            /* Maintain first-line baseline regardless of
+               what happens in the message-content area (e.g., a
+               collapsed message, or source/edit view). This
+               line-height also keeps EDITED/MOVED messages
+               in place, care of their baseline-group participation
+               within the grid.
+
+               That said, 28px is a bit of a magical number.
+               In theory, this should be 27px. That's the height
+               of a single-message row without a sender. (See the
+               calculations for the height of a single-line,
+               sender-less message row in the message box grid.)
+               But when shifting into collapsed or source views,
+               28px is necessary to maintain the vertical alignment
+               of the EDITED messages, hover controls, and
+               timestamp. It's possible that this is also due to a
+               a rounding error, given how --message-box-line-height
+               is expressed as a unitless decimal. */
+            line-height: 28px;
             text-align: end;
             grid-area: time;
 
@@ -346,6 +365,10 @@ $time_column_min_width: 50px; /* + padding */
 
             .message_time {
                 grid-area: time;
+                /* Don't adjust the line-height for collapsed or
+                   edited/source messages when there's a sender,
+                   as the sender text is always visible. */
+                line-height: inherit;
             }
 
             .slow-send-spinner {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -266,6 +266,23 @@ $time_column_min_width: 50px; /* + padding */
             grid-area: more;
         }
 
+        .collapsed ~ .message_length_controller {
+            /* When content is collapsed, the length controller
+               should occupy the space ordinarily assigned to
+               the message. */
+            grid-area: message;
+            /* However, don't let the SHOW MORE button participate
+               in the baseline group. */
+            align-self: start;
+
+            .message_length_toggle {
+                /* Ensure that a collapsed message maintains the
+                   same space around the toggle button as any other
+                   message-row content. */
+                margin: 4px 0;
+            }
+        }
+
         &.content_edit_mode .message_length_controller {
             /* If entering edit mode on a collapsed message,
                just hide the controller area. This preserves

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -246,6 +246,15 @@ $time_column_min_width: 50px; /* + padding */
         .message_length_controller {
             grid-area: more;
         }
+
+        &.content_edit_mode .message_length_controller {
+            /* If entering edit mode on a collapsed message,
+               just hide the controller area. This preserves
+               the collapsed state of the message, which need
+               not be touched. We just need to hide the button.
+               This works for condensed messages, too. */
+            display: none;
+        }
     }
 
     &.include-sender {


### PR DESCRIPTION
This PR employs better control over line-heights to fix a couple of related issues spread across different message modes (viewing, collapsing, editing/viewing source), resulting in a more robust message and grid presentation.

* It removes an apparent empty line of space with collapsed messages, as noted by Tim in #26433, by allowing the SHOW MORE button to occupy the grid area ordinarily occupied by the message itself. This produces what is likely user intent: collapsing messages into their smallest possible footprint.
* It eliminates a small shift in EDITED/MOVED markers and timestamps, as [also noted](https://github.com/zulip/zulip/pull/26433#issuecomment-1670109935) in #26433.
* It fixes [a regression](https://chat.zulip.org/#narrow/stream/6-frontend/topic/message.20edit.20form.20height/near/1621758) from #25997 where messages with images would display unnecessary and unwanted whitespace beneath the source/edit view of the message.
* It hides the SHOW MORE button when entering source/edit view from a collapsed message ([CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Going.20to.20source.2Fedit.20view.20on.20collapsed.20message/near/1622351))

**Screenshots and screen captures:**

For the collapsing message views, be sure to watch for shifts in the timestamps and EDITED markers, and also the space occupied by SHOW MORE on different types of messages (with and without a sender; long and short). Note especially the single-line, senderless message, which actually occupies _additional_ space because the SHOW MORE button is itself taller than a single-line message. That's probably acceptable, since manually collapsing a single-line message is probably pretty unusual/unlikely anyway.

| Collapsing Messages Before | Collapsing Messages After |
| --- | --- |
| ![collapsed-before](https://github.com/zulip/zulip/assets/170719/28692b6c-4786-4ba4-9e5a-90a36a42183a) | ![collapsed-after](https://github.com/zulip/zulip/assets/170719/9f533b39-732d-401d-a487-b28858e5db6d) |

For message-source views, note especially a desired change in UI behavior when entering source view from a collapsed message. Previously, the SHOW MORE button remained visible. Now it is hidden, purely in CSS--meaning that we make no effort to change the state of a collapsed message from how a user had it before entering source/edit mode.

| Source-view Toggle Before | Source-view Toggle After |
| --- | --- |
| ![source-before](https://github.com/zulip/zulip/assets/170719/b318e724-0ac5-4a9e-b64f-9cb9486ede63) | ![source-after](https://github.com/zulip/zulip/assets/170719/1a8179d3-4ede-433f-80cd-aa41dd321901) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>