### PR TITLE
Extract into separate module and migrate to Tippy playground links popover.

### DIFF
--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -134,6 +134,7 @@ EXEMPT_FILES = make_set(
         "web/src/overlays.ts",
         "web/src/padded_widget.ts",
         "web/src/page_params.ts",
+        "web/src/playground_links_popover.js",
         "web/src/plotly.js.d.ts",
         "web/src/pm_list.js",
         "web/src/pm_list_dom.js",

--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -34,6 +34,7 @@ import * as narrow_state from "./narrow_state";
 import * as navigate from "./navigate";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
+import * as playground_links_popover from "./playground_links_popover";
 import * as popover_menus from "./popover_menus";
 import * as popovers from "./popovers";
 import * as reactions from "./reactions";
@@ -397,6 +398,11 @@ function handle_popover_events(event_name) {
 
     if (user_group_popover.is_open()) {
         user_group_popover.handle_keyboard(event_name);
+        return true;
+    }
+
+    if (playground_links_popover.is_open()) {
+        playground_links_popover.handle_keyboard(event_name);
         return true;
     }
 

--- a/web/src/playground_links_popover.js
+++ b/web/src/playground_links_popover.js
@@ -38,7 +38,7 @@ function toggle_playground_links_popover(element, playground_info) {
     }
 }
 
-export function hide_playground_links_popover() {
+export function hide() {
     if ($current_playground_links_popover_elem !== undefined) {
         $current_playground_links_popover_elem.popover("destroy");
         $current_playground_links_popover_elem = undefined;
@@ -78,7 +78,7 @@ function register_click_handlers() {
     );
 
     $("body").on("click", ".popover_playground_link", (e) => {
-        hide_playground_links_popover();
+        hide();
         e.stopPropagation();
     });
 }

--- a/web/src/playground_links_popover.js
+++ b/web/src/playground_links_popover.js
@@ -35,6 +35,7 @@ function toggle_playground_links_popover(element, playground_info) {
             fixed: true,
         });
         $elt.popover("show");
+        $elt.addClass("active-playground-links-reference");
         $current_playground_links_popover_elem = $elt;
     }
 }
@@ -45,6 +46,7 @@ export function is_open() {
 
 export function hide() {
     if (is_open()) {
+        $current_playground_links_popover_elem.removeClass("active-playground-links-reference");
         $current_playground_links_popover_elem.popover("destroy");
         $current_playground_links_popover_elem = undefined;
     }

--- a/web/src/playground_links_popover.js
+++ b/web/src/playground_links_popover.js
@@ -12,7 +12,7 @@ let $current_playground_links_popover_elem;
 // Playground_info contains all the data we need to generate a popover of
 // playground links for each code block. The element is the target element
 // to pop off of.
-function toggle_playground_link_popover(element, playground_info) {
+function toggle_playground_links_popover(element, playground_info) {
     const $last_popover_elem = $current_playground_links_popover_elem;
     popovers.hide_all();
     if ($last_popover_elem !== undefined && $last_popover_elem.get()[0] === element) {
@@ -72,7 +72,7 @@ function register_click_handlers() {
                     const url_template = url_template_lib.parse($playground.url_template);
                     $playground.playground_url = url_template.expand({code: extracted_code});
                 }
-                toggle_playground_link_popover(this, playground_info);
+                toggle_playground_links_popover(this, playground_info);
             }
         },
     );

--- a/web/src/playground_links_popover.js
+++ b/web/src/playground_links_popover.js
@@ -38,8 +38,12 @@ function toggle_playground_links_popover(element, playground_info) {
     }
 }
 
+function is_open() {
+    return Boolean($current_playground_links_popover_elem);
+}
+
 export function hide() {
-    if ($current_playground_links_popover_elem !== undefined) {
+    if (is_open()) {
         $current_playground_links_popover_elem.popover("destroy");
         $current_playground_links_popover_elem = undefined;
     }

--- a/web/src/playground_links_popover.js
+++ b/web/src/playground_links_popover.js
@@ -3,6 +3,7 @@ import url_template_lib from "url-template";
 
 import render_playground_links_popover_content from "../templates/playground_links_popover_content.hbs";
 
+import * as blueslip from "./blueslip";
 import * as message_viewport from "./message_viewport";
 import * as popovers from "./popovers";
 import * as realm_playground from "./realm_playground";
@@ -38,7 +39,7 @@ function toggle_playground_links_popover(element, playground_info) {
     }
 }
 
-function is_open() {
+export function is_open() {
     return Boolean($current_playground_links_popover_elem);
 }
 
@@ -47,6 +48,26 @@ export function hide() {
         $current_playground_links_popover_elem.popover("destroy");
         $current_playground_links_popover_elem = undefined;
     }
+}
+
+function get_playground_links_popover_items() {
+    if (!is_open()) {
+        blueslip.error("Trying to get menu items when playground links popover is closed.");
+        return undefined;
+    }
+
+    const popover_data = $current_playground_links_popover_elem.data("popover");
+    if (!popover_data) {
+        blueslip.error("Cannot find playground links popover data");
+        return undefined;
+    }
+
+    return $("li:not(.divider):visible a", popover_data.$tip);
+}
+
+export function handle_keyboard(key) {
+    const $items = get_playground_links_popover_items();
+    popovers.popover_items_handle_keyboard(key, $items);
 }
 
 function register_click_handlers() {

--- a/web/src/playground_links_popover.js
+++ b/web/src/playground_links_popover.js
@@ -1,0 +1,88 @@
+import $ from "jquery";
+import url_template_lib from "url-template";
+
+import render_playground_links_popover_content from "../templates/playground_links_popover_content.hbs";
+
+import * as message_viewport from "./message_viewport";
+import * as popovers from "./popovers";
+import * as realm_playground from "./realm_playground";
+
+let $current_playground_links_popover_elem;
+
+// Playground_info contains all the data we need to generate a popover of
+// playground links for each code block. The element is the target element
+// to pop off of.
+function toggle_playground_link_popover(element, playground_info) {
+    const $last_popover_elem = $current_playground_links_popover_elem;
+    popovers.hide_all();
+    if ($last_popover_elem !== undefined && $last_popover_elem.get()[0] === element) {
+        // We want it to be the case that a user can dismiss a popover
+        // by clicking on the same element that caused the popover.
+        return;
+    }
+    const $elt = $(element);
+    if ($elt.data("popover") === undefined) {
+        const ypos = $elt.get_offset_to_window().top;
+        $elt.popover({
+            // It's unlikely we'll have more than 3-4 playground links
+            // for one language, so it should be OK to hardcode 120 here.
+            placement: message_viewport.height() - ypos < 120 ? "top" : "bottom",
+            title: "",
+            content: render_playground_links_popover_content({playground_info}),
+            html: true,
+            trigger: "manual",
+            fixed: true,
+        });
+        $elt.popover("show");
+        $current_playground_links_popover_elem = $elt;
+    }
+}
+
+export function hide_playground_links_popover() {
+    if ($current_playground_links_popover_elem !== undefined) {
+        $current_playground_links_popover_elem.popover("destroy");
+        $current_playground_links_popover_elem = undefined;
+    }
+}
+
+function register_click_handlers() {
+    $("#main_div, #preview_content, #message-history").on(
+        "click",
+        ".code_external_link",
+        function (e) {
+            const $view_in_playground_button = $(this);
+            const $codehilite_div = $(this).closest(".codehilite");
+            e.stopPropagation();
+            const playground_info = realm_playground.get_playground_info_for_languages(
+                $codehilite_div.data("code-language"),
+            );
+            // We do the code extraction here and set the target href expanding
+            // the url_template with the extracted code. Depending on whether
+            // the language has multiple playground links configured, a popover
+            // is shown.
+            const extracted_code = $codehilite_div.find("code").text();
+            if (playground_info.length === 1) {
+                const url_template = url_template_lib.parse(playground_info[0].url_template);
+                $view_in_playground_button.attr(
+                    "href",
+                    url_template.expand({code: extracted_code}),
+                );
+            } else {
+                for (const $playground of playground_info) {
+                    const url_template = url_template_lib.parse($playground.url_template);
+                    $playground.playground_url = url_template.expand({code: extracted_code});
+                }
+                toggle_playground_link_popover(this, playground_info);
+            }
+        },
+    );
+
+    $("body").on("click", ".popover_playground_link", (e) => {
+        hide_playground_links_popover();
+        e.stopPropagation();
+    });
+}
+
+export function initialize() {
+    register_click_handlers();
+}

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -145,6 +145,7 @@ export function any_active() {
         user_card_popover.is_message_user_card_open() ||
         user_card_popover.is_user_card_open() ||
         emoji_picker.is_open() ||
+        playground_links_popover.is_open() ||
         $("[class^='column-'].expanded").length
     );
 }

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -162,7 +162,7 @@ export function hide_all_except_sidebars(opts) {
     stream_popover.hide_stream_popover();
     user_group_popover.hide();
     user_card_popover.hide_all_user_card_popovers();
-    playground_links_popover.hide_playground_links_popover();
+    playground_links_popover.hide();
 
     // look through all the popovers that have been added and removed.
     for (const $o of list_of_popovers) {

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -18,11 +18,6 @@ import * as user_group_popover from "./user_group_popover";
 let $current_playground_links_popover_elem;
 let list_of_popovers = [];
 
-export function clear_for_testing() {
-    $current_playground_links_popover_elem = undefined;
-    list_of_popovers.length = 0;
-}
-
 // this utilizes the proxy pattern to intercept all calls to $.fn.popover
 // and push the $.fn.data($o, "popover") results to an array.
 // this is needed so that when we try to unload popovers, we can kill all dead

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -1,21 +1,17 @@
 import $ from "jquery";
 import {hideAll} from "tippy.js";
-import url_template_lib from "url-template";
-
-import render_playground_links_popover_content from "../templates/playground_links_popover_content.hbs";
 
 import * as blueslip from "./blueslip";
 import * as emoji_picker from "./emoji_picker";
 import * as message_viewport from "./message_viewport";
 import * as overlays from "./overlays";
+import * as playground_links_popover from "./playground_links_popover";
 import * as popover_menus from "./popover_menus";
-import * as realm_playground from "./realm_playground";
 import * as resize from "./resize";
 import * as stream_popover from "./stream_popover";
 import * as user_card_popover from "./user_card_popover";
 import * as user_group_popover from "./user_group_popover";
 
-let $current_playground_links_popover_elem;
 let list_of_popovers = [];
 
 // this utilizes the proxy pattern to intercept all calls to $.fn.popover
@@ -108,79 +104,7 @@ export function set_suppress_scroll_hide() {
     suppress_scroll_hide = true;
 }
 
-// Playground_info contains all the data we need to generate a popover of
-// playground links for each code block. The element is the target element
-// to pop off of.
-function toggle_playground_link_popover(element, playground_info) {
-    const $last_popover_elem = $current_playground_links_popover_elem;
-    hide_all();
-    if ($last_popover_elem !== undefined && $last_popover_elem.get()[0] === element) {
-        // We want it to be the case that a user can dismiss a popover
-        // by clicking on the same element that caused the popover.
-        return;
-    }
-    const $elt = $(element);
-    if ($elt.data("popover") === undefined) {
-        const ypos = $elt.get_offset_to_window().top;
-        $elt.popover({
-            // It's unlikely we'll have more than 3-4 playground links
-            // for one language, so it should be OK to hardcode 120 here.
-            placement: message_viewport.height() - ypos < 120 ? "top" : "bottom",
-            title: "",
-            content: render_playground_links_popover_content({playground_info}),
-            html: true,
-            trigger: "manual",
-            fixed: true,
-        });
-        $elt.popover("show");
-        $current_playground_links_popover_elem = $elt;
-    }
-}
-
-export function hide_playground_links_popover() {
-    if ($current_playground_links_popover_elem !== undefined) {
-        $current_playground_links_popover_elem.popover("destroy");
-        $current_playground_links_popover_elem = undefined;
-    }
-}
-
 export function register_click_handlers() {
-    $("#main_div, #preview_content, #message-history").on(
-        "click",
-        ".code_external_link",
-        function (e) {
-            const $view_in_playground_button = $(this);
-            const $codehilite_div = $(this).closest(".codehilite");
-            e.stopPropagation();
-            const playground_info = realm_playground.get_playground_info_for_languages(
-                $codehilite_div.data("code-language"),
-            );
-            // We do the code extraction here and set the target href expanding
-            // the url_template with the extracted code. Depending on whether
-            // the language has multiple playground links configured, a popover
-            // is shown.
-            const extracted_code = $codehilite_div.find("code").text();
-            if (playground_info.length === 1) {
-                const url_template = url_template_lib.parse(playground_info[0].url_template);
-                $view_in_playground_button.attr(
-                    "href",
-                    url_template.expand({code: extracted_code}),
-                );
-            } else {
-                for (const $playground of playground_info) {
-                    const url_template = url_template_lib.parse($playground.url_template);
-                    $playground.playground_url = url_template.expand({code: extracted_code});
-                }
-                toggle_playground_link_popover(this, playground_info);
-            }
-        },
-    );
-
-    $("body").on("click", ".popover_playground_link", (e) => {
-        hide_playground_links_popover();
-        e.stopPropagation();
-    });
-
     $("body").on("click", ".flatpickr-calendar", (e) => {
         e.stopPropagation();
         e.preventDefault();
@@ -238,7 +162,7 @@ export function hide_all_except_sidebars(opts) {
     stream_popover.hide_stream_popover();
     user_group_popover.hide();
     user_card_popover.hide_all_user_card_popovers();
-    hide_playground_links_popover();
+    playground_links_popover.hide_playground_links_popover();
 
     // look through all the popovers that have been added and removed.
     for (const $o of list_of_popovers) {

--- a/web/src/ui_init.js
+++ b/web/src/ui_init.js
@@ -67,6 +67,7 @@ import * as notifications from "./notifications";
 import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
+import * as playground_links_popover from "./playground_links_popover";
 import * as pm_conversations from "./pm_conversations";
 import * as pm_list from "./pm_list";
 import * as popover_menus from "./popover_menus";
@@ -770,6 +771,7 @@ export function initialize_everything() {
     emoji_picker.initialize();
     user_group_popover.initialize();
     user_card_popover.initialize();
+    playground_links_popover.initialize();
     pm_list.initialize();
     topic_list.initialize({
         on_topic_click(stream_id, topic) {

--- a/web/styles/reactions.css
+++ b/web/styles/reactions.css
@@ -134,7 +134,8 @@
     }
 }
 
-.active-emoji-picker-reference {
+.active-emoji-picker-reference,
+.active-playground-links-reference {
     visibility: visible !important;
     pointer-events: all !important;
     opacity: 1 !important;

--- a/web/templates/view_code_in_playground.hbs
+++ b/web/templates/view_code_in_playground.hbs
@@ -1,2 +1,2 @@
 {{! Display the "view code in playground" option for code blocks}}
-<a target="_blank" rel="noopener noreferrer" class="code_external_link"><i class="fa fa-external-link"></i></a>
+<a target="_blank" rel="noopener noreferrer" class="code_external_link"><i class="fa fa-external-link playground-links-popover-container"></i></a>


### PR DESCRIPTION
## Description:
This PR is part of our ongoing effort to migrate from Bootstrap-based popovers to Tippy.

## Checklist for manual testing:
- Keyboard Navigation
- Positioning
- Visual Appearance
- Dark/Light Theme Compatibility
- Scrolling Behavior
- Narrow/Wide Screen Rendering

## Screenshots:
<details>
<summary>Screenshots:</summary>

| Before | After |
| ------ | ------- |
| Narrow screen |
| ![image](https://github.com/zulip/zulip/assets/53193850/40f48c06-195e-40d6-8311-adbd68ebc871) | ![image](https://github.com/zulip/zulip/assets/53193850/26d40aea-a3e1-4f51-aa61-56775f493355)  |
</details>

---
### Fixes part of #23632.