### PR TITLE
api-docs: Fix documentation of `realm_emoji` in register response.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11415,15 +11415,11 @@ paths:
                         description: |
                           Present if `realm_emoji` is present in `fetch_event_types`.
 
-                          An array of dictionaries where each dictionary describes a custom
+                          A dictionary of objects where each object describes a custom
                           emoji that has been uploaded in this Zulip organization.
-                        oneOf:
-                          - type: object
-                            additionalProperties:
-                              $ref: "#/components/schemas/RealmEmoji"
-                          - type: array
-                            items:
-                              type: integer
+                        type: object
+                        additionalProperties:
+                          $ref: "#/components/schemas/RealmEmoji"
                       realm_linkifiers:
                         type: array
                         description: |

--- a/zerver/tests/test_event_system.py
+++ b/zerver/tests/test_event_system.py
@@ -89,7 +89,8 @@ class EventsEndpointTest(ZulipTestCase):
         # We choose realm_emoji somewhat randomly--we want
         # a "boring" event type for the purpose of this test.
         event_type = "realm_emoji"
-        test_event = dict(id=6, type=event_type, realm_emoji=[])
+        empty_realm_emoji_dict: Dict[str, Any] = {}
+        test_event = dict(id=6, type=event_type, realm_emoji=empty_realm_emoji_dict)
 
         # Test that call is made to deal with a returning soft deactivated user.
         with mock.patch("zerver.lib.events.reactivate_user_if_soft_deactivated") as fa:
@@ -122,7 +123,7 @@ class EventsEndpointTest(ZulipTestCase):
         self.assertEqual(result_dict["queue_id"], "15:12")
 
         # sanity check the data relevant to our event
-        self.assertEqual(result_dict["realm_emoji"], [])
+        self.assertEqual(result_dict["realm_emoji"], {})
 
         # Now test with `fetch_event_types` not matching the event
         return_event_queue = "15:13"
@@ -161,7 +162,7 @@ class EventsEndpointTest(ZulipTestCase):
 
         # Check that the realm_emoji data is in there.
         self.assertIn("realm_emoji", result_dict)
-        self.assertEqual(result_dict["realm_emoji"], [])
+        self.assertEqual(result_dict["realm_emoji"], {})
         self.assertEqual(result_dict["queue_id"], "15:13")
 
     def test_events_register_spectators(self) -> None:


### PR DESCRIPTION
Fixes the `/api/register-queue` endpoint documentation so that the `realm_emoji` has the correct type, an object that contains objects that describe custom emoji in an organization.

By correcting the API documentation, we also fix an error in the test for the events system, which had been relying on the API documentation having a list as a possible type for `realm_emoji` in the register response.

See [relevant CZO disucssion](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/register.3A.20shape.20of.20.60realm_emoji.60.20object/near/1626354).

**Screenshots and screen captures:**

<details>
<summary>Updated realm_emoji in register response</summary>

[Current documentation](https://zulip.com/api/register-queue) - search for "realm_emoji" on page
![Screenshot from 2023-08-16 20-48-18](https://github.com/zulip/zulip/assets/63245456/1208c094-3682-41ef-b5b2-221c438ea3c7)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
