### PR TITLE
help: Document `unarchive_stream` management command.

### DIFF
--- a/docs/production/management-commands.md
+++ b/docs/production/management-commands.md
@@ -125,6 +125,9 @@ There are dozens of useful management commands under
 - `./manage.py export_single_user`: does a limited version of the [main
   export tools](export-and-import.md) containing just
   the messages accessible by a single user.
+- `./manage.py unarchive_stream`:
+  [Reactivates](https://zulip.com/help/archive-a-stream#unarchiving-archived-streams)
+  an archived stream.
 - `./manage.py reactivate_realm`: Reactivates a realm.
 - `./manage.py deactivate_user`: Deactivates a user. This can be done
   more easily in Zulip's organization administrator UI.

--- a/help/add-or-remove-users-from-a-stream.md
+++ b/help/add-or-remove-users-from-a-stream.md
@@ -130,7 +130,7 @@ subscribe the user.
 !!! tip ""
 
     You can also hover over a stream in the left sidebar, click on the
-    **ellipsis** (<i class="zulip-icon zulip-icon-ellipsis-v-solid"></i>), and
+    **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>), and
     select **Stream settings** to access the **Subscribers** tab.
 
 {end_tabs}

--- a/help/archive-a-stream.md
+++ b/help/archive-a-stream.md
@@ -13,24 +13,33 @@ messages and topics in the stream may or may not continue to work.
 In most cases, we recommend [renaming streams](/help/rename-a-stream) rather
 than archiving them.
 
-### Archive a stream
+## Archive a stream
 
 {start_tabs}
+
+{tab|desktop-web}
 
 {relative|stream|all}
 
 1. Select a stream.
 
-1. Click the <i class="fa fa-trash-o"></i> on the right.
+1. Click the **trash** <i class="fa fa-trash-o"></i> icon near the top right
+   corner of the stream settings panel.
 
 1. Approve by clicking **Confirm**.
+
+!!! tip ""
+
+    You can also hover over a stream in the left sidebar, click on the
+    **ellipsis** (<i class="zulip-icon zulip-icon-more-vertical"></i>), and
+    select **Stream settings** to access the **trash**
+    <i class="fa fa-trash-o"></i> icon.
 
 {end_tabs}
 
 !!! warn ""
 
-    Archiving a stream is currently irreversible, but we plan to add support
-    for unarchiving streams in the future.
+    Archiving a stream is currently irreversible via the UI.
 
 ## Related articles
 
@@ -38,3 +47,4 @@ than archiving them.
 * [Delete a message](/help/delete-a-message)
 * [Delete a topic](/help/delete-a-topic)
 * [Message retention policy](/help/message-retention-policy)
+* [Stream permissions](/help/stream-permissions)

--- a/help/archive-a-stream.md
+++ b/help/archive-a-stream.md
@@ -41,6 +41,17 @@ than archiving them.
 
     Archiving a stream is currently irreversible via the UI.
 
+## Unarchiving archived streams
+
+If you are self-hosting, you can unarchive an archived stream using the
+`unarchive_stream` [management command][management-command]. This will restore
+it as a private stream with shared history, and subscribe all organization
+owners to it. If you are using Zulip Cloud, you can [contact us](/help/contact-support)
+for help.
+
+[management-command]:
+https://zulip.readthedocs.io/en/latest/production/management-commands.html#other-useful-manage-py-commands
+
 ## Related articles
 
 * [Edit a message](/help/edit-a-message)
@@ -48,3 +59,4 @@ than archiving them.
 * [Delete a topic](/help/delete-a-topic)
 * [Message retention policy](/help/message-retention-policy)
 * [Stream permissions](/help/stream-permissions)
+* [Zulip Cloud or self-hosting?](/help/zulip-cloud-or-self-hosting)

--- a/zerver/actions/streams.py
+++ b/zerver/actions/streams.py
@@ -158,7 +158,7 @@ def deactivated_streams_by_old_name(realm: Realm, stream_name: str) -> QuerySet[
 
 
 @transaction.atomic(savepoint=False)
-def do_reactivate_stream(
+def do_unarchive_stream(
     stream: Stream, new_name: str, *, acting_user: Optional[UserProfile]
 ) -> None:
     realm = stream.realm

--- a/zerver/management/commands/unarchive_stream.py
+++ b/zerver/management/commands/unarchive_stream.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from django.core.management.base import CommandError
 
-from zerver.actions.streams import deactivated_streams_by_old_name, do_reactivate_stream
+from zerver.actions.streams import deactivated_streams_by_old_name, do_unarchive_stream
 from zerver.lib.management import ZulipBaseCommand
 from zerver.models import RealmAuditLog, Stream
 
@@ -88,4 +88,4 @@ class Command(ZulipBaseCommand):
             )
 
         assert stream is not None
-        do_reactivate_stream(stream, new_name, acting_user=None)
+        do_unarchive_stream(stream, new_name, acting_user=None)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -32,7 +32,7 @@ from zerver.actions.streams import (
     do_change_stream_group_based_setting,
     do_change_stream_post_policy,
     do_deactivate_stream,
-    do_reactivate_stream,
+    do_unarchive_stream,
 )
 from zerver.actions.user_groups import add_subgroups_to_user_group, check_add_user_group
 from zerver.actions.users import do_change_user_role, do_deactivate_user
@@ -1444,19 +1444,19 @@ class StreamAdminTest(ZulipTestCase):
         old_style.save()
         self.assertEqual(set(deactivated_streams_by_old_name(realm, "old_style")), {old_style})
 
-    def test_reactivate_stream_active_stream(self) -> None:
+    def test_unarchive_stream_active_stream(self) -> None:
         stream = self.make_stream("new_stream")
         with self.assertRaisesRegex(JsonableError, "Stream is not currently deactivated"):
-            do_reactivate_stream(stream, new_name="new_stream", acting_user=None)
+            do_unarchive_stream(stream, new_name="new_stream", acting_user=None)
 
-    def test_reactivate_stream_existing_name(self) -> None:
+    def test_unarchive_stream_existing_name(self) -> None:
         stream = self.make_stream("new_stream")
         self.make_stream("existing")
         do_deactivate_stream(stream, acting_user=None)
         with self.assertRaisesRegex(JsonableError, "Stream named existing already exists"):
-            do_reactivate_stream(stream, new_name="existing", acting_user=None)
+            do_unarchive_stream(stream, new_name="existing", acting_user=None)
 
-    def test_reactivate_stream(self) -> None:
+    def test_unarchive_stream(self) -> None:
         desdemona = self.example_user("desdemona")
         iago = self.example_user("iago")
         hamlet = self.example_user("hamlet")
@@ -1467,7 +1467,7 @@ class StreamAdminTest(ZulipTestCase):
         self.subscribe(cordelia, stream.name)
         do_deactivate_stream(stream, acting_user=None)
         with self.capture_send_event_calls(expected_num_events=4) as events:
-            do_reactivate_stream(stream, new_name="new_stream", acting_user=None)
+            do_unarchive_stream(stream, new_name="new_stream", acting_user=None)
 
         # Tell all admins and owners that the stream exists
         self.assertEqual(events[0]["event"]["op"], "create")


### PR DESCRIPTION
As discussed in [CZO thread](https://chat.zulip.org/#narrow/stream/101-design/topic/unarchiving.20streams/near/1636451), this PR updates the [Archive a stream](https://zulip.com/help/archive-a-stream) help center page, and documents the `unarchive_stream` [management command](https://zulip.readthedocs.io/en/latest/production/management-commands.html#other-useful-manage-py-commands) in the contributor docs.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/2343554/7a1981d5-181e-42e8-bffb-30e813bd7c29)

![image](https://github.com/zulip/zulip/assets/2343554/76f474b2-0c9a-4751-adf5-7e7d52a8aacd)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>