### PR TITLE
message_time: Lighten font-weight to 350.

### DIFF
--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -1148,7 +1148,7 @@ td.pointer {
 .messagebox-content .message_time {
     display: block;
     font-size: 13px;
-    font-weight: normal;
+    font-weight: 350;
     text-align: right;
     opacity: 0.8;
     color: var(--color-text-default);


### PR DESCRIPTION
The tabular figures in Source Sans 3 place a foot on the 1, and overall just feel visually a little heavier than their proportional counterparts.

To compensate for that, this takes advantage of the variable-font properties of Source Sans 3 to subtly drop the weight to keep the timestamp readable but not in fierce competition with the message area.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/lighter.20text.20weight.20for.20timestamps.3F/near/1629966)

**Screenshots and screen captures:**

| Before (normal/400) | After (350) |
| --- | --- |
| <img width="288" alt="dark-400" src="https://github.com/zulip/zulip/assets/170719/0a49bbfd-fd10-4c95-9bc8-a604bd58d0f0"> | <img width="288" alt="dark-350" src="https://github.com/zulip/zulip/assets/170719/2eee219f-6b87-4444-998a-7e4a142f6b25"> |
| <img width="288" alt="light-400" src="https://github.com/zulip/zulip/assets/170719/84ac501f-ba25-46f6-97bb-80f59792e73a"> | <img width="288" alt="light-350" src="https://github.com/zulip/zulip/assets/170719/2e6dbc35-c393-4bfa-a59e-b1b427438c65"> |


