### PR TITLE
widgets: Rename confusing identifiers for tabbed sections in API/help docs.

### DIFF
--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -77,7 +77,7 @@ function add_copy_to_clipboard_element($codehilite) {
 }
 
 function render_tabbed_sections() {
-    $(".code-section").each(function () {
+    $(".tabbed-section").each(function () {
         activate_correct_tab($(this));
         register_tabbed_section($(this));
     });

--- a/web/src/portico/help.js
+++ b/web/src/portico/help.js
@@ -8,9 +8,9 @@ import * as common from "../common";
 
 import {activate_correct_tab} from "./tabbed-instructions";
 
-function register_code_section($code_section) {
-    const $li = $code_section.find("ul.nav li");
-    const $blocks = $code_section.find(".blocks div");
+function register_tabbed_section($tabbed_section) {
+    const $li = $tabbed_section.find("ul.nav li");
+    const $blocks = $tabbed_section.find(".blocks div");
 
     $li.on("click", function () {
         const tab_key = this.dataset.tabKey;
@@ -76,10 +76,10 @@ function add_copy_to_clipboard_element($codehilite) {
     });
 }
 
-function render_code_sections() {
+function render_tabbed_sections() {
     $(".code-section").each(function () {
         activate_correct_tab($(this));
-        register_code_section($(this));
+        register_tabbed_section($(this));
     });
 
     // Add a copy-to-clipboard button for each .codehilite element
@@ -119,6 +119,6 @@ $(".markdown").on("click", () => {
     }
 });
 
-render_code_sections();
+render_tabbed_sections();
 
 $(".highlighted")[0]?.scrollIntoView({block: "center"});

--- a/web/src/portico/tabbed-instructions.ts
+++ b/web/src/portico/tabbed-instructions.ts
@@ -67,6 +67,6 @@ export function activate_correct_tab($codeSection: JQuery): void {
     }
 }
 
-$(".code-section").each(function () {
+$(".tabbed-section").each(function () {
     activate_correct_tab($(this));
 });

--- a/web/src/portico/tabbed-instructions.ts
+++ b/web/src/portico/tabbed-instructions.ts
@@ -24,11 +24,11 @@ export function detect_user_os(): UserOS {
     return "mac"; // if unable to determine OS return Mac by default
 }
 
-export function activate_correct_tab($codeSection: JQuery): void {
+export function activate_correct_tab($tabbed_section: JQuery): void {
     const user_os = detect_user_os();
     const desktop_os = new Set(["mac", "linux", "windows"]);
-    const $li = $codeSection.find("ul.nav li");
-    const $blocks = $codeSection.find(".blocks div");
+    const $li = $tabbed_section.find("ul.nav li");
+    const $blocks = $tabbed_section.find(".blocks div");
 
     $li.each(function () {
         const tab_key = this.dataset.tabKey;

--- a/web/styles/portico/markdown.css
+++ b/web/styles/portico/markdown.css
@@ -419,7 +419,7 @@
         }
     }
 
-    .code-section {
+    .tabbed-section {
         & ol {
             margin-left: 15px;
             margin-top: 10px;

--- a/web/styles/portico/portico.css
+++ b/web/styles/portico/portico.css
@@ -64,7 +64,7 @@ html {
 
 /* The API tabbed content tends to have a lot of code blocks,
    which look nicer against a different background */
-.api-center .code-section {
+.api-center .tabbed-section {
     .blocks {
         background-color: hsl(0deg 0% 98%);
     }

--- a/zerver/lib/html_to_text.py
+++ b/zerver/lib/html_to_text.py
@@ -16,8 +16,8 @@ def html_to_text(content: Union[str, bytes], tags: Mapping[str, str] = {"p": " |
     for tag in bs.find_all("div", class_="admonition"):
         tag.clear()
 
-    # Skip code-sections, which just contains navigation instructions.
-    for tag in bs.find_all("div", class_="code-section"):
+    # Skip tabbed-sections, which just contain navigation instructions.
+    for tag in bs.find_all("div", class_="tabbed-section"):
         tag.clear()
 
     text = ""

--- a/zerver/lib/markdown/tabbed_sections.py
+++ b/zerver/lib/markdown/tabbed_sections.py
@@ -11,8 +11,8 @@ START_TABBED_SECTION_REGEX = re.compile(r"^\{start_tabs\}$")
 END_TABBED_SECTION_REGEX = re.compile(r"^\{end_tabs\}$")
 TAB_CONTENT_REGEX = re.compile(r"^\{tab\|\s*(.+?)\s*\}$")
 
-CODE_SECTION_TEMPLATE = """
-<div class="code-section {tab_class}" markdown="1">
+TABBED_SECTION_TEMPLATE = """
+<div class="tabbed-section {tab_class}" markdown="1">
 {nav_bar}
 <div class="blocks">
 {blocks}
@@ -131,7 +131,7 @@ class TabbedSectionsPreprocessor(Preprocessor):
                 ]
             nav_bar = self.generate_nav_bar(tab_section)
             content_blocks = self.generate_content_blocks(tab_section, lines)
-            rendered_tabs = CODE_SECTION_TEMPLATE.format(
+            rendered_tabs = TABBED_SECTION_TEMPLATE.format(
                 tab_class=tab_class, nav_bar=nav_bar, blocks=content_blocks
             )
 

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -36,7 +36,7 @@ header
 
 <h1 id="heading">Heading</h1>
 <p>
-  <div class="code-section has-tabs" markdown="1">
+  <div class="tabbed-section has-tabs" markdown="1">
     <ul class="nav">
       <li data-tab-key="ios" tabindex="0">iOS</li>
       <li data-tab-key="desktop-web" tabindex="0">Desktop/Web</li>
@@ -54,7 +54,7 @@ header
 
 <h2 id="heading-2">Heading 2</h2>
 <p>
-  <div class="code-section has-tabs" markdown="1">
+  <div class="tabbed-section has-tabs" markdown="1">
     <ul class="nav">
       <li data-tab-key="desktop-web" tabindex="0">Desktop/Web</li>
       <li data-tab-key="android" tabindex="0">Android</li>
@@ -72,7 +72,7 @@ header
 
 <h2 id="heading-3">Heading 3</h2>
 <p>
-  <div class="code-section no-tabs" markdown="1">
+  <div class="tabbed-section no-tabs" markdown="1">
     <ul class="nav">
       <li data-tab-key="instructions-for-all-platforms" tabindex="0">Instructions for all platforms</li>
     </ul>


### PR DESCRIPTION
As discussed in https://github.com/zulip/zulip/pull/26092#issuecomment-1603037633, this is a follow-up PR to rename misleading identifiers using  the term "code section" to refer to tabbed sections in both the API docs and help center docs.