### PR TITLE
reactions: Rectify reaction-container colors.

### DIFF
--- a/web/src/message_list_tooltips.js
+++ b/web/src/message_list_tooltips.js
@@ -12,7 +12,7 @@ import {page_params} from "./page_params";
 import * as reactions from "./reactions";
 import * as rows from "./rows";
 import * as timerender from "./timerender";
-import {LONG_HOVER_DELAY} from "./tippyjs";
+import {INTERACTIVE_HOVER_DELAY, LONG_HOVER_DELAY} from "./tippyjs";
 import {parse_html} from "./ui_util";
 
 // We need to store all message list instances together to destroy them in case of re-rendering.
@@ -105,6 +105,7 @@ export function initialize() {
     // message reaction tooltip showing who reacted.
     let observer;
     message_list_tooltip(".message_reaction, .message_reactions .reaction_button", {
+        delay: INTERACTIVE_HOVER_DELAY,
         placement: "bottom",
         onShow(instance) {
             if (!document.body.contains(instance.reference)) {

--- a/web/src/tippyjs.js
+++ b/web/src/tippyjs.js
@@ -18,12 +18,17 @@ function get_tooltip_content(reference) {
     return "";
 }
 
-// We use three delay settings for tooltips. The default "instant"
+// We use different delay settings for tooltips. The default "instant"
 // version has just a tiny bit of delay to create a natural feeling
 // transition, while the "long" version is intended for elements where
 // we want to avoid distracting the user with the tooltip
 // unnecessarily.
 const INSTANT_HOVER_DELAY = [100, 20];
+// INTERACTIVE_HOVER_DELAY is for elements like the emoji reactions, where
+// the tooltip includes useful information (who reacted?), but that
+// needs a short delay for users who are just tapping a reaction
+// element and not interested in the tooltip's contents.
+export const INTERACTIVE_HOVER_DELAY = [425, 20];
 export const LONG_HOVER_DELAY = [750, 20];
 // EXTRA_LONG_HOVER_DELAY is for elements like the compose box send
 // button where the tooltip content is almost exactly the same as the

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -561,8 +561,7 @@
     .new-style .tab-switcher .ind-tab.selected,
     div.message_content thead,
     .table-striped thead th,
-    .emoji-popover .reaction.reacted,
-    .message_reactions .message_reaction.reacted {
+    .emoji-popover .reaction.reacted {
         background-color: hsl(0deg 0% 0% / 50%);
         border-color: hsl(0deg 0% 0% / 90%);
     }
@@ -573,17 +572,6 @@
 
     .message_time:hover {
         color: var(--color-message-action-interactive);
-    }
-
-    .message_reactions:hover .message_reaction + .reaction_button,
-    .message_reactions .message_reaction {
-        background-color: transparent;
-        border-color: hsl(0deg 0% 0% / 80%);
-        color: inherit;
-
-        &:hover {
-            border-color: hsl(236deg 33% 90%);
-        }
     }
 
     .emoji-popover .reaction:focus {

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -415,12 +415,6 @@
         color: inherit;
     }
 
-    .message_reactions .message_reaction_count,
-    .message_reactions .reaction_button i,
-    .message_reactions:hover .message_reaction + .reaction_button {
-        color: inherit !important;
-    }
-
     .active_private_messages_section {
         #private_messages_section,
         #direct-messages-list,

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -84,9 +84,18 @@
     }
 
     .message_reaction_count {
+        /* 90% works out here to 12.6px */
         font-size: 90%;
-        margin: 2px 3px;
-        line-height: 1em;
+        /* No top and bottom margin; just allow
+           flexbox to handle the vertical alignment. */
+        margin: 0 3px;
+        /* Set the 12.6px text on a 13px line;
+           the goal is to have that 13px line
+           center correctly on the vertical with
+           the 17px-square emoji, resulting in
+           2px of space above and below the
+           reaction count/name. */
+        line-height: 13px;
     }
 
     .message_reaction:hover .message_reaction_count {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -7,17 +7,18 @@
         display: flex;
         padding: 0 2px 0 0;
         cursor: pointer;
-        background-color: hsl(0deg 0% 100%);
-        border: 1px solid hsl(194deg 37% 84%);
+        background-color: var(--color-message-reaction-background);
+        border: 1px solid var(--color-message-reaction-border);
         border-radius: 4px;
         align-items: center;
 
         &.reacted {
-            background-color: hsl(195deg 50% 95%);
+            background-color: var(--color-message-reaction-background-reacted);
+            border-color: var(--color-message-reaction-border-reacted);
         }
 
         &:hover {
-            border: 1px solid hsl(200deg 100% 40%);
+            border: 1px solid var(--color-message-reaction-border-hover);
         }
 
         + .reaction_button {
@@ -122,15 +123,6 @@
         &:hover .message_reaction_count {
             color: hsl(200deg 100% 40%);
         }
-    }
-}
-
-.private-message .message_reactions .message_reaction {
-    background-color: hsl(192deg 20% 95%);
-
-    &.reacted {
-        background-color: hsl(196deg 51% 93%);
-        border-color: hsl(193deg 38% 70%);
     }
 }
 

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -28,7 +28,7 @@
             height: 13px;
             border-radius: 4px;
             padding-left: 0.3em;
-            border: 1px solid hsl(0deg 0% 73%);
+            border: 1px solid var(--color-message-reaction-button-border);
             padding-right: 0.3em;
             /* TODO: Eventually this space will be set on the message
                box, but for now this preserves the space beneath the
@@ -67,19 +67,19 @@
     }
 
     .message_reaction:hover .message_reaction_count {
-        color: hsl(200deg 100% 40%);
+        color: var(--color-message-reaction-button-text-hover);
     }
 
     & i {
         font-size: 1.3em;
         float: left;
-        color: hsl(0deg 0% 33%);
+        color: var(--color-message-reaction-button-text);
     }
 
     &:hover .message_reaction + .reaction_button {
         visibility: visible;
         pointer-events: all;
-        background-color: hsl(0deg 0% 98%);
+        background-color: var(--color-message-reaction-button-background);
     }
 
     .reaction_button,
@@ -94,7 +94,7 @@
         }
 
         &:hover i {
-            color: hsl(200deg 100% 40%);
+            color: var(--color-message-reaction-button-text-hover);
         }
 
         /* Configure the reaction button to appear if and only if there's an
@@ -107,21 +107,23 @@
         }
 
         &:hover {
-            border: 1px solid hsl(200deg 100% 40%);
-            background-color: hsl(195deg 50% 95%);
+            border: 1px solid var(--color-message-reaction-button-border-hover);
+            background-color: var(
+                --color-message-reaction-button-background-hover
+            );
             cursor: pointer;
             opacity: 1;
-            color: hsl(200deg 100% 40%);
+            color: var(--color-message-reaction-button-text-hover);
         }
 
         .message_reaction_count {
             font-size: 1.1em;
-            color: hsl(0deg 0% 33%);
+            color: var(--color-message-reaction-button-text);
             margin-right: 0;
         }
 
         &:hover .message_reaction_count {
-            color: hsl(200deg 100% 40%);
+            color: var(--color-message-reaction-button-text-hover);
         }
     }
 }

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -1,39 +1,62 @@
 .message_reactions {
     overflow: hidden;
-
     user-select: none;
 
     .message_reaction {
         display: flex;
-        padding: 0 2px 0 0;
+        padding: 1px 4px 1px 3px;
+        box-sizing: border-box;
+        min-width: 44px;
         cursor: pointer;
+        color: var(--color-message-reaction-text);
         background-color: var(--color-message-reaction-background);
         border: 1px solid var(--color-message-reaction-border);
-        border-radius: 4px;
+        border-radius: 21px;
         align-items: center;
+        box-shadow: inset 0 0 5px 0 var(--color-message-reaction-shadow-inner);
+        transition:
+            transform 100ms linear,
+            font-weight 100ms linear;
 
         &.reacted {
+            color: var(--color-message-reaction-text-reacted);
             background-color: var(--color-message-reaction-background-reacted);
             border-color: var(--color-message-reaction-border-reacted);
+            font-weight: var(--font-weight-message-reaction);
+            box-shadow: none;
         }
 
         &:hover {
-            border: 1px solid var(--color-message-reaction-border-hover);
+            background-color: var(--color-message-reaction-background-hover);
+        }
+
+        &:active {
+            transform: scale(var(--scale-message-reaction-active));
         }
 
         + .reaction_button {
             visibility: hidden;
             pointer-events: none;
-            padding: 3px;
+            padding: 4px 6px;
             height: 13px;
-            border-radius: 4px;
-            padding-left: 0.3em;
+            border-radius: 21px;
+            color: var(--color-message-reaction-button-text);
+            background-color: var(--color-message-reaction-button-background);
             border: 1px solid var(--color-message-reaction-button-border);
-            padding-right: 0.3em;
             /* TODO: Eventually this space will be set on the message
-               box, but for now this preserves the space beneath the
-               reactions area. */
-            margin-bottom: 2px;
+               box, at least in part, but for now this preserves the
+               space beneath the reactions area. */
+            margin-bottom: 4px;
+
+            &:hover {
+                color: var(--color-message-reaction-button-text-hover);
+                background-color: var(
+                    --color-message-reaction-button-background-hover
+                );
+                border-color: var(--color-message-reaction-button-border-hover);
+                box-shadow: inset 0 0 5px 0
+                    var(--color-message-reaction-shadow-inner);
+            }
         }
 
         .emoji {
@@ -79,7 +102,6 @@
     &:hover .message_reaction + .reaction_button {
         visibility: visible;
         pointer-events: all;
-        background-color: var(--color-message-reaction-button-background);
     }
 
     .reaction_button,
@@ -117,7 +139,7 @@
         }
 
         .message_reaction_count {
-            font-size: 1.1em;
+            font-weight: 700;
             color: var(--color-message-reaction-button-text);
             margin-right: 0;
         }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -110,6 +110,11 @@ body {
     --message-box-icon-height: 25px;
 
     /*
+    Reaction container UI scaling.
+    */
+    --scale-message-reaction-active: 0.96;
+
+    /*
     Left position of unread marker. Only needs to be tracked if it is negative so that
     it doesn't leak through message header.
     */
@@ -288,17 +293,27 @@ body {
     --color-tab-picker-icon: hsl(200deg 100% 40%);
 
     /* Reaction container colors */
-    --color-message-reaction-border: hsl(194deg 37% 84%);
-    --color-message-reaction-border-reacted: hsl(193deg 38% 70%);
-    --color-message-reaction-border-hover: hsl(200deg 100% 40%);
-    --color-message-reaction-background: transparent;
-    --color-message-reaction-background-reacted: hsl(196deg 51% 93%);
-    --color-message-reaction-button-text: hsl(0deg 0% 33%);
-    --color-message-reaction-button-text-hover: hsl(200deg 100% 40%);
-    --color-message-reaction-button-background: hsl(0deg 0% 98%);
-    --color-message-reaction-button-background-hover: hsl(195deg 50% 95%);
-    --color-message-reaction-button-border: hsl(0deg 0% 73%);
-    --color-message-reaction-button-border-hover: hsl(200deg 100% 40%);
+    --color-message-reaction-border: hsl(0deg 0% 0% / 12%);
+    --color-message-reaction-border-reacted: hsl(0deg 0% 0% / 40%);
+    --color-message-reaction-background: hsl(0deg 0% 100%);
+    --color-message-reaction-background-reacted: hsl(0deg 0% 100%);
+    --color-message-reaction-background-hover: hsl(210deg 30% 96%);
+    --color-message-reaction-shadow-inner: hsl(210deg 50% 50% / 15%);
+    --color-message-reaction-text: hsl(210deg 20% 25% / 100%);
+    --color-message-reaction-text-reacted: hsl(210deg 20% 20% / 100%);
+    --color-message-reaction-button-text: hsl(210deg 20% 20% / 60%);
+    --color-message-reaction-button-text-hover: var(
+        --color-message-reaction-text
+    );
+    --color-message-reaction-button-background: inherit;
+    --color-message-reaction-button-background-hover: var(
+        --color-message-reaction-background
+    );
+    --color-message-reaction-button-border: transparent;
+    --color-message-reaction-button-border-hover: var(
+        --color-message-reaction-border
+    );
+    --font-weight-message-reaction: 600;
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 0% / 34%);
@@ -538,25 +553,28 @@ body {
     --color-tab-picker-icon: hsl(0deg 0% 80%);
 
     /* Reaction container colors */
-    --color-message-reaction-border: hsl(0deg 0% 0% / 80%);
-    --color-message-reaction-border-reacted: hsl(0deg 0% 0% / 90%);
-    --color-message-reaction-border-hover: hsl(236deg 33% 90%);
-    --color-message-reaction-background: transparent;
-    --color-message-reaction-background-reacted: hsl(0deg 0% 0% / 50%);
-    --color-message-reaction-button-text: inherit;
-    --color-message-reaction-button-text-hover: inherit;
-    --color-message-reaction-button-background: var(
-        --color-message-reaction-background
+    --color-message-reaction-border: hsl(0deg 0% 100% / 15%);
+    --color-message-reaction-border-reacted: hsl(0deg 0% 100% / 50%);
+    --color-message-reaction-background: hsl(0deg 0% 0% / 30%);
+    --color-message-reaction-background-reacted: hsl(0deg 0% 0% / 80%);
+    --color-message-reaction-background-hover: hsl(0deg 0% 100% / 10%);
+    /* No shadow in dark mode. */
+    --color-message-reaction-shadow-inner: transparent;
+    --color-message-reaction-text: hsl(0deg 0% 100% / 75%);
+    --color-message-reaction-text-reacted: hsl(0deg 0% 100% / 85%);
+    --color-message-reaction-button-text: var(--color-message-reaction-text);
+    --color-message-reaction-button-text-hover: var(
+        --color-message-reaction-text-reacted
     );
+    --color-message-reaction-button-background: inherit;
     --color-message-reaction-button-background-hover: var(
-        --color-message-reaction-background
+        --color-message-reaction-background-hover
     );
-    --color-message-reaction-button-border: var(
+    --color-message-reaction-button-border: transparent;
+    --color-message-reaction-button-border-hover: var(
         --color-message-reaction-border
     );
-    --color-message-reaction-button-border-hover: var(
-        --color-message-reaction-border-hover
-    );
+    --font-weight-message-reaction: 550;
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 100% / 50%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -287,6 +287,13 @@ body {
     );
     --color-tab-picker-icon: hsl(200deg 100% 40%);
 
+    /* Reaction container colors */
+    --color-message-reaction-border: hsl(194deg 37% 84%);
+    --color-message-reaction-border-reacted: hsl(193deg 38% 70%);
+    --color-message-reaction-border-hover: hsl(200deg 100% 40%);
+    --color-message-reaction-background: transparent;
+    --color-message-reaction-background-reacted: hsl(196deg 51% 93%);
+
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 0% / 34%);
     --color-zulip-logo-loading: hsl(0deg 0% 27%);
@@ -523,6 +530,13 @@ body {
         --color-left-sidebar-navigation-icon
     );
     --color-tab-picker-icon: hsl(0deg 0% 80%);
+
+    /* Reaction container colors */
+    --color-message-reaction-border: hsl(0deg 0% 0% / 80%);
+    --color-message-reaction-border-reacted: hsl(0deg 0% 0% / 90%);
+    --color-message-reaction-border-hover: hsl(236deg 33% 90%);
+    --color-message-reaction-background: transparent;
+    --color-message-reaction-background-reacted: hsl(0deg 0% 0% / 50%);
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 100% / 50%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -293,6 +293,12 @@ body {
     --color-message-reaction-border-hover: hsl(200deg 100% 40%);
     --color-message-reaction-background: transparent;
     --color-message-reaction-background-reacted: hsl(196deg 51% 93%);
+    --color-message-reaction-button-text: hsl(0deg 0% 33%);
+    --color-message-reaction-button-text-hover: hsl(200deg 100% 40%);
+    --color-message-reaction-button-background: hsl(0deg 0% 98%);
+    --color-message-reaction-button-background-hover: hsl(195deg 50% 95%);
+    --color-message-reaction-button-border: hsl(0deg 0% 73%);
+    --color-message-reaction-button-border-hover: hsl(200deg 100% 40%);
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 0% / 34%);
@@ -537,6 +543,20 @@ body {
     --color-message-reaction-border-hover: hsl(236deg 33% 90%);
     --color-message-reaction-background: transparent;
     --color-message-reaction-background-reacted: hsl(0deg 0% 0% / 50%);
+    --color-message-reaction-button-text: inherit;
+    --color-message-reaction-button-text-hover: inherit;
+    --color-message-reaction-button-background: var(
+        --color-message-reaction-background
+    );
+    --color-message-reaction-button-background-hover: var(
+        --color-message-reaction-background
+    );
+    --color-message-reaction-button-border: var(
+        --color-message-reaction-border
+    );
+    --color-message-reaction-button-border-hover: var(
+        --color-message-reaction-border-hover
+    );
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 100% / 50%);


### PR DESCRIPTION
This PR does two primary things:

1. It implements new reaction-container colors and rounded-pill styles defined by @terpimost.
2. It expresses all reaction-container colors and reaction button colors as CSS variables, in the process streamlining the number CSS selectors required.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/Reactions.20background.20color/near/1631057)

**Screenshots as of 2023-10-13**

| Before | After |
| --- | --- |
| ![light-before-2023-10-13](https://github.com/zulip/zulip/assets/170719/e3b55813-3c3f-4f7e-aa0e-f67d3ff492ec) | ![light-after-2023-10-13](https://github.com/zulip/zulip/assets/170719/d07c91ed-1ca7-444d-a702-b3168e4eff2c) |
| ![dark-before-2023-10-13](https://github.com/zulip/zulip/assets/170719/b66aec82-b1ad-4d66-9e97-c9a43c9d5190) | ![dark-after-2023-10-13](https://github.com/zulip/zulip/assets/170719/14bddb10-2e1c-4c2c-9c8c-ddeca6f17caf) |

**Interactions**
| Light mode | Dark mode |
| --- | --- |
| ![light-mode-interactive-2023-10-13](https://github.com/zulip/zulip/assets/170719/a9a86fcc-460f-4daf-ba33-08414454db08) | ![dark-interactive-2023-10-13](https://github.com/zulip/zulip/assets/170719/61c139a9-9c00-4956-bc14-c3580d3f3bc2) | 



<details>
<summary>[Outdated] Complete comparative screenshots and captures</summary>

**Appearance established by this PR, with [Vlad's new color scheme](#issuecomment-1705734770):**

| Light streams | Dark streams |
| --- | --- |
| ![streams-light-09142023](https://github.com/zulip/zulip/assets/170719/a7d45bee-25cb-4cec-aad2-eedb0d8c7e05) | ![streams-dark-09142023](https://github.com/zulip/zulip/assets/170719/d08b5aef-4db1-403c-9984-768a36e9b2da) |

| Light DMs | Dark DMs |
| --- | --- |
| ![dms-light-09142023](https://github.com/zulip/zulip/assets/170719/e3c1cf47-6ccd-4450-9e66-ef85e6e0398a) | ![dms-dark-09142023](https://github.com/zulip/zulip/assets/170719/65bbd62d-980a-42e3-a050-3b34a5d322b2) |

| Light hover states | Dark hover states |
| --- | --- |
| ![light-hovers-20220911](https://github.com/zulip/zulip/assets/170719/92ac78e9-e842-409c-9eb0-dcf591a78aec) | ![dark-hovers-20220911](https://github.com/zulip/zulip/assets/170719/339f6854-0363-44e8-abc6-51a15c295839) |

| Light Mode | Dark Mode |
| --- | --- |
| ![light-new-colors](https://github.com/zulip/zulip/assets/170719/6e3a715a-5773-412e-ab2a-b0bc70aa9f20) | ![dark-new-colors](https://github.com/zulip/zulip/assets/170719/dfca1115-e41e-4a20-89bc-0e48a5d5cfa8) |
| ![light-hovers](https://github.com/zulip/zulip/assets/170719/ec1b0fc4-4f54-4c7e-8ce3-4abab23043c2) | ![dark-hovers](https://github.com/zulip/zulip/assets/170719/19b906d1-ff25-4529-9564-c887fc127230) |

**Scaling (0.96) on click/active state**

![reactions-active](https://github.com/zulip/zulip/assets/170719/45560899-0dd2-4931-b705-8520734177c0)

**Static screenshots:**

| Streams, Before | Streams, After |
| --- | --- |
| ![light-stream-before](https://github.com/zulip/zulip/assets/170719/555c93d7-de1a-48ed-a8dd-a4501d9c9a03) | ![light-stream-after](https://github.com/zulip/zulip/assets/170719/3719f55c-5997-4368-bff2-9fcdb9e54c21) |
| ![dark-stream-before](https://github.com/zulip/zulip/assets/170719/cf41eee8-ea95-4a65-9f65-0ea3f6348765) | ![dark-stream-after](https://github.com/zulip/zulip/assets/170719/e581edfa-aabf-4e0a-90ee-5a1b7fbf903f) |

| DMs, Before | DMs, After |
| --- | --- |
| ![light-dm-before](https://github.com/zulip/zulip/assets/170719/b3df1d37-4c06-431d-8864-43689e2f58a4) | ![light-dm-after](https://github.com/zulip/zulip/assets/170719/fbcf1536-1e1a-41e7-ba5e-0b949d907ebd) |
| ![dark-dm-before](https://github.com/zulip/zulip/assets/170719/524a9a54-7b78-4a0e-84a3-0d6597d4360f) | ![dark-dm-after](https://github.com/zulip/zulip/assets/170719/1b9ab35e-9f3e-4103-bd9e-080675b7dce4) |

**Kinetic screenshots (hover styles):**

| Stream Hovers, Before | Stream Hovers, After |
| --- | --- |
| ![light-stream-hovers-before](https://github.com/zulip/zulip/assets/170719/82e83942-fc5a-4fd7-9660-8affa138b29c) | ![light-stream-hovers-after](https://github.com/zulip/zulip/assets/170719/96da6f7c-75a8-48bc-92fa-3225cd7e7595) |
| ![dark-stream-hovers-before](https://github.com/zulip/zulip/assets/170719/bf9223c1-0058-4244-85a3-8e656bbb7ac7) | ![dark-stream-hovers-after](https://github.com/zulip/zulip/assets/170719/7d150f18-106a-4b02-8b22-dd1c982de877) |

| DM Hovers, Before | DM Hovers, After |
| --- | --- |
| ![light-dm-hovers-before](https://github.com/zulip/zulip/assets/170719/7303a41a-3252-4c48-8a00-606ae4cd31a0) | ![light-dm-hovers-after](https://github.com/zulip/zulip/assets/170719/7da31e48-d18b-450d-b7f5-fd2dc92d7b0d) |
| ![dark-dm-hovers-before](https://github.com/zulip/zulip/assets/170719/a94ff4a3-1644-4178-9d92-3c4ae779dc05)| ![dark-dm-hovers-after](https://github.com/zulip/zulip/assets/170719/33249f31-43d9-47b5-8241-d80f5b8d9437) |

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>