### PR TITLE
Add provision support for Fedora 38

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -22,7 +22,7 @@ are:
 - Ubuntu 20.04, 22.04
 - Debian 11, 12
 - CentOS 7 (beta)
-- Fedora 33 and 34 (beta)
+- Fedora 38 (beta)
 - RHEL 7 (beta)
 
 **Note**: You should not use the `root` user to run the installation.

--- a/scripts/lib/build-groonga
+++ b/scripts/lib/build-groonga
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+version="13.0.5"
+sha256=f49c4b2bd24f60a3237495dda241017c42076f4d2012bc523fcfa4f349f069a0
+
+tmpdir="$(mktemp -d)"
+trap 'rm -r "$tmpdir"' EXIT
+cd "$tmpdir"
+tarball="groonga-$version.tar.gz"
+curl -fLO --retry 3 "https://github.com/groonga/groonga/releases/download/v$version/$tarball"
+sha256sum -c <<<"$sha256 $tarball"
+tar -xzf "$tarball"
+cd "groonga-$version"
+
+./configure --prefix=/usr
+make -j "$(nproc)"
+make install


### PR DESCRIPTION
Tweaked provision script to run successfully in Fedora 38 and included a script to build the groonga libs from source because the packages in Fedora repos are outdated.

There is a major version jump from the last supported version (F34) which is EOL so references and support for older versions were removed.

Fixes: #20635

<details>

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
