### PR TITLE
billing: Rename a few confusing references to "Zulip Limited".

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -2735,7 +2735,7 @@ class StripeTest(StripeTestCase):
                 response = self.client_get("/billing/")
                 self.assert_in_success_response(
                     [
-                        "Your plan will be downgraded to <strong>Zulip Limited</strong> on "
+                        "Your plan will be downgraded to <strong>Zulip Free</strong> on "
                         "<strong>January 2, 2013</strong>",
                         "You plan is scheduled for downgrade on <strong>January 2, 2013</strong>",
                         "Cancel downgrade",

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -54,7 +54,7 @@
                                 Your plan will be upgraded to <strong>{{ plan_name }}</strong> on <strong>{{ renewal_date }}</strong> for
                                 <strong>${{ renewal_amount }}</strong>.
                                 {% elif downgrade_at_end_of_cycle %}
-                                Your plan will be downgraded to <strong>Zulip Limited</strong> on <strong>{{ renewal_date }}</strong>.
+                                Your plan will be downgraded to <strong>Zulip Free</strong> on <strong>{{ renewal_date }}</strong>.
                                 {% elif switch_to_annual_at_end_of_cycle %}
                                 Your plan will be switched from monthly to annual billing on <strong>{{ renewal_date }}</strong>.
                                 {% else %}
@@ -135,7 +135,7 @@
                                 <h3>Downgrade</h3>
                                 {% if free_trial %}
                                     <p>
-                                        End Free Trial and downgrade plan to <strong>Zulip Limited</strong>.
+                                        End Free Trial and downgrade plan to <strong>Zulip Free</strong>.
                                     </p>
                                     <input name="status" type="hidden" value="{{ CustomerPlan.ENDED }}" />
                                     <button class="btn-danger" id="change-plan-status">End free trial</button>
@@ -148,7 +148,7 @@
                                     <button class="btn-info" id="change-plan-status">Cancel downgrade</button>
                                     {% else %}
                                     <p>
-                                        Downgrade to <strong>Zulip Limited</strong> at the end of current billing period.
+                                        Downgrade to <strong>Zulip Free</strong> at the end of current billing period.
                                     </p>
                                     <input name="status" type="hidden" value="{{ CustomerPlan.DOWNGRADE_AT_END_OF_CYCLE }}" />
                                     <button class="btn-danger" id="change-plan-status">Start downgrade process</button>


### PR DESCRIPTION
We call this Free on the /plans page, not Limited

This is for this page when trying to downgrade, which says "Downgrade to Zulip Limited", which can be confusing (and we had a customer complain about not being whether this downgrade will cancel their subscription)
![image](https://github.com/zulip/zulip/assets/45007152/ad137353-66e7-4acd-8e72-d33df3233f2a)
