### PR TITLE
thirdparty: Organize and update docs/THIRDPARTY.

### DIFF
--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -99,25 +99,25 @@ License: Apache-2.0
 Comment: Material volume up icon (rounded)
 
 Files: web/third/bootstrap/css/bootstrap.css
-Copyright: 2012 Twitter, Inc
+Copyright: 2012 Twitter, Inc.
 License: Apache-2.0
 Comment: The software has been modified.
 
 Files: web/third/bootstrap/css/bootstrap-btn.css
-Copyright: 2011-2014 Twitter, Inc
+Copyright: 2011-2014 Twitter, Inc.
 License: Expat
 
 Files: web/third/bootstrap/js/bootstrap.js
-Copyright: 2012 Twitter, Inc
+Copyright: 2012 Twitter, Inc.
 License: Apache-2.0
 
 Files: web/third/bootstrap-tooltip/*
-Copyright: 2012 Twitter, Inc
+Copyright: 2012 Twitter, Inc.
 License: Apache-2.0
 Comment: Bootstrap tooltip and bootstrap popover.  The software has been modified.
 
 Files: web/third/bootstrap-typeahead/*
-Copyright: 2012 Twitter, Inc
+Copyright: 2012 Twitter, Inc.
 License: Apache-2.0
 Comment: Bootstrap typeahead.  The software has been modified.
 

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -71,6 +71,11 @@ Files: web/images/icons/search.svg
 Copyright: 2015-present Ionic (http://ionic.io/)
 License: Expat
 
+Files: web/shared/icons/edit.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
 Files: web/shared/icons/ellipsis-v-solid.svg
 Copyright: 2017 Fonticons, Inc.
 License: CC-BY-4.0
@@ -80,6 +85,26 @@ Files: web/shared/icons/globe.svg
 Source: https://github.com/ionic-team/ionicons/blob/v5.5.2/src/svg/earth.svg, modified to increase the width of the globe outline.
 Copyright: 2015-present Ionic (http://ionic.io/)
 License: Expat
+
+Files: web/shared/icons/more-vertical.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
+Files: web/shared/icons/more-vertical-spread.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
+Files: web/shared/icons/move.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
+Files: web/shared/icons/move-alt.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
 
 Files: web/shared/icons/mute.svg
 Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:volume_mute
@@ -91,6 +116,31 @@ Files: web/shared/icons/smart-toy.svg
 Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:smart_toy
 Copyright: Google, Inc.
 License: Apache-2.0
+
+Files: web/shared/icons/smile.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
+Files: web/shared/icons/source.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
+Files: web/shared/icons/source-alt.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
+Files: web/shared/icons/star.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
+
+Files: web/shared/icons/star-filled.svg
+Copyright: 2013-2023 Cole Bemis (https://feathericons.com)
+License: Expat
+Comment: Icon has been modified by Vlad Koborov
 
 Files: web/shared/icons/unmute.svg
 Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:volume_up

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -17,7 +17,7 @@ Comment:
  information or errors found in these notices.
 
 Files: *
-Copyright: 2012–2015 Dropbox, Inc., 2015–2021 Kandra Labs, Inc., and contributors
+Copyright: 2012–2015 Dropbox, Inc., 2015–2023 Kandra Labs, Inc., and contributors
 License: Apache-2.0
 
 Files: confirmation/*

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -42,6 +42,10 @@ Copyright: 2003-2006 Thom May
            2018-2019 Kandra Labs, Inc., and contributors
 License: BSD-3-Clause
 
+Files: static/audio/notification_sounds/*
+Copyright: 2021 Stefan Mertens
+License: CC0-1.0
+
 Files: static/audio/notification_sounds/ding.*
 Copyright: 2017 InspectorJ
 License: CC-BY-3.0
@@ -51,32 +55,71 @@ Files: static/audio/notification_sounds/zulip.*
 Copyright: 2011 Vidsyn
 License: CC0-1.0
 
-Files: web/third/bootstrap/css/bootstrap-btn.css
-Copyright: 2011-2014 Twitter, Inc
+Files: static/generated/emoji/images/emoji/unicode/*
+Copyright: Google, Inc.
+License: Apache-2.0
+
+Files: tools/check-thirdparty
+Copyright: 2020 Kandra Labs, Inc.
+License: GPL-2.0+
+
+Files: web/images/icons/close.svg
+Copyright: 2013-2017 Cole Bemis (https://feathericons.com)
 License: Expat
+
+Files: web/images/icons/search.svg
+Copyright: 2015-present Ionic (http://ionic.io/)
+License: Expat
+
+Files: web/shared/icons/ellipsis-v-solid.svg
+Copyright: 2017 Fonticons, Inc.
+License: CC-BY-4.0
+Comment: This icon is picked from Version 5.13.0 of Font Awesome
+
+Files: web/shared/icons/globe.svg
+Source: https://github.com/ionic-team/ionicons/blob/v5.5.2/src/svg/earth.svg, modified to increase the width of the globe outline.
+Copyright: 2015-present Ionic (http://ionic.io/)
+License: Expat
+
+Files: web/shared/icons/mute.svg
+Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:volume_mute
+Copyright: Google, Inc.
+License: Apache-2.0
+Comment: Material volume icon (rounded) with custom cross symbol
+
+Files: web/shared/icons/smart-toy.svg
+Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:smart_toy
+Copyright: Google, Inc.
+License: Apache-2.0
+
+Files: web/shared/icons/unmute.svg
+Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:volume_up
+Copyright: Google, Inc.
+License: Apache-2.0
+Comment: Material volume up icon (rounded)
 
 Files: web/third/bootstrap/css/bootstrap.css
 Copyright: 2012 Twitter, Inc
 License: Apache-2.0
 Comment: The software has been modified.
 
+Files: web/third/bootstrap/css/bootstrap-btn.css
+Copyright: 2011-2014 Twitter, Inc
+License: Expat
+
 Files: web/third/bootstrap/js/bootstrap.js
 Copyright: 2012 Twitter, Inc
 License: Apache-2.0
-
-Files: web/third/bootstrap-typeahead/*
-Copyright: 2012 Twitter, Inc
-License: Apache-2.0
-Comment: Bootstrap typeahead.  The software has been modified.
 
 Files: web/third/bootstrap-tooltip/*
 Copyright: 2012 Twitter, Inc
 License: Apache-2.0
 Comment: Bootstrap tooltip and bootstrap popover.  The software has been modified.
 
-Files: static/generated/emoji/images/emoji/unicode/*
-Copyright: Google, Inc.
+Files: web/third/bootstrap-typeahead/*
+Copyright: 2012 Twitter, Inc
 License: Apache-2.0
+Comment: Bootstrap typeahead.  The software has been modified.
 
 Files: web/third/jquery-idle/jquery.idle.js
 Copyright: 2011-2013 Henrique Boaventura
@@ -87,61 +130,18 @@ Files: web/third/marked/*
 Copyright: 2011-2013, Christopher Jeffrey
 License: Expat
 
-Files: web/shared/icons/ellipsis-v-solid.svg
-Copyright: 2017 Fonticons, Inc.
-License: CC-BY-4.0
-Comment: This icon is picked from Version 5.13.0 of Font Awesome
-
-Files: zerver/lib/markdown/fenced_code.py
-Copyright: 2006-2008 Waylan Limberg
+Files: zerver/decorator.py zerver/management/commands/runtornado.py scripts/setup/generate_secrets.py
+Copyright: Django Software Foundation and individual contributors
 License: BSD-3-Clause
-Comment: https://pypi.python.org/pypi/Markdown
 
 Files: zerver/lib/ccache.py
 Copyright: 2013 David Benjamin and Alan Huang
 License: Expat
 
-Files: zerver/decorator.py zerver/management/commands/runtornado.py scripts/setup/generate_secrets.py
-Copyright: Django Software Foundation and individual contributors
+Files: zerver/lib/markdown/fenced_code.py
+Copyright: 2006-2008 Waylan Limberg
 License: BSD-3-Clause
-
-Files: static/audio/notification_sounds/*
-Copyright: 2021 Stefan Mertens
-License: CC0-1.0
-
-Files: web/shared/icons/globe.svg
-Source: https://github.com/ionic-team/ionicons/blob/v5.5.2/src/svg/earth.svg, modified to increase the width of the globe outline.
-Copyright: 2015-present Ionic (http://ionic.io/)
-License: Expat
-
-Files: web/images/icons/search.svg
-Copyright: 2015-present Ionic (http://ionic.io/)
-License: Expat
-
-Files: web/images/icons/close.svg
-Copyright: 2013-2017 Cole Bemis (https://feathericons.com)
-License: Expat
-
-Files: tools/check-thirdparty
-Copyright: 2020 Kandra Labs, Inc.
-License: GPL-2.0+
-
-Files: web/shared/icons/mute.svg
-Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:volume_mute
-Copyright: Google, Inc.
-License: Apache-2.0
-Comment: Material volume icon (rounded) with custom cross symbol
-
-Files: web/shared/icons/unmute.svg
-Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:volume_up
-Copyright: Google, Inc.
-License: Apache-2.0
-Comment: Material volume up icon (rounded)
-
-Files: web/shared/icons/smart-toy.svg
-Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:smart_toy
-Copyright: Google, Inc.
-License: Apache-2.0
+Comment: https://pypi.python.org/pypi/Markdown
 
 License: Apache-2.0
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -25,7 +25,7 @@ Copyright: 2008, Jarek Zgoda <jarek.zgoda@gmail.com>
 License: BSD-3-Clause
 
 Files: docs/code-of-conduct.md
-Copyright: 2017, Kandra Labs Inc.
+Copyright: 2017, Kandra Labs, Inc.
 License: CC-BY-SA-4.0
 
 Files: puppet/zulip/files/nagios_plugins/zulip_base/check_debian_packages

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -17,7 +17,7 @@ Comment:
  information or errors found in these notices.
 
 Files: *
-Copyright: 2012–2015 Dropbox, Inc., 2015–2023 Kandra Labs, Inc., and contributors
+Copyright: 2012-2015 Dropbox, Inc., 2015-2023 Kandra Labs, Inc., and contributors
 License: Apache-2.0
 
 Files: confirmation/*

--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -21,11 +21,11 @@ Copyright: 2012–2015 Dropbox, Inc., 2015–2023 Kandra Labs, Inc., and contrib
 License: Apache-2.0
 
 Files: confirmation/*
-Copyright: 2008, Jarek Zgoda <jarek.zgoda@gmail.com>
+Copyright: 2008 Jarek Zgoda <jarek.zgoda@gmail.com>
 License: BSD-3-Clause
 
 Files: docs/code-of-conduct.md
-Copyright: 2017, Kandra Labs, Inc.
+Copyright: 2017 Kandra Labs, Inc.
 License: CC-BY-SA-4.0
 
 Files: puppet/zulip/files/nagios_plugins/zulip_base/check_debian_packages
@@ -127,7 +127,7 @@ License: Expat
 Comment: The software has been modified.
 
 Files: web/third/marked/*
-Copyright: 2011-2013, Christopher Jeffrey
+Copyright: 2011-2013 Christopher Jeffrey
 License: Expat
 
 Files: zerver/decorator.py zerver/management/commands/runtornado.py scripts/setup/generate_secrets.py


### PR DESCRIPTION
This PR cleans up the `docs/THIRDPARTY` file by alphabetizing the paths of files using a dictionary-style nothing-comes-before-something scheme (e.g., `move.svg` is listed before `move-alt.svg`). It includes minor typographical and date corrections, too.

It also properly notes icons introduced in #26283, though some of those icons are likely unused and should be cleaned up accordingly in a follow-up PR.

[CZO Discussion](https://chat.zulip.org/#narrow/stream/19-documentation/topic/docs.2FTHIRDPARTY.20and.20MIT.20License/near/1638434)
