### PR TITLE
subscribe-unsubscribe: Improve error response for unexpected users.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,16 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 208**
+
+* [`POST /users/me/subscriptions`](/api/subscribe),
+  [`DELETE /users/me/subscriptions`](/api/unsubscribe): These endpoints
+  now return an HTTP status code of 400 with `code: "BAD_REQUEST"` in
+  the error response when a user specified in the `principals` parameter
+  is deactivated or does not exist. Previously, these endpoints returned
+  an HTTP status code of 403 with `code: "UNAUTHORIZED_PRINCIPAL"` in the
+  error response for these cases.
+
 **Feature level 207**
 
 * [`POST /register`](/api/register-queue): Added `display_name` and

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 207
+API_FEATURE_LEVEL = 208
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8529,6 +8529,16 @@ paths:
 
         Note that the ability to subscribe oneself and/or other users to a specified
         stream depends on the [stream's privacy settings](/help/stream-permissions).
+
+        **Changes**: Before Zulip 8.0 (feature level 208), if a user
+        specified by the [`principals`][principals-param] parameter was
+        a deactivated user, or did not exist, then an HTTP status code
+        of 403 was returned with `code: "UNAUTHORIZED_PRINCIPAL"` in the
+        error response. As of this feature level, an HTTP status code of
+        400 is returned with `code: "BAD_REQUEST"` in the error response
+        for these cases.
+
+        [principals-param]: /api/subscribe#parameter-principals
       x-curl-examples-parameters:
         oneOf:
           - type: include
@@ -8834,7 +8844,15 @@ paths:
           by the [`can_remove_subscribers_group`][can-remove-parameter]
           for the stream.
 
-        **Changes**: Before Zulip 8.0 (feature level 197),
+        **Changes**: Before Zulip 8.0 (feature level 208), if a user
+        specified by the [`principals`][principals-param] parameter was
+        a deactivated user, or did not exist, then an HTTP status code
+        of 403 was returned with `code: "UNAUTHORIZED_PRINCIPAL"` in the
+        error response. As of this feature level, an HTTP status code of
+        400 is returned with `code: "BAD_REQUEST"` in the error response
+        for these cases.
+
+        Before Zulip 8.0 (feature level 197),
         the `can_remove_subscribers_group` setting
         was named `can_remove_subscribers_group_id`.
 
@@ -8845,6 +8863,7 @@ paths:
         Before Zulip 6.0 (feature level 145), users had no special
         privileges for managing bots that they own.
 
+        [principals-param]: /api/unsubscribe#parameter-principals
         [can-remove-parameter]: /api/subscribe#parameter-can_remove_subscribers_group
       x-curl-examples-parameters:
         oneOf:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2834,9 +2834,7 @@ class StreamAdminTest(ZulipTestCase):
                 "principals": orjson.dumps([99]).decode(),
             },
         )
-        self.assert_json_error(
-            result, "User not authorized to execute queries on behalf of '99'", status_code=403
-        )
+        self.assert_json_error(result, "No such user", status_code=400)
 
 
 class DefaultStreamTest(ZulipTestCase):
@@ -5091,11 +5089,7 @@ class SubscriptionAPITest(ZulipTestCase):
         result = self.common_subscribe_to_streams(
             self.test_user, "Denmark", post_data, allow_fail=True
         )
-        self.assert_json_error(
-            result,
-            f"User not authorized to execute queries on behalf of '{target_profile.id}'",
-            status_code=403,
-        )
+        self.assert_json_error(result, "User is deactivated", status_code=400)
 
     def test_subscriptions_add_for_principal_invite_only(self) -> None:
         """
@@ -5138,11 +5132,7 @@ class SubscriptionAPITest(ZulipTestCase):
             {"principals": orjson.dumps([invalid_principal]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(
-            result,
-            f"User not authorized to execute queries on behalf of '{invalid_principal}'",
-            status_code=403,
-        )
+        self.assert_json_error(result, "No such user", status_code=400)
 
     def test_subscription_add_invalid_principal(self) -> None:
         invalid_principal = 999
@@ -5155,11 +5145,7 @@ class SubscriptionAPITest(ZulipTestCase):
             {"principals": orjson.dumps([invalid_principal]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(
-            result,
-            f"User not authorized to execute queries on behalf of '{invalid_principal}'",
-            status_code=403,
-        )
+        self.assert_json_error(result, "No such user", status_code=400)
 
     def test_subscription_add_principal_other_realm(self) -> None:
         """
@@ -5176,11 +5162,7 @@ class SubscriptionAPITest(ZulipTestCase):
             {"principals": orjson.dumps([principal]).decode()},
             allow_fail=True,
         )
-        self.assert_json_error(
-            result,
-            f"User not authorized to execute queries on behalf of '{principal}'",
-            status_code=403,
-        )
+        self.assert_json_error(result, "No such user", status_code=400)
 
     def helper_check_subs_before_and_after_remove(
         self,


### PR DESCRIPTION
Updates the API error response when there is an unknown or deactivated user in the `principals` parameter for either the [`/api/subscribe`](https://zulip.com/api/subscribe) or [`/api/unsubscribe`](https://zulip.com/api/unsubscribe) endpoints. We now use the `access_user_by_email` and `access_user_by_id` code paths, which return an HTTP response of 400 and a `"BAD_REQUEST"` code.

Previously, an HTTP response of 403 was returned with a special `"UNAUTHORIZED_PRINCIPAL"` code in the error response. This code was not documented in the API documentation and is removed as a potential `JsonableError` code with these changes.

Fixes #26593.

**Notes**:
- Started a conversation on CZO to double check these changes won't impact how either the mobile or terminal clients handle these error responses here: https://chat.zulip.org/#narrow/stream/378-api-design/topic/error.20subscribing.2Funsubscribing.20unexpected.20user.2C.20.2326593/near/1633038.2E01

**Screenshots and screen captures:**

<details>
<summary>API changelog</summary>

![Screenshot from 2023-08-31 11-16-47](https://github.com/zulip/zulip/assets/63245456/c1499697-5714-4215-ad8c-4ea9d42b4877)
</details>
<details>
<summary>Subscribe to a stream</summary>

[Current documentation](https://zulip.com/api/subscribe)
![Screenshot from 2023-08-31 11-17-02](https://github.com/zulip/zulip/assets/63245456/2ca6aa08-6e93-4109-8585-38da2aecf5a1)
</details>
<details>
<summary>Unsubscribe from a stream</summary>

[Current documentation](https://zulip.com/api/unsubscribe)
![Screenshot from 2023-08-31 11-17-10](https://github.com/zulip/zulip/assets/63245456/a432718d-b711-4a6b-854a-f01fb12e8bc8)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
