### PR TITLE
Migrate user card manage menu popover.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -266,8 +266,8 @@ export function process_escape_key(e) {
     }
 
     if (popovers.any_active()) {
-        if (user_card_popover.is_user_card_manage_menu_open()) {
-            user_card_popover.hide_user_card_popover_manage_menu();
+        if (user_card_popover.manage_menu.is_open()) {
+            user_card_popover.manage_menu.hide();
             $("#user_card_popover .user-card-popover-manage-menu-btn").trigger("focus");
             return true;
         }
@@ -371,8 +371,8 @@ function handle_popover_events(event_name) {
         return true;
     }
 
-    if (user_card_popover.is_user_card_manage_menu_open()) {
-        user_card_popover.user_card_popover_manage_menu_handle_keyboard(event_name);
+    if (user_card_popover.manage_menu.is_open()) {
+        user_card_popover.manage_menu.handle_keyboard(event_name);
         return true;
     }
 

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -57,7 +57,7 @@ export function popover_items_handle_keyboard(key, $items) {
 
     if (key === "enter" && index >= 0 && index < $items.length) {
         $items[index].click();
-        if (user_card_popover.is_user_card_manage_menu_open()) {
+        if (user_card_popover.manage_menu.is_open()) {
             const $items = user_card_popover.get_user_card_popover_manage_menu_items();
             focus_first_popover_item($items);
         }
@@ -66,7 +66,7 @@ export function popover_items_handle_keyboard(key, $items) {
     if (index === -1) {
         if (
             $(".user-card-popover-manage-menu-btn").is(":visible") &&
-            !user_card_popover.is_user_card_manage_menu_open()
+            !user_card_popover.manage_menu.is_open()
         ) {
             // If we have a "Manage Menu" button in the user card popover,
             // the first item to receive focus shouldn't be that button.

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -64,7 +64,14 @@ export function popover_items_handle_keyboard(key, $items) {
         return;
     }
     if (index === -1) {
-        if ($(".user-card-popover-manage-menu-btn").is(":visible")) {
+        if (
+            $(".user-card-popover-manage-menu-btn").is(":visible") &&
+            !user_card_popover.is_user_card_manage_menu_open()
+        ) {
+            // If we have a "Manage Menu" button in the user card popover,
+            // the first item to receive focus shouldn't be that button.
+            // However, if the Manage Menu is open, focus should shift to
+            // the first item in that popover.
             index = 1;
         } else {
             index = 0;

--- a/web/src/popovers.js
+++ b/web/src/popovers.js
@@ -58,8 +58,28 @@ export function popover_items_handle_keyboard(key, $items) {
     if (key === "enter" && index >= 0 && index < $items.length) {
         $items[index].click();
         if (user_card_popover.manage_menu.is_open()) {
-            const $items = user_card_popover.get_user_card_popover_manage_menu_items();
-            focus_first_popover_item($items);
+            // If we just opened the little manage menu via the
+            // keyboard, we need to focus the first item for a
+            // continuation of the keyboard experience.
+
+            // TODO: This might be cleaner to just call
+            // toggle_user_card_popover_manage_menu rather than
+            // triggering a click.
+
+            const previously_defined_on_mount =
+                user_card_popover.manage_menu.instance.props.onMount;
+            user_card_popover.manage_menu.instance.setProps({
+                onMount() {
+                    // We're monkey patching the onMount method here to ensure we start
+                    // focusing on the item after the popover is mounted to the DOM;
+                    // otherwise, it won't work correctly.
+                    if (previously_defined_on_mount) {
+                        previously_defined_on_mount();
+                    }
+                    const $items = user_card_popover.get_user_card_popover_manage_menu_items();
+                    focus_first_popover_item($items);
+                },
+            });
         }
         return;
     }

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -392,13 +392,13 @@ export function user_card_popover_manage_menu_handle_keyboard(key) {
 
 export function get_user_card_popover_manage_menu_items() {
     if (!$current_user_card_popover_manage_menu) {
-        blueslip.error("Trying to get menu items when action popover is closed.");
+        blueslip.error("Trying to get menu items when manage menu popover is closed.");
         return undefined;
     }
 
     const popover_data = $current_user_card_popover_manage_menu.data("popover");
     if (!popover_data) {
-        blueslip.error("Cannot find popover data for actions menu.");
+        blueslip.error("Cannot find popover data for manage menu.");
         return undefined;
     }
 
@@ -495,13 +495,13 @@ export function user_card_popover_for_message_handle_keyboard(key) {
 
 function get_user_card_popover_for_message_items() {
     if (!$current_message_user_card_popover_elem) {
-        blueslip.error("Trying to get menu items when action popover is closed.");
+        blueslip.error("Trying to get menu items when message user card popover is closed.");
         return undefined;
     }
 
     const popover_data = $current_message_user_card_popover_elem.data("popover");
     if (!popover_data) {
-        blueslip.error("Cannot find popover data for actions menu.");
+        blueslip.error("Cannot find popover data for message user card menu.");
         return undefined;
     }
 

--- a/web/src/user_card_popover.js
+++ b/web/src/user_card_popover.js
@@ -49,7 +49,59 @@ let current_user_sidebar_user_id;
 
 let userlist_placement = "right";
 
+class PopoverMenu {
+    constructor() {
+        this.instance = null;
+    }
+
+    is_open() {
+        return Boolean(this.instance);
+    }
+
+    hide() {
+        if (this.is_open()) {
+            this.instance.destroy();
+            this.instance = undefined;
+        }
+    }
+
+    handle_keyboard(key) {
+        if (!this.is_open()) {
+            blueslip.error("Trying to get the items when popover is closed.");
+            return;
+        }
+
+        const $popover = $(this.instance?.popper);
+        if (!$popover) {
+            blueslip.error("Cannot find popover data.");
+            return;
+        }
+
+        const $items = $("li:not(.divider):visible a", $popover);
+        popover_items_handle_keyboard(key, $items);
+    }
+}
+
+export const manage_menu = new PopoverMenu();
+
+const user_card_popovers = {
+    manage_menu,
+};
+
+export function any_active() {
+    return Object.values(user_card_popovers).some((instance) => instance.is_open());
+}
+
+export function hide_all_instances() {
+    for (const key in user_card_popovers) {
+        if (user_card_popovers[key].hide) {
+            user_card_popovers[key].hide();
+        }
+    }
+}
+
 export function hide_all_user_card_popovers() {
+    hide_all_instances();
     hide_user_card_popover_manage_menu();
     hide_message_user_card_popover();
     hide_user_sidebar_popover();

--- a/web/tests/hotkey.test.js
+++ b/web/tests/hotkey.test.js
@@ -66,10 +66,12 @@ const overlays = mock_esm("../src/overlays", {
     is_overlay_or_modal_open: () => overlays.is_modal_open() || overlays.is_active(),
 });
 const popovers = mock_esm("../src/user_card_popover", {
-    is_user_card_manage_menu_open: () => false,
     is_message_user_card_open: () => false,
     user_sidebar_popped: () => false,
     is_user_card_open: () => false,
+    manage_menu: {
+        is_open: () => false,
+    },
 });
 const popover_menus = mock_esm("../src/popover_menus", {
     get_visible_instance: () => undefined,


### PR DESCRIPTION
## Description:
This PR is part of our ongoing effort to migrate from Bootstrap-based popovers to Tippy.

## Checklist for manual testing:
- Keyboard Navigation
- Positioning
- Visual Appearance
- Dark/Light Theme Compatibility

## Screenshots:
<details>
<summary>manage menu popover</summary>

| Before | After |
| ------ | ------- |
| Light theme |
| ![image](https://github.com/zulip/zulip/assets/53193850/c198558c-cdb8-49d3-941a-ac6bc8c58c23) | ![image](https://github.com/zulip/zulip/assets/53193850/8ff794b7-4741-49ef-acfa-427359007018) |
| Dark theme |
| ![image](https://github.com/zulip/zulip/assets/53193850/e2e48acd-5c5f-488c-a798-5a90733de852) | ![image](https://github.com/zulip/zulip/assets/53193850/268af4ee-dbf5-49df-857a-0e6b9ca9fc59) |
</details>

---
### Fixes part of #23632.
