### PR TITLE
ci: Temporarily upgrade postgresql-client-common before upgrading.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -288,6 +288,17 @@ jobs:
           sudo mkdir -p "${dirs[@]}"
           sudo chown -R github "${dirs[@]}"
 
+      - name: Temporarily bootstrap PostgreSQL upgrades
+        # https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/postgres.20client.20upgrade.20failures/near/1640444
+        # On Debian, there is an ordering issue with post-install maintainer
+        # scripts when postgresql-client-common is upgraded at the same time as
+        # postgresql-client and postgresql-client-15.  Upgrade just
+        # postgresql-client-common first, so the main upgrade process can
+        # succeed.  This is a _temporary_ work-around to improve CI signal, as
+        # the failure does represent a real failure that production systems may
+        # encounter.
+        run: sudo apt-get update && sudo apt-get install -y --only-upgrade postgresql-client-common
+
       - name: Upgrade production
         run: sudo /tmp/production-upgrade
 


### PR DESCRIPTION
This works around a failure in the current postgresql-client-common and postgresql-client-15 packages; it exists primarily to improve the signal on our CI builds, as the failure is a real failure caused by the package upgrade process.

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
