### PR TITLE
toggle_resolve_topic: Display spinner while request is in progress. 

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -401,7 +401,7 @@ export function initialize() {
         const $recipient_row = $(e.target).closest(".recipient_row");
         const message_id = rows.id_for_recipient_row($recipient_row);
         const topic_name = $(e.target).attr("data-topic-name");
-        message_edit.toggle_resolve_topic(message_id, topic_name);
+        message_edit.toggle_resolve_topic(message_id, topic_name, false, $recipient_row);
     });
 
     $("body").on("click", ".message_header .on_hover_topic_unresolve", (e) => {
@@ -409,7 +409,7 @@ export function initialize() {
         const $recipient_row = $(e.target).closest(".recipient_row");
         const message_id = rows.id_for_recipient_row($recipient_row);
         const topic_name = $(e.target).attr("data-topic-name");
-        message_edit.toggle_resolve_topic(message_id, topic_name);
+        message_edit.toggle_resolve_topic(message_id, topic_name, false, $recipient_row);
     });
 
     // Mute topic in a unmuted stream

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -241,6 +241,7 @@ body {
     --color-unread-marker: hsl(217deg 64% 59%);
     --color-background-modal: hsl(212deg 28% 18%);
     --color-unmuted-or-followed-topic-list-item: hsl(236deg 33% 90%);
+    --color-recipient-bar-controls-spinner: hsl(0deg 0% 100%);
 
     /* Text colors */
     --color-text-default: hsl(0deg 0% 100% / 75%);
@@ -2474,6 +2475,10 @@ div.topic_edit_spinner {
 div.topic_edit_spinner .loading_indicator_spinner {
     width: 14px;
     height: 14px;
+
+    & path {
+        fill: var(--color-recipient-bar-controls-spinner);
+    }
 }
 
 .message_edit_spinner {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -2472,7 +2472,13 @@ div.topic_edit_spinner {
     vertical-align: middle;
 }
 
-div.topic_edit_spinner .loading_indicator_spinner {
+div.toggle_resolve_topic_spinner {
+    margin-top: -12px;
+    padding-left: 9px;
+}
+
+div.topic_edit_spinner .loading_indicator_spinner,
+div.toggle_resolve_topic_spinner .loading_indicator_spinner {
     width: 14px;
     height: 14px;
 

--- a/web/templates/recipient_row.hbs
+++ b/web/templates/recipient_row.hbs
@@ -55,6 +55,7 @@
                 {{else}}
                     <i class="fa fa-check on_hover_topic_resolve recipient_bar_icon hidden-for-spectators" data-topic-name="{{topic}}" data-tippy-content="{{t 'Mark as resolved' }}" role="button" tabindex="0" aria-label="{{t 'Mark as resolved' }}"></i>
                 {{/if}}
+                <div class="toggle_resolve_topic_spinner" style="display: none"></div>
             {{/if}}
 
             {{#if development}}


### PR DESCRIPTION

**First Commit**

A spinner is shown when the request is in progress for inline topic edit.

Earlier, the spinner was not visible in the dark theme.

**Before**

[old.webm](https://github.com/zulip/zulip/assets/56781761/f5922fc4-39ab-4114-848d-bfdbaa86d2e4)

**After**

[new.webm](https://github.com/zulip/zulip/assets/56781761/e159ace5-07c0-4196-be39-2cbf9b9f2306)


**Second Commit**

We replace the check icon for "Mark as resolved/unresolved" with a spinner while the request is still ongoing.

This helps to prevent double-clicking and reduce possible race conditions.

Fixes: #26190 

[spinner-2.webm](https://github.com/zulip/zulip/assets/56781761/5029c736-b691-46d7-94e7-3c1c67dd7926)

Note: To replicate the "request in progress" behavior for testing, comment out the [`channel.patch({`](https://github.com/zulip/zulip/blob/main/web/src/message_edit.js#L701) part.

---


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
