### PR TITLE
api-docs: Update the add and remove `update_message_flags` events.

### DIFF
--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -1630,7 +1630,7 @@ update_message_flags_remove_event = event_dict_type(
         ("type", Equals("update_message_flags")),
         ("op", Equals("remove")),
         ("operation", Equals("remove")),
-        ("flag", EnumType(["read", "starred"])),
+        ("flag", str),
         ("messages", ListType(int)),
         ("all", bool),
     ],

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2726,7 +2726,7 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent to a user when [message flags][message-flags] are added
-                                to a message.
+                                to messages.
 
                                 [message-flags]: /api/update-message-flags#available-flags
                               properties:
@@ -2744,17 +2744,17 @@ paths:
                                 operation:
                                   deprecated: true
                                   description: |
-                                    Old name for `op` for this event type.
+                                    Old name for the `op` field in this event type.
 
-                                    **Deprecated**: This is deprecated; please use `op` instead
-                                    starting with Zulip 4.0 (feature level 32).
+                                    **Deprecated** in Zulip 4.0 (feature level 32), and
+                                    replaced by the `op` field.
                                   type: string
                                   enum:
                                     - add
                                 flag:
                                   type: string
                                   description: |
-                                    The flag that was added.
+                                    The [flag][message-flags] that was added.
                                 messages:
                                   type: array
                                   description: |
@@ -2765,9 +2765,12 @@ paths:
                                 all:
                                   type: boolean
                                   description: |
-                                    Whether the flag was added to all messages (E.g. all messages
-                                    were marked as read).
-                                    If this is true, then the `messages` array will be empty.
+                                    Whether the specified flag was added to all messages.
+                                    This field is only relevant for the `"read"` flag, and
+                                    will be `false` for all other flags.
+
+                                    When `true` for the `"read"` flag, then the `messages`
+                                    array will be empty.
                               example:
                                 {
                                   "type": "update_message_flags",
@@ -2782,19 +2785,9 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent to a user when [message flags][message-flags] are
-                                removed from a message.
+                                removed from messages.
 
                                 [message-flags]: /api/update-message-flags#available-flags
-                              required:
-                                [
-                                  "id",
-                                  "type",
-                                  "op",
-                                  "operation",
-                                  "flag",
-                                  "messages",
-                                  "all",
-                                ]
                               properties:
                                 id:
                                   $ref: "#/components/schemas/EventIdSchema"
@@ -2811,19 +2804,16 @@ paths:
                                   deprecated: true
                                   type: string
                                   description: |
-                                    Old name for `op` for this event type.
+                                    Old name for the `op` field in this event type.
 
-                                    **Deprecated**: This is deprecated; please use `op` instead
-                                    starting with Zulip 4.0 (feature level 32).
+                                    **Deprecated** in Zulip 4.0 (feature level 32), and
+                                    replaced by the `op` field.
                                   enum:
                                     - remove
                                 flag:
                                   type: string
                                   description: |
-                                    The flag to be removed.
-                                  enum:
-                                    - starred
-                                    - read
+                                    The [flag][message-flags] to be removed.
                                 messages:
                                   type: array
                                   description: |
@@ -2832,18 +2822,19 @@ paths:
                                   items:
                                     type: integer
                                 all:
+                                  deprecated: true
                                   type: boolean
                                   description: |
-                                    Whether the flag was removed from all messages.
-                                    If this is true then the `messages` array will be empty.
+                                    Will be `false` for all specified flags.
+
+                                    **Deprecated** and will be removed in a future release.
                                 message_details:
                                   description: |
-                                    Present if `message` and `update_message_flags` are both present in
-                                    `event_types` and the `flag` is `read` and the `op` is `remove`.
+                                    Only present if the specified `flag` is `"read"`.
 
                                     A set of data structures describing the messages that
                                     are being marked as unread with additional details to
-                                    allow a client to update the `unread_msgs` data
+                                    allow clients to update the `unread_msgs` data
                                     structure for these messages (which may not be
                                     otherwise known to the client).
 
@@ -2898,8 +2889,7 @@ paths:
                                         type: boolean
                                         deprecated: true
                                         description: |
-                                          **Deprecated**
-                                          Internal implementation detail. Clients should
+                                          **Deprecated** internal implementation detail. Clients should
                                           ignore this field as it will be removed in the future.
                               example:
                                 {


### PR DESCRIPTION
See [relevant CZO discussion](https://chat.zulip.org/#narrow/stream/378-api-design/topic/.60all.60.20in.20update_message_flags.2Fremove/near/1638953) about these changes.

**Notes**:
- Clarifies that the `all` field in the `op: "add"` event is only relevant for the `"read"` message flag, and that it will be false for all other specified flags in theses events.
- Deprecates the `all` field in the `op: "remove"` event and document that it is false for all specified flags.
- Updates the deprecated `operation` field description and makes a few other small revisions to the event text for clarity and accuracy.

**Questions**:
- We have a handful of **Deprecated** notes in the API documentation without a feature level, and I add one here as we're not changing the server/backend code, but only updating the docs with these changes. But I can see it being not helpful for clients to not have a feature level to reference. Thoughts?

@chrisbobbe would you be up for reviewing these updates?

**Screenshots and screen captures:**

<details>
<summary>op: add event</summary>

[Current documentation](https://zulip.com/api/get-events#update_message_flags-add)
![Screenshot from 2023-09-19 14-02-12](https://github.com/zulip/zulip/assets/63245456/00926107-e76e-4061-a918-283a8e7fa016)
</details>
<details>
<summary>op: remove event</summary>

[Current documentation](https://zulip.com/api/get-events#update_message_flags-remove)
![Screenshot from 2023-09-19 14-03-21](https://github.com/zulip/zulip/assets/63245456/43f34749-465e-48b8-a0c5-bbcb34e15421)
![Screenshot from 2023-09-19 14-03-34](https://github.com/zulip/zulip/assets/63245456/b63b0b2e-29da-44c8-b3c0-8e883b2a6756)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
