### PR TITLE
"All direct messages" should work with keyboard

### DIFF
--- a/web/src/click_handlers.js
+++ b/web/src/click_handlers.js
@@ -719,7 +719,7 @@ export function initialize() {
         "click",
         ".private_messages_container.zoom-out #private_messages_section_header",
         (e) => {
-            if (e.target.classList.value === "fa fa-align-right") {
+            if ($(e.target).closest("#show_all_private_messages").length === 1) {
                 // Let the browser handle the "all direct messages" widget.
                 return;
             }

--- a/web/templates/left_sidebar.hbs
+++ b/web/templates/left_sidebar.hbs
@@ -79,7 +79,7 @@
         <div id="private_messages_section">
             <div id="private_messages_section_header" class="zoom-out zoom-in-sticky">
                 <span id="pm_tooltip_container">
-                    <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down toggle_private_messages_section zoom-in-hide" aria-hidden="true"></i>
+                    <i id="toggle_private_messages_section_icon" class="fa fa-sm fa-caret-down toggle_private_messages_section zoom-in-hide" aria-hidden="true" tabindex="0" role="button"></i>
                     <h4 class="sidebar-title toggle_private_messages_section">{{t 'DIRECT MESSAGES' }}</h4>
                 </span>
                 <span class="unread_count"></span>


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

**Issue:** #25647 

- The issue was `toggle_private_messages_section_icon` was not keyboard focusable. So making it keyboard accessible also correctly handled the enter key press scenario through the hotkey.js to treat it the same way as a click, correctly togging the current state of the PM list.
- Also, it was suggested that we smartly use [Element closest](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) for show_all_private_messages to early return for both mouse click and keyboard click scenarios.

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

https://github.com/zulip/zulip/assets/26189424/6df0b7ab-f945-46ca-b98b-286929903d67

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
