### PR TITLE
recent_view: Reduce width of unread header.

### DIFF
--- a/web/styles/recent_view.css
+++ b/web/styles/recent_view.css
@@ -105,6 +105,8 @@
             }
 
             .unread_sort {
+                padding-left: 6px;
+
                 .zulip-icon-unread {
                     position: absolute;
                     right: 30px;


### PR DESCRIPTION
<img width="362" alt="Screenshot 2023-09-14 at 1 49 04 PM" src="https://github.com/zulip/zulip/assets/25124304/be4449da-d08d-402e-bef6-89b88fd24e2b">

discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/sorting.20by.20unread.20count.20.2322790