### PR TITLE
api-docs: Clean up descriptions in `unread_msgs` object register response.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11776,21 +11776,19 @@ paths:
                           pms:
                             type: array
                             description: |
-                              An array of dictionaries where each entry contains details
-                              of unread direct messages with a specific user.
+                              An array of objects where each object contains details of unread
+                              one-on-one direct messages with a specific user.
+
+                              Note that it is possible for a message that the current user sent
+                              to the specified user to be marked as unread and thus appear here.
                             items:
                               type: object
-                              description: |
-                                Object containing the details of unread direct messages with
-                                a specific user. Note that in rare situations, it is possible
-                                for a message that the current user sent to another user to
-                                be marked as unread and thus appear here.
                               additionalProperties: false
                               properties:
                                 other_user_id:
                                   type: integer
                                   description: |
-                                    The user ID of the other participant in this non-group direct
+                                    The user ID of the other participant in this one-on-one direct
                                     message conversation. Will be the current user's ID for messages
                                     that they sent in a one-on-one direct message conversation with
                                     themself.
@@ -11812,34 +11810,30 @@ paths:
                                   type: array
                                   description: |
                                     The message IDs of the recent unread direct messages sent
-                                    by the other user.
+                                    by either user in this one-on-one direct message conversation.
                                   items:
                                     type: integer
                           streams:
                             type: array
                             description: |
-                              An array of dictionaries where each dictionary contains
-                              details of all unread messages of a single subscribed stream,
-                              including muted streams.
+                              An array of objects where each object contains details of unread
+                              messages of a single subscribed stream, including muted streams.
 
-                              **Changes**: Prior to Zulip 5.0 (feature level 90), the
-                              dictionaries included an additional `sender_ids` key listing
-                              the set of IDs of users who had sent the unread messages.
+                              **Changes**: Prior to Zulip 5.0 (feature level 90), these objects
+                              included a `sender_ids` property, which listed the set of IDs of
+                              users who had sent the unread messages.
                             items:
                               type: object
-                              description: |
-                                `{message_id}`: Object containing the details of a unread stream
-                                message with the message_id as the key.
                               additionalProperties: false
                               properties:
                                 topic:
                                   type: string
                                   description: |
-                                    The topic under which the message was sent.
+                                    The topic under which the messages were sent.
                                 stream_id:
                                   type: integer
                                   description: |
-                                    The ID of the stream to which the message was sent.
+                                    The ID of the stream to which the messages were sent.
                                 unread_message_ids:
                                   type: array
                                   description: |
@@ -11849,13 +11843,10 @@ paths:
                           huddles:
                             type: array
                             description: |
-                              An array of dictionaries where each entry contains details
-                              of unread group direct messages with a specific group of users.
+                              An array of objects where each object contains details of unread
+                              group direct messages with a specific group of users.
                             items:
                               type: object
-                              description: |
-                                Object containing the details of unread group direct messages
-                                with a specific group of users.
                               additionalProperties: false
                               properties:
                                 user_ids_string:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -11862,8 +11862,9 @@ paths:
                                   type: string
                                   description: |
                                     A string containing the IDs of all users in the group
-                                    direct message conversation separated by commas; for
-                                    example: `"1,2,3"`.
+                                    direct message conversation, including the current user,
+                                    separated by commas and sorted numerically; for example:
+                                    `"1,2,3"`.
                                 unread_message_ids:
                                   type: array
                                   description: |


### PR DESCRIPTION
For arrays of objects in return values of API endpoints, any general description of the objects in the arrays should be documented in the description of the array. A description at the level of the items in the array will not be rendered in the API documentation. Descriptions of each property of the object will be rendered, but these are specific to the property and not the object as a whole.

Updates the `pms`, `streams` and `huddles` arrays of objects included in the `unread_msgs` object of the register response so that these general descriptions are at the array level in the OpenAPI documentation.

See these relevant CZO discussions:
- [#api documentation > unread_msgs.pms ...](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/register.3A.20.60unread_msgs.2Epms.5B.5D.2Eunread_message_ids.60/near/1641028)
- [#api documentation > unread_msgs.huddles ...](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/register.3A.20.60unread_msgs.2Ehuddles.5B.5D.2Euser_ids_string.60/near/1641022)

A follow-up to this PR would be to audit other instances of arrays of objects in the OpenAPI documentation for whether there are descriptions at the items level of the array that include relevant information for folks using the API documentation. After a quick glance through the documentation currently, there are a few `"Object containing the details of X."` descriptions, which seem fine but it would take a closer look to be sure that there aren't any other cases of more specific, detailed descriptions being in the wrong place.

@chrisbobbe would you be up for doing a review of these updates?

**Screenshots and screen captures:**

<details>
<summary>Updated arrays of objects in unread_msgs</summary>

[Current documentation](https://zulip.com/api/register-queue) - search for unread_msgs
![Screenshot from 2023-09-15 14-15-38](https://github.com/zulip/zulip/assets/63245456/70485b92-a8fb-430f-b3d7-d47455f446ba)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
