### PR TITLE
scim: Add supporting for syncing the user role.

### DIFF
--- a/help/scim.md
+++ b/help/scim.md
@@ -70,6 +70,20 @@ Zulip's SCIM integration has the following limitations:
      * **givenName**
      * **familyName**
 
+1. **Optional:** If you'd like to also sync [user role](/help/roles-and-permissions),
+   you can do it by by adding a custom attribute in Okta. Go to the **Profile Editor**,
+   click into the entry of the SCIM app you've just set up and **Add Attribute**.
+   Configure the following:
+    * **Data type**: `string`
+    * **Variable name**: `role`
+    * **External name**: `role`
+    * **External namespace**: `urn:ietf:params:scim:schemas:core:2.0:User`
+
+    With the attribute added, you will now be able to set it for your users directly
+    or configure an appropriate **Attribute mapping** in the app's **Provisioning**
+    section.
+    The valid values are: **owner**, **administrator**, **moderator**, **member**, **guest**.
+
 1. Now that the integration is ready to manage Zulip user accounts, **assign**
    users to the SCIM app.
      * When you assign a user, Okta will check if the account exists in your

--- a/zerver/actions/users.py
+++ b/zerver/actions/users.py
@@ -372,7 +372,7 @@ def send_stream_events_for_role_update(
         send_event_on_commit(user_profile.realm, event, [user_profile.id])
 
 
-@transaction.atomic(durable=True)
+@transaction.atomic(savepoint=False)
 def do_change_user_role(
     user_profile: UserProfile, value: int, *, acting_user: Optional[UserProfile]
 ) -> None:


### PR DESCRIPTION
This adds support for syncing user role via the newly added "role" attribute, which can be set to either of
['owner', 'administrator', 'moderator', 'member', 'guest'].

Removes durable=True from the atomic decorator of do_change_user_role, as django-scim2 runs PATCH operations in an atomic block (https://github.com/15five/django-scim2/blob/33e7caa0c996d1977cb70a0f7463ba31d5ee24b8/src/django_scim/views.py#L393). We could also override the upstream's `PatchView.dispatch` if we really needed to - or just not support role sync via PATCH at all, since Okta doesn't need it. But I kind of don't see why `do_change_user_role` should intrinsically be prohibited form being called in a nested `atomic`, so it makes sense to me to just remove that resitrction :thinking: 

Tested manually with Okta.

- [ ] Should still add some documentation on configuring this on Okta side if we stick with this approach