### PR TITLE
topic_list: Add icon, update color, and order of 'Followed Topics'.

### DIFF
--- a/web/src/topic_list_data.js
+++ b/web/src/topic_list_data.js
@@ -128,13 +128,13 @@ export function get_list_info(stream_id, zoomed, search_term) {
     }
 
     if (stream_muted && !zoomed) {
-        const unmuted_topics = topic_names.filter((topic) =>
-            user_topics.is_topic_unmuted(stream_id, topic),
+        const unmuted_or_followed_topics = topic_names.filter((topic) =>
+            user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
-        choose_topics(stream_id, unmuted_topics, zoomed, topic_choice_state);
+        choose_topics(stream_id, unmuted_or_followed_topics, zoomed, topic_choice_state);
 
         const other_topics = topic_names.filter(
-            (topic) => !user_topics.is_topic_unmuted(stream_id, topic),
+            (topic) => !user_topics.is_topic_unmuted_or_followed(stream_id, topic),
         );
         choose_topics(stream_id, other_topics, zoomed, topic_choice_state);
     } else {

--- a/web/src/topic_list_data.js
+++ b/web/src/topic_list_data.js
@@ -16,7 +16,11 @@ function choose_topics(stream_id, topic_names, zoomed, topic_choice_state) {
         const num_unread = unread.num_unread_for_topic(stream_id, topic_name);
         const is_active_topic = topic_choice_state.active_topic === topic_name.toLowerCase();
         const is_topic_muted = user_topics.is_topic_muted(stream_id, topic_name);
-        const is_topic_unmuted = user_topics.is_topic_unmuted(stream_id, topic_name);
+        const is_topic_followed = user_topics.is_topic_followed(stream_id, topic_name);
+        const is_topic_unmuted_or_followed = user_topics.is_topic_unmuted_or_followed(
+            stream_id,
+            topic_name,
+        );
         const [topic_resolved_prefix, topic_display_name] =
             resolved_topic.display_parts(topic_name);
         // Important: Topics are lower-case in this set.
@@ -93,7 +97,8 @@ function choose_topics(stream_id, topic_names, zoomed, topic_choice_state) {
             unread: num_unread,
             is_zero: num_unread === 0,
             is_muted: is_topic_muted,
-            is_unmuted: is_topic_unmuted,
+            is_followed: is_topic_followed,
+            is_unmuted_or_followed: is_topic_unmuted_or_followed,
             is_active_topic,
             url: hash_util.by_stream_topic_url(stream_id, topic_name),
             contains_unread_mention,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -38,10 +38,6 @@
             color: hsl(236deg 33% 90%/50%);
         }
 
-        & li.unmuted_topic {
-            color: hsl(236deg 33% 90%);
-        }
-
         & li.out_of_home_view {
             &:hover {
                 color: hsl(236deg 33% 90%/ 75%);

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -396,8 +396,8 @@ ul.filters {
             }
         }
 
-        & li.unmuted_topic {
-            color: var(--color-unmuted-topic-list-item);
+        & li.unmuted_or_followed_topic {
+            color: var(--color-unmuted-or-followed-topic-list-item);
 
             .unread_count {
                 opacity: 1;

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -397,7 +397,7 @@ ul.filters {
         }
 
         & li.unmuted_topic {
-            color: hsl(0deg 0% 20%);
+            color: var(--color-unmuted-topic-list-item);
 
             .unread_count {
                 opacity: 1;

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -163,6 +163,7 @@ body {
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
     --color-background-modal: hsl(0deg 0% 98%);
+    --color-unmuted-topic-list-item: hsl(0deg 0% 20%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -219,6 +220,7 @@ body {
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-background-modal: hsl(212deg 28% 18%);
+    --color-unmuted-topic-list-item: hsl(236deg 33% 90%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -163,7 +163,7 @@ body {
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-failed-message-send-icon: hsl(3.88deg 98.84% 66.27%);
     --color-background-modal: hsl(0deg 0% 98%);
-    --color-unmuted-topic-list-item: hsl(0deg 0% 20%);
+    --color-unmuted-or-followed-topic-list-item: hsl(0deg 0% 20%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 20%);
@@ -220,7 +220,7 @@ body {
     --color-navbar-bottom-border: hsl(0deg 0% 0% / 60%);
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-background-modal: hsl(212deg 28% 18%);
-    --color-unmuted-topic-list-item: hsl(236deg 33% 90%);
+    --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -1,4 +1,4 @@
-<li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} {{#if is_unmuted}}unmuted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
+<li class='bottom_left_row {{#if is_active_topic}}active-sub-filter{{/if}} {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} {{#if is_unmuted_or_followed}}unmuted_or_followed_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
         <span class="sidebar-topic-check">
             {{topic_resolved_prefix}}
@@ -10,6 +10,9 @@
             <span class="unread_mention_info">
                 @
             </span>
+        {{else if is_followed}}
+            <i class="zulip-icon zulip-icon-follow" aria-hidden="true"> </i>
+            &nbsp;
         {{/if}}
         <span class="unread_count {{#if is_zero}}zero_count{{/if}}">
             {{unread}}

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -19,7 +19,10 @@ const user_topics = mock_esm("../src/user_topics", {
     is_topic_muted() {
         return false;
     },
-    is_topic_unmuted() {
+    is_topic_followed() {
+        return false;
+    },
+    is_topic_unmuted_or_followed() {
         return false;
     },
 });
@@ -95,7 +98,8 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         contains_unread_mention: false,
         is_active_topic: false,
         is_muted: false,
-        is_unmuted: false,
+        is_followed: false,
+        is_unmuted_or_followed: false,
         is_zero: true,
         topic_display_name: "topic 9",
         topic_name: "✔ topic 9",
@@ -108,7 +112,8 @@ test("get_list_info w/real stream_topic_history", ({override}) => {
         contains_unread_mention: false,
         is_active_topic: false,
         is_muted: false,
-        is_unmuted: false,
+        is_followed: false,
+        is_unmuted_or_followed: false,
         is_zero: true,
         topic_display_name: "topic 8",
         topic_name: "topic 8",

--- a/web/tests/topic_list_data.test.js
+++ b/web/tests/topic_list_data.test.js
@@ -265,7 +265,7 @@ test("get_list_info unreads", ({override}) => {
     // this should make topic 5 at top in items array
     general.is_muted = true;
     add_unreads("topic 5", 1);
-    override(user_topics, "is_topic_unmuted", (stream_id, topic_name) => {
+    override(user_topics, "is_topic_unmuted_or_followed", (stream_id, topic_name) => {
         assert.equal(stream_id, general.stream_id);
         return topic_name === "topic 5";
     });


### PR DESCRIPTION
#### [Update - Sep 11, 2023](https://github.com/zulip/zulip/pull/26579#issuecomment-1713507968)
---
[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Follow.20Topics.20UI/near/1629130)

> When we follow a topic in a muted stream. It should not stay faded and also moves to the top in the topics list.

>  yeah, basically a followed topic is not correctly being treated as also unmuted in muted streams (being a tier of interest above being unmuted).

* First commit: It should not stay faded
* Second commit: moves to the top in the topics list

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**


https://github.com/zulip/zulip/assets/56781761/b4cb1d2b-7e70-4903-9fee-88e8c9527507




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
