### PR TITLE
settings: Play button alignment.

### DIFF
--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -188,11 +188,12 @@ h3,
 
 .setting_notification_sound,
 .play_notification_sound {
-    display: inline;
     margin-right: 4px;
 
     & i {
         font-size: 22px;
+        /* Visually center with chevron in select */
+        line-height: 26px;
         cursor: pointer;
     }
 }
@@ -396,6 +397,40 @@ td .button {
 
     & label.checkbox + label {
         cursor: pointer;
+    }
+}
+
+/* Class for displaying an input with an
+   auxiliary control, e.g., the play button
+   next to the notification sound dropdown. */
+.input-element-with-control {
+    display: flex;
+    align-items: center;
+    /* Preserve the effective space allotted
+       inside the input group.
+
+       Select element: 325px
+       Button element: ~29px
+       Right margin:     4px
+       TOTAL           358px */
+    max-width: 358px;
+
+    .settings_select {
+        /* Hold the settings select to its usual 325px;
+           a TODO would be to fix up the min- and max-
+           width values on the parent class, as the
+           min-width always applies, and max-width: 100%
+           has no meaning without an actual width:
+           declaration. */
+        max-width: 325px;
+        /* Disregard the min-width from the main
+           .settings_select selector. */
+        min-width: 0;
+        /* Allow the select to grow within the flex
+           container to keep the play button in the
+           viewport, and not force dodgy looking wrap
+           onto a second line. */
+        flex: 1 0 auto;
     }
 }
 

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -74,7 +74,7 @@
             {{t "Notification sound" }}
         </label>
 
-        <div class="input-group {{#unless enable_sound_select}}control-label-disabled{{/unless}}">
+        <div class="input-group input-element-with-control {{#unless enable_sound_select}}control-label-disabled{{/unless}}">
             <select name="notification_sound" class="setting_notification_sound prop-element settings_select bootstrap-focus-style" id="{{prefix}}notification_sound" data-setting-widget-type="string"
               {{#unless enable_sound_select}}
               disabled

--- a/web/templates/settings/notification_settings.hbs
+++ b/web/templates/settings/notification_settings.hbs
@@ -70,7 +70,7 @@
               prefix=../prefix}}
         {{/each}}
 
-        <label for="notification_sound">
+        <label for="{{prefix}}notification_sound">
             {{t "Notification sound" }}
         </label>
 


### PR DESCRIPTION
This PR vertically aligns the notification-sound play button in a flex layout.

This allows the select to flex, keeping the buttons position on screen even at mobile-scale viewports.

While other most other controls are currently not so responsive, this might provide some direction (along with a TODO) on how to go about moving controls in that direction.

One note here is that previously, the play button was presented as an inline element. That means that whitespace in the HTML was keeping the button separate from the select element. Rather than try to eyeball that value, I allowed the space to collapse down to the 4px specified in the CSS--and open a discussion on how far that button ought to appear from the select.

One other note is that there's a commit that aligns the `for` attribute on the `<label>` element with the `id` value on the form control it labels. A quick glance through the different Handlebars templates suggests that there are a whole lot of incorrect `for` attributes, which ought to be fixed wholesale in a separate PR. But I wanted to fix this one while I was standing right next to it.

Fixes: #26563

See also [CZO discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/alignment.20of.20notification.20sound.20icon.20in.20settings.2C.20.2326563/near/1630709)

**Screenshots and screen captures:**

| Org Settings, Before | Org Settings, After |
| --- | --- |
| ![org-play-button-before](https://github.com/zulip/zulip/assets/170719/2eea8787-e4d1-4db5-a8cd-3061468a565e) | ![org-play-button-after](https://github.com/zulip/zulip/assets/170719/c339ff1b-b8cd-48e0-853b-428071ff71fd) |

| Personal Settings, Before | Personal Settings, After |
| --- | --- |
| ![personal-play-button-before](https://github.com/zulip/zulip/assets/170719/25c2f12f-a7b3-4aad-8705-d57380d0e7fa) | ![personal-play-button-after](https://github.com/zulip/zulip/assets/170719/16f02040-f325-49f3-878a-fa4e057e208c) |

**Responsive layout:**
![responsive-input-group](https://github.com/zulip/zulip/assets/170719/48cafec2-0b5b-485c-900c-61abdf0771ba)

