### PR TITLE
[WIP] render: Halt logic on undefined table name.

### DIFF
--- a/web/src/message_util.js
+++ b/web/src/message_util.js
@@ -20,6 +20,11 @@ export function add_messages(messages, msg_list, opts) {
     if (!messages) {
         return undefined;
     }
+    // Don't proceed with rendering logic on an undefined
+    // table name (i.e., the recent topics list)
+    if (msg_list.table_name === undefined) {
+        return undefined;
+    }
 
     loading.destroy_indicator($("#page_loading_indicator"));
 


### PR DESCRIPTION
This prevents a long-standing, seemingly non-deterministic error that caused the poll widget to appear to sometimes fail to render.

But because it is only the recent topics list that excludes a table name, and because no messages are rendered in the recent conversations view, it makes sense to avoid the processing overhead incurred by going through the motions of rendering a message view that never actually makes it into the DOM.

[CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/polls.20rendered.20incorrectly/near/1633972)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
