### PR TITLE
dialog_widget: Add horizontal padding to the modal content.

### DIFF
--- a/web/styles/modal.css
+++ b/web/styles/modal.css
@@ -86,7 +86,7 @@
     flex-direction: column;
     font-size: 1rem;
     overflow-y: auto;
-    padding: 0 24px;
+    padding: 2px 24px;
     line-height: 1.5;
 
     &.simplebar-scrollable-y + .modal__footer {


### PR DESCRIPTION
Previously, the modal content bottom border sometimes got hidden due to subpixel rounding. 

This happens only at some Zoom levels and on Google Chrome.

<details>

<summary> <b>Screenshots and screen captures:</b> </summary>

<table>
  <tr>
    <th colspan="2">On 75% Zoom - Chrome 110</th>
  </tr>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/sbansal1999/zulip/assets/35286603/5996a059-8945-4b8d-948f-180e544296ca)" alt="image"></td>
    <td><img src="https://github.com/sbansal1999/zulip/assets/35286603/45b67ef3-3c7c-4394-ad73-c20f544287de" alt="image"></td>
  </tr>
</table>

</details>

CZO Discussion: [Link](https://chat.zulip.org/#narrow/stream/6-frontend/topic/border.20disappearing.20on.20zooming.20out/near/1625327)


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
