### PR TITLE
linkifiers: Use only the handle for dragging.

### DIFF
--- a/web/src/settings_linkifiers.js
+++ b/web/src/settings_linkifiers.js
@@ -163,6 +163,7 @@ export function populate_linkifiers(linkifiers_data) {
     if (page_params.is_admin) {
         Sortable.create($linkifiers_table[0], {
             onUpdate: update_linkifiers_order,
+            handle: ".move-handle",
             filter: "input",
             preventOnFilter: false,
         });

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -753,10 +753,28 @@ input[type="checkbox"] {
 
 .admin_profile_fields_table,
 .edit_profile_field_choices_container,
-.admin_linkifiers_table,
 .profile_field_choices_table {
     .movable-row {
         cursor: move;
+
+        .fa-ellipsis-v {
+            color: hsl(0deg 0% 75%);
+            position: relative;
+            top: 1px;
+
+            + i {
+                margin-right: 5px;
+            }
+        }
+    }
+}
+
+.admin_linkifiers_table {
+    .movable-row {
+        .move-handle {
+            cursor: move;
+            user-select: none;
+        }
 
         .fa-ellipsis-v {
             color: hsl(0deg 0% 75%);

--- a/web/templates/settings/admin_linkifier_list.hbs
+++ b/web/templates/settings/admin_linkifier_list.hbs
@@ -2,8 +2,10 @@
 <tr class="linkifier_row{{#if (and ../can_modify ../can_drag)}} movable-row{{/if}}" data-linkifier-id="{{id}}">
     <td>
         {{#if (and ../can_modify ../can_drag)}}
-            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
-            <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+            <span class="move-handle">
+                <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+                <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+            </span>
         {{/if}}
         <span class="linkifier_pattern">{{pattern}}</span>
     </td>


### PR DESCRIPTION
So that the user can still select and copy text from the body of the
linkifier rows. It might be helpful if we extend this behavior to other
draggable rows, like those for custom profile fields settings.

<!-- Describe your pull request here.-->

Fixes:
#26798
https://chat.zulip.org/#narrow/stream/6-frontend/topic/Reordering.20linkifiers/near/1644433 <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**
![reorder-new](https://github.com/zulip/zulip/assets/39874143/430bee6a-a90f-4e29-a15f-0768adc5d734)


<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
