### PR TITLE
help: Document troubleshooting screen for mobile notifications.

### DIFF
--- a/help/mobile-notifications.md
+++ b/help/mobile-notifications.md
@@ -8,6 +8,8 @@ apps.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {settings_tab|notifications}
 
 1. Toggle the checkboxes for **Streams** and **DMs, mentions, and alerts**
@@ -28,6 +30,8 @@ notifications while you are actively using one of the Zulip apps.
 
 {start_tabs}
 
+{tab|desktop-web}
+
 {settings_tab|notifications}
 
 1. Under **Mobile message notifications**, toggle
@@ -42,6 +46,29 @@ delivery of mobile notifications to apps like Zulip. If you're having issues
 with Zulip notifications on your Android phone, we recommend Signal's excellent
 [troubleshooting guide](https://support.signal.org/hc/en-us/articles/360007318711-Troubleshooting-Notifications#android_notifications_troubleshooting),
 which explains the notification settings for many popular Android vendors.
+
+### Contacting Zulip support
+
+If you are still having trouble with your push notifications, you can send an
+email to [Zulip support](/help/contact-support). Please be sure to include the
+troubleshooting data provided by the mobile app.
+
+{start_tabs}
+
+{tab|mobile}
+
+{!mobile-profile-menu.md!}
+
+1. Tap **Settings**.
+
+1. Tap **Notifications**.
+
+1. Tap **Troubleshooting**.
+
+1. Use the **Copy to clipboard** button or the **Email support@zulip.com**
+   button to email the troubleshooting data to the Zulip support team.
+
+{end_tabs}
 
 ## Related articles
 


### PR DESCRIPTION
This is a follow-up PR (https://github.com/zulip/zulip/pull/26655#issuecomment-1710364566) to add instructions for getting to the "Troubleshooting" screen, and a short intro paragraph for context.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/ba41cfd4-7670-40c5-9d61-e8baa4e90a16)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans.
- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>
