### PR TITLE
models: Remove duplicate index definition for date_sent

### DIFF
--- a/zerver/migrations/0244_message_copy_pub_date_to_date_sent.py
+++ b/zerver/migrations/0244_message_copy_pub_date_to_date_sent.py
@@ -79,8 +79,19 @@ class Migration(migrations.Migration):
         """
         ),
         migrations.RunPython(copy_pub_date_to_date_sent, elidable=True),
-        AddIndexConcurrently(
-            model_name="message",
-            index=models.Index("date_sent", name="zerver_message_date_sent_3b5b05d8"),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                AddIndexConcurrently(
+                    model_name="message",
+                    index=models.Index("date_sent", name="zerver_message_date_sent_3b5b05d8"),
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="message",
+                    name="date_sent",
+                    field=models.DateTimeField(db_index=True, null=True, verbose_name="date sent"),
+                ),
+            ],
         ),
     ]

--- a/zerver/migrations/0245_message_date_sent_finalize_part1.py
+++ b/zerver/migrations/0245_message_date_sent_finalize_part1.py
@@ -13,19 +13,16 @@ class Migration(migrations.Migration):
             """
             DROP TRIGGER zerver_message_date_sent_to_pub_date_trigger ON zerver_message;
             DROP FUNCTION zerver_message_date_sent_to_pub_date_trigger_function();
-
-            ALTER TABLE zerver_message ALTER COLUMN date_sent SET NOT NULL;
-            ALTER TABLE zerver_message ALTER COLUMN pub_date DROP NOT NULL;
-            """,
-            state_operations=[
-                # This just tells Django to, after running the above SQL, consider the AlterField below
-                # as done. The building of the index actually happened in the previous migration, not here,
-                # but nevertheless this seems like the correct place to put this fake AlterField.
-                migrations.AlterField(
-                    model_name="message",
-                    name="date_sent",
-                    field=models.DateTimeField(db_index=True, verbose_name="date sent"),
-                ),
-            ],
+            """
+        ),
+        migrations.AlterField(
+            model_name="message",
+            name="date_sent",
+            field=models.DateTimeField(db_index=True, verbose_name="date sent"),
+        ),
+        migrations.AlterField(
+            model_name="message",
+            name="pub_date",
+            field=models.DateTimeField(db_index=True, null=True, verbose_name="date published"),
         ),
     ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -3070,7 +3070,6 @@ class Message(AbstractMessage):
         indexes = [
             GinIndex("search_tsvector", fastupdate=False, name="zerver_message_search_tsvector"),
             models.Index(Upper("subject"), name="upper_subject_idx"),
-            models.Index("date_sent", name="zerver_message_date_sent_3b5b05d8"),
             models.Index(
                 "recipient",
                 Upper("subject"),


### PR DESCRIPTION
Commit cf0eb46afcb22a236211ee2b3e3d23b8ef924eab (#21222) added this to let Django understand the `CREATE INDEX CONCURRENTLY` statement that had been hidden in a RunSQL query in migration 0244.  However, migration 0245 explained that same index to Django in a different way by setting `db_index=True`.  Move that to 0244 where the index is actually created, using `SeparateDatabaseAndState`.

Also remove the part of the SQL that was mirrored by dummy `state_operations`, and replace it with real operations.

[Discussion](https://chat.zulip.org/#narrow/stream/3-backend/topic/django.20migrations/near/1636383).