### PR TITLE
postgres_exporter: Build from source for per-index stats.

### DIFF
--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -121,6 +121,12 @@ class zulip::common {
       },
     },
 
+    # https://github.com/prometheus-community/postgres_exporter/pull/843
+    'postgres_exporter-src' => {
+      'version' => '4881e566207b1675f8b2ceae9bcd71f61800ccd1',
+      'sha256'  => '1b0aaf32e3834f02e5448fb21c0de114a4e42cc0937300e307899efb8438bf16',
+    },
+
     # https://github.com/ncabatoff/process-exporter/releases
     'process_exporter' => {
       'version' => '0.7.10',

--- a/puppet/zulip_ops/manifests/prometheus/postgresql.pp
+++ b/puppet/zulip_ops/manifests/prometheus/postgresql.pp
@@ -3,15 +3,48 @@
 class zulip_ops::prometheus::postgresql {
   include zulip_ops::prometheus::base
   include zulip::supervisor
+  include zulip::golang
 
-  $version = $zulip::common::versions['postgres_exporter']['version']
-  $dir = "/srv/zulip-postgres_exporter-${version}"
-  $bin = "${dir}/postgres_exporter"
+  $version = $zulip::common::versions['postgres_exporter-src']['version']
+  $dir = "/srv/zulip-postgres_exporter-src-${version}"
+  $bin = "/usr/local/bin/postgres_exporter-${version}-go-${zulip::golang::version}"
 
-  zulip::external_dep { 'postgres_exporter':
+  # Binary builds: https://github.com/prometheus-community/postgres_exporter/releases/download/v${version}/postgres_exporter-${version}.linux-${zulip::common::goarch}.tar.gz
+
+  zulip::external_dep { 'postgres_exporter-src':
     version        => $version,
-    url            => "https://github.com/prometheus-community/postgres_exporter/releases/download/v${version}/postgres_exporter-${version}.linux-${zulip::common::goarch}.tar.gz",
-    tarball_prefix => "postgres_exporter-${version}.linux-${zulip::common::goarch}",
+    url            => "https://github.com/Sticksman/postgres_exporter/archive/${version}.tar.gz",
+    tarball_prefix => "postgres_exporter-${version}",
+  }
+
+  exec { 'compile postgres_exporter':
+    command     => "make build && cp ./postgres_exporter ${bin}",
+    cwd         => $dir,
+    # GOCACHE is required; nothing is written to GOPATH, but it is required to be set
+    environment => ['GOCACHE=/tmp/gocache', 'GOPATH=/root/go'],
+    path        => [
+      "${zulip::golang::dir}/bin",
+      '/usr/local/bin',
+      '/usr/bin',
+      '/bin',
+    ],
+    creates     => $bin,
+    require     => [
+      Zulip::External_Dep['golang'],
+      Zulip::External_Dep['postgres_exporter-src'],
+    ]
+  }
+  # This resource exists purely so it doesn't get tidied; it is
+  # created by the 'compile postgres_exporter' step.
+  file { $bin:
+    ensure  => file,
+    require => Exec['compile postgres_exporter'],
+  }
+  tidy { '/usr/local/bin/postgres_exporter-*':
+    path    => '/usr/local/bin',
+    recurse => 1,
+    matches => 'postgres_exporter-*',
+    require => Exec['compile postgres_exporter'],
   }
 
   exec { 'create prometheus postgres user':
@@ -27,7 +60,7 @@ class zulip_ops::prometheus::postgresql {
       Exec['create prometheus postgres user'],
       User[prometheus],
       Package[supervisor],
-      Zulip::External_Dep['postgres_exporter'],
+      File[$bin],
     ],
     owner   => 'root',
     group   => 'root',

--- a/puppet/zulip_ops/templates/supervisor/conf.d/prometheus_postgres_exporter.conf.template.erb
+++ b/puppet/zulip_ops/templates/supervisor/conf.d/prometheus_postgres_exporter.conf.template.erb
@@ -1,5 +1,5 @@
 [program:prometheus_postgres_exporter]
-command=<%= @bin %>
+command=<%= @bin %> --collector.stat_user_indexes
 environment=DATA_SOURCE_NAME="postgresql://prometheus@:5432/zulip?host=/var/run/postgresql"
 priority=10
 autostart=true


### PR DESCRIPTION
This builds prometheus-community/postgres_exporter#843 to track per-index statistics.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
