### PR TITLE
push_notifications: Remove TODOs from 'get_apns_alert_subtitle'.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -842,7 +842,6 @@ def get_apns_alert_title(message: Message) -> str:
 
 
 def get_apns_alert_subtitle(
-    user_profile: UserProfile,
     message: Message,
     trigger: str,
     mentioned_user_group_name: Optional[str] = None,
@@ -923,9 +922,7 @@ def get_message_payload_apns(
         apns_data = {
             "alert": {
                 "title": get_apns_alert_title(message),
-                "subtitle": get_apns_alert_subtitle(
-                    user_profile, message, trigger, mentioned_user_group_name
-                ),
+                "subtitle": get_apns_alert_subtitle(message, trigger, mentioned_user_group_name),
                 "body": content,
             },
             "sound": "default",

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -856,15 +856,12 @@ def get_apns_alert_subtitle(
             )
         else:
             return _("{full_name} mentioned you:").format(full_name=message.sender.full_name)
-    elif trigger == NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC:
-        return _("TODO - 2")
-    elif trigger == NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC:
-        return _("TODO")
-    elif trigger == NotificationTriggers.TOPIC_WILDCARD_MENTION:
-        return _("{full_name} mentioned all topic participants:").format(
-            full_name=message.sender.full_name
-        )
-    elif trigger == NotificationTriggers.STREAM_WILDCARD_MENTION:
+    elif trigger in (
+        NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
+        NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
+        NotificationTriggers.TOPIC_WILDCARD_MENTION,
+        NotificationTriggers.STREAM_WILDCARD_MENTION,
+    ):
         return _("{full_name} mentioned everyone:").format(full_name=message.sender.full_name)
     elif message.recipient.type == Recipient.PERSONAL:
         return ""

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2016,10 +2016,10 @@ class TestGetAPNsPayload(PushNotificationTest):
         self.assertDictEqual(payload, expected)
         mock_push_notifications.assert_called()
 
-    def test_get_message_payload_apns_stream_message(self) -> None:
+    def _test_get_message_payload_apns_stream_message(self, trigger: str) -> None:
         stream = Stream.objects.filter(name="Verona").get()
         message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
-        payload = get_message_payload_apns(self.sender, message, NotificationTriggers.STREAM_PUSH)
+        payload = get_message_payload_apns(self.sender, message, trigger)
         expected = {
             "alert": {
                 "title": "#Verona > Test topic",
@@ -2045,6 +2045,12 @@ class TestGetAPNsPayload(PushNotificationTest):
             },
         }
         self.assertDictEqual(payload, expected)
+
+    def test_get_message_payload_apns_stream_message(self) -> None:
+        self._test_get_message_payload_apns_stream_message(NotificationTriggers.STREAM_PUSH)
+
+    def test_get_message_payload_apns_followed_topic_message(self) -> None:
+        self._test_get_message_payload_apns_stream_message(NotificationTriggers.FOLLOWED_TOPIC_PUSH)
 
     def test_get_message_payload_apns_stream_mention(self) -> None:
         user_profile = self.example_user("othello")

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2115,113 +2115,14 @@ class TestGetAPNsPayload(PushNotificationTest):
         }
         self.assertDictEqual(payload, expected)
 
-    def test_get_message_payload_apns_topic_wildcard_mention_in_followed_topic(self) -> None:
+    def _test_get_message_payload_apns_wildcard_mention(self, trigger: str) -> None:
         user_profile = self.example_user("othello")
         stream = Stream.objects.filter(name="Verona").get()
         message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
         payload = get_message_payload_apns(
             user_profile,
             message,
-            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC,
-        )
-        expected = {
-            "alert": {
-                "title": "#Verona > Test topic",
-                "subtitle": "TODO - 2",
-                "body": message.content,
-            },
-            "sound": "default",
-            "badge": 0,
-            "custom": {
-                "zulip": {
-                    "message_ids": [message.id],
-                    "recipient_type": "stream",
-                    "sender_email": self.sender.email,
-                    "sender_id": self.sender.id,
-                    "stream": stream.name,
-                    "stream_id": stream.id,
-                    "topic": message.topic_name(),
-                    "server": settings.EXTERNAL_HOST,
-                    "realm_id": self.sender.realm.id,
-                    "realm_uri": self.sender.realm.uri,
-                    "user_id": user_profile.id,
-                },
-            },
-        }
-        self.assertDictEqual(payload, expected)
-
-    def test_get_message_payload_apns_stream_wildcard_mention_in_followed_topic(self) -> None:
-        user_profile = self.example_user("othello")
-        stream = Stream.objects.filter(name="Verona").get()
-        message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
-        payload = get_message_payload_apns(
-            user_profile, message, NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC
-        )
-        expected = {
-            "alert": {
-                "title": "#Verona > Test topic",
-                "subtitle": "TODO",
-                "body": message.content,
-            },
-            "sound": "default",
-            "badge": 0,
-            "custom": {
-                "zulip": {
-                    "message_ids": [message.id],
-                    "recipient_type": "stream",
-                    "sender_email": self.sender.email,
-                    "sender_id": self.sender.id,
-                    "stream": stream.name,
-                    "stream_id": stream.id,
-                    "topic": message.topic_name(),
-                    "server": settings.EXTERNAL_HOST,
-                    "realm_id": self.sender.realm.id,
-                    "realm_uri": self.sender.realm.uri,
-                    "user_id": user_profile.id,
-                },
-            },
-        }
-        self.assertDictEqual(payload, expected)
-
-    def test_get_message_payload_apns_topic_wildcard_mention(self) -> None:
-        user_profile = self.example_user("othello")
-        stream = Stream.objects.filter(name="Verona").get()
-        message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
-        payload = get_message_payload_apns(
-            user_profile, message, NotificationTriggers.TOPIC_WILDCARD_MENTION
-        )
-        expected = {
-            "alert": {
-                "title": "#Verona > Test topic",
-                "subtitle": "King Hamlet mentioned all topic participants:",
-                "body": message.content,
-            },
-            "sound": "default",
-            "badge": 0,
-            "custom": {
-                "zulip": {
-                    "message_ids": [message.id],
-                    "recipient_type": "stream",
-                    "sender_email": self.sender.email,
-                    "sender_id": self.sender.id,
-                    "stream": stream.name,
-                    "stream_id": stream.id,
-                    "topic": message.topic_name(),
-                    "server": settings.EXTERNAL_HOST,
-                    "realm_id": self.sender.realm.id,
-                    "realm_uri": self.sender.realm.uri,
-                    "user_id": user_profile.id,
-                },
-            },
-        }
-        self.assertDictEqual(payload, expected)
-
-    def test_get_message_payload_apns_stream_wildcard_mention(self) -> None:
-        user_profile = self.example_user("othello")
-        stream = Stream.objects.filter(name="Verona").get()
-        message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
-        payload = get_message_payload_apns(
-            user_profile, message, NotificationTriggers.STREAM_WILDCARD_MENTION
+            trigger,
         )
         expected = {
             "alert": {
@@ -2248,6 +2149,26 @@ class TestGetAPNsPayload(PushNotificationTest):
             },
         }
         self.assertDictEqual(payload, expected)
+
+    def test_get_message_payload_apns_topic_wildcard_mention_in_followed_topic(self) -> None:
+        self._test_get_message_payload_apns_wildcard_mention(
+            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC
+        )
+
+    def test_get_message_payload_apns_stream_wildcard_mention_in_followed_topic(self) -> None:
+        self._test_get_message_payload_apns_wildcard_mention(
+            NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC
+        )
+
+    def test_get_message_payload_apns_topic_wildcard_mention(self) -> None:
+        self._test_get_message_payload_apns_wildcard_mention(
+            NotificationTriggers.TOPIC_WILDCARD_MENTION
+        )
+
+    def test_get_message_payload_apns_stream_wildcard_mention(self) -> None:
+        self._test_get_message_payload_apns_wildcard_mention(
+            NotificationTriggers.STREAM_WILDCARD_MENTION
+        )
 
     @override_settings(PUSH_NOTIFICATION_REDACT_CONTENT=True)
     def test_get_message_payload_apns_redacted_content(self) -> None:


### PR DESCRIPTION
<!-- Describe your pull request here.-->

[CZO Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/notification.20emails/near/1609672)
> Given that context, I think the same "mentioned everyone" text actually works well for all four of those scenarios.
The exact scope of "everyone" is different between different scenarios: everyone in the stream, or in the topic. But that distinction can be seen in the @-mention in the text (unless it comes so late in a long message that it's cut off).

> And I think it's best to get pretty quickly to the content of the message without a lot of extra text explaining precisely what settings you have that caused it to notify you.

* First commit: Remove the stale `user_profile` parameter.
* Second commit: Remove the TODOs from `get_apns_alert_subtitle`.
* Third commit: Add a test to verify the payload for `FOLLOWED_TOPIC_PUSH` notification trigger.


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
