### PR TITLE
[WIP] compose box: Structural cleanup.

### DIFF
--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -82,7 +82,7 @@ export function update_audio_and_video_chat_button_display() {
 
 export function update_video_chat_button_display() {
     const show_video_chat_button = compute_show_video_chat_button();
-    $("#below-compose-content .video_link").toggle(show_video_chat_button);
+    $(".compose_bottom_top_container .video_link").toggle(show_video_chat_button);
     $(".message-edit-feature-group .video_link").toggle(show_video_chat_button);
 }
 
@@ -101,7 +101,7 @@ export function compute_show_audio_chat_button() {
 
 export function update_audio_chat_button_display() {
     const show_audio_chat_button = compute_show_audio_chat_button();
-    $("#below-compose-content .audio_link").toggle(show_audio_chat_button);
+    $(".compose_bottom_top_container .audio_link").toggle(show_audio_chat_button);
     $(".message-edit-feature-group .audio_link").toggle(show_audio_chat_button);
 }
 
@@ -457,8 +457,8 @@ export function initialize() {
     // Register hooks for compose_actions.
     setup_compose_actions_hooks();
 
-    $("#below-compose-content .video_link").toggle(compute_show_video_chat_button());
-    $("#below-compose-content .audio_link").toggle(compute_show_audio_chat_button());
+    $(".compose_bottom_top_container .video_link").toggle(compute_show_video_chat_button());
+    $(".compose_bottom_top_container .audio_link").toggle(compute_show_audio_chat_button());
 
     $("#compose-textarea").on("keydown", (event) => {
         compose_ui.handle_keydown(event, $("#compose-textarea").expectOne());

--- a/web/styles/app_components.css
+++ b/web/styles/app_components.css
@@ -87,18 +87,6 @@ kbd {
     visibility: hidden;
 }
 
-.order-1 {
-    order: 1;
-}
-
-.order-2 {
-    order: 2;
-}
-
-.order-3 {
-    order: 3;
-}
-
 /*
 Consistent placeholder styling, introduced to allow us to style the
 Reply box like a placeholder.  Chrome uses color to set placeholder,

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -174,21 +174,15 @@
     height: 100%;
 }
 
-#below-compose-content {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
+.compose_bottom_top_container {
     margin-top: 6px;
+    display: flex;
+}
+
+.compose_bottom_bottom_container {
+    display: flex;
+    justify-content: space-between;
     margin-bottom: -2px;
-
-    .compose_bottom_top_container {
-        display: flex;
-    }
-
-    .compose_bottom_bottom_container {
-        display: flex;
-        justify-content: space-between;
-    }
 }
 
 #compose_limit_indicator {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -177,6 +177,8 @@
 .compose_bottom_top_container {
     margin-top: 6px;
     display: flex;
+    /* Preserve sensible tab order despite layout shift. */
+    flex-flow: row-reverse;
 }
 
 .compose_bottom_bottom_container {
@@ -213,8 +215,8 @@
 
 #compose_top {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    /* Preserve sensible tab order despite layout shift. */
+    flex-flow: row-reverse;
     padding-bottom: 5px;
 }
 

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -172,26 +172,6 @@
 #send_message_form {
     margin: 0;
     height: 100%;
-
-    .messagebox-wrapper {
-        flex: 1;
-    }
-
-    .messagebox {
-        /* normally 5px 14px; pull in the right and bottom a bit */
-        cursor: default;
-        padding: 0;
-        background: none;
-        box-shadow: none;
-        border: none;
-        height: 100%;
-        display: flex;
-        flex-flow: column;
-    }
-
-    .message_content {
-        margin-right: 0;
-    }
 }
 
 #below-compose-content {

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -49,15 +49,12 @@
             <form id="send_message_form" action="/json/messages" method="post">
                 <div class="compose_table">
                     <div id="compose_top">
-                        <div id="compose_top_right" class="order-2">
+                        <div id="compose_top_right">
                             <button type="button" class="expand_composebox_button fa fa-chevron-up" aria-label="{{t 'Expand compose' }}" data-tippy-content="{{t 'Expand compose' }}"></button>
                             <button type="button" class="collapse_composebox_button fa fa-chevron-down" aria-label="{{t 'Collapse compose' }}" data-tippy-content="{{t 'Collapse compose' }}"></button>
                             <button type="button" class="close fa fa-times" id='compose_close' data-tooltip-template-id="compose_close_tooltip_template"></button>
                         </div>
-                        <div id="compose-recipient" class="order-1">
-                            <div class="topic-marker-container order-1">
-                                <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle" data-tooltip-template-id="narrow_to_compose_recipients_tooltip"></a>
-                            </div>
+                        <div id="compose-recipient">
                             {{> dropdown_widget_with_stream_colorblock
                               widget_name="compose_select_recipient"}}
                             <div class="topic-marker-container">
@@ -66,6 +63,9 @@
                             <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="{{ max_topic_length }}" value="" placeholder="{{t 'Topic' }}" autocomplete="off" tabindex="0" aria-label="{{t 'Topic' }}" />
                             <div id="compose-direct-recipient" class="pill-container" data-before="{{t 'You and' }}">
                                 <div class="input" contenteditable="true" id="private_message_recipient" data-no-recipients-text="{{t 'Add one or more users' }}" data-some-recipients-text="{{t 'Add another user...' }}"></div>
+                            </div>
+                            <div class="topic-marker-container">
+                                <a role="button" class="narrow_to_compose_recipients zulip-icon zulip-icon-arrow-left-circle" data-tooltip-template-id="narrow_to_compose_recipients_tooltip"></a>
                             </div>
                         </div>
                     </div>
@@ -76,7 +76,7 @@
                     </div>
                     <div class="drag"></div>
                     <div class="compose_bottom_top_container">
-                        <div class="compose_right_float_container order-3">
+                        <div class="compose_right_float_container">
                             <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
                                 <img class="loader" alt="" src="" />
                                 <span>{{t 'Send' }}</span>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -75,37 +75,35 @@
                         <div class="preview_content rendered_markdown"></div>
                     </div>
                     <div class="drag"></div>
-                    <div id="below-compose-content">
-                        <div class="compose_bottom_top_container">
-                            <div class="compose_right_float_container order-3">
-                                <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
-                                    <img class="loader" alt="" src="" />
-                                    <span>{{t 'Send' }}</span>
-                                </button>
-                                <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
-                                    <div class="separator-line"></div>
-                                    <i class="zulip-icon zulip-icon-more-vertical"></i>
-                                </button>
-                            </div>
-                            {{> compose_control_buttons }}
+                    <div class="compose_bottom_top_container">
+                        <div class="compose_right_float_container order-3">
+                            <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
+                                <img class="loader" alt="" src="" />
+                                <span>{{t 'Send' }}</span>
+                            </button>
+                            <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
+                                <div class="separator-line"></div>
+                                <i class="zulip-icon zulip-icon-more-vertical"></i>
+                            </button>
                         </div>
-                        <div class="compose_bottom_bottom_container">
-                            <span id="compose_limit_indicator"></span>
-                            <div class="open_enter_sends_dialog">
-                                <span class="enter_sends_true">
-                                    {{#tr}}
-                                        <z-shortcut></z-shortcut> to send
-                                        {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
-                                    {{/tr}}
-                                </span>
-                                <span class="enter_sends_false">
-                                    {{#tr}}
-                                        <z-shortcut></z-shortcut> to send
-                                        {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
-                                    {{/tr}}
-                                </span>
-                                <i class="fa fa-caret-down" aria-hidden="true"></i>
-                            </div>
+                        {{> compose_control_buttons }}
+                    </div>
+                    <div class="compose_bottom_bottom_container">
+                        <span id="compose_limit_indicator"></span>
+                        <div class="open_enter_sends_dialog">
+                            <span class="enter_sends_true">
+                                {{#tr}}
+                                    <z-shortcut></z-shortcut> to send
+                                    {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
+                                {{/tr}}
+                            </span>
+                            <span class="enter_sends_false">
+                                {{#tr}}
+                                    <z-shortcut></z-shortcut> to send
+                                    {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
+                                {{/tr}}
+                            </span>
+                            <i class="fa fa-caret-down" aria-hidden="true"></i>
                         </div>
                     </div>
                 </div>

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -69,46 +69,42 @@
                             </div>
                         </div>
                     </div>
-                    <div class="messagebox-wrapper">
-                        <div class="messagebox">
-                            <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
-                            <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
-                                <div class="markdown_preview_spinner"></div>
-                                <div class="preview_content rendered_markdown"></div>
+                    <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{t 'Compose your message here' }}" tabindex="0" aria-label="{{t 'Compose your message here...' }}"></textarea>
+                    <div class="scrolling_list preview_message_area" data-simplebar id="preview_message_area" style="display:none;">
+                        <div class="markdown_preview_spinner"></div>
+                        <div class="preview_content rendered_markdown"></div>
+                    </div>
+                    <div class="drag"></div>
+                    <div id="below-compose-content">
+                        <div class="compose_bottom_top_container">
+                            <div class="compose_right_float_container order-3">
+                                <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
+                                    <img class="loader" alt="" src="" />
+                                    <span>{{t 'Send' }}</span>
+                                </button>
+                                <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
+                                    <div class="separator-line"></div>
+                                    <i class="zulip-icon zulip-icon-more-vertical"></i>
+                                </button>
                             </div>
-                            <div class="drag"></div>
-                            <div id="below-compose-content">
-                                <div class="compose_bottom_top_container">
-                                    <div class="compose_right_float_container order-3">
-                                        <button type="submit" id="compose-send-button" class="button small send_message compose-submit-button animated-purple-button">
-                                            <img class="loader" alt="" src="" />
-                                            <span>{{t 'Send' }}</span>
-                                        </button>
-                                        <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
-                                            <div class="separator-line"></div>
-                                            <i class="zulip-icon zulip-icon-more-vertical"></i>
-                                        </button>
-                                    </div>
-                                    {{> compose_control_buttons }}
-                                </div>
-                                <div class="compose_bottom_bottom_container">
-                                    <span id="compose_limit_indicator"></span>
-                                    <div class="open_enter_sends_dialog">
-                                        <span class="enter_sends_true">
-                                            {{#tr}}
-                                                <z-shortcut></z-shortcut> to send
-                                                {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
-                                            {{/tr}}
-                                        </span>
-                                        <span class="enter_sends_false">
-                                            {{#tr}}
-                                                <z-shortcut></z-shortcut> to send
-                                                {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
-                                            {{/tr}}
-                                        </span>
-                                        <i class="fa fa-caret-down" aria-hidden="true"></i>
-                                    </div>
-                                </div>
+                            {{> compose_control_buttons }}
+                        </div>
+                        <div class="compose_bottom_bottom_container">
+                            <span id="compose_limit_indicator"></span>
+                            <div class="open_enter_sends_dialog">
+                                <span class="enter_sends_true">
+                                    {{#tr}}
+                                        <z-shortcut></z-shortcut> to send
+                                        {{#*inline "z-shortcut"}}<kbd>Enter</kbd>{{/inline}}
+                                    {{/tr}}
+                                </span>
+                                <span class="enter_sends_false">
+                                    {{#tr}}
+                                        <z-shortcut></z-shortcut> to send
+                                        {{#*inline "z-shortcut"}}<kbd>Ctrl</kbd>+<kbd>Enter</kbd>{{/inline}}
+                                    {{/tr}}
+                                </span>
+                                <i class="fa fa-caret-down" aria-hidden="true"></i>
                             </div>
                         </div>
                     </div>

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -1,4 +1,4 @@
-<div class="compose_control_buttons_container order-1">
+<div class="compose_control_buttons_container">
     <input type="file" class="file_input notvisible" multiple />
     {{#if file_upload_enabled }}
     <div class="compose_control_button_container preview_mode_disabled" data-tippy-content="{{t 'Upload files' }}">

--- a/web/templates/compose_control_buttons_popover.hbs
+++ b/web/templates/compose_control_buttons_popover.hbs
@@ -1,3 +1,3 @@
-<div class="compose_control_buttons_container order-1 {{#if preview_mode_on}} preview_mode {{/if}}">
+<div class="compose_control_buttons_container {{#if preview_mode_on}} preview_mode {{/if}}">
     {{> compose_control_buttons_in_popover}}
 </div>

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -29,7 +29,7 @@ set_global(
 const server_events_dispatch = zrequire("server_events_dispatch");
 const compose = zrequire("compose");
 function stub_out_video_calls() {
-    const $elem = $("#below-compose-content .video_link");
+    const $elem = $(".compose_bottom_top_container .video_link");
     $elem.toggle = (show) => {
         /* istanbul ignore if */
         if (show) {
@@ -234,7 +234,7 @@ test("test_video_chat_button_toggle disabled", ({override}) => {
 
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.disabled.id;
     compose.initialize();
-    assert.equal($("#below-compose-content .video_link").visible(), false);
+    assert.equal($(".compose_bottom_top_container .video_link").visible(), false);
 });
 
 test("test_video_chat_button_toggle no url", ({override}) => {
@@ -244,7 +244,7 @@ test("test_video_chat_button_toggle no url", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = null;
     compose.initialize();
-    assert.equal($("#below-compose-content .video_link").visible(), false);
+    assert.equal($(".compose_bottom_top_container .video_link").visible(), false);
 });
 
 test("test_video_chat_button_toggle enabled", ({override}) => {
@@ -254,5 +254,5 @@ test("test_video_chat_button_toggle enabled", ({override}) => {
     page_params.realm_video_chat_provider = realm_available_video_chat_providers.jitsi_meet.id;
     page_params.jitsi_server_url = "https://meet.jit.si";
     compose.initialize();
-    assert.equal($("#below-compose-content .video_link").visible(), true);
+    assert.equal($(".compose_bottom_top_container .video_link").visible(), true);
 });


### PR DESCRIPTION
This PR cleans up the HTML structure of the compose box, eliminating unnecessary elements (and adjusting any CSS/JS references as needed) and reordering the HTML structure based on preferred tab movement, while using flexbox's `flex-flow` property to achieve the appropriate layout.

As a cleanup PR, this introduces no visual changes--though some of the CSS here for preserving layout will be short-lived as the compose-box redesign proceeds.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
