### PR TITLE
markdown: Fix URL link topic skipping query.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2284,7 +2284,7 @@ def make_md_engine(linkifiers_key: int, email_gateway: bool) -> None:
 
 # Split the topic name into multiple sections so that we can easily use
 # our common single link matching regex on it.
-basic_link_splitter = re.compile(r"[ !;\?\),\'\"]")
+basic_link_splitter = re.compile(r"[ !;\),\'\"]")
 
 
 def percent_escape_format_string(format_string: str) -> str:

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1160,6 +1160,36 @@ class MarkdownTest(ZulipTestCase):
             ],
         )
 
+        # Query strings in a URL should be included in the link.
+        msg.set_topic_name("https://google.com/test?foo=bar")
+        converted_topic = topic_links(realm.id, msg.topic_name())
+        self.assertEqual(
+            converted_topic,
+            [
+                {
+                    "url": "https://google.com/test?foo=bar",
+                    "text": "https://google.com/test?foo=bar",
+                },
+            ],
+        )
+        # But question marks at the end of sentence are not part of the URL.
+        msg.set_topic_name("Have you seen github.com/zulip?")
+        converted_topic = topic_links(realm.id, msg.topic_name())
+        self.assertEqual(
+            converted_topic,
+            [
+                {"url": "https://github.com/zulip", "text": "github.com/zulip"},
+            ],
+        )
+        msg.set_topic_name("Do you like https://example.com? I love it.")
+        converted_topic = topic_links(realm.id, msg.topic_name())
+        self.assertEqual(
+            converted_topic,
+            [
+                {"url": "https://example.com", "text": "https://example.com"},
+            ],
+        )
+
     def check_add_linkifiers(
         self, linkifiers: List[RealmFilter], expected_linkifier_reprs: List[str]
     ) -> None:


### PR DESCRIPTION
When searching for links inside a topic name, the question mark (?) was used to split the topic. If a URL had a query after the URL (e.g., "?foo=bar"), then the query was trimmed from the URL.

Removing the question mark from `basic_link_splitter` is sufficient to fix this issue. The `get_web_link_regex` function then removes the trailing punctuation if any, including literal question marks.

[ZCO thread](https://chat.zulip.org/#narrow/stream/9-issues/topic/URL.20link.20for.20topic.20name.20not.20exact.20match.2C.20.2326368).

Fixes #26368 

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [X] Explains differences from previous plans (e.g., issue description).
- [X] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [X] Each commit is a coherent idea.
- [X] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
