### PR TITLE
widgets: Fix bug where a new line right after /todo broke rendering.

### DIFF
--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -8,7 +8,7 @@ from zerver.models import Message, SubMessage
 
 def get_widget_data(content: str) -> Tuple[Optional[str], Optional[str]]:
     valid_widget_types = ["poll", "todo"]
-    tokens = content.split(" ")
+    tokens = re.split(r"\s+|\n+", content)
 
     # tokens[0] will always exist
     if tokens[0].startswith("/"):


### PR DESCRIPTION
When there was no space right after `/todo` but there was content on a new line, the message would be rendered plainly, not as a todo widget. This was because we split on only the space character to then check if the first token was a valid widget.

Now we split on both spaces and newlines to extract the widget name, irrespective of whether it is followed by a space or a newline. This results in the message being rendered as a todo widget as expected.

Fixes: [Issue's CZO thread here](https://chat.zulip.org/#narrow/stream/9-issues/topic/.2Ftodo.20list.20bug.3F)

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/8fcf1151-2f31-467d-a534-c3ff5119f37c)

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
