### PR TITLE
emails: Add onboarding team to zulip email. (edit pass)

### DIFF
--- a/templates/zerver/emails/onboarding_team_to_zulip.html
+++ b/templates/zerver/emails/onboarding_team_to_zulip.html
@@ -7,18 +7,20 @@
 {% block content %}
 
 <p>
-    {% trans %}If you have already decided to use Zulip for your organization, welcome! You can use our <a href="{{ get_organization_started }}">guide for setting up your organization</a> to get started.{% endtrans %}
+    {% trans %}If you've already decided to use Zulip for your organization, welcome! You can use our <a href="{{ get_organization_started }}">guide for setting up your organization</a> to get started.{% endtrans %}
 </p>
 <p>
-    {% trans %}Otherwise, here are some tips for successfully evaluating <i>any</i> team chat product:{% endtrans %}
-    <ul>
-        <li>{% trans %}<a href="{{ invite_users }}">Invite your teammates</a> to explore with you and share their unique perspectives.{% endtrans %}
-            {% trans %}Use the app itself to chat about your impressions.{% endtrans %}</li>
-        <li>{% trans %}<b>Run a week-long trial</b> with your team, without using any other chat tools. This is the only way to truly get a feel for how a new chat app will impact your team's communication and workflows in the coming months.{% endtrans %}</li>
-    </ul>
+    {% trans %}Otherwise, here is some advice we often hear from customers for evaluating <i>any</i> team chat product:{% endtrans %}
+    <ol>
+        <li>{% trans %}<a href="{{ invite_users }}"><b>Invite your teammates</b></a> to explore with you and share their unique perspectives.{% endtrans %}
+            {% trans %}Use the app itself to chat about your impressions.{% endtrans %}
+        </li>
+        <li>{% trans %}<b>Run a week-long trial</b> with your team, without using any other chat tools. This is the only way to truly experience how a new chat app will help your team communicate.{% endtrans %}
+        </li>
+    </ol>
 </p>
 <p>
-    {% trans %}We hope this advice helps you find a tool that <a href="{{ why_zulip }}">enables efficient communication</a> for your team.{% endtrans %}
+    {% trans %}We hope these tips help you find a tool that <a href="{{ why_zulip }}">enables efficient communication</a> for your team.{% endtrans %}
 </p>
 
 <p>

--- a/templates/zerver/emails/onboarding_team_to_zulip.html
+++ b/templates/zerver/emails/onboarding_team_to_zulip.html
@@ -1,0 +1,37 @@
+{% extends "zerver/emails/email_base_default.html" %}
+
+{% block illustration %}
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+
+<p>
+    {% trans %}If you have already decided to use Zulip for your organization, welcome! You can use our <a href="{{ get_organization_started }}">guide for setting up your organization</a> to get started.{% endtrans %}
+</p>
+<p>
+    {% trans %}If you are still deciding between a few different options, here are some tips for successfully evaluating any team chat product:{% endtrans %}
+    <ul>
+        <li>{% trans %}<a href="{{ invite_users }}">Invite others</a> to explore it with you.{% endtrans %} {% trans %}You'll learn how the tool might (or might not) fit your organization when everyone brings their unique perspective. Besides, most of the time using a chat app is spent reading messages, and there's not much to read when you are alone.{% endtrans %} &#128521;</li>
+        <li>{% trans %}Run a week-long trial with your team. Stop using any other chat tools, and fully commit to trying something different. This is the only way to truly get a feel for how a new chat app will impact your team's communication and workflows in the coming months.{% endtrans %}</li>
+    </ul>
+</p>
+<p>
+    {% trans %}Choosing a tool that <a href="{{ why_zulip }}">enables efficient communication</a> is one of the most impactful ways to improve productivity in your organization, and we hope this advice helps you find the best chat app for your team.{% endtrans %}
+</p>
+
+<p>
+    {% if corporate_enabled %}
+        {{macros.contact_us_zulip_cloud(support_email)}}
+    {% else %}
+        {{macros.contact_us_self_hosted(support_email)}}
+    {% endif %}
+</p>
+
+{% endblock %}
+
+{% block manage_preferences %}
+
+<p><a href="{{ unsubscribe_link }}">{% trans %}Unsubscribe from welcome emails for {{ realm_name }}{% endtrans %}</a></p>
+
+{% endblock %}

--- a/templates/zerver/emails/onboarding_team_to_zulip.html
+++ b/templates/zerver/emails/onboarding_team_to_zulip.html
@@ -10,14 +10,15 @@
     {% trans %}If you have already decided to use Zulip for your organization, welcome! You can use our <a href="{{ get_organization_started }}">guide for setting up your organization</a> to get started.{% endtrans %}
 </p>
 <p>
-    {% trans %}If you are still deciding between a few different options, here are some tips for successfully evaluating any team chat product:{% endtrans %}
+    {% trans %}Otherwise, here are some tips for successfully evaluating <i>any</i> team chat product:{% endtrans %}
     <ul>
-        <li>{% trans %}<a href="{{ invite_users }}">Invite others</a> to explore it with you.{% endtrans %} {% trans %}You'll learn how the tool might (or might not) fit your organization when everyone brings their unique perspective. Besides, most of the time using a chat app is spent reading messages, and there's not much to read when you are alone.{% endtrans %} &#128521;</li>
-        <li>{% trans %}Run a week-long trial with your team. Stop using any other chat tools, and fully commit to trying something different. This is the only way to truly get a feel for how a new chat app will impact your team's communication and workflows in the coming months.{% endtrans %}</li>
+        <li>{% trans %}<a href="{{ invite_users }}">Invite your teammates</a> to explore with you and share their unique perspectives.{% endtrans %}
+            {% trans %}Use the app itself to chat about your impressions.{% endtrans %}</li>
+        <li>{% trans %}<b>Run a week-long trial</b> with your team, without using any other chat tools. This is the only way to truly get a feel for how a new chat app will impact your team's communication and workflows in the coming months.{% endtrans %}</li>
     </ul>
 </p>
 <p>
-    {% trans %}Choosing a tool that <a href="{{ why_zulip }}">enables efficient communication</a> is one of the most impactful ways to improve productivity in your organization, and we hope this advice helps you find the best chat app for your team.{% endtrans %}
+    {% trans %}We hope this advice helps you find a tool that <a href="{{ why_zulip }}">enables efficient communication</a> for your team.{% endtrans %}
 </p>
 
 <p>

--- a/templates/zerver/emails/onboarding_team_to_zulip.subject.txt
+++ b/templates/zerver/emails/onboarding_team_to_zulip.subject.txt
@@ -1,0 +1,1 @@
+{{ _("Choosing the chat app for your team") }}

--- a/templates/zerver/emails/onboarding_team_to_zulip.txt
+++ b/templates/zerver/emails/onboarding_team_to_zulip.txt
@@ -1,0 +1,26 @@
+{% trans %}If you have already decided to use Zulip for your organization, welcome! You can use our guide for setting up your organization to get started.{% endtrans %}
+
+<{{ get_organization_started }}>
+
+{% trans %}If you are still deciding between a few different options, here are some tips for successfully evaluating any team chat product:{% endtrans %}
+
+
+- {% trans %}Invite others to explore it with you: {{ invite_users }}.{% endtrans %} {% trans %}You'll learn how the tool might (or might not) fit your organization when everyone brings their unique perspective. Besides, most of the time using a chat app is spent reading messages, and there's not much to read when you are alone.{% endtrans %} ;)
+
+
+- {% trans %}Run a week-long trial with your team. Stop using any other chat tools, and fully commit to trying something different. This is the only way to truly get a feel for how a new chat app will impact your team's communication and workflows in the coming months.{% endtrans %}
+
+
+{% trans %}Choosing a tool that enables efficient communication is one of the most impactful ways to improve productivity in your organization, and we hope this advice helps you find the best chat app for your team.{% endtrans %}
+
+<{{ why_zulip }}>
+
+{% if corporate_enabled %}
+    {% trans %}Do you have questions or feedback to share? Contact us at {{ support_email }} — we'd love to help!{% endtrans %}
+{% else %}
+    {% trans %}If you have any questions, please contact this Zulip server's administrators at {{ support_email }}.{% endtrans %}
+{% endif %}
+
+----
+{% trans %}Unsubscribe from welcome emails for {{ realm_name }}{% endtrans %}:
+{{ unsubscribe_link }}

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -696,6 +696,7 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
         # or comes in while they are dealing with their inbox.
         "onboarding_zulip_topics": timedelta(days=2, hours=-1),
         "onboarding_zulip_guide": timedelta(days=4, hours=-1),
+        "onboarding_team_to_zulip": timedelta(days=6, hours=-1),
     }
 
     user_tz = user.timezone
@@ -707,17 +708,24 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
     # -Do not send emails on Saturday or Sunday
     # -Have at least one weekday between each (potential) email
 
+    # User signed up on Monday
+    if signup_day == 1:
+        # Send onboarding_team_to_zulip on Tuesday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
+
     # User signed up on Tuesday
     if signup_day == 2:
-        # Send onboarding_zulip_topics on Thursday
         # Send onboarding_zulip_guide on Monday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Wednesday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     # User signed up on Wednesday
     if signup_day == 3:
-        # Send onboarding_zulip_topics on Friday
         # Send onboarding_zulip_guide on Tuesday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Thursday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     # User signed up on Thursday
     if signup_day == 4:
@@ -725,6 +733,8 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
         onboarding_emails["onboarding_zulip_topics"] = timedelta(days=4, hours=-1)
         # Send onboarding_zulip_guide on Wednesday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Friday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     # User signed up on Friday
     if signup_day == 5:
@@ -732,6 +742,15 @@ def get_onboarding_email_schedule(user: UserProfile) -> Dict[str, timedelta]:
         onboarding_emails["onboarding_zulip_topics"] = timedelta(days=4, hours=-1)
         # Send onboarding_zulip_guide on Thursday
         onboarding_emails["onboarding_zulip_guide"] = timedelta(days=6, hours=-1)
+        # Send onboarding_team_to_zulip on Monday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=10, hours=-1)
+
+    # User signed up on Saturday; no adjustments needed
+
+    # User signed up on Sunday
+    if signup_day == 7:
+        # Send onboarding_team_to_zulip on Monday
+        onboarding_emails["onboarding_team_to_zulip"] = timedelta(days=8, hours=-1)
 
     return onboarding_emails
 
@@ -893,6 +912,27 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool = False) -> N
             from_address=from_address,
             context=onboarding_zulip_guide_context,
             delay=onboarding_email_schedule["onboarding_zulip_guide"],
+        )
+
+    # We only send the onboarding_team_to_zulip email to user who created the organization.
+    if realm_creation:
+        onboarding_team_to_zulip_context = common_context(user)
+        onboarding_team_to_zulip_context.update(
+            unsubscribe_link=unsubscribe_link,
+            get_organization_started=realm_url
+            + "/help/getting-your-organization-started-with-zulip",
+            invite_users=realm_url + "/help/invite-users-to-join",
+            why_zulip="https://zulip.com/why-zulip/",
+        )
+
+        send_future_email(
+            "zerver/emails/onboarding_team_to_zulip",
+            user.realm,
+            to_user_ids=[user.id],
+            from_name=from_name,
+            from_address=from_address,
+            context=onboarding_team_to_zulip_context,
+            delay=onboarding_email_schedule["onboarding_team_to_zulip"],
         )
 
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -4622,6 +4622,7 @@ EMAIL_TYPES = {
     "account_registered": ScheduledEmail.WELCOME,
     "onboarding_zulip_topics": ScheduledEmail.WELCOME,
     "onboarding_zulip_guide": ScheduledEmail.WELCOME,
+    "onboarding_team_to_zulip": ScheduledEmail.WELCOME,
     "digest": ScheduledEmail.DIGEST,
     "invitation_reminder": ScheduledEmail.INVITATION_REMINDER,
 }

--- a/zerver/tests/test_email_log.py
+++ b/zerver/tests/test_email_log.py
@@ -26,7 +26,7 @@ class EmailLogTest(ZulipTestCase):
             output_log = (
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )
-            self.assertEqual(m.output, [output_log for i in range(17)])
+            self.assertEqual(m.output, [output_log for i in range(18)])
 
     def test_forward_address_details(self) -> None:
         try:

--- a/zerver/tests/test_example.py
+++ b/zerver/tests/test_example.py
@@ -402,7 +402,7 @@ class TestDevelopmentEmailsLog(ZulipTestCase):
                 "INFO:root:Emails sent in development are available at http://testserver/emails"
             )
             # logger.output is a list of all the log messages captured. Verify it is as expected.
-            self.assertEqual(logger.output, [output_log] * 17)
+            self.assertEqual(logger.output, [output_log] * 18)
 
             # Now, lets actually go the URL the above call redirects to, i.e., /emails/
             result = self.client_get(result["Location"])

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -147,7 +147,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
     send_account_registered_email(get_user_by_delivery_email("iago@zulip.com", realm))
 
     # Onboarding emails for admin user
-    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm))
+    enqueue_welcome_emails(get_user_by_delivery_email("iago@zulip.com", realm), realm_creation=True)
 
     # Realm reactivation email
     do_send_realm_reactivation_email(realm, acting_user=None)


### PR DESCRIPTION
This PR is based on #25258. I tried to tighten up the wording in the email.

Once we have a version we like, we can propagate the changes to the .txt file.

<img width="578" alt="Screen Shot 2023-09-12 at 1 31 25 PM" src="https://github.com/zulip/zulip/assets/2090066/06d090bf-30d7-4652-8539-8e4557b3958e">
