### PR TITLE
help: Document keyboard shortcuts for starring messages and viewing message edit history.

### DIFF
--- a/help/star-a-message.md
+++ b/help/star-a-message.md
@@ -17,6 +17,11 @@ tasks you need to go back to or documents you reference often.
     Starred messages have a filled in star (<i class="zulip-icon zulip-icon-star-filled"></i>)
     to their right. You can unstar a message using the same instructions used to star it.
 
+!!! keyboard_tip ""
+
+    You can use <kbd>Ctrl</kbd> + <kbd>S</kbd> to star or unstar the selected
+    message.
+
 {tab|mobile}
 
 {!message-long-press-menu.md!}

--- a/help/view-a-messages-edit-history.md
+++ b/help/view-a-messages-edit-history.md
@@ -25,6 +25,11 @@ Organization administrators can
     never see a **MOVED** label; messages that have been moved will be
     marked as **EDITED** just like those whose content has been edited.
 
+!!! keyboard_tip ""
+
+    You can use <kbd>Shift</kbd> + <kbd>H</kbd> to view the edit history of the
+    selected message.
+
 {end_tabs}
 
 ## Related articles


### PR DESCRIPTION
- Adds `keyboard_tip` to [View a message's edit history](https://zulip.com/help/view-a-messages-edit-history#via-the-main-message-feed).
- Adds `keyboard_tip` to [Star a message](https://zulip.com/help/star-a-message#star-a-message_1).


Fixes: #26573.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/4f734317-f252-41e8-9c2e-895e5387e8d0)

![image](https://github.com/zulip/zulip/assets/2343554/bdfbb1a1-694d-4643-911a-e3c3e4c636df)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>