### PR TITLE
left_sidebar: Hold hoverable area to + icon.

### DIFF
--- a/web/styles/left_sidebar.css
+++ b/web/styles/left_sidebar.css
@@ -89,14 +89,11 @@ li.show-more-topics {
 
 .streams_inline_icon_wrapper {
     float: right;
+    margin-right: 8px;
 }
 
 .streams_filter_icon.web_public {
     margin-right: 10px;
-}
-
-#streams_inline_icon {
-    margin-right: 8px;
 }
 
 .tooltip {


### PR DESCRIPTION
This shifts the 8px of margin to the wrapper, preserving the space to the right of the + icon, but no longer allowing it to shift the hover state or trigger the tooltip when clicking actually activates the search filter.

Fixes #11494 (at least the one fixable part; the rest should be closed as wontfix)

See [CZO discussion](https://chat.zulip.org/#narrow/stream/9-issues/topic/clickable.20sidebar.20headings.20and.20icons/near/1643752).

**Screenshots and screen captures:**

| Before | After (no change to layout) |
| --- | --- |
| ![streams-icons-before](https://github.com/zulip/zulip/assets/170719/8fe5548b-2915-4132-977d-3edee95435f3) | ![streams-icons-after](https://github.com/zulip/zulip/assets/170719/cbfc54be-bbfe-4546-b96d-47243cb4cf78) |

| Hover States, Before | Hover States, After |
| --- | --- |
| ![streams-hover-before](https://github.com/zulip/zulip/assets/170719/a5c9122a-39ce-4a2c-b425-5cc8ab285584) | ![streams-hover-after](https://github.com/zulip/zulip/assets/170719/6ea128a4-cf1b-40f4-af68-6d9c524ca286) |

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>