### PR TITLE
i18n: Fixes formatting of translated strings in `subscribe_to_more_streams` and `recent_topic_row` templates.

### DIFF
--- a/web/templates/recent_view_row.hbs
+++ b/web/templates/recent_view_row.hbs
@@ -4,7 +4,7 @@
             <div class="left_part recent_view_focusable">
                 {{#if is_private}}
                 <span class="fa fa-envelope"></span>
-                <a href="{{pm_url}}">Direct messages</a>
+                <a href="{{pm_url}}">{{t "Direct messages" }}</a>
                 {{else}}
                 <span class="stream-privacy-original-color-{{stream_id}} stream-privacy filter-icon" style="color: {{stream_color}}">
                     {{> stream_privacy }}

--- a/web/templates/subscribe_to_more_streams.hbs
+++ b/web/templates/subscribe_to_more_streams.hbs
@@ -1,16 +1,16 @@
 {{#if exactly_one_unsubscribed_stream}}
     <a href="#streams/all">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
-        {{~#tr}}Browse 1 more stream{{/tr~}}
+        {{~t "Browse 1 more stream" ~}}
     </a>
 {{else if can_subscribe_stream_count}}
     <a href="#streams/all">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
-        {{~#tr}}Browse {can_subscribe_stream_count} more streams{{/tr~}}
+        {{~t "Browse {can_subscribe_stream_count} more streams" ~}}
     </a>
 {{else if can_create_streams}}
     <a href="#streams/new">
         <i class="fa fa-plus-circle" aria-hidden="true"></i>
-        {{~t "Create a stream"~}}
+        {{~t "Create a stream" ~}}
     </a>
 {{/if}}

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -52,9 +52,9 @@ strip_whitespace_left = re.compile(
 )
 
 regexes = [
-    r"{{#tr}}([\s\S]*?)(?:{{/tr}}|{{#\*inline )",  # '.' doesn't match '\n' by default
-    r'{{\s*t "([\s\S]*?)"\W*}}',
-    r"{{\s*t '([\s\S]*?)'\W*}}",
+    r"{{~?#tr}}([\s\S]*?)(?:~?{{/tr}}|{{#\*inline )",  # '.' doesn't match '\n' by default
+    r'{{~?\s*t "([\s\S]*?)"\W*~?}}',
+    r"{{~?\s*t '([\s\S]*?)'\W*~?}}",
     r'\(t "([\s\S]*?)"\)',
     r'=\(t "([\s\S]*?)"\)(?=[^{]*}})',
     r"=\(t '([\s\S]*?)'\)(?=[^{]*}})",


### PR DESCRIPTION
Corrects the formatting of translated strings in two Handlebars templates: `subscribe_to_more_streams.hbs`,  `recent_topic_row.hbs`.

Fixes #26640.

**Recent topics - Direct messages**:
| Before | After |
| --- | --- |
| ![Screenshot from 2023-09-06 12-16-14](https://github.com/zulip/zulip/assets/63245456/80c19e22-8c47-4669-b8b0-c4f4052946ad) | ![Screenshot from 2023-09-06 12-16-01](https://github.com/zulip/zulip/assets/63245456/3a713c17-0589-479a-bbce-2e7ebdb5bd09) |

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
