### PR TITLE
Notify user when messages in unsubscribed streams are not marked as unread

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,13 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 209**
+
+* [`POST /messages/flags/narrow`](/api/update-message-flags-for-narrow):
+  Added `skipped_marking_unread_stream_ids` field in the response, which
+  is a list of the streams whose messages were skipped to mark as unread
+  because the user is not subscribed to them.
+
 **Feature level 208**
 
 * [`POST /users/me/subscriptions`](/api/subscribe),

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 208
+API_FEATURE_LEVEL = 209
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/web/src/feedback_widget.ts
+++ b/web/src/feedback_widget.ts
@@ -34,8 +34,8 @@ type FeedbackWidgetMeta = {
 type FeedbackWidgetOptions = {
     populate: (element: JQuery) => void;
     title_text: string;
-    undo_button_text: string;
-    on_undo: () => void;
+    undo_button_text?: string;
+    on_undo?: () => void;
 };
 
 const meta: FeedbackWidgetMeta = {
@@ -162,8 +162,17 @@ export function show(opts: FeedbackWidgetOptions): void {
     // add a four second delay before closing up.
     meta.hide_me_time = Date.now() + 4000;
 
+    // Show or hide the undo button based on the presence of on_undo callback
+    // and undo_button_text.
+    const $undo_button = meta.$container.find(".feedback_undo");
+    if (opts.on_undo && opts.undo_button_text) {
+        meta.undo = opts.on_undo;
+        $undo_button.text(opts.undo_button_text);
+    } else {
+        $undo_button.hide();
+    }
+
     meta.$container.find(".feedback_title").text(opts.title_text);
-    meta.$container.find(".feedback_undo").text(opts.undo_button_text);
     opts.populate(meta.$container.find(".feedback_content"));
 
     animate.fadeIn();

--- a/web/templates/skipped_marking_unread.hbs
+++ b/web/templates/skipped_marking_unread.hbs
@@ -1,0 +1,15 @@
+{{#if stream_names_with_privacy_symbol_html.[1]}}
+    {{#tr}}
+        Because you are not subscribed to <z-streams></z-streams>, messages in these streams were not marked as unread.
+        {{#*inline "z-streams"}}
+            {{~#each stream_names_with_privacy_symbol_html ~}}
+                <strong>{{{this}}}</strong>{{~#unless @last~}}, {{/unless~}}
+            {{~/each~}}
+        {{/inline}}
+    {{/tr}}
+    {{ else }}
+    {{#tr}}
+        Because you are not subscribed to <z-stream></z-stream>, messages in this stream were not marked as unread.
+        {{#*inline "z-stream"}}<strong>{{{stream_names_with_privacy_symbol_html.[0]}}}</strong>{{/inline}}
+    {{/tr}}
+{{/if}}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6612,6 +6612,19 @@ paths:
                           bulk update to decide whether to issue
                           another request anchored at
                           `last_processed_id`).
+                      skipped_marking_unread_stream_ids:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          Only present if the flag is `read` and the operation is `remove`.
+
+                          Zulip has an invariant that all unread messages must be in streams
+                          the user is subsubscribed to. This field will contain a list of the
+                          streams whose messages were skipped to mark as unread because the
+                          user is not subscribed to them.
+
+                          **Changes**: New in Zulip 8.0 (feature level 209).
                     example:
                       {
                         "result": "success",
@@ -6622,6 +6635,7 @@ paths:
                         "last_processed_id": 55,
                         "found_oldest": false,
                         "found_newest": true,
+                        "skipped_marking_unread_stream_ids": [12, 13, 9],
                       }
   /messages/render:
     post:

--- a/zerver/tests/test_message_flags.py
+++ b/zerver/tests/test_message_flags.py
@@ -294,6 +294,61 @@ class UnreadCountTests(ZulipTestCase):
             message_ids[5::2],
         )
 
+        # Testing the response when marking messages as unread in a
+        # narrow that contains messages from unsubscribed streams
+        stream_name = "Test Stream"
+        stream = self.subscribe(user, stream_name)
+        self.subscribe(self.example_user("cordelia"), stream_name)
+        message_id = self.send_stream_message(self.example_user("cordelia"), stream_name, "hello")
+
+        self.assert_json_success(
+            self.client_post(
+                "/json/mark_stream_as_read",
+                {
+                    "stream_id": stream.id,
+                },
+            )
+        )
+        um = UserMessage.objects.get(
+            user_profile_id=user.id,
+            message_id=message_id,
+        )
+        self.assertTrue(um.flags.read)
+
+        # Unsubscribe the user from the stream
+        self.unsubscribe(user, stream_name)
+
+        # Marking recently added message and all other
+        # messages added at the start of the test as unread
+        # from an interleaved public narrow
+        response = self.assert_json_success(
+            self.client_post(
+                "/json/messages/flags/narrow",
+                {
+                    "anchor": message_id,
+                    "num_before": 10,
+                    "num_after": 0,
+                    "narrow": orjson.dumps([{"operator": "streams", "operand": "public"}]).decode(),
+                    "op": "remove",
+                    "flag": "read",
+                },
+            )
+        )
+
+        self.assertEqual(response["processed_count"], 11)
+        self.assertEqual(response["updated_count"], 5)
+        self.assertEqual(response["first_processed_id"], message_ids[0])
+        self.assertEqual(response["last_processed_id"], message_id)
+        self.assertEqual(response["found_oldest"], False)
+        self.assertEqual(response["found_newest"], False)
+        self.assertEqual(response["skipped_marking_unread_stream_ids"], [stream.id])
+        self.assertCountEqual(
+            UserMessage.objects.filter(user_profile_id=user.id, message_id__in=message_ids)
+            .extra(where=[UserMessage.where_unread()])
+            .values_list("message_id", flat=True),
+            message_ids,
+        )
+
     def test_update_flags_for_narrow_misuse(self) -> None:
         self.login("hamlet")
 


### PR DESCRIPTION
<!-- Describe your pull request here.-->
Discussion: [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/not.20marked.20as.20unread.20banner/near/1627530)

Fixes: #23470

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![Screenshot 2023-09-03 162435](https://github.com/zulip/zulip/assets/87542880/10902796-bd46-4c0c-b928-fa6ddee46c15)
![Screenshot 2023-09-03 162351](https://github.com/zulip/zulip/assets/87542880/a46ed78a-8cc5-42d7-ab42-93c2dcbd35eb)



<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
