### PR TITLE
test-js-with-node: Remove deleted dropdown-list-widget module.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -83,7 +83,6 @@ EXEMPT_FILES = make_set(
         "web/src/desktop_integration.js",
         "web/src/dialog_widget.ts",
         "web/src/drafts.js",
-        "web/src/dropdown_list_widget.js",
         "web/src/dropdown_widget.js",
         "web/src/echo.js",
         "web/src/emoji_picker.js",


### PR DESCRIPTION
Fixes #25741

@timabbott  looks like this is the only things that needs to removed from [that](https://github.com/zulip/zulip/issues/25741#issuecomment-1712331240) list.