### PR TITLE
Add explanation when Inbox view and Recent conversations views are empty

### DIFF
--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -393,8 +393,6 @@ function reset_data() {
         }
     }
 
-    const has_unread = unread_dms_count + unread_stream_msg_count > 0;
-
     if (unread_stream_msg_count) {
         for (const [stream_id, topic_dict] of unread_streams_dict) {
             const stream_unread = unread.num_unread_for_stream(stream_id);
@@ -427,7 +425,6 @@ function reset_data() {
         unread_dms_count,
         is_dms_collaped,
         has_dms_post_filter,
-        has_unread,
     };
 }
 

--- a/web/src/recent_view_ui.js
+++ b/web/src/recent_view_ui.js
@@ -290,6 +290,7 @@ export function revive_current_focus() {
 
 export function show_loading_indicator() {
     loading.make_indicator($("#recent_view_loading_messages_indicator"));
+    $("#recent_view_table tbody").removeClass("required-text");
 }
 
 export function hide_loading_indicator() {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -7,6 +7,7 @@
     border-radius: 4px;
     border-right: 1px solid var(--color-border-inbox);
     border-left: 1px solid var(--color-border-inbox);
+    min-height: 100vh;
 
     #inbox-pane {
         max-width: 100%;

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -31,7 +31,7 @@
         .search_group {
             position: sticky;
             top: var(--navbar-fixed-height);
-            background: var(--color-background);
+            background: var(--color-background-inbox);
             display: flex;
             padding: 15px 0 10px;
             z-index: 1;
@@ -100,6 +100,12 @@
                 border: 2px solid transparent;
                 border-radius: 3px;
                 box-sizing: border-box;
+            }
+
+            .inbox-empty-text {
+                display: none;
+                font-style: italic;
+                opacity: 0.8;
             }
 
             .inbox-header {

--- a/web/templates/inbox_view/inbox_list.hbs
+++ b/web/templates/inbox_view/inbox_list.hbs
@@ -21,3 +21,10 @@
 <div id="inbox-streams-container">
     {{> inbox_stream_container }}
 </div>
+
+<div id="inbox-empty-with-search" class="inbox-empty-text">
+    {{t "No conversations match your filters."}}
+</div>
+<div id="inbox-empty-without-search"  class="inbox-empty-text">
+    {{t "There are no unread messages in your inbox."}}
+</div>

--- a/web/templates/recent_view_table.hbs
+++ b/web/templates/recent_view_table.hbs
@@ -11,6 +11,7 @@
 </div>
 <div class="table_fix_head" data-simplebar>
     <table class="table table-responsive">
+        <tbody data-empty="{{t 'No conversations match your filters.' }}" class="required-text"></tbody>
         <thead>
             <tr>
                 <th data-sort="stream_sort">{{t 'Stream' }}</th>
@@ -22,6 +23,5 @@
                 <th data-sort="numeric" data-sort-prop="last_msg_id" class="last_msg_time_header active descend">{{t 'Time' }}</th>
             </tr>
         </thead>
-        <tbody data-empty="{{t 'No topics match your current filter.' }}"></tbody>
     </table>
 </div>


### PR DESCRIPTION
Fixes #26746

Inbox:
<img width="748" alt="Screenshot 2023-09-18 at 4 10 46 PM" src="https://github.com/zulip/zulip/assets/25124304/87d50448-b679-40ea-bad6-3f10e7f39394">
<img width="748" alt="Screenshot 2023-09-18 at 4 11 22 PM" src="https://github.com/zulip/zulip/assets/25124304/3874edf5-e60e-4625-969b-2443c3116bad">

Recent topics
<img width="748" alt="Screenshot 2023-09-18 at 4 11 07 PM" src="https://github.com/zulip/zulip/assets/25124304/4e2649b6-1ff8-4092-9e8f-a638c395511c">
