### PR TITLE
nginx: Suppress proxy warnings when the proxy itself sent the request.

### DIFF
--- a/puppet/zulip/templates/nginx/trusted-proto.template.erb
+++ b/puppet/zulip/templates/nginx/trusted-proto.template.erb
@@ -8,9 +8,9 @@ map $http_x_forwarded_for $x_proxy_misconfiguration {
     "~." "No proxies configured in Zulip, but proxy headers detected from proxy at $remote_addr; see https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
 }
 <% else %>
-# We do this in two steps because `geo` does not support variable
-# interpolation in the value, but does support CIDR notation,
-# which the loadbalancer list may use.
+# Check if the request's original `REMOTE_ADDR` header was from a
+# trusted host -- that is, the request did bounce through a proxy and
+# we should trust `X-Forwarded-Proto`
 geo $realip_remote_addr $is_x_forwarded_proto_trusted {
     default 0;
 <% @loadbalancers.each do |host| -%>
@@ -18,13 +18,27 @@ geo $realip_remote_addr $is_x_forwarded_proto_trusted {
 <% end -%>
 }
 
+# Check if the IP address that we resolved the request as coming
+# (after looking at X-Fowarded-For, if any) from is actually the proxy
+# itself.
+geo $remote_addr $is_from_proxy {
+    default 0;
+<% @loadbalancers.each do |host| -%>
+    <%= host %> 1;
+<% end -%>
+}
+
+# We set $trusted_x_forwarded_proto in two steps because `geo` does
+# not support variable interpolation in the value, but does support
+# CIDR notation, which the loadbalancer list may use.
 map $is_x_forwarded_proto_trusted $trusted_x_forwarded_proto {
     0 $scheme;
     1 $http_x_forwarded_proto;
 }
-map "$is_x_forwarded_proto_trusted:$http_x_forwarded_proto" $x_proxy_misconfiguration {
-    "~^0:" "Incorrect reverse proxy IPs set in Zulip (try $remote_addr?); see https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
-    "~^1:$" "No X-Forwarded-Proto header sent from trusted proxy $realip_remote_addr; see example configurations in https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
+
+map "$is_from_proxy:$is_x_forwarded_proto_trusted:$http_x_forwarded_proto" $x_proxy_misconfiguration {
+    "~^0:0:" "Incorrect reverse proxy IPs set in Zulip (try $remote_addr?); see https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
+    "~^0:1:$" "No X-Forwarded-Proto header sent from trusted proxy $realip_remote_addr; see example configurations in https://zulip.readthedocs.io/en/latest/production/deployment.html#putting-the-zulip-application-behind-a-reverse-proxy";
     default "";
 }
 <% end %>


### PR DESCRIPTION
This is common in cases where the reverse proxy itself is making health-check requests to the Zulip server; these requests have no X-Forwarded-* headers, so would normally hit the error case of "request through the proxy, but no X-Forwarded-Proto header".

Add an additional special-case for when the request's originating IP address is resolved to be the reverse proxy itself; in these cases, HTTP requests with no X-Forwarded-Proto are acceptable.

[CZO discussion](https://chat.zulip.org/#narrow/stream/31-production-help/topic/x-forwarded-proto.20in.207.2E3/near/1634982)

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
