### PR TITLE
compose: Verify request payload in Zoom meeting creation test

### DIFF
--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import orjson
 import responses
 from django.core.signing import Signer
 from django.http import HttpResponseRedirect
@@ -68,6 +69,15 @@ class TestVideoCall(ZulipTestCase):
             "https://api.zoom.us/v2/users/me/meetings",
         )
         self.assertEqual(
+            orjson.loads(responses.calls[-1].request.body),
+            {
+                "settings": {
+                    "host_video": True,
+                    "participant_video": True,
+                },
+            },
+        )
+        self.assertEqual(
             responses.calls[-1].request.headers["Authorization"],
             "Bearer newtoken",
         )
@@ -91,6 +101,15 @@ class TestVideoCall(ZulipTestCase):
         self.assertEqual(
             responses.calls[-1].request.url,
             "https://api.zoom.us/v2/users/me/meetings",
+        )
+        self.assertEqual(
+            orjson.loads(responses.calls[-1].request.body),
+            {
+                "settings": {
+                    "host_video": False,
+                    "participant_video": False,
+                },
+            },
         )
         self.assertEqual(
             responses.calls[-1].request.headers["Authorization"],


### PR DESCRIPTION
Verify that Zoom meeting creation logic sends the expected request payload for configuring host_video and participant video.

<!-- Describe your pull request here.-->

Addresses feedback from #26588.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
