### PR TITLE
inbox: Calculate unread count of headers based on active filters.

### DIFF
--- a/web/src/hotkey.js
+++ b/web/src/hotkey.js
@@ -256,7 +256,7 @@ export function process_escape_key(e) {
         return true;
     }
 
-    if (inbox_util.is_in_focus() && inbox_ui.change_focused_element($(e.target), "escape")) {
+    if (inbox_util.is_in_focus() && inbox_ui.change_focused_element("escape")) {
         return true;
     }
 

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -829,6 +829,9 @@ function get_focus_class_for_header() {
             focus_class = ".unread_count";
             break;
         }
+        case COLUMNS.ACTION_MENU: {
+            focus_class = ".inbox-stream-menu";
+        }
     }
 
     return focus_class;

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -899,7 +899,7 @@ export function initialize() {
         }
     });
 
-    $("body").on("click", "#inbox-list .inbox-row, #inbox-list .inbox-header", (e) => {
+    $("body").on("click", "#inbox-list .inbox-left-part-wrapper", (e) => {
         const $elt = $(e.currentTarget);
         col_focus = COLUMNS.RECIPIENT;
         focus_clicked_element($elt);

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -39,6 +39,7 @@ const COLUMNS = {
     COLLAPSE_BUTTON: 0,
     RECIPIENT: 1,
     UNREAD_COUNT: 2,
+    ACTION_MENU: 3,
 };
 let col_focus = COLUMNS.COLLAPSE_BUTTON;
 let row_focus = 0;
@@ -600,20 +601,22 @@ function set_list_focus(input_key) {
     }
 
     const $row_to_focus = $($all_rows.get(row_focus));
+    const $cols_to_focus = $row_to_focus.find("[tabindex=0]");
+    const total_cols = $cols_to_focus.length;
     current_focus_id = $row_to_focus.attr("id");
     const not_a_header_row = !is_row_a_header($row_to_focus);
 
-    if (col_focus > COLUMNS.UNREAD_COUNT) {
-        col_focus = COLUMNS.COLLAPSE_BUTTON;
-    } else if (col_focus < COLUMNS.COLLAPSE_BUTTON) {
-        col_focus = COLUMNS.UNREAD_COUNT;
+    // Loop through columns.
+    if (col_focus > total_cols) {
+        col_focus = 0;
+    } else if (col_focus < 0) {
+        col_focus = total_cols;
     }
 
     // Since header rows always have a collapse button, other rows have one less element to focus.
     if (col_focus === COLUMNS.COLLAPSE_BUTTON) {
         if (not_a_header_row && ["left_arrow", "shift_tab"].includes(input_key)) {
-            // Focus on unread count.
-            col_focus = COLUMNS.UNREAD_COUNT;
+            col_focus = total_cols - 1;
         } else {
             $row_to_focus.trigger("focus");
             return;
@@ -632,7 +635,6 @@ function set_list_focus(input_key) {
         }
     }
 
-    const $cols_to_focus = $row_to_focus.find("[tabindex=0]");
     $($cols_to_focus.get(col_focus - 1)).trigger("focus");
 }
 
@@ -836,6 +838,8 @@ function get_focus_class_for_row() {
     let focus_class = ".inbox-left-part";
     if (col_focus === COLUMNS.UNREAD_COUNT) {
         focus_class = ".unread_count";
+    } else if (col_focus === COLUMNS.ACTION_MENU) {
+        focus_class = ".inbox-topic-menu";
     }
     return focus_class;
 }

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -250,6 +250,7 @@ function format_stream(stream_id) {
         // Will be displayed if any topic is visible.
         is_hidden: true,
         is_collapsed: collapsed_containers.has(STREAM_HEADER_PREFIX + stream_id),
+        mention_in_unread: unread.stream_has_any_unread_mentions(stream_id),
     };
 }
 
@@ -292,6 +293,7 @@ function format_topic(stream_id, topic, topic_unread_count) {
         topic_url: hash_util.by_stream_topic_url(stream_id, topic),
         is_hidden: filter_should_hide_row({stream_id, topic}),
         is_collapsed: collapsed_containers.has(STREAM_HEADER_PREFIX + stream_id),
+        mention_in_unread: unread.topic_has_any_unread_mentions(stream_id, topic),
     };
 
     return context;

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -462,7 +462,10 @@ export function complete_rerender() {
     );
     update_filters();
     show_empty_inbox_text(has_visible_unreads);
-
+    // If the focus is not on the inbox rows, the inbox view scrolls
+    // downwhen moving from other views to the inbox view. To avoid
+    // this, we scroll to top before restoring focus.
+    $("html").scrollTop(0);
     setTimeout(() => {
         // We don't want to focus on simplebar ever.
         $("#inbox-list .simplebar-content-wrapper").attr("tabindex", "-1");

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -674,6 +674,9 @@ export function change_focused_element(input_key) {
                 focus_muted_filter();
                 return true;
             case "escape":
+                if (get_all_rows().length === 0) {
+                    return false;
+                }
                 set_list_focus();
                 return true;
             case "shift_tab":

--- a/web/src/inbox_ui.js
+++ b/web/src/inbox_ui.js
@@ -696,6 +696,7 @@ export function change_focused_element(input_key) {
             case "down_arrow":
                 row_focus += 1;
                 set_list_focus();
+                center_focus_if_offscreen();
                 return true;
             case "vim_up":
             case "up_arrow":
@@ -705,6 +706,7 @@ export function change_focused_element(input_key) {
                 }
                 row_focus -= 1;
                 set_list_focus();
+                center_focus_if_offscreen();
                 return true;
             case "vim_right":
             case "right_arrow":
@@ -838,7 +840,8 @@ function get_focus_class_for_row() {
     return focus_class;
 }
 
-function center_focus_if_offscreen($elt) {
+function center_focus_if_offscreen() {
+    const $elt = $(".inbox-row:focus, .inbox-header:focus");
     if ($elt.length === 0) {
         return;
     }
@@ -951,10 +954,5 @@ export function initialize() {
         } else {
             unread_ops.mark_stream_as_read(stream_id);
         }
-    });
-
-    $("body").on("focus", ".inbox-row, .inbox-header", (e) => {
-        const $elt = $(e.currentTarget);
-        center_focus_if_offscreen($elt);
     });
 }

--- a/web/src/message_edit.js
+++ b/web/src/message_edit.js
@@ -719,12 +719,17 @@ export function toggle_resolve_topic(
         url: "/json/messages/" + message_id,
         data: request,
         success() {
-            const $spinner = $row.find(".toggle_resolve_topic_spinner");
-            loading.destroy_indicator($spinner);
+            if ($row) {
+                const $spinner = $row.find(".toggle_resolve_topic_spinner");
+                loading.destroy_indicator($spinner);
+            }
         },
         error(xhr) {
-            const $spinner = $row.find(".toggle_resolve_topic_spinner");
-            loading.destroy_indicator($spinner);
+            if ($row) {
+                const $spinner = $row.find(".toggle_resolve_topic_spinner");
+                loading.destroy_indicator($spinner);
+            }
+
             if (xhr.responseJSON) {
                 if (xhr.responseJSON.code === "MOVE_MESSAGES_TIME_LIMIT_EXCEEDED") {
                     handle_resolve_topic_failure_due_to_time_limit(topic_is_resolved);

--- a/web/src/stream_popover.js
+++ b/web/src/stream_popover.js
@@ -120,6 +120,10 @@ function build_stream_popover(opts) {
     });
 
     popover_menus.toggle_popover_menu(elt, {
+        // Add a delay to separate `hideOnClick` and `onShow` so that
+        // `onShow` is called after `hideOnClick`.
+        // See https://github.com/atomiks/tippyjs/issues/230 for more details.
+        delay: [100, 0],
         ...left_sidebar_tippy_options,
         onCreate(instance) {
             stream_popover_instance = instance;
@@ -490,6 +494,18 @@ export function register_click_handlers() {
         const elt = e.currentTarget;
         const $stream_li = $(elt).parents("li");
         const stream_id = elem_to_stream_id($stream_li);
+
+        build_stream_popover({
+            elt,
+            stream_id,
+        });
+
+        e.stopPropagation();
+    });
+
+    $("body").on("click", ".inbox-stream-menu", (e) => {
+        const elt = e.currentTarget;
+        const stream_id = Number.parseInt($(elt).attr("data-stream-id"), 10);
 
         build_stream_popover({
             elt,

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -344,7 +344,8 @@
             top: 1px;
         }
 
-        .inbox-row {
+        .inbox-row,
+        .inbox-header {
             &:focus,
             &:focus-within,
             &:hover {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -119,8 +119,8 @@
                 }
 
                 .inbox-left-part {
-                    grid-template: auto / auto min-content;
-                    grid-template-areas: "header_name unread_count";
+                    grid-template: auto / auto min-content min-content;
+                    grid-template-areas: "header_name unread_mention_info unread_count";
                 }
 
                 .inbox-header-name {
@@ -227,8 +227,8 @@
                 }
 
                 .inbox-left-part {
-                    grid-template: auto / min-content auto min-content;
-                    grid-template-areas: "match_topic_and_dm_start recipient_info unread_count";
+                    grid-template: auto / min-content auto min-content min-content;
+                    grid-template-areas: "match_topic_and_dm_start recipient_info unread_mention_info unread_count";
                 }
 
                 .fake-collapse-button,
@@ -247,6 +247,10 @@
                 margin-right: 5px;
                 margin-left: 10px;
                 align-self: center;
+            }
+
+            .unread_mention_info {
+                grid-area: unread_mention_info;
             }
 
             .stream-privacy {

--- a/web/styles/inbox.css
+++ b/web/styles/inbox.css
@@ -102,6 +102,7 @@
                 border: 2px solid transparent;
                 border-radius: 3px;
                 box-sizing: border-box;
+                justify-content: space-between;
             }
 
             .inbox-empty-text {
@@ -330,12 +331,54 @@
             }
         }
 
+        .inbox-right-part-wrapper {
+            display: flex;
+            align-items: center;
+        }
+
         #inbox_filter_mute_toggle {
             font-size: 16px;
             width: 16px;
             height: 16px;
             position: relative;
             top: 1px;
+        }
+
+        .inbox-row {
+            &:focus,
+            &:focus-within,
+            &:hover {
+                .inbox-action-button {
+                    opacity: 1;
+                }
+            }
+        }
+
+        .inbox-action-button {
+            display: flex;
+            border-radius: 3px;
+            outline: none;
+            opacity: 0;
+
+            &.hide {
+                display: none;
+            }
+
+            &:focus {
+                box-shadow: 0 0 0 2px var(--color-outline-focus);
+            }
+
+            & i {
+                padding: 5px;
+                font-size: 16px;
+                opacity: 0.3;
+                color: var(--color-vdots-hover);
+
+                &:hover {
+                    opacity: 1;
+                    cursor: pointer;
+                }
+            }
         }
     }
 }

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -37,6 +37,17 @@
                     {{/if}}
                 </div>
             </div>
+            {{#unless is_direct}}
+            <div class="inbox-right-part-wrapper">
+                <div class="inbox-right-part">
+                    <div class="inbox-action-button inbox-topic-menu"
+                      {{#if is_topic}}data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
+                      data-topic-url="{{topic_url}}"{{/if}}>
+                        <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
+                    </div>
+                </div>
+            </div>
+            {{/unless}}
         </div>
     </div>
 {{/if}}

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -42,7 +42,7 @@
                 <div class="inbox-right-part">
                     <div class="inbox-action-button inbox-topic-menu"
                       {{#if is_topic}}data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
-                      data-topic-url="{{topic_url}}"{{/if}}>
+                      data-topic-url="{{topic_url}}"{{/if}} tabindex="0">
                         <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
                     </div>
                 </div>

--- a/web/templates/inbox_view/inbox_row.hbs
+++ b/web/templates/inbox_view/inbox_row.hbs
@@ -26,6 +26,9 @@
                         <div class="inbox-topic-name">
                             <a tabindex="-1" href="{{topic_url}}">{{topic_name}}</a>
                         </div>
+                        <span class="unread_mention_info tippy-zulip-tooltip
+                          {{#unless mention_in_unread}}hidden{{/unless}}"
+                          data-tippy-content="{{t 'You have mentions'}}">@</span>
                         <span class="unread_count tippy-zulip-tooltip on_hover_topic_read"
                           data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}"
                           data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -15,5 +15,12 @@
                 <span class="unread_count tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
             </div>
         </div>
+        <div class="inbox-right-part-wrapper">
+            <div class="inbox-right-part">
+                <div class="inbox-action-button inbox-stream-menu" data-stream-id="{{stream_id}}" tabindex="0">
+                    <i class="zulip-icon zulip-icon-more-vertical" aria-hidden="true"></i>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/web/templates/inbox_view/inbox_stream_header_row.hbs
+++ b/web/templates/inbox_view/inbox_stream_header_row.hbs
@@ -9,6 +9,9 @@
                     </span>
                     <a tabindex="-1" href="{{stream_url}}">{{stream_name}}</a>
                 </div>
+                <span class="unread_mention_info tippy-zulip-tooltip
+                  {{#unless mention_in_unread}}hidden{{/unless}}"
+                  data-tippy-content="{{t 'You have mentions'}}">@</span>
                 <span class="unread_count tippy-zulip-tooltip on_hover_topic_read" data-stream-id="{{stream_id}}" data-tippy-content="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}">{{unread_count}}</span>
             </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/26773

Now unread count of header is a sum of non hidden topics / DMs
unread count.
<img width="868" alt="Screenshot 2023-09-19 at 1 23 59 PM" src="https://github.com/zulip/zulip/assets/25124304/bd7ad6c0-1de0-4b16-9c7e-9a97642320fa">
