### PR TITLE
actions: Icon pointers and tooltips in Recent conversations.

### DIFF
--- a/web/styles/recent_topics.css
+++ b/web/styles/recent_topics.css
@@ -175,6 +175,8 @@
             margin-right: 0;
             /* Match with its font-size. */
             line-height: 14px;
+            /* Present a default/arrow cursor */
+            cursor: default;
         }
 
         .unread_hidden {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1540,6 +1540,7 @@ td.pointer {
 
     &:hover {
         opacity: 0.4 !important;
+        cursor: pointer;
     }
 }
 

--- a/web/templates/recent_topic_row.hbs
+++ b/web/templates/recent_topic_row.hbs
@@ -51,7 +51,8 @@
                     </div>
                 </div>
                 {{else}}
-                <span class="unread_mention_info {{#unless mention_in_unread}}unread_hidden{{/unless}}">@</span>
+                <span class="unread_mention_info tippy-zulip-tooltip {{#unless mention_in_unread}}unread_hidden{{/unless}}"
+                  data-tippy-content="{{t 'You have mentions'}}">@</span>
                 <div class="recent_topic_actions">
                     <div class="recent_topics_focusable hidden-for-spectators">
                         <span class="unread_count {{#unless unread_count}}unread_hidden{{/unless}} tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>


### PR DESCRIPTION
This PR adds a little polish to the actions icon in the Recent Conversations view.

1. It adds a tooltip to the @ indicator
2. It introduces appropriate cursor: a default/arrow cursor for @, and a pointer for the bell icon.

One known remaining rough edge here is that the Tippies on @ and the unread count display with only the default short Zulip delay, whereas the bell icon is presented with the extra-long delay.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/6-frontend/topic/aligning.20actions.20in.20Recent.20conversations/near/1629960)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| ![icon-interactions-before](https://github.com/zulip/zulip/assets/170719/a4ac7d3f-0ca4-4903-a8f5-5fbb1f00e56f) | ![icon-interactions-after](https://github.com/zulip/zulip/assets/170719/6ac59c59-6c04-4927-8e36-af8855624830) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>