### PR TITLE
postgres_exporter: Explicitly specify the zulip database.

### DIFF
--- a/puppet/zulip_ops/templates/supervisor/conf.d/prometheus_postgres_exporter.conf.template.erb
+++ b/puppet/zulip_ops/templates/supervisor/conf.d/prometheus_postgres_exporter.conf.template.erb
@@ -1,6 +1,6 @@
 [program:prometheus_postgres_exporter]
-command=<%= @bin %> --auto-discover-databases
-environment=DATA_SOURCE_NAME="postgresql://prometheus@:5432/postgres?host=/var/run/postgresql"
+command=<%= @bin %>
+environment=DATA_SOURCE_NAME="postgresql://prometheus@:5432/zulip?host=/var/run/postgresql"
 priority=10
 autostart=true
 autorestart=true


### PR DESCRIPTION
Some of the collectors (e.g. `pg_stat_user_tables`) don't appear to work with `--auto-discover-databases`, which is deprecated since version 0.13.0[^1].

Explicitly set the database name.

[^1]: https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.13.0

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
