### PR TITLE
time: Revert to Source Sans lnum, tnum defaults.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1152,9 +1152,6 @@ td.pointer {
     text-align: right;
     opacity: 0.8;
     color: var(--color-text-default);
-    font-feature-settings:
-        "pnum" on,
-        "lnum" on;
     letter-spacing: 0.02em;
     /* Disable blue link styling for the message timestamp link. */
     &:hover {


### PR DESCRIPTION
Source Sans 3 [defaults](https://github.com/adobe-fonts/source-sans/issues/236#issuecomment-983224391) to lining (lnum), tabular (tnum) figures, the latter of which is necessary to have times like 11:11 and 11:18 line up in short, adjacent messages (much the way other numerals in the interface align from row to row, such as unread counts).

Because `lnum` is the default, there's no need to set it, which is why this PR just deletes the entire line (for reference, `pnum` is the opposite of `tnum`--it's impossible to have both).

CZO discussion:
https://chat.zulip.org/#narrow/stream/6-frontend/topic/redesigned.20hover.20icons.20.2326283/near/1629117

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="312" alt="proportional-numerals" src="https://github.com/zulip/zulip/assets/170719/2049dc25-33fe-4ef3-891d-e6446c79fa7c"> | <img width="312" alt="tabular-numerals" src="https://github.com/zulip/zulip/assets/170719/6b4d4776-3209-41f2-afc0-da1dee3f946c"> |