### PR TITLE
compose: Present banners with intrinsic layout.

### DIFF
--- a/web/styles/compose.css
+++ b/web/styles/compose.css
@@ -278,19 +278,38 @@
     border-radius: 5px;
     border: 1px solid;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    /* Baseline alignment ensures the closing X
+       appears centered with the banner text. */
+    align-items: baseline;
     font-size: 15px;
     line-height: 18px;
+
+    .main-view-banner-elements-wrapper {
+        display: flex;
+        /* Baseline alignment ensures the banner
+           and button text appear centered with
+           each other. */
+        align-items: baseline;
+        /* Allow this flex container to grow or
+           shrink to fit the outer container. */
+        flex: 1 1 auto;
+        /* Allow items to wrap; this supports an
+           intrinsic layout for banner text and
+           buttons, which will always occupy the
+           space available, without our having
+           to fiddle with tons of media queries. */
+        flex-wrap: wrap;
+    }
 
     & p {
         margin: 0; /* override bootstrap */
         /* 5px right padding + 10px left-margin of the neighbouring button will match the left padding */
         padding: 8px 5px 8px 15px;
-    }
-
-    .banner_content {
-        flex-grow: 1;
+        /* The banner text uses a flex-basis of 150px,
+           which is roughly the width at which banner
+           text lines are still comfortably readable.
+           Still, it can grow and shrink as needed. */
+        flex: 1 1 150px;
     }
 
     .main-view-banner-action-button,
@@ -299,12 +318,45 @@
         border-radius: 4px;
         padding: 5px 10px;
         font-weight: 600;
-        margin-left: 10px;
         margin-top: 4.5px;
         margin-bottom: 4.5px;
-        height: 32px;
-        white-space: nowrap;
+        /* Buttons take a minimum height for
+           when their text fits on a single
+           line. */
+        min-height: 32px;
+        /* When we're larger than large mobile
+           scales ($ml_min), flex the button to
+           its max-content, i.e., all its text
+           on a single line. But do not grow in
+           order to avoid awkward, oversized
+           buttons within the flex group. */
+        flex: 0 1 max-content;
+        /* Use this margin-left hack to keep
+           the button to the righthand side of
+           the banner. */
+        margin-left: auto;
 
+        @media (width < $ml_min) {
+            /* When we're smaller than large mobile
+               scales, we allow the button to grow,
+               so that it can span the full width of
+               narrow, mobile-scale banners as it
+               wraps onto a second line.
+
+               We also allow the button to shrink,
+               so that, for example, the text can
+               wrap on the schedule-message button
+               that appears when undoing a scheduled
+               message. */
+            flex: 1 1 max-content;
+            /* Use a 10px left margin to keep the
+               button away from the edge of the
+               banner box to match the banner text;
+               we need this only at small scales,
+               when the button grows to the full
+               width of the flex container. */
+            margin-left: 10px;
+        }
         /* Extra margin to ensure the layout is identical when there is no
            close button. */
         &.right_edge {

--- a/web/templates/compose_banner/compose_banner.hbs
+++ b/web/templates/compose_banner/compose_banner.hbs
@@ -3,14 +3,16 @@
   {{#if user_id}}data-user-id="{{user_id}}"{{/if}}
   {{#if stream_id}}data-stream-id="{{stream_id}}"{{/if}}
   {{#if topic_name}}data-topic-name="{{topic_name}}"{{/if}}>
-    {{#if banner_text}}
-    <p class="banner_content">{{banner_text}}</p>
-    {{else}}
-    <div class="banner_content">{{> @partial-block}}</div>
-    {{/if}}
-    {{#if button_text}}
-    <button class="main-view-banner-action-button{{#if hide_close_button}} right_edge{{/if}}" {{#if scheduling_message}}data-validation-trigger="schedule"{{/if}}>{{button_text}}</button>
-    {{/if}}
+    <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
+        {{#if banner_text}}
+        <p class="banner_content">{{banner_text}}</p>
+        {{else}}
+        <div class="banner_content">{{> @partial-block}}</div>
+        {{/if}}
+        {{#if button_text}}
+        <button class="main-view-banner-action-button{{#if hide_close_button}} right_edge{{/if}}" {{#if scheduling_message}}data-validation-trigger="schedule"{{/if}}>{{button_text}}</button>
+        {{/if}}
+    </div>
     {{#if hide_close_button}}
     {{!-- hide_close_button is null by default, and false if explicitly set as false. --}}
     {{else}}

--- a/web/templates/compose_banner/success_message_scheduled_banner.hbs
+++ b/web/templates/compose_banner/success_message_scheduled_banner.hbs
@@ -1,9 +1,11 @@
 <div
   class="main-view-banner success message_scheduled_success_compose_banner"
   data-scheduled-message-id="{{scheduled_message_id}}">
-    <p class="banner_content">{{t 'Your message has been scheduled for {deliver_at}.' }}
-        <a href="#scheduled">{{t "View scheduled messages" }}</a>
-    </p>
-    <button class="main-view-banner-action-button undo_scheduled_message" >{{t "Undo"}}</button>
+    <div class="main-view-banner-elements-wrapper {{#if button_text}}banner-contains-button{{/if}}">
+        <p class="banner_content">{{t 'Your message has been scheduled for {deliver_at}.' }}
+            <a href="#scheduled">{{t "View scheduled messages" }}</a>
+        </p>
+        <button class="main-view-banner-action-button undo_scheduled_message" >{{t "Undo"}}</button>
+    </div>
     <a role="button" class="zulip-icon zulip-icon-close main-view-banner-close-button"></a>
 </div>


### PR DESCRIPTION
By implementing a careful flexbox declaration on a new banner-element container, this presents banners accessibly across the full range of possible viewports--and relies only on a single, small media query to do so.

This also corrects the vertical center-alignment of the banner text, button (if any) and closing X button (if any).

Fixes: #25847

**Screenshots and screen captures:**

| Before, Unresolve banner | After, Unresolve banner |
| --- | --- |
| ![resolve-english-before](https://github.com/zulip/zulip/assets/170719/e8940c51-5c61-48f4-8ba4-49b7f129d311) | ![resolve-english-after](https://github.com/zulip/zulip/assets/170719/de70ef31-6409-4fda-81f9-9e12867219c6) |

| Before, Unresolve banner (Russian) | After, Unresolve banner (Russian) |
| --- | --- |
| ![resolve-russian-before](https://github.com/zulip/zulip/assets/170719/146384ec-9330-4840-ba04-1459aa2f8fde) | ![resolve-russian-after](https://github.com/zulip/zulip/assets/170719/d0f780d7-a19e-4504-91c7-1a4deb609fec) |

| Before, Undo-scheduled banner | After, Undo-scheduled banner |
| --- | --- |
| ![schedule-undo-before](https://github.com/zulip/zulip/assets/170719/033b779e-a975-4b44-b65d-d7ee7362e2a3) | ![schedule-undo-after](https://github.com/zulip/zulip/assets/170719/61d8ec6d-5d1c-48c1-bbcc-11168d3e8119) |

| Before, Reschedule banner | After, Reschedule banner |
| --- | --- |
| ![reschedule-before](https://github.com/zulip/zulip/assets/170719/14d98bc8-538e-4296-9966-0076bafbd6d2) | ![reschedule-after](https://github.com/zulip/zulip/assets/170719/52712926-e3db-44a7-a8f0-2c2e16bd56dd) |