### PR TITLE
message_body: Allow sender name to be selected.

### DIFF
--- a/web/src/copy_and_paste.js
+++ b/web/src/copy_and_paste.js
@@ -132,7 +132,7 @@ export function copy_handler() {
     // `Ctrl+C` in Zulip (note that this is totally independent of the
     // "select region" copy behavior on Linux; that is handled
     // entirely by the browser, our HTML layout, and our use of the
-    // no-select/auto-select CSS classes).  We put considerable effort
+    // no-select CSS classes).  We put considerable effort
     // into producing a nice result that pastes well into other tools.
     // Our user-facing specification is the following:
     //

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -1406,7 +1406,6 @@
     .new-style label.checkbox input[type="checkbox"]:focus ~ span,
     i.fa:focus,
     i.zulip-icon:focus,
-    .auto-select:focus,
     [role="button"]:focus {
         outline-color: hsl(0deg 0% 67%);
     }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -380,10 +380,6 @@ pre {
     user-select: none;
 }
 
-.auto-select {
-    user-select: auto;
-}
-
 .text-select {
     user-select: text;
 }
@@ -868,7 +864,6 @@ button:focus,
 .new-style label.checkbox input[type="checkbox"]:focus ~ span,
 i.fa:focus,
 i.zulip-icon:focus-visible,
-.auto-select:focus,
 [role="button"]:focus {
     outline: 2px solid var(--color-outline-focus);
     /* TODO: change solid to auto once the Chromium bug #1105822 is fixed */

--- a/web/templates/edited_notice.hbs
+++ b/web/templates/edited_notice.hbs
@@ -1,13 +1,13 @@
 {{#if msg/local_edit_timestamp}}
-<div class="message_edit_notice auto-select" data-tippy-content="{{t 'Last edited {last_edit_timestr}' }}">
+<div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}' }}">
     {{t "SAVING" }}
 </div>
 {{else if moved}}
-<div class="message_edit_notice auto-select" data-tippy-content="{{t 'Last moved {last_edit_timestr}' }}">
+<div class="message_edit_notice" data-tippy-content="{{t 'Last moved {last_edit_timestr}' }}">
     {{t "MOVED" }}
 </div>
 {{else}}
-<div class="message_edit_notice auto-select" data-tippy-content="{{t 'Last edited {last_edit_timestr}' }}">
+<div class="message_edit_notice" data-tippy-content="{{t 'Last edited {last_edit_timestr}' }}">
     {{t "EDITED" }}
 </div>
 {{/if}}

--- a/web/templates/message_avatar.hbs
+++ b/web/templates/message_avatar.hbs
@@ -1,4 +1,4 @@
-<div class="u-{{msg/sender_id}} message-avatar sender_info_hover view_user_card_tooltip" aria-hidden="true" data-tooltip-template-id="view-user-card-tooltip-template">
+<div class="u-{{msg/sender_id}} message-avatar sender_info_hover view_user_card_tooltip no-select" aria-hidden="true" data-tooltip-template-id="view-user-card-tooltip-template">
     <div class="inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}">
         <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
     </div>

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -1,7 +1,7 @@
 {{#if include_sender}}
     {{> message_avatar ~}}
 {{/if}}
-<span class="message_sender no-select">
+<span class="message_sender">
     {{#if include_sender}}
         <span class="sender_info_hover sender_name auto-select" role="button" tabindex="0">
             <span class="view_user_card_tooltip inline-status-emoji" data-tooltip-template-id="view-user-card-tooltip-template">

--- a/web/templates/message_body.hbs
+++ b/web/templates/message_body.hbs
@@ -3,7 +3,7 @@
 {{/if}}
 <span class="message_sender">
     {{#if include_sender}}
-        <span class="sender_info_hover sender_name auto-select" role="button" tabindex="0">
+        <span class="sender_info_hover sender_name" role="button" tabindex="0">
             <span class="view_user_card_tooltip inline-status-emoji" data-tooltip-template-id="view-user-card-tooltip-template">
                 {{msg/sender_full_name}}
                 {{#unless status_message}}
@@ -15,7 +15,7 @@
         <i class="zulip-icon zulip-icon-bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}
         {{#if status_message}}
-            <span class="rendered_markdown status-message auto-select">{{rendered_markdown status_message}}</span>
+            <span class="rendered_markdown status-message">{{rendered_markdown status_message}}</span>
             {{#if edited_status_msg}}
                 {{> edited_notice}}
             {{/if}}


### PR DESCRIPTION
This allows message content in `/me` messages to be selected as well since the content in `/me` messages is a part of `sender_name`.