### PR TITLE
linkifiers: Disable dragging when a filter is applied

### DIFF
--- a/web/src/list_widget.ts
+++ b/web/src/list_widget.ts
@@ -36,7 +36,7 @@ type ListWidgetFilterOpts<Item = unknown> = {
 type ListWidgetOpts<Key = unknown, Item = Key> = {
     name?: string;
     get_item: (key: Key) => Item;
-    modifier: (item: Item) => string;
+    modifier: (item: Item, filter_value: string) => string;
     init_sort?: string | SortingFunction<Item>;
     initially_descending_sort?: boolean;
     html_selector?: (item: Item) => JQuery;
@@ -256,7 +256,7 @@ export function create<Key = unknown, Item = Key>(
 
             let html = "";
             for (const item of slice) {
-                const s = opts.modifier(item);
+                const s = opts.modifier(item, meta.filter_value);
 
                 if (typeof s !== "string") {
                     blueslip.error("List item is not a string", {item: s});
@@ -293,7 +293,7 @@ export function create<Key = unknown, Item = Key>(
                 return;
             }
 
-            const html = opts.modifier(item);
+            const html = opts.modifier(item, meta.filter_value);
             if (typeof html !== "string") {
                 blueslip.error("List item is not a string", {item: html});
                 return;
@@ -432,7 +432,7 @@ export function create<Key = unknown, Item = Key>(
                         "Please specify modifier and html_selector when creating the widget.",
                     );
                 }
-                const rendered_row = opts.modifier(item);
+                const rendered_row = opts.modifier(item, meta.filter_value);
                 if (insert_index === meta.filtered_list.length - 1) {
                     const $target_row = opts.html_selector!(meta.filtered_list[insert_index - 1]);
                     $target_row.after(rendered_row);

--- a/web/src/settings_linkifiers.js
+++ b/web/src/settings_linkifiers.js
@@ -133,7 +133,7 @@ export function populate_linkifiers(linkifiers_data) {
     ListWidget.create($linkifiers_table, linkifiers_data, {
         name: "linkifiers_list",
         get_item: ListWidget.default_get_item,
-        modifier(linkifier) {
+        modifier(linkifier, filter_value) {
             return render_admin_linkifier_list({
                 linkifier: {
                     pattern: linkifier.pattern,
@@ -141,6 +141,7 @@ export function populate_linkifiers(linkifiers_data) {
                     id: linkifier.id,
                 },
                 can_modify: page_params.is_admin,
+                can_drag: filter_value.length === 0,
             });
         },
         filter: {

--- a/web/templates/settings/admin_linkifier_list.hbs
+++ b/web/templates/settings/admin_linkifier_list.hbs
@@ -1,7 +1,7 @@
 {{#with linkifier}}
-<tr class="linkifier_row{{#if ../can_modify}} movable-row{{/if}}" data-linkifier-id="{{id}}">
+<tr class="linkifier_row{{#if (and ../can_modify ../can_drag)}} movable-row{{/if}}" data-linkifier-id="{{id}}">
     <td>
-        {{#if ../can_modify}}
+        {{#if (and ../can_modify ../can_drag)}}
             <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
             <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
         {{/if}}

--- a/web/tests/list_widget.test.js
+++ b/web/tests/list_widget.test.js
@@ -239,13 +239,17 @@ run_test("filtering", () => {
 
     const $search_input = make_search_input();
 
+    let last_filter_value = "";
     const list = ["apple", "banana", "carrot", "dog", "egg", "fence", "grape"];
     const opts = {
         filter: {
             $element: $search_input,
             predicate: (item, value) => item.includes(value),
         },
-        modifier: (item) => div(item),
+        modifier(item, filter_value) {
+            last_filter_value = filter_value;
+            return div(item);
+        },
         get_item: (item) => item,
         $simplebar_container: $scroll_container,
     };
@@ -268,6 +272,7 @@ run_test("filtering", () => {
     // is a glorified indexOf call.)
     $search_input.val = () => "g";
     $search_input.simulate_input_event();
+    assert.equal(last_filter_value, "g");
     assert.deepEqual(widget.get_current_list(), ["dog", "egg", "grape"]);
     expected_html = "<div>dog</div><div>egg</div><div>grape</div>";
     assert.deepEqual($container.$appended_data.html(), expected_html);


### PR DESCRIPTION
This is a follow-up to #26464. Linkifier items are no longer draggable if the filter value is non-empty. This is implemented by extending list widget to pass the filter value to the modifier.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![reorder-filter](https://github.com/zulip/zulip/assets/39874143/e421c6c4-66a4-4b8d-ac28-503f73ecc0da)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
