### PR TITLE
Replace functools.partial with type-safe returns.curry.partial; enable B023 bound-loop-variable

### DIFF
--- a/analytics/views/installation_activity.py
+++ b/analytics/views/installation_activity.py
@@ -73,25 +73,23 @@ def get_realm_day_counts() -> Dict[str, Dict[str, Markup]]:
     for row in rows:
         counts[row["string_id"]][row["age"]] = row["cnt"]
 
+    def format_count(cnt: int, style: Optional[str] = None) -> Markup:
+        if style is not None:
+            good_bad = style
+        elif cnt == min_cnt:
+            good_bad = "bad"
+        elif cnt == max_cnt:
+            good_bad = "good"
+        else:
+            good_bad = "neutral"
+
+        return Markup('<td class="number {good_bad}">{cnt}</td>').format(good_bad=good_bad, cnt=cnt)
+
     result = {}
     for string_id in counts:
         raw_cnts = [counts[string_id].get(age, 0) for age in range(8)]
         min_cnt = min(raw_cnts[1:])
         max_cnt = max(raw_cnts[1:])
-
-        def format_count(cnt: int, style: Optional[str] = None) -> Markup:
-            if style is not None:
-                good_bad = style
-            elif cnt == min_cnt:
-                good_bad = "bad"
-            elif cnt == max_cnt:
-                good_bad = "good"
-            else:
-                good_bad = "neutral"
-
-            return Markup('<td class="number {good_bad}">{cnt}</td>').format(
-                good_bad=good_bad, cnt=cnt
-            )
 
         cnts = format_count(raw_cnts[0], "neutral") + Markup().join(map(format_count, raw_cnts[1:]))
         result[string_id] = dict(cnts=cnts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ ignore = [
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
     "B007", # Loop control variable not used within the loop body
     "B008", # Do not perform function calls in argument defaults
-    "B023", # Function definition does not bind loop variable
     "B904", # Within an except clause, raise exceptions with raise ... from err or raise ... from None to distinguish them from errors in exception handling
     "C408", # Unnecessary `dict` call (rewrite as a literal)
     "COM812", # Trailing comma missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,11 @@ warn_unreachable = true
 # with this behavior.
 local_partial_types = true
 
-plugins = ["mypy_django_plugin.main", "pydantic.mypy"]
+plugins = [
+    "mypy_django_plugin.main",
+    "pydantic.mypy",
+    "returns.contrib.mypy.returns_plugin",
+]
 
 [[tool.mypy.overrides]]
 module = [

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -8,6 +8,9 @@ Django[argon2]==4.2.*
 # needed for NotRequired, ParamSpec
 typing-extensions
 
+# For type-safe returns.curry.partial
+returns
+
 # Needed for rendering backend templates
 Jinja2
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2442,6 +2442,10 @@ responses==0.23.3 \
     # via
     #   -r requirements/dev.in
     #   moto
+returns==0.22.0 \
+    --hash=sha256:c7bd85bd1e0041b44fe46c7e2f68fcc76a0546142c876229e395174bcd674f37 \
+    --hash=sha256:d38d6324692eeb29ec4bd698e1b859ec0ac79fb2c17bf0d302f92c8c42ef35c1
+    # via -r requirements/common.in
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -3059,6 +3063,7 @@ typing-extensions==4.7.1 \
     #   pyre-check
     #   pyre-extensions
     #   qrcode
+    #   returns
     #   rich
     #   semgrep
     #   sqlalchemy2-stubs

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1921,6 +1921,10 @@ requests-oauthlib==1.3.1 \
     #   -r requirements/common.in
     #   python-twitter
     #   social-auth-core
+returns==0.22.0 \
+    --hash=sha256:c7bd85bd1e0041b44fe46c7e2f68fcc76a0546142c876229e395174bcd674f37 \
+    --hash=sha256:d38d6324692eeb29ec4bd698e1b859ec0ac79fb2c17bf0d302f92c8c42ef35c1
+    # via -r requirements/common.in
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -2173,6 +2177,7 @@ typing-extensions==4.7.1 \
     #   pydantic
     #   pydantic-core
     #   qrcode
+    #   returns
     #   stripe
     #   zulip
     #   zulip-bots

--- a/tools/lib/pretty_print.py
+++ b/tools/lib/pretty_print.py
@@ -107,6 +107,10 @@ def adjust_block_indentation(tokens: List[Token], fn: str) -> None:
 
 
 def fix_indents_for_multi_line_tags(tokens: List[Token]) -> None:
+    def fix(frag: str) -> str:
+        frag = frag.strip()
+        return continue_indent + frag if frag else ""
+
     for token in tokens:
         if token.kind == "code":
             continue
@@ -120,10 +124,6 @@ def fix_indents_for_multi_line_tags(tokens: List[Token]) -> None:
             continue_indent = token.indent + "  "
 
         frags = token.new_s.split("\n")
-
-        def fix(frag: str) -> str:
-            frag = frag.strip()
-            return continue_indent + frag if frag else ""
 
         token.new_s = frags[0] + "\n" + "\n".join(fix(frag) for frag in frags[1:])
 

--- a/tools/lib/template_parser.py
+++ b/tools/lib/template_parser.py
@@ -489,6 +489,20 @@ def validate(fn: Optional[str] = None, text: Optional[str] = None) -> List[Token
 
 
 def ensure_matching_indentation(fn: str, tokens: List[Token], lines: List[str]) -> None:
+    def has_bad_indentation() -> bool:
+        is_inline_tag = start_tag in HTML_INLINE_TAGS and start_token.kind == "html_start"
+
+        if end_line > start_line + 1:
+            if is_inline_tag:
+                end_row_text = lines[end_line - 1]
+                if end_row_text.lstrip().startswith(end_token.s) and end_col != start_col:
+                    return True
+            else:
+                if end_col != start_col:
+                    return True
+
+        return False
+
     for token in tokens:
         if token.start_token is None:
             continue
@@ -502,20 +516,6 @@ def ensure_matching_indentation(fn: str, tokens: List[Token], lines: List[str]) 
         end_tag = end_token.tag.strip("~")
         end_line = end_token.line
         end_col = end_token.col
-
-        def has_bad_indentation() -> bool:
-            is_inline_tag = start_tag in HTML_INLINE_TAGS and start_token.kind == "html_start"
-
-            if end_line > start_line + 1:
-                if is_inline_tag:
-                    end_row_text = lines[end_line - 1]
-                    if end_row_text.lstrip().startswith(end_token.s) and end_col != start_col:
-                        return True
-                else:
-                    if end_col != start_col:
-                        return True
-
-            return False
 
         if has_bad_indentation():
             raise TemplateParserError(

--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -250,3 +250,9 @@ rules:
     message: 'Use ".exists()" instead; it is more efficient'
     languages: [python]
     severity: ERROR
+
+  - id: functools-partial
+    pattern: functools.partial
+    message: "Replace functools.partial with returns.curry.partial for type safety"
+    languages: [python]
+    severity: ERROR

--- a/version.py
+++ b/version.py
@@ -48,4 +48,4 @@ API_FEATURE_LEVEL = 209
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = (249, 0)
+PROVISION_VERSION = (249, 1)

--- a/zerver/data_import/import_util.py
+++ b/zerver/data_import/import_util.py
@@ -4,7 +4,6 @@ import random
 import shutil
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from functools import partial
 from typing import (
     AbstractSet,
     Any,
@@ -25,6 +24,7 @@ import orjson
 import requests
 from django.forms.models import model_to_dict
 from django.utils.timezone import now as timezone_now
+from returns.curry import partial
 from typing_extensions import TypeAlias
 
 from zerver.data_import.sequencer import NEXT_ID

--- a/zerver/lib/subscription_info.py
+++ b/zerver/lib/subscription_info.py
@@ -316,6 +316,9 @@ def bulk_get_subscriber_user_ids(
 ) -> Dict[int, List[int]]:
     """sub_dict maps stream_id => whether the user is subscribed to that stream."""
     target_stream_dicts = []
+    is_subscribed: bool
+    check_user_subscribed = lambda user_profile: is_subscribed
+
     for stream_dict in stream_dicts:
         stream_id = stream_dict["id"]
         is_subscribed = stream_id in subscribed_stream_ids
@@ -324,7 +327,7 @@ def bulk_get_subscriber_user_ids(
             validate_user_access_to_subscribers_helper(
                 user_profile,
                 stream_dict,
-                lambda user_profile: is_subscribed,
+                check_user_subscribed,
             )
         except JsonableError:
             continue

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -3,7 +3,6 @@ import os
 import random
 import shutil
 import unittest
-from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
 from unittest import TestSuite, runner
 from unittest.result import TestResult
@@ -14,6 +13,7 @@ from django.db import ProgrammingError, connections
 from django.test import runner as django_runner
 from django.test.runner import DiscoverRunner
 from django.test.signals import template_rendered
+from returns.curry import partial
 from typing_extensions import TypeAlias
 
 from scripts.lib.zulip_tools import (

--- a/zerver/tests/test_invite.py
+++ b/zerver/tests/test_invite.py
@@ -14,6 +14,7 @@ from django.http import HttpRequest
 from django.test import override_settings
 from django.urls import reverse
 from django.utils.timezone import now as timezone_now
+from returns.curry import partial
 
 from confirmation import settings as confirmation_settings
 from confirmation.models import (
@@ -1116,7 +1117,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         for email in existing:
             self.assertRaises(
                 PreregistrationUser.DoesNotExist,
-                lambda: PreregistrationUser.objects.get(email=email),
+                partial(PreregistrationUser.objects.get, email=email),
             )
         for email in new:
             self.assertTrue(PreregistrationUser.objects.get(email=email))

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1350,19 +1350,19 @@ class EmojiTest(UploadSerializeMixin, ZulipTestCase):
         with self.assertRaises(BadImageError):
             resize_emoji(corrupted_img_data)
 
+        def test_resize(size: int = 50) -> None:
+            resized_img_data, is_animated, still_img_data = resize_emoji(
+                animated_large_img_data, size=50
+            )
+            im = Image.open(io.BytesIO(resized_img_data))
+            self.assertEqual((size, size), im.size)
+            self.assertTrue(is_animated)
+            assert still_img_data
+            still_image = Image.open(io.BytesIO(still_img_data))
+            self.assertEqual((50, 50), still_image.size)
+
         for img_format in ("gif", "png"):
             animated_large_img_data = read_test_image_file(f"animated_large_img.{img_format}")
-
-            def test_resize(size: int = 50) -> None:
-                resized_img_data, is_animated, still_img_data = resize_emoji(
-                    animated_large_img_data, size=50
-                )
-                im = Image.open(io.BytesIO(resized_img_data))
-                self.assertEqual((size, size), im.size)
-                self.assertTrue(is_animated)
-                assert still_img_data
-                still_image = Image.open(io.BytesIO(still_img_data))
-                self.assertEqual((50, 50), still_image.size)
 
             # Test an image larger than max is resized
             with patch("zerver.lib.upload.base.MAX_EMOJI_GIF_SIZE", 128):

--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.db import transaction
 from requests.adapters import ConnectionError, HTTPAdapter
 from requests.models import PreparedRequest, Response
+from returns.curry import partial
 from urllib3.util import Retry
 
 from zerver.lib.queue import queue_json_publish
@@ -185,7 +186,7 @@ def send_event(
         queue_json_publish(
             notify_tornado_queue_name(port),
             dict(event=event, users=port_users),
-            lambda *args, **kwargs: send_notification_http(port, *args, **kwargs),
+            partial(send_notification_http, port),
         )
 
 

--- a/zerver/views/video_calls.py
+++ b/zerver/views/video_calls.py
@@ -3,7 +3,6 @@ import json
 import random
 import secrets
 from base64 import b32encode
-from functools import partial
 from typing import Dict
 from urllib.parse import quote, urlencode, urljoin
 
@@ -21,6 +20,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from oauthlib.oauth2 import OAuth2Error
 from requests_oauthlib import OAuth2Session
+from returns.curry import partial
 
 from zerver.actions.video_calls import do_set_zoom_token
 from zerver.decorator import zulip_login_required

--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -1,10 +1,10 @@
 # Webhooks for external integrations.
 import re
 import string
-from functools import partial
 from typing import Dict, List, Optional, Protocol
 
 from django.http import HttpRequest, HttpResponse
+from returns.curry import partial
 
 from zerver.decorator import log_unsupported_webhook_event, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError

--- a/zerver/webhooks/bitbucket3/view.py
+++ b/zerver/webhooks/bitbucket3/view.py
@@ -1,8 +1,8 @@
 import string
-from functools import partial
 from typing import Dict, List, Optional, Protocol
 
 from django.http import HttpRequest, HttpResponse
+from returns.curry import partial
 
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError

--- a/zerver/webhooks/clubhouse/view.py
+++ b/zerver/webhooks/clubhouse/view.py
@@ -1,7 +1,7 @@
-from functools import partial
 from typing import Callable, Dict, Iterable, Iterator, List, Optional
 
 from django.http import HttpRequest, HttpResponse
+from returns.curry import partial
 
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -1,8 +1,8 @@
 import re
-from functools import partial
 from typing import Callable, Dict, Optional
 
 from django.http import HttpRequest, HttpResponse
+from returns.curry import partial
 
 from zerver.decorator import log_unsupported_webhook_event, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -1,9 +1,9 @@
 import re
-from functools import partial
 from typing import Dict, List, Optional, Protocol, Union
 
 from django.http import HttpRequest, HttpResponse
 from pydantic import Json
+from returns.curry import partial
 
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError

--- a/zerver/webhooks/groove/view.py
+++ b/zerver/webhooks/groove/view.py
@@ -1,8 +1,8 @@
 # Webhooks for external integrations.
-from functools import partial
 from typing import Callable, Dict, Optional
 
 from django.http import HttpRequest, HttpResponse
+from returns.curry import partial
 
 from zerver.decorator import webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError

--- a/zerver/webhooks/intercom/view.py
+++ b/zerver/webhooks/intercom/view.py
@@ -1,8 +1,8 @@
-from functools import partial
 from html.parser import HTMLParser
 from typing import Callable, Dict, List, Tuple
 
 from django.http import HttpRequest, HttpResponse
+from returns.curry import partial
 
 from zerver.decorator import return_success_on_head_request, webhook_view
 from zerver.lib.exceptions import UnsupportedWebhookEventTypeError

--- a/zilencer/management/commands/queue_rate.py
+++ b/zilencer/management/commands/queue_rate.py
@@ -70,10 +70,7 @@ class Command(BaseCommand):
                         lambda: queue_json_publish(queue_name, {}),
                         number=count,
                     )
-                    duration = timeit(
-                        lambda: worker.start(),
-                        number=1,
-                    )
+                    duration = timeit(worker.start, number=1)
                     print(f"    {i}/{reps}: {count}/{duration}s = {count / duration}/s")
                     total_time += duration
                     writer.writerow(


### PR DESCRIPTION
* python: Replace `functools.partial` with type-safe `returns.curry.partial`.

  The type annotation for `functools.partial` uses unchecked `Any` for all the function parameters (both early and late). [`returns.curry.partial`](https://returns.readthedocs.io/en/latest/pages/curry.html
) uses a mypy plugin to check the parameters safely.

* ruff: Enable `B023` Function definition does not bind loop variable.

  Python’s loop scoping is misdesigned, resulting in a very [common gotcha](https://docs.python-guide.org/writing/gotchas/#late-binding-closures) for functions that close over loop variables. The general problem is so bad that even the Go developers plan to break compatibility in order to [fix the same design mistake](https://go.dev/s/loopvar-design) in their language.

  Enable the Ruff rule [`function-uses-loop-variable` (`B023`)](https://beta.ruff.rs/docs/rules/function-uses-loop-variable/
), which conservatively prohibits functions from binding loop variables at all.