### PR TITLE
grid: Mobile-scale message area tweaks.

### DIFF
--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -144,10 +144,11 @@ $time_column_min_width: 42px; /* + padding */
             ".      reactions .        . .   ";
 
         @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
-            grid-template-columns: $avatar_column_width minmax(0, 1fr) max-content 8px minmax(
-                    $time_column_min_width,
-                    max-content
-                );
+            grid-template-columns:
+                $avatar_column_width minmax(0, 1fr) calc(
+                    2 * var(--message-box-icon-width)
+                )
+                8px minmax($time_column_min_width, max-content);
         }
 
         .message_controls {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -144,7 +144,7 @@ $time_column_min_width: 42px; /* + padding */
             ".      reactions .        . .   ";
 
         @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
-            grid-template-columns: $avatar_column_width auto max-content 8px minmax(
+            grid-template-columns: $avatar_column_width minmax(0, 1fr) max-content 8px minmax(
                     $time_column_min_width,
                     max-content
                 );

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -153,12 +153,9 @@ $time_column_min_width: 42px; /* + padding */
         .message_controls {
             grid-area: controls;
             justify-self: end;
-            padding: 0;
 
             @media (width < $sm_min),
                 ((width >= $md_min) and (width < $mc_min)) {
-                padding: 0 4px;
-
                 /* This is intended to target the first message_controls child
                    when there are 3 displayed. 4 = 3 + hidden message_failed element. */
                 .message_control_button:nth-last-child(4) {

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -143,6 +143,15 @@ $time_column_min_width: 42px; /* + padding */
             ".      more      .        . .   "
             ".      reactions .        . .   ";
 
+        &.content_edit_mode {
+            /* Set the controls area to 0 to give more space
+               to the edit/source view area. */
+            grid-template-columns: $avatar_column_width minmax(0, 1fr) 0 8px minmax(
+                    $time_column_min_width,
+                    max-content
+                );
+        }
+
         @media (width < $sm_min), ((width >= $md_min) and (width < $mc_min)) {
             grid-template-columns:
                 $avatar_column_width minmax(0, 1fr) calc(

--- a/web/styles/message_row.css
+++ b/web/styles/message_row.css
@@ -152,7 +152,6 @@ $time_column_min_width: 42px; /* + padding */
 
         .message_controls {
             grid-area: controls;
-            justify-self: end;
 
             @media (width < $sm_min),
                 ((width >= $md_min) and (width < $mc_min)) {
@@ -411,10 +410,6 @@ $time_column_min_width: 42px; /* + padding */
                 vertical-align: baseline;
                 /* A bit of margin here helps these not look associated with the name. */
                 margin-left: 4px;
-            }
-
-            .message_controls {
-                grid-area: controls;
             }
 
             .message_sender {

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3103,7 +3103,6 @@ select.invite-as {
 
     .include-sender .message_controls {
         background: none !important;
-        padding: 0 !important;
         border: none !important;
     }
 }

--- a/web/styles/zulip.css
+++ b/web/styles/zulip.css
@@ -3100,11 +3100,6 @@ select.invite-as {
     #navbar-buttons ul.nav li.active .dropdown-toggle {
         top: -8px;
     }
-
-    .include-sender .message_controls {
-        background: none !important;
-        border: none !important;
-    }
 }
 
 @media (width < $mm_min) {


### PR DESCRIPTION
This PR primarily corrects a sneaky discrepancy between messages with and without a sender a mobile scales. I discovered this while confirming it was safe to close #17986. This fix is essential for both RTL and LTR languages; it was just more obviously a problem with an RTL language.

In fixing that discrepancy, it now also extends across all viewports a more generous area for message editing and message source views. That was originally available only in very narrow message-feed views, as part of a fluke with `max-content`. But this is now no longer a fluke, but a deliberate design choice (which can be adjusted further, of course). See [the discussion on CZO](https://chat.zulip.org/#narrow/stream/101-design/topic/adjusting.20the.20message-edit.20form/near/1643675).

The PR also does a bit of shoring up and cleanup:

* Mobile-scale grids now use `minmax(0, 1fr)` in lieu of `auto` on the message column to prevent blowouts
* Mobile-scale grids now use the `--message-icon-width` value to more precisely describe their width, rather than `max-content` (although visually both values are the same)
* The controls area is now defined uniformly regardless of whether there is a sender or not (reflecting reality, as visually there should be no difference); some unused styles that are no longer relevant to the design are also removed

**Screenshots and screen captures:**

Both rows of screenshots are identical, except the second row has the grid lines turned on to help verify both the problem and the fix.

| Mobile Grid, Before | Mobile Grid, After |
| --- | --- |
| ![mobile-grid-before](https://github.com/zulip/zulip/assets/170719/e6df2c4c-8ab3-4fdd-a0dc-14809a420102) | ![mobile-grid-after](https://github.com/zulip/zulip/assets/170719/70b5fc4e-38f8-41a7-8891-0e040a36dfe2) |
| ![mobile-grid-showing-before](https://github.com/zulip/zulip/assets/170719/e5a1b556-1167-4e8f-bcca-5995c78c5922) | ![mobile-grid-showing-after](https://github.com/zulip/zulip/assets/170719/0799e2e8-2e85-4579-9097-65139328e0e8) |

| Edit Area, Before | Edit Area, After |
| --- | --- |
| ![message-edit-before](https://github.com/zulip/zulip/assets/170719/f301880c-00d9-4d9f-a9f9-b73a2ec4571d) | ![message-edit-after](https://github.com/zulip/zulip/assets/170719/f7599841-1041-4801-a225-861995b640d9) |


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>