### PR TITLE
push_notifications: Fix logging.exception misuse

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -282,7 +282,7 @@ def send_apple_push_notification(
                 device.token,
             )
         elif isinstance(result, BaseException):
-            logger.exception(
+            logger.error(
                 "APNs: Error sending for user %s to device %s",
                 user_identity,
                 device.token,


### PR DESCRIPTION
`logging.exception` should only be called from an exception handler.
https://docs.python.org/3/library/logging.html#logging.exception

Cc @alexmv