### PR TITLE
reactions: Improve reactions layout.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -228,10 +228,15 @@ $time_column_min_width: 50px; /* + padding */
 
         .message_reactions {
             grid-area: reactions;
-            margin-top: -1px;
             display: flex;
             /* Allow reactions to wrap in mobile viewports */
             flex-wrap: wrap;
+            /* Keep reactions aligned to start (top), so that the
+               margin on the reaction button doesn't appear to
+               stretch the reactions taller. */
+            align-items: flex-start;
+            /* Control reaction spacing with a gap */
+            gap: 4px;
         }
 
         .message_edit {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -229,6 +229,9 @@ $time_column_min_width: 50px; /* + padding */
         .message_reactions {
             grid-area: reactions;
             margin-top: -1px;
+            display: flex;
+            /* Allow reactions to wrap in mobile viewports */
+            flex-wrap: wrap;
         }
 
         .message_edit {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -5,7 +5,6 @@
 
     .message_reaction {
         display: flex;
-        float: left;
         margin: 0.15em;
         padding: 0 2px 0 0;
         cursor: pointer;

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -5,7 +5,6 @@
 
     .message_reaction {
         display: flex;
-        margin: 0.15em;
         padding: 0 2px 0 0;
         cursor: pointer;
         background-color: hsl(0deg 0% 100%);
@@ -24,37 +23,34 @@
         + .reaction_button {
             visibility: hidden;
             pointer-events: none;
-            /* Match margins to .message_reaction;
-               probably need to put this in a variable,
-               if it's kept. */
-            margin: 0.15em;
             padding: 3px;
             height: 13px;
             border-radius: 4px;
             padding-left: 0.3em;
             border: 1px solid hsl(0deg 0% 73%);
             padding-right: 0.3em;
+            /* TODO: Eventually this space will be set on the message
+               box, but for now this preserves the space beneath the
+               reactions area. */
+            margin-bottom: 2px;
         }
 
         .emoji {
-            display: inline-block;
-            flex-shrink: 0;
-            vertical-align: top;
-            top: 0;
             margin: 1px 3px;
             height: 17px;
             width: 17px;
-            position: relative;
+            /* Preserve the emoji's dimensions, no
+               matter what the flexbox does. */
+            flex-shrink: 0;
+            /* Don't inherit position: relative; from
+               the base .emoji class. */
+            position: static;
         }
     }
 
     .message_reaction_count {
-        position: relative;
-        top: 1px;
         font-size: 90%;
-        display: flex;
-        margin: 0 3px;
-        padding: 2px 0;
+        margin: 2px 3px;
         line-height: 1em;
     }
 

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -46,6 +46,17 @@
                the base .emoji class. */
             position: static;
         }
+
+        .emoji_alt_code {
+            /* Apply the same margins as on graphical emoji. */
+            margin: 1px 3px;
+            /* Reset some properties from the base .emoji_alt_code
+               class that aren't appropriate in a flexbox context. */
+            position: static;
+            /* Flexbox will handle baselines, so don't mess with the
+               line-height. */
+            line-height: inherit;
+        }
     }
 
     .message_reaction_count {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -24,14 +24,16 @@
         + .reaction_button {
             visibility: hidden;
             pointer-events: none;
-            margin: 2px 0.1em 3px;
+            /* Match margins to .message_reaction;
+               probably need to put this in a variable,
+               if it's kept. */
+            margin: 0.15em;
             padding: 3px;
             height: 13px;
             border-radius: 4px;
             padding-left: 0.3em;
             border: 1px solid hsl(0deg 0% 73%);
             padding-right: 0.3em;
-            float: left;
         }
 
         .emoji {


### PR DESCRIPTION
This PR tightens up how reactions are laid out. Most notably, that means setting `.message_reactions` as a flex container (rather than floats on individual reactions, as had beeen used previously) and letting the individual reactions participate in the flexbox as first-class flex items--meaning that they are spaced from one another via gaps, not margins. Judicious use of the `flex-wrap` property ensures that this presentation is responsive across all viewport sizes.

The previous margins were set as 0.15em. Given that the font-size on reactions is the 14px inherited from the body, that works out to 2.1px margins, which I have rounded down to 2px for the sake of the 4px grid-gap. There is no visual difference from that, predictably.

Space at the bottom of the message box is still preserved by a bit of margin on the bottom of the reaction button; I've left a note in the comments to clean that up as part of [the broader whitespace project](https://chat.zulip.org/#narrow/stream/101-design/topic/some.20thoughts.20about.20vertical.20space.20.28LONG.29/near/1626496) in the message area.

Finally, because of the new layout mechanism, there are some very subtle changes (I believe improvements) to the design:

* The reactions area is no longer pulled upward by `margin-top: -1px`; that's unnecessary, because there is no longer any top margin to the emoji reactions (those spaces are all handled by flex gap now, and gap only applies to interstitial spaces--not the tops and bottoms of reactions, as margins did).
* Reactions now share the same lefthand edge as the message-text above (that was impossible before with wrapping floats and the margins required to separate them).
* Emoji and counts/names are now truly centered inside each reaction box.
* Alt code emoji, which had fallen into a state of disrepair, are now presented with the same space around them as graphic emoji; however, owing to their height being less than those of their graphic counterparts, they continue to appear shorter.

These changes were all motivated by [this issue on CZO](https://chat.zulip.org/#narrow/stream/9-issues/topic/Plain.20text.20emoji.20reaction.20alignment/near/1623169).

**Screenshots and screen captures:**

| Reactions, Before | Reactions After |
| --- | --- |
| ![main-reactions](https://github.com/zulip/zulip/assets/170719/e117f7b0-5778-4b93-a442-3f034209843f) | ![new-reactions](https://github.com/zulip/zulip/assets/170719/e8de0723-8a63-4be9-83fc-205c89ece4de) |

| Hover Controls, Before | Hover Controls, After |
| --- | --- |
| ![main-reaction-hover-highlight](https://github.com/zulip/zulip/assets/170719/97dd3f3f-808c-441d-b31f-d3667fc63354) | ![new-reaction-hover-highlight](https://github.com/zulip/zulip/assets/170719/4ad5bc42-7bdc-433c-a265-f9c76cb1e32f) |

| Alt-Code Emoji Before (😳) | Alt-Code Emoji, After |
| --- | --- |
| ![main-plain-text-reaction](https://github.com/zulip/zulip/assets/170719/619e4ec0-4e99-4fce-a7f3-743c84c56780) | ![new-plain-text-reaction](https://github.com/zulip/zulip/assets/170719/bad2df18-c9ad-457a-849d-e5c7457a005c) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>