### PR TITLE
help: Add mobile instructions to "Unsubscribe from a stream".

### DIFF
--- a/help/unsubscribe-from-a-stream.md
+++ b/help/unsubscribe-from-a-stream.md
@@ -4,19 +4,44 @@ You can always unsubscribe from any stream in Zulip.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {!stream-actions.md!}
 
 1. Click **Unsubscribe**.
 
 {end_tabs}
 
-## From the streams page (alternate method)
+## Alternate methods to unsubscribe from a stream
+
+### Via manage streams
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {relative|stream|subscribed}
 
-1. Click on the green checkmark the left of the stream name.
+1. Click the green checkmark to the left of a stream to unsubscribe from it.
+
+{end_tabs}
+
+### Via stream settings
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{!stream-actions.md!}
+
+1. Click **Stream settings**.
+
+1. Click **Unsubscribe** near the top right corner of the stream settings panel.
+
+!!! keyboard_tip ""
+
+    You can also use <kbd>Shift</kbd> + <kbd>S</kbd> to unsubscribe from the
+    selected stream.
 
 {end_tabs}
 

--- a/help/unsubscribe-from-a-stream.md
+++ b/help/unsubscribe-from-a-stream.md
@@ -10,6 +10,14 @@ You can always unsubscribe from any stream in Zulip.
 
 1. Click **Unsubscribe**.
 
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Unsubscribe**.
+
+{!stream-long-press-menu-tip.md!}
+
 {end_tabs}
 
 ## Alternate methods to unsubscribe from a stream
@@ -23,6 +31,19 @@ You can always unsubscribe from any stream in Zulip.
 {relative|stream|subscribed}
 
 1. Click the green checkmark to the left of a stream to unsubscribe from it.
+
+{tab|mobile}
+
+{!mobile-all-streams-view.md!}
+
+1. Tap the **checkmark**
+   (<img src="/static/images/help/mobile-check-icon.svg" alt="checkmark" class="mobile-icon"/>)
+   icon to the right of a stream to unsubscribe from it.
+
+!!! tip ""
+
+    You can also press and hold a stream until the long-press menu appears, and
+    tap **Unsubscribe**.
 
 {end_tabs}
 
@@ -42,6 +63,16 @@ You can always unsubscribe from any stream in Zulip.
 
     You can also use <kbd>Shift</kbd> + <kbd>S</kbd> to unsubscribe from the
     selected stream.
+
+{tab|mobile}
+
+{!stream-long-press-menu.md!}
+
+1. Tap **Stream settings**.
+
+1. Tap **Unsubscribe**.
+
+{!mobile-stream-settings-menu-tip.md!}
 
 {end_tabs}
 

--- a/static/images/help/mobile-check-icon.svg
+++ b/static/images/help/mobile-check-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#6492fd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-check"><polyline points="20 6 9 17 4 12"></polyline></svg>


### PR DESCRIPTION
- Updates [Unsubscribe from a stream](https://zulip.com/help/unsubscribe-from-a-stream) to follow current help center documentation patterns.
- Adds Desktop/web instructions to unsubscribe from a stream via the stream settings panel.
- Adds mobile instructions to unsubscribe via long-press menu, all streams, and stream settings.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/8f6c1048-6d7a-496e-9aee-fea6e74322b4)

![image](https://github.com/zulip/zulip/assets/2343554/d1b361c4-9926-4405-b810-dadaa86cf705)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Highlights technical choices and bugs encountered.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>
