### PR TITLE
unread: Fix logic for wildcard mentions in direct messages.

### DIFF
--- a/web/src/unread.js
+++ b/web/src/unread.js
@@ -709,10 +709,17 @@ export function update_message_for_mention(message, content_edited = false) {
         return false;
     }
 
+    // A message is said to have an unmuted mention if message contains a mention and
+    // if the message is a direct message or
+    // if the message is in a non muted topic in an unmuted stream or
+    // if the message is in a followed or an unmuted topic in a muted stream.
     const is_unmuted_mention =
-        message.type === "stream" &&
         message.mentioned &&
-        !user_topics.is_topic_muted(message.stream_id, message.topic);
+        (message.type === "private" ||
+            (!stream_data.is_muted(message.stream_id) &&
+                !user_topics.is_topic_muted(message.stream_id, message.topic)) ||
+            (stream_data.is_muted(message.stream_id) &&
+                user_topics.is_topic_unmuted_or_followed(message.stream_id, message.topic)));
 
     if (is_unmuted_mention || message.mentioned_me_directly) {
         unread_mentions_counter.add(message.id);

--- a/web/tests/unread.test.js
+++ b/web/tests/unread.test.js
@@ -472,14 +472,32 @@ test("mentions", () => {
     assert.deepEqual(unread.get_msg_ids_for_mentions(), []);
     test_notifiable_count(counts.home_unread_messages, 0);
 
-    const muted_stream_id = 401;
+    const muted_stream_id = 900;
+    const unmuted_stream_id = 901;
 
-    user_topics.update_user_topics(401, "lunch", user_topics.all_visibility_policies.MUTED);
+    sub_store.add_hydrated_sub(muted_stream_id, {
+        muted_stream_id,
+        name: "muted stream for testing unread mentions",
+        subscribed: true,
+        is_muted: true,
+    });
+    sub_store.add_hydrated_sub(unmuted_stream_id, {
+        unmuted_stream_id,
+        name: "unmuted stream for testing unread mention",
+        subscribed: true,
+        is_muted: false,
+    });
+
+    user_topics.update_user_topics(
+        muted_stream_id,
+        "lunch",
+        user_topics.all_visibility_policies.MUTED,
+    );
 
     const already_read_message = {
         id: 14,
         type: "stream",
-        stream_id: 400,
+        stream_id: unmuted_stream_id,
         topic: "lunch",
         mentioned: true,
         mentioned_me_directly: true,
@@ -489,7 +507,7 @@ test("mentions", () => {
     const mention_me_message = {
         id: 15,
         type: "stream",
-        stream_id: 400,
+        stream_id: unmuted_stream_id,
         topic: "lunch",
         mentioned: true,
         mentioned_me_directly: true,
@@ -499,7 +517,7 @@ test("mentions", () => {
     const mention_all_message = {
         id: 16,
         type: "stream",
-        stream_id: 400,
+        stream_id: unmuted_stream_id,
         topic: "lunch",
         mentioned: true,
         mentioned_me_directly: false,
@@ -577,8 +595,10 @@ test("mentions", () => {
 });
 
 test("mention updates", () => {
+    // Unread message in an unmuted stream.
     const message = {
         id: 17,
+        stream_id: 901,
         unread: false,
         type: "stream",
         topic: "hello",


### PR DESCRIPTION
CZO: https://chat.zulip.org/#narrow/stream/6-frontend/topic/Wildcard.20mentions.20in.20direct.20messages

Wildcard mentions in direct messages were not being counted as mentions due to incorrect calculation of the `is_unmuted_mention` variable in the `update_message_for_mention()` function in `unread.js`. Fixed this by correcting the calculation of the `is_unmuted_mention` variable to be equal to the `message.mentioned && (message.type === "private" || !user_topics.is_topic_muted(message.stream_id, message.topic))`.

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
