### PR TITLE
ui_report: Reuse `channel.xhr_error_message` function in `error` method.

### DIFF
--- a/web/src/channel.ts
+++ b/web/src/channel.ts
@@ -201,10 +201,7 @@ export function patch(
     return post(options);
 }
 
-export function xhr_error_message(
-    message: string | null,
-    xhr: JQuery.jqXHR<unknown>,
-): string | null {
+export function xhr_error_message(message: string, xhr: JQuery.jqXHR<unknown>): string {
     if (xhr.status.toString().charAt(0) === "4" && xhr.responseJSON?.msg) {
         // Only display the error response for 4XX, where we've crafted
         // a nice response.

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -1032,7 +1032,7 @@ export function save_message_row_edit($row) {
                 }
 
                 hide_message_edit_spinner($row);
-                const message = channel.xhr_error_message(null, xhr);
+                const message = channel.xhr_error_message("", xhr);
                 const $container = compose_banner.get_compose_banner_container(
                     $row.find("textarea"),
                 );

--- a/web/src/ui_report.ts
+++ b/web/src/ui_report.ts
@@ -1,6 +1,6 @@
 import $ from "jquery";
-import _ from "lodash";
 
+import * as channel from "./channel";
 import * as common from "./common";
 import {$t} from "./i18n";
 
@@ -38,18 +38,8 @@ export function error(
     status_box: JQuery,
     remove_after?: number,
 ): void {
-    if (xhr && xhr.status >= 400 && xhr.status < 500 && xhr.responseJSON?.msg) {
-        // Only display the error response for 4XX, where we've crafted
-        // a nice response.
-        const server_response_html = _.escape(xhr.responseJSON.msg);
-        if (response_html) {
-            response_html += ": " + server_response_html;
-        } else {
-            response_html = server_response_html;
-        }
-    }
-
-    message(response_html, status_box, "alert-error", remove_after);
+    const msg = xhr ? channel.xhr_error_message(response_html, xhr) : response_html;
+    message(msg, status_box, "alert-error", remove_after);
 }
 
 export function client_error(

--- a/web/tests/channel.test.js
+++ b/web/tests/channel.test.js
@@ -348,7 +348,7 @@ test("xhr_error_message", () => {
     msg = "some message";
     assert.equal(channel.xhr_error_message(msg, xhr), "some message: file not found");
 
-    msg = null;
+    msg = "";
     assert.equal(channel.xhr_error_message(msg, xhr), "file not found");
 });
 


### PR DESCRIPTION
We should reuse the `channel.xhr_error_message` in `ui_report` to reduce code duplication.

Also, I changed the type of `message` parameter to `string` instead of `string | null` so that we do not need to alter the types of the functions that depends on the return value of `xhr_error_message`.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
