### PR TITLE
message_scroll: Update sticky header date more frequently.

### DIFF
--- a/web/src/message_scroll.js
+++ b/web/src/message_scroll.js
@@ -139,6 +139,7 @@ export function initialize() {
         "scroll",
         _.throttle(() => {
             unread_ops.process_visible();
+            message_lists.current.view.update_sticky_recipient_headers();
             scroll_finish();
         }, 50),
     );


### PR DESCRIPTION
To make the date change in recipient header more smooth, we update it with throttled scroll event. This can cause some performance regressions on slow computers during scrolling but nothing I can notice even with 6x CPU slowdown on Intel i7 on mac.

This is an alternative to #25163 since implementing it seems harder than expected. The date changing animation cannot be made smooth without serious structural changes to how messages are rendered.
