### PR TITLE
ts: Migrate `settings_emoji.js` to TypeScript.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -163,7 +163,7 @@ EXEMPT_FILES = make_set(
         "web/src/settings_account.js",
         "web/src/settings_bots.js",
         "web/src/settings_display.js",
-        "web/src/settings_emoji.js",
+        "web/src/settings_emoji.ts",
         "web/src/settings_exports.js",
         "web/src/settings_invites.js",
         "web/src/settings_linkifiers.js",

--- a/web/src/emoji.ts
+++ b/web/src/emoji.ts
@@ -1,19 +1,22 @@
 import _ from "lodash";
 
 import * as blueslip from "./blueslip";
+import type {User} from "./people";
 
 // This is the data structure that we get from the server on initialization.
-type RealmEmojiMap = Record<
-    string,
-    {
-        id: number;
-        author_id: number;
-        deactivated: boolean;
-        name: string;
-        source_url: string;
-        still_url: string | null;
-    }
->;
+export type ServerEmoji = {
+    id: number;
+    author_id: number;
+    deactivated: boolean;
+    name: string;
+    source_url: string;
+    still_url: string | null;
+
+    // Added later in `settings_emoji.ts` when setting up the emoji settings.
+    author?: User | null;
+};
+
+type RealmEmojiMap = Record<string, ServerEmoji>;
 
 // The data the server provides about unicode emojis.
 type ServerUnicodeEmojiData = {

--- a/web/src/settings_emoji.js
+++ b/web/src/settings_emoji.js
@@ -21,6 +21,7 @@ import * as settings_config from "./settings_config";
 import * as settings_data from "./settings_data";
 import * as ui_report from "./ui_report";
 import * as upload_widget from "./upload_widget";
+import * as util from "./util";
 
 const meta = {
     loaded: false,
@@ -68,12 +69,19 @@ export function reset() {
 }
 
 function sort_author_full_name(a, b) {
-    if (a.author.full_name > b.author.full_name) {
-        return 1;
-    } else if (a.author.full_name === b.author.full_name) {
+    const author_a = a.author?.full_name;
+    const author_b = b.author?.full_name;
+
+    if (author_a === author_b) {
         return 0;
     }
-    return -1;
+
+    if (author_a && author_b) {
+        return util.strcmp(author_a, author_b);
+    }
+
+    // If one of the author is null, then we put the null author at the end.
+    return author_a ? -1 : 1;
 }
 
 function is_default_emoji(emoji_name) {


### PR DESCRIPTION
This PR migrates `settings_emoji.js` module to TypeScript.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
