### PR TITLE
narrow: Fix by_topic and by_recipient for stream and message ID.

### DIFF
--- a/web/src/narrow.js
+++ b/web/src/narrow.js
@@ -903,8 +903,9 @@ export function by_topic(target_id, opts) {
         unread_ops.notify_server_message_read(original);
     }
 
+    const stream_name = stream_data.get_stream_name_from_id(original.stream_id);
     const search_terms = [
-        {operator: "stream", operand: original.stream},
+        {operator: "stream", operand: stream_name},
         {operator: "topic", operand: original.topic},
     ];
     opts = {then_select_id: target_id, ...opts};
@@ -942,7 +943,7 @@ export function by_recipient(target_id, opts) {
                 // in the new view.
                 unread_ops.notify_server_message_read(message);
             }
-            by("stream", stream_data.get_stream_name_from_id(message.stream_id));
+            by("stream", stream_data.get_stream_name_from_id(message.stream_id), opts);
             break;
     }
 }


### PR DESCRIPTION
In commit 846b470b99, `narrow.by_topic` was missed for getting the stream name via the stream ID in the message data. Updates function to get the stream name to pass in the filter terms to `narrow.activate`.

In that same commit, `narrow.by_recipient` was updated to not pass the message ID to `then_select_id`. Updates call to `narrow.activate` to include that opts parameter so that the selected message doesn't change.

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
