### PR TITLE
search: Add title to the search bar when in "sender:" narrow & rewrite is_common_narrow.

### DIFF
--- a/web/src/filter.js
+++ b/web/src/filter.js
@@ -575,6 +575,9 @@ export class Filter {
         if (_.isEqual(term_types, ["streams-public"])) {
             return true;
         }
+        if (_.isEqual(term_types, ["sender"])) {
+            return true;
+        }
         return false;
     }
 
@@ -713,6 +716,23 @@ export class Filter {
             // and also to ensure that we return a string and not an array so that we
             // can have the same return type as other cases.
             return names.join(", ");
+        }
+        if (term_types.length === 1 && _.isEqual(term_types, ["sender"])) {
+            const email = this.operands("sender")[0];
+            const user = people.get_by_email(email);
+            let sender = email;
+            if (user) {
+                if (people.is_my_user_id(user.user_id)) {
+                    return $t({defaultMessage: "Messages sent by you"});
+                }
+                sender = user.full_name;
+            }
+            return $t(
+                {defaultMessage: "Messages sent by {sender}"},
+                {
+                    sender,
+                },
+            );
         }
         if (term_types.length === 1) {
             switch (term_types[0]) {

--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -120,6 +120,22 @@ export function compute_narrow_title(filter) {
         return $t({defaultMessage: "Invalid user"});
     }
 
+    if (filter.has_operator("sender")) {
+        const user = people.get_by_email(filter.operands("sender")[0]);
+        if (user) {
+            if (people.is_my_user_id(user.user_id)) {
+                return $t({defaultMessage: "Messages sent by you"});
+            }
+            return $t(
+                {defaultMessage: "Messages sent by {sender}"},
+                {
+                    sender: user.full_name,
+                },
+            );
+        }
+        return $t({defaultMessage: "Invalid user"});
+    }
+
     return filter_title;
 }
 

--- a/web/tests/filter.test.js
+++ b/web/tests/filter.test.js
@@ -1522,6 +1522,7 @@ test("navbar_helpers", () => {
         test_redirect_url_with_search(test_case);
     }
 
+    const sender = [{operator: "sender", operand: joe.email}];
     const in_home = [{operator: "in", operand: "home"}];
     const in_all = [{operator: "in", operand: "all"}];
     const is_starred = [{operator: "is", operand: "starred"}];
@@ -1563,6 +1564,13 @@ test("navbar_helpers", () => {
     ];
 
     const test_cases = [
+        {
+            operator: sender,
+            is_common_narrow: true,
+            icon: undefined,
+            title: "translated: Messages sent by " + joe.full_name,
+            redirect_url_with_search: "/#narrow/sender/" + joe.user_id + "-joe",
+        },
         {
             operator: is_starred,
             is_common_narrow: true,
@@ -1722,12 +1730,12 @@ test("navbar_helpers", () => {
         {
             operator: sender_me,
             redirect_url_with_search: "/#narrow/sender/" + me.user_id + "-Me-Myself",
-            is_common_narrow: false,
+            is_common_narrow: true,
         },
         {
             operator: sender_joe,
             redirect_url_with_search: "/#narrow/sender/" + joe.user_id + "-joe",
-            is_common_narrow: false,
+            is_common_narrow: true,
         },
     ];
 

--- a/web/tests/narrow.test.js
+++ b/web/tests/narrow.test.js
@@ -786,7 +786,7 @@ run_test("narrow_compute_title", ({override}) => {
     assert.equal(narrow.compute_narrow_title(filter), "translated: Search results");
 
     filter = new Filter([{operator: "sender", operand: "me"}]);
-    assert.equal(narrow.compute_narrow_title(filter), "translated: Search results");
+    assert.equal(narrow.compute_narrow_title(filter), "translated: Messages sent by you");
 
     // Stream narrows
     const sub = {


### PR DESCRIPTION
- Display title to the search bar in `sender:` narrow:

    -   for me: Messages sent by you
    -   for any user: Messages sent by User

- Rewrite the `is_common_narrow`
---------------------

Fixes: #18690
Czo: [is_common_narrow topic](https://chat.zulip.org/#narrow/stream/6-frontend/topic/is_common_narrow.20rewrite)

--------------

**Screenshots and screen captures:**

<details>
<summary>Before:</summary>
<br>


<img width="890" alt="Screenshot 2023-08-13 at 1 16 56 AM" src="https://github.com/zulip/zulip/assets/66828942/4a514dc3-cde2-4117-9c6b-1d80464f2173">




</details>

<details>
<summary>After:</summary>
<br>


<img width="890" alt="Screenshot 2023-08-13 at 1 12 08 AM" src="https://github.com/zulip/zulip/assets/66828942/27cbc540-2279-4157-975d-240f693c2d3a">

-------------------

<img width="890" alt="Screenshot 2023-08-13 at 1 12 14 AM" src="https://github.com/zulip/zulip/assets/66828942/baec1635-6724-47e8-9380-038d319f549e">

</details>

-------------

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
