### PR TITLE
help: Document "Show unread count for" display preference.

### DIFF
--- a/help/configure-unread-message-counters.md
+++ b/help/configure-unread-message-counters.md
@@ -1,0 +1,30 @@
+# Configure unread message counters
+
+To provide information about unread messages, Zulip can show unread message
+counters next to stream names in the left sidebar. This is likely to be helpful
+if you generally read (or otherwise [mark as read](/help/marking-messages-as-read))
+all the messages in a stream, but may otherwise feel unnecessary.
+
+Zulip offers an option to display a dot instead of an unread counter for streams
+in the left sidebar. You can use a dot for all streams, or just for streams you
+have [muted](/help/mute-a-stream). You will still be able to see the number of
+unread messages in a stream by moving your mouse over it in the left sidebar.
+
+{start_tabs}
+
+{tab|desktop-web}
+
+{settings_tab|preferences}
+
+1. Under **Advanced**, select your preferred option from the
+   **Show unread counts for** dropdown.
+
+{end_tabs}
+
+## Related articles
+
+* [Reading strategies](/help/reading-strategies)
+* [Marking messages as read](/help/marking-messages-as-read)
+* [Marking messages as unread](/help/marking-messages-as-unread)
+* [Star a message](/help/star-a-message)
+* [Desktop notifications](/help/desktop-notifications)

--- a/help/include/sidebar_index.md
+++ b/help/include/sidebar_index.md
@@ -99,6 +99,7 @@
 * [Message actions](/help/message-actions)
 * [Marking messages as read](/help/marking-messages-as-read)
 * [Marking messages as unread](/help/marking-messages-as-unread)
+* [Configure unread message counters](/help/configure-unread-message-counters)
 * [Emoji reactions](/help/emoji-reactions)
 * [View your mentions](/help/view-your-mentions)
 * [Star a message](/help/star-a-message)


### PR DESCRIPTION
- Adds a new page in the "Reading messages" section to document this new feature (#24237).

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/5326044b-18d3-4809-a531-616a8bae49af)

<details>
<summary>Self-review checklist</summary>

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability

Communicate decisions, questions, and potential concerns.

- [x] Automated tests.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/version-control.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Links.
</details>