### PR TITLE
push_notifs: Add endpoint for sending a test notification.

### DIFF
--- a/api_docs/changelog.md
+++ b/api_docs/changelog.md
@@ -20,6 +20,11 @@ format used by the Zulip server that they are interacting with.
 
 ## Changes in Zulip 8.0
 
+**Feature level 217**
+
+* [`POST /mobile_push/test_notification`](/api/test-notify): Added new endpoint
+  to send a test push notification to a mobile device or devices.
+
 **Feature level 216**:
 
 * `PATCH /realm`, [`POST register`](/api/register-queue),

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -233,7 +233,7 @@ def check_banned_words(text: str) -> List[str]:
         if word in lower_cased_text:
             # Hack: Should move this into BANNED_WORDS framework; for
             # now, just hand-code the skips:
-            if "realm_name" in lower_cased_text:
+            if "realm_name" in lower_cased_text or "realm_uri" in lower_cased_text:
                 continue
             kwargs = dict(word=word, text=text, reason=reason)
             msg = "{word} found in '{text}'. {reason}".format(**kwargs)

--- a/version.py
+++ b/version.py
@@ -33,7 +33,7 @@ DESKTOP_WARNING_VERSION = "5.9.3"
 # Changes should be accompanied by documentation explaining what the
 # new level means in api_docs/changelog.md, as well as "**Changes**"
 # entries in the endpoint's documentation in `zulip.yaml`.
-API_FEATURE_LEVEL = 216
+API_FEATURE_LEVEL = 217
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -25,6 +25,8 @@ class ErrorCode(Enum):
     CSRF_FAILED = auto()
     INVITATION_FAILED = auto()
     INVALID_ZULIP_SERVER = auto()
+    INVALID_PUSH_DEVICE_TOKEN = auto()
+    INVALID_REMOTE_PUSH_DEVICE_TOKEN = auto()
     INVALID_MARKDOWN_INCLUDE_STATEMENT = auto()
     REQUEST_CONFUSING_VAR = auto()
     INVALID_API_KEY = auto()

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -34,7 +34,7 @@ from typing_extensions import TypeAlias, override
 
 from zerver.lib.avatar import absolute_avatar_url
 from zerver.lib.emoji_utils import hex_codepoint_to_emoji
-from zerver.lib.exceptions import JsonableError
+from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.message import access_message, huddle_users
 from zerver.lib.outgoing_http import OutgoingSession
 from zerver.lib.remote_server import send_json_to_push_bouncer, send_to_push_bouncer
@@ -1251,3 +1251,27 @@ def send_test_push_notification(user_profile: UserProfile, devices: List[PushDev
     send_test_push_notification_directly_to_devices(
         user_identity, devices, base_payload, remote=None
     )
+
+
+class InvalidPushDeviceTokenError(JsonableError):
+    code = ErrorCode.INVALID_PUSH_DEVICE_TOKEN
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Device not recognized")
+
+
+class InvalidRemotePushDeviceTokenError(JsonableError):
+    code = ErrorCode.INVALID_REMOTE_PUSH_DEVICE_TOKEN
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    @override
+    def msg_format() -> str:
+        return _("Device not recognized by the push bouncer")

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -92,6 +92,17 @@ def send_to_push_bouncer(
             raise PushNotificationBouncerError(
                 _("Push notifications bouncer error: {error}").format(error=msg)
             )
+        elif (
+            endpoint == "push/test_notification"
+            and "code" in result_dict
+            and result_dict["code"] == "INVALID_REMOTE_PUSH_DEVICE_TOKEN"
+        ):
+            # This error from the notification debugging endpoint should just be directly
+            # communicated to the device.
+            # TODO: Extend this to use a more general mechanism when we add more such error responses.
+            from zerver.lib.push_notifications import InvalidRemotePushDeviceTokenError
+
+            raise InvalidRemotePushDeviceTokenError
         else:
             # But most other errors coming from the push bouncer
             # server are client errors (e.g. never-registered token)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9142,6 +9142,54 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SimpleSuccess"
+  /mobile_push/test_notification:
+    post:
+      operationId: test-notify
+      summary: Sends a test notifications to the user's mobile device(s)
+      tags: ["mobile"]
+      description: |
+        This endpoint allows a user to trigger a test push notification to their
+        selected mobile devices, or all their mobile devices.
+
+        **Changes**: New in Zulip 8.0 (feature level 217).
+      parameters:
+        - name: token
+          in: query
+          description: |
+            The push token for the device to send the test notification to.
+
+            If this parameter is not submitted, the test notification will be sent to all of the
+            user's devices registered on the server.
+
+            Mobile device clients should pass this parameter in order to trigger a notification
+            that is only delivered to this client.
+          schema:
+            type: string
+          example: "111222"
+          required: false
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonSuccess"
+        "400":
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "msg": "Token does not exist",
+                        "result": "error",
+                      }
+                    description: |
+                      An example JSON response for when a device with the specified token
+                      does not exist:
   /user_topics:
     post:
       operationId: update-user-topic

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9175,21 +9175,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/JsonSuccess"
         "400":
-          description: Bad request.
+          description: |
+            Bad request.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: "#/components/schemas/CodedError"
-                  - example:
-                      {
-                        "code": "BAD_REQUEST",
-                        "msg": "Token does not exist",
-                        "result": "error",
-                      }
-                    description: |
-                      An example JSON response for when a device with the specified token
-                      does not exist:
+                oneOf:
+                  - $ref: "#/components/schemas/InvalidPushDeviceTokenError"
+                  - $ref: "#/components/schemas/InvalidRemotePushDeviceTokenError"
   /user_topics:
     post:
       operationId: update-user-topic
@@ -19619,6 +19612,33 @@ components:
             before Zulip 5.0 (feature level 76).
 
             A typical failed json response for when user's organization is deactivated:
+    InvalidPushDeviceTokenError:
+      allOf:
+        - $ref: "#/components/schemas/CodedError"
+        - example:
+            {
+              "code": "INVALID_PUSH_DEVICE_TOKEN",
+              "msg": "Device not recognized",
+              "result": "error",
+            }
+          description: |
+            ## Invalid push device token
+
+            A typical failed JSON response for when the push device token is invalid:
+    InvalidRemotePushDeviceTokenError:
+      allOf:
+        - $ref: "#/components/schemas/CodedError"
+        - example:
+            {
+              "code": "INVALID_REMOTE_PUSH_DEVICE_TOKEN",
+              "msg": "Device not recognized by the push bouncer",
+              "result": "error",
+            }
+          description: |
+            ## Invalid push device token
+
+            A typical failed JSON response for when the push device token is not recognized
+            by the push notification bouncer:
 
   ###################
   # Shared responses

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1028,6 +1028,7 @@ class OpenAPIAttributesTest(ZulipTestCase):
             "drafts",
             "webhooks",
             "scheduled_messages",
+            "mobile",
         ]
         paths = OpenAPISpec(OPENAPI_SPEC_PATH).openapi()["paths"]
         for path, path_item in paths.items():

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext as _
 from zerver.decorator import human_users_only
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.push_notifications import (
+    InvalidPushDeviceTokenError,
     add_push_device_token,
     b64_to_hex,
     remove_push_device_token,
@@ -83,7 +84,7 @@ def send_test_push_notification_api(
         try:
             devices = [PushDeviceToken.objects.get(token=token, user=user_profile)]
         except PushDeviceToken.DoesNotExist:
-            raise JsonableError(_("Token does not exist"))
+            raise InvalidPushDeviceTokenError
     else:
         devices = list(PushDeviceToken.objects.filter(user=user_profile))
 

--- a/zerver/views/push_notifications.py
+++ b/zerver/views/push_notifications.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import gettext as _
@@ -8,6 +10,7 @@ from zerver.lib.push_notifications import (
     add_push_device_token,
     b64_to_hex,
     remove_push_device_token,
+    send_test_push_notification,
 )
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
@@ -65,4 +68,25 @@ def remove_android_reg_id(
 ) -> HttpResponse:
     validate_token(token, PushDeviceToken.GCM)
     remove_push_device_token(user_profile, token, PushDeviceToken.GCM)
+    return json_success(request)
+
+
+@human_users_only
+@has_request_variables
+def send_test_push_notification_api(
+    request: HttpRequest, user_profile: UserProfile, token: Optional[str] = REQ(default=None)
+) -> HttpResponse:
+    # If a token is specified in the request, the test notification is supposed to be sent
+    # to that device. If no token is provided, the test notification should be sent to
+    # all devices registered for the user.
+    if token is not None:
+        try:
+            devices = [PushDeviceToken.objects.get(token=token, user=user_profile)]
+        except PushDeviceToken.DoesNotExist:
+            raise JsonableError(_("Token does not exist"))
+    else:
+        devices = list(PushDeviceToken.objects.filter(user=user_profile))
+
+    send_test_push_notification(user_profile, devices)
+
     return json_success(request)

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -11,6 +11,7 @@ from zilencer.views import (
     remote_server_check_analytics,
     remote_server_notify_push,
     remote_server_post_analytics,
+    remote_server_send_test_notification,
     unregister_all_remote_push_devices,
     unregister_remote_push_device,
 )
@@ -23,6 +24,7 @@ push_bouncer_patterns = [
     remote_server_path("remotes/push/unregister", POST=unregister_remote_push_device),
     remote_server_path("remotes/push/unregister/all", POST=unregister_all_remote_push_devices),
     remote_server_path("remotes/push/notify", POST=remote_server_notify_push),
+    remote_server_path("remotes/push/test_notification", POST=remote_server_send_test_notification),
     # Push signup doesn't use the REST API, since there's no auth.
     path("remotes/server/register", register_remote_server),
     remote_server_path("remotes/server/deactivate", POST=deactivate_remote_server),

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -22,6 +22,7 @@ from corporate.lib.stripe import do_deactivate_remote_server
 from zerver.decorator import require_post
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.push_notifications import (
+    InvalidRemotePushDeviceTokenError,
     UserPushIdentityCompat,
     send_android_push_notification,
     send_apple_push_notification,
@@ -322,7 +323,7 @@ def remote_server_send_test_notification(
             user_identity.filter_q(), token=token, kind=token_kind, server=server
         )
     except RemotePushDeviceToken.DoesNotExist:
-        raise JsonableError(err_("Token does not exist"))
+        raise InvalidRemotePushDeviceTokenError
 
     send_test_push_notification_directly_to_devices(
         user_identity, [device], base_payload, remote=server

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -92,6 +92,7 @@ from zerver.views.push_notifications import (
     add_apns_device_token,
     remove_android_reg_id,
     remove_apns_device_token,
+    send_test_push_notification_api,
 )
 from zerver.views.reactions import add_reaction, remove_reaction
 from zerver.views.read_receipts import read_receipts
@@ -380,6 +381,7 @@ v1_api_and_json_patterns = [
         "users/me/apns_device_token", POST=add_apns_device_token, DELETE=remove_apns_device_token
     ),
     rest_path("users/me/android_gcm_reg_id", POST=add_android_reg_id, DELETE=remove_android_reg_id),
+    rest_path("mobile_push/test_notification", POST=send_test_push_notification_api),
     # users/*/presence => zerver.views.presence.
     rest_path("users/me/presence", POST=update_active_status_backend),
     # It's important that this sit after users/me/presence so that


### PR DESCRIPTION
Still missing more complete tests, and I imagine we will want to add some error handling with informative error responses to make the endpoint useful?

Will fix #23997 when complete.

Adds two endpoints:
1. Remote server endpoint `users/me/test_notify`, to which the mobile app will be able to make a request.
2. This will cause the remote server to request the bouncer to send the notification to the device at `/api/v1/remotes/push/test_notify`.

A server like the bouncer itself skips step 2 of course and send the notification directly.

