### PR TITLE
push_notifications: Remove 'alert' field from the payload for android.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -662,45 +662,6 @@ def initialize_push_notifications() -> None:
         )
 
 
-def get_gcm_alert(
-    message: Message, trigger: str, mentioned_user_group_name: Optional[str] = None
-) -> str:
-    """
-    Determine what alert string to display based on the missed messages.
-    """
-    sender_str = message.sender.full_name
-    if (
-        message.recipient.type == Recipient.HUDDLE
-        and trigger == NotificationTriggers.DIRECT_MESSAGE
-    ):
-        return f"New direct group message from {sender_str}"
-    elif (
-        message.recipient.type == Recipient.PERSONAL
-        and trigger == NotificationTriggers.DIRECT_MESSAGE
-    ):
-        return f"New direct message from {sender_str}"
-
-    assert message.is_stream_message()
-    stream_name = get_message_stream_name_from_database(message)
-
-    if trigger == NotificationTriggers.MENTION:
-        if mentioned_user_group_name is None:
-            return f"{sender_str} mentioned you in #{stream_name}"
-        else:
-            return f"{sender_str} mentioned @{mentioned_user_group_name} in #{stream_name}"
-    elif trigger == NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC:
-        return "TODO - 2"
-    elif trigger == NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC:
-        return "TODO"
-    elif trigger == NotificationTriggers.TOPIC_WILDCARD_MENTION:
-        return f"{sender_str} mentioned all topic participants in #{stream_name} > {message.topic_name()}"
-    elif trigger == NotificationTriggers.STREAM_WILDCARD_MENTION:
-        return f"{sender_str} mentioned everyone in #{stream_name}"
-    else:
-        assert trigger == NotificationTriggers.STREAM_PUSH
-        return f"New stream message from {sender_str} in #{stream_name}"
-
-
 def get_mobile_push_content(rendered_content: str) -> str:
     def get_text(elem: lxml.html.HtmlElement) -> str:
         # Convert default emojis to their Unicode equivalent.
@@ -938,7 +899,6 @@ def get_message_payload_apns(
 def get_message_payload_gcm(
     user_profile: UserProfile,
     message: Message,
-    trigger: str,
     mentioned_user_group_id: Optional[int] = None,
     mentioned_user_group_name: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
@@ -951,7 +911,6 @@ def get_message_payload_gcm(
         content, truncated = truncate_content(get_mobile_push_content(message.rendered_content))
         data.update(
             event="message",
-            alert=get_gcm_alert(message, trigger, mentioned_user_group_name),
             zulip_message_id=message.id,  # message_id is reserved for CCS
             time=datetime_to_timestamp(message.date_sent),
             content=content,
@@ -1166,7 +1125,7 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
         user_profile, message, trigger, mentioned_user_group_id, mentioned_user_group_name
     )
     gcm_payload, gcm_options = get_message_payload_gcm(
-        user_profile, message, trigger, mentioned_user_group_id, mentioned_user_group_name
+        user_profile, message, mentioned_user_group_id, mentioned_user_group_name
     )
     logger.info("Sending push notifications to mobile clients for user %s", user_profile_id)
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2293,14 +2293,18 @@ class TestGetAPNsPayload(PushNotificationTest):
 class TestGetGCMPayload(PushNotificationTest):
     def _test_get_message_payload_gcm_stream_message(
         self,
+        truncate_content: bool = False,
         mentioned_user_group_id: Optional[int] = None,
         mentioned_user_group_name: Optional[str] = None,
     ) -> None:
         stream = Stream.objects.filter(name="Verona").get()
         message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
-        message.content = "a" * 210
-        message.rendered_content = "a" * 210
-        message.save()
+        content = message.content
+        if truncate_content:
+            message.content = "a" * 210
+            message.rendered_content = "a" * 210
+            message.save()
+            content = "a" * 200 + "…"
 
         hamlet = self.example_user("hamlet")
         payload, gcm_options = get_message_payload_gcm(
@@ -2311,8 +2315,8 @@ class TestGetGCMPayload(PushNotificationTest):
             "event": "message",
             "zulip_message_id": message.id,
             "time": datetime_to_timestamp(message.date_sent),
-            "content": "a" * 200 + "…",
-            "content_truncated": True,
+            "content": content,
+            "content_truncated": truncate_content,
             "server": settings.EXTERNAL_HOST,
             "realm_id": hamlet.realm.id,
             "realm_uri": hamlet.realm.uri,
@@ -2342,6 +2346,9 @@ class TestGetGCMPayload(PushNotificationTest):
     # wildcard mention, stream push, or followed topic push.
     def test_get_message_payload_gcm_stream_message(self) -> None:
         self._test_get_message_payload_gcm_stream_message()
+
+    def test_get_message_payload_gcm_stream_message_truncate_content(self) -> None:
+        self._test_get_message_payload_gcm_stream_message(truncate_content=True)
 
     def test_get_message_payload_gcm_user_group_mention(self) -> None:
         # Note that the @mobile_team user group doesn't actually
@@ -2376,40 +2383,6 @@ class TestGetGCMPayload(PushNotificationTest):
                 "sender_full_name": "King Hamlet",
                 "sender_avatar_url": absolute_avatar_url(message.sender),
                 "recipient_type": "private",
-            },
-        )
-        self.assertDictEqual(
-            gcm_options,
-            {
-                "priority": "high",
-            },
-        )
-
-    def test_get_message_payload_gcm_stream_notifications(self) -> None:
-        stream = Stream.objects.get(name="Denmark")
-        message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
-        hamlet = self.example_user("hamlet")
-        payload, gcm_options = get_message_payload_gcm(hamlet, message)
-        self.assertDictEqual(
-            payload,
-            {
-                "user_id": hamlet.id,
-                "event": "message",
-                "zulip_message_id": message.id,
-                "time": datetime_to_timestamp(message.date_sent),
-                "content": message.content,
-                "content_truncated": False,
-                "server": settings.EXTERNAL_HOST,
-                "realm_id": hamlet.realm.id,
-                "realm_uri": hamlet.realm.uri,
-                "sender_id": hamlet.id,
-                "sender_email": hamlet.email,
-                "sender_full_name": "King Hamlet",
-                "sender_avatar_url": absolute_avatar_url(message.sender),
-                "recipient_type": "stream",
-                "topic": "Test topic",
-                "stream": "Denmark",
-                "stream_id": stream.id,
             },
         )
         self.assertDictEqual(

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2291,11 +2291,8 @@ class TestGetAPNsPayload(PushNotificationTest):
 
 
 class TestGetGCMPayload(PushNotificationTest):
-    def _test_get_message_payload_gcm_mentions(
+    def _test_get_message_payload_gcm_stream_message(
         self,
-        trigger: str,
-        alert: str,
-        *,
         mentioned_user_group_id: Optional[int] = None,
         mentioned_user_group_name: Optional[str] = None,
     ) -> None:
@@ -2307,12 +2304,11 @@ class TestGetGCMPayload(PushNotificationTest):
 
         hamlet = self.example_user("hamlet")
         payload, gcm_options = get_message_payload_gcm(
-            hamlet, message, trigger, mentioned_user_group_id, mentioned_user_group_name
+            hamlet, message, mentioned_user_group_id, mentioned_user_group_name
         )
         expected_payload = {
             "user_id": hamlet.id,
             "event": "message",
-            "alert": alert,
             "zulip_message_id": message.id,
             "time": datetime_to_timestamp(message.date_sent),
             "content": "a" * 200 + "…",
@@ -2341,41 +2337,18 @@ class TestGetGCMPayload(PushNotificationTest):
             },
         )
 
-    def test_get_message_payload_gcm_personal_mention(self) -> None:
-        self._test_get_message_payload_gcm_mentions(
-            NotificationTriggers.MENTION, "King Hamlet mentioned you in #Verona"
-        )
+    # Here, the payload is notification trigger independent. This test covers
+    # the case when the trigger for push notifications is personal mention,
+    # wildcard mention, stream push, or followed topic push.
+    def test_get_message_payload_gcm_stream_message(self) -> None:
+        self._test_get_message_payload_gcm_stream_message()
 
     def test_get_message_payload_gcm_user_group_mention(self) -> None:
         # Note that the @mobile_team user group doesn't actually
         # exist; this test is just verifying the formatting logic.
-        self._test_get_message_payload_gcm_mentions(
-            NotificationTriggers.MENTION,
-            "King Hamlet mentioned @mobile_team in #Verona",
+        self._test_get_message_payload_gcm_stream_message(
             mentioned_user_group_id=3,
             mentioned_user_group_name="mobile_team",
-        )
-
-    def test_get_message_payload_gcm_topic_wildcard_mention_in_followed_topic(self) -> None:
-        self._test_get_message_payload_gcm_mentions(
-            NotificationTriggers.TOPIC_WILDCARD_MENTION_IN_FOLLOWED_TOPIC, "TODO - 2"
-        )
-
-    def test_get_message_payload_gcm_stream_wildcard_mention_in_followed_topic(self) -> None:
-        self._test_get_message_payload_gcm_mentions(
-            NotificationTriggers.STREAM_WILDCARD_MENTION_IN_FOLLOWED_TOPIC, "TODO"
-        )
-
-    def test_get_message_payload_gcm_topic_wildcard_mention(self) -> None:
-        self._test_get_message_payload_gcm_mentions(
-            NotificationTriggers.TOPIC_WILDCARD_MENTION,
-            "King Hamlet mentioned all topic participants in #Verona > Test topic",
-        )
-
-    def test_get_message_payload_gcm_stream_wildcard_mention(self) -> None:
-        self._test_get_message_payload_gcm_mentions(
-            NotificationTriggers.STREAM_WILDCARD_MENTION,
-            "King Hamlet mentioned everyone in #Verona",
         )
 
     def test_get_message_payload_gcm_direct_message(self) -> None:
@@ -2385,15 +2358,12 @@ class TestGetGCMPayload(PushNotificationTest):
             realm_id=self.personal_recipient_user.realm_id,
         )
         hamlet = self.example_user("hamlet")
-        payload, gcm_options = get_message_payload_gcm(
-            hamlet, message, NotificationTriggers.DIRECT_MESSAGE
-        )
+        payload, gcm_options = get_message_payload_gcm(hamlet, message)
         self.assertDictEqual(
             payload,
             {
                 "user_id": hamlet.id,
                 "event": "message",
-                "alert": "New direct message from King Hamlet",
                 "zulip_message_id": message.id,
                 "time": datetime_to_timestamp(message.date_sent),
                 "content": message.content,
@@ -2419,15 +2389,12 @@ class TestGetGCMPayload(PushNotificationTest):
         stream = Stream.objects.get(name="Denmark")
         message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
         hamlet = self.example_user("hamlet")
-        payload, gcm_options = get_message_payload_gcm(
-            hamlet, message, NotificationTriggers.STREAM_PUSH
-        )
+        payload, gcm_options = get_message_payload_gcm(hamlet, message)
         self.assertDictEqual(
             payload,
             {
                 "user_id": hamlet.id,
                 "event": "message",
-                "alert": "New stream message from King Hamlet in #Denmark",
                 "zulip_message_id": message.id,
                 "time": datetime_to_timestamp(message.date_sent),
                 "content": message.content,
@@ -2457,15 +2424,12 @@ class TestGetGCMPayload(PushNotificationTest):
         stream = Stream.objects.get(name="Denmark")
         message = self.get_message(Recipient.STREAM, stream.id, stream.realm_id)
         hamlet = self.example_user("hamlet")
-        payload, gcm_options = get_message_payload_gcm(
-            hamlet, message, NotificationTriggers.STREAM_PUSH
-        )
+        payload, gcm_options = get_message_payload_gcm(hamlet, message)
         self.assertDictEqual(
             payload,
             {
                 "user_id": hamlet.id,
                 "event": "message",
-                "alert": "New stream message from King Hamlet in #Denmark",
                 "zulip_message_id": message.id,
                 "time": datetime_to_timestamp(message.date_sent),
                 "content": "*This organization has disabled including message content in mobile push notifications*",


### PR DESCRIPTION
<!-- Describe your pull request here.-->

[CZO Discussion:](https://chat.zulip.org/#narrow/stream/101-design/topic/notification.20emails/near/1609662)
> Fun fact about these (the gcm_alert function specifically): I believe these strings do not get used at all, and have not been used since at least 2019. On Android, we construct the notification UI ourselves in the client, and we ignore the alert string which that function is used to compute.

> So these can be whatever we like. Separately, a good PR would be to remove alert from the Android/FCM notification payloads entirely. We'd want to run that as an experiment for a bit on [chat.zulip.org](http://chat.zulip.org/) just to double-check I haven't missed some way it matters.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

This should be test deployed on CZO

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
