### PR TITLE
demo-orgs: Fix shortened references in codebase and update help article draft.

### DIFF
--- a/help/demo-organizations.md
+++ b/help/demo-organizations.md
@@ -14,9 +14,10 @@ Demo organizations differ from a regular Zulip organization in a few
 ways:
 
 * A demo organization will be automatically deleted 30 days after
-  creation. You can convert a demo organization into a regular
-  organization if you'd prefer to keep its history.
-* You do not need to choose a URL when creating a demo organization;
+  creation. You can [convert a demo organization into a regular
+  organization](#convert-a-demo-organization-to-a-permanent-organization)
+  if you'd prefer to keep its history.
+* You do not need to choose a URL or when creating a demo organization;
   one will be generated automatically for you.
 * A demo organization cannot be directly upgraded to a paid Zulip
   Cloud plan without first converting to a regular organization.
@@ -31,11 +32,31 @@ apps, etc.
 
 1. Go to zulip.com and click **New organization** in the top-right corner.
 
-1. Enter your email and click **Create organization**. After confirming your
-   email, you will be taken to the **Create your organization** page.
+{end_tabs}
 
-1. Check the **Make this a demo organization** checkbox and once you have
-   filled out the rest of the form, click **Sign up**.
+## Configure email for demo organization owner
+
+To convert a demo organization to a permanent organization, and to access
+certain features like [inviting other users](/help/invite-new-users) and
+[configuring authentication methods](/help/configure-authentication-methods),
+the creator of the demo organization will need to add an email address
+and set a password for their account.
+
+{start_tabs}
+
+{settings_tab|account-and-privacy}
+
+1. Under **Account**, click **Add email**.
+
+1. Enter your email address.
+
+1. *(optional)* If the name on the account is still a placeholder,
+   edit the **Full name** field.
+
+1. Click **Add**.
+
+1. You will receive a confirmation email within a few minutes. Open
+   it and click **Confirm and set password**.
 
 {end_tabs}
 
@@ -52,3 +73,9 @@ apps, etc.
    **Convert**.
 
 {end_tabs}
+
+## Related articles
+
+* [Getting started with Zulip](/help/getting-started-with-zulip)
+* [Setting up your organization](/help/getting-your-organization-started-with-zulip)
+* [Invite users to join](/help/invite-users-to-join)

--- a/templates/zerver/emails/account_registered.html
+++ b/templates/zerver/emails/account_registered.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 {% if realm_creation %}
-{% if is_demo_org %}
+{% if is_demo_organization %}
 <p>
     {% trans demo_organizations_help_link="https://zulip.com/help/demo-organizations" %}Congratulations, you have created a new Zulip demo organization. Note
     that this organization will be automatically deleted in 30 days. Learn more

--- a/templates/zerver/emails/account_registered.txt
+++ b/templates/zerver/emails/account_registered.txt
@@ -1,7 +1,7 @@
 {{ _('Welcome to Zulip!') }}
 
 {% if realm_creation %}
-    {% if is_demo_org %}
+    {% if is_demo_organization %}
         {% trans demo_organizations_help_link="https://zulip.com/help/demo-organizations" %} Congratulations, you have created a new demo Zulip organization. Note that this organization will be automatically deleted in 30 days. Learn more about demo organizations here: {{ demo_organizations_help_link }}!{% endtrans %}
     {% else %}
         {% trans %}Congratulations, you have created a new Zulip organization: {{ realm_name }}.{% endtrans %}

--- a/web/src/navbar_alerts.js
+++ b/web/src/navbar_alerts.js
@@ -199,7 +199,7 @@ export function initialize() {
         $(window).trigger("resize");
     });
 
-    $(".hide-demo-org-notice").on("click", function () {
+    $(".hide-demo-organization-notice").on("click", function () {
         $(this).closest(".alert").hide();
         $(window).trigger("resize");
     });

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -3,7 +3,7 @@
     <div class="alert" id="dev_env_msg"></div>
     {{/if}}
     {{#unless user_has_email_set }}
-    <div class="tip">{{t "You must add an email address to your account to be able to invite users to Zulip." }}</div>
+    <div class="tip">{{t "You must configure your email to access this feature." }}</div>
     {{/unless}}
     <div class="input-group">
         <label>{{t "How would you like to invite users?" }}</label>

--- a/web/templates/invite_user_modal.hbs
+++ b/web/templates/invite_user_modal.hbs
@@ -3,7 +3,12 @@
     <div class="alert" id="dev_env_msg"></div>
     {{/if}}
     {{#unless user_has_email_set }}
-    <div class="tip">{{t "You must configure your email to access this feature." }}</div>
+    <div class="tip">
+        {{#tr}}
+            You must <z-link>configure your email</z-link> to access this feature.
+            {{#*inline "z-link"}}<a href="/help/demo-organizations#configure-email-for-demo-organization-owner" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
+        {{/tr}}
+    </div>
     {{/unless}}
     <div class="input-group">
         <label>{{t "How would you like to invite users?" }}</label>

--- a/web/templates/navbar_alerts/demo_organization_deadline.hbs
+++ b/web/templates/navbar_alerts/demo_organization_deadline.hbs
@@ -3,5 +3,5 @@
         This is a <z-link>demo organization</z-link> and will be automatically deleted in {days_remaining} days.
         {{#*inline "z-link"}}<a class="alert-link" href="/help/demo-organizations" target="_blank" rel="noopener noreferrer" role="button" tabindex=0>{{> @partial-block}}</a>{{/inline}}
     {{/tr}}
-    <a class="alert-link hide-demo-org-notice" role="button" tabindex=0>{{t "Hide notice" }}</a>
+    <a class="alert-link hide-demo-organization-notice" role="button" tabindex=0>{{t "Hide notice" }}</a>
 </div>

--- a/web/templates/settings/auth_methods_settings_admin.hbs
+++ b/web/templates/settings/auth_methods_settings_admin.hbs
@@ -3,7 +3,12 @@
     <div class='tip'>{{t "Only organization owners can edit these settings."}}</div>
     {{/unless}}
     {{#unless user_has_email_set}}
-    <div class='tip'>{{t "You must configure your email to access this feature."}}</div>
+    <div class="tip">
+        {{#tr}}
+            You must <z-link>configure your email</z-link> to access this feature.
+            {{#*inline "z-link"}}<a href="/help/demo-organizations#configure-email-for-demo-organization-owner" target="_blank" rel="noopener noreferrer">{{> @partial-block }}</a>{{/inline}}
+        {{/tr}}
+    </div>
     {{/unless}}
     <form class="admin-realm-form org-authentications-form">
         <div id="org-auth_settings" class="admin-table-wrapper settings-subsection-parent">

--- a/web/tests/navbar_alerts.test.js
+++ b/web/tests/navbar_alerts.test.js
@@ -99,7 +99,7 @@ test("server_upgrade_alert hide_duration_expired", ({override}) => {
     assert.equal(navbar_alerts.should_show_server_upgrade_notification(ls), false);
 });
 
-test("demo_org_days_remaining", ({override}) => {
+test("demo_organization_days_remaining", ({override}) => {
     const start_time = new Date(1620327447050); // Thursday 06/5/2021 07:02:27 AM (UTC+0)
 
     const high_priority_deadline = addDays(start_time, 5);

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -782,7 +782,7 @@ def send_account_registered_email(user: UserProfile, realm_creation: bool = Fals
         realm_creation=realm_creation,
         email=user.delivery_email,
         is_realm_admin=user.is_realm_admin,
-        is_demo_org=user.realm.demo_organization_scheduled_deletion_date is not None,
+        is_demo_organization=user.realm.demo_organization_scheduled_deletion_date is not None,
     )
 
     account_registered_context["getting_organization_started_link"] = (


### PR DESCRIPTION
This PR takes care of a few follow-up issues from ongoing demo organizaiton work:
- Updates references in the code base with the shortened "demo org" to be the unabbreviated "demo organization" version. See https://github.com/zulip/zulip/pull/19741#discussion_r932758538.
- Makes all tooltips and tip banners for the demo organization owner needing to set an email address consistent, to reduce extra work for translators. See https://github.com/zulip/zulip/pull/22666#discussion_r1312328910.
- Adds a section to the demo organizations help article (which is still in draft state) about configuring an email for the organization owner, and link to that subheader in the tip banners (invite users modal and authentications methods tab). See https://github.com/zulip/zulip/pull/22666#issuecomment-1701839732.
- Also, cleans up the drafted help center article to have a related articles section and removes out-of-date information in the instructions for creating a demo organization.

**Screenshots and screen captures:**

<details>
<summary>Updated demo organization help center article</summary>

[Current documentation](https://zulip.com/help/demo-organizations)
![Screenshot from 2023-09-01 13-39-34](https://github.com/zulip/zulip/assets/63245456/72e0be8b-397d-4dc5-ac3d-b44782fc718c)
</details>
<details>
<summary>Invite users modal</summary>

![Screenshot from 2023-09-01 13-41-26](https://github.com/zulip/zulip/assets/63245456/4a9d6d31-d076-483e-a7ad-c4bcf9a9041b)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
