### PR TITLE
help: Fix formatting issue in "Dark theme" page.

### DIFF
--- a/help/dark-theme.md
+++ b/help/dark-theme.md
@@ -11,17 +11,8 @@ for working in a dark space.
 
 {settings_tab|preferences}
 
-
-1. Under **General**, select the desired color scheme from the **Theme** dropdown.
-
-
-The default is **Automatic (follows system settings)**, which detects which theme to use based
-on the color scheme used by your operating system.
-
-You can also specify **Light** or **Dark** if you'd like
-
-Zulip to use the same color scheme regardless of your operating system
-configuration.
+1. Under **General**, select the desired color scheme from the **Theme**
+   dropdown.
 
 {tab|mobile}
 
@@ -32,6 +23,12 @@ configuration.
 1. Toggle **Night mode**.
 
 {end_tabs}
+
+The default is **Automatic (follows system settings)**, which detects which
+theme to use based on the color scheme used by your operating system.
+
+You can also specify **Light** or **Dark** if you'd like Zulip to use the same
+color scheme regardless of your operating system configuration.
 
 ## Related articles
 


### PR DESCRIPTION
This fixes a formatting bug on https://zulip.com/help/dark-theme since the info after the last instruction shouldn't be inside the instructions block.

**Screenshots and screen captures:**

![image](https://github.com/zulip/zulip/assets/2343554/dcb54e57-fdd6-454d-a010-f52fa36d493b)