### PR TITLE
api-docs: Update `subscription` event for `op: peer_add` in feature level 205.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -75,6 +75,9 @@ format used by the Zulip server that they are interacting with.
 * [`GET /events`](/api/get-events): Events for stream creation and deletion
   are now sent to clients when a user gains or loses access to any streams
   due to a change in their [role](/help/roles-and-permissions).
+* [`GET /events`](/api/get-events): The `subscription` events for `op:
+  "peer_add"` are now sent to clients when a user gains access to a stream
+  due to a change in their role.
 
 **Feature level 204**
 

--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -694,6 +694,9 @@ user's profile.
   to the response. This generalizes and replaces the previous
   `muted_topics` array, which will no longer be sent if `user_topic`
   is included in `fetch_event_types`.
+* [`GET /events`](/api/get-events): When private streams are made
+  public, `stream` events for `op: "create"` and `subscription` events
+  for `op: "peer_add"` are now sent to clients.
 
 **Feature level 133**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -763,18 +763,25 @@ paths:
                                 }
                             - type: object
                               description: |
-                                Event sent to other users when users have been subscribed to
-                                streams. Sent to all users if the stream is public or to only
-                                the existing subscribers if the stream is private.
+                                Event sent when another user subscribes to a stream, or their
+                                subscription is newly visible to the current user.
 
-                                **Changes**: In Zulip 4.0 (feature level 35), the singular
-                                `user_id` and `stream_id` integers included in this event
-                                were replaced with plural `user_ids` and `stream_ids` integer
-                                arrays.
+                                When a user subscribes to a stream, the current user will receive this
+                                event only if they [have permission to see the stream's subscriber
+                                list](/help/stream-permissions). When the current user gains permission
+                                to see a given stream's subscriber list, they will receive this event
+                                for the existing subscriptions to the stream.
 
-                                In Zulip 3.0 (feature level 19), the `stream_id` field was
-                                added to identify the stream the user subscribed to,
-                                replacing the `name` field.
+                                **Changes**: Prior to Zulip 8.0 (feature level 205), this event was not
+                                sent when a user gained access to a stream due to their [role
+                                changing](/help/roles-and-permissions).
+
+                                In Zulip 4.0 (feature level 35), the singular `user_id` and `stream_id`
+                                integers included in this event were replaced with plural `user_ids` and
+                                `stream_ids` integer arrays.
+
+                                In Zulip 3.0 (feature level 19), the `stream_id` field was added to
+                                identify the stream the user subscribed to, replacing the `name` field.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -790,7 +797,7 @@ paths:
                                 stream_ids:
                                   type: array
                                   description: |
-                                    The IDs of the streams to which the user has subscribed.
+                                    The IDs of streams that have new or updated subscriber data.
 
                                     **Changes**: New in Zulip 4.0 (feature level 35), replacing
                                     the `stream_id` integer.
@@ -799,7 +806,8 @@ paths:
                                 user_ids:
                                   type: array
                                   description: |
-                                    The IDs of the users who subscribed.
+                                    The IDs of the users who are newly visible as subscribed to
+                                    the specified streams.
 
                                     **Changes**: New in Zulip 4.0 (feature level 35), replacing
                                     the `user_id` integer.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -776,6 +776,9 @@ paths:
                                 sent when a user gained access to a stream due to their [role
                                 changing](/help/roles-and-permissions).
 
+                                Prior to Zulip 6.0 (feature level 134), this event was not sent when a
+                                private stream was made public.
+
                                 In Zulip 4.0 (feature level 35), the singular `user_id` and `stream_id`
                                 integers included in this event were replaced with plural `user_ids` and
                                 `stream_ids` integer arrays.
@@ -1191,6 +1194,9 @@ paths:
                                 Prior to Zulip 8.0 (feature level 192), this event was not sent
                                 when guest users gained access to a public stream by being
                                 subscribed.
+
+                                Prior to Zulip 6.0 (feature level 134), this event was not sent
+                                when a private stream was made public.
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"


### PR DESCRIPTION
In commit ada2991f1c, when a user gains access to a stream due to a role change, in addition to sending `stream op: create` events, `subscription op: peer_add` events are sent for streams that the user gains access to due to their role change.

Updates the API changelog entry for feature level 205 and the `subcription op: peer_add` event documentation for this change.

**Notes**:
- I updated the `user_ids` and `stream_ids` field descriptions in the event documentation for the role change case as the general case description wasn't quite accurate.
- This API change has been merged, but I don't know if it warrants a discussion in **#api design** since the definition of the `subcription op: peer_add` event has changed a bit.

@sahil839 mentioning you for a review of these documentation udpates, and for your thoughts on whether to start a discussion on CZO.

---

**Screenshots and screen captures:**

<details>
<summary>API changelog - feature level 205</summary>

[Current documentation](https://chat.zulip.org/api/changelog)
![Screenshot from 2023-09-05 13-39-11](https://github.com/zulip/zulip/assets/63245456/562b41c3-c208-4b9c-adc3-63c2555c162a)
</details>
<details>
<summary>Events: subscription op: peer_add</summary>

[Current documentation](https://zulip.com/api/get-events#subscription-peer_add)
![Screenshot from 2023-09-05 13-39-26](https://github.com/zulip/zulip/assets/63245456/8a19d97a-739f-4a63-acfe-0550c0001242)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
