### PR TITLE
dependencies: Patch source-sans to correct `format()` for variable fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,9 @@
   "pnpm": {
     "overrides": {
       "source-map@^0.6": "npm:source-map-js@1.0.1"
+    },
+    "patchedDependencies": {
+      "source-sans@3.46.0": "patches/source-sans@3.46.0.patch"
     }
   },
   "nyc": {

--- a/patches/source-sans@3.46.0.patch
+++ b/patches/source-sans@3.46.0.patch
@@ -1,0 +1,28 @@
+diff --git a/source-sans-3VF.css b/source-sans-3VF.css
+index 99213736a3fdb72eb4e3fbdd9dc342883bf2ec13..a6821c48738a673b098d99372e023604b1bad056 100755
+--- a/source-sans-3VF.css
++++ b/source-sans-3VF.css
+@@ -3,9 +3,9 @@
+     font-weight: 200 900;
+     font-style: normal;
+     font-stretch: normal;
+-    src: url('WOFF2/VAR/SourceSans3VF-Roman.ttf.woff2') format('woff2'),
+-         url('WOFF/VAR/SourceSans3VF-Roman.ttf.woff') format('woff'),
+-         url('VAR/SourceSans3VF-Roman.ttf') format('truetype');
++    src: url('WOFF2/VAR/SourceSans3VF-Roman.ttf.woff2') format('woff2-variations'),
++         url('WOFF/VAR/SourceSans3VF-Roman.ttf.woff') format('woff-variations'),
++         url('VAR/SourceSans3VF-Roman.ttf') format('truetype-variations');
+ }
+ 
+ @font-face{
+@@ -13,7 +13,7 @@
+     font-weight: 200 900;
+     font-style: italic;
+     font-stretch: normal;
+-    src: url('WOFF2/VAR/SourceSans3VF-Italic.ttf.woff2') format('woff2'),
+-         url('WOFF/VAR/SourceSans3VF-Italic.ttf.woff') format('woff'),
+-         url('VAR/SourceSans3VF-Italic.ttf') format('truetype');
++    src: url('WOFF2/VAR/SourceSans3VF-Italic.ttf.woff2') format('woff2-variations'),
++         url('WOFF/VAR/SourceSans3VF-Italic.ttf.woff') format('woff-variations'),
++         url('VAR/SourceSans3VF-Italic.ttf') format('truetype-variations');
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   source-map@^0.6: npm:source-map-js@1.0.1
 
+patchedDependencies:
+  source-sans@3.46.0:
+    hash: 4n7ij66tzyhzaqnxsenbilrxr4
+    path: patches/source-sans@3.46.0.patch
+
 dependencies:
   '@babel/core':
     specifier: ^7.5.5
@@ -211,7 +216,7 @@ dependencies:
     version: 2.38.0
   source-sans:
     specifier: ^3.28.0
-    version: 3.46.0
+    version: 3.46.0(patch_hash=4n7ij66tzyhzaqnxsenbilrxr4)
   spectrum-colorpicker:
     specifier: ^1.8.1
     version: 1.8.1
@@ -10815,9 +10820,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /source-sans@3.46.0:
+  /source-sans@3.46.0(patch_hash=4n7ij66tzyhzaqnxsenbilrxr4):
     resolution: {integrity: sha512-bVC2YX4VNiv5vMcy77dL0XKsNp794ThfynNsr+FqSAwk8TGG0pZsg7eUQi6yHwaRBMVmZ3Aaf4FY46dxIIGgsg==}
     dev: false
+    patched: true
 
   /spawn-wrap@2.0.0:
     resolution: {integrity: sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==}


### PR DESCRIPTION
https://github.com/adobe-fonts/source-sans/pull/262

[Discussion](https://chat.zulip.org/#narrow/stream/101-design/topic/Font.20Rendering.20Issues/near/1622093).