### PR TITLE
test_openapi: Use subtests for arguments test.

### DIFF
--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -614,7 +614,8 @@ so maybe we shouldn't include it in pending_endpoints.
 
                 function_name = f"{function.__module__}.{function.__name__}"
 
-                self.check_openapi_arguments_for_view(p, function_name, function, method, tags)
+                with self.subTest(function_name):
+                    self.check_openapi_arguments_for_view(p, function_name, function, method, tags)
 
         self.check_for_non_existent_openapi_endpoints()
 


### PR DESCRIPTION
Each unittest subTest can fail without interrupting the other subTests. By wrapping the test for each view function, we can get all validation errors at once, which can be useful if multiple endpoints are updated.

More importantly, if the test fails anywhere inside test_openapi but before the formatted output is printed, we will not lose the information of which view function fails the validation. Because we attach the name of the function to the subTest:

```
FAIL: test_openapi_arguments (zerver.tests.test_openapi.OpenAPIArgumentsTest) [zerver.views.alert_words.add_alert_words]
```


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
