### PR TITLE
help: Add "Troubleshooting" section to mobile notifications page.

### DIFF
--- a/help/mobile-notifications.md
+++ b/help/mobile-notifications.md
@@ -35,6 +35,14 @@ notifications while you are actively using one of the Zulip apps.
 
 {end_tabs}
 
+## Troubleshooting mobile notifications
+
+Some Android vendors have added extra device-level settings that can impact the
+delivery of mobile notifications to apps like Zulip. If you're having issues
+with Zulip notifications on your Android phone, we recommend Signal's excellent
+[troubleshooting guide](https://support.signal.org/hc/en-us/articles/360007318711-Troubleshooting-Notifications#android_notifications_troubleshooting),
+which explains the notification settings for many popular Android vendors.
+
 ## Related articles
 
 * [Stream notifications](/help/stream-notifications)


### PR DESCRIPTION
As discussed in [CZO thread](https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/.E2.9C.94.20inconsistent.20notifications/near/1631712), this PR adds a new section to the [Mobile notifications](https://zulip.com/help/mobile-notifications) page including a link to [Signal's Android troubleshooting guide](https://support.signal.org/hc/en-us/articles/360007318711-Troubleshooting-Notifications#android_notifications_troubleshooting) as a useful external resource.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/45df0e7a-1e89-49fb-bf2e-a201ac60ccae)