### PR TITLE
compose: Allow the user to direct message bots despite of policy.

### DIFF
--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -15,6 +15,7 @@ import * as dropdown_widget from "./dropdown_widget";
 import {$t} from "./i18n";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
+import * as people from "./people";
 import * as settings_config from "./settings_config";
 import * as stream_bar from "./stream_bar";
 import * as stream_data from "./stream_data";
@@ -110,10 +111,8 @@ export function update_on_recipient_change() {
 
 export function get_posting_policy_error_message() {
     if (selected_recipient_id === "direct") {
-        if (
-            page_params.realm_private_message_policy ===
-            settings_config.private_message_policy_values.disabled.code
-        ) {
+        const recipients = compose_pm_pill.get_user_ids_string();
+        if (!people.user_can_direct_message(recipients)) {
             return $t({
                 defaultMessage: "Direct messages are disabled in this organization.",
             });

--- a/web/src/compose_recipient.js
+++ b/web/src/compose_recipient.js
@@ -114,7 +114,7 @@ export function get_posting_policy_error_message() {
         const recipients = compose_pm_pill.get_user_ids_string();
         if (!people.user_can_direct_message(recipients)) {
             return $t({
-                defaultMessage: "Direct messages are disabled in this organization.",
+                defaultMessage: "You are not allowed to send direct messages in this organization.",
             });
         }
         return "";

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -295,7 +295,7 @@ export function user_ids_string_to_emails_string(user_ids_string: string): strin
 }
 
 export function user_ids_string_to_ids_array(user_ids_string: string): number[] {
-    const user_ids = user_ids_string.split(",");
+    const user_ids = user_ids_string.length === 0 ? [] : user_ids_string.split(",");
     const ids = user_ids.map(Number);
     return ids;
 }

--- a/web/tests/compose_actions.test.js
+++ b/web/tests/compose_actions.test.js
@@ -27,7 +27,9 @@ const compose_fade = mock_esm("../src/compose_fade", {
     set_focused_recipient: noop,
     update_all: noop,
 });
-const compose_pm_pill = mock_esm("../src/compose_pm_pill");
+const compose_pm_pill = mock_esm("../src/compose_pm_pill", {
+    get_user_ids_string: () => "",
+});
 const compose_ui = mock_esm("../src/compose_ui", {
     autosize_textarea: noop,
     is_full_size: () => false,


### PR DESCRIPTION
<!-- Describe your pull request here.-->
After the changes in https://github.com/zulip/zulip/pull/25572, users were no longer able to start a direct
message with bots if the organization disabled direct messages. However,
we should allow direct messages to bots regardless of the policy because
it's a useful interface for users to interact with various classes of
bots.

user_ids_string_to_ids_array was also modified to prevent cases where
the split function returned an array of [0] rather than [] when dealing
with a empty id string of "".

Fixes: #21896.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/62449508/fbed6359-c774-44d7-ab1f-cf712085e115)
![image](https://github.com/zulip/zulip/assets/62449508/83212af4-36a1-44b5-9889-99ae7ad879b0)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
