### PR TITLE
navbar_alerts: Improve "Complete the organization profile" banner.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 203**
+
+* [`POST /register`](/api/register-queue): Add
+  `realm_date_created` field to realm data.
+
 **Feature level 202**
 
 * [`PATCH /realm/linkifiers`](/api/reorder-linkifiers): Added new endpoint

--- a/web/src/navbar_alerts.js
+++ b/web/src/navbar_alerts.js
@@ -15,6 +15,7 @@ import * as keydown_util from "./keydown_util";
 import {localstorage} from "./localstorage";
 import * as notifications from "./notifications";
 import {page_params} from "./page_params";
+import {should_display_profile_incomplete_alert} from "./timerender";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
 import * as unread_ui from "./unread_ui";
@@ -94,6 +95,9 @@ export function dismiss_upgrade_nag(ls) {
 
 export function check_profile_incomplete() {
     if (!page_params.is_admin) {
+        return false;
+    }
+    if (!should_display_profile_incomplete_alert(page_params.realm_date_created)) {
         return false;
     }
 

--- a/web/src/timerender.ts
+++ b/web/src/timerender.ts
@@ -490,3 +490,14 @@ export function get_time_limit_setting_in_appropriate_unit(
     const time_limit_in_days = Math.floor(time_limit_in_hours / 24);
     return {value: time_limit_in_days, unit: "day"};
 }
+
+export function should_display_profile_incomplete_alert(timestamp: number): boolean {
+    const today = new Date(Date.now());
+    const time = new Date(timestamp);
+    const days_old = differenceInCalendarDays(today, time);
+
+    if (days_old >= 15) {
+        return true;
+    }
+    return false;
+}

--- a/web/templates/navbar_alerts/profile_incomplete.hbs
+++ b/web/templates/navbar_alerts/profile_incomplete.hbs
@@ -1,7 +1,7 @@
 <div data-step="1">
     {{#tr}}
-        Complete the <z-link>organization profile</z-link>
-        to brand and explain the purpose of this Zulip organization.
+        Complete your <z-link>organization profile</z-link>,
+        which is displayed on your organization's registration and login pages.
         {{#*inline "z-link"}}<a class="alert-link" href="#organization/organization-profile">{{> @partial-block}}</a>{{/inline}}
     {{/tr}}
 </div>

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -12,6 +12,7 @@ page_params.is_spectator = false;
 
 const notifications = mock_esm("../src/notifications");
 const util = mock_esm("../src/util");
+const timerender = mock_esm("../src/timerender");
 
 const {localstorage} = zrequire("localstorage");
 const navbar_alerts = zrequire("navbar_alerts");
@@ -62,7 +63,10 @@ test("allow_notification_alert", ({disallow, override}) => {
     assert.equal(navbar_alerts.should_show_notifications(ls), false);
 });
 
-test("profile_incomplete_alert", () => {
+test("profile_incomplete_alert", ({override}) => {
+    // Don't test time related conditions
+    override(timerender, "should_display_profile_incomplete_alert", () => true);
+
     // Show alert.
     page_params.is_admin = true;
     page_params.realm_description = "Organization imported from Slack!";

--- a/web/tests/timerender.test.js
+++ b/web/tests/timerender.test.js
@@ -597,3 +597,17 @@ run_test("set_full_datetime", () => {
     expected = "10:52 AM";
     assert.equal(time_str, expected);
 });
+
+run_test("should_display_profile_incomplete_alert", () => {
+    // Organization created < 15 days ago
+    let realm_date_created = new Date();
+    realm_date_created.setDate(realm_date_created.getDate() - 5);
+
+    assert.equal(timerender.should_display_profile_incomplete_alert(realm_date_created), false);
+
+    // Organization created > 15 days ago
+    realm_date_created = new Date();
+    realm_date_created.setDate(realm_date_created.getDate() - 15);
+
+    assert.equal(timerender.should_display_profile_incomplete_alert(realm_date_created), true);
+});

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -359,6 +359,7 @@ def fetch_initial_state_data(
             state["demo_organization_scheduled_deletion_date"] = datetime_to_timestamp(
                 realm.demo_organization_scheduled_deletion_date
             )
+        state["realm_date_created"] = datetime_to_timestamp(realm.date_created)
 
         # Presence system parameters for client behavior.
         state["server_presence_ping_interval_seconds"] = settings.PRESENCE_PING_INTERVAL_SECS

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11195,6 +11195,13 @@ paths:
                               type: string
                               description: |
                                 The name of the custom profile field type.
+                      realm_date_created:
+                        type: integer
+                        description: |
+                          The UNIX timestamp (UTC) for when the organization was
+                          created.
+
+                          **Changes**: New in Zulip 8.0 (feature level 203).
                       demo_organization_scheduled_deletion_date:
                         type: integer
                         description: |

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -118,6 +118,7 @@ class HomeTest(ZulipTestCase):
         "realm_create_private_stream_policy",
         "realm_create_public_stream_policy",
         "realm_create_web_public_stream_policy",
+        "realm_date_created",
         "realm_default_code_block_language",
         "realm_default_external_accounts",
         "realm_default_language",


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Currently, we are displaying the "Complete the organization profile"
banner immediately after the organization was created. It's important to
strongly encourage orgs to configure their profile, so we should delay
showing the banner if the profile has not been configured after 15 days.
Thus also allows the users to check out Zulip and see how it works before
configuring the organization settings.

Previously, the reason to complete the organization profile on the banner
wasn't clear and at times confusing. With the updated wording, it clears
up the confusion and improves the explaination of "why" as well.

Fixes: #24122.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/62449508/a8654c76-3d47-4ce8-b2a8-8636fdb60eb5)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
