### PR TITLE
zilencer: Remove /json versions of push bouncer endpoints.

### DIFF
--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1134,11 +1134,11 @@ class TestAuthenticatedRequirePostDecorator(ZulipTestCase):
             )
 
         with self.assertLogs(level="WARNING") as mock_warning:
-            result = self.client_get(r"/json/remotes/server/register", {"stream": "Verona"})
+            result = self.client_get(r"/json/subscriptions/exists", {"stream": "Verona"})
             self.assertEqual(result.status_code, 405)
             self.assertEqual(
                 mock_warning.output,
-                ["WARNING:root:Method Not Allowed (GET): /json/remotes/server/register"],
+                ["WARNING:root:Method Not Allowed (GET): /json/subscriptions/exists"],
             )
 
 
@@ -1466,7 +1466,7 @@ class RestAPITest(ZulipTestCase):
         self.assert_in_response("Method Not Allowed", result)
 
         with self.settings(ZILENCER_ENABLED=True):
-            result = self.client_patch("/json/remotes/push/register")
+            result = self.client_patch("/api/v1/remotes/push/register")
             self.assertEqual(result.status_code, 405)
             self.assert_in_response("Method Not Allowed", result)
 

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -18,7 +18,7 @@ from zilencer.views import (
 i18n_urlpatterns: Any = []
 
 # Zilencer views following the REST API style
-v1_api_and_json_patterns = [
+push_bouncer_patterns = [
     remote_server_path("remotes/push/register", POST=register_remote_push_device),
     remote_server_path("remotes/push/unregister", POST=unregister_remote_push_device),
     remote_server_path("remotes/push/unregister/all", POST=unregister_all_remote_push_devices),
@@ -32,6 +32,5 @@ v1_api_and_json_patterns = [
 ]
 
 urlpatterns = [
-    path("api/v1/", include(v1_api_and_json_patterns)),
-    path("json/", include(v1_api_and_json_patterns)),
+    path("api/v1/", include(push_bouncer_patterns)),
 ]


### PR DESCRIPTION
These don't make sense (because authentication here is not based on sessions) and aren't used.

https://chat.zulip.org/#narrow/stream/378-api-design/topic/Push.20bouncer.20endpoints.20namespaces

Tested in dev env by accessing `http://localhost:9991/api/v1/remotes/push/notify` or `http://localhost:9991/json/remotes/push/notify` and verifying the `/json` endpoint stops existing, while the `/api/v1` run still works.