### PR TITLE
compose_banner: Remove the warning for messages sent in FOLLOWED topics in muted stream.

### DIFF
--- a/web/src/notifications.js
+++ b/web/src/notifications.js
@@ -583,7 +583,7 @@ export function get_muted_narrow(message) {
     if (
         message.type === "stream" &&
         stream_data.is_muted(message.stream_id) &&
-        !user_topics.is_topic_unmuted(message.stream_id, message.topic)
+        !user_topics.is_topic_unmuted_or_followed(message.stream_id, message.topic)
     ) {
         return "stream";
     }

--- a/web/src/user_topics.js
+++ b/web/src/user_topics.js
@@ -63,6 +63,10 @@ export function is_topic_muted(stream_id, topic) {
     return get_topic_visibility_policy(stream_id, topic) === all_visibility_policies.MUTED;
 }
 
+export function is_topic_unmuted_or_followed(stream_id, topic) {
+    return is_topic_unmuted(stream_id, topic) || is_topic_followed(stream_id, topic);
+}
+
 export function get_user_topics_for_visibility_policy(visibility_policy) {
     const topics = [];
     for (const [stream_id, sub_dict] of all_user_topics) {


### PR DESCRIPTION
[**CZO Report**](https://chat.zulip.org/#narrow/stream/9-issues/topic/muted.20stream.20notice/near/1635312)

Earlier, when a message was sent in a `followed topic` in a `muted stream`, a compose banner warning with a suggestion to `UNMUTE` the topic was shown.

<details><summary>Compose banner warning</summary>
<img width="872" alt="compose-banner-warning" src="https://github.com/zulip/zulip/assets/56781761/52c33f6f-5ec6-4945-ba62-b2025efe53c8">
">
</details> 

This PR fixes the incorrect behavior. No warning is shown in the case mentioned above.

<!-- Describe your pull request here.-->


<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

[compose-banner.webm](https://github.com/zulip/zulip/assets/56781761/f548d4e3-af16-4178-a410-6384854de7ab)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
