### PR TITLE
[WIP] compose box: CSS cleanup.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -212,7 +212,6 @@
 }
 
 #compose_limit_indicator {
-    margin-right: 8px;
     font-size: 12px;
     color: hsl(39deg 100% 50%);
     align-self: center;
@@ -627,12 +626,8 @@ input.recipient_box {
 
 .open_enter_sends_dialog {
     font-size: 12px;
-    height: 14px;
-    padding-left: 4px;
+    height: 19px;
     opacity: 0.7;
-    margin-bottom: 5px;
-    position: relative;
-    top: -2px;
     cursor: pointer;
 
     @media (width < $mm_min) {
@@ -641,6 +636,7 @@ input.recipient_box {
 
     & kbd {
         padding: 0 4px;
+        margin: 0.1em 0.1em 0;
     }
 
     &:hover {

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -572,7 +572,9 @@ input.recipient_box {
 }
 
 #compose-send-button {
-    padding: 3px 12px;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
     margin-bottom: 0;
     font-weight: 600;
     font-size: 0.9em;
@@ -580,8 +582,6 @@ input.recipient_box {
 
     .loader {
         display: none;
-        position: relative;
-        top: -6px;
     }
 }
 
@@ -756,9 +756,6 @@ input.recipient_box {
 
 .compose_right_float_container {
     display: flex;
-    flex-direction: row;
-    white-space: nowrap;
-    margin-top: 2px;
     height: 24px;
 
     &.disabled-compose-send-button-container {
@@ -874,11 +871,8 @@ input.recipient_box {
 #send_later {
     display: flex;
     align-items: center;
-    float: right;
-    color: hsl(0deg 0% 100%);
     border-radius: 0 4px 4px 0;
     padding: 0;
-    margin: 0;
 
     .zulip-icon {
         padding: 5px 9px;


### PR DESCRIPTION
This PR cleans up and streamlines the CSS applied to the compose box layout.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
