### PR TITLE
Fix poll and todo input focus box-shadow being cropped.

### DIFF
--- a/web/styles/widgets.css
+++ b/web/styles/widgets.css
@@ -112,9 +112,8 @@
         &:focus {
             border-color: hsl(206deg 80% 62% / 80%);
             outline: 0;
-            box-shadow:
-                inset 0 1px 1px hsl(0deg 0% 0% / 7.5%),
-                0 0 8px hsl(206deg 80% 62% / 60%);
+            box-shadow: none;
+            background-color: var(--color-background-widget-input);
         }
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -153,7 +153,7 @@ body {
     --color-message-header-icon-non-interactive: hsl(0deg 0% 0% / 30%);
     --color-message-header-icon-interactive: hsl(0deg 0% 0%);
     --color-background: hsl(0deg 0% 94%);
-    --color-background-dropdown-input: hsl(0deg 0% 100%);
+    --color-background-widget-input: hsl(0deg 0% 100%);
     --color-background-navbar: hsl(0deg 0% 96%);
     --color-background-active-narrow-filter: hsl(202deg 56% 91%);
     --color-background-hover-narrow-filter: hsl(120deg 12.3% 71.4% / 38%);
@@ -207,7 +207,7 @@ body {
     --color-private-message-header-border-bottom: hsl(0deg 0% 0% / 37%);
     --color-message-list-border: hsl(0deg 0% 0% / 40%);
     --color-background: hsl(0deg 0% 11%);
-    --color-background-dropdown-input: hsl(225deg 6% 10%);
+    --color-background-widget-input: hsl(225deg 6% 10%);
     --color-background-navbar: hsl(0deg 0% 13%);
     --color-background-active-narrow-filter: hsl(200deg 17% 18%);
     --color-background-hover-narrow-filter: hsl(136deg 25% 73% / 20%);
@@ -3112,7 +3112,7 @@ select.invite-as {
         display: flex;
 
         .dropdown-list-search-input {
-            background: var(--color-background-dropdown-input);
+            background: var(--color-background-widget-input);
             color: var(--color-text-dropdown-input);
             width: 100%;
             margin: 4px 4px 2px;


### PR DESCRIPTION
before:
<img width="479" alt="image" src="https://github.com/zulip/zulip/assets/25124304/5d73a092-fba5-4c20-854d-d592296b8bbc">
<img width="480" alt="image" src="https://github.com/zulip/zulip/assets/25124304/54ad2121-95dd-42df-9ec9-5c62d45fe87c">


after:
<img width="471" alt="image" src="https://github.com/zulip/zulip/assets/25124304/275c24f8-4166-4c4a-ac3b-86867445697b">
<img width="510" alt="image" src="https://github.com/zulip/zulip/assets/25124304/782a1915-b4ed-4806-98e0-270d25858fff">
