### PR TITLE
unread_count: Remove letter spacing for better horizontal alignment.

### DIFF
--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -578,7 +578,6 @@ div.overlay {
     line-height: 16px;
     font-size: 12px;
     font-weight: normal;
-    letter-spacing: 0.6px;
     border-radius: 4px;
     background-color: hsl(105deg 2% 50%);
     color: hsl(0deg 0% 100%);


### PR DESCRIPTION
Related [CZO discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/unread.20count.20horizontal.20aligning)

<details>
<summary>Screenshots:</summary>

| Before | After |
| ------ | ------- |
| ![before](https://github.com/zulip/zulip/assets/53193850/c60143b8-fad8-4df7-996e-ebfd2c389fd3) | ![after](https://github.com/zulip/zulip/assets/53193850/a4d233c1-e288-48bb-8458-0e4e7546511f) |
 
</details>

