### PR TITLE
vdots: Place new more-vertical icon across UI.

### DIFF
--- a/help/emoji-reactions.md
+++ b/help/emoji-reactions.md
@@ -14,12 +14,12 @@ message.
 
 {!message-actions.md!}
 
-1. Click the **smiley face** (<i class="fa fa-smile-o"></i>) icon.
+1. Click the **smiley face** (<i class="zulip-icon zulip-icon-smile"></i>) icon.
 
     !!! warn ""
 
         For messages that you've sent, click on the **ellipsis**
-        (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) and then
+        (<i class="zulip-icon zulip-icon-more-vertical-spread"></i>) and then
         **Add emoji reaction**.
 
 1. Select an emoji. Type to search, use the arrow keys, or click on an emoji

--- a/help/include/message-actions-menu.md
+++ b/help/include/message-actions-menu.md
@@ -1,3 +1,3 @@
 1. Hover over a message to reveal three icons on the right.
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical-spread"></i>).

--- a/help/include/right-sidebar-user-card.md
+++ b/help/include/right-sidebar-user-card.md
@@ -1,4 +1,4 @@
 1. Hover over a user's name in the right sidebar.
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
    to the right of their name to open their **user card**.

--- a/help/include/self-user-card.md
+++ b/help/include/self-user-card.md
@@ -1,4 +1,4 @@
 1. Hover over your name in the right sidebar.
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>)
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>)
    to open your **user card**.

--- a/help/include/stream-actions.md
+++ b/help/include/stream-actions.md
@@ -1,3 +1,3 @@
 1. Hover over a stream in the left sidebar.
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).

--- a/help/include/topic-actions.md
+++ b/help/include/topic-actions.md
@@ -1,3 +1,3 @@
 1. Hover over a topic in the left sidebar.
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).

--- a/help/include/user-card-three-dot-menu.md
+++ b/help/include/user-card-three-dot-menu.md
@@ -1,3 +1,3 @@
 {!right-sidebar-user-card.md!}
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>) in the user card.
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>) in the user card.

--- a/help/marking-messages-as-read.md
+++ b/help/marking-messages-as-read.md
@@ -61,7 +61,7 @@ stream or topic as read**.
 
 1. Hover over a stream, topic, or **All messages** in the left sidebar.
 
-1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>).
+1. Click on the **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>).
 
 1. Click **Mark all messages as read**.
 

--- a/help/schedule-a-message.md
+++ b/help/schedule-a-message.md
@@ -15,7 +15,7 @@ can schedule a message for next morning to avoid disturbing others.
 1. Write a message.
 
 1. Click on the **ellipsis** (<i class="zulip-icon
-   zulip-icon-ellipsis-v-solid"></i>) next to the **Send** button.
+   zulip-icon-more-vertical"></i>) next to the **Send** button.
 
 1. Click **Schedule message**.
 
@@ -42,7 +42,7 @@ can schedule a message for next morning to avoid disturbing others.
 1. *(optional)* Edit the message.
 
 1. Click the **ellipsis** (<i class="zulip-icon
-   zulip-icon-ellipsis-v-solid"></i>) next to the **Send** button.
+   zulip-icon-more-vertical"></i>) next to the **Send** button.
 
 1. Select the previously scheduled time, or click **Schedule message** to pick a
    new time.
@@ -105,7 +105,7 @@ can schedule a message for next morning to avoid disturbing others.
 !!! tip ""
 
     You can also view scheduled messages by clicking on the **ellipsis** (<i class="zulip-icon
-    zulip-icon-ellipsis-v-solid"></i>) next to the **Send** button in the compose
+    zulip-icon-more-vertical"></i>) next to the **Send** button in the compose
     box, and selecting **View scheduled messages**.
 
 {end_tabs}

--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -710,8 +710,8 @@ input.recipient_box {
     }
 
     .compose_control_menu {
-        padding: 0 7px;
-        font-size: 15px;
+        padding: 0 1px;
+        font-size: 18px;
     }
 
     .compose_control_menu_wrapper {
@@ -885,7 +885,8 @@ input.recipient_box {
     margin: 0;
 
     .zulip-icon {
-        padding: 5px 9px;
+        padding: 5px 3px;
+        font-size: 17px;
     }
 
     .separator-line {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -581,9 +581,10 @@ li.top_left_scheduled_messages {
     right: 10px;
 
     & i {
-        padding-right: 0.25em;
+        padding-right: 0.35em;
         display: inline-block;
         width: 13px;
+        font-size: 17px;
         vertical-align: middle;
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -92,8 +92,8 @@
 }
 
 .user_info_popover_action_buttons {
-    display: flex;
     margin-left: auto;
+    line-height: 1;
 }
 
 .user_info_popover_manage_menu_btn {
@@ -141,9 +141,6 @@
 }
 
 .info_popover_actions .user_info_popover_manage_menu_btn {
-    /* Create a larger click target around the icon. */
-    padding: 0 6px;
-
     opacity: 0.8;
 
     &:hover {
@@ -231,6 +228,12 @@ ul {
 
             &:not(.zulip-icon-bot) {
                 top: 2px;
+            }
+
+            &.popover_action_icon {
+                font-size: 17px;
+                line-height: 1;
+                top: 1px;
             }
         }
     }

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -38,9 +38,10 @@ $user_status_emoji_width: 24px;
             padding: 0 6px;
 
             & i {
-                padding-right: 0.25em;
+                padding-right: 0.35em;
                 display: inline-block;
                 width: 13px;
+                font-size: 17px;
                 vertical-align: middle;
             }
 

--- a/web/templates/compose.hbs
+++ b/web/templates/compose.hbs
@@ -86,7 +86,7 @@
                                         </button>
                                         <button class="animated-purple-button message-control-button" id="send_later" tabindex=0 type="button" data-tippy-content="{{t 'Send later' }}">
                                             <div class="separator-line"></div>
-                                            <i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>
+                                            <i class="zulip-icon zulip-icon-more-vertical"></i>
                                         </button>
                                     </div>
                                     {{> compose_control_buttons }}

--- a/web/templates/compose_control_buttons.hbs
+++ b/web/templates/compose_control_buttons.hbs
@@ -21,6 +21,6 @@
         {{t 'Drafts' }}
     </a>
     <div class="compose_control_menu_wrapper" role="button" tabindex=0>
-        <a class="compose_control_button zulip-icon zulip-icon-ellipsis-v-solid hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
+        <a class="compose_control_button zulip-icon zulip-icon-more-vertical hide {{#if message_id}}show-lg{{else}}show-sm{{/if}} compose_control_menu" tabindex="-1" data-tippy-content="Compose actions"></a>
     </div>
 </div>

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -11,7 +11,7 @@
                     <span class="global-filter-name">{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
+                <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             {{#if development_environment}}
             <li class="top_left_inbox top_left_row hidden-for-spectators" title="{{t 'Inbox' }} (t)">
@@ -52,7 +52,7 @@
                     <span class="global-filter-name">{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
+                <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_drafts top_left_row hidden-for-spectators">
                 <a href="#drafts" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="drafts-tooltip-template">
@@ -63,7 +63,7 @@
                     <span class="global-filter-name">{{t 'Drafts' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
+                <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
                 <a class="global-filter-container" href="#scheduled">

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -20,5 +20,5 @@
         </a>
         <span class="unread_count">{{#if num_unread}}{{num_unread}}{{/if}}</span>
     </div>
-    <span class="user-list-sidebar-menu-icon"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
+    <span class="user-list-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
 </li>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -13,6 +13,6 @@
             <span class="unread_mention_info"></span>
             <span class="unread_count"></span>
         </div>
-        <span class="stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i></span>
+        <span class="stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
     </div>
 </li>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -19,6 +19,6 @@
         </span>
     </span>
     <span class="topic-sidebar-menu-icon">
-        <i class="zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i>
+        <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
     </span>
 </li>

--- a/web/templates/user_info_popover_content.hbs
+++ b/web/templates/user_info_popover_content.hbs
@@ -12,7 +12,7 @@
         {{#if show_manage_menu }}
         <span class="user_info_popover_action_buttons">
             <a class="user_info_popover_manage_menu_btn" role="button" tabindex="0" aria-haspopup="true">
-                <i class="popover_action_icon zulip-icon zulip-icon-ellipsis-v-solid" aria-hidden="true"></i>
+                <i class="popover_action_icon zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
             </a>
         </span>
         {{/if}}


### PR DESCRIPTION
This PR swaps out the remaining references to `ellipsis-v-solid`, whose middle dot was ever so smaller than the top and bottom dots. Adjustments to the CSS keep the layout as it was, with the exception of the left sidebar dots, which now share perfect alignment with the anchor point that is the + icon adjacent the STREAMS label.

Help documents have also been updated, including the new `more-vertical-spread` icon that appears in the redesigned hover controls and was merged there in #26283. 

The icon used for the vdots in this PR was added back in bf7cdc8f7af7d676873fa76d7e688295c128c1f6.

TODO:
- [ ] Screenshots of documentation changes.

**Screenshots and screen captures:**

| Sidebars, Before (temporary CSS used to display all dots) | Sidebars, After |
| --- | --- |
| ![vdots-before](https://github.com/zulip/zulip/assets/170719/ea3d5c4d-95e0-45c6-adce-e217e42aefe4) | ![vdots-after](https://github.com/zulip/zulip/assets/170719/70cdfa29-91e4-4307-861b-1140c4aa14b0) |

| Left Sidebar Detail, Before | Left Sidebar Detail, After |
| --- | --- |
| <img width="278" alt="vdots-lsb-before" src="https://github.com/zulip/zulip/assets/170719/eb3f0ba6-65d1-454d-8a65-8e6f272b6a97"> | <img width="278" alt="vdots-lsb-after" src="https://github.com/zulip/zulip/assets/170719/51214c98-637a-4570-b87b-186cd60a2426"> |

| Compose Box, Before | Compose Box, After |
| --- | --- |
| ![vdots-compose-before](https://github.com/zulip/zulip/assets/170719/adf570c7-398e-4682-bc17-40d190e6c939) | ![vdots-compose-after](https://github.com/zulip/zulip/assets/170719/844f1497-4f3e-4613-be49-334c5ca608b8) |

| User Popover, Before | User Popover, After |
| --- | --- |
| <img width="278" alt="user-popover-before" src="https://github.com/zulip/zulip/assets/170719/c589b822-928b-4e40-b775-0b672d31e864"> | <img width="278" alt="user-popover-after" src="https://github.com/zulip/zulip/assets/170719/c3d743f7-d7cf-4d40-b089-dd741c6be573"> |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>