### PR TITLE
ts: Migrate `compose_fade_helper.js` , `compose_fade_users.js`, and `recent_topics_util.js` to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -148,7 +148,6 @@ EXEMPT_FILES = make_set(
         "web/src/realm_playground.ts",
         "web/src/realm_user_settings_defaults.ts",
         "web/src/recent_view_ui.js",
-        "web/src/recent_view_util.js",
         "web/src/reload.js",
         "web/src/reminder.js",
         "web/src/resize.js",

--- a/web/src/compose_fade_helper.ts
+++ b/web/src/compose_fade_helper.ts
@@ -1,27 +1,36 @@
+import assert from "minimalistic-assert";
+
 import * as stream_data from "./stream_data";
 import * as sub_store from "./sub_store";
 import * as util from "./util";
+import type {DirectRecipient, StreamRecipient} from "./util";
 
-let focused_recipient;
+type Recipient = DirectRecipient | StreamRecipient;
 
-export function should_fade_message(message) {
+let focused_recipient: Recipient | undefined;
+
+export function should_fade_message(message: Recipient): boolean {
     return !util.same_recipient(focused_recipient, message);
 }
 
-export function clear_focused_recipient() {
+export function clear_focused_recipient(): void {
     focused_recipient = undefined;
 }
 
-export function set_focused_recipient(recipient) {
+export function set_focused_recipient(recipient: Recipient): void {
     focused_recipient = recipient;
 }
 
-function is_pm_recipient(user_id) {
-    const recipients = focused_recipient.to_user_ids.split(",");
+function is_pm_recipient(user_id: number): boolean {
+    // This function is called only when focused_recipient.type==="private",
+    // so it's safe to use non-null assertion (!) here.
+    assert(focused_recipient?.type === "private");
+    const recipients = focused_recipient.to_user_ids?.split(",") || [];
     return recipients.includes(user_id.toString());
 }
 
-export function would_receive_message(user_id) {
+export function would_receive_message(user_id: number): boolean | undefined {
+    assert(focused_recipient !== undefined, "focused recipient is undefined.");
     if (focused_recipient.type === "stream") {
         const sub = sub_store.get(focused_recipient.stream_id);
         if (!sub) {
@@ -38,7 +47,7 @@ export function would_receive_message(user_id) {
     return is_pm_recipient(user_id);
 }
 
-export function want_normal_display() {
+export function want_normal_display(): boolean {
     // If we're not composing show a normal display.
     if (focused_recipient === undefined) {
         return true;

--- a/web/src/compose_fade_users.ts
+++ b/web/src/compose_fade_users.ts
@@ -1,7 +1,13 @@
 import * as compose_fade_helper from "./compose_fade_helper";
 import * as people from "./people";
 
-function update_user_row_when_fading(li, conf) {
+export type Configuration = {
+    get_user_id(li: JQuery<HTMLElement>): number;
+    unfade(li: JQuery<HTMLElement>): void;
+    fade(li: JQuery<HTMLElement>): void;
+};
+
+function update_user_row_when_fading(li: JQuery<HTMLElement>, conf: Configuration): void {
     const user_id = conf.get_user_id(li);
     const would_receive = compose_fade_helper.would_receive_message(user_id);
 
@@ -12,19 +18,19 @@ function update_user_row_when_fading(li, conf) {
     }
 }
 
-export function fade_users(items, conf) {
+export function fade_users(items: JQuery<HTMLElement>[], conf: Configuration): void {
     for (const li of items) {
         update_user_row_when_fading(li, conf);
     }
 }
 
-export function display_users_normally(items, conf) {
+export function display_users_normally(items: JQuery<HTMLElement>[], conf: Configuration): void {
     for (const li of items) {
         conf.unfade(li);
     }
 }
 
-export function update_user_info(items, conf) {
+export function update_user_info(items: JQuery<HTMLElement>[], conf: Configuration): void {
     if (compose_fade_helper.want_normal_display()) {
         display_users_normally(items, conf);
     } else {

--- a/web/src/recent_topics_util.ts
+++ b/web/src/recent_topics_util.ts
@@ -1,0 +1,27 @@
+import type {DirectRecipient, StreamRecipient} from "./util";
+
+type Recipient = DirectRecipient | StreamRecipient;
+
+let is_rt_visible = false;
+
+export function set_visible(value: boolean): void {
+    is_rt_visible = value;
+}
+
+export function is_visible(): boolean {
+    return is_rt_visible;
+}
+
+export function get_topic_key(stream_id: number, topic: string): string {
+    return stream_id + ":" + topic.toLowerCase();
+}
+
+export function get_key_from_message(msg: Recipient): string | undefined {
+    if (msg.type === "private") {
+        // The to_user_ids field on a direct message object is a
+        // string containing the user IDs involved in the message in
+        // sorted order.
+        return msg.to_user_ids;
+    }
+    return get_topic_key(msg.stream_id, msg.topic);
+}

--- a/web/src/util.ts
+++ b/web/src/util.ts
@@ -4,6 +4,24 @@ import * as blueslip from "./blueslip";
 import {$t} from "./i18n";
 import type {MatchedMessage, Message, RawMessage, UpdateMessageEvent} from "./types";
 
+// When the type is "private", properties from to_user_ids might be undefined.
+// See https://github.com/zulip/zulip/pull/23032#discussion_r1038480596.
+// Recipient type in direct messages (DM)
+export type DirectRecipient = {
+    type: "private";
+    to_user_ids: string | undefined;
+    reply_to: string;
+};
+
+// Recipient type in a stream
+export type StreamRecipient = {
+    type: "stream";
+    stream_id: number;
+    topic: string;
+};
+
+export type Recipient = DirectRecipient | StreamRecipient;
+
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
 export function random_int(min: number, max: number): number {
     return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -68,10 +86,6 @@ export const same_stream_and_topic = function util_same_stream_and_topic(
 export function extract_pm_recipients(recipients: string): string[] {
     return recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");
 }
-
-// When the type is "private", properties from to_user_ids might be undefined.
-// See https://github.com/zulip/zulip/pull/23032#discussion_r1038480596.
-type Recipient = {to_user_ids?: string; type: "private"} | (StreamTopic & {type: "stream"});
 
 export const same_recipient = function util_same_recipient(a?: Recipient, b?: Recipient): boolean {
     if (a === undefined || b === undefined) {


### PR DESCRIPTION
This PR consists of 5 commits:

1. sub_store: Move PartialBy to util.
This aids reusability of this utility type in the codebase.

2. util: Redefine Recipient type.
Redefined `Recipient` type by spliting it into `DirectRecipient`
and `StreamRecipient`. Splitting makes each of sub-type reusable. 
This is a prep-commit for migrating `compose_fade_helpers`.

3. ts: Migrate `compose_fade_helper.js` to TypeScript.
 
4. ts: Migrate `compose_fade_users.js` to TypeScript.
Created a type `Configuration` in `compose_fade_users.ts` that very likely will be re-used in `compose_fade.js`, `buddy_data.js`,  `buddy_list.js`, etc.

5. ts: Migrate `recent_topics_util.js`  to TypeScript.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
