### PR TITLE
api-docs: Update various areas of endpoint response documentation.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5206,10 +5206,16 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - description: |
-                      JSON response for when no draft exists with the provided ID.
-                    example: {"result": "error", "msg": "Draft does not exist"}
+                      A typical failed JSON response for when no draft exists with
+                      the provided ID:
+                    example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "result": "error",
+                        "msg": "Draft does not exist",
+                      }
     delete:
       operationId: delete-draft
       tags: ["drafts"]
@@ -5235,10 +5241,16 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - description: |
-                      JSON response for when no draft exists with the provided ID.
-                    example: {"result": "error", "msg": "Draft does not exist"}
+                      A typical failed JSON response for when no draft exists with
+                      the provided ID:
+                    example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "result": "error",
+                        "msg": "Draft does not exist",
+                      }
   /scheduled_messages:
     get:
       operationId: get-scheduled-messages
@@ -5542,16 +5554,22 @@ paths:
                         description: |
                           A typical failed JSON response for when a direct message is scheduled
                           to be sent to a user that does not exist:
-                  - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - description: |
-                          Example response for when no scheduled message exists with the provided ID.
-                        example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "result": "error",
-                            "msg": "Scheduled message does not exist",
-                          }
+        "404":
+          description: Not Found.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/CodedError"
+                  - description: |
+                      A typical failed JSON response for when no scheduled message exists
+                      with the provided ID:
+                    example:
+                      {
+                        "code": "BAD_REQUEST",
+                        "result": "error",
+                        "msg": "Scheduled message does not exist",
+                      }
     delete:
       operationId: delete-scheduled-message
       tags: ["scheduled_messages"]
@@ -5582,9 +5600,10 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - description: |
-                      Example response for when no scheduled message exists with the provided ID.
+                      A typical failed JSON response for when no scheduled message exists
+                      with the provided ID:
                     example:
                       {
                         "code": "BAD_REQUEST",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -18956,6 +18956,7 @@ components:
             result: {}
             msg: {}
             ignored_parameters_unsupported: {}
+          example: {"msg": "", "result": "success"}
     JsonSuccessBase:
       description: |
         **Changes**: As of Zulip 7.0 (feature level 167), if any
@@ -18979,7 +18980,6 @@ components:
               type: string
             ignored_parameters_unsupported:
               $ref: "#/components/schemas/IgnoredParametersUnsupported"
-          example: {"msg": "", "result": "success"}
     IgnoredParametersSuccess:
       allOf:
         - $ref: "#/components/schemas/IgnoredParametersBase"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5023,14 +5023,15 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
+                        "code": "UNAUTHORIZED",
                         "result": "error",
                         "msg": "Not logged in: API authentication or user session required",
                       }
                     description: |
-                      A typical failed JSON response for when the user is not logged in
+                      A typical failed JSON response for when the user is not logged in:
   /drafts:
     get:
       operationId: get-drafts

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9160,19 +9160,34 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example: {"msg": "Cannot mute self", "result": "error"}
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "Cannot mute self",
+                            "result": "error",
+                          }
                         description: |
-                          An example JSON response for when the user is yourself:
+                          An example JSON response for when the user ID is the current
+                          user's ID:
                   - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example: {"msg": "No such user", "result": "error"}
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "No such user",
+                            "result": "error",
+                          }
                         description: |
                           An example JSON response for when the user is nonexistent or inaccessible:
                   - allOf:
-                      - $ref: "#/components/schemas/JsonError"
+                      - $ref: "#/components/schemas/CodedError"
                       - example:
-                          {"msg": "User already muted", "result": "error"}
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "User already muted",
+                            "result": "error",
+                          }
                         description: |
                           An example JSON response for when the user is already muted:
     delete:
@@ -9196,13 +9211,23 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example: {"msg": "No such user", "result": "error"}
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "No such user",
+                            "result": "error",
+                          }
                         description: |
                           An example JSON response for when the user is nonexistent or inaccessible:
                   - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example: {"msg": "User is not muted", "result": "error"}
+                      - $ref: "#/components/schemas/CodedError"
+                      - example:
+                          {
+                            "code": "BAD_REQUEST",
+                            "msg": "User is not muted",
+                            "result": "error",
+                          }
                         description: |
                           An example JSON response for when the user is not previously muted:
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8097,9 +8097,10 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
+                        "code": "BAD_REQUEST",
                         "msg": "Cannot deactivate the only organization owner",
                         "result": "error",
                       }
@@ -10624,9 +10625,10 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
+                        "code": "BAD_REQUEST",
                         "msg": "Cannot deactivate the only organization owner",
                         "result": "error",
                       }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -16244,7 +16244,7 @@ paths:
                       - description: |
                           An example JSON response for when the supplied stream does not exist:
                   - allOf:
-                      - $ref: "#/components/schemas/JsonError"
+                      - $ref: "#/components/schemas/CodedError"
                       - example:
                           {
                             "code": "BAD_REQUEST",
@@ -16253,7 +16253,7 @@ paths:
                           }
                         description: |
                           An example JSON response for when invalid combination of stream permission
-                          parameters are passed.
+                          parameters are passed:
   /streams/{stream_id}/delete_topic:
     post:
       operationId: delete-topic
@@ -16330,7 +16330,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
                         "result": "error",
@@ -16479,7 +16479,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
                         "code": "BAD_REQUEST",
@@ -16488,7 +16488,6 @@ paths:
                       }
                     description: |
                       An example JSON error response for when user sends to multiple streams:
-
   /user_groups/create:
     post:
       operationId: create-user-group
@@ -16553,7 +16552,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
                         "result": "error",
@@ -16693,7 +16692,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
                         "code": "BAD_REQUEST",
@@ -16720,7 +16719,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
                         "code": "BAD_REQUEST",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5640,14 +5640,8 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/CodedError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid stream ID",
-                            "result": "error",
-                          }
-                        description: |
+                      - $ref: "#/components/schemas/InvalidStreamError"
+                      - description: |
                           A typical failed JSON response for when an invalid stream ID is passed:
                   - allOf:
                       - $ref: "#/components/schemas/CodedError"
@@ -5688,15 +5682,9 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/CodedError"
+                  - $ref: "#/components/schemas/InvalidStreamError"
                   - description: |
                       A typical failed JSON response for when an invalid stream ID is passed:
-                    example:
-                      {
-                        "code": "BAD_REQUEST",
-                        "msg": "Invalid stream ID",
-                        "result": "error",
-                      }
   /messages:
     get:
       operationId: get-messages
@@ -8484,14 +8472,8 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
-                  - example:
-                      {
-                        "code": "BAD_REQUEST",
-                        "msg": "Invalid stream ID",
-                        "result": "error",
-                      }
-                    description: |
+                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - description: |
                       An example JSON response for when the user is attempting to fetch the topics
                       of a non-existing stream (or also a private stream they don't have access to):
   /users/me/subscriptions:
@@ -15799,14 +15781,8 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
-                  - example:
-                      {
-                        "code": "BAD_REQUEST",
-                        "msg": "Invalid stream ID",
-                        "result": "error",
-                      }
-                    description: |
+                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - description: |
                       An example JSON response for when the requested stream does not exist,
                       or where the user does not have permission to access the target stream:
   /streams:
@@ -16070,15 +16046,9 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/CodedError"
-                  - example:
-                      {
-                        "code": "BAD_REQUEST",
-                        "msg": "Invalid stream ID",
-                        "result": "error",
-                      }
-                    description: |
-                      An example JSON response for when the stream ID is not valid.
+                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - description: |
+                      An example JSON response for when the stream ID is not valid:
     delete:
       operationId: archive-stream
       summary: Archive a stream
@@ -16097,14 +16067,8 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
-                  - example:
-                      {
-                        "code": "BAD_REQUEST",
-                        "msg": "Invalid stream ID",
-                        "result": "error",
-                      }
-                    description: |
+                  - $ref: "#/components/schemas/InvalidStreamError"
+                  - description: |
                       An example JSON response for when the supplied stream does not exist:
     patch:
       operationId: update-stream
@@ -16251,14 +16215,8 @@ paths:
               schema:
                 oneOf:
                   - allOf:
-                      - $ref: "#/components/schemas/JsonError"
-                      - example:
-                          {
-                            "code": "BAD_REQUEST",
-                            "msg": "Invalid stream ID",
-                            "result": "error",
-                          }
-                        description: |
+                      - $ref: "#/components/schemas/InvalidStreamError"
+                      - description: |
                           An example JSON response for when the supplied stream does not exist:
                   - allOf:
                       - $ref: "#/components/schemas/JsonError"
@@ -19160,6 +19118,20 @@ components:
           example:
             {
               "msg": "Invalid message(s)",
+              "code": "BAD_REQUEST",
+              "result": "error",
+            }
+    InvalidStreamError:
+      allOf:
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+          example:
+            {
+              "msg": "Invalid stream ID",
               "code": "BAD_REQUEST",
               "result": "error",
             }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19004,6 +19004,13 @@ components:
         A typical successful JSON response with ignored parameters may look like:
 
         [ignored_params]: /api/rest-error-handling#ignored-parameters
+      example:
+        {
+          "ignored_parameters_unsupported":
+            ["invalid_param_1", "invalid_param_2"],
+          "msg": "",
+          "result": "success",
+        }
     IgnoredParametersBase:
       allOf:
         - $ref: "#/components/schemas/JsonResponseBase"
@@ -19018,13 +19025,6 @@ components:
               type: string
             ignored_parameters_unsupported:
               $ref: "#/components/schemas/IgnoredParametersUnsupported"
-          example:
-            {
-              "ignored_parameters_unsupported":
-                ["invalid_param_1", "invalid_param_2"],
-              "msg": "",
-              "result": "success",
-            }
     JsonError:
       allOf:
         - $ref: "#/components/schemas/JsonErrorBase"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19063,23 +19063,6 @@ components:
               type: string
             ignored_parameters_unsupported:
               $ref: "#/components/schemas/IgnoredParametersUnsupported"
-    PartiallyCompleted:
-      allOf:
-        - $ref: "#/components/schemas/JsonResponseBase"
-        - required:
-            - result
-            - code
-          additionalProperties: false
-          properties:
-            result:
-              enum:
-                - partially_completed
-            code:
-              type: string
-              description: |
-                A string that identifies the cause of the partial completion of the request.
-            msg:
-              type: string
     ApiKeyResponse:
       allOf:
         - $ref: "#/components/schemas/JsonSuccessBase"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19307,14 +19307,8 @@ components:
             A typical failed json response for when user's account is deactivated:
     RateLimitedError:
       allOf:
-        - $ref: "#/components/schemas/CodedError"
-        - example:
-            {
-              "code": "RATE_LIMIT_HIT",
-              "msg": "API usage exceeded rate limit",
-              "result": "error",
-              "retry-after": 28.706807374954224,
-            }
+        - $ref: "#/components/schemas/CodedErrorBase"
+        - additionalProperties: false
           description: |
             ## Rate limit exceeded
 
@@ -19330,6 +19324,22 @@ components:
             A typical failed JSON response for when a rate limit is exceeded:
 
             [rate-limit-headers]: /api/http-headers#rate-limiting-response-headers
+          properties:
+            result: {}
+            msg: {}
+            code: {}
+            retry-after:
+              type: integer
+              description: |
+                How many seconds the client must wait before making
+                additional requests.
+          example:
+            {
+              "code": "RATE_LIMIT_HIT",
+              "msg": "API usage exceeded rate limit",
+              "result": "error",
+              "retry-after": 28.706807374954224,
+            }
     RealmDeactivatedError:
       allOf:
         - $ref: "#/components/schemas/CodedError"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19223,8 +19223,13 @@ components:
                 authorized to subscribe to. Only present if `"authorization_errors_fatal": false`.
     InvalidApiKeyError:
       allOf:
-        - $ref: "#/components/schemas/JsonError"
-        - example: {"msg": "Invalid API key", "result": "error"}
+        - $ref: "#/components/schemas/CodedError"
+        - example:
+            {
+              "code": "INVALID_API_KEY",
+              "msg": "Invalid API key",
+              "result": "error",
+            }
           description: |
             ## Invalid API key
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -9343,15 +9343,15 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - description: |
-                      JSON response for when no emoji exists with the provided name.
+                      An example JSON response for when no emoji exists with the provided name:
                     example:
                       {
+                        "code": "BAD_REQUEST",
                         "result": "error",
                         "msg": "Emoji 'green_tick' does not exist",
                       }
-
   /realm/emoji:
     get:
       operationId: get-custom-emoji

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -8726,8 +8726,46 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/AddSubscriptionsResponse"
-                  - example:
+                  - $ref: "#/components/schemas/JsonSuccessBase"
+                  - additionalProperties: false
+                    properties:
+                      result: {}
+                      msg: {}
+                      ignored_parameters_unsupported: {}
+                      subscribed:
+                        type: object
+                        description: |
+                          A dictionary where the key is the Zulip API email address of the user/bot
+                          and the value is a list of the names of the streams that were subscribed
+                          to as a result of the query.
+                        additionalProperties:
+                          description: |
+                            `{email_address}`: List of the names of the streams that were subscribed
+                            to as a result of the query.
+                          type: array
+                          items:
+                            type: string
+                      already_subscribed:
+                        type: object
+                        description: |
+                          A dictionary where the key is the Zulip API email address of the user/bot
+                          and the value is a list of the names of the streams that the user/bot is
+                          already subscribed to.
+                        additionalProperties:
+                          description: |
+                            `{email_address}`: List of the names of the streams that the user is
+                            already subscribed to.
+                          type: array
+                          items:
+                            type: string
+                      unauthorized:
+                        type: array
+                        items:
+                          type: string
+                        description: |
+                          A list of names of streams that the requesting user/bot was not
+                          authorized to subscribe to. Only present if `"authorization_errors_fatal": false`.
+                    example:
                       {
                         "already_subscribed":
                           {"iago@zulip.com": ["new stream"]},
@@ -19025,25 +19063,6 @@ components:
               type: string
             ignored_parameters_unsupported:
               $ref: "#/components/schemas/IgnoredParametersUnsupported"
-    JsonError:
-      allOf:
-        - $ref: "#/components/schemas/JsonErrorBase"
-        - additionalProperties: false
-          properties:
-            result: {}
-            msg: {}
-    JsonErrorBase:
-      allOf:
-        - $ref: "#/components/schemas/JsonResponseBase"
-        - required:
-            - result
-            - msg
-          properties:
-            result:
-              enum:
-                - error
-            msg:
-              type: string
     PartiallyCompleted:
       allOf:
         - $ref: "#/components/schemas/JsonResponseBase"
@@ -19104,12 +19123,17 @@ components:
             code: {}
     CodedErrorBase:
       allOf:
-        - $ref: "#/components/schemas/JsonErrorBase"
+        - $ref: "#/components/schemas/JsonResponseBase"
         - required:
+            - result
+            - msg
             - code
           properties:
-            result: {}
-            msg: {}
+            result:
+              enum:
+                - error
+            msg:
+              type: string
             code:
               type: string
               description: |
@@ -19199,47 +19223,6 @@ components:
               "result": "error",
               "stream_id": 9,
             }
-    AddSubscriptionsResponse:
-      allOf:
-        - $ref: "#/components/schemas/JsonSuccessBase"
-        - additionalProperties: false
-          properties:
-            result: {}
-            msg: {}
-            ignored_parameters_unsupported: {}
-            subscribed:
-              type: object
-              description: |
-                A dictionary where the key is the Zulip API email address of the user/bot
-                and the value is a list of the names of the streams that were subscribed
-                to as a result of the query.
-              additionalProperties:
-                description: |
-                  `{email_address}`: List of the names of the streams that were subscribed
-                  to as a result of the query.
-                type: array
-                items:
-                  type: string
-            already_subscribed:
-              type: object
-              description: |
-                A dictionary where the key is the Zulip API email address of the user/bot
-                and the value is a list of the names of the streams that the user/bot is
-                already subscribed to.
-              additionalProperties:
-                description: |
-                  `{email_address}`: List of the names of the streams that the user is
-                  already subscribed to.
-                type: array
-                items:
-                  type: string
-            unauthorized:
-              type: array
-              items:
-                type: string
-              description: |
-                A list of names of streams that the requesting user/bot was not
-                authorized to subscribe to. Only present if `"authorization_errors_fatal": false`.
     InvalidApiKeyError:
       allOf:
         - $ref: "#/components/schemas/CodedError"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -6907,14 +6907,11 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
-                  - example: {"msg": "Invalid message(s)", "result": "error"}
-                    description: |
-                      A typical JSON response when attempting to
-                      access read receipts for a message ID that
-                      either does not exist or is not accessible to
-                      the current user.
-
+                  - $ref: "#/components/schemas/InvalidMessageError"
+                  - description: |
+                      A typical JSON response when attempting to access read receipts for
+                      a message ID that either does not exist or is not accessible to the
+                      current user:
   /messages/matches_narrow:
     get:
       operationId: check-messages-match-narrow
@@ -19151,11 +19148,12 @@ components:
             }
     InvalidMessageError:
       allOf:
-        - $ref: "#/components/schemas/JsonErrorBase"
+        - $ref: "#/components/schemas/CodedErrorBase"
         - additionalProperties: false
           properties:
             result: {}
             msg: {}
+            code: {}
           example:
             {
               "msg": "Invalid message(s)",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -19105,7 +19105,9 @@ components:
     CodedErrorBase:
       allOf:
         - $ref: "#/components/schemas/JsonErrorBase"
-        - properties:
+        - required:
+            - code
+          properties:
             result: {}
             msg: {}
             code:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -7773,9 +7773,10 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: "#/components/schemas/JsonError"
+                  - $ref: "#/components/schemas/CodedError"
                   - example:
                       {
+                        "code": "BAD_REQUEST",
                         "msg": "Email 'newbie@zulip.com' already in use",
                         "result": "error",
                       }


### PR DESCRIPTION
Updates various parts of the endpoint response documentation, with a big focus on error responses.

**Notes**:
- The error responses are currently not validated in the backend `test_openapi` tests. There are a couple of reasons why, which I'll start a conversation about in CZO so we can hopefully get a plan/issue up to track fixing that.
- These changes update many error responses for the `code` field that's currently returned.
  - Most of them are the generic `"BAD_REQUEST"` string.
  - For non-generic `code` strings added to the documentation in these changes, I didn't go back to see when they were added to that error response for a feature level **Changes** note. I thought that could be a follow-up issue after these changes are merged.
- Removes the `JsonErrorBase` and `JsonError` shared schemas from the documentation as we don't document any error responses that don't have a `code` field.
  - After these changes, we only have `CodedErrorBase` and `CodedError`, so that any new documentation added for error responses will have the `code` field included.
- Removes the `PartiallyCompleted` schema, which was missed in #26658.
- Moves some of the general example responses from the base schema to the more specific shared schema. The base response schemas are used to generate more specific responses, so it doesn't make sense for these examples to be part of those schemas.

---

<details>
<summary>Diff of rendered API documentation changes</summary>

```diff
diff -r -B -U 1 current_api_html/create-user.html new_api_html/create-user.html
--- current_api_html/create-user.html	2023-09-20 16:55:37.205908766 +0200
+++ new_api_html/create-user.html	2023-09-20 16:54:57.149624505 +0200
@@ -393,2 +393,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Email 'newbie@zulip.com' already in use"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/deactivate-custom-emoji.html new_api_html/deactivate-custom-emoji.html
--- current_api_html/deactivate-custom-emoji.html	2023-09-20 16:55:41.061936154 +0200
+++ new_api_html/deactivate-custom-emoji.html	2023-09-20 16:55:01.217653352 +0200
@@ -330,4 +330,5 @@
 </code></pre></div>
-<p>JSON response for when no emoji exists with the provided name.</p>
+<p>An example JSON response for when no emoji exists with the provided name:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Emoji 'green_tick' does not exist"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/deactivate-own-user.html new_api_html/deactivate-own-user.html
--- current_api_html/deactivate-own-user.html	2023-09-20 16:55:37.521911010 +0200
+++ new_api_html/deactivate-own-user.html	2023-09-20 16:54:57.609627766 +0200
@@ -322,2 +322,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Cannot deactivate the only organization owner"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/deactivate-user.html new_api_html/deactivate-user.html
--- current_api_html/deactivate-user.html	2023-09-20 16:55:37.297909419 +0200
+++ new_api_html/deactivate-user.html	2023-09-20 16:54:57.405626320 +0200
@@ -345,2 +345,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Cannot deactivate the only organization owner"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/delete-draft.html new_api_html/delete-draft.html
--- current_api_html/delete-draft.html	2023-09-20 16:55:34.513889647 +0200
+++ new_api_html/delete-draft.html	2023-09-20 16:54:53.805600796 +0200
@@ -309,4 +309,6 @@
 </code></pre></div>
-<p>JSON response for when no draft exists with the provided ID.</p>
+<p>A typical failed JSON response for when no draft exists with
+the provided ID:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Draft does not exist"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/delete-scheduled-message.html new_api_html/delete-scheduled-message.html
--- current_api_html/delete-scheduled-message.html	2023-09-20 16:55:34.181887290 +0200
+++ new_api_html/delete-scheduled-message.html	2023-09-20 16:54:53.369597704 +0200
@@ -312,3 +312,4 @@
 </code></pre></div>
-<p>Example response for when no scheduled message exists with the provided ID.</p>
+<p>A typical failed JSON response for when no scheduled message exists
+with the provided ID:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>

diff -r -B -U 1 current_api_html/edit-draft.html new_api_html/edit-draft.html
--- current_api_html/edit-draft.html	2023-09-20 16:55:34.429889051 +0200
+++ new_api_html/edit-draft.html	2023-09-20 16:54:53.697600030 +0200
@@ -351,4 +351,6 @@
 </code></pre></div>
-<p>JSON response for when no draft exists with the provided ID.</p>
+<p>A typical failed JSON response for when no draft exists with
+the provided ID:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Draft does not exist"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/get-read-receipts.html new_api_html/get-read-receipts.html
--- current_api_html/get-read-receipts.html	2023-09-20 16:55:33.777884421 +0200
+++ new_api_html/get-read-receipts.html	2023-09-20 16:54:52.849594018 +0200
@@ -355,7 +355,7 @@
 </code></pre></div>
-<p>A typical JSON response when attempting to
-access read receipts for a message ID that
-either does not exist or is not accessible to
-the current user.</p>
+<p>A typical JSON response when attempting to access read receipts for
+a message ID that either does not exist or is not accessible to the
+current user:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Invalid message(s)"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/get-stream-by-id.html new_api_html/get-stream-by-id.html
--- current_api_html/get-stream-by-id.html	2023-09-20 16:55:35.461896380 +0200
+++ new_api_html/get-stream-by-id.html	2023-09-20 16:54:55.101609984 +0200
@@ -441,3 +441,3 @@
 </code></pre></div>
-<p>An example JSON response for when the stream ID is not valid.</p>
+<p>An example JSON response for when the stream ID is not valid:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>

diff -r -B -U 1 current_api_html/mute-user.html new_api_html/mute-user.html
--- current_api_html/mute-user.html	2023-09-20 16:55:39.509925130 +0200
+++ new_api_html/mute-user.html	2023-09-20 16:54:59.561641608 +0200
@@ -353,4 +353,6 @@
 </code></pre></div>
-<p>An example JSON response for when the user is yourself:</p>
+<p>An example JSON response for when the user ID is the current
+user's ID:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Cannot mute self"</span><span class="p">,</span>
@@ -361,2 +363,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"No such user"</span><span class="p">,</span>
@@ -367,2 +370,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"User already muted"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/remove-attachment.html new_api_html/remove-attachment.html
--- current_api_html/remove-attachment.html	2023-09-20 16:55:38.141915414 +0200
+++ new_api_html/remove-attachment.html	2023-09-20 16:54:58.197631935 +0200
@@ -341,4 +341,5 @@
 </code></pre></div>
-<p>A typical failed JSON response for when the user is not logged in</p>
+<p>A typical failed JSON response for when the user is not logged in:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"UNAUTHORIZED"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Not logged in: API authentication or user session required"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/rest-error-handling.html new_api_html/rest-error-handling.html
--- current_api_html/rest-error-handling.html	2023-09-20 16:55:31.513868344 +0200
+++ new_api_html/rest-error-handling.html	2023-09-20 16:54:49.105567477 +0200
@@ -288,2 +288,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"INVALID_API_KEY"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"Invalid API key"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/unmute-user.html new_api_html/unmute-user.html
--- current_api_html/unmute-user.html	2023-09-20 16:55:39.613925869 +0200
+++ new_api_html/unmute-user.html	2023-09-20 16:54:59.665642346 +0200
@@ -329,2 +329,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"No such user"</span><span class="p">,</span>
@@ -335,2 +336,3 @@
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
+<span class="w">    </span><span class="nt">"code"</span><span class="p">:</span><span class="w"> </span><span class="s2">"BAD_REQUEST"</span><span class="p">,</span>
 <span class="w">    </span><span class="nt">"msg"</span><span class="p">:</span><span class="w"> </span><span class="s2">"User is not muted"</span><span class="p">,</span>

diff -r -B -U 1 current_api_html/update-scheduled-message.html new_api_html/update-scheduled-message.html
--- current_api_html/update-scheduled-message.html	2023-09-20 16:55:34.097886693 +0200
+++ new_api_html/update-scheduled-message.html	2023-09-20 16:54:53.277597052 +0200
@@ -402,3 +402,4 @@
 </code></pre></div>
-<p>Example response for when no scheduled message exists with the provided ID.</p>
+<p>A typical failed JSON response for when no scheduled message exists
+with the provided ID:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>

diff -r -B -U 1 current_api_html/update-stream.html new_api_html/update-stream.html
--- current_api_html/update-stream.html	2023-09-20 16:55:35.693898027 +0200
+++ new_api_html/update-stream.html	2023-09-20 16:54:55.377611940 +0200
@@ -493,3 +493,3 @@
 <p>An example JSON response for when invalid combination of stream permission
-parameters are passed.</p>
+parameters are passed:</p>
 <div class="codehilite" data-code-language="JSON"><pre><span></span><code><span class="p">{</span>
```
</details>

---

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
