### PR TITLE
api-docs: Fix documentation of `unread_msgs` object in `POST /register` response.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11712,7 +11712,7 @@ paths:
                                     **Changes**: Deprecated in Zulip 5.0 (feature level 119).
                                     We expect to provide a next version of the full `unread_msgs`
                                     API before removing this legacy name.
-                                message_ids:
+                                unread_message_ids:
                                   type: array
                                   description: |
                                     The message IDs of the recent unread direct messages sent
@@ -11768,7 +11768,7 @@ paths:
                                     A string containing the IDs of all users in the group
                                     direct message conversation separated by commas; for
                                     example: `"1,2,3"`.
-                                message_ids:
+                                unread_message_ids:
                                   type: array
                                   description: |
                                     The message IDs of the recent unread messages which have been sent in

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11691,22 +11691,26 @@ paths:
                               description: |
                                 Object containing the details of unread direct messages with
                                 a specific user. Note that in rare situations, it is possible
-                                for a message that you sent to another user to be marked as
-                                unread and thus appear here.
+                                for a message that the current user sent to another user to
+                                be marked as unread and thus appear here.
                               additionalProperties: false
                               properties:
                                 other_user_id:
                                   type: integer
                                   description: |
                                     The user ID of the other participant in this non-group direct
-                                    message conversation. Will be your own user ID for messages
-                                    that you sent to only yourself.
+                                    message conversation. Will be the current user's ID for messages
+                                    that they sent in a one-on-one direct message conversation with
+                                    themself.
+
+                                    **Changes**: New in Zulip 5.0 (feature level 119), replacing
+                                    the less clearly named `sender_id` field.
                                 sender_id:
                                   deprecated: true
                                   type: integer
                                   description: |
-                                    Old name for `other_user_id`. Clients should access this
-                                    field in Zulip server versions that do not yet support
+                                    Old name for the `other_user_id` field. Clients should access
+                                    this field in Zulip server versions that do not yet support
                                     `other_user_id`.
 
                                     **Changes**: Deprecated in Zulip 5.0 (feature level 119).
@@ -11772,14 +11776,15 @@ paths:
                                   type: array
                                   description: |
                                     The message IDs of the recent unread messages which have been sent in
-                                    this group.
+                                    this group direct message conversation.
                                   items:
                                     type: integer
                           mentions:
                             type: array
                             description: |
-                              Array containing the IDs of all messages in which the user has been mentioned.
-                              For muted streams, wildcard mentions will not be considered for this array.
+                              Array containing the IDs of all unread messages in which the user has been
+                              mentioned. For muted streams, wildcard mentions will not be considered for
+                              this array.
                             items:
                               type: integer
                           old_unreads_missing:


### PR DESCRIPTION
Fixes various issues in the `POST /register` documentation for the `unread_msgs` object. See two relevant CZO conversations:
- [Missing changes note conversation in #api documentation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/register.3A.20When.20was.20.60unread_msgs.2Epms.5B.5D.2Eother_user_id.60.20added.3F/near/1623961)
- [Incorrect field name conversation in #api documentation](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/register.3A.20.60unread_msgs.2Epms.5B.5D.2Eunread_message_ids.60/near/1623940)

Specific changes:
- Fixes incorrectly named `message_ids` fields in `pms` and `huddles` objects to be `unread_message_ids`.
- Adds **Changes** note for when `other_user_id` was added to `pms` object.
- Changes a few uses of "you" to be "current user"
- Clarifies a few places the type of the group conversation (one-on-one or group) and that the messages in these objects/arrays are unread.

**Follow-ups**:
- This PR fixes the documentation errors, but does not fix the testing gap for errors in the documentation of the `POST /register` response.

**Screenshots and screen captures:**

<details>
<summary>unread_msgs object in register response</summary>

[Current documentation](https://zulip.com/api/register-queue) - search for "unread_msgs:"
![Screenshot from 2023-08-28 18-56-36](https://github.com/zulip/zulip/assets/63245456/82ec7f9b-10fd-41e9-bb0f-5dd8968ed406)
![Screenshot from 2023-08-28 18-56-51](https://github.com/zulip/zulip/assets/63245456/6f0206d6-066e-4335-b07c-c51345c942e3)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
