### PR TITLE
recent_topics: Move is_in_focus to UI module.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -236,7 +236,7 @@ export function in_content_editable_widget(e) {
 // Returns true if we handled it, false if the browser should.
 export function process_escape_key(e) {
     if (
-        recent_topics_util.is_in_focus() &&
+        recent_topics_ui.is_in_focus() &&
         // This will return false if `e.target` is not
         // any of the recent topics elements by design.
         recent_topics_ui.change_focused_element($(e.target), "escape")
@@ -622,7 +622,7 @@ export function process_hotkey(e, hotkey) {
         case "tab":
         case "shift_tab":
         case "open_recent_topics":
-            if (recent_topics_util.is_in_focus()) {
+            if (recent_topics_ui.is_in_focus()) {
                 return recent_topics_ui.change_focused_element($(e.target), event_name);
             }
     }

--- a/web/src/recent_topics_ui.js
+++ b/web/src/recent_topics_ui.js
@@ -9,6 +9,7 @@ import render_user_with_status_icon from "../templates/user_with_status_icon.hbs
 import * as blueslip from "./blueslip";
 import * as buddy_data from "./buddy_data";
 import * as compose_closed_ui from "./compose_closed_ui";
+import * as compose_state from "./compose_state";
 import * as hash_util from "./hash_util";
 import {$t} from "./i18n";
 import * as left_sidebar_navigation_area from "./left_sidebar_navigation_area";
@@ -22,19 +23,14 @@ import * as muted_users from "./muted_users";
 import * as narrow from "./narrow";
 import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
+import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pm_list from "./pm_list";
 import * as popovers from "./popovers";
 import * as recent_senders from "./recent_senders";
 import {get, process_message, topics} from "./recent_topics_data";
-import {
-    get_key_from_message,
-    get_topic_key,
-    is_in_focus,
-    is_visible,
-    set_visible,
-} from "./recent_topics_util";
+import {get_key_from_message, get_topic_key, is_visible, set_visible} from "./recent_topics_util";
 import * as resize from "./resize";
 import * as scroll_util from "./scroll_util";
 import * as search from "./search";
@@ -106,6 +102,17 @@ export function clear_for_tests() {
 
 export function save_filters() {
     ls.set(ls_key, [...filters]);
+}
+
+export function is_in_focus() {
+    // Check if user is focused on recent topics.
+    return (
+        is_visible() &&
+        !compose_state.composing() &&
+        !popovers.any_active() &&
+        !overlays.is_overlay_or_modal_open() &&
+        !$(".home-page-input").is(":focus")
+    );
 }
 
 export function set_default_focus() {

--- a/web/src/recent_topics_util.js
+++ b/web/src/recent_topics_util.js
@@ -1,9 +1,3 @@
-import $ from "jquery";
-
-import * as compose_state from "./compose_state";
-import * as overlays from "./overlays";
-import * as popovers from "./popovers";
-
 let is_rt_visible = false;
 
 export function set_visible(value) {
@@ -12,18 +6,6 @@ export function set_visible(value) {
 
 export function is_visible() {
     return is_rt_visible;
-}
-
-export function is_in_focus() {
-    // Check if user is focused on
-    // recent topics.
-    return (
-        is_visible() &&
-        !compose_state.composing() &&
-        !popovers.any_active() &&
-        !overlays.is_overlay_or_modal_open() &&
-        !$(".home-page-input").is(":focus")
-    );
 }
 
 export function get_topic_key(stream_id, topic) {

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -84,7 +84,7 @@ mock_esm("../src/hotspots", {
     is_open: () => false,
 });
 
-mock_esm("../src/recent_topics_util", {
+mock_esm("../src/recent_topics_ui", {
     is_in_focus: () => false,
 });
 


### PR DESCRIPTION
This better fits how this function is used, and cuts unnecessary dependencies from recent_topics_util.js.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
