### PR TITLE
giphy: Fix giphy popover rendering on narrow screens.

### DIFF
--- a/web/src/giphy.js
+++ b/web/src/giphy.js
@@ -2,7 +2,6 @@ import $ from "jquery";
 import _ from "lodash";
 
 import render_giphy_picker from "../templates/giphy_picker.hbs";
-import render_giphy_picker_mobile from "../templates/giphy_picker_mobile.hbs";
 
 import * as blueslip from "./blueslip";
 import * as compose_ui from "./compose_ui";
@@ -175,19 +174,11 @@ export function hide_giphy_popover() {
     return false;
 }
 
-function get_popover_content() {
-    if (window.innerWidth <= media_breakpoints_num.md) {
-        // Show as modal in the center for small screens.
-        return render_giphy_picker_mobile();
-    }
-    return render_giphy_picker();
-}
-
-export function initialize() {
-    popover_menus.register_popover_menu(".compose_control_button.compose_gif_icon", {
+function toggle_giphy_popover(target) {
+    popover_menus.toggle_popover_menu(target, {
         placement: "top",
         onCreate(instance) {
-            instance.setContent(ui_util.parse_html(get_popover_content()));
+            instance.setContent(ui_util.parse_html(render_giphy_picker()));
             $(instance.popper).addClass("giphy-popover");
         },
         async onShow(instance) {
@@ -237,4 +228,14 @@ export function initialize() {
             hide_giphy_popover();
         },
     });
+}
+
+function register_click_handlers() {
+    $("body").on("click", ".compose_control_button.compose_gif_icon", (e) => {
+        toggle_giphy_popover(e.currentTarget);
+    });
+}
+
+export function initialize() {
+    register_click_handlers();
 }

--- a/web/styles/popovers.css
+++ b/web/styles/popovers.css
@@ -867,14 +867,6 @@ ul {
     }
 }
 
-@media (width < $md_min) {
-    #giphy_grid_in_popover {
-        position: static;
-        top: 0 !important;
-        left: 0 !important;
-    }
-}
-
 .user_info_status_text {
     opacity: 0.8;
 

--- a/web/templates/giphy_picker_mobile.hbs
+++ b/web/templates/giphy_picker_mobile.hbs
@@ -1,3 +1,0 @@
-<div class='popover-flex'>
-    {{> giphy_picker }}
-</div>


### PR DESCRIPTION
We should render the giphy popover as a centered overlay for mobile-sized screens.

<details>
<summary>Screenshots:</summary>

| Before | After |
| ------ | ------- |
| broken | ![image](https://github.com/zulip/zulip/assets/53193850/2257c6a2-0793-4c56-a98c-02e05c5890ce) |
</details>
