### PR TITLE
typed_endpoint: Add missing tuple comma for OptionalTopic aliases

### DIFF
--- a/zerver/lib/typed_endpoint.py
+++ b/zerver/lib/typed_endpoint.py
@@ -106,7 +106,7 @@ PathOnly: TypeAlias = Annotated[T, ApiParamConfig(path_only=True)]
 OptionalTopic: TypeAlias = Annotated[
     Optional[str],
     StringConstraints(strip_whitespace=True),
-    ApiParamConfig(whence="topic", aliases=("subject")),
+    ApiParamConfig(whence="topic", aliases=("subject",)),
 ]
 
 # Reusable annotation metadata for Annotated types


### PR DESCRIPTION
This is alarming—apparently mypy doesn’t type-check the extra expressions in `Annotated` at all?

I think the symptom here will be that `update_message_backend` accepts aliases of `s`, `u`, `b`, `j`, `e`, `c`, `t` for `topic` instead of `subject`.

Cc @PIG208
