### PR TITLE
Migrate from spectrum to the HTML5 <input type="color"/>.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "sorttable": "^1.0.2",
     "source-code-pro": "^2.38.0",
     "source-sans": "^3.28.0",
-    "spectrum-colorpicker": "^1.8.1",
     "stackframe": "^1.3.4",
     "stacktrace-gps": "^3.0.4",
     "style-loader": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,9 +217,6 @@ dependencies:
   source-sans:
     specifier: ^3.28.0
     version: 3.46.0(patch_hash=4n7ij66tzyhzaqnxsenbilrxr4)
-  spectrum-colorpicker:
-    specifier: ^1.8.1
-    version: 1.8.1
   stackframe:
     specifier: ^1.3.4
     version: 1.3.4
@@ -10945,10 +10942,6 @@ packages:
       spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
-
-  /spectrum-colorpicker@1.8.1:
-    resolution: {integrity: sha512-x1picQ5giVso71ESII7jZ3+ZFdit8WthNkzwJqLNdPDPzrltKUQGpTohWyPfSAID+bK1zGdO6bDbSh1S6GoLYA==}
-    dev: false
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 211
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (249, 3)
+PROVISION_VERSION = (250, 0)

--- a/web/src/bundles/app.ts
+++ b/web/src/bundles/app.ts
@@ -5,7 +5,6 @@ import "../../third/bootstrap-typeahead/typeahead";
 import "../../third/bootstrap-tooltip/tooltip";
 import "jquery-caret-plugin/dist/jquery.caret";
 import "../../third/jquery-idle/jquery.idle";
-import "spectrum-colorpicker";
 import "jquery-validation";
 import "flatpickr";
 
@@ -24,7 +23,6 @@ import "../zulip_test";
 import "tippy.js/dist/tippy.css";
 import "tippy.js/themes/light-border.css";
 import "../../third/bootstrap-tooltip/tooltip.css";
-import "spectrum-colorpicker/spectrum.css";
 import "katex/dist/katex.css";
 import "flatpickr/dist/flatpickr.css";
 import "flatpickr/dist/plugins/confirmDate/confirmDate.css";

--- a/web/src/stream_color.js
+++ b/web/src/stream_color.js
@@ -3,7 +3,6 @@ import lchPlugin from "colord/plugins/lch";
 import mixPlugin from "colord/plugins/mix";
 import $ from "jquery";
 
-import {$t} from "./i18n";
 import * as inbox_util from "./inbox_util";
 import * as message_lists from "./message_lists";
 import * as message_view_header from "./message_view_header";
@@ -93,11 +92,31 @@ function update_message_recipient_color(stream_name, color) {
     }
 }
 
-const stream_color_palette = [
-    ["a47462", "c2726a", "e4523d", "e7664d", "ee7e4a", "f4ae55"],
-    ["76ce90", "53a063", "94c849", "bfd56f", "fae589", "f5ce6e"],
-    ["a6dcbf", "addfe5", "a6c7e5", "4f8de4", "95a5fd", "b0a5fd"],
-    ["c2c2c2", "c8bebf", "c6a8ad", "e79ab5", "bd86e5", "9987e1"],
+export const stream_color_palette = [
+    "a47462",
+    "c2726a",
+    "e4523d",
+    "e7664d",
+    "ee7e4a",
+    "f4ae55",
+    "76ce90",
+    "53a063",
+    "94c849",
+    "bfd56f",
+    "fae589",
+    "f5ce6e",
+    "a6dcbf",
+    "addfe5",
+    "a6c7e5",
+    "4f8de4",
+    "95a5fd",
+    "b0a5fd",
+    "c2c2c2",
+    "c8bebf",
+    "c6a8ad",
+    "e79ab5",
+    "bd86e5",
+    "9987e1",
 ];
 
 const subscriptions_table_colorpicker_options = {
@@ -124,14 +143,11 @@ export function update_stream_color(sub, color) {
         color,
     );
     // The swatch in the color picker.
-    set_colorpicker_color(
-        $(
-            `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
-                stream_id,
-            )}'] .colorpicker`,
-        ),
-        color,
-    );
+    $(
+        `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
+            stream_id,
+        )}'] .dropdown-color-preview`,
+    ).css("background-color", color);
     $(
         `#subscription_overlay .subscription_settings[data-stream-id='${CSS.escape(
             stream_id,
@@ -143,32 +159,32 @@ export function update_stream_color(sub, color) {
     message_view_header.colorize_message_view_header();
 }
 
-export const sidebar_popover_colorpicker_options_full = {
-    clickoutFiresChange: false,
-    showPalette: true,
-    showInput: true,
-    flat: true,
-    cancelText: "",
-    chooseText: $t({defaultMessage: "Confirm"}),
-    palette: stream_color_palette,
-    change: picker_do_change_color,
-};
+export function update_chosen_color($target) {
+    let selected_color;
+    if ($target.hasClass("colorpicker-input")) {
+        selected_color = $target.val();
+    }
+    if ($target.hasClass("color-block")) {
+        selected_color = $target.data("color");
+    }
 
-function picker_do_change_color(color) {
-    $(".colorpicker").spectrum("destroy");
-    $(".colorpicker").spectrum(sidebar_popover_colorpicker_options_full);
-    const stream_id = Number.parseInt($(this).attr("stream_id"), 10);
-    const hex_color = color.toHexString();
-    stream_settings_ui.set_color(stream_id, hex_color);
+    if (selected_color) {
+        const $colorpicker = $target.closest(".colorpicker");
+        const $preview_color_elem = $colorpicker.find(".preview-color");
+
+        $colorpicker.find(".colorpicker-input").val(selected_color);
+
+        $preview_color_elem.css("background-color", selected_color);
+        $preview_color_elem.data("color", selected_color);
+    }
 }
-subscriptions_table_colorpicker_options.change = picker_do_change_color;
 
-export const sidebar_popover_colorpicker_options = {
-    clickoutFiresChange: true,
-    showPaletteOnly: true,
-    showPalette: true,
-    showInput: true,
-    flat: true,
-    palette: stream_color_palette,
-    change: picker_do_change_color,
-};
+export function save_color($target, sub) {
+    const stream_color = sub.color;
+    const $save_btn = $target.closest(".submit-color-btn");
+    const selected_color = $save_btn.find(".preview-color").data("color");
+
+    if (selected_color !== stream_color) {
+        stream_settings_ui.set_color(sub.stream_id, selected_color);
+    }
+}

--- a/web/src/stream_edit.js
+++ b/web/src/stream_edit.js
@@ -134,9 +134,6 @@ export function update_stream_description(sub) {
 function show_subscription_settings(sub) {
     const $edit_container = stream_settings_containers.get_edit_container(sub);
 
-    const $colorpicker = $edit_container.find(".colorpicker");
-    const color = stream_data.get_color(sub.stream_id);
-    stream_color.set_colorpicker_color($colorpicker, color);
     stream_ui_updates.update_add_subscriptions_elements(sub);
 
     if (!sub.render_subscribers) {
@@ -255,6 +252,7 @@ export function show_settings_for(node) {
             page_params.realm_org_type === settings_config.all_org_type_values.business.code,
         is_admin: page_params.is_admin,
         org_level_message_retention_setting: get_display_text_for_realm_message_retention_setting(),
+        stream_color_palette: stream_color.stream_color_palette,
     });
     scroll_util.get_content_element($("#stream_settings")).html(html);
 
@@ -601,6 +599,21 @@ export function initialize() {
         ".sub_setting_checkbox .sub_setting_control",
         stream_setting_changed,
     );
+
+    $("#streams_overlay_container").on("input click", ".color-choice", (e) => {
+        e.stopPropagation();
+
+        stream_color.update_chosen_color($(e.target));
+    });
+
+    $("#streams_overlay_container").on("click", ".submit-color-btn", (e) => {
+        e.stopPropagation();
+
+        $("#toggle-colorpicker").dropdown("toggle");
+
+        const sub = get_sub_for_target(e.target);
+        stream_color.save_color($(e.target), sub);
+    });
 
     // This handler isn't part of the normal edit interface; it's the convenient
     // checkmark in the subscriber list.

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -117,6 +117,7 @@ function build_stream_popover(opts) {
     popovers.hide_all_except_sidebars();
     const content = render_stream_sidebar_actions({
         stream: sub_store.get(stream_id),
+        stream_color_palette: stream_color.stream_color_palette,
     });
 
     popover_menus.toggle_popover_menu(elt, {
@@ -192,25 +193,29 @@ function build_stream_popover(opts) {
             // Choose a different color.
             $popper.on("click", ".choose_stream_color", (e) => {
                 const $popover = $(e.target).closest(".streams_popover");
-                const $colorpicker = $popover.find(".colorpicker-container").find(".colorpicker");
-                $(".colorpicker-container").show();
-                $colorpicker.spectrum("destroy");
-                $colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options_full);
-                // In theory this should clean up the old color picker,
-                // but this seems a bit flaky -- the new colorpicker
-                // doesn't fire until you click a button, but the buttons
-                // have been hidden.  We work around this by just manually
-                // fixing it up here.
-                $colorpicker.parent().find(".sp-container").removeClass("sp-buttons-disabled");
-                $(e.target).hide();
+                const $show_colorpicker = $popover.find(".show-colorpicker");
+                $popover.children().hide();
+                $show_colorpicker.show();
 
-                $(".streams_popover").on("click", "a.sp-cancel", () => {
-                    hide_stream_popover();
-                });
-                if ($(window).width() <= media_breakpoints_num.md) {
+                if ($(window).width() <= media_breakpoints_num.sm) {
                     $(".popover-inner").hide().fadeIn(300);
                     $(".popover").addClass("colorpicker-popover");
                 }
+                e.stopPropagation();
+            });
+
+            $popper.on("input click", ".color-choice", (e) => {
+                stream_color.update_chosen_color($(e.target));
+
+                e.stopPropagation();
+            });
+
+            $popper.on("click", ".submit-color-btn", (e) => {
+                hide_stream_popover();
+
+                const sub = stream_popover_sub(e);
+                stream_color.save_color($(e.target), sub);
+
                 e.stopPropagation();
             });
         },

--- a/web/src/stream_settings_ui.js
+++ b/web/src/stream_settings_ui.js
@@ -860,7 +860,6 @@ export function launch(section) {
             $overlay: $("#subscription_overlay"),
             on_close() {
                 browser_history.exit_overlay();
-                $(".colorpicker").spectrum("destroy");
             },
         });
         change_state(section);

--- a/web/styles/components.css
+++ b/web/styles/components.css
@@ -136,3 +136,66 @@ button.dropdown-toggle {
         transition: none;
     }
 }
+
+.colorpicker {
+    & > div,
+    & > hr {
+        margin: 10px 0;
+    }
+
+    .palette-container {
+        display: grid;
+        grid-template-columns: repeat(6, 1fr);
+        gap: 10px;
+        justify-items: center;
+    }
+
+    .colorpicker-button-container {
+        display: flex;
+        gap: 10px;
+
+        & > button {
+            border-radius: 40px;
+            width: 90px;
+
+            &:focus {
+                outline: 0;
+            }
+        }
+
+        .more-colors-btn {
+            position: relative;
+
+            .colorpicker-input {
+                position: absolute;
+                top: 0;
+                left: 0;
+                opacity: 0;
+                width: 100%;
+                height: 100%;
+            }
+        }
+
+        .submit-color-btn {
+            justify-content: space-around;
+
+            .preview-color {
+                pointer-events: none;
+            }
+        }
+    }
+
+    .color-block {
+        width: 17px;
+        height: 17px;
+        border: none;
+        border-radius: 50%;
+        transition: all 0.1s ease-in-out;
+
+        &:hover,
+        &:focus {
+            transform: scale(1.1);
+            outline: 0;
+        }
+    }
+}

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -380,17 +380,19 @@
         border-color: hsl(0deg 0% 100% / 40%);
     }
 
-    .streams_popover .sp-container {
-        background-color: transparent;
+    .colorpicker .colorpicker-button-container {
+        & > button {
+            background-color: hsl(0deg 0% 0% / 20%);
+            border-color: hsl(0deg 0% 0%);
+            color: hsl(0deg 0% 100%);
 
-        & button {
-            background-color: hsl(208deg 35% 11%);
-            border: 1px solid hsl(210deg 36% 4%);
-            color: hsl(236deg 31% 90%);
+            &:hover {
+                background-color: hsl(0deg 0% 0% / 50%);
+            }
         }
 
-        .sp-picker-container {
-            border-left: solid 1px hsl(210deg 36% 4%);
+        .colorpicker-input {
+            opacity: 0;
         }
     }
 

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -154,54 +154,11 @@
     }
 }
 
-.sp-container {
-    z-index: 106;
-}
-
 .streams_popover {
     .topic-name {
         text-align: center;
         margin-top: 5px;
         margin-bottom: 5px;
-    }
-
-    .colorpicker-container {
-        display: none;
-        margin-right: 10px;
-
-        .sp-container {
-            background-color: hsl(0deg 0% 100%);
-            cursor: pointer;
-            border: none;
-
-            .sp-palette-container {
-                border-right: none;
-            }
-
-            & input {
-                box-sizing: inherit; /* IE */
-                box-sizing: initial;
-
-                width: calc(100% - 13px);
-            }
-
-            & button {
-                background-color: hsl(0deg 0% 100%);
-                background-image: none;
-                border: 1px solid hsl(0deg 0% 80%);
-                border-radius: 4px;
-                color: hsl(0deg 0% 25%);
-                font-size: 12px;
-                padding: 6px;
-                text-transform: capitalize;
-                text-align: center;
-                text-shadow: none;
-            }
-
-            .sp-picker-container {
-                border-left: solid 1px hsl(0deg 0% 88%);
-            }
-        }
     }
 
     .popover_sub_unsub_button {
@@ -712,16 +669,6 @@ ul {
         .popover-inner {
             background-color: hsl(0deg 0% 100%);
             pointer-events: all;
-        }
-
-        @media (width < $sm_min) {
-            .popover-inner {
-                width: 70%;
-            }
-
-            .sp-picker-container {
-                border-left: none !important;
-            }
         }
     }
 

--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -29,18 +29,6 @@
     border-radius: 4px;
 }
 
-.sp-preview {
-    width: 20px;
-    border: none;
-    box-shadow: 0 0 1px hsl(0deg 0% 0%);
-}
-
-.sp-replacer {
-    margin-right: 12px;
-    border: none;
-    box-shadow: 0 0 2px hsl(0deg 0% 0% / 80%);
-}
-
 .stream-email .email-address {
     display: block;
     margin: auto;
@@ -947,8 +935,37 @@ h4.user_group_setting_subsection_title {
             border-bottom: none;
         }
 
-        .sp-replacer {
-            box-shadow: none;
+        .dropdown {
+            .colorpicker-dropdown-btn {
+                position: relative;
+                width: 3rem;
+                height: 35px;
+                color: hsl(0deg 0% 40%);
+                cursor: pointer;
+
+                .dropdown-color-preview {
+                    position: absolute;
+                    inset: 0;
+                    border-radius: 4px;
+                    border: 1px solid hsl(0deg 0% 93%);
+                }
+
+                .dropdown-icon {
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                    bottom: 0;
+                    padding: 0 2px;
+                    background-color: hsl(0deg 0% 93%);
+                    border-radius: 0 4px 4px 0;
+                    display: flex;
+                    align-items: center;
+                }
+            }
+
+            .colorpicker {
+                margin: 0 10px;
+            }
         }
 
         & input[type="radio"] {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -960,11 +960,6 @@ strong {
     white-space: pre-wrap;
 }
 
-.sp-input {
-    width: calc(100% - 14px);
-    box-sizing: initial !important;
-}
-
 .logout {
     white-space: nowrap;
 }

--- a/web/templates/stream_settings/stream_colorpicker.hbs
+++ b/web/templates/stream_settings/stream_colorpicker.hbs
@@ -1,0 +1,22 @@
+<div class="colorpicker" {{#if is_left_sidebar_menu}}style="display: none;"{{/if}} data-stream-color="{{stream_color}}">
+    {{#if is_left_sidebar_menu}}<hr />{{/if}}
+    <div class="palette-container">
+        {{#each stream_color_palette}}
+            <button class="color-block color-choice" style="background-color: #{{this}};" data-color="#{{this}}"></button>
+        {{/each}}
+    </div>
+    <hr />
+    <div class="colorpicker-button-container">
+        <button type="button" class="btn btn-default more-colors-btn">
+            <label>
+                More Colors
+                <input id="colorpicker-input" type="color" class="colorpicker-input color-choice" value="{{stream_color}}"/>
+            </label>
+        </button>
+        <button type="button" class="btn btn-default flex submit-color-btn">
+            <span class="color-block preview-color" style="background-color: {{stream_color}};" data-color="{{stream_color}}"></span>
+            <span>Save</span>
+        </button>
+    </div>
+</div>
+

--- a/web/templates/stream_settings/stream_settings.hbs
+++ b/web/templates/stream_settings/stream_settings.hbs
@@ -105,10 +105,18 @@
                     {{/each}}
 
                     <div class="input-group">
-                        <label for="streamcolor">{{t "Stream color" }}</label>
-                        <span class="sub_setting_control">
-                            <input stream_id="{{sub.stream_id}}" class="colorpicker" id="streamcolor" type="text" value="{{sub.color}}" tabindex="-1" />
-                        </span>
+                        <span>{{t "Stream color" }}</span>
+                        <div class="dropdown">
+                            <div class="colorpicker-dropdown-btn dropdown-toggle" type="button" id="toggle-colorpicker" data-toggle="dropdown" aria-haspopup="true">
+                                <div class="dropdown-color-preview" style="background-color: {{sub.color}};"></div>
+                                <div class="dropdown-icon">
+                                    <i class="fa fa-caret-down" aria-hidden="true"></i>
+                                </div>
+                            </div>
+                            <div class="dropdown-menu">
+                                {{> stream_colorpicker stream_color=sub.color}}
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <h4 class="stream_setting_subsection_title">{{t "Notification settings" }}</h4>

--- a/web/templates/stream_sidebar_actions.hbs
+++ b/web/templates/stream_sidebar_actions.hbs
@@ -1,6 +1,6 @@
 {{! Contents of the "stream actions" popup }}
 <ul class="nav nav-list streams_popover" data-stream-id="{{ stream.stream_id }}" data-name="{{ stream.name }}">
-    <li>
+    <li class="show-colorpicker">
         <p class="topic-name">
             <span class="stream-privacy-original-color-{{stream.stream_id}} stream-privacy filter-icon" style="color: {{stream.color}}">
                 {{> stream_privacy
@@ -11,7 +11,7 @@
         </p>
     </li>
 
-    <hr />
+    <hr class="show-colorpicker"/>
 
     {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
     <li>
@@ -60,11 +60,13 @@
         </a>
     </li>
     <li class="hidden-for-spectators">
-        <span class="colorpicker-container"><input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" /></span>
         <a tabindex="0" class="choose_stream_color">
             <i class="fa fa-eyedropper" aria-hidden="true"></i>
             {{t "Change color" }}
         </a>
     </li>
 
+    <li class="show-colorpicker" style="display: none;">
+        {{> stream_settings/stream_colorpicker is_left_sidebar_menu=false stream_color=stream.color}}
+    </li>
 </ul>


### PR DESCRIPTION
Discussion: [CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/colorpicker.20migration.20and.20redesign/near/1630238)
Fixes #14961.

<!-- Describe your pull request here.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

<details>
<summary>Screenshots and screen captures:</summary>

Light:


https://github.com/zulip/zulip/assets/87542880/b2304c73-6211-448f-b24b-9be6958438b1

Dark:


https://github.com/zulip/zulip/assets/87542880/c6a8add7-7e49-4e54-a7ab-9f1b0a3102f8

Screen recorder is not capturing the popover after clicking 'More colors'. Here is a screenshot instead.

![Screenshot 2023-09-11 145224](https://github.com/zulip/zulip/assets/87542880/151519d6-f70b-4441-aa0d-0a654d8ec027)
![Screenshot 2023-09-11 145300](https://github.com/zulip/zulip/assets/87542880/91810556-e5cb-4a0a-9232-37f62ec14458)
![Screenshot 2023-09-11 151152](https://github.com/zulip/zulip/assets/87542880/5a65bd69-a981-4482-b850-a04bc57f51bc)



</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
