### PR TITLE
api-docs: Remove incorrect error response from `/api/subscribe`.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8701,40 +8701,27 @@ paths:
                   - example:
                       {
                         "already_subscribed":
-                          {"newbie@zulip.com": ["new stream"]},
+                          {"iago@zulip.com": ["new stream"]},
                         "msg": "",
                         "result": "success",
-                        "subscribed": {"iago@zulip.com": ["new stream"]},
+                        "subscribed": {"newbie@zulip.com": ["new stream"]},
                       }
         "400":
           description: Bad request.
           content:
             application/json:
               schema:
-                oneOf:
-                  - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example:
-                          {
-                            "msg": "Unable to access stream (private_stream).",
-                            "result": "error",
-                          }
-                        description: |
-                          A typical response for when the requesting user does not have access to
-                          a private stream and `"authorization_errors_fatal": true`:
-                  - allOf:
-                      - $ref: "#/components/schemas/AddSubscriptionsResponse"
-                      - example:
-                          {
-                            "already_subscribed": {},
-                            "msg": "",
-                            "result": "success",
-                            "subscribed": {},
-                            "unauthorized": ["private_stream"],
-                          }
-                        description: |
-                          A typical response for when the requesting user does not have access to
-                          a private stream and `"authorization_errors_fatal": false`:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "msg": "Unable to access stream (private_stream).",
+                        "result": "error",
+                        "code": "BAD_REQUEST",
+                      }
+                    description: |
+                      An example JSON response for when the requesting user does not have
+                      access to a private stream and `"authorization_errors_fatal": true`:
     patch:
       operationId: update-subscriptions
       summary: Update subscriptions


### PR DESCRIPTION
Removes a response example in the `POST users/me/subscriptions` documentation that was listed in `zerver/openapi/zulip.yaml` as a 400 error response. It is actually a variation on the success response for this endpoint.

The current rendering of our API documentation is not set up to support `"anyOf"` which would allow for validating examples that match multiple response schemas. Adding that support can be a follow-up issue to fixing this error.

The updated documentation for the endpoint's response does clearly document that the `unauthorized` list of stream names that weren't subscribed is only present if `"authorization_errors_fatal": false`. And the unique error for when that parameter is `true` is still documented.

**Screenshots and screen captures:**

<details>
<summary>Subscribe to a stream - response documentation</summary>

[Current documentation](https://zulip.com/api/subscribe#response)
![Screenshot from 2023-08-17 16-24-15](https://github.com/zulip/zulip/assets/63245456/0d083de7-9e76-4bff-8c74-8e968959d698)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
