### PR TITLE
ci: Restore commented `clean_unused_caches.py` invocation

### DIFF
--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -100,10 +100,7 @@ jobs:
         run: |
           # This is the main setup job for the test suite
           ./tools/ci/setup-backend --skip-dev-db-build
-
-          # Cleaning caches is mostly unnecessary in GitHub Actions, because
-          # most builds don't get to write to the cache.
-          # scripts/lib/clean_unused_caches.py --verbose --threshold 0
+          scripts/lib/clean_unused_caches.py --verbose --threshold=0
 
       - name: Run tools test
         run: |


### PR DESCRIPTION
The comment logic doesn’t make sense.  Every build gets to write to the caches; some builds do in fact add new items, and without `clean_unused_caches.py` there’s no way for them to remove items.

[Discussion](https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/CI.20skipping.20Debian.2011/near/1629980).