### PR TITLE
[WIP] message_row: Remove mentioned background color date row.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -471,7 +471,9 @@ $time_column_min_width: 42px; /* + padding */
        for details on how this works */
     .message_row.unread {
         .date_unread_marker {
-            display: none;
+            .unread-marker-fill {
+                opacity: 0;
+            }
         }
     }
 
@@ -479,7 +481,56 @@ $time_column_min_width: 42px; /* + padding */
        and remove the properties set from the previous rule. */
     .message_row.unread ~ .message_row.unread {
         .date_unread_marker {
+            .unread-marker-fill {
+                opacity: 1;
+            }
+        }
+    }
+
+    /* Don't apply mention background color message date row if the previous
+       message don't have user mentioned. */
+    .message_row:not(.direct_mention) + .message_row.direct_mention {
+        /* Since message left border is 1px and unread marker is 2px,
+            we leave 1px transparent so that the border is visible. */
+        .date_unread_marker {
+            background: linear-gradient(
+                to right,
+                transparent,
+                var(--color-background-stream-message-content) 50% 100%
+            );
+        }
+
+        .date_row {
+            background: var(--color-background-stream-message-content);
+        }
+
+        &:not(.unread) .date_unread_marker {
             display: block;
+            opacity: 1;
+
+            .unread-marker-fill {
+                transition: all 2s ease-out;
+                opacity: 0;
+            }
+        }
+
+        .unread .date_unread_marker .unread-marker-fill {
+            opacity: 1;
+        }
+    }
+
+    .message_row:not(.direct_mention)
+        + .message_row.direct_mention.private-message {
+        .date_unread_marker {
+            background: linear-gradient(
+                to right,
+                transparent,
+                var(--color-background-private-message-content) 50% 100%
+            );
+        }
+
+        .date_row {
+            background: var(--color-background-private-message-content);
         }
     }
 }


### PR DESCRIPTION
If the messages row is the first one where user is mentioned and it has a date row, then we don't change the background color of the date row.

before: 
![image](https://github.com/zulip/zulip/assets/25124304/5ecc9314-57e9-4f0f-8b50-da115bbc7d50)

after:
<img width="649" alt="image" src="https://github.com/zulip/zulip/assets/25124304/4564d345-5ca5-4d73-aab3-1948771a2cfa">
<img width="641" alt="image" src="https://github.com/zulip/zulip/assets/25124304/a6048544-4210-47a1-8401-ed29923efd50">
<img width="654" alt="image" src="https://github.com/zulip/zulip/assets/25124304/8b1d6c79-0996-4fd6-b6ab-727eeb5fccdc">



discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/message.20highlights