### PR TITLE
Fixes: Prevent color leak due to drag in settings.

### DIFF
--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -901,7 +901,7 @@
     .modal-footer,
     .modal-bg .modal-header {
         border-color: hsl(0deg 0% 0% / 20%);
-        background-color: hsl(0deg 0% 0% / 20%);
+        background-color: hsl(213deg 28% 14%);
     }
 
     .table-striped tbody tr:nth-child(odd) td {


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes:#26480

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures**


image representing the dragging state

![first](https://github.com/zulip/zulip/assets/119918405/47f93d7d-b16a-45ba-aacc-cdd83ea803ac)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>

I have changed the background color which had 20% transparency (initially)  to a hsl value with no transparency. 
