### PR TITLE
typing: Update main typing notifications protocol documentation.

### DIFF
--- a/docs/subsystems/typing-indicators.md
+++ b/docs/subsystems/typing-indicators.md
@@ -2,18 +2,17 @@
 
 Zulip supports a feature called "typing indicators."
 
-Typing indicators are status messages that tell you when
-another user is composing a message to you. Zulip's typing UI
-is similar to what you see in other chat/text systems.
+Typing indicators are status messages (or visual indicators) that
+tell you when another user is writing a message to you. Zulip's
+typing UI is similar to what you see in other chat/text systems.
 
-This document describes how we have implemented the feature in Zulip,
-and our main audience is developers who want to understand the
-system and possibly improve it. This document assumes that the
-client is our web app, but any client can play along with this
-protocol.
+This document describes how we have implemented the feature in
+the Zulip web app, and our main audience is developers who want to
+understand the system and possibly improve it. Any client should
+be able follow the protocol documented here.
 
-Right now typing indicators are only used in "Direct messages"
-views.
+Right now typing indicators are only implemented for direct
+message conversations in the web app.
 
 There are two major roles for users in this system:
 
@@ -33,27 +32,38 @@ On a high level the typing indicators system works like this:
 - The clients for "receiving users" receive events and conditionally
   show typing indicators, depending on where the clients are narrowed.
 
+## Privacy settings
+
+Note that there is a user-level privacy setting to disable sending
+typing notifications that a client should check when implementing
+the "writing user" protocol below. See `send_private_typing_notifications`
+in the `UserBaseSettings` model in `zerver/models.py` and in the
+`user_settings` object in the `POST /register` response.
+
 ## Writing user
 
-When a "writing user" starts to compose a message, the client app
-sends a request to an endpoint called `/json/typing` with an `op`
-of `start` and a list of potential message recipients. The JS
-function that facilitates this is called `send_typing_notification_ajax`.
+When a "writing user" starts to compose a message, the client
+sends a request to `POST /typing` with an `op` of `start` and
+a list of potential message recipients. The web app function
+that facilitates this is called `send_typing_notification_ajax`.
 
 If the "writing user" is composing a long message, we want to send
-repeated updates to the server, so that downstream clients know that the
-user is still typing. (Zulip messages tend to be longer than
-messages in other chat/text clients, so this detail is important.)
+repeated updates to the server so that downstream clients know the
+user is still typing. Zulip messages tend to be longer than
+messages in other chat/text clients, so this detail is important.
 
-We have a small state machine in `web/shared/src/typing_status.js` that
-makes sure subsequent "start" requests get sent out every ten
-seconds. (This document is intended to describe the high level
-architecture; the actual time values may be tuned in future releases.
-See the constant `TYPING_STARTED_WAIT_PERIOD`, for example.)
+We have a small state machine in `web/shared/src/typing_status.ts`
+that makes sure subsequent "start" requests get sent out. The
+frequency of these requests is determined by
+`server_typing_started_wait_period_milliseconds` in the
+`POST /register` response.
 
-If the "writing user" goes more than five seconds without any text
-input, then we send a request with an `op` of `stop`. We also send
-"stop" messages when the user explicitly aborts composing a message
+If the "writing user" goes for a while without any text input,
+then we send a request to `POST /typing` with an `op` of `stop`.
+The time period a client should wait before sending the request
+is determined by `server_typing_stopped_wait_period_milliseconds`
+in the `POST /register` response. We also immediately send "stop"
+notification when the user explicitly aborts composing a message
 by closing the compose box (or other actions).
 
 A common scenario is that a user is just pausing to think for a few
@@ -79,22 +89,24 @@ As such, the server piece here is basically a single Django view
 function with a small bit of library support to send out events
 to clients.
 
-Requests come into `/json/typing`. The view mostly calls out
-to `check_send_typing_notification` to do the heavy lifting.
+Requests come in to `send_notification_backend`, which is in
+`zerver/views/typing.py`. For direct message typing notifications,
+the call to `check_send_typing_notification` does the heavy lifting.
 
-One of the main things that the server does is to simply validate
-that the `to` users are for valid, active users in the realm.
+One of the main things that the server does is to validate that
+the user IDs in the `to` parameter are for valid, active users in
+the realm.
 
 Once the request has been validated, the server sends events to
 potential recipients of the message. The event type for that
 payload is `typing`. See the function `do_send_typing_notification`
-for more details.
+in `zerver/actions/typing.py` for more details.
 
 ## Receiving user
 
 When a user plays the role of a "receiving user," the client handles
 incoming "typing" events from the server, and the client will
-display typing notification only when both of these conditions are
+display a typing indicator only when both of these conditions are
 true:
 
 - The "writing user" is still likely typing.
@@ -124,8 +136,9 @@ like the following:
 - `get_all_typists`
 
 One subtle thing that the client has to do here is to maintain
-timers for typing notifications. The constant
-`TYPING_STARTED_EXPIRY_PERIOD` is used to determine that the
+timers for typing notifications. The value of
+`server_typing_started_expiry_period_milliseconds` in the
+`POST /register` response is used to determine when the
 "writing user" has abandoned the message. Of course, the
 "writing user" will also explicitly send us `stop` notifications
 at certain times.
@@ -157,24 +170,12 @@ not let the notifications become too "sticky" either.
 
 ## Roadmap
 
-This document is being written just under a year after typing
-indicators were first implemented. The feature has been popular,
-and after some initial cleanup, it has not required a lot of
-maintenance.
-
 The most likely big change to typing indicators is that we will
 add them for stream conversations. This will require some thought
 for large streams, in terms of both usability and performance.
 
 Another area for refinement is to tune the timing values a bit.
-Right now we are probably too aggressive about sending `stop`
-messages, when users often are just pausing. It's possible
+Right now, we are possibly too aggressive about sending `stop`
+messages when users are just pausing to think. It's possible
 to better account for typing speed or other heuristic things
 like how much of the message has already been typed.
-
-From an infrastructure perspective, we should be mindful of
-bandwidth concerns. A fairly easy change would be to send
-user ids instead of emails.
-
-Some folks may want to turn off typing indicators, so we will
-eventually want customized settings here.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -16113,38 +16113,56 @@ paths:
       summary: Set "typing" status
       tags: ["users"]
       description: |
-        Notify other users whether the current user is [typing a message](/help/typing-notifications).
+        Notify other users whether the current user is
+        [typing a message][help-typing].
 
-        Clients implementing Zulip's typing notifications protocol should work as follows:
+        Clients implementing Zulip's typing notifications
+        protocol should work as follows:
 
-        - Send a request to this endpoint with `"op": "start"` when a user starts typing a message,
-          and also every 10 seconds (`TYPING_STARTED_WAIT_PERIOD`) that the user continues to
-          actively type or otherwise interact with the compose UI (e.g. interacting with the
-          compose box emoji picker).
-        - Send a request to this endpoint with `"op": "stop"` when a user pauses using the
-          compose UI for at least 5 seconds (`TYPING_STOPPED_WAIT_PERIOD`) or cancels
-          the compose action (if it had previously sent a "start" operation for that
-          compose action).
-        - Start displaying "Sender is typing" for a given conversation when the client
-          receives an `"op": "start"` event from the [`GET /events`](/api/get-events#typing-start)
-          endpoint.
-        - Continue displaying "Sender is typing" until they receive an `"op": "stop"` event
-          from the [`GET /events`](/api/get-events#typing-stop) endpoint or
-          15 seconds (`TYPING_STARTED_EXPIRY_PERIOD`) have passed without a new `"op": "start"`
-          event for that conversation.
-        - Support for displaying stream typing notifications was new in Zulip 4.0
-          (feature level 58). Clients should indicate they support processing stream typing
-          events via the `stream_typing_notifications` value in the `client_capabilities`
-          parameter to [`POST /register`](/api/register-queue#parameter-client_capabilities)
-          endpoint.
+        - Send a request to this endpoint with `"op": "start"` when a user
+          starts composing a message.
+        - While the user continues to actively type or otherwise interact with
+          the compose UI (e.g. interacting with the compose box emoji picker),
+          send regular `"op": "start"` requests to this endpoint, using
+          `server_typing_started_wait_period_milliseconds` in the
+          [`POST /register`][api-register] response as the time interval
+          between each request.
+        - Send a request to this endpoint with `"op": "stop"` when a user
+          has stopped using the compose UI for the time period indicated by
+          `server_typing_stopped_wait_period_milliseconds` in the
+          [`POST /register`][api-register] response or when a user
+          cancels the compose action (if it had previously sent a "start"
+          notification for that compose action).
+        - Start displaying a visual typing indicator for a given conversation
+          when a [`typing op:start`][start-typing] event is received
+          from the server.
+        - Continue displaying a visual typing indicator for the conversation
+          until a [`typing op:stop`][stop-typing] event is received
+          from the server or the time period indicated by
+          `server_typing_started_expiry_period_milliseconds` in the
+          [`POST /register`][api-register] response has passed without
+          a new `typing "op": "start"` event for the conversation.
 
-        This protocol is designed to allow the server-side typing notifications implementation
-        to be stateless while being resilient; network failures cannot result in a user being
-        incorrectly displayed as perpetually typing.
+        This protocol is designed to allow the server-side typing notifications
+        implementation to be stateless while being resilient as network failures
+        will not result in a user being incorrectly displayed as perpetually
+        typing.
 
-        See
-        [the typing notification docs](https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html)
+        See the subsystems documentation on [typing indicators][typing-protocol-docs]
         for additional design details on Zulip's typing notifications protocol.
+
+        **Changes**: Support for displaying stream typing notifications was new
+        in Zulip 4.0 (feature level 58). Clients should indicate they support
+        processing stream typing notifications via the `stream_typing_notifications`
+        value in the `client_capabilities` parameter of the
+        [`POST /register`][client-capabilities] endpoint.
+
+        [help-typing]: /help/typing-notifications
+        [api-register]: /api/register-queue
+        [start-typing]: /api/get-events#typing-start
+        [stop-typing]: /api/get-events#typing-stop
+        [client-capabilities]: /api/register-queue#parameter-client_capabilities
+        [typing-protocol-docs]: https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html
       x-curl-examples-parameters:
         oneOf:
           - type: exclude


### PR DESCRIPTION
This is a follow-up PR to #26477 and should be merged after those changes.

Updates the main description of the [`api/set-typing-status`](https://zulip.com/api/set-typing-status) endpoint for the new fields in the `POST register` response for the typing start, stop, expired time intervals. Previously these were hardcoded by the client-side code and not the server-side code.

Also updates the developer documentation for [typing indicators](https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html) in the subsystems docs. This refreshes a few parts of that doc that were already out of date, as well as adds the information about the new register response fields noted above.

See the Read the Docs build in CI for the updates to the subsystems documentation.

**Screenshots and screen captures:**

<details>
<summary>Set "typing" status - main description</summary>

[Current documentation](https://zulip.com/api/set-typing-status)
![Screenshot from 2023-08-23 19-18-58](https://github.com/zulip/zulip/assets/63245456/e88d7bee-69ba-48bd-84a4-be093d598199)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
