### PR TITLE
emails: Fix contact_us macros for "mailto" in email links.

### DIFF
--- a/templates/zerver/emails/account_registered.html
+++ b/templates/zerver/emails/account_registered.html
@@ -54,7 +54,7 @@
 
 <p>
     {% if corporate_enabled %}
-        {% trans %}Questions? <a href="{{ support_email }}">Contact us</a> — we'd love to help!{% endtrans %}
+        {% trans %}Questions? <a href="mailto:{{ support_email }}">Contact us</a> — we'd love to help!{% endtrans %}
     {% else %}
         {{macros.contact_us_self_hosted(support_email)}}
     {% endif %}

--- a/templates/zerver/emails/macros.html
+++ b/templates/zerver/emails/macros.html
@@ -11,9 +11,9 @@
 {%- endmacro %}
 
 {% macro contact_us_self_hosted(email) -%}
-    {% trans %}If you have any questions, please contact this Zulip server's administrators at <a href="{{ email }}">{{ email }}</a>.{% endtrans %}
+    {% trans %}If you have any questions, please contact this Zulip server's administrators at <a href="mailto:{{ email }}">{{ email }}</a>.{% endtrans %}
 {%- endmacro %}
 
 {% macro contact_us_zulip_cloud(email) -%}
-    {% trans %}Do you have questions or feedback to share? <a href="{{ email }}">Contact us</a> — we'd love to help!{% endtrans %}
+    {% trans %}Do you have questions or feedback to share? <a href="mailto:{{ email }}">Contact us</a> — we'd love to help!{% endtrans %}
 {%- endmacro %}


### PR DESCRIPTION
As noted in [this CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/.22contact.20us.22.20link.20in.20email.20not.20working/near/1642615), the new macros introduced for contact us links in commit dcea17eb4496ffa708c90b2d57dd7bc56b2400a2 were missing the "mailto:" in the anchor tags.

**Notes**:
- Updates the `contact_us_zulip_cloud` and `contact_us_self_hosted` email macros to have the "mailto:" scheme in the anchor tag for the support email address.
- Also updates the Zulip Cloud version of the support email anchor tag for the `account_registered` email, which has a slightly different format/text than the macro.
- Did a sweep of all anchor tags in the `templates/zerver/emails` directory to make sure there are no other email links that are broken.

**Screenshots and screen captures:**

<details>
<summary>Zulip cloud - new account registered email in dev environment</summary>

![Screenshot from 2023-09-20 16-23-18](https://github.com/zulip/zulip/assets/63245456/0e9f0326-13e0-478f-9f34-048ffed4d73a)
</details>
<details>
<summary>Self-hosted org - new account registered email in dev environment</summary>

![Screenshot from 2023-09-20 16-24-39](https://github.com/zulip/zulip/assets/63245456/73cd4c73-2b0d-4133-9184-429ba5c77e5f)
</details>
<details>
<summary>Zulip cloud - onboarding guide in dev environment</summary>

![Screenshot from 2023-09-20 16-27-10](https://github.com/zulip/zulip/assets/63245456/511c76b1-48e5-458f-ae46-e8747df92da6)
</details>
<details>
<summary>Self-hosted org - onboarding guide in dev environment</summary>

![Screenshot from 2023-09-20 16-27-25](https://github.com/zulip/zulip/assets/63245456/ecad15ac-67f2-4623-9bc0-d018e489e5c2)
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
