### PR TITLE
ts: Migrate `hash_util`, `browser_history`, `spectators` to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -94,7 +94,7 @@ EXEMPT_FILES = make_set(
         "web/src/gear_menu.ts",
         "web/src/giphy.js",
         "web/src/global.d.ts",
-        "web/src/hash_util.js",
+        "web/src/hash_util.ts",
         "web/src/hashchange.js",
         "web/src/hbs.d.ts",
         "web/src/hotkey.js",

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -181,7 +181,7 @@ EXEMPT_FILES = make_set(
         "web/src/settings_user_topics.js",
         "web/src/settings_users.js",
         "web/src/setup.ts",
-        "web/src/spectators.js",
+        "web/src/spectators.ts",
         "web/src/spoilers.ts",
         "web/src/starred_messages_ui.js",
         "web/src/stream_bar.js",

--- a/web/src/browser_history.ts
+++ b/web/src/browser_history.ts
@@ -5,7 +5,13 @@ import * as hash_util from "./hash_util";
 import * as ui_util from "./ui_util";
 import {user_settings} from "./user_settings";
 
-export const state = {
+export const state: {
+    is_internal_change: boolean;
+    hash_before_overlay: string | null;
+    old_hash: string;
+    changing_hash: boolean;
+    spectator_old_hash: string;
+} = {
     is_internal_change: false,
     hash_before_overlay: null,
     old_hash: window.location.hash,
@@ -19,21 +25,21 @@ export const state = {
         : `#${user_settings.default_view}`,
 };
 
-export function clear_for_testing() {
+export function clear_for_testing(): void {
     state.is_internal_change = false;
     state.hash_before_overlay = null;
     state.old_hash = "#";
 }
 
-export function old_hash() {
+export function old_hash(): string {
     return state.old_hash;
 }
 
-export function set_hash_before_overlay(hash) {
+export function set_hash_before_overlay(hash: string): void {
     state.hash_before_overlay = hash;
 }
 
-export function update_web_public_hash(hash) {
+export function update_web_public_hash(hash: string): boolean {
     // Returns true if hash is web-public compatible.
     if (hash_util.is_spectator_compatible(hash)) {
         state.spectator_old_hash = hash;
@@ -42,7 +48,7 @@ export function update_web_public_hash(hash) {
     return false;
 }
 
-export function save_old_hash() {
+export function save_old_hash(): boolean {
     state.old_hash = window.location.hash;
 
     const was_internal_change = state.is_internal_change;
@@ -51,7 +57,7 @@ export function save_old_hash() {
     return was_internal_change;
 }
 
-export function update(new_hash) {
+export function update(new_hash: string): void {
     const old_hash = window.location.hash;
 
     if (!new_hash.startsWith("#")) {
@@ -73,7 +79,7 @@ export function update(new_hash) {
     window.location.hash = new_hash;
 }
 
-export function exit_overlay() {
+export function exit_overlay(): void {
     if (hash_util.is_overlay_hash(window.location.hash) && !state.changing_hash) {
         ui_util.blur_active_element();
         const new_hash = state.hash_before_overlay || `#${user_settings.default_view}`;
@@ -81,18 +87,18 @@ export function exit_overlay() {
     }
 }
 
-export function go_to_location(hash) {
+export function go_to_location(hash: string): void {
     // Call this function when you WANT the hashchanged
     // function to run.
     window.location.hash = hash;
 }
 
-export function update_hash_internally_if_required(hash) {
+export function update_hash_internally_if_required(hash: string): void {
     if (window.location.hash !== hash) {
         update(hash);
     }
 }
 
-export function return_to_web_public_hash() {
+export function return_to_web_public_hash(): void {
     window.location.hash = state.spectator_old_hash;
 }

--- a/web/src/spectators.ts
+++ b/web/src/spectators.ts
@@ -14,7 +14,7 @@ import * as hash_util from "./hash_util";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 
-export function login_to_access(empty_narrow) {
+export function login_to_access(empty_narrow?: boolean): void {
     // Hide all overlays, popover and go back to the previous hash if the
     // hash has changed.
     const login_link = hash_util.build_login_link();


### PR DESCRIPTION
This PR migrates 3 modules:-
- `hash_util`
- `browser_history`
- `spectators`

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
