### PR TITLE
portico_signin: Fix back to login button alignment.

### DIFF
--- a/web/styles/portico/portico_signin.css
+++ b/web/styles/portico/portico_signin.css
@@ -871,13 +871,14 @@ button#register_auth_button_gitlab {
     text-align: left;
 }
 
-.back-to-login-wrapper {
-    line-height: 0;
+.back-to-login-wrapper .back-to-login {
+    display: flex;
+    gap: 5px;
+    align-items: center;
 
-    .back-to-login i {
+    i {
         position: relative;
-        top: 5px;
-
+        top: -1px;
         font-size: 0.8em;
     }
 }


### PR DESCRIPTION
This is only visible on desktop app.

before:
<img width="548" alt="image" src="https://github.com/zulip/zulip/assets/25124304/3cb310c7-b513-430b-a759-d3f6d2cd229f">


after:
<img width="464" alt="image" src="https://github.com/zulip/zulip/assets/25124304/0b667a2f-8b06-4cc8-b1b6-eed826383088">
