### PR TITLE
nginx: Do not forward X-amz-cf-id header to S3.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/uploads-internal.conf
@@ -12,8 +12,12 @@ location ~ ^/internal/s3/(?<s3_hostname>[^/]+)/(?<s3_path>.*) {
     set $download_url https://$s3_hostname/$s3_path;
     proxy_set_header Host $s3_hostname;
 
-    # Ensure that we only get _one_ of these headers: the one that
-    # Django added, not the one from S3.
+    # Strip off X-amz-cf-id header, which otherwise the request has to
+    # have been signed over, leading to signature mismatches.
+    proxy_set_header x-amz-cf-id "";
+
+    # Ensure that we only get _one_ of these response headers: the one
+    # that Django added, not the one from S3.
     proxy_hide_header Cache-Control;
     proxy_hide_header Expires;
     proxy_hide_header Set-Cookie;


### PR DESCRIPTION
All `X-amz-*` headers must be included in the signed request to S3; since Django did not take those headers into account (it constructed a request from scratch, while nginx's request inherits them from the end-user's request), the proxied request fails to be signed correctly.

Strip off the `X-amz-cf-id` header added by CloudFront.  While we would ideally strip off all `X-amz-*` headers, this requires a third-party module[^1].

[^1]: https://github.com/openresty/headers-more-nginx-module#more_clear_input_headers

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
