### PR TITLE
vdots: Simplify color states across UI.

### DIFF
--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -35,7 +35,7 @@ let $stream_header_colorblock;
 
 // Keep the menu icon over which the popover is based off visible.
 function show_left_sidebar_menu_icon(element) {
-    $(element).closest("[class*='-sidebar-menu-icon']").addClass("left_sidebar_menu_icon_visible");
+    $(element).closest(".sidebar-menu-icon").addClass("left_sidebar_menu_icon_visible");
 }
 
 // Remove the class from element when popover is closed

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -728,8 +728,7 @@
     .clear_search_button:active,
     .clear_search_button:disabled:hover,
     #user-groups .save-instructions,
-    .close,
-    #user_presences li:hover .user-list-sidebar-menu-icon {
+    .close {
         color: hsl(236deg 33% 80%);
     }
 
@@ -748,10 +747,6 @@
 
     .spectator_narrow_login_button .login_button i {
         color: hsl(236deg 33% 90%);
-    }
-
-    #user_presences li .user-list-sidebar-menu-icon:hover {
-        color: hsl(0deg 0% 100%) !important;
     }
 
     #streamlist-toggle,

--- a/web/styles/dark_theme.css
+++ b/web/styles/dark_theme.css
@@ -729,12 +729,7 @@
     .clear_search_button:disabled:hover,
     #user-groups .save-instructions,
     .close,
-    #user_presences li:hover .user-list-sidebar-menu-icon,
-    li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
-    li.top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,
-    li.top_left_drafts:hover .drafts-sidebar-menu-icon,
-    #stream_filters li:hover .stream-sidebar-menu-icon,
-    li.topic-list-item:hover .topic-sidebar-menu-icon {
+    #user_presences li:hover .user-list-sidebar-menu-icon {
         color: hsl(236deg 33% 80%);
     }
 
@@ -755,12 +750,7 @@
         color: hsl(236deg 33% 90%);
     }
 
-    #user_presences li .user-list-sidebar-menu-icon:hover,
-    .all-messages-sidebar-menu-icon:hover,
-    .starred-messages-sidebar-menu-icon:hover,
-    .drafts-sidebar-menu-icon:hover,
-    .stream-sidebar-menu-icon:hover,
-    .topic-sidebar-menu-icon:hover {
+    #user_presences li .user-list-sidebar-menu-icon:hover {
         color: hsl(0deg 0% 100%) !important;
     }
 

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -626,14 +626,15 @@ li.top_left_scheduled_messages {
     All of our left sidebar handlers use absolute
     positioning.  We should fix that.
 */
-.all-messages-sidebar-menu-icon,
-.stream-sidebar-menu-icon,
-.starred-messages-sidebar-menu-icon,
-.drafts-sidebar-menu-icon,
-.topic-sidebar-menu-icon {
+.top_left_row .sidebar-menu-icon,
+.bottom_left_row .sidebar-menu-icon {
     position: absolute;
     display: none;
-    right: 10px;
+    top: 1px;
+    right: 0;
+    font-size: 1em;
+    text-align: center;
+    padding: 0 6px;
 
     & i {
         padding-right: 0.35em;
@@ -649,7 +650,7 @@ li.top_left_scheduled_messages {
     */
 
     &:hover {
-        color: hsl(0deg 0% 0%) !important;
+        color: var(--color-vdots-hover);
     }
 
     /*
@@ -661,22 +662,34 @@ li.top_left_scheduled_messages {
 
     @media (hover: none) {
         display: block;
+        /* Show dots on touchscreens in a less distracting,
+           lighter shade. */
+        color: var(--color-vdots-hint);
     }
 }
 
 /*
-    The All messages and stream ellipsis-v (vertical 3 dots) are
-    pretty similar.
+    When you hover over list items, we hover
+    the vdots in light gray.
+
+    The stream icon should always display when
+    any topic is hovered, which is why it gets
+    a more specific selector here.
 */
-.all-messages-sidebar-menu-icon,
-.starred-messages-sidebar-menu-icon,
-.drafts-sidebar-menu-icon,
-.stream-sidebar-menu-icon {
-    top: 1px;
-    right: 0;
-    font-size: 1em;
-    text-align: center;
-    padding: 0 6px;
+#stream_filters li:hover .stream-sidebar-menu-icon,
+.top_left_row:hover .sidebar-menu-icon,
+.bottom_left_row:hover .sidebar-menu-icon {
+    display: inline;
+    cursor: pointer;
+    color: var(--color-vdots-visible);
+
+    /*
+        If you hover directly over the vdots icon,
+        show it in black.
+    */
+    &:hover {
+        color: var(--color-vdots-hover);
+    }
 }
 
 /*
@@ -684,26 +697,12 @@ li.top_left_scheduled_messages {
     font to show they're "lower" in the hierarchy,
     which also affects it positioning.
 */
-.topic-sidebar-menu-icon {
+.bottom_left_row .topic-sidebar-menu-icon {
     top: 2px;
     right: 0;
     font-size: 0.9em;
     text-align: center;
     padding: 1px 6px 0;
-}
-
-/*
-    When you hover over list items, we hover
-    the relevant ellipsis-v(vertical 3 dots) in light gray.
-*/
-li.top_left_all_messages:hover .all-messages-sidebar-menu-icon,
-li.top_left_starred_messages:hover .starred-messages-sidebar-menu-icon,
-li.top_left_drafts:hover .drafts-sidebar-menu-icon,
-#stream_filters li:hover .stream-sidebar-menu-icon,
-li.topic-list-item:hover .topic-sidebar-menu-icon {
-    display: inline;
-    cursor: pointer;
-    color: hsl(0deg 0% 53%);
 }
 
 ul.topic-list {

--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -58,6 +58,10 @@ $before_unread_count_padding: 3px;
     }
 }
 
+#global_filters .filter-icon i {
+    color: var(--color-global-filter-icon);
+}
+
 #stream_filters,
 #global_filters {
     margin-right: 12px;
@@ -540,10 +544,6 @@ li.active-sub-filter {
         /* The border takes up space, so we need to
            subtract 1px from the usual 2px margin-top */
         margin-top: 1px !important;
-    }
-
-    & i {
-        opacity: 0.7;
     }
 
     .zulip-icon-inbox {

--- a/web/styles/right_sidebar.css
+++ b/web/styles/right_sidebar.css
@@ -45,12 +45,6 @@ $user_status_emoji_width: 24px;
                 vertical-align: middle;
             }
 
-            &:hover {
-                display: inline;
-                cursor: pointer;
-                color: hsl(0deg 0% 0%) !important;
-            }
-
             /*
             Hover does not work for touch-based devices like mobile phones.
             Hence the the icons does not appear, making the user unaware of its
@@ -60,6 +54,9 @@ $user_status_emoji_width: 24px;
 
             @media (hover: none) {
                 display: inline;
+                /* Show dots on touchscreens in a less distracting,
+                   lighter shade. */
+                color: var(--color-vdots-hint);
             }
         }
 
@@ -67,7 +64,11 @@ $user_status_emoji_width: 24px;
             .user-list-sidebar-menu-icon {
                 display: inline;
                 cursor: pointer;
-                color: hsl(0deg 0% 53%);
+                color: var(--color-vdots-visible);
+
+                &:hover {
+                    color: var(--color-vdots-hover);
+                }
             }
         }
 

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -181,6 +181,9 @@ body {
     --color-message-action-visible: hsl(216deg 43% 20% / 50%);
     --color-message-action-interactive: hsl(216deg 43% 20% / 100%);
     --color-message-star-action: hsl(41deg 100% 47% / 100%);
+    /* The gray on the filter icons is the same as
+       what's set on ul.filters, but with 70% opacity. */
+    --color-global-filter-icon: hsl(0deg 0% 20% / 70%);
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 0% / 34%);
@@ -260,6 +263,7 @@ body {
     --color-icon-bot: hsl(180deg 5% 50% / 100%);
     --color-message-action-visible: hsl(217deg 41% 90% / 50%);
     --color-message-action-interactive: hsl(217deg 41% 90% / 100%);
+    --color-global-filter-icon: hsl(0deg 0% 100% / 56%);
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 100% / 50%);

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -184,6 +184,9 @@ body {
     /* The gray on the filter icons is the same as
        what's set on ul.filters, but with 70% opacity. */
     --color-global-filter-icon: hsl(0deg 0% 20% / 70%);
+    --color-vdots-hint: hsl(0deg 0% 0% / 30%);
+    --color-vdots-visible: hsl(0deg 0% 0% / 53%);
+    --color-vdots-hover: hsl(0deg 0% 0%);
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 0% / 34%);
@@ -264,6 +267,9 @@ body {
     --color-message-action-visible: hsl(217deg 41% 90% / 50%);
     --color-message-action-interactive: hsl(217deg 41% 90% / 100%);
     --color-global-filter-icon: hsl(0deg 0% 100% / 56%);
+    --color-vdots-hint: hsl(0deg 0% 100% / 30%);
+    --color-vdots-visible: hsl(236deg 33% 80%);
+    --color-vdots-hover: hsl(0deg 0% 100%);
 
     /* Message feed loading indicator colors */
     --color-zulip-logo: hsl(0deg 0% 100% / 50%);

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -11,7 +11,7 @@
                     <span class="global-filter-name">{{t 'All messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+                <span class="arrow sidebar-menu-icon all-messages-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             {{#if development_environment}}
             <li class="top_left_inbox top_left_row hidden-for-spectators">
@@ -52,7 +52,7 @@
                     <span class="global-filter-name">{{t 'Starred messages' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+                <span class="arrow sidebar-menu-icon starred-messages-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_drafts top_left_row hidden-for-spectators">
                 <a href="#drafts" class="tippy-left-sidebar-tooltip global-filter-container" data-tooltip-template-id="drafts-tooltip-template">
@@ -63,7 +63,7 @@
                     <span class="global-filter-name">{{t 'Drafts' }}</span>
                     <span class="unread_count"></span>
                 </a>
-                <span class="arrow drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+                <span class="arrow sidebar-menu-icon drafts-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_scheduled_messages top_left_row hidden-for-spectators">
                 <a class="global-filter-container" href="#scheduled">

--- a/web/templates/presence_row.hbs
+++ b/web/templates/presence_row.hbs
@@ -20,5 +20,5 @@
         </a>
         <span class="unread_count">{{#if num_unread}}{{num_unread}}{{/if}}</span>
     </div>
-    <span class="user-list-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+    <span class="sidebar-menu-icon user-list-sidebar-menu-icon"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
 </li>

--- a/web/templates/stream_sidebar_row.hbs
+++ b/web/templates/stream_sidebar_row.hbs
@@ -14,6 +14,6 @@
             <span class="unread_count"></span>
             <span class="masked_unread_count"></span>
         </div>
-        <span class="stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
+        <span class="sidebar-menu-icon stream-sidebar-menu-icon hidden-for-spectators"><i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i></span>
     </div>
 </li>

--- a/web/templates/topic_list_item.hbs
+++ b/web/templates/topic_list_item.hbs
@@ -18,7 +18,7 @@
             {{unread}}
         </span>
     </span>
-    <span class="topic-sidebar-menu-icon">
+    <span class="sidebar-menu-icon topic-sidebar-menu-icon">
         <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
     </span>
 </li>


### PR DESCRIPTION
This expresses the colors for vdots icons in just three variations, all as CSS variables. The colors are all derived from the existing design, and the dots colors in the streams/topics area was used as as reference. The only visual change here, then, is to the global filters area, whose vdots were the outliers prior to this change.

The three variations are:

1. hint: for touchscreens where a :hover state is not available
2. visible: for all screens when a parent element is highlighted/hovered
3. hover: for when the vdots themselves are hovered

The hint is a new color variation, which makes the always-visible dots considerably less distracting on touch screens, as the iPad screenshots below show.

Of course, now that those are expressed as variables--and any opacity shifts are part of the color definition, rather than a freestanding `opacity` value--it will be easier than ever to tune the colors as part of reviewing this PR, not to mention proceeding with the left sidebar redesign.

The selectors have been streamlined to use a new `sidebar-menu-icon` utility class, and the hover-within-a-hover color on vdots is expressed more directly, eliminating the need for selector-specificity busting via `!important`.

This goes a bit beyond the issue as noted in #20600 by also applying the simplified states and colors to the right sidebar. There are no visual changes there, though, as you can see in the screenshots. So the right sidebar fix is purely to address code quality and parity with the left sidebar code.

Fixes: #20600

<details>
<summary><b>Screenshots and screen captures:</b></summary>

| Global Filters, Before | Global Filters, After |
| --- | --- |
| <img width="280" alt="global-light-before" src="https://github.com/zulip/zulip/assets/170719/81ef7c15-8fb8-4350-8701-540c933b0ea4"> | <img width="280" alt="global-light-after" src="https://github.com/zulip/zulip/assets/170719/e0d2460d-3d59-4627-9575-1afb26d5e6ba"> |
| <img width="280" alt="global-dark-before" src="https://github.com/zulip/zulip/assets/170719/a97754d5-c55e-4e7d-8a17-47a9732491f3"> | <img width="280" alt="global-dark-after" src="https://github.com/zulip/zulip/assets/170719/6b03a939-285a-4c44-8760-3e76830a3a50"> |

| Streams/Topics, Before | Streams/Topics, After |
| --- | --- |
| <img width="280" alt="topic-light-before" src="https://github.com/zulip/zulip/assets/170719/f1567a6b-4c63-4349-8b96-bbe9e33e1a1d"> | <img width="280" alt="topic-light-after" src="https://github.com/zulip/zulip/assets/170719/6b5408b0-09c6-4878-acc2-a59d20b332d7"> |
| <img width="280" alt="topic-dark-before" src="https://github.com/zulip/zulip/assets/170719/7dd44cac-fa43-4bb0-b13e-2b5f9b0fdf00"> | <img width="280" alt="topic-dark-after" src="https://github.com/zulip/zulip/assets/170719/a2119430-b7c5-43d9-aad5-d5dd89bcdd51"> |

| User List, Before | User List, After |
| --- | --- |
| <img width="248" alt="user-light-before" src="https://github.com/zulip/zulip/assets/170719/21bbb8ee-ab2c-44d6-b98d-f273c949008f"> | <img width="248" alt="user-light-after" src="https://github.com/zulip/zulip/assets/170719/9c70e22c-b5b2-41a4-b58f-c6c024f1c984"> |
| <img width="248" alt="user-dark-before" src="https://github.com/zulip/zulip/assets/170719/f9f4dc1a-6688-4764-8ca0-907f82007ec0"> | <img width="248" alt="user-dark-after" src="https://github.com/zulip/zulip/assets/170719/4076e725-0238-47aa-b5fb-927c1b121926"> |

| Always-visible Touchscreen Dots, Before | Always-visible Touchscreen Dots, After |
| --- | --- |
| ![light-touch-before](https://github.com/zulip/zulip/assets/170719/7ca10368-b072-4beb-8e75-52b750796a70) | ![light-touch-after](https://github.com/zulip/zulip/assets/170719/7bc7693f-009f-49de-aa53-93cb4696f16d) |
| ![dark-touch-before](https://github.com/zulip/zulip/assets/170719/91524065-74ee-414f-ae55-71f2d6fbc530) | ![dark-touch-after](https://github.com/zulip/zulip/assets/170719/f342daa7-7013-4de2-90c0-3e5455490c63) |

</details>

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>