### PR TITLE
compose: Add support for Zoom audio call

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,12 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 206**
+
+* `POST /calls/zoom/create`: Added `is_video_call` parameter
+  controlling whether to request a Zoom meeting that defaults to
+  having video enabled.
+
 **Feature level 205**
 
 * [`POST /register`](/api/register-queue): `streams` field in the response

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 205
+API_FEATURE_LEVEL = 206
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/tests/compose_video.test.js
+++ b/web/tests/compose_video.test.js
@@ -132,7 +132,7 @@ test("videos", ({override}) => {
         assert.match(syntax_to_insert, video_link_regex);
     })();
 
-    (function test_zoom_video_link_compose_clicked() {
+    (function test_zoom_video_and_audio_links_compose_clicked() {
         let syntax_to_insert;
         let called = false;
 
@@ -152,9 +152,6 @@ test("videos", ({override}) => {
             called = true;
         });
 
-        const handler = $("body").get_on_handler("click", ".video_link");
-        $("#compose-textarea").val("");
-
         page_params.realm_video_chat_provider = realm_available_video_chat_providers.zoom.id;
         page_params.has_zoom_token = false;
 
@@ -172,10 +169,19 @@ test("videos", ({override}) => {
             return {abort() {}};
         };
 
-        handler(ev);
+        $("#compose-textarea").val("");
+        const video_handler = $("body").get_on_handler("click", ".video_link");
+        video_handler(ev);
         const video_link_regex = /\[translated: Join video call\.]\(example\.zoom\.com\)/;
         assert.ok(called);
         assert.match(syntax_to_insert, video_link_regex);
+
+        $("#compose-textarea").val("");
+        const audio_handler = $("body").get_on_handler("click", ".audio_link");
+        audio_handler(ev);
+        const audio_link_regex = /\[translated: Join audio call\.]\(example\.zoom\.com\)/;
+        assert.ok(called);
+        assert.match(syntax_to_insert, audio_link_regex);
     })();
 
     (function test_bbb_video_link_compose_clicked() {


### PR DESCRIPTION
This PR implements the audio call feature for Zoom. This is done by explicitly telling Zoom to create a meeting where the host's video and participants' video are off by default.

Another key change is that when creating a video call, the host's and participants' video will be on by default. The old code doesn't specify that setting, so meetings actually start with video being off. This new behavior has less work for users to do. They don't have to turn on video when joining a call advertised as "video call". It still respects users' preferences because they can still configure their own personal setting that overrides the meeting
defaults.

The Zoom API documentation can be found at https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetingCreate

<!-- Describe your pull request here.-->

Fixes: #26549

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/859317/0f772ee4-9962-4878-8296-1e60cbbea7c9




<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
