### PR TITLE
api-docs: Fix endpoint formatting in API changelog and feature levels 11 and 12 changes/entries.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1552,8 +1552,9 @@ No changes; feature level used for Zulip 3.0 release.
   as 86400 seconds (1 day).
 * [`POST /register`](/api/register-queue): The response now contains a
   `is_owner`, similar to the existing `is_admin` and `is_guest` fields.
-* [`POST /set-typing-status`](/api/set-typing-status): Removed legacy support for sending email
-  addresses, rather than user IDs, to encode private message recipients.
+* [`POST /set-typing-status`](/api/set-typing-status): Removed legacy
+  support for sending email addresses in the `to` parameter, rather
+  than user IDs, to encode direct message recipients.
 
 **Feature level 10**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -1550,8 +1550,9 @@ No changes; feature level used for Zulip 3.0 release.
   time limit before community topic editing is forbidden.  A `null`
   value means no limit. This was previously hard-coded in the server
   as 86400 seconds (1 day).
-* [`POST /register`](/api/register-queue): The response now contains a
-  `is_owner`, similar to the existing `is_admin` and `is_guest` fields.
+* [`POST /register`](/api/register-queue): The response now contains
+  an `is_owner` boolean field, which is similar to the existing
+  `is_admin` and `is_guest` fields.
 * [`POST /typing`](/api/set-typing-status): Removed legacy
   support for sending email addresses in the `to` parameter, rather
   than user IDs, to encode direct message recipients.

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -87,7 +87,7 @@ format used by the Zulip server that they are interacting with.
 
 * [`POST /users/me/subscriptions`](/api/subscribe),
   [`PATCH /streams/{stream_id}`](/api/update-stream),
-  [`GET users/me/subscriptions`](/api/get-subscriptions),
+  [`GET /users/me/subscriptions`](/api/get-subscriptions),
   [`GET /streams`](/api/get-streams),
   [`POST /register`](/api/register-queue),
   [`GET /events`](/api/get-events): Renamed
@@ -239,7 +239,7 @@ No changes; feature level used for Zulip 7.0 release.
 
 **Feature level 178**
 
-* `POST users/me/presence`,
+* `POST /users/me/presence`,
   [`GET /users/<user_id_or_email>/presence`](/api/get-user-presence),
   [`GET /realm/presence`](/api/get-presence),
   [`POST /register`](/api/register-queue),
@@ -265,7 +265,7 @@ No changes; feature level used for Zulip 7.0 release.
 **Feature level 176**
 
 * [`POST /realm/filters`](/api/add-linkifier),
-  [`PATCH realm/filters/<int:filter_id>`](/api/update-linkifier):
+  [`PATCH /realm/filters/<int:filter_id>`](/api/update-linkifier):
   The `url_format_string` parameter is replaced by `url_template`.
   [Linkifiers](/help/add-a-custom-linkifier) now only accept
   [RFC 6570][rfc6570] compliant URL templates. The old URL format
@@ -557,7 +557,7 @@ user's profile.
 
 **Feature level 145**
 
-* [`DELETE users/me/subscriptions`](/api/unsubscribe): Normal users can
+* [`DELETE /users/me/subscriptions`](/api/unsubscribe): Normal users can
   now remove bots that they own from streams.
 
 **Feature level 144**
@@ -578,7 +578,7 @@ user's profile.
 
 **Feature level 142**
 
-* [`GET users/me/subscriptions`](/api/get-subscriptions), [`GET
+* [`GET /users/me/subscriptions`](/api/get-subscriptions), [`GET
   /streams`](/api/get-streams), [`POST /register`](/api/register-queue),
   [`GET /events`](/api/get-events): Added `can_remove_subscribers_group_id`
   field to Stream and Subscription objects.
@@ -765,7 +765,7 @@ No changes; feature level used for Zulip 5.0 release.
   field. These changes substantially simplify client complexity for
   processing historical message edits.
 
-* [`GET messages/{message_id}/history`](/api/get-message-history):
+* [`GET /messages/{message_id}/history`](/api/get-message-history):
   Added `stream` field to message history `snapshot` indicating
   the updated stream ID of messages moved to a new stream.
 
@@ -914,7 +914,7 @@ No changes; feature level used for Zulip 5.0 release.
 
 **Feature level 98**
 
-* [`POST /subscribe`](/api/subscribe): Added `is_web_public` parameter
+* [`POST /users/me/subscriptions`](/api/subscribe): Added `is_web_public` parameter
   for requesting the creation of a web-public stream.
 * [`PATCH /streams/{stream_id}`](/api/update-stream): Added
   `is_web_public` parameter for converting a stream into a web-public stream.
@@ -1054,7 +1054,7 @@ No changes; feature level used for Zulip 5.0 release.
 
 **Feature level 83**
 
-* * [`POST /register`](/api/register-queue): The `cross_realm_bots`
+* [`POST /register`](/api/register-queue): The `cross_realm_bots`
   section of the response now uses the `is_system_bot` flag to
   indicate whether the bot is a system bot.
 
@@ -1227,7 +1227,7 @@ No changes; feature level used for Zulip 4.0 release.
   events to support typing notifications in stream messages. These new
   events are only sent to clients with `client_capabilities`
   showing support for `stream_typing_notifications`.
-* [`POST /set-typing-status`](/api/set-typing-status): Added support
+* [`POST /typing`](/api/set-typing-status): Added support
   for sending typing notifications for stream messages.
 
 **Feature level 57**
@@ -1406,7 +1406,7 @@ field with an integer field `invite_to_realm_policy`.
 
 **Feature level 31**
 
-* [`GET users/me/subscriptions`](/api/get-subscriptions): Added a
+* [`GET /users/me/subscriptions`](/api/get-subscriptions): Added a
   `role` field to Subscription objects representing whether the user
   is a stream administrator.
 
@@ -1419,7 +1419,7 @@ user to be a stream administrator at this feature level.
 
 **Feature level 30**
 
-* [`GET users/me/subscriptions`](/api/get-subscriptions), [`GET
+* [`GET /users/me/subscriptions`](/api/get-subscriptions), [`GET
   /streams`](/api/get-streams): Added `date_created` to Stream
   objects.
 * [`POST /users`](/api/create-user), `POST /bots`: The ID of the newly
@@ -1501,11 +1501,11 @@ No changes; feature level used for Zulip 3.0 release.
 
 **Feature level 17**
 
-* [`GET users/me/subscriptions`](/api/get-subscriptions),
+* [`GET /users/me/subscriptions`](/api/get-subscriptions),
   [`GET /streams`](/api/get-streams): Added
   `message_retention_days` to Stream objects.
-* [`POST users/me/subscriptions`](/api/subscribe), [`PATCH
-  streams/{stream_id}`](/api/update-stream): Added `message_retention_days`
+* [`POST /users/me/subscriptions`](/api/subscribe), [`PATCH
+  /streams/{stream_id}`](/api/update-stream): Added `message_retention_days`
   parameter.
 
 **Feature level 16**
@@ -1523,7 +1523,7 @@ No changes; feature level used for Zulip 3.0 release.
 
 **Feature level 14**
 
-* [`GET users/me/subscriptions`](/api/get-subscriptions): Removed
+* [`GET /users/me/subscriptions`](/api/get-subscriptions): Removed
   the `is_old_stream` field from Stream objects.  This field was
   always equivalent to `stream_weekly_traffic != null` on the same object.
 
@@ -1540,7 +1540,7 @@ No changes; feature level used for Zulip 3.0 release.
 
 **Feature level 12**
 
-* [`GET users/{user_id}/subscriptions/{stream_id}`](/api/get-subscription-status):
+* [`GET /users/{user_id}/subscriptions/{stream_id}`](/api/get-subscription-status):
   New endpoint added for checking if another user is subscribed to a stream.
 
 **Feature level 11**
@@ -1552,21 +1552,21 @@ No changes; feature level used for Zulip 3.0 release.
   as 86400 seconds (1 day).
 * [`POST /register`](/api/register-queue): The response now contains a
   `is_owner`, similar to the existing `is_admin` and `is_guest` fields.
-* [`POST /set-typing-status`](/api/set-typing-status): Removed legacy
+* [`POST /typing`](/api/set-typing-status): Removed legacy
   support for sending email addresses in the `to` parameter, rather
   than user IDs, to encode direct message recipients.
 
 **Feature level 10**
 
-* [`GET users/me`](/api/get-own-user): Added `avatar_version`, `is_guest`,
+* [`GET /users/me`](/api/get-own-user): Added `avatar_version`, `is_guest`,
   `is_active`, `timezone`, and `date_joined` fields to the User objects.
-* [`GET users/me`](/api/get-own-user): Removed `client_id` and `short_name`
+* [`GET /users/me`](/api/get-own-user): Removed `client_id` and `short_name`
   from the response to this endpoint.  These fields had no purpose and
   were inconsistent with other API responses describing users.
 
 **Feature level 9**
 
-* [`POST users/me/subscriptions`](/api/subscribe), [`DELETE
+* [`POST /users/me/subscriptions`](/api/subscribe), [`DELETE
   /users/me/subscriptions`](/api/unsubscribe): Other users to
   subscribe/unsubscribe, declared in the `principals` parameter, can
   now be referenced by user_id, rather than Zulip display email
@@ -1655,7 +1655,7 @@ No changes; feature level used for Zulip 3.0 release.
   Added `prev_stream` as a potential property of the `edit_history` object
   within message objects to indicate when a message was moved to another
   stream.
-* [`GET messages/{message_id}/history`](/api/get-message-history):
+* [`GET /messages/{message_id}/history`](/api/get-message-history):
   `prev_stream` is present in `snapshot` objects within `message_history`
   object when a message was moved to another stream.
 * [`GET /server_settings`](/api/get-server-settings): Added
@@ -1759,7 +1759,7 @@ No changes; feature level used for Zulip 3.0 release.
   encoding topics using the `topic` parameter name.  The previous
   `subject` parameter name was deprecated but is still supported for
   backwards-compatibility.
-* [`POST /set-typing-status`](/api/set-typing-status): Added support for specifying the
+* [`POST /typing`](/api/set-typing-status): Added support for specifying the
   recipients with user IDs, deprecating the original API of specifying
   them using email addresses.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -14487,6 +14487,8 @@ paths:
                           Present if `realm_user` is present in `fetch_event_types`.
 
                           Whether the current user is an [organization owner](/api/roles-and-permissions).
+
+                          **Changes**: New in Zulip 3.0 (feature level 11).
                       is_billing_admin:
                         type: boolean
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9149,7 +9149,7 @@ paths:
       description: |
         Check whether a user is subscribed to a stream.
 
-        **Changes**: New in Zulip 3.0 (feature level 11).
+        **Changes**: New in Zulip 3.0 (feature level 12).
       parameters:
         - $ref: "#/components/parameters/UserId"
         - $ref: "#/components/parameters/StreamIdInPath"


### PR DESCRIPTION
Specific changes:
- Updates the last remaining reference to "private messages" in the API changelog to be "direct messages", which was in the feature level 11 entry for `POST /typing`.
- Adds a **Changes** note to `is_owner` in the `POST /register` response for when it was added in feature level 11.
- Fixes the feature level for when the `GET /users/{user_id}/subscriptions/{stream_id}` endpoint was added from feature level 11 to feature level 12.
- Does a sweep of the formatting for endpoints in the API changelog for missing backslashes and a few other inconsistencies.

Addresses feature level 11 and 12 points in #22102.

---

**Screenshots**:

<details>
<summary>Updated feature level 11 and 12 entries</summary>

[Current documentation](https://zulip.com/api/changelog#changes-in-zulip-30)
![Screenshot from 2023-08-30 15-14-06](https://github.com/zulip/zulip/assets/63245456/624bf30e-2922-4f2d-80ed-5e08acd9eca8)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
