### PR TITLE
topic_mentions: Fix the incorrectly set `wildcard_mentioned` flag.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -191,6 +191,8 @@ class SendMessageRequest:
     # (having stream wildcard) is being sent to, and have the
     # 'followed_topic_wildcard_mentions_notify' setting ON.
     stream_wildcard_mention_in_followed_topic_user_ids: Set[int]
+    # A topic participant is anyone who either sent or reacted to messages in the topic.
+    topic_participant_user_ids: Set[int]
     links_for_embed: Set[str]
     widget_content: Optional[Dict[str, Any]]
     submessages: List[Dict[str, Any]] = field(default_factory=list)

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -2060,13 +2060,19 @@ class EditMessageTest(EditMessageTestCase):
         )
         message_id = self.send_stream_message(hamlet, stream_name, "Hello everyone")
 
-        def notify(user_id: int) -> Dict[str, Any]:
-            return {
-                "id": user_id,
-                "flags": ["wildcard_mentioned"],
-            }
-
-        users_to_be_notified = sorted(map(notify, [cordelia.id, hamlet.id]), key=itemgetter("id"))
+        users_to_be_notified = sorted(
+            [
+                {
+                    "id": hamlet.id,
+                    "flags": ["wildcard_mentioned"],
+                },
+                {
+                    "id": cordelia.id,
+                    "flags": [],
+                },
+            ],
+            key=itemgetter("id"),
+        )
         result = self.client_patch(
             f"/json/messages/{message_id}",
             {
@@ -2155,13 +2161,19 @@ class EditMessageTest(EditMessageTestCase):
         self.login_user(hamlet)
         message_id = self.send_stream_message(hamlet, stream_name, "Hello everyone")
 
-        def notify(user_id: int) -> Dict[str, Any]:
-            return {
-                "id": user_id,
-                "flags": ["wildcard_mentioned"],
-            }
-
-        users_to_be_notified = sorted(map(notify, [cordelia.id, hamlet.id]), key=itemgetter("id"))
+        users_to_be_notified = sorted(
+            [
+                {
+                    "id": hamlet.id,
+                    "flags": ["wildcard_mentioned"],
+                },
+                {
+                    "id": cordelia.id,
+                    "flags": [],
+                },
+            ],
+            key=itemgetter("id"),
+        )
         result = self.client_patch(
             f"/json/messages/{message_id}",
             {

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1859,6 +1859,7 @@ class RecipientInfoTest(ZulipTestCase):
             default_bot_user_ids=set(),
             service_bot_tuples=[],
             all_bot_user_ids=set(),
+            topic_participant_user_ids=set(),
         )
 
         self.assertEqual(info, expected_info)


### PR DESCRIPTION
**First commit:**

message_send: Fix `wildcard_mentioned` flag unset for few participants.

Earlier, the flag was set if the `user_profile_id` exists in `all_topic_wildcard_mention_user_ids`.

`all_topic_wildcard_mention_user_ids` contains the ids of those users who are topic participants **and** have enabled notifications for '@topic' mentions.
    
The earlier approach was incorrect, as it would set the `wildcard_mentioned` flag only for those topic participants who have enabled the notifications for '@topic' mention instead of setting the flag for all the topic participants.

---

**Second commit:**

message_edit: Fix `wildcard_mentioned` flag set for all user-messages.

Earlier, for topic wildcard mentions, the `wildcard_mentioned` flag was set for all the user-messages. (similar to stream wildcard mention).
    
The flag should be set for the topic participants only.

---

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
