### PR TITLE
compose: Disable unneeded control buttons in preview mode while editing.

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -361,6 +361,12 @@ export function initialize() {
         const $row = rows.get_closest_row(e.target);
         const $msg_edit_content = $row.find(".message_edit_content");
         const content = $msg_edit_content.val();
+
+        // Disable unneeded compose_control_buttons as we don't
+        // need them in preview mode.
+        $row.addClass("preview_mode");
+        $row.find(".preview_mode_disabled .compose_control_button").attr("tabindex", -1);
+
         $msg_edit_content.hide();
         $row.find(".markdown_preview").hide();
         $row.find(".undo_markdown_preview").show();
@@ -376,6 +382,12 @@ export function initialize() {
     $("body").on("click", ".message_edit_form .undo_markdown_preview", (e) => {
         e.preventDefault();
         const $row = rows.get_closest_row(e.target);
+
+        // While in preview mode we disable unneeded compose_control_buttons,
+        // so here we are re-enabling those compose_control_buttons
+        $row.removeClass("preview_mode");
+        $row.find(".preview_mode_disabled .compose_control_button").attr("tabindex", 0);
+
         $row.find(".message_edit_content").show();
         $row.find(".undo_markdown_preview").hide();
         $row.find(".preview_message_area").hide();

--- a/web/src/compose.js
+++ b/web/src/compose.js
@@ -125,7 +125,7 @@ export function clear_preview_area() {
     autosize.update($("#compose-textarea"));
 
     // While in preview mode we disable unneeded compose_control_buttons,
-    // so here we are re-enabling that compose_control_buttons
+    // so here we are re-enabling those compose_control_buttons
     $("#compose").removeClass("preview_mode");
     $("#compose .preview_mode_disabled .compose_control_button").attr("tabindex", 0);
 }

--- a/web/src/popover_menus.js
+++ b/web/src/popover_menus.js
@@ -511,11 +511,20 @@ export function initialize() {
     register_popover_menu(".compose_control_menu_wrapper", {
         placement: "top",
         onShow(instance) {
+            const parent_row = rows.get_closest_row(instance.reference);
+            let preview_mode_on;
+            // If the popover is opened from a message edit form, we want to
+            // infer the preview mode from that row, else from the compose box.
+            if (parent_row.length) {
+                preview_mode_on = parent_row.hasClass("preview_mode");
+            } else {
+                preview_mode_on = $("#compose").hasClass("preview_mode");
+            }
             instance.setContent(
                 parse_html(
                     render_compose_control_buttons_popover({
                         giphy_enabled: giphy.is_giphy_enabled(),
-                        preview_mode_on: $("#compose").hasClass("preview_mode"),
+                        preview_mode_on,
                     }),
                 ),
             );


### PR DESCRIPTION
This is a follow up to #26728, which disables buttons in preview mode for any message being edited.

Care is taken to pass the correct preview state (compose vs the message row being edited) to the popover menu so the buttons in it too can be disabled as needed.

**Screenshots and screen captures:**
![image](https://github.com/zulip/zulip/assets/68962290/b99a29fe-3d12-4b55-9631-90a1159e240c)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
