### PR TITLE
tests: Eliminate refresh_from_db on UserProfile objects

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -106,6 +106,7 @@ from zerver.models import (
     get_system_bot,
     get_user,
     get_user_by_delivery_email,
+    get_user_profile_by_id,
 )
 from zerver.openapi.openapi import validate_against_openapi_schema, validate_request
 from zerver.tornado.event_queue import clear_client_event_queues_for_testing
@@ -651,6 +652,9 @@ Output:
 
     def notification_bot(self, realm: Realm) -> UserProfile:
         return get_system_bot(settings.NOTIFICATION_BOT, realm.id)
+
+    def refresh_user(self, user: UserProfile) -> UserProfile:
+        return get_user_profile_by_id(user.id)
 
     def create_test_bot(
         self, short_name: str, user_profile: UserProfile, full_name: str = "Foo Bot", **extras: Any

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -176,6 +176,9 @@ class ZulipTestCaseMixin(SimpleTestCase):
                 self.mock_ldap.reset()
             self.mock_initialize.stop()
 
+    def get_user_from_email(self, email: str, realm: Realm) -> UserProfile:
+        return get_user(email, realm)
+
     def run(self, result: Optional[TestResult] = None) -> Optional[TestResult]:  # nocoverage
         if not settings.BAN_CONSOLE_OUTPUT and self.expected_console_output is None:
             return super().run(result)
@@ -631,11 +634,11 @@ Output:
 
     def mit_user(self, name: str) -> UserProfile:
         email = self.mit_user_map[name]
-        return get_user(email, get_realm("zephyr"))
+        return self.get_user_from_email(email, get_realm("zephyr"))
 
     def lear_user(self, name: str) -> UserProfile:
         email = self.lear_user_map[name]
-        return get_user(email, get_realm("lear"))
+        return self.get_user_from_email(email, get_realm("lear"))
 
     def nonreg_email(self, name: str) -> str:
         return self.nonreg_user_map[name]
@@ -661,7 +664,7 @@ Output:
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_success(result)
         bot_email = f"{short_name}-bot@zulip.testserver"
-        bot_profile = get_user(bot_email, user_profile.realm)
+        bot_profile = self.get_user_from_email(bot_email, user_profile.realm)
         return bot_profile
 
     def fail_to_create_test_bot(
@@ -2016,7 +2019,7 @@ class WebhookTestCase(ZulipTestCase):
 
     @property
     def test_user(self) -> UserProfile:
-        return get_user(self.TEST_USER_EMAIL, get_realm("zulip"))
+        return self.get_user_from_email(self.TEST_USER_EMAIL, get_realm("zulip"))
 
     def setUp(self) -> None:
         super().setUp()

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1658,79 +1658,93 @@ Output:
         self, policy: str, validation_func: Callable[[UserProfile], bool]
     ) -> None:
         realm = get_realm("zulip")
-        owner_user = self.example_user("desdemona")
-        admin_user = self.example_user("iago")
-        moderator_user = self.example_user("shiva")
-        member_user = self.example_user("hamlet")
-        new_member_user = self.example_user("othello")
-        guest_user = self.example_user("polonius")
+
+        owner = "desdemona"
+        admin = "iago"
+        moderator = "shiva"
+        member = "hamlet"
+        new_member = "othello"
+        guest = "polonius"
+
+        def set_age(user_name: str, age: int) -> None:
+            user = self.example_user(user_name)
+            user.date_joined = timezone_now() - timedelta(age)
+            user.save()
 
         do_set_realm_property(realm, "waiting_period_threshold", 1000, acting_user=None)
-        new_member_user.date_joined = timezone_now() - timedelta(
-            days=(realm.waiting_period_threshold - 1)
-        )
-        new_member_user.save()
+        set_age(member, age=realm.waiting_period_threshold + 1)
+        set_age(new_member, age=realm.waiting_period_threshold - 1)
 
-        member_user.date_joined = timezone_now() - timedelta(
-            days=(realm.waiting_period_threshold + 1)
-        )
-        member_user.save()
+        def allow(user_name: str) -> None:
+            # Fetch a clean object for the user.
+            user = self.example_user(user_name)
+            with self.assert_database_query_count(0):
+                self.assertTrue(validation_func(user))
 
-        do_set_realm_property(realm, policy, Realm.POLICY_NOBODY, acting_user=None)
-        self.assertFalse(validation_func(owner_user))
-        self.assertFalse(validation_func(admin_user))
-        self.assertFalse(validation_func(moderator_user))
-        self.assertFalse(validation_func(member_user))
-        self.assertFalse(validation_func(new_member_user))
-        self.assertFalse(validation_func(guest_user))
+        def prevent(user_name: str) -> None:
+            # Fetch a clean object for the user.
+            user = self.example_user(user_name)
+            with self.assert_database_query_count(0):
+                self.assertFalse(validation_func(user))
 
-        do_set_realm_property(realm, policy, Realm.POLICY_OWNERS_ONLY, acting_user=None)
-        self.assertTrue(validation_func(owner_user))
-        self.assertFalse(validation_func(admin_user))
-        self.assertFalse(validation_func(moderator_user))
-        self.assertFalse(validation_func(member_user))
-        self.assertFalse(validation_func(new_member_user))
-        self.assertFalse(validation_func(guest_user))
+        def set_policy(level: int) -> None:
+            do_set_realm_property(realm, policy, level, acting_user=None)
 
-        do_set_realm_property(realm, policy, Realm.POLICY_ADMINS_ONLY, acting_user=None)
-        self.assertTrue(validation_func(owner_user))
-        self.assertTrue(validation_func(admin_user))
-        self.assertFalse(validation_func(moderator_user))
-        self.assertFalse(validation_func(member_user))
-        self.assertFalse(validation_func(new_member_user))
-        self.assertFalse(validation_func(guest_user))
+        set_policy(Realm.POLICY_NOBODY)
+        prevent(owner)
+        prevent(admin)
+        prevent(moderator)
+        prevent(member)
+        prevent(new_member)
+        prevent(guest)
 
-        do_set_realm_property(realm, policy, Realm.POLICY_MODERATORS_ONLY, acting_user=None)
-        self.assertTrue(validation_func(owner_user))
-        self.assertTrue(validation_func(admin_user))
-        self.assertTrue(validation_func(moderator_user))
-        self.assertFalse(validation_func(member_user))
-        self.assertFalse(validation_func(new_member_user))
-        self.assertFalse(validation_func(guest_user))
+        set_policy(Realm.POLICY_OWNERS_ONLY)
+        allow(owner)
+        prevent(admin)
+        prevent(moderator)
+        prevent(member)
+        prevent(new_member)
+        prevent(guest)
 
-        do_set_realm_property(realm, policy, Realm.POLICY_FULL_MEMBERS_ONLY, acting_user=None)
-        self.assertTrue(validation_func(owner_user))
-        self.assertTrue(validation_func(admin_user))
-        self.assertTrue(validation_func(moderator_user))
-        self.assertTrue(validation_func(member_user))
-        self.assertFalse(validation_func(new_member_user))
-        self.assertFalse(validation_func(guest_user))
+        set_policy(Realm.POLICY_ADMINS_ONLY)
+        allow(owner)
+        allow(admin)
+        prevent(moderator)
+        prevent(member)
+        prevent(new_member)
+        prevent(guest)
 
-        do_set_realm_property(realm, policy, Realm.POLICY_MEMBERS_ONLY, acting_user=None)
-        self.assertTrue(validation_func(owner_user))
-        self.assertTrue(validation_func(admin_user))
-        self.assertTrue(validation_func(moderator_user))
-        self.assertTrue(validation_func(member_user))
-        self.assertTrue(validation_func(new_member_user))
-        self.assertFalse(validation_func(guest_user))
+        set_policy(Realm.POLICY_MODERATORS_ONLY)
+        allow(owner)
+        allow(admin)
+        allow(moderator)
+        prevent(member)
+        prevent(new_member)
+        prevent(guest)
 
-        do_set_realm_property(realm, policy, Realm.POLICY_EVERYONE, acting_user=None)
-        self.assertTrue(validation_func(owner_user))
-        self.assertTrue(validation_func(admin_user))
-        self.assertTrue(validation_func(moderator_user))
-        self.assertTrue(validation_func(member_user))
-        self.assertTrue(validation_func(new_member_user))
-        self.assertTrue(validation_func(guest_user))
+        set_policy(Realm.POLICY_FULL_MEMBERS_ONLY)
+        allow(owner)
+        allow(admin)
+        allow(moderator)
+        allow(member)
+        prevent(new_member)
+        prevent(guest)
+
+        set_policy(Realm.POLICY_MEMBERS_ONLY)
+        allow(owner)
+        allow(admin)
+        allow(moderator)
+        allow(member)
+        allow(new_member)
+        prevent(guest)
+
+        set_policy(Realm.POLICY_EVERYONE)
+        allow(owner)
+        allow(admin)
+        allow(moderator)
+        allow(member)
+        allow(new_member)
+        allow(guest)
 
     def subscribe_realm_to_manual_license_management_plan(
         self, realm: Realm, licenses: int, licenses_at_next_renewal: int, billing_schedule: int

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1883,23 +1883,32 @@ Output:
             UserGroupMembership.objects.filter(user_profile=user, user_group=user_group).exists()
         )
 
-    @contextmanager
-    def soft_deactivate_and_check_long_term_idle(
-        self, user: UserProfile, expected: bool
-    ) -> Iterator[None]:
-        """
-        Ensure that the user is soft deactivated (long term idle), and check if the user
-        has been reactivated when exiting the context with an assertion
-        """
+    def _assert_long_term_idle(self, user: UserProfile) -> None:
         if not user.long_term_idle:
-            do_soft_deactivate_users([user])
-            self.assertTrue(user.long_term_idle)
-        try:
-            yield
-        finally:
-            # Prevent from using the old user object
-            user.refresh_from_db()
-            self.assertEqual(user.long_term_idle, expected)
+            raise AssertionError(
+                """
+                We expect you to explicitly call self.soft_deactivate_user
+                if your user is not already soft-deactivated.
+            """
+            )
+
+    def expect_soft_reactivation(self, user: UserProfile, action: Callable[[], None]) -> None:
+        self._assert_long_term_idle(user)
+        action()
+        # Prevent from using the old user object
+        user.refresh_from_db()
+        self.assertEqual(user.long_term_idle, False)
+
+    def expect_to_stay_long_term_idle(self, user: UserProfile, action: Callable[[], None]) -> None:
+        self._assert_long_term_idle(user)
+        action()
+        # Prevent from using the old user object
+        user.refresh_from_db()
+        self.assertEqual(user.long_term_idle, True)
+
+    def soft_deactivate_user(self, user: UserProfile) -> None:
+        do_soft_deactivate_users([user])
+        assert user.long_term_idle
 
 
 class ZulipTestCase(ZulipTestCaseMixin, TestCase):

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1899,16 +1899,14 @@ Output:
     def expect_soft_reactivation(self, user: UserProfile, action: Callable[[], None]) -> None:
         self._assert_long_term_idle(user)
         action()
-        # Prevent from using the old user object
-        user.refresh_from_db()
-        self.assertEqual(user.long_term_idle, False)
+        fresh_user = self.refresh_user(user)
+        self.assertEqual(fresh_user.long_term_idle, False)
 
     def expect_to_stay_long_term_idle(self, user: UserProfile, action: Callable[[], None]) -> None:
         self._assert_long_term_idle(user)
         action()
-        # Prevent from using the old user object
-        user.refresh_from_db()
-        self.assertEqual(user.long_term_idle, True)
+        fresh_user = self.refresh_user(user)
+        self.assertEqual(fresh_user.long_term_idle, True)
 
     def soft_deactivate_user(self, user: UserProfile) -> None:
         do_soft_deactivate_users([user])

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -7000,7 +7000,7 @@ class EmailValidatorTestCase(ZulipTestCase):
 
         realm = inviter.realm
         do_set_realm_property(realm, "emails_restricted_to_domains", True, acting_user=None)
-        inviter.realm.refresh_from_db()
+
         error = validate_email_is_valid(
             "fred+5555@zulip.com",
             get_realm_email_validator(realm),

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2312,7 +2312,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
             '<samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />', saml_response
         )
 
-        hamlet.refresh_from_db()
+        hamlet = self.example_user("hamlet")
         # Ensure that the user's api_key was rotated:
         self.assertNotEqual(hamlet.api_key, old_api_key)
 
@@ -2332,7 +2332,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
         self.make_idp_initiated_logout_request(cordelia.delivery_email)
         self.assert_logged_in_user_id(hamlet.id)
 
-        cordelia.refresh_from_db()
+        cordelia = self.example_user("cordelia")
         # Cordelia's api_key should have been rotated:
         self.assertNotEqual(cordelia.api_key, cordelia_old_api_key)
 
@@ -6387,12 +6387,11 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS,
             acting_user=None,
         )
-        hamlet.refresh_from_db()
 
         self.change_ldap_user_attr("hamlet", "cn", "New Name")
         self.perform_ldap_sync(hamlet)
 
-        hamlet.refresh_from_db()
+        hamlet = self.example_user("hamlet")
         self.assertEqual(hamlet.full_name, "New Name")
 
     def test_update_split_full_name(self) -> None:
@@ -6458,7 +6457,8 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             AUTH_LDAP_USER_ATTR_MAP={"full_name": "cn", "deactivated": "someCustomAttr"}
         ), self.assertLogs("zulip.ldap") as info_logs:
             self.perform_ldap_sync(self.example_user("hamlet"))
-        hamlet.refresh_from_db()
+
+        hamlet = self.example_user("hamlet")
         self.assertTrue(hamlet.is_active)
         self.assertEqual(
             info_logs.output,
@@ -6472,7 +6472,8 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             AUTH_LDAP_USER_ATTR_MAP={"full_name": "cn", "deactivated": "someCustomAttr"}
         ), self.assertLogs("django_auth_ldap") as ldap_logs, self.assertRaises(AssertionError):
             self.perform_ldap_sync(self.example_user("hamlet"))
-        hamlet.refresh_from_db()
+
+        hamlet = self.example_user("hamlet")
         self.assertTrue(hamlet.is_active)
         self.assertEqual(
             ldap_logs.output,

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -326,7 +326,9 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             RealmUserDefault.EMAIL_ADDRESS_VISIBILITY_ADMINS,
             acting_user=None,
         )
-        user.refresh_from_db()
+
+        # refresh user
+        user = self.example_user("hamlet")
 
         self.login_user(user)
         self.assert_num_bots_equal(0)
@@ -1127,7 +1129,8 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         result = self.client_patch(f"/json/bots/{bot_user.id}", bot_info)
         self.assert_json_success(result)
 
-        bot_user.refresh_from_db()
+        # refresh bot user for next check
+        bot_user = get_user(bot_email, bot_realm)
         self.assertEqual(bot_user.bot_owner, cordelia)
 
     def test_patch_bot_owner_with_private_streams(self) -> None:

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -118,15 +118,19 @@ class EmailChangeTestCase(ZulipTestCase):
 
     def test_change_email_link_cant_be_reused(self) -> None:
         new_email = "hamlet-new@zulip.com"
-        user_profile = self.example_user("hamlet")
-        self.login_user(user_profile)
+        hamlet = self.example_user("hamlet")
+        hamlet_id = hamlet.id
+        self.login_user(hamlet)
+
+        self.assertNotEqual(hamlet.delivery_email, new_email)
 
         activation_url = self.generate_email_change_link(new_email)
         response = self.client_get(activation_url)
         self.assertEqual(response.status_code, 200)
 
-        user_profile.refresh_from_db()
-        self.assertEqual(user_profile.delivery_email, new_email)
+        # Verify our email actually did change.
+        user = UserProfile.objects.get(delivery_email=new_email)
+        self.assertEqual(user.id, hamlet_id)
 
         response = self.client_get(activation_url)
         self.assertEqual(response.status_code, 404)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -257,6 +257,15 @@ class BaseAction(ZulipTestCase):
         super().setUp()
         self.user_profile = self.example_user("hamlet")
 
+    def refresh_user_profile(self) -> None:
+        # Call this to make sure you don't have a stale UserProfile
+        # object after doing some kind of setup on the user before
+        # some action that acts on self.user_profile.
+        #
+        # Most of our callers are probably calling this for legacy
+        # reasons that no longer apply, but it's cheap enough.
+        self.user_profile = self.example_user("hamlet")
+
     def verify_action(
         self,
         action: Callable[[], object],
@@ -1658,10 +1667,9 @@ class NormalActionsTest(BaseAction):
             UserProfile.EMAIL_ADDRESS_VISIBILITY_ADMINS,
             acting_user=None,
         )
-        # Important: We need to refresh from the database here so that
-        # we don't have a stale UserProfile object with an old value
-        # for email being passed into this next function.
-        self.user_profile.refresh_from_db()
+
+        self.refresh_user_profile()
+
         action = lambda: do_change_user_delivery_email(self.user_profile, "newhamlet@zulip.com")
         events = self.verify_action(action, num_events=2, client_gravatar=False)
 
@@ -1677,10 +1685,9 @@ class NormalActionsTest(BaseAction):
             UserProfile.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
             acting_user=None,
         )
-        # Important: We need to refresh from the database here so that
-        # we don't have a stale UserProfile object with an old value
-        # for email being passed into this next function.
-        self.user_profile.refresh_from_db()
+
+        self.refresh_user_profile()
+
         action = lambda: do_change_user_delivery_email(self.user_profile, "newhamlet@zulip.com")
         events = self.verify_action(action, num_events=3, client_gravatar=False)
 
@@ -1855,12 +1862,9 @@ class NormalActionsTest(BaseAction):
     def test_change_is_admin(self) -> None:
         reset_email_visibility_to_everyone_in_zulip_realm()
 
-        # Important: We need to refresh from the database here so that
-        # we don't have a stale UserProfile object with an old value
-        # for email being passed into this next function.
-        self.user_profile.refresh_from_db()
-
+        self.refresh_user_profile()
         do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
+
         for role in [UserProfile.ROLE_REALM_ADMINISTRATOR, UserProfile.ROLE_MEMBER]:
             events = self.verify_action(
                 lambda: do_change_user_role(self.user_profile, role, acting_user=None),
@@ -1880,10 +1884,7 @@ class NormalActionsTest(BaseAction):
     def test_change_is_billing_admin(self) -> None:
         reset_email_visibility_to_everyone_in_zulip_realm()
 
-        # Important: We need to refresh from the database here so that
-        # we don't have a stale UserProfile object with an old value
-        # for email being passed into this next function.
-        self.user_profile.refresh_from_db()
+        self.refresh_user_profile()
 
         events = self.verify_action(lambda: do_make_user_billing_admin(self.user_profile))
         check_realm_user_update("events[0]", events[0], "is_billing_admin")
@@ -1892,10 +1893,7 @@ class NormalActionsTest(BaseAction):
     def test_change_is_owner(self) -> None:
         reset_email_visibility_to_everyone_in_zulip_realm()
 
-        # Important: We need to refresh from the database here so that
-        # we don't have a stale UserProfile object with an old value
-        # for email being passed into this next function.
-        self.user_profile.refresh_from_db()
+        self.refresh_user_profile()
 
         do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         for role in [UserProfile.ROLE_REALM_OWNER, UserProfile.ROLE_MEMBER]:
@@ -1917,10 +1915,7 @@ class NormalActionsTest(BaseAction):
     def test_change_is_moderator(self) -> None:
         reset_email_visibility_to_everyone_in_zulip_realm()
 
-        # Important: We need to refresh from the database here so that
-        # we don't have a stale UserProfile object with an old value
-        # for email being passed into this next function.
-        self.user_profile.refresh_from_db()
+        self.refresh_user_profile()
 
         do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         for role in [UserProfile.ROLE_MODERATOR, UserProfile.ROLE_MEMBER]:
@@ -1945,10 +1940,7 @@ class NormalActionsTest(BaseAction):
 
         reset_email_visibility_to_everyone_in_zulip_realm()
 
-        # Important: We need to refresh from the database here so that
-        # we don't have a stale UserProfile object with an old value
-        # for email being passed into this next function.
-        self.user_profile.refresh_from_db()
+        self.refresh_user_profile()
 
         do_change_user_role(self.user_profile, UserProfile.ROLE_MEMBER, acting_user=None)
         for role in [UserProfile.ROLE_GUEST, UserProfile.ROLE_MEMBER]:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2464,7 +2464,7 @@ class NormalActionsTest(BaseAction):
         do_deactivate_user(self.example_user("hamlet"), acting_user=None)
 
         reset_email_visibility_to_everyone_in_zulip_realm()
-        bot.refresh_from_db()
+        bot = self.refresh_user(bot)
 
         self.user_profile = self.example_user("iago")
         action = lambda: do_reactivate_user(bot, acting_user=self.example_user("iago"))

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -1120,7 +1120,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries:
             self.assertEqual(self.soft_activate_and_get_unread_count(), 2)
         query_count = len(queries)
-        long_term_idle_user.refresh_from_db()
+        long_term_idle_user = self.refresh_user(long_term_idle_user)
         self.assertFalse(long_term_idle_user.long_term_idle)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assertEqual(idle_user_msg_list[-1].content, message)
@@ -1152,7 +1152,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries:
             self.assertEqual(self.soft_activate_and_get_unread_count(), 4)
         query_count = len(queries)
-        long_term_idle_user.refresh_from_db()
+        long_term_idle_user = self.refresh_user(long_term_idle_user)
         self.assertFalse(long_term_idle_user.long_term_idle)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
         self.assertEqual(idle_user_msg_list[-1].content, message)

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -795,7 +795,6 @@ class InviteUserTest(InviteUserBase):
 
     def test_can_invite_others_to_realm(self) -> None:
         def validation_func(user_profile: UserProfile) -> bool:
-            user_profile.refresh_from_db()
             return user_profile.can_invite_others_to_realm()
 
         realm = get_realm("zulip")

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -4503,7 +4503,6 @@ class EditMessageTest(EditMessageTestCase):
 
     def test_can_move_messages_between_streams(self) -> None:
         def validation_func(user_profile: UserProfile) -> bool:
-            user_profile.refresh_from_db()
             return user_profile.can_move_messages_between_streams()
 
         self.check_has_permission_policies("move_messages_between_streams_policy", validation_func)

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -2768,12 +2768,10 @@ class CheckMessageTest(ZulipTestCase):
         addressee = Addressee.for_stream(stream, topic_name)
 
         do_set_realm_property(realm, "mandatory_topics", True, acting_user=None)
-        realm.refresh_from_db()
 
         with self.assertRaisesRegex(JsonableError, "Topics are required in this organization"):
             check_message(sender, client, addressee, message_content, realm)
 
         do_set_realm_property(realm, "mandatory_topics", False, acting_user=None)
-        realm.refresh_from_db()
         ret = check_message(sender, client, addressee, message_content, realm)
         self.assertEqual(ret.message.sender.id, sender.id)

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -289,7 +289,8 @@ class TestNotifyNewUser(ZulipTestCase):
 
         realm.signup_notifications_stream = None
         realm.save(update_fields=["signup_notifications_stream"])
-        new_user.refresh_from_db()
+
+        new_user = self.refresh_user(new_user)
         notify_new_user(new_user)
         self.assertEqual(self.get_message_count(), message_count + 1)
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -58,7 +58,6 @@ from zerver.lib.remote_server import (
     send_to_push_bouncer,
 )
 from zerver.lib.response import json_response_from_error
-from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import mock_queue_publish
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -1063,6 +1062,10 @@ class PushNotificationTest(BouncerTestCase):
 class HandlePushNotificationTest(PushNotificationTest):
     DEFAULT_SUBDOMAIN = ""
 
+    def soft_deactivate_main_user(self) -> None:
+        self.user_profile = self.example_user("hamlet")
+        self.soft_deactivate_user(self.user_profile)
+
     def request_callback(self, request: PreparedRequest) -> Tuple[int, ResponseHeaders, bytes]:
         assert request.url is not None  # allow mypy to infer url is present.
         assert settings.PUSH_NOTIFICATION_BOUNCER_URL is not None
@@ -1589,7 +1592,8 @@ class HandlePushNotificationTest(PushNotificationTest):
         self.subscribe(sender, "public_stream")
         logger_string = "zulip.soft_deactivation"
         with self.assertLogs(logger_string, level="INFO") as info_logs:
-            do_soft_deactivate_users([self.user_profile])
+            self.soft_deactivate_main_user()
+
         self.assertEqual(
             info_logs.output,
             [
@@ -1646,7 +1650,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         )
 
         # Personal mention in a stream message should soft reactivate the user
-        with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=False):
+        def mention_in_stream() -> None:
             mention = f"@**{self.user_profile.full_name}**"
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_push_notification(
@@ -1657,8 +1661,11 @@ class HandlePushNotificationTest(PushNotificationTest):
                 },
             )
 
+        self.soft_deactivate_main_user()
+        self.expect_soft_reactivation(self.user_profile, mention_in_stream)
+
         # Direct message should soft reactivate the user
-        with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=False):
+        def direct_message() -> None:
             # Soft reactivate the user by sending a personal message
             personal_message_id = self.send_personal_message(othello, self.user_profile, "Message")
             handle_push_notification(
@@ -1668,6 +1675,9 @@ class HandlePushNotificationTest(PushNotificationTest):
                     "trigger": NotificationTriggers.DIRECT_MESSAGE,
                 },
             )
+
+        self.soft_deactivate_main_user()
+        self.expect_soft_reactivation(self.user_profile, direct_message)
 
         # User FOLLOWS the topic.
         # 'wildcard_mentions_notify' is disabled to verify the corner case when only
@@ -1685,7 +1695,8 @@ class HandlePushNotificationTest(PushNotificationTest):
         # Topic wildcard mention in followed topic should soft reactivate the user
         # user should be a topic participant
         self.send_stream_message(self.user_profile, "Denmark", "topic paticipant")
-        with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=False):
+
+        def send_topic_wildcard_mention() -> None:
             mention = "@**topic**"
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_push_notification(
@@ -1696,8 +1707,11 @@ class HandlePushNotificationTest(PushNotificationTest):
                 },
             )
 
+        self.soft_deactivate_main_user()
+        self.expect_soft_reactivation(self.user_profile, send_topic_wildcard_mention)
+
         # Stream wildcard mention in followed topic should NOT soft reactivate the user
-        with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=True):
+        def send_stream_wildcard_mention() -> None:
             mention = "@**all**"
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_push_notification(
@@ -1707,6 +1721,9 @@ class HandlePushNotificationTest(PushNotificationTest):
                     "trigger": NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
                 },
             )
+
+        self.soft_deactivate_main_user()
+        self.expect_to_stay_long_term_idle(self.user_profile, send_stream_wildcard_mention)
 
         # Reset
         do_set_user_topic_visibility_policy(
@@ -1720,31 +1737,14 @@ class HandlePushNotificationTest(PushNotificationTest):
         )
 
         # Topic Wildcard mention should soft reactivate the user
-        with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=False):
-            mention = "@**topic**"
-            stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
-            handle_push_notification(
-                self.user_profile.id,
-                {
-                    "message_id": stream_mentioned_message_id,
-                    "trigger": NotificationTriggers.TOPIC_WILDCARD_MENTION,
-                },
-            )
+        self.expect_soft_reactivation(self.user_profile, send_topic_wildcard_mention)
 
         # Stream Wildcard mention should NOT soft reactivate the user
-        with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=True):
-            mention = "@**all**"
-            stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
-            handle_push_notification(
-                self.user_profile.id,
-                {
-                    "message_id": stream_mentioned_message_id,
-                    "trigger": NotificationTriggers.STREAM_WILDCARD_MENTION,
-                },
-            )
+        self.soft_deactivate_main_user()
+        self.expect_to_stay_long_term_idle(self.user_profile, send_stream_wildcard_mention)
 
         # Group mention should NOT soft reactivate the user
-        with self.soft_deactivate_and_check_long_term_idle(self.user_profile, expected=True):
+        def send_group_mention() -> None:
             mention = "@*large_user_group*"
             stream_mentioned_message_id = self.send_stream_message(othello, "Denmark", mention)
             handle_push_notification(
@@ -1755,6 +1755,9 @@ class HandlePushNotificationTest(PushNotificationTest):
                     "mentioned_user_group_id": large_user_group.id,
                 },
             )
+
+        self.soft_deactivate_main_user()
+        self.expect_to_stay_long_term_idle(self.user_profile, send_group_mention)
 
     @mock.patch("zerver.lib.push_notifications.logger.info")
     @mock.patch("zerver.lib.push_notifications.push_notifications_enabled", return_value=True)

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -161,7 +161,6 @@ class RealmEmojiTest(ZulipTestCase):
 
     def test_can_add_custom_emoji(self) -> None:
         def validation_func(user_profile: UserProfile) -> bool:
-            user_profile.refresh_from_db()
             return user_profile.can_add_custom_emoji()
 
         self.check_has_permission_policies("add_custom_emoji_policy", validation_func)

--- a/zerver/tests/test_scim.py
+++ b/zerver/tests/test_scim.py
@@ -506,7 +506,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_put(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.delivery_email, "bjensen@zulip.com")
         self.assertEqual(hamlet.full_name, "Ms. Barbara J Jensen III")
 
@@ -533,7 +533,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_put(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.delivery_email, hamlet_email)
         self.assertEqual(hamlet.full_name, "Ms. Barbara J Jensen III")
 
@@ -574,7 +574,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_put(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.is_active, False)
 
         # We modify the active attribute in the payload to cause reactivation of the user.
@@ -582,7 +582,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_put(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.is_active, True)
 
     def test_patch_with_path(self) -> None:
@@ -596,7 +596,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_patch(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.delivery_email, "hamlet_new@zulip.com")
 
         output_data = orjson.loads(result.content)
@@ -615,7 +615,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_patch(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.full_name, "New Name")
         self.assertEqual(hamlet.delivery_email, "hamlet_new2@zulip.com")
 
@@ -640,7 +640,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_patch(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.delivery_email, "hamlet_new@zulip.com")
 
         output_data = orjson.loads(result.content)
@@ -658,7 +658,7 @@ class TestSCIMUser(SCIMTestCase):
         result = self.json_patch(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
 
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.is_active, False)
 
         # Payload for a PATCH request to reactivate the user.
@@ -668,7 +668,7 @@ class TestSCIMUser(SCIMTestCase):
         }
         result = self.json_patch(f"/scim/v2/Users/{hamlet.id}", payload, **self.scim_headers())
         self.assertEqual(result.status_code, 200)
-        hamlet.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
         self.assertEqual(hamlet.is_active, True)
 
     def test_patch_unsupported_attribute(self) -> None:

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -58,7 +58,8 @@ class ChangeSettingsTest(ZulipTestCase):
         )
         self.assert_json_success(json_result)
 
-        user.refresh_from_db()
+        user = self.refresh_user(user)
+
         self.assertEqual(user.full_name, "Foo Bar")
         self.logout()
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -754,13 +754,17 @@ class PasswordResetTest(ZulipTestCase):
     def test_password_reset_for_soft_deactivated_user(self) -> None:
         user_profile = self.example_user("hamlet")
         email = user_profile.delivery_email
-        with self.soft_deactivate_and_check_long_term_idle(user_profile, False):
+
+        def reset_password() -> None:
             # start the password reset process by supplying an email address
             result = self.client_post("/accounts/password/reset/", {"email": email})
 
             # check the redirect link telling you to check mail for password reset link
             self.assertEqual(result.status_code, 302)
             self.assertTrue(result["Location"].endswith("/accounts/password/reset/done/"))
+
+        self.soft_deactivate_user(user_profile)
+        self.expect_soft_reactivation(user_profile, reset_password)
 
 
 class LoginTest(ZulipTestCase):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1114,7 +1114,7 @@ class EmailUnsubscribeTests(ZulipTestCase):
 
         self.assertEqual(result.status_code, 200)
 
-        user_profile.refresh_from_db()
+        user_profile = self.refresh_user(user_profile)
         self.assertFalse(user_profile.enable_offline_email_notifications)
 
     def test_welcome_unsubscribe(self) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -3966,7 +3966,7 @@ class UserSignUpTest(ZulipTestCase):
         self.assertEqual(get_default_language_for_new_user(req, realm), "de")
 
         do_set_realm_property(realm, "default_language", "hi", acting_user=None)
-        realm.refresh_from_db()
+
         req = HostRequestMock()
         req.META["HTTP_ACCEPT_LANGUAGE"] = "de,en"
         self.assertEqual(get_default_language_for_new_user(req, realm), "de")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1171,9 +1171,8 @@ class EmailUnsubscribeTests(ZulipTestCase):
 
         # The setting is toggled off, and scheduled jobs have been removed.
         self.assertEqual(result.status_code, 200)
-        # Circumvent user_profile caching.
 
-        user_profile.refresh_from_db()
+        user_profile = self.example_user("hamlet")
         self.assertFalse(user_profile.enable_digest_emails)
         self.assertEqual(0, ScheduledEmail.objects.filter(users=user_profile).count())
 
@@ -1192,7 +1191,7 @@ class EmailUnsubscribeTests(ZulipTestCase):
 
         self.assertEqual(result.status_code, 200)
 
-        user_profile.refresh_from_db()
+        user_profile = self.example_user("hamlet")
         self.assertFalse(user_profile.enable_login_emails)
 
     def test_marketing_unsubscribe(self) -> None:
@@ -1208,8 +1207,7 @@ class EmailUnsubscribeTests(ZulipTestCase):
         result = self.client_get(urllib.parse.urlparse(unsubscribe_link).path)
         self.assertEqual(result.status_code, 200)
 
-        # Circumvent user_profile caching.
-        user_profile.refresh_from_db()
+        user_profile = self.example_user("hamlet")
         self.assertFalse(user_profile.enable_marketing_emails)
 
     def test_marketing_unsubscribe_post(self) -> None:
@@ -1229,8 +1227,7 @@ class EmailUnsubscribeTests(ZulipTestCase):
         )
         self.assertEqual(result.status_code, 200)
 
-        # Circumvent user_profile caching.
-        user_profile.refresh_from_db()
+        user_profile = self.example_user("hamlet")
         self.assertFalse(user_profile.enable_marketing_emails)
 
 
@@ -2585,7 +2582,8 @@ class UserSignUpTest(ZulipTestCase):
         self.login("hamlet")
         with get_test_image_file("img.png") as image_file:
             self.client_post("/json/users/me/avatar", {"file": image_file})
-        hamlet_in_zulip.refresh_from_db()
+
+        hamlet_in_zulip = self.example_user("hamlet")
         hamlet_in_zulip.left_side_userlist = True
         hamlet_in_zulip.default_language = "de"
         hamlet_in_zulip.emojiset = "twitter"

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4403,13 +4403,11 @@ class SubscriptionAPITest(ZulipTestCase):
         if invite_only:
 
             def validation_func(user_profile: UserProfile) -> bool:
-                user_profile.refresh_from_db()
                 return user_profile.can_create_private_streams()
 
         else:
 
             def validation_func(user_profile: UserProfile) -> bool:
-                user_profile.refresh_from_db()
                 return user_profile.can_create_public_streams()
 
         self.check_has_permission_policies(stream_policy, validation_func)
@@ -4422,7 +4420,6 @@ class SubscriptionAPITest(ZulipTestCase):
 
     def test_can_create_web_public_streams(self) -> None:
         def validation_func(user_profile: UserProfile) -> bool:
-            user_profile.refresh_from_db()
             return user_profile.can_create_web_public_streams()
 
         self.check_has_permission_policies("create_web_public_stream_policy", validation_func)
@@ -4524,7 +4521,6 @@ class SubscriptionAPITest(ZulipTestCase):
         """
 
         def validation_func(user_profile: UserProfile) -> bool:
-            user_profile.refresh_from_db()
             return user_profile.can_subscribe_other_users()
 
         self.check_has_permission_policies("invite_to_stream_policy", validation_func)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -4399,26 +4399,19 @@ class SubscriptionAPITest(ZulipTestCase):
             "create_web_public_stream_policy", invite_only=False, is_web_public=True
         )
 
-    def _test_can_create_streams(self, stream_policy: str, invite_only: bool) -> None:
-        if invite_only:
+    def test_private_stream_policies(self) -> None:
+        def validation_func(user_profile: UserProfile) -> bool:
+            return user_profile.can_create_private_streams()
 
-            def validation_func(user_profile: UserProfile) -> bool:
-                return user_profile.can_create_private_streams()
+        self.check_has_permission_policies("create_private_stream_policy", validation_func)
 
-        else:
+    def test_public_stream_policies(self) -> None:
+        def validation_func(user_profile: UserProfile) -> bool:
+            return user_profile.can_create_public_streams()
 
-            def validation_func(user_profile: UserProfile) -> bool:
-                return user_profile.can_create_public_streams()
+        self.check_has_permission_policies("create_public_stream_policy", validation_func)
 
-        self.check_has_permission_policies(stream_policy, validation_func)
-
-    def test_can_create_private_streams(self) -> None:
-        self._test_can_create_streams("create_private_stream_policy", invite_only=True)
-
-    def test_can_create_public_streams(self) -> None:
-        self._test_can_create_streams("create_public_stream_policy", invite_only=False)
-
-    def test_can_create_web_public_streams(self) -> None:
+    def test_web_public_stream_policies(self) -> None:
         def validation_func(user_profile: UserProfile) -> bool:
             return user_profile.can_create_web_public_streams()
 

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -406,7 +406,6 @@ class UserGroupAPITestCase(UserGroupTestCase):
 
     def test_can_edit_user_groups(self) -> None:
         def validation_func(user_profile: UserProfile) -> bool:
-            user_profile.refresh_from_db()
             return user_profile.can_edit_user_groups()
 
         self.check_has_permission_policies("user_group_edit_policy", validation_func)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -350,8 +350,8 @@ class PermissionTest(ZulipTestCase):
         # it doesn't need to be, but client-side changes would be
         # required in apps like the mobile apps.
         # delivery_email is sent for admins.
-        admin.refresh_from_db()
-        user.refresh_from_db()
+        admin = self.refresh_user(admin)
+        user = self.refresh_user(user)
         self.login_user(admin)
         result = self.client_get("/json/users", {"client_gravatar": "true"})
         members = self.assert_json_success(result)["members"]
@@ -1474,12 +1474,12 @@ class ActivateTest(ZulipTestCase):
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)
-        user.refresh_from_db()
+        user = self.refresh_user(user)
         self.assertFalse(user.is_active)
 
         # Reactivate user
         do_reactivate_user(user, acting_user=None)
-        user.refresh_from_db()
+        user = self.refresh_user(user)
         self.assertTrue(user.is_active)
 
         # Verify no email sent by default.
@@ -1490,7 +1490,7 @@ class ActivateTest(ZulipTestCase):
             ),
         )
         self.assert_json_success(result)
-        user.refresh_from_db()
+        user = self.refresh_user(user)
         self.assertFalse(user.is_active)
 
         self.assert_length(outbox, 1)
@@ -2633,9 +2633,9 @@ class TestBulkRegenerateAPIKey(ZulipTestCase):
 
         bulk_regenerate_api_keys([hamlet.id, cordelia.id])
 
-        hamlet.refresh_from_db()
-        cordelia.refresh_from_db()
-        othello.refresh_from_db()
+        hamlet = self.refresh_user(hamlet)
+        cordelia = self.refresh_user(cordelia)
+        othello = self.refresh_user(othello)
 
         self.assertNotEqual(hamlet_old_api_key, hamlet.api_key)
         self.assertNotEqual(cordelia_old_api_key, cordelia.api_key)


### PR DESCRIPTION
For all the reasons that we avoid refresh_from_db in our real code, we should also avoid it in tests.  It's usually just as easy to re-fetch a new object using the same simple mechanism that allowed you to fetch the original object.

From a test perspective, this means subsequent assertions about query counts, and just behavior in general with respect to things like caches, will be more correct.

Last but not least, this removes a nuisance for us doing an audit of our codebase using django-seal. (See https://chat.zulip.org/#narrow/stream/3-backend/topic/django-seal.20audits/near/1625400 for more context.)