### PR TITLE
compose: Render Mac Cmd button and Return at compose bottom.

### DIFF
--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -242,7 +242,7 @@ function initialize_compose_box() {
         }),
     );
     $(`.enter_sends_${user_settings.enter_sends}`).show();
-    common.adjust_mac_kbd_tags(".enter_sends kbd");
+    common.adjust_mac_kbd_tags(".open_enter_sends_dialog kbd");
 }
 
 function initialize_message_feed_errors() {


### PR DESCRIPTION
oes what it says on the tin; there doesn't appear to be a plain `enter_sends` class any more in the compose area, so this is hopefully the fix for a long-standing regression.

Although I did not screenshot it, the popup menu is unaffected by these changes, as its keyboard rendering is updated in separate logic.

**Screenshots and screen captures:**

| Before | After |
| --- | --- |
| <img width="398" alt="ctrl-before" src="https://github.com/zulip/zulip/assets/170719/ac23496b-6a2f-4c8f-b312-27a453a40b17"> | <img width="398" alt="cmd-after" src="https://github.com/zulip/zulip/assets/170719/1cd05674-beb9-4853-97c2-fc8339dca503"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>