### PR TITLE
requirements: Fix transitively replaced two_factor migrations

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -130,7 +130,7 @@ cryptography
 lxml
 
 # Needed for 2-factor authentication
-django-two-factor-auth[call,phonenumberslite,sms]
+https://github.com/andersk/django-two-factor-auth/archive/b0ae80051d45ac360595ed327b044c766f57d32f.zip#egg=django-two-factor-auth[call,phonenumberslite,sms]==1.15.4+git  # https://github.com/jazzband/django-two-factor-auth/pull/649
 
 # Needed for processing payments (in corporate)
 stripe

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -659,9 +659,8 @@ django-stubs-ext==4.2.2 \
     # via
     #   -r requirements/common.in
     #   django-stubs
-django-two-factor-auth[call,phonenumberslite,sms]==1.15.4 \
-    --hash=sha256:4570ffa774bbced191f670079fea4e72a350ee91b2a937d5eb08e535ca47f1a6 \
-    --hash=sha256:6be4313069bffcaef8b657573ddc82f82e77da1a0bdb31175b1649c2411c0b0a
+https://github.com/andersk/django-two-factor-auth/archive/b0ae80051d45ac360595ed327b044c766f57d32f.zip#egg=django-two-factor-auth[call,phonenumberslite,sms]==1.15.4+git \
+    --hash=sha256:e5d5c876316fc60057efac812de0dae1b064b35bb2798fac44c04c6bb70c50a5
     # via -r requirements/common.in
 dnspython==2.4.2 \
     --hash=sha256:57c6fbaaeaaf39c891292012060beb141791735dbb4004798328fc2c467402d8 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -479,9 +479,8 @@ django-stubs-ext==4.2.2 \
     --hash=sha256:c69d1cc46f1c4c3b7894b685a5022c29b2a36c7cfb52e23762eaf357ebfc2c98 \
     --hash=sha256:fdacc65a14d2d4b97334b58ff178a5853ec8c8c76cec406e417916ad67536ce4
     # via -r requirements/common.in
-django-two-factor-auth[call,phonenumberslite,sms]==1.15.4 \
-    --hash=sha256:4570ffa774bbced191f670079fea4e72a350ee91b2a937d5eb08e535ca47f1a6 \
-    --hash=sha256:6be4313069bffcaef8b657573ddc82f82e77da1a0bdb31175b1649c2411c0b0a
+https://github.com/andersk/django-two-factor-auth/archive/b0ae80051d45ac360595ed327b044c766f57d32f.zip#egg=django-two-factor-auth[call,phonenumberslite,sms]==1.15.4+git \
+    --hash=sha256:e5d5c876316fc60057efac812de0dae1b064b35bb2798fac44c04c6bb70c50a5
     # via -r requirements/common.in
 dnspython==2.4.2 \
     --hash=sha256:57c6fbaaeaaf39c891292012060beb141791735dbb4004798328fc2c467402d8 \

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 204
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (247, 5)
+PROVISION_VERSION = (247, 6)


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/49-development-help/topic/puppeteer.20migration.20two_factor/near/1630646

I’m not sure if we strictly need this as no real symptoms have been observed, but it does silence a distracting message from the dev server after `tools/rebuild-dev-database`:

```
You have 1 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): two_factor.
Run 'python manage.py migrate' to apply them.
```